### PR TITLE
Initialize the test personalization string

### DIFF
--- a/crypto/s2n_drbg.c
+++ b/crypto/s2n_drbg.c
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+#include <sys/param.h>
+
 #include <openssl/evp.h>
 
 #include "crypto/s2n_sequence.h"
@@ -124,9 +126,7 @@ int s2n_drbg_instantiate(struct s2n_drbg *drbg, struct s2n_blob *personalization
     /* Copy the personalization string */
     GUARD(s2n_blob_zero(&ps));
 
-    for (int i = 0; i < personalization_string->size && i < ps.size; i++) {
-        ps.data[i] = personalization_string->data[i];
-    }
+    memcpy_check(ps.data, personalization_string->data, MIN(ps.size, personalization_string->size));
 
     /* Seed / update the DRBG */
     GUARD(s2n_drbg_seed(drbg));

--- a/tests/unit/s2n_drbg_test.c
+++ b/tests/unit/s2n_drbg_test.c
@@ -122,7 +122,7 @@ int nist_fake_urandom_data(struct s2n_blob *blob)
 
 int main(int argc, char **argv)
 {
-    uint8_t data[256];
+    uint8_t data[256] = { 0 };
     struct s2n_drbg drbg = {{ 0 }};
     struct s2n_blob blob = {.data = data, .size = 16 };
     struct s2n_timer timer;


### PR DESCRIPTION
1. correctly zero initializes the personalization string
used in our DRBG test case.

2. Use memcpy to copy the personalization string.

Closes #146