### PR TITLE
Avoid calling memset with 0 length arguments

### DIFF
--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -149,7 +149,7 @@ int s2n_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm alg, const vo
 
         memcpy_check(state->xor_pad, state->digest_pad, state->digest_size);
         copied = state->digest_size;
-    } else if (klen) {
+    } else {
         memcpy_check(state->xor_pad, key, klen);
     }
 

--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -149,7 +149,7 @@ int s2n_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm alg, const vo
 
         memcpy_check(state->xor_pad, state->digest_pad, state->digest_size);
         copied = state->digest_size;
-    } else {
+    } else if (klen) {
         memcpy_check(state->xor_pad, key, klen);
     }
 

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -121,8 +121,10 @@ int s2n_stuffer_wipe_n(struct s2n_stuffer *stuffer, const uint32_t size)
     }
 
     /* Use '0' instead of 0 precisely to prevent C string compatibility */
-    memset(stuffer->blob.data + stuffer->write_cursor - n, '0', n);
-    stuffer->write_cursor -= n;
+    if (n) {
+        memset(stuffer->blob.data + stuffer->write_cursor - n, '0', n);
+        stuffer->write_cursor -= n;
+    }
 
     if (stuffer->write_cursor == 0) {
         stuffer->wiped = 1;

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -121,10 +121,8 @@ int s2n_stuffer_wipe_n(struct s2n_stuffer *stuffer, const uint32_t size)
     }
 
     /* Use '0' instead of 0 precisely to prevent C string compatibility */
-    if (n) {
-        memset(stuffer->blob.data + stuffer->write_cursor - n, '0', n);
-        stuffer->write_cursor -= n;
-    }
+    memset_check(stuffer->blob.data + stuffer->write_cursor - n, '0', n);
+    stuffer->write_cursor -= n;
 
     if (stuffer->write_cursor == 0) {
         stuffer->wiped = 1;

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -27,8 +27,8 @@
 /* Check memcpy's return, if it's not right (very unlikely!) bail, set an error
  * err and return -1;
  */
-#define memcpy_check( d, s, n )     do { notnull_check( (d) ); memcpy( (d), (s), (n)); } while(0)
-#define memset_check( d, c, n )     do { notnull_check( (d) ); memset( (d), (c), (n)); } while(0)
+#define memcpy_check( d, s, n )     do { notnull_check( (d) ); if ( (n) && (s) ) { memcpy( (d), (s), (n)); } } while(0)
+#define memset_check( d, c, n )     do { notnull_check( (d) ); if ( (n) && (s) ) { memset( (d), (c), (n)); } } while(0)
 
 /* Range check a number */
 #define gte_check(n, min)  do { if ( (n) < min ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -28,7 +28,7 @@
  * err and return -1;
  */
 #define memcpy_check( d, s, n )     do { notnull_check( (d) ); if ( (n) && (s) ) { memcpy( (d), (s), (n)); } } while(0)
-#define memset_check( d, c, n )     do { notnull_check( (d) ); if ( (n) && (s) ) { memset( (d), (c), (n)); } } while(0)
+#define memset_check( d, c, n )     do { notnull_check( (d) ); if ( (n) && (c) ) { memset( (d), (c), (n)); } } while(0)
 
 /* Range check a number */
 #define gte_check(n, min)  do { if ( (n) < min ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -27,7 +27,7 @@
 /* Check memcpy's return, if it's not right (very unlikely!) bail, set an error
  * err and return -1;
  */
-#define memcpy_check( d, s, n )     do { if ( (n) && (s) ) { notnull_check( (d) ); memcpy( (d), (s), (n)); } } while(0)
+#define memcpy_check( d, s, n )     do { if ( (n) ) { notnull_check( (d) ); memcpy( (d), (s), (n)); } } while(0)
 #define memset_check( d, c, n )     do { if ( (n) ) { notnull_check( (d) ); memset( (d), (c), (n)); } } while(0)
 
 /* Range check a number */

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -27,8 +27,8 @@
 /* Check memcpy's return, if it's not right (very unlikely!) bail, set an error
  * err and return -1;
  */
-#define memcpy_check( d, s, n )     do { notnull_check( (d) ); if ( (n) && (s) ) { memcpy( (d), (s), (n)); } } while(0)
-#define memset_check( d, c, n )     do { notnull_check( (d) ); if ( (n) && (c) ) { memset( (d), (c), (n)); } } while(0)
+#define memcpy_check( d, s, n )     do { if ( (n) && (s) ) { notnull_check( (d) ); memcpy( (d), (s), (n)); } } while(0)
+#define memset_check( d, c, n )     do { if ( (n) ) { notnull_check( (d) ); memset( (d), (c), (n)); } } while(0)
 
 /* Range check a number */
 #define gte_check(n, min)  do { if ( (n) < min ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)


### PR DESCRIPTION
Per issue #161 , there are compiler optimizations that mean calling
memset() with a NULL pointer, even when the length argument is 0,
is a bad idea which may lead to undefined behavior.

This change guards two calls to memset() in the s2n code base
that may result in such a call.

fixes #161