### PR TITLE
Update USAGE-GUIDE.md - replace broken link to current version of openssl

### DIFF
--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -80,11 +80,11 @@ To build s2n with OpenSSL-1.0.2, do the following:
 cd libcrypto-build
 
 # Download the latest version of OpenSSL
-curl https://www.openssl.org/source/openssl-1.0.2.tar.gz > openssl-1.0.2.tar.gz
-tar -xzvf openssl-1.0.2.tar.gz
+curl https://www.openssl.org/source/openssl-1.0.2c.tar.gz > openssl-1.0.2c.tar.gz
+tar -xzvf openssl-1.0.2c.tar.gz
 
 # Build openssl' libcrypto
-cd openssl-1.0.2
+cd openssl-1.0.2c
 ./config -fPIC no-shared no-libunbound no-gmp no-jpake no-krb5              \
          no-md2 no-rc5 no-rfc3779 no-sctp no-ssl-trace no-store no-zlib     \
          no-hw no-mdc2 no-seed no-idea enable-ec-nist_64_gcc_128 no-camellia\
@@ -92,7 +92,7 @@ cd openssl-1.0.2
          -DSSL_FORBID_ENULL -DOPENSSL_NO_DTLS1 -DOPENSSL_NO_HEARTBEATS      \
          --prefix=`pwd`/../../libcrypto-root/
 make depend
-make -j 32
+make
 make install
 
 # Make to the main s2n directory


### PR DESCRIPTION
Replaces broken link to current version of openssl (the link to openssl-1.0.2.tar.gz returns a 404).

Additionally removed the "-j 32". Sometimes this causes linking errors (it did for me and removing that seemed to clear it, apparently this is sporadic with openssl: http://stackoverflow.com/questions/28639207/why-cant-i-compile-openssl-with-multiple-threads-make-j3)