### PR TITLE
Add munlock to s2n_free

### DIFF
--- a/error/s2n_errno.c
+++ b/error/s2n_errno.c
@@ -37,6 +37,7 @@ struct s2n_error_translation EN[] = {
     { S2N_ERR_MADVISE, "error calling madvise" },
     { S2N_ERR_ALLOC,   "error allocating memory" },
     { S2N_ERR_MLOCK,   "error calling mlock" },
+    { S2N_ERR_MUNLOCK, "error calling munlock" },
     { S2N_ERR_FSTAT,   "error calling fstat" },
     { S2N_ERR_OPEN,    "error calling open" },
     { S2N_ERR_MMAP,    "error calling mmap" },

--- a/error/s2n_errno.h
+++ b/error/s2n_errno.h
@@ -28,6 +28,7 @@ typedef enum {
     S2N_ERR_MADVISE,
     S2N_ERR_ALLOC,
     S2N_ERR_MLOCK,
+    S2N_ERR_MUNLOCK,
     S2N_ERR_FSTAT,
     S2N_ERR_OPEN,
     S2N_ERR_MMAP,

--- a/utils/s2n_blob.h
+++ b/utils/s2n_blob.h
@@ -21,6 +21,7 @@ struct s2n_blob {
     uint8_t *data;
     uint32_t size;
     uint32_t allocated;
+    unsigned int mlocked:1;
 };
 
 extern int s2n_blob_init(struct s2n_blob *b, uint8_t *data, uint32_t size);

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -94,15 +94,17 @@ int s2n_realloc(struct s2n_blob *b, uint32_t size)
 
 int s2n_free(struct s2n_blob *b)
 {
-    void *freed_data = b->data;
-    uint32_t freed_size = b->size;
+    int munlock_rc = 0;
+    if (b->mlocked) {
+       munlock_rc = munlock(b->data, b->size);
+    }
 
     free(b->data);
     b->data = NULL;
     b->size = 0;
     b->allocated = 0;
 
-    if (b->mlocked && munlock(freed_data, freed_size) < 0) {
+    if (munlock_rc < 0 ) {
         S2N_ERROR(S2N_ERR_MUNLOCK);
     }
     b->mlocked = 0;


### PR DESCRIPTION
Previously, pages for freed blobs would remain locked in resident memory even
after calling s2n_free. According to http://linux.die.net/man/2/munlock:
these pages would stay locked until the process exits.

The mlocked bit field is added to help track which s2n_blobs need to be
munlock'd when freed. Currently any *successfully* allocated blob
will have mlocked == 1.

Decided to do this in a separate PR than #194 because it might need some work. 