### PR TITLE
Use a temporary variable to store the return of realloc in s2n_realloc

### DIFF
--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -38,10 +38,11 @@ int s2n_realloc(struct s2n_blob *b, uint32_t size)
         return 0;
     }
 
-    b->data = realloc(b->data, size);
-    if (b->data == NULL) {
+    uint8_t *data = realloc(b->data, size);
+    if (data == NULL) {
         S2N_ERROR(S2N_ERR_REALLOC);
     }
+    b->data = data;
     if (mlock(b->data, size) < 0) {
         GUARD(s2n_free(b));
         S2N_ERROR(S2N_ERR_MLOCK);


### PR DESCRIPTION
This leaves the initial blob untouched, the caller can decide what to do with it at this point.

closes awslabs#88