### PR TITLE
user canceled is 90, rather than 80

### DIFF
--- a/tests/unit/s2n_fragmentation_coalescing_test.c
+++ b/tests/unit/s2n_fragmentation_coalescing_test.c
@@ -158,7 +158,7 @@ uint8_t heartbeat_message[] = {
 };
 
 uint8_t warning_alert[] = {       /* warning: user cancelled */
-    0x02, 0x50
+    0x02, 0x5a
 };
 
 uint8_t fatal_alert[] = {       /* Fatal: unexpected message */


### PR DESCRIPTION
https://tools.ietf.org/html/rfc5246#appendix-A.3 has `user_canceled` as 90 (0x5a in hexadecimal) rather than 0x50.