### PR TITLE
Handle EINTR consistently

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -61,7 +61,7 @@ extern int s2n_connection_set_write_fd(struct s2n_connection *conn, int readfd);
 
 typedef enum { S2N_BUILT_IN_BLINDING, S2N_SELF_SERVICE_BLINDING } s2n_blinding;
 extern int s2n_connection_set_blinding(struct s2n_connection *conn, s2n_blinding blinding);
-extern int s2n_connection_get_delay(struct s2n_connection *conn);
+extern int64_t s2n_connection_get_delay(struct s2n_connection *conn);
 
 extern int s2n_set_server_name(struct s2n_connection *conn, const char *server_name);
 extern const char *s2n_get_server_name(struct s2n_connection *conn);

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -181,7 +181,7 @@ Setting the **S2N_SELF_SERVICE_BLINDING** option with **s2n_connection_set_blind
 turns off this behavior. This is useful for applications that are handling many connections
 in a single thread. In that case, if s2n_recv() or s2n_negotiate() return an error, 
 self-service applications should call **s2n_connection_get_delay** and pause 
-activity on the connection  for the specified number of microseconds before calling
+activity on the connection  for the specified number of nanoseconds before calling
 close() or shutdown().
 
 ```c
@@ -431,10 +431,10 @@ built-in blinding (set blinding to S2N_BUILT_IN_BLINDING) or self-service blindi
 ### s2n\_connection\_get\_delay
 
 ```c
-int s2n_connection_get_delay(struct s2n_connection *conn);
+int64_t s2n_connection_get_delay(struct s2n_connection *conn);
 ```
 
-**s2n_connection_get_delay** returns the number of microseconds an application
+**s2n_connection_get_delay** returns the number of nanoseconds an application
 using self-service blinding should pause before calling close() or shutdown().
 
 ### s2n\_connection\_get\_wire\_bytes

--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -96,12 +96,12 @@ extern int s2n_stuffer_read_base64(struct s2n_stuffer *stuffer, struct s2n_stuff
 extern int s2n_stuffer_write_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *in);
 
 /* Useful for text manipulation ... */
-#define s2n_stuffer_init_text( stuffer, text, len, err )  s2n_stuffer_init( (stuffer), (uint8_t *) (text), (len), (err) )
-#define s2n_stuffer_write_char( stuffer, c, err )  s2n_stuffer_write_uint8( (stuffer), (uint8_t) (c), (err) )
-#define s2n_stuffer_read_char( stuffer, c, err )  s2n_stuffer_read_uint8( (stuffer), (uint8_t *) (c), (err) )
-#define s2n_stuffer_write_str( stuffer, c, n, err )  s2n_stuffer_write( (stuffer), (const uint8_t *) (c), strlen((c)), (err) )
-#define s2n_stuffer_write_text( stuffer, c, n, err )  s2n_stuffer_write( (stuffer), (const uint8_t *) (c), (n), (err) )
-#define s2n_stuffer_read_text( stuffer, c, n, err )  s2n_stuffer_read( (stuffer), (uint8_t *) (c), (n), (err) )
+#define s2n_stuffer_init_text( stuffer, text, len )  s2n_stuffer_init( (stuffer), (uint8_t *) (text), (len) )
+#define s2n_stuffer_write_char( stuffer, c )  s2n_stuffer_write_uint8( (stuffer), (uint8_t) (c) )
+#define s2n_stuffer_read_char( stuffer, c )  s2n_stuffer_read_uint8( (stuffer), (uint8_t *) (c) )
+#define s2n_stuffer_write_str( stuffer, c, n )  s2n_stuffer_write( (stuffer), (const uint8_t *) (c), strlen((c)) )
+#define s2n_stuffer_write_text( stuffer, c, n )  s2n_stuffer_write( (stuffer), (const uint8_t *) (c), (n) )
+#define s2n_stuffer_read_text( stuffer, c, n )  s2n_stuffer_read( (stuffer), (uint8_t *) (c), (n) )
 extern int s2n_stuffer_peek_char(struct s2n_stuffer *stuffer, char *c);
 extern int s2n_stuffer_read_token(struct s2n_stuffer *stuffer, struct s2n_stuffer *token, char delim);
 extern int s2n_stuffer_skip_whitespace(struct s2n_stuffer *stuffer);

--- a/stuffer/s2n_stuffer_file.c
+++ b/stuffer/s2n_stuffer_file.c
@@ -97,8 +97,12 @@ int s2n_stuffer_alloc_ro_from_file(struct s2n_stuffer *stuffer, const char *file
 {
     int fd;
 
+    OPEN:
     fd = open(file, O_RDONLY);
     if (fd < 0) {
+        if (errno == EINTR) {
+            goto OPEN;
+        }
         S2N_ERROR(S2N_ERR_OPEN);
     }
 

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -17,6 +17,7 @@
 
 #include <stdint.h>
 #include <signal.h>
+#include <errno.h>
 #include <s2n.h>
 
 #include "tls/s2n_tls_parameters.h"

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -113,9 +113,9 @@ int s2n_get_urandom_data(struct s2n_blob *blob)
     return 0;
 }
 
-int s2n_public_random(int max)
+int64_t s2n_public_random(int64_t max)
 {
-    unsigned int r;
+    uint64_t r;
 
     gt_check(max, 0);
 
@@ -136,7 +136,7 @@ int s2n_public_random(int max)
          * But since 'max' is an int and INT_MAX is <= UINT_MAX / 2,
          * in the worst case we discard 25% - 1 r's.
          */
-        if (r < (UINT_MAX - (UINT_MAX % max))) {
+        if (r < (UINT64_MAX - (UINT64_MAX % max))) {
             return r % max;
         }
     }

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -178,8 +178,12 @@ RAND_METHOD s2n_openssl_rand_method = {
 
 int s2n_init(void)
 {
+    OPEN:
     entropy_fd = open(ENTROPY_SOURCE, O_RDONLY);
     if (entropy_fd == -1) {
+        if (errno == EINTR) {
+            goto OPEN;
+        }
         S2N_ERROR(S2N_ERR_OPEN_RANDOM);
     }
 

--- a/utils/s2n_random.h
+++ b/utils/s2n_random.h
@@ -23,4 +23,4 @@
 extern int s2n_get_public_random_data(struct s2n_blob *blob);
 extern int s2n_get_private_random_data(struct s2n_blob *blob);
 extern int s2n_get_urandom_data(struct s2n_blob *blob);
-extern int s2n_public_random(int max);
+extern int64_t s2n_public_random(int64_t max);


### PR DESCRIPTION
This change adds additional EINTR handling in the stuffer file implementation, opening /dev/urandom, our sleep delay, and in the sample sender/receiver code.
    
closes https://github.com/awslabs/s2n/issues/89