### PR TITLE
Save memory and tighten up CBC processing

### DIFF
--- a/crypto/s2n_hmac.h
+++ b/crypto/s2n_hmac.h
@@ -26,6 +26,8 @@ typedef enum { S2N_HMAC_NONE, S2N_HMAC_MD5, S2N_HMAC_SHA1, S2N_HMAC_SHA224, S2N_
 struct s2n_hmac_state {
     s2n_hmac_algorithm alg;
 
+    uint16_t hash_block_size;
+    uint32_t currently_in_hash_block;
     uint16_t block_size;
     uint8_t digest_size;
 
@@ -45,6 +47,7 @@ extern int s2n_hmac_digest_size(s2n_hmac_algorithm alg);
 extern int s2n_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm alg, const void *key, uint32_t klen);
 extern int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size);
 extern int s2n_hmac_digest(struct s2n_hmac_state *state, void *out, uint32_t size);
+extern int s2n_hmac_digest_two_compression_rounds(struct s2n_hmac_state *state, void *out, uint32_t size);
 extern int s2n_hmac_digest_verify(const void *a, uint32_t alen, const void *b, uint32_t blen);
 extern int s2n_hmac_reset(struct s2n_hmac_state *state);
 extern int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from);

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -220,6 +220,8 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     GUARD(s2n_hash_init(&conn->handshake.server_md5, S2N_HASH_MD5));
     GUARD(s2n_hash_init(&conn->handshake.server_sha1, S2N_HASH_SHA1));
     GUARD(s2n_hash_init(&conn->handshake.server_sha256, S2N_HASH_SHA256));
+    GUARD(s2n_hmac_init(&conn->client->client_record_mac, S2N_HMAC_NONE, NULL, 0));
+    GUARD(s2n_hmac_init(&conn->server->server_record_mac, S2N_HMAC_NONE, NULL, 0));
 
     memcpy_check(&conn->alert_in, &alert_in, sizeof(struct s2n_stuffer));
     memcpy_check(&conn->reader_alert_out, &reader_alert_out, sizeof(struct s2n_stuffer));

--- a/tls/s2n_record.h
+++ b/tls/s2n_record.h
@@ -24,6 +24,5 @@ extern int s2n_record_write(struct s2n_connection *conn, uint8_t content_type, s
 extern int s2n_record_parse(struct s2n_connection *conn);
 extern int s2n_record_header_parse(struct s2n_connection *conn, uint8_t *content_type, uint16_t *fragment_length);
 extern int s2n_sslv2_record_header_parse(struct s2n_connection *conn, uint8_t *record_type, uint8_t *client_protocol_version, uint16_t *fragment_length);
-extern int s2n_cbc_masks_init();
 extern int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, struct s2n_blob *decrypted);
 extern int s2n_aead_aad_init(const struct s2n_connection *conn, uint8_t *sequence_number, uint8_t content_type, uint16_t record_length, struct s2n_stuffer *ad);

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -31,8 +31,6 @@
 
 #include "error/s2n_errno.h"
 
-#include "tls/s2n_record.h"
-
 #include "utils/s2n_safety.h"
 #include "utils/s2n_random.h"
 
@@ -196,9 +194,6 @@ int s2n_init(void)
         }
         S2N_ERROR(S2N_ERR_OPEN_RANDOM);
     }
-
-    /* Create the CBC masks */
-    GUARD(s2n_cbc_masks_init());
 
 #if defined(MAP_INHERIT_ZERO)
     if ((zero_if_forked_ptr = mmap(NULL, sizeof(int), PROT_READ|PROT_WRITE,


### PR DESCRIPTION
This commit makes two changes:

    * Convert our CBC padding checking to using a bit-fiddling
      generated mask, instead of pre-generated masks. Previously
      we generated 256 masks of 255 bytes each at init time
      and used those masks to validate CBC padding. This works,
      but ends up costing 32k of memory. In this commit we convert
      to using a bit-fiddling mask similar to how do we constant
      time copies.

    * Add and use s2n_hmac_digest_two_compression_rounds() .
      Since we launched, several bug reporters (including
      Martin R. Albrecht and Kenny Paterson from Royal Holloway,
      University of London) got in touch to point out that
      s2n_hmac_digest() does not run in constant time and varies
      depending in the length of the padding.

      If the length of the data section covered by the mac
      leaves fewer than 8 bytes spare in the hash block used
      by HMAC, then the underlying hash function will add and
      compress an additional hash block when _digest() is called.

      This doesn't result in leaking a measureable timing side-channel
      because of the additional timing blinding in s2n_recv.c (s2n
      adds between 1ms and 10 seconds of delay in the event of an error,
      which raises the number of trials required to measure any signal
      by at least a factor of 83 trillion, and more likely renders it
      completely unmeasureable). But it's still worth tightening up
      here.

      Previously we'd been thinking that doing anything here would
      involve "opening up" the hash function in ways that prevent
      us from using hardware hash acceleration, but Martin R. Albrecht
      and Kenny Paterson had a good idea: count and use compression
      rounds explicitly, which is what this change goes with.