### PR TITLE
Renamed s2n_check_fork method to be more descriptive

### DIFF
--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -59,7 +59,7 @@ static __thread int *zero_if_forked_ptr;
 
 #endif
 
-static inline int s2n_check_fork(void)
+static inline int s2n_defend_if_forked(void)
 {
     uint8_t s2n_public_drbg[] = "s2n public drbg";
     uint8_t s2n_private_drbg[] = "s2n private drbg";
@@ -77,7 +77,7 @@ static inline int s2n_check_fork(void)
 
 int s2n_get_public_random_data(struct s2n_blob *blob)
 {
-    GUARD(s2n_check_fork());
+    GUARD(s2n_defend_if_forked());
     GUARD(s2n_drbg_generate(&per_thread_public_drbg, blob));
 
     return 0;
@@ -85,7 +85,7 @@ int s2n_get_public_random_data(struct s2n_blob *blob)
 
 int s2n_get_private_random_data(struct s2n_blob *blob)
 {
-    GUARD(s2n_check_fork());
+    GUARD(s2n_defend_if_forked());
     GUARD(s2n_drbg_generate(&per_thread_private_drbg, blob));
 
     return 0;
@@ -216,7 +216,7 @@ int s2n_init(void)
     }
 #endif
 
-    GUARD(s2n_check_fork());
+    GUARD(s2n_defend_if_forked());
 
 #ifndef OPENSSL_IS_BORINGSSL
     /* Create an engine */


### PR DESCRIPTION
The name 'check_fork' implies that the function is passive and does not alter the programs state in any way, however, the function will reinstantiate the random number generators if the program is found to have forked. I have renamed the function to s2n_defend_if_forked, which correctly implies that the programs state may or may not change dependent on whether it has forked since the last initialisation.