### PR TITLE
Guard against lazy s2n_negotiate caller

### DIFF
--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -13,6 +13,9 @@
  * permissions and limitations under the License.
  */
 
+#define _XOPEN_SOURCE 500       /* For usleep() */
+
+#include <unistd.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -349,6 +352,18 @@ int s2n_connection_get_delay(struct s2n_connection *conn)
     /* Delay between 1ms and 10 seconds in microseconds */
     int min = 1000, max = 10 * 1000 * 1000;
     return min + s2n_public_random(max - min);
+}
+
+int s2n_sleep_delay(struct s2n_connection *conn)
+{
+    if (conn->blinding == S2N_BUILT_IN_BLINDING) {
+        int delay;
+        GUARD(delay = s2n_connection_get_delay(conn));
+        GUARD(sleep(delay / 1000000));
+        GUARD(usleep(delay % 1000000));
+    }
+
+    return 0;
 }
 
 const uint8_t *s2n_connection_get_ocsp_response(struct s2n_connection *conn, uint32_t *length)

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -133,3 +133,6 @@ struct s2n_connection {
     s2n_status_request_type status_type;
     struct s2n_blob status_response;
 };
+
+/* Sleep s2n_connection_get_delay() ammount of time */
+int s2n_sleep_delay(struct s2n_connection *conn);

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -13,10 +13,6 @@
  * permissions and limitations under the License.
  */
 
-/* Use usleep */
-#define _XOPEN_SOURCE 500
-#include <unistd.h>
-
 #include <errno.h>
 #include <s2n.h>
 
@@ -309,12 +305,7 @@ static int handshake_read_io(struct s2n_connection *conn)
         GUARD(s2n_stuffer_wipe(&conn->handshake.io));
 
         if (r < 0) {
-            if (conn->blinding == S2N_BUILT_IN_BLINDING) {
-                int delay;
-                GUARD(delay = s2n_connection_get_delay(conn));
-                GUARD(sleep(delay / 1000000));
-                GUARD(usleep(delay % 1000000));
-            }
+            GUARD(s2n_sleep_delay(conn));
 
             return r;
         }

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -98,13 +98,7 @@ int s2n_read_full_record(struct s2n_connection *conn, uint8_t *record_type, int 
     if (s2n_record_parse(conn) < 0) {
         conn->closed = 1;
         GUARD(s2n_connection_wipe(conn));
-
-        if (conn->blinding == S2N_BUILT_IN_BLINDING) {
-            int delay;
-            GUARD(delay = s2n_connection_get_delay(conn)); 
-            GUARD(sleep(delay / 1000000));
-            GUARD(usleep(delay % 1000000));
-        }
+        GUARD(s2n_sleep_delay(conn));
 
         return -1;
     }


### PR DESCRIPTION
s2n wipes stuffers and adds a non-deterministic delay in the failure
cases, and this logic is contained inside s2n_recv/s2n_read_full_record.

If a caller uses s2n_negotiate() explicitly, but does not call
s2n_close() subsequent to a failed negotiation, we might skip this
logic. This is a bad call pattern, but we should guard against it.