### PR TITLE
Use ${CC} instead of hard-coded gcc

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -29,7 +29,7 @@ libs2n.a: ${OBJS}
 	ranlib libs2n.a
 
 libs2n.so: ${OBJS}
-	gcc -shared ${LIBS} -o libs2n.so ${OBJS}
+	${CC} -shared ${LIBS} -o libs2n.so ${OBJS}
 
 libs2n.dylib: ${OBJS}
 	test ! -f /usr/lib/libSystem.dylib || libtool -dynamic ${LIBS} -o libs2n.dylib ${OBJS}

--- a/tests/testlib/Makefile
+++ b/tests/testlib/Makefile
@@ -24,7 +24,7 @@ CFLAGS += -I../../ -I../../api/ -I../../libcrypto-root/include/
 LDFLAGS += -L../../lib/ -lcrypto -lpthread -ls2n
 
 libtests2n.so: ${OBJS}
-	gcc ${CFLAGS} -shared ${LDFLAGS} -o libtests2n.so ${OBJS}
+	${CC} ${CFLAGS} -shared ${LDFLAGS} -o libtests2n.so ${OBJS}
 
 libtests2n.dylib: ${OBJS}
 	test ! -f /usr/lib/libSystem.dylib || libtool ${LDFLAGS} -dynamic -o libtests2n.dylib ${OBJS}


### PR DESCRIPTION
`${CC}` is the predominantly used "compiler", but there are some hard-coded references to `gcc` which this removes.