### PR TITLE
Fix memory leak in s2n_realloc

### DIFF
--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -57,7 +57,7 @@ int s2n_realloc(struct s2n_blob *b, uint32_t size)
         return 0;
     }
 
-    uint32_t allocate = page_size * ((size + (page_size - 1)) / page_size); 
+    uint32_t allocate = page_size * ((size + (page_size - 1)) / page_size);
 
     void *data;
     if (posix_memalign(&data, page_size, allocate)) {
@@ -66,6 +66,7 @@ int s2n_realloc(struct s2n_blob *b, uint32_t size)
 
     if (b->size) {
         memcpy_check(data, b->data, b->size);
+        GUARD(s2n_free(b));
     }
 
     b->data = data;


### PR DESCRIPTION
Previously, any call to s2n_stuffer_skip_write that requires a reallocation
would leak memory.

fixes #181 