### PR TITLE
Make curl follow redirects when fetching openssl-latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
 
 before_script:
   - cd libcrypto-build
-  - curl https://www.openssl.org/source/openssl-1.0.2-latest.tar.gz > openssl-1.0.2.tar.gz
+  - curl -L https://www.openssl.org/source/openssl-1.0.2-latest.tar.gz > openssl-1.0.2.tar.gz
   - tar -xzvf openssl-1.0.2.tar.gz
   - rm openssl-1.0.2.tar.gz
   - cd openssl-1.0.2*

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -79,7 +79,7 @@ To build s2n with OpenSSL-1.0.2, do the following:
 cd libcrypto-build
 
 # Download the latest version of OpenSSL
-curl -O https://www.openssl.org/source/openssl-1.0.2-latest.tar.gz
+curl -LO https://www.openssl.org/source/openssl-1.0.2-latest.tar.gz
 tar -xzvf openssl-1.0.2-latest.tar.gz
 
 # Build openssl' libcrypto  (NOTE: check directory name 1.0.2-latest unpacked as)


### PR DESCRIPTION
The url for downloading openssl works in a browser, as the browser will follow the redirect.  However, curl dumps out a 302 body to disk.  adding -L will instruct curl to follow the redirect and re-request the object.
