### PR TITLE
CentOS 7 Build

### DIFF
--- a/bin/Makefile
+++ b/bin/Makefile
@@ -19,7 +19,7 @@ include ../s2n.mk
 ifeq ($(shell uname),Darwin)
     LIBS = 
 else
-    LIBS = -ldl -lrt -lpthread
+    LIBS = -ldl -lrt -lpthread -lssl
 endif
 
 LDFLAGS += -L../lib/ -ls2n ${LIBS}

--- a/bin/Makefile
+++ b/bin/Makefile
@@ -22,7 +22,7 @@ else
     LIBS = -ldl -lrt -lpthread -lssl
 endif
 
-LDFLAGS += -L../lib/ -ls2n ${LIBS}
+LDFLAGS += -L../lib -ls2n ${LIBS}
 CRUFT += s2nc s2nd
 
 s2nc: s2nc.c echo.c


### PR DESCRIPTION
Fixed build of bin directory on CentOS 7 and removes unnecessary slash.