### PR TITLE
More paranoia for pre-master secret handling

### DIFF
--- a/crypto/s2n_rsa.c
+++ b/crypto/s2n_rsa.c
@@ -188,6 +188,7 @@ int s2n_rsa_decrypt(struct s2n_rsa_private_key *key, struct s2n_blob *in, struct
     }
 
     int r = RSA_private_decrypt(in->size, (unsigned char *)in->data, intermediate, key->rsa, RSA_PKCS1_PADDING);
+    GUARD(s2n_constant_time_copy_or_dont(out->data, intermediate, out->size, r != out->size));
     if (r != out->size) {
         S2N_ERROR(S2N_ERR_SIZE_MISMATCH);
     }

--- a/tests/unit/s2n_safety_test.c
+++ b/tests/unit/s2n_safety_test.c
@@ -195,5 +195,23 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(success_inclusive_range());
     EXPECT_SUCCESS(success_exclusive_range());
 
+    uint8_t a[4] = { 1, 2, 3, 4 };
+    uint8_t b[4] = { 1, 2, 3, 4 };
+    uint8_t c[4] = { 5, 6, 7, 8 };
+    uint8_t d[4] = { 5, 6, 7, 8 };
+    uint8_t e[4] = { 1, 2, 3, 4 };
+
+    EXPECT_EQUAL(s2n_constant_time_equals(a, b, sizeof(a)), 1);
+    EXPECT_EQUAL(s2n_constant_time_equals(a, c, sizeof(a)), 0);
+
+    EXPECT_SUCCESS(s2n_constant_time_copy_or_dont(a, c, sizeof(a), 0));
+    EXPECT_EQUAL(s2n_constant_time_equals(a, c, sizeof(a)), 1);
+
+    for (int i = 1; i < 256; i++) {
+        EXPECT_SUCCESS(s2n_constant_time_copy_or_dont(b, d, sizeof(a), i));
+        EXPECT_EQUAL(s2n_constant_time_equals(b, d, sizeof(a)), 0);
+        EXPECT_EQUAL(s2n_constant_time_equals(b, e, sizeof(a)), 1);
+    }
+
     END_TEST();
 }

--- a/tls/s2n_client_finished.c
+++ b/tls/s2n_client_finished.c
@@ -32,7 +32,7 @@ int s2n_client_finished_recv(struct s2n_connection *conn)
     uint8_t *their_version = s2n_stuffer_raw_read(&conn->handshake.io, S2N_TLS_FINISHED_LEN);
     notnull_check(their_version);
 
-    if (!s2n_constant_time_equals(our_version, their_version, S2N_TLS_FINISHED_LEN)) {
+    if (!s2n_constant_time_equals(our_version, their_version, S2N_TLS_FINISHED_LEN) || conn->handshake.rsa_failed) {
         S2N_ERROR(S2N_ERR_BAD_MESSAGE);
     }
 

--- a/utils/s2n_safety.c
+++ b/utils/s2n_safety.c
@@ -46,3 +46,18 @@ int s2n_constant_time_equals(const uint8_t *a, const uint8_t *b, uint32_t len)
 
     return !xor;
 }
+
+int s2n_constant_time_copy_or_dont(uint8_t *a, const uint8_t *b, uint32_t len, uint8_t dont)
+{
+    uint8_t mask = ~(0xff << ((!!dont) * 8));
+
+    /* dont = 0 : mask = 0x00 */
+    /* dont > 0 : mask = 0xff */
+
+    for (int i = 0; i < len; i++) {
+        a[i] &= mask;
+        a[i] |= b[i] & ~mask;
+    }
+
+    return 0;
+}

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -53,3 +53,6 @@ extern pid_t s2n_actual_getpid();
 
 /* Returns 1 if a and b are equal, in constant time */
 extern int s2n_constant_time_equals(const uint8_t *a, const uint8_t *b, uint32_t len);
+
+/* Copy src to dst, or don't copy it, in constant time */
+extern int s2n_constant_time_copy_or_dont(const uint8_t *dst, const uint8_t *src, uint32_t len, uint8_t dont);


### PR DESCRIPTION
* Add a new safety routine: constant_time_copy_or_dont(). We now use
  this instead of memcpy() for copying the pre-master secret. The
  routine copies a src array to a dst array, or doesn't, either way
  using a constant number of operations and we didn't rely on memcpy(). 

* Move the generation of a random pre-master secret out of a branch;
  always do it and then throw away if neccessary.

* Add an rsa_failed check to the client finished processing. NOTE: This
  is redundant, the handshake fails at this point anyway due to using
  a random PMS, but it's a good precaution against any errors
  introduced in future changes and we'll soon be adding ECDSA around
  here.