### PR TITLE
Use S2N_ERROR/GUARD macros

### DIFF
--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -228,8 +228,7 @@ int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *ver
         }
     }
 
-    s2n_errno = S2N_ERR_INVALID_CIPHER_PREFERENCES;
-    return -1;
+    S2N_ERROR(S2N_ERR_INVALID_CIPHER_PREFERENCES);
 }
 
 int s2n_config_set_protocol_preferences(struct s2n_config *config, const char * const *protocols, int protocol_count)

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -326,7 +326,6 @@ int s2n_set_server_name(struct s2n_connection *conn, const char *server_name)
     int len = strlen(server_name);
     if (len > 255) {
         S2N_ERROR(S2N_ERR_SERVER_NAME_TOO_LONG);
-        return -1;
     }
 
     memcpy_check(conn->server_name, server_name, len);

--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -39,10 +39,7 @@ int s2n_flush(struct s2n_connection *conn, s2n_blocked_status *blocked)
     /* Write any data that's already pending */
   WRITE:
     while (s2n_stuffer_data_available(&conn->out)) {
-        w = s2n_stuffer_send_to_fd(&conn->out, conn->writefd, s2n_stuffer_data_available(&conn->out));
-        if (w < 0) {
-            return -1;
-        }
+        GUARD(w = s2n_stuffer_send_to_fd(&conn->out, conn->writefd, s2n_stuffer_data_available(&conn->out)));
         conn->wire_bytes_out += w;
     }
     if (conn->closing) {


### PR DESCRIPTION
This change uses S2N_ERROR and GUARD in places where appropriate,
and avoids dead branches found by Ernie Cohen while verifying s2n.