### PR TITLE
Build improvements

### DIFF
--- a/tests/testlib/Makefile
+++ b/tests/testlib/Makefile
@@ -21,7 +21,7 @@ all: libtests2n.so libtests2n.dylib
 include ../../s2n.mk
 
 CFLAGS += -I../../ -I../../api/ -I../../libcrypto-root/include/
-LDFLAGS += -L../../lib/ -lcrypto -lpthread -ls2n
+LDFLAGS += -L../../lib/ -L../../libcrypto-root/lib -lcrypto -lpthread -ls2n
 
 libtests2n.so: ${OBJS}
 	${CC} ${CFLAGS} -shared ${LDFLAGS} -o libtests2n.so ${OBJS}

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -33,7 +33,7 @@ endif
 # Suppress the unreachable code warning, because tests involve what should be
 # unreachable code
 CFLAGS += -Wno-unreachable-code -I../../libcrypto-root/include/ -I../../ -I../../api/
-LDFLAGS += -L../../lib/ -L../testlib/ -ltests2n -ls2n ${LIBS}
+LDFLAGS += -L../../lib/ -L../../libcrypto-root/lib -L../testlib/ -ltests2n -ls2n ${LIBS}
 
 $(TESTS)::
 	@${CC} ${CFLAGS} -o $@ $@.c ${LDFLAGS} 2>&1

--- a/tls/s2n_server_extensions.c
+++ b/tls/s2n_server_extensions.c
@@ -113,10 +113,6 @@ int s2n_server_recv_alpn(struct s2n_connection *conn, struct s2n_stuffer *extens
 
     uint8_t protocol_len;
     GUARD(s2n_stuffer_read_uint8(extension, &protocol_len));
-    if (protocol_len > sizeof(conn->application_protocol) - 1) {
-        /* ignore invalid extension size */
-        return 0;
-    }
 
     uint8_t *protocol = s2n_stuffer_raw_read(extension, protocol_len);
     notnull_check(protocol);


### PR DESCRIPTION
s2n_server_recv_alpn: Remove no-op size check
Bin and Tests: Explictly add libcrypto to linker path.