### PR TITLE
Add 'blocked on $direction' to s2n I/O APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ if (s2n_connection_set_fd(conn, fd) < 0) {
 }
 
 /* Negotiate the TLS handshake */
-int more;
-if (s2n_negotiate(conn, &more) < 0) {
+s2n_blocked_status blocked;
+if (s2n_negotiate(conn, &blocked) < 0) {
     ... error ...
 }
     
 /* Write data to the connection */
 int bytes_written;
-bytes_written = s2n_send(conn, "Hello World", sizeof("Hello World"), &more);
+bytes_written = s2n_send(conn, "Hello World", sizeof("Hello World"), &blocked);
 ```
 
 For details on building the s2n library and how to use s2n in an application you are developing, see the [API Reference](https://github.com/awslabs/s2n/blob/master/docs/USAGE-GUIDE.md).

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -68,13 +68,14 @@ extern const char *s2n_get_server_name(struct s2n_connection *conn);
 extern const char *s2n_get_application_protocol(struct s2n_connection *conn);
 extern const uint8_t *s2n_connection_get_ocsp_response(struct s2n_connection *conn, uint32_t *length);
 
-extern int s2n_negotiate(struct s2n_connection *conn, int *more);
-extern ssize_t s2n_send(struct s2n_connection *conn, void *buf, ssize_t size, int *more);
-extern ssize_t s2n_recv(struct s2n_connection *conn,  void *buf, ssize_t size, int *more);
+typedef enum { S2N_NOT_BLOCKED = 0, S2N_BLOCKED_ON_READ, S2N_BLOCKED_ON_WRITE } s2n_blocked_status;
+extern int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status *blocked);
+extern ssize_t s2n_send(struct s2n_connection *conn, void *buf, ssize_t size, s2n_blocked_status *blocked);
+extern ssize_t s2n_recv(struct s2n_connection *conn,  void *buf, ssize_t size, s2n_blocked_status *blocked);
 
 extern int s2n_connection_wipe(struct s2n_connection *conn);
 extern int s2n_connection_free(struct s2n_connection *conn);
-extern int s2n_shutdown(struct s2n_connection *conn, int *more);
+extern int s2n_shutdown(struct s2n_connection *conn, s2n_blocked_status *blocked);
 
 extern uint64_t s2n_connection_get_wire_bytes_in(struct s2n_connection *conn);
 extern uint64_t s2n_connection_get_wire_bytes_out(struct s2n_connection *conn);

--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -149,7 +149,7 @@ int s2n_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm alg, const vo
 
         memcpy_check(state->xor_pad, state->digest_pad, state->digest_size);
         copied = state->digest_size;
-    } else if (klen) {
+    } else {
         memcpy_check(state->xor_pad, key, klen);
     }
 

--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -149,7 +149,7 @@ int s2n_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm alg, const vo
 
         memcpy_check(state->xor_pad, state->digest_pad, state->digest_size);
         copied = state->digest_size;
-    } else {
+    } else if (klen) {
         memcpy_check(state->xor_pad, key, klen);
     }
 

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -121,8 +121,10 @@ int s2n_stuffer_wipe_n(struct s2n_stuffer *stuffer, const uint32_t size)
     }
 
     /* Use '0' instead of 0 precisely to prevent C string compatibility */
-    memset(stuffer->blob.data + stuffer->write_cursor - n, '0', n);
-    stuffer->write_cursor -= n;
+    if (n) {
+        memset(stuffer->blob.data + stuffer->write_cursor - n, '0', n);
+        stuffer->write_cursor -= n;
+    }
 
     if (stuffer->write_cursor == 0) {
         stuffer->wiped = 1;

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -121,10 +121,8 @@ int s2n_stuffer_wipe_n(struct s2n_stuffer *stuffer, const uint32_t size)
     }
 
     /* Use '0' instead of 0 precisely to prevent C string compatibility */
-    if (n) {
-        memset(stuffer->blob.data + stuffer->write_cursor - n, '0', n);
-        stuffer->write_cursor -= n;
-    }
+    memset_check(stuffer->blob.data + stuffer->write_cursor - n, '0', n);
+    stuffer->write_cursor -= n;
 
     if (stuffer->write_cursor == 0) {
         stuffer->wiped = 1;

--- a/tests/unit/s2n_client_extensions_test.c
+++ b/tests/unit/s2n_client_extensions_test.c
@@ -110,8 +110,8 @@ int main(int argc, char **argv)
         struct s2n_connection *client_conn;
         struct s2n_connection *server_conn;
         struct s2n_config *server_config;
-        int client_more;
-        int server_more;
+        s2n_blocked_status client_blocked;
+        s2n_blocked_status server_blocked;
         int server_to_client[2];
         int client_to_server[2];
 
@@ -137,18 +137,18 @@ int main(int argc, char **argv)
 
         do {
             int ret;
-            ret = s2n_negotiate(client_conn, &client_more);
-            EXPECT_TRUE(ret == 0 || (client_more && errno == EAGAIN));
-            ret = s2n_negotiate(server_conn, &server_more);
-            EXPECT_TRUE(ret == 0 || (server_more && errno == EAGAIN));
-        } while (client_more || server_more);
+            ret = s2n_negotiate(client_conn, &client_blocked);
+            EXPECT_TRUE(ret == 0 || (client_blocked && errno == EAGAIN));
+            ret = s2n_negotiate(server_conn, &server_blocked);
+            EXPECT_TRUE(ret == 0 || (server_blocked && errno == EAGAIN));
+        } while (client_blocked || server_blocked);
 
         /* Verify that the server didn't receive the server name. */
         EXPECT_NULL(s2n_get_server_name(server_conn));
 
-        EXPECT_SUCCESS(s2n_shutdown(client_conn, &client_more));
+        EXPECT_SUCCESS(s2n_shutdown(client_conn, &client_blocked));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
-        EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_more));
+        EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_blocked));
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
 
         EXPECT_SUCCESS(s2n_config_free(server_config));
@@ -164,8 +164,8 @@ int main(int argc, char **argv)
         struct s2n_connection *client_conn;
         struct s2n_connection *server_conn;
         struct s2n_config *server_config;
-        int client_more;
-        int server_more;
+        s2n_blocked_status client_blocked;
+        s2n_blocked_status server_blocked;
         int server_to_client[2];
         int client_to_server[2];
 
@@ -197,20 +197,20 @@ int main(int argc, char **argv)
 
         do {
             int ret;
-            ret = s2n_negotiate(client_conn, &client_more);
-            EXPECT_TRUE(ret == 0 || (client_more && errno == EAGAIN));
-            ret = s2n_negotiate(server_conn, &server_more);
-            EXPECT_TRUE(ret == 0 || (server_more && errno == EAGAIN));
-        } while (client_more || server_more);
+            ret = s2n_negotiate(client_conn, &client_blocked);
+            EXPECT_TRUE(ret == 0 || (client_blocked && errno == EAGAIN));
+            ret = s2n_negotiate(server_conn, &server_blocked);
+            EXPECT_TRUE(ret == 0 || (server_blocked && errno == EAGAIN));
+        } while (client_blocked || server_blocked);
 
         /* Verify that the server name was received intact. */
         EXPECT_NOT_NULL(received_server_name = s2n_get_server_name(server_conn));
         EXPECT_EQUAL(strlen(received_server_name), strlen(sent_server_name));
         EXPECT_BYTEARRAY_EQUAL(received_server_name, sent_server_name, strlen(received_server_name));
 
-        EXPECT_SUCCESS(s2n_shutdown(client_conn, &client_more));
+        EXPECT_SUCCESS(s2n_shutdown(client_conn, &client_blocked));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
-        EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_more));
+        EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_blocked));
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
 
         EXPECT_SUCCESS(s2n_config_free(server_config));
@@ -224,7 +224,7 @@ int main(int argc, char **argv)
     {
         struct s2n_connection *server_conn;
         struct s2n_config *server_config;
-        int server_more;
+        s2n_blocked_status server_blocked;
         int server_to_client[2];
         int client_to_server[2];
         const char *sent_server_name = "svr";
@@ -311,8 +311,8 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(write(client_to_server[1], client_extensions, sizeof(client_extensions)), sizeof(client_extensions));
 
         /* Verify that the CLIENT HELLO is accepted */
-        s2n_negotiate(server_conn, &server_more);
-        EXPECT_EQUAL(server_more, 1);
+        s2n_negotiate(server_conn, &server_blocked);
+        EXPECT_EQUAL(server_blocked, 1);
         EXPECT_EQUAL(server_conn->handshake.state, CLIENT_KEY);
 
         /* Verify that the server name was received intact. */
@@ -320,7 +320,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(strlen(received_server_name), strlen(sent_server_name));
         EXPECT_BYTEARRAY_EQUAL(received_server_name, sent_server_name, strlen(received_server_name));
 
-        EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_more));
+        EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_blocked));
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
 
         EXPECT_SUCCESS(s2n_config_free(server_config));
@@ -335,8 +335,8 @@ int main(int argc, char **argv)
         struct s2n_connection *client_conn;
         struct s2n_connection *server_conn;
         struct s2n_config *server_config;
-        int client_more;
-        int server_more;
+        s2n_blocked_status client_blocked;
+        s2n_blocked_status server_blocked;
         int server_to_client[2];
         int client_to_server[2];
         uint32_t length;
@@ -363,19 +363,19 @@ int main(int argc, char **argv)
 
         do {
             int ret;
-            ret = s2n_negotiate(client_conn, &client_more);
-            EXPECT_TRUE(ret == 0 || client_more);
-            ret = s2n_negotiate(server_conn, &server_more);
-            EXPECT_TRUE(ret == 0 || server_more);
-        } while (client_more || server_more);
+            ret = s2n_negotiate(client_conn, &client_blocked);
+            EXPECT_TRUE(ret == 0 || client_blocked);
+            ret = s2n_negotiate(server_conn, &server_blocked);
+            EXPECT_TRUE(ret == 0 || server_blocked);
+        } while (client_blocked || server_blocked);
 
         /* Verify that the client didn't receive an OCSP response. */
         EXPECT_NULL(s2n_connection_get_ocsp_response(client_conn, &length));
         EXPECT_EQUAL(length, 0);
 
-        EXPECT_SUCCESS(s2n_shutdown(client_conn, &client_more));
+        EXPECT_SUCCESS(s2n_shutdown(client_conn, &client_blocked));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
-        EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_more));
+        EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_blocked));
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
 
         EXPECT_SUCCESS(s2n_config_free(server_config));
@@ -392,8 +392,8 @@ int main(int argc, char **argv)
         struct s2n_connection *server_conn;
         struct s2n_config *server_config;
         struct s2n_config *client_config;
-        int client_more;
-        int server_more;
+        s2n_blocked_status client_blocked;
+        s2n_blocked_status server_blocked;
         int server_to_client[2];
         int client_to_server[2];
         uint32_t length;
@@ -424,19 +424,19 @@ int main(int argc, char **argv)
 
         do {
             int ret;
-            ret = s2n_negotiate(client_conn, &client_more);
-            EXPECT_TRUE(ret == 0 || client_more);
-            ret = s2n_negotiate(server_conn, &server_more);
-            EXPECT_TRUE(ret == 0 || server_more);
-        } while (client_more || server_more);
+            ret = s2n_negotiate(client_conn, &client_blocked);
+            EXPECT_TRUE(ret == 0 || client_blocked);
+            ret = s2n_negotiate(server_conn, &server_blocked);
+            EXPECT_TRUE(ret == 0 || server_blocked);
+        } while (client_blocked || server_blocked);
 
         /* Verify that the client didn't receive an OCSP response. */
         EXPECT_NULL(s2n_connection_get_ocsp_response(client_conn, &length));
         EXPECT_EQUAL(length, 0);
 
-        EXPECT_SUCCESS(s2n_shutdown(client_conn, &client_more));
+        EXPECT_SUCCESS(s2n_shutdown(client_conn, &client_blocked));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
-        EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_more));
+        EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_blocked));
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
 
         EXPECT_SUCCESS(s2n_config_free(server_config));
@@ -454,8 +454,8 @@ int main(int argc, char **argv)
         struct s2n_connection *server_conn;
         struct s2n_config *server_config;
         struct s2n_config *client_config;
-        int client_more;
-        int server_more;
+        s2n_blocked_status client_blocked;
+        s2n_blocked_status server_blocked;
         int server_to_client[2];
         int client_to_server[2];
         uint32_t length;
@@ -486,19 +486,19 @@ int main(int argc, char **argv)
 
         do {
             int ret;
-            ret = s2n_negotiate(client_conn, &client_more);
-            EXPECT_TRUE(ret == 0 || client_more);
-            ret = s2n_negotiate(server_conn, &server_more);
-            EXPECT_TRUE(ret == 0 || server_more);
-        } while (client_more || server_more);
+            ret = s2n_negotiate(client_conn, &client_blocked);
+            EXPECT_TRUE(ret == 0 || client_blocked);
+            ret = s2n_negotiate(server_conn, &server_blocked);
+            EXPECT_TRUE(ret == 0 || server_blocked);
+        } while (client_blocked || server_blocked);
 
         /* Verify that the client didn't receive an OCSP response. */
         EXPECT_NULL(s2n_connection_get_ocsp_response(client_conn, &length));
         EXPECT_EQUAL(length, 0);
 
-        EXPECT_SUCCESS(s2n_shutdown(client_conn, &client_more));
+        EXPECT_SUCCESS(s2n_shutdown(client_conn, &client_blocked));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
-        EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_more));
+        EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_blocked));
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
 
         EXPECT_SUCCESS(s2n_config_free(server_config));

--- a/tests/unit/s2n_fragmentation_coalescing_test.c
+++ b/tests/unit/s2n_fragmentation_coalescing_test.c
@@ -392,6 +392,7 @@ void interleaved_fragmented_warning_alert(int write_fd)
 int main(int argc, char **argv)
 {
     struct s2n_connection *conn;
+    s2n_blocked_status blocked;
     int status;
     pid_t pid;
     int p[2];
@@ -426,7 +427,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(close(p[1]));
 
     /* Negotiate the handshake. This will fail due to EOF, but that's ok. */
-    EXPECT_FAILURE(s2n_negotiate(conn, &status));
+    EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
     /* Verify that the data is as we expect it */
     EXPECT_EQUAL(memcmp(conn->pending.server_random, zero_to_thirty_one, 32), 0);
@@ -467,7 +468,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(close(p[1]));
 
     /* Negotiate the handshake. This will fail due to EOF, but that's ok. */
-    EXPECT_FAILURE(s2n_negotiate(conn, &status));
+    EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
     /* Verify that the data is as we expect it */
     EXPECT_EQUAL(memcmp(conn->pending.server_random, zero_to_thirty_one, 32), 0);
@@ -508,7 +509,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(close(p[1]));
 
     /* Negotiate the handshake. This will fail due to EOF, but that's ok. */
-    EXPECT_FAILURE(s2n_negotiate(conn, &status));
+    EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
     /* Verify that the data is as we expect it */
     EXPECT_EQUAL(memcmp(conn->pending.server_random, zero_to_thirty_one, 32), 0);
@@ -549,7 +550,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(close(p[1]));
 
     /* Negotiate the handshake. This will fail due to EOF, but that's ok. */
-    EXPECT_FAILURE(s2n_negotiate(conn, &status));
+    EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
     /* Verify that the data is as we expect it */
     EXPECT_NOT_EQUAL(memcmp(conn->pending.server_random, zero_to_thirty_one, 32), 0);
@@ -590,7 +591,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(close(p[1]));
 
     /* Negotiate the handshake. This will fail due to EOF, but that's ok. */
-    EXPECT_FAILURE(s2n_negotiate(conn, &status));
+    EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
     /* Verify that the data failed */
     EXPECT_NOT_EQUAL(memcmp(conn->pending.server_random, zero_to_thirty_one, 32), 0);

--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -109,8 +109,8 @@ int main(int argc, char **argv)
         struct s2n_cipher_preferences server_cipher_preferences;
         struct s2n_connection *client_conn;
         struct s2n_connection *server_conn;
-        int client_more;
-        int server_more;
+        s2n_blocked_status client_blocked;
+        s2n_blocked_status server_blocked;
         int server_to_client[2];
         int client_to_server[2];
 
@@ -141,15 +141,15 @@ int main(int argc, char **argv)
 
         do {
             int ret;
-            ret = s2n_negotiate(client_conn, &client_more);
-            EXPECT_TRUE(ret == 0 || (client_more && errno == EAGAIN));
-            ret = s2n_negotiate(server_conn, &server_more);
-            EXPECT_TRUE(ret == 0 || (server_more && errno == EAGAIN));
-        } while (client_more || server_more);
+            ret = s2n_negotiate(client_conn, &client_blocked);
+            EXPECT_TRUE(ret == 0 || (client_blocked && errno == EAGAIN));
+            ret = s2n_negotiate(server_conn, &server_blocked);
+            EXPECT_TRUE(ret == 0 || (server_blocked && errno == EAGAIN));
+        } while (client_blocked || server_blocked);
 
-        EXPECT_SUCCESS(s2n_shutdown(client_conn, &client_more));
+        EXPECT_SUCCESS(s2n_shutdown(client_conn, &client_blocked));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
-        EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_more));
+        EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_blocked));
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
 
         for (int i = 0; i < 2; i++) {

--- a/tests/unit/s2n_malformed_handshake_test.c
+++ b/tests/unit/s2n_malformed_handshake_test.c
@@ -228,6 +228,7 @@ void send_messages(int write_fd, uint8_t *server_hello, uint32_t server_hello_le
 int main(int argc, char **argv)
 {
     struct s2n_connection *conn;
+    s2n_blocked_status blocked;
     int status;
     pid_t pid;
     int p[2];
@@ -266,7 +267,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(close(p[1]));
 
     /* Negotiate the handshake. This will fail due to EOF, but that's ok. */
-    EXPECT_FAILURE(s2n_negotiate(conn, &status));
+    EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
     /* Verify that the data is as we expect it */
     EXPECT_EQUAL(memcmp(conn->pending.server_random, zero_to_thirty_one, 32), 0);
@@ -308,7 +309,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(close(p[1]));
 
     /* Negotiate the handshake. This will fail due to EOF, but that's ok. */
-    EXPECT_FAILURE(s2n_negotiate(conn, &status));
+    EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
     /* Verify that the data is as we expect it */
     EXPECT_EQUAL(memcmp(conn->pending.server_random, zero_to_thirty_one, 32), 0);
@@ -350,7 +351,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(close(p[1]));
 
     /* Negotiate the handshake. This will fail due to EOF, but that's ok. */
-    EXPECT_FAILURE(s2n_negotiate(conn, &status));
+    EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
     /* Verify that the data is as we expect it */
     EXPECT_EQUAL(memcmp(conn->pending.server_random, zero_to_thirty_one, 32), 0);
@@ -392,7 +393,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(close(p[1]));
 
     /* Negotiate the handshake. This will fail due to EOF, but that's ok. */
-    EXPECT_FAILURE(s2n_negotiate(conn, &status));
+    EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
     /* Verify that the data is as we expect it */
     EXPECT_EQUAL(memcmp(conn->pending.server_random, zero_to_thirty_one, 32), 0);
@@ -434,7 +435,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(close(p[1]));
 
     /* Negotiate the handshake. This will fail due to EOF, but that's ok. */
-    EXPECT_FAILURE(s2n_negotiate(conn, &status));
+    EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
     /* Verify that the data is as we expect it */
     EXPECT_EQUAL(memcmp(conn->pending.server_random, zero_to_thirty_one, 32), 0);
@@ -476,7 +477,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(close(p[1]));
 
     /* Negotiate the handshake. This will fail due to EOF, but that's ok. */
-    EXPECT_FAILURE(s2n_negotiate(conn, &status));
+    EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
     /* Verify that the data is as we expect it */
     EXPECT_EQUAL(memcmp(conn->pending.server_random, zero_to_thirty_one, 32), 0);

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -120,7 +120,7 @@ static int s2n_connection_free_keys(struct s2n_connection *conn)
     return 0;
 }
 
-int s2n_shutdown(struct s2n_connection *conn, int *more)
+int s2n_shutdown(struct s2n_connection *conn, s2n_blocked_status *more)
 {
     /* Write any pending I/O */
     GUARD(s2n_flush(conn, more));

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -132,6 +132,7 @@ ssize_t s2n_recv(struct s2n_connection *conn, void *buf, ssize_t size, s2n_block
             if (r == -2) {
                 conn->closed = 1;
                 GUARD(s2n_connection_wipe(conn));
+                *blocked = S2N_NOT_BLOCKED;
                 return bytes_read;
             }
             return -1;

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -106,7 +106,7 @@ int s2n_read_full_record(struct s2n_connection *conn, uint8_t *record_type, int 
     return 0;
 }
 
-ssize_t s2n_recv(struct s2n_connection *conn, void *buf, ssize_t size, int *more)
+ssize_t s2n_recv(struct s2n_connection *conn, void *buf, ssize_t size, s2n_blocked_status *blocked)
 {
     ssize_t bytes_read = 0;
     struct s2n_blob out = {.data = (uint8_t *) buf };
@@ -115,7 +115,7 @@ ssize_t s2n_recv(struct s2n_connection *conn, void *buf, ssize_t size, int *more
         return 0;
     }
 
-    *more = 1;
+    *blocked = S2N_BLOCKED_ON_READ;
 
     while (size && !conn->closed) {
         int isSSLv2 = 0;
@@ -144,7 +144,7 @@ ssize_t s2n_recv(struct s2n_connection *conn, void *buf, ssize_t size, int *more
         if (record_type != TLS_APPLICATION_DATA) {
             if (record_type == TLS_ALERT) {
                 GUARD(s2n_process_alert_fragment(conn));
-                GUARD(s2n_flush(conn, more));
+                GUARD(s2n_flush(conn, blocked));
             }
 
             GUARD(s2n_stuffer_wipe(&conn->header_in));
@@ -178,7 +178,7 @@ ssize_t s2n_recv(struct s2n_connection *conn, void *buf, ssize_t size, int *more
     }
 
     if (s2n_stuffer_data_available(&conn->in) == 0) {
-        *more = 0;
+        *blocked = S2N_NOT_BLOCKED;
     }
 
     return bytes_read;

--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -143,7 +143,7 @@ ssize_t s2n_send(struct s2n_connection *conn, void *buf, ssize_t size, s2n_block
         size -= in.size;
     }
 
-    *blocked = 0;
+    *blocked = S2N_NOT_BLOCKED;
 
     return bytes_written;
 }

--- a/tls/s2n_tls.h
+++ b/tls/s2n_tls.h
@@ -29,7 +29,7 @@ struct s2n_tls_session_id {
     uint8_t session_id_len;
 };
 
-extern int s2n_flush(struct s2n_connection *conn, int *more);
+extern int s2n_flush(struct s2n_connection *conn, s2n_blocked_status *more);
 extern int s2n_client_hello_send(struct s2n_connection *conn);
 extern int s2n_client_hello_recv(struct s2n_connection *conn);
 extern int s2n_sslv2_client_hello_recv(struct s2n_connection *conn);

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -27,8 +27,8 @@
 /* Check memcpy's return, if it's not right (very unlikely!) bail, set an error
  * err and return -1;
  */
-#define memcpy_check( d, s, n )     do { notnull_check( (d) ); memcpy( (d), (s), (n)); } while(0)
-#define memset_check( d, c, n )     do { notnull_check( (d) ); memset( (d), (c), (n)); } while(0)
+#define memcpy_check( d, s, n )     do { notnull_check( (d) ); if ( (n) && (s) ) { memcpy( (d), (s), (n)); } } while(0)
+#define memset_check( d, c, n )     do { notnull_check( (d) ); if ( (n) && (s) ) { memset( (d), (c), (n)); } } while(0)
 
 /* Range check a number */
 #define gte_check(n, min)  do { if ( (n) < min ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -28,7 +28,7 @@
  * err and return -1;
  */
 #define memcpy_check( d, s, n )     do { notnull_check( (d) ); if ( (n) && (s) ) { memcpy( (d), (s), (n)); } } while(0)
-#define memset_check( d, c, n )     do { notnull_check( (d) ); if ( (n) && (s) ) { memset( (d), (c), (n)); } } while(0)
+#define memset_check( d, c, n )     do { notnull_check( (d) ); if ( (n) && (c) ) { memset( (d), (c), (n)); } } while(0)
 
 /* Range check a number */
 #define gte_check(n, min)  do { if ( (n) < min ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -27,7 +27,7 @@
 /* Check memcpy's return, if it's not right (very unlikely!) bail, set an error
  * err and return -1;
  */
-#define memcpy_check( d, s, n )     do { if ( (n) && (s) ) { notnull_check( (d) ); memcpy( (d), (s), (n)); } } while(0)
+#define memcpy_check( d, s, n )     do { if ( (n) ) { notnull_check( (d) ); memcpy( (d), (s), (n)); } } while(0)
 #define memset_check( d, c, n )     do { if ( (n) ) { notnull_check( (d) ); memset( (d), (c), (n)); } } while(0)
 
 /* Range check a number */

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -27,8 +27,8 @@
 /* Check memcpy's return, if it's not right (very unlikely!) bail, set an error
  * err and return -1;
  */
-#define memcpy_check( d, s, n )     do { notnull_check( (d) ); if ( (n) && (s) ) { memcpy( (d), (s), (n)); } } while(0)
-#define memset_check( d, c, n )     do { notnull_check( (d) ); if ( (n) && (c) ) { memset( (d), (c), (n)); } } while(0)
+#define memcpy_check( d, s, n )     do { if ( (n) && (s) ) { notnull_check( (d) ); memcpy( (d), (s), (n)); } } while(0)
+#define memset_check( d, c, n )     do { if ( (n) ) { notnull_check( (d) ); memset( (d), (c), (n)); } } while(0)
 
 /* Range check a number */
 #define gte_check(n, min)  do { if ( (n) < min ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)


### PR DESCRIPTION
This change takes s2n prior 'more' parameter and recasts it as a new 'blocked'
parameter with 3 potential values:

    S2N_NOT_BLOCKED
    S2N_BLOCKED_ON_READ
    S2N_BLOCKED_ON_WRITE

which indicate how s2n is currently blocked. This permits non-blocking callers
to detect when they should call s2n again. For example if s2n is in the
S2N_BLOCKED_ON_READ status, then the caller can wait until it detects that
there is pending I/O available to be read on the underlying socket.

Closes #167 