### PR TITLE
Support caller-specified time source via callback

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -38,6 +38,7 @@ extern struct s2n_config *s2n_config_new(void);
 extern int s2n_config_free(struct s2n_config *config);
 extern int s2n_config_free_dhparams(struct s2n_config *config);
 extern int s2n_config_free_cert_chain_and_key(struct s2n_config *config);
+extern int s2n_config_set_nanoseconds_since_epoch_callback(struct s2n_config *config, int (*nanoseconds_since_epoch)(void *, uint64_t *), void * data);
 extern const char *s2n_strerror(int error, const char *lang);
 
 extern int s2n_config_add_cert_chain_and_key(struct s2n_config *config, char *cert_chain_pem, char *private_key_pem);

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -360,6 +360,23 @@ int s2n_config_set_status_request_type(struct s2n_config *config, s2n_status_req
 server certificate status during an SSL handshake.  If set to
 S2N_STATUS_REQUEST_NONE, no status request is made.
 
+### s2n\_config\_set\_nanoseconds\_since\_epoch\_callback
+
+```c
+int s2n_config_set_nanoseconds_since_epoch_callback(struct s2n_config *config, int (*nanoseconds_since_epoch)(void *, uint64_t *), void * data);
+```
+
+**s2n_config_set_nanoseconds_since_epoch_callback** allows the caller to set a
+callback function that will be used to get the time. The callback function
+takes two arguments; a pointer to abitrary data for use within the callback,
+and a pointer to a 64 bit unsigned integer. The former pointer will be set to
+the value of **data** which supplied by the caller when setting the callback.
+The integer pointed to by the second pointer should be set to the number of
+nanoseconds since the Unix epoch (Midnight, January 1st, 1970). The function
+should return 0 on success and -1 on error. The function is also required to 
+implement a monotonic time source; the number of nanoseconds returned should
+never decrease between calls.
+
 ## Connection-oriented functions
 
 ### s2n\_connection\_new

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -369,7 +369,7 @@ int s2n_config_set_nanoseconds_since_epoch_callback(struct s2n_config *config, i
 **s2n_config_set_nanoseconds_since_epoch_callback** allows the caller to set a
 callback function that will be used to get the time. The callback function
 takes two arguments; a pointer to abitrary data for use within the callback,
-and a pointer to a 64 bit unsigned integer. The former pointer will be set to
+and a pointer to a 64 bit unsigned integer. The first pointer will be set to
 the value of **data** which supplied by the caller when setting the callback.
 The integer pointed to by the second pointer should be set to the number of
 nanoseconds since the Unix epoch (Midnight, January 1st, 1970). The function

--- a/tests/unit/s2n_drbg_test.c
+++ b/tests/unit/s2n_drbg_test.c
@@ -27,6 +27,8 @@
 #include "utils/s2n_random.h"
 #include "utils/s2n_timer.h"
 
+#include "tls/s2n_config.h"
+
 #include "testlib/s2n_testlib.h"
 
 
@@ -131,6 +133,7 @@ int main(int argc, char **argv)
     struct s2n_stuffer nist_reference_personalization_strings;
     struct s2n_stuffer nist_reference_returned_bits;
     struct s2n_stuffer nist_reference_values;
+    struct s2n_config *config = s2n_config_new();
 
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_init());
@@ -185,18 +188,18 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_drbg_instantiate(&drbg, &blob));
 
     /* Use the DRBG for 16MB of data */
-    EXPECT_SUCCESS(s2n_timer_start(&timer));
+    EXPECT_SUCCESS(s2n_timer_start(config, &timer));
     for (int i = 0; i < 1000000; i++) {
         EXPECT_SUCCESS(s2n_drbg_generate(&drbg, &blob));
     }
-    EXPECT_SUCCESS(s2n_timer_reset(&timer, &drbg_nanoseconds));
+    EXPECT_SUCCESS(s2n_timer_reset(config, &timer, &drbg_nanoseconds));
 
     /* Use urandom for 16MB of data */
-    EXPECT_SUCCESS(s2n_timer_start(&timer));
+    EXPECT_SUCCESS(s2n_timer_start(config, &timer));
     for (int i = 0; i < 1000000; i++) {
         EXPECT_SUCCESS(s2n_get_urandom_data(&blob));
     }
-    EXPECT_SUCCESS(s2n_timer_reset(&timer, &urandom_nanoseconds));
+    EXPECT_SUCCESS(s2n_timer_reset(config, &timer, &urandom_nanoseconds));
 
     /* Confirm that the DRBG is faster than urandom */
     EXPECT_TRUE(drbg_nanoseconds < urandom_nanoseconds);

--- a/tests/unit/s2n_timer_test.c
+++ b/tests/unit/s2n_timer_test.c
@@ -41,55 +41,5 @@ int main(int argc, char **argv)
     EXPECT_TRUE(nanoseconds > 1000000000);
     EXPECT_TRUE(nanoseconds < 2000000000);
 
-#if !defined(__APPLE__) || !defined(__MACH__)
-    /* Next: perform some tests around timespec boundaries */
-
-    /* Pretend that there were 999,999,999 nanoseconds elapsed in the
-     * previously measured instant. Keep reseting the timer until
-     * the second progresses from that instant, and there are also
-     * less than 999,999,999 nanoseconds elapsed.
-     *
-     * This sets up a situation in which the tv_sec field causes time
-     * to move "forwards", and tv_nsec causes it to move backwards.
-     * e.g.
-     *
-     * previous_time = 10
-     *
-     * timer.time.tv_sec = 11
-     * timer.time.tv_nsec = 123456789;
-     *
-     * delta will be:
-     *   (11 - 10) * 1000000000
-     * + (123456789 - 999999999)
-     *
-     * = 123456790 (same as 1 + 123456789)
-     */
-    time_t previous_time;
-    do {
-        previous_time = timer.time.tv_sec;
-        timer.time.tv_nsec = 999999999;
-
-        EXPECT_SUCCESS(s2n_timer_reset(config, &timer, &nanoseconds));
-    }
-    while(previous_time != (timer.time.tv_sec - 1) || timer.time.tv_nsec == 999999999);
-
-    EXPECT_TRUE(nanoseconds < 1000000000);
-    EXPECT_TRUE(nanoseconds == 1 + timer.time.tv_nsec);
-
-    /* Now we perform the oppossite test: make sure that the previous value for
-     * nsec is smaller than the later one */
-    do {
-        previous_time = timer.time.tv_sec;
-        timer.time.tv_nsec = 0;
-
-        EXPECT_SUCCESS(s2n_timer_reset(config, &timer, &nanoseconds));
-    }
-    while(previous_time != (timer.time.tv_sec - 1) || timer.time.tv_nsec == 0);
-
-    EXPECT_TRUE(nanoseconds > 1000000000);
-    EXPECT_TRUE(nanoseconds < 2000000000);
-    EXPECT_TRUE(nanoseconds == 1000000000 + timer.time.tv_nsec);
-#endif
-
     END_TEST();
 }

--- a/tests/unit/s2n_timer_test.c
+++ b/tests/unit/s2n_timer_test.c
@@ -16,25 +16,28 @@
 
 #include "utils/s2n_timer.h"
 
+#include "tls/s2n_config.h"
+
 int main(int argc, char **argv)
 {
+    struct s2n_config *config = s2n_config_new();
     struct s2n_timer timer;
     uint64_t nanoseconds;
 
     BEGIN_TEST();
 
     /* First: Perform some tests using the real clock */
-    EXPECT_SUCCESS(s2n_timer_start(&timer));
-    EXPECT_SUCCESS(s2n_timer_reset(&timer, &nanoseconds));
+    EXPECT_SUCCESS(s2n_timer_start(config, &timer));
+    EXPECT_SUCCESS(s2n_timer_reset(config, &timer, &nanoseconds));
     EXPECT_TRUE(nanoseconds < 1000000000);
-    EXPECT_SUCCESS(s2n_timer_elapsed(&timer, &nanoseconds));
+    EXPECT_SUCCESS(s2n_timer_elapsed(config, &timer, &nanoseconds));
     EXPECT_TRUE(nanoseconds < 1000000000);
     EXPECT_SUCCESS(sleep(1));
-    EXPECT_SUCCESS(s2n_timer_reset(&timer, &nanoseconds));
+    EXPECT_SUCCESS(s2n_timer_reset(config, &timer, &nanoseconds));
     EXPECT_TRUE(nanoseconds > 1000000000);
     EXPECT_TRUE(nanoseconds < 2000000000);
     EXPECT_SUCCESS(sleep(1));
-    EXPECT_SUCCESS(s2n_timer_elapsed(&timer, &nanoseconds));
+    EXPECT_SUCCESS(s2n_timer_elapsed(config, &timer, &nanoseconds));
     EXPECT_TRUE(nanoseconds > 1000000000);
     EXPECT_TRUE(nanoseconds < 2000000000);
 
@@ -66,7 +69,7 @@ int main(int argc, char **argv)
         previous_time = timer.time.tv_sec;
         timer.time.tv_nsec = 999999999;
 
-        EXPECT_SUCCESS(s2n_timer_reset(&timer, &nanoseconds));
+        EXPECT_SUCCESS(s2n_timer_reset(config, &timer, &nanoseconds));
     }
     while(previous_time != (timer.time.tv_sec - 1) || timer.time.tv_nsec == 999999999);
 
@@ -79,7 +82,7 @@ int main(int argc, char **argv)
         previous_time = timer.time.tv_sec;
         timer.time.tv_nsec = 0;
 
-        EXPECT_SUCCESS(s2n_timer_reset(&timer, &nanoseconds));
+        EXPECT_SUCCESS(s2n_timer_reset(config, &timer, &nanoseconds));
     }
     while(previous_time != (timer.time.tv_sec - 1) || timer.time.tv_nsec == 0);
 

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -42,6 +42,8 @@ struct s2n_config {
     struct s2n_cipher_preferences *cipher_preferences;
     struct s2n_blob application_protocols;
     s2n_status_request_type status_request_type;
+    int (*nanoseconds_since_epoch)(void *, uint64_t *);
+    void *data_for_nanoseconds_since_epoch;
 };
 
 extern struct s2n_config s2n_default_config;

--- a/utils/s2n_timer.h
+++ b/utils/s2n_timer.h
@@ -17,22 +17,10 @@
 
 #include <stdint.h>
 
-#if defined(__APPLE__) && defined(__MACH__)
-    
-    struct s2n_timer {
-        uint64_t time;
-    };
+struct s2n_timer {
+    uint64_t time;
+};
 
-#else
-
-    #include <time.h>
-
-    struct s2n_timer {
-        struct timespec time;
-    };
-
-#endif
-
-extern int s2n_timer_start(struct s2n_timer *timer);
-extern int s2n_timer_elapsed(struct s2n_timer *timer, uint64_t *nanoseconds);
-extern int s2n_timer_reset(struct s2n_timer *timer, uint64_t *nanoseconds);
+extern int s2n_timer_start(struct s2n_config *config, struct s2n_timer *timer);
+extern int s2n_timer_elapsed(struct s2n_config *config, struct s2n_timer *timer, uint64_t *nanoseconds);
+extern int s2n_timer_reset(struct s2n_config *config, struct s2n_timer *timer, uint64_t *nanoseconds);


### PR DESCRIPTION
This change adds a new callback that allows the caller to specify
a time-providing function for s2n. This allows us to use faster
time sources in some environments, and will also allow for time
to be mocked in certain unit tests.