### PR TITLE
s2n_recv: clear *more when connection is closed.

### DIFF
--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -206,6 +206,8 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     /* Zero the whole connection structure */
     memset_check(conn, 0, sizeof(struct s2n_connection));
 
+    conn->readfd = -1;
+    conn->writefd = -1;
     conn->mode = mode;
     conn->config = config;
     conn->active.cipher_suite = &s2n_null_cipher_suite;

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -132,7 +132,7 @@ ssize_t s2n_recv(struct s2n_connection *conn, void *buf, ssize_t size, int *more
             if (r == -2) {
                 conn->closed = 1;
                 GUARD(s2n_connection_wipe(conn));
-		*more = 0;
+                *more = 0;
                 return bytes_read;
             }
             return -1;

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -132,6 +132,7 @@ ssize_t s2n_recv(struct s2n_connection *conn, void *buf, ssize_t size, int *more
             if (r == -2) {
                 conn->closed = 1;
                 GUARD(s2n_connection_wipe(conn));
+		*more = 0;
                 return bytes_read;
             }
             return -1;


### PR DESCRIPTION
Discussed in Issue #165 .