### PR TITLE
stuffer/s2n_stuffer.c: fix signed overflow

### DIFF
--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -323,7 +323,7 @@ int s2n_stuffer_read_uint32(struct s2n_stuffer *stuffer, uint32_t *u)
 
     GUARD(s2n_stuffer_read(stuffer, &b));
 
-    *u = data[0] << 24;
+    *u = ((uint32_t) data[0]) << 24;
     *u |= data[1] << 16;
     *u |= data[2] << 8;
     *u |= data[3];


### PR DESCRIPTION
One unfortunate feature of C's integer promotions is that when u is an unsigned char, u << 24 is computed as a signed int, and can still be a signed overflow (and thus undefined behavior).

The OpenSSL project has fixed their instance of this bug here, for instance: https://github.com/openssl/openssl/commit/8b37e5c14f0eddb10c7f91ef91004622d90ef361