### PR TITLE
prettify Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,39 +17,45 @@ DIRS=$(wildcard */)
 SRCS=$(wildcard *.c)
 OBJS=$(SRCS:.c=.o)
 
+.PHONY : all
 all: bin
-	make -C tests
+	$(MAKE) -C tests
 
 include s2n.mk
 
+.PHONY : libs
 libs:
-	make -C utils
-	make -C error
-	make -C stuffer
-	make -C crypto
-	make -C tls
-	make -C lib
+	$(MAKE) -C utils
+	$(MAKE) -C error
+	$(MAKE) -C stuffer
+	$(MAKE) -C crypto
+	$(MAKE) -C tls
+	$(MAKE) -C lib
 
+.PHONY : bin
 bin: libs
-	make -C bin
+	$(MAKE) -C bin
 
+.PHONY : indent
 indent:
-	make -C tests indentsource
-	make -C stuffer indentsource
-	make -C crypto indentsource
-	make -C utils indentsource
-	make -C error indentsource
-	make -C tls indentsource
-	make -C bin indentsource
+	$(MAKE) -C tests indentsource
+	$(MAKE) -C stuffer indentsource
+	$(MAKE) -C crypto indentsource
+	$(MAKE) -C utils indentsource
+	$(MAKE) -C error indentsource
+	$(MAKE) -C tls indentsource
+	$(MAKE) -C bin indentsource
 
+.PHONY : pre_commit_check
 pre_commit_check: all indent clean
 
+.PHONY : clean
 clean:
-	make -C tests clean
-	make -C stuffer decruft
-	make -C crypto decruft
-	make -C utils decruft
-	make -C error decruft
-	make -C tls decruft
-	make -C bin decruft
-	make -C lib decruft
+	$(MAKE) -C tests clean
+	$(MAKE) -C stuffer decruft
+	$(MAKE) -C crypto decruft
+	$(MAKE) -C utils decruft
+	$(MAKE) -C error decruft
+	$(MAKE) -C tls decruft
+	$(MAKE) -C bin decruft
+	$(MAKE) -C lib decruft

--- a/bin/Makefile
+++ b/bin/Makefile
@@ -13,6 +13,7 @@
 # permissions and limitations under the License.
 #
 
+.PHONY : all
 all: s2nc s2nd
 include ../s2n.mk
 

--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -16,6 +16,7 @@
 SRCS=$(wildcard *.c)
 OBJS=$(SRCS:.c=.o)
 
+.PHONY : all
 all: $(OBJS)
 
 include ../s2n.mk

--- a/error/Makefile
+++ b/error/Makefile
@@ -16,6 +16,7 @@
 SRCS=$(wildcard *.c)
 OBJS=$(SRCS:.c=.o)
 
+.PHONY : all
 all: $(OBJS)
 
 include ../s2n.mk

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -20,6 +20,8 @@ else
 endif
 
 OBJS = $(wildcard ../utils/*.o ../stuffer/*.o ../tls/*.o ../iana/*.o ../crypto/*.o ../error/*.o ../libcrypto-root/lib/libcrypto.a)
+
+.PHONY : all
 all: libs2n.a libs2n.so libs2n.dylib
 
 include ../s2n.mk

--- a/s2n.mk
+++ b/s2n.mk
@@ -25,8 +25,10 @@ CFLAGS = -pedantic -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-subscripts
 
 INDENTOPTS = -npro -kr -i4 -ts4 -nut -sob -l180 -ss -ncs -cp1
 
+.PHONY : indentsource
 indentsource:
 	( for source in ${SOURCES} ; do ${INDENT} ${INDENTOPTS} $$source; done )
 
+.PHONY : decruft
 decruft:
-	rm -f ${CRUFT}
+	$(RM) -- ${CRUFT}

--- a/stuffer/Makefile
+++ b/stuffer/Makefile
@@ -16,6 +16,7 @@
 SRCS=$(wildcard *.c)
 OBJS=$(SRCS:.c=.o)
 
+.PHONY : all
 all: $(OBJS)
 
 include ../s2n.mk

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,12 +13,14 @@
 # permissions and limitations under the License.
 #
 
+.PHONY : all
 all:
 	make -C testlib
 	make -C unit
 
 include ../s2n.mk
 
+.PHONY : clean
 clean:
 	make -C testlib decruft
 	make -C unit decruft

--- a/tests/testlib/Makefile
+++ b/tests/testlib/Makefile
@@ -16,6 +16,7 @@
 SRCS=$(wildcard *.c)
 OBJS=$(SRCS:.c=.o)
 
+.PHONY : all
 all: libtests2n.so libtests2n.dylib
 
 include ../../s2n.mk

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -18,6 +18,7 @@ OBJS=$(SRCS:.c=.o)
 TESTS=$(SRCS:.c=)
 VALGRIND_TESTS=$(SRCS:.c=_valgrind)
 
+.PHONY : all
 all: $(TESTS)
 
 include ../../s2n.mk
@@ -39,5 +40,6 @@ $(TESTS)::
 	@${CC} ${CFLAGS} -o $@ $@.c ${LDFLAGS} 2>&1
 	@DYLD_LIBRARY_PATH="../../lib/:../testlib/:$$DYLD_LIBRARY_PATH" LD_LIBRARY_PATH="../../lib/:../testlib/:$$LD_LIBRARY_PATH" ./$@
 
+.PHONY : valgrind
 valgrind: $(TESTS)
 	(for test in *_test ; do DYLD_LIBRARY_PATH="../../lib/:../testlib/:$$DYLD_LIBRARY_PATH" LD_LIBRARY_PATH="../../lib/:../testlib/:$$LD_LIBRARY_PATH" valgrind --leak-check=full --run-libc-freeres=no -q --error-exitcode=0 --gen-suppressions=all --log-fd=2 --num-callers=40 --leak-resolution=high --log-file=$$test-valgrind.log --undef-value-errors=no --trace-children=yes ./$$test; done )

--- a/tls/Makefile
+++ b/tls/Makefile
@@ -16,6 +16,7 @@
 SRCS=$(wildcard *.c)
 OBJS=$(SRCS:.c=.o)
 
+.PHONY : all
 all: $(OBJS)
 
 include ../s2n.mk

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -16,6 +16,7 @@
 SRCS=$(wildcard *.c)
 OBJS=$(SRCS:.c=.o)
 
+.PHONY : all
 all: $(OBJS)
 
 include ../s2n.mk


### PR DESCRIPTION
Declare non-file targets as PHONY. Use $(MAKE) and $(RM) appropriately.