### PR TITLE
Fix travis build error.  openssl was updated today and the new openss…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 before_script:
   - cd libcrypto-build
   - curl https://www.openssl.org/source/openssl-1.0.2-latest.tar.gz > openssl-1.0.2.tar.gz
-  - tar -xzvf openssl-1.0.2.tar.gz
+  - tar -ixzvf openssl-1.0.2.tar.gz
   - rm openssl-1.0.2.tar.gz
   - cd openssl-1.0.2*
   - (test "$TRAVIS_OS_NAME" = "linux" && ./config -fPIC no-shared no-libunbound no-gmp no-jpake no-krb5 no-md2 no-rc5 no-rfc3779 no-sctp no-ssl-trace no-store no-zlib no-hw no-mdc2 no-seed no-idea enable-ec-nist_64_gcc_128 no-camellia no-bf no-ripemd no-dsa no-ssl2 no-ssl3 no-capieng -DSSL_FORBID_ENULL -DOPENSSL_NO_DTLS1 -DOPENSSL_NO_HEARTBEATS --prefix=`pwd`/../../libcrypto-root/) || true

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -80,10 +80,10 @@ cd libcrypto-build
 
 # Download the latest version of OpenSSL
 curl -O https://www.openssl.org/source/openssl-1.0.2-latest.tar.gz
-tar -xzvf openssl-1.0.2-latest.tar.gz
+tar -ixzvf openssl-1.0.2-latest.tar.gz
 
 # Build openssl' libcrypto  (NOTE: check directory name 1.0.2-latest unpacked as)
-cd openssl-1.0.2c
+cd openssl-1.0.2d
 ./config -fPIC no-shared no-libunbound no-gmp no-jpake no-krb5              \
          no-md2 no-rc5 no-rfc3779 no-sctp no-ssl-trace no-store no-zlib     \
          no-hw no-mdc2 no-seed no-idea enable-ec-nist_64_gcc_128 no-camellia\


### PR DESCRIPTION
…l tar apparently requires "-i" to successfully untar.

This seems odd to me, but apparently it's happened before:
https://groups.google.com/d/msg/mailing.openssl.users/GCitvgKku6U/HjcbjF50u5oJ

I've mailed the person who signed to openssl tar file, but since he's the same as responded in that thread, this is perhaps normal?