### PR TITLE
Adding 'const' to various write routines within stuffer

### DIFF
--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -39,7 +39,7 @@ int s2n_stuffer_init(struct s2n_stuffer *stuffer, struct s2n_blob *in)
     return 0;
 }
 
-int s2n_stuffer_alloc(struct s2n_stuffer *stuffer, uint32_t size)
+int s2n_stuffer_alloc(struct s2n_stuffer *stuffer, const uint32_t size)
 {
 
     GUARD(s2n_alloc(&stuffer->blob, size));
@@ -50,7 +50,7 @@ int s2n_stuffer_alloc(struct s2n_stuffer *stuffer, uint32_t size)
     return 0;
 }
 
-int s2n_stuffer_growable_alloc(struct s2n_stuffer *stuffer, uint32_t size)
+int s2n_stuffer_growable_alloc(struct s2n_stuffer *stuffer, const uint32_t size)
 {
     GUARD(s2n_stuffer_alloc(stuffer, size));
 
@@ -76,7 +76,7 @@ int s2n_stuffer_free(struct s2n_stuffer *stuffer)
     return 0;
 }
 
-int s2n_stuffer_resize(struct s2n_stuffer *stuffer, uint32_t size)
+int s2n_stuffer_resize(struct s2n_stuffer *stuffer, const uint32_t size)
 {
     if (stuffer->growable == 0) {
         S2N_ERROR(S2N_ERR_RESIZE_STATIC_STUFFER);
@@ -113,8 +113,9 @@ int s2n_stuffer_reread(struct s2n_stuffer *stuffer)
     return 0;
 }
 
-int s2n_stuffer_wipe_n(struct s2n_stuffer *stuffer, uint32_t n)
+int s2n_stuffer_wipe_n(struct s2n_stuffer *stuffer, const uint32_t size)
 {
+    uint32_t n = size;
     if (stuffer->write_cursor < n) {
         n = stuffer->write_cursor;
     }
@@ -194,7 +195,7 @@ int s2n_stuffer_read_bytes(struct s2n_stuffer *stuffer, uint8_t *data, uint32_t 
     return 0;
 }
 
-int s2n_stuffer_skip_write(struct s2n_stuffer *stuffer, uint32_t n)
+int s2n_stuffer_skip_write(struct s2n_stuffer *stuffer, const uint32_t n)
 {
     if (s2n_stuffer_space_remaining(stuffer) < n) {
         if (stuffer->growable) {
@@ -214,7 +215,7 @@ int s2n_stuffer_skip_write(struct s2n_stuffer *stuffer, uint32_t n)
     return 0;
 }
 
-void *s2n_stuffer_raw_write(struct s2n_stuffer *stuffer, uint32_t data_len)
+void *s2n_stuffer_raw_write(struct s2n_stuffer *stuffer, const uint32_t data_len)
 {
     GUARD_PTR(s2n_stuffer_skip_write(stuffer, data_len));
 
@@ -223,12 +224,12 @@ void *s2n_stuffer_raw_write(struct s2n_stuffer *stuffer, uint32_t data_len)
     return stuffer->blob.data + stuffer->write_cursor - data_len;
 }
 
-int s2n_stuffer_write(struct s2n_stuffer *stuffer, struct s2n_blob *in)
+int s2n_stuffer_write(struct s2n_stuffer *stuffer, const struct s2n_blob *in)
 {
     return s2n_stuffer_write_bytes(stuffer, in->data, in->size);
 }
 
-int s2n_stuffer_write_bytes(struct s2n_stuffer *stuffer, uint8_t *data, uint32_t size)
+int s2n_stuffer_write_bytes(struct s2n_stuffer *stuffer, const uint8_t *data, const uint32_t size)
 {
     GUARD(s2n_stuffer_skip_write(stuffer, size));
 
@@ -253,7 +254,7 @@ int s2n_stuffer_read_uint8(struct s2n_stuffer *stuffer, uint8_t *u)
     return 0;
 }
 
-int s2n_stuffer_write_uint8(struct s2n_stuffer *stuffer, uint8_t u)
+int s2n_stuffer_write_uint8(struct s2n_stuffer *stuffer, const uint8_t u)
 {
     GUARD(s2n_stuffer_write_bytes(stuffer, &u, 1));
 
@@ -272,7 +273,7 @@ int s2n_stuffer_read_uint16(struct s2n_stuffer *stuffer, uint16_t *u)
     return 0;
 }
 
-int s2n_stuffer_write_uint16(struct s2n_stuffer *stuffer, uint16_t u)
+int s2n_stuffer_write_uint16(struct s2n_stuffer *stuffer, const uint16_t u)
 {
     uint8_t data[2] = { u >> 8, u & 0xff };
 
@@ -294,7 +295,7 @@ int s2n_stuffer_read_uint24(struct s2n_stuffer *stuffer, uint32_t *u)
     return 0;
 }
 
-int s2n_stuffer_write_uint24(struct s2n_stuffer *stuffer, uint32_t u)
+int s2n_stuffer_write_uint24(struct s2n_stuffer *stuffer, const uint32_t u)
 {
     uint8_t data[3] = { u >> 16, u >> 8, u & 0xff };
 
@@ -317,7 +318,7 @@ int s2n_stuffer_read_uint32(struct s2n_stuffer *stuffer, uint32_t *u)
     return 0;
 }
 
-int s2n_stuffer_write_uint32(struct s2n_stuffer *stuffer, uint32_t u)
+int s2n_stuffer_write_uint32(struct s2n_stuffer *stuffer, const uint32_t u)
 {
     uint8_t data[4] = { u >> 24, u >> 16, u >> 8, u & 0xff };
 
@@ -326,7 +327,7 @@ int s2n_stuffer_write_uint32(struct s2n_stuffer *stuffer, uint32_t u)
     return 0;
 }
 
-int s2n_stuffer_copy(struct s2n_stuffer *from, struct s2n_stuffer *to, uint32_t len)
+int s2n_stuffer_copy(struct s2n_stuffer *from, struct s2n_stuffer *to, const uint32_t len)
 {
     GUARD(s2n_stuffer_skip_read(from, len));
 

--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -47,28 +47,28 @@ struct s2n_stuffer {
 
 /* Initialize and destroying stuffers */
 extern int s2n_stuffer_init(struct s2n_stuffer *stuffer, struct s2n_blob *in);
-extern int s2n_stuffer_alloc(struct s2n_stuffer *stuffer, uint32_t size);
-extern int s2n_stuffer_growable_alloc(struct s2n_stuffer *stuffer, uint32_t size);
+extern int s2n_stuffer_alloc(struct s2n_stuffer *stuffer, const uint32_t size);
+extern int s2n_stuffer_growable_alloc(struct s2n_stuffer *stuffer, const uint32_t size);
 extern int s2n_stuffer_free(struct s2n_stuffer *stuffer);
-extern int s2n_stuffer_resize(struct s2n_stuffer *stuffer, uint32_t size);
+extern int s2n_stuffer_resize(struct s2n_stuffer *stuffer, const uint32_t size);
 extern int s2n_stuffer_reread(struct s2n_stuffer *stuffer);
 extern int s2n_stuffer_rewrite(struct s2n_stuffer *stuffer);
 extern int s2n_stuffer_wipe(struct s2n_stuffer *stuffer);
-extern int s2n_stuffer_wipe_n(struct s2n_stuffer *stuffer, uint32_t n);
+extern int s2n_stuffer_wipe_n(struct s2n_stuffer *stuffer, const uint32_t n);
 
 /* Basic read and write */
 extern int s2n_stuffer_read(struct s2n_stuffer *stuffer, struct s2n_blob *out);
 extern int s2n_stuffer_erase_and_read(struct s2n_stuffer *stuffer, struct s2n_blob *out);
-extern int s2n_stuffer_write(struct s2n_stuffer *stuffer, struct s2n_blob *in);
+extern int s2n_stuffer_write(struct s2n_stuffer *stuffer, const struct s2n_blob *in);
 extern int s2n_stuffer_read_bytes(struct s2n_stuffer *stuffer, uint8_t *out, uint32_t n);
-extern int s2n_stuffer_write_bytes(struct s2n_stuffer *stuffer, uint8_t *in, uint32_t n);
+extern int s2n_stuffer_write_bytes(struct s2n_stuffer *stuffer, const uint8_t *in, const uint32_t n);
 extern int s2n_stuffer_skip_read(struct s2n_stuffer *stuffer, uint32_t n);
-extern int s2n_stuffer_skip_write(struct s2n_stuffer *stuffer, uint32_t n);
+extern int s2n_stuffer_skip_write(struct s2n_stuffer *stuffer, const uint32_t n);
 
 /* Raw read/write move the cursor along and give you a pointer you can
  * read/write data_len bytes from/to in-place.
  */
-extern void *s2n_stuffer_raw_write(struct s2n_stuffer *stuffer, uint32_t data_len);
+extern void *s2n_stuffer_raw_write(struct s2n_stuffer *stuffer, const uint32_t data_len);
 extern void *s2n_stuffer_raw_read(struct s2n_stuffer *stuffer, uint32_t data_len);
 
 /* Send/receive stuffer to/from a file descriptor */
@@ -82,11 +82,11 @@ extern int s2n_stuffer_read_uint24(struct s2n_stuffer *stuffer, uint32_t *u);
 extern int s2n_stuffer_read_uint32(struct s2n_stuffer *stuffer, uint32_t *u);
 extern int s2n_stuffer_read_uint64(struct s2n_stuffer *stuffer, uint64_t *u);
 
-extern int s2n_stuffer_write_uint8(struct s2n_stuffer *stuffer, uint8_t u);
-extern int s2n_stuffer_write_uint16(struct s2n_stuffer *stuffer, uint16_t u);
-extern int s2n_stuffer_write_uint24(struct s2n_stuffer *stuffer, uint32_t u);
-extern int s2n_stuffer_write_uint32(struct s2n_stuffer *stuffer, uint32_t u);
-extern int s2n_stuffer_write_uint64(struct s2n_stuffer *stuffer, uint64_t u);
+extern int s2n_stuffer_write_uint8(struct s2n_stuffer *stuffer, const uint8_t u);
+extern int s2n_stuffer_write_uint16(struct s2n_stuffer *stuffer, const uint16_t u);
+extern int s2n_stuffer_write_uint24(struct s2n_stuffer *stuffer, const uint32_t u);
+extern int s2n_stuffer_write_uint32(struct s2n_stuffer *stuffer, const uint32_t u);
+extern int s2n_stuffer_write_uint64(struct s2n_stuffer *stuffer, const uint64_t u);
 
 /* Copy one stuffer to another */
 extern int s2n_stuffer_copy(struct s2n_stuffer *from, struct s2n_stuffer *to, uint32_t len);
@@ -104,7 +104,7 @@ extern int s2n_stuffer_write_base64(struct s2n_stuffer *stuffer, struct s2n_stuf
 extern int s2n_stuffer_peek_char(struct s2n_stuffer *stuffer, char *c);
 extern int s2n_stuffer_read_token(struct s2n_stuffer *stuffer, struct s2n_stuffer *token, char delim);
 extern int s2n_stuffer_skip_whitespace(struct s2n_stuffer *stuffer);
-extern int s2n_stuffer_alloc_ro_from_string(struct s2n_stuffer *stuffer, char *str);
+extern int s2n_stuffer_alloc_ro_from_string(struct s2n_stuffer *stuffer, const char *str);
 
 /* Read an RSA private key from a PEM encoded stuffer to an ASN1/DER encoded one */
 extern int s2n_stuffer_rsa_private_key_from_pem(struct s2n_stuffer *pem, struct s2n_stuffer *asn1);

--- a/stuffer/s2n_stuffer_text.c
+++ b/stuffer/s2n_stuffer_text.c
@@ -71,12 +71,10 @@ int s2n_stuffer_read_token(struct s2n_stuffer *stuffer, struct s2n_stuffer *toke
     return 0;
 }
 
-int s2n_stuffer_alloc_ro_from_string(struct s2n_stuffer *stuffer, char *str)
+int s2n_stuffer_alloc_ro_from_string(struct s2n_stuffer *stuffer, const char *str)
 {
     uint32_t length = strlen(str);
-    struct s2n_blob b = {.data = (uint8_t *) str,.size = length };
 
     GUARD(s2n_stuffer_alloc(stuffer, length + 1));
-
-    return s2n_stuffer_write(stuffer, &b);
+    return s2n_stuffer_write_bytes(stuffer, (const uint8_t *)str, length);
 }


### PR DESCRIPTION
Adding 'const' to the API makes the data contract more explicit, and gives the compiler some more information with which to optimize if it can.

This kind of change should be applied to all places across the entirety of the API, but starting with the stuffer is useful due to its central role, and relatively small size.