### PR TITLE
Use total ordering function between u64s in s2n_cbc_verify_test

### DIFF
--- a/tests/unit/s2n_cbc_verify_test.c
+++ b/tests/unit/s2n_cbc_verify_test.c
@@ -37,7 +37,9 @@
 /* qsort() u64s numerically */
 static int u64cmp (const void * left, const void * right)
 {
-   return *(const uint64_t *)left - *(const uint64_t *)right;
+   if (*(const uint64_t *)left > *(const uint64_t *)right) return 1;
+   if (*(const uint64_t *)left < *(const uint64_t *)right) return -1;
+   return 0;
 }
 
 /* Generate summary statistics from a list of u64s */


### PR DESCRIPTION
The function `u64cmp` only works as a total order if no two elements to compare are separated by more than 2^31. This works for the timings being compared here, but if the scope of the function was expanded to u64s from a different source, `qsort` might then see a function that isn't a total order, resulting in undefined behavior.