### PR TITLE
Avoid linking with system libcrypto

### DIFF
--- a/tests/testlib/Makefile
+++ b/tests/testlib/Makefile
@@ -21,7 +21,7 @@ all: libtests2n.so libtests2n.dylib
 include ../../s2n.mk
 
 CFLAGS += -I../../ -I../../api/ -I../../libcrypto-root/include/
-LDFLAGS += -L../../lib/ -lcrypto -lpthread -ls2n
+LDFLAGS += -L../../lib/ -L../../libcrypto-root/lib -lcrypto -lpthread -ls2n
 
 libtests2n.so: ${OBJS}
 	${CC} ${CFLAGS} -shared ${LDFLAGS} -o libtests2n.so ${OBJS}

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -27,7 +27,7 @@ CRUFT += $(wildcard *_test)
 ifeq ($(shell uname),Darwin)
     LIBS = -lpthread -lm
 else
-    LIBS = -lpthread -lm -ldl -lrt -lcrypto
+    LIBS = -lpthread -lm -ldl -lrt -L../../libcrypto-root/lib -lcrypto
 endif
 
 # Suppress the unreachable code warning, because tests involve what should be


### PR DESCRIPTION
Linking with system `libcrypto.*` takes out control on crypto library version. Which is potentially insecure. Library built in `libcrypto-build/` shold be used instead.

Verified on Linux with `-Wl,--verbose`.
Before:
```
cc -Wl,--verbose -pedantic -Wall -Wimplicit -Wunused -Wcomment -Wchar-subscripts -Wuninitialized -Wshadow -Wcast-qual -Wcast-align -Wwrite-strings -Wstack-protector -fPIC -std=c99 -D_POSIX_C_SOURCE=200112L -fstack-protector-all -O2 -I../libcrypto-root/include/ -I../api/ -I../ -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security -D_FORTIFY_SOURCE=2 -I../../ -I../../api/ -I../../libcrypto-root/include/ -shared -L../../lib/ -lcrypto -lpthread -ls2n -o       libtests2n.so s2n_print_connection.o s2n_stuffer_hex.o
...
attempt to open ../../lib//libcrypto.so failed
attempt to open ../../lib//libcrypto.a failed
attempt to open /usr/lib/gcc/x86_64-redhat-linux/4.1.2/libcrypto.so failed
attempt to open /usr/lib/gcc/x86_64-redhat-linux/4.1.2/libcrypto.a failed
attempt to open /usr/lib/gcc/x86_64-redhat-linux/4.1.2/libcrypto.so failed                                                                                                                                                                   
attempt to open /usr/lib/gcc/x86_64-redhat-linux/4.1.2/libcrypto.a failed                                                                                                                                                                    
attempt to open /usr/lib/gcc/x86_64-redhat-linux/4.1.2/../../../../lib64/libcrypto.so succeeded                                                                                                                                              
-lcrypto (/usr/lib/gcc/x86_64-redhat-linux/4.1.2/../../../../lib64/libcrypto.so)                                             
```
After:
```
cc -Wl,--verbose -pedantic -Wall -Wimplicit -Wunused -Wcomment -Wchar-subscripts -Wuninitialized -Wshadow -Wcast-qual -Wcast-align -Wwrite-strings -Wstack-protector -fPIC -std=c99 -D_POSIX_C_SOURCE=200112L -fstack-protector-all -O2 -I../libcrypto-root/include/ -I../api/ -I../ -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security -D_FORTIFY_SOURCE=2 -I../../ -I../../api/ -I../../libcrypto-root/include/ -shared -L../../lib/ -L../../libcrypto-root/lib -lcrypto -lpthread -ls2n -o libtests2n.so s2n_print_connection.o s2n_stuffer_hex.o
...
attempt to open ../../lib//libcrypto.so failed
attempt to open ../../lib//libcrypto.a failed
attempt to open ../../libcrypto-root/lib/libcrypto.so failed
attempt to open ../../libcrypto-root/lib/libcrypto.a succeeded
```