### PR TITLE
Simplify s2n_hmac_digest_verify

### DIFF
--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -219,9 +219,9 @@ int s2n_hmac_reset(struct s2n_hmac_state *state)
     return 0;
 }
 
-int s2n_hmac_digest_verify(const void *a, uint32_t alen, const void *b, uint32_t blen)
+int s2n_hmac_digest_verify(const void *a, const void *b, uint32_t len)
 {
-    return 0 - (!s2n_constant_time_equals(a, b, alen) | !!(alen - blen));
+    return 0 - !s2n_constant_time_equals(a, b, len);
 }
 
 int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)

--- a/crypto/s2n_hmac.h
+++ b/crypto/s2n_hmac.h
@@ -48,6 +48,6 @@ extern int s2n_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm alg, c
 extern int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size);
 extern int s2n_hmac_digest(struct s2n_hmac_state *state, void *out, uint32_t size);
 extern int s2n_hmac_digest_two_compression_rounds(struct s2n_hmac_state *state, void *out, uint32_t size);
-extern int s2n_hmac_digest_verify(const void *a, uint32_t alen, const void *b, uint32_t blen);
+extern int s2n_hmac_digest_verify(const void *a, const void *b, uint32_t len);
 extern int s2n_hmac_reset(struct s2n_hmac_state *state);
 extern int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from);

--- a/tests/unit/s2n_hmac_test.c
+++ b/tests/unit/s2n_hmac_test.c
@@ -105,7 +105,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_hmac_init(&cmac, S2N_HMAC_MD5, longsekrit, strlen((char *)longsekrit)));
     EXPECT_SUCCESS(s2n_hmac_update(&cmac, hello, strlen((char *)hello)));
     EXPECT_SUCCESS(s2n_hmac_digest(&cmac, check_pad, 16));
-    EXPECT_SUCCESS(s2n_hmac_digest_verify(digest_pad, 16, check_pad, 16));
+    EXPECT_SUCCESS(s2n_hmac_digest_verify(digest_pad, check_pad, 16));
 
     /* Try SHA1 */
     EXPECT_EQUAL(s2n_hmac_digest_size(S2N_HMAC_SHA1), 20);

--- a/tests/unit/s2n_record_test.c
+++ b/tests/unit/s2n_record_test.c
@@ -152,7 +152,7 @@ int main(int argc, char **argv)
 
         uint8_t check_digest[20];
         EXPECT_SUCCESS(s2n_hmac_digest(&check_mac, check_digest, 20));
-        EXPECT_SUCCESS(s2n_hmac_digest_verify(conn->out.blob.data + 5 + bytes_written, 20, check_digest, 20));
+        EXPECT_SUCCESS(s2n_hmac_digest_verify(conn->out.blob.data + 5 + bytes_written, check_digest, 20));
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
@@ -246,7 +246,7 @@ int main(int argc, char **argv)
 
         uint8_t check_digest[20];
         EXPECT_SUCCESS(s2n_hmac_digest(&check_mac, check_digest, 20));
-        EXPECT_SUCCESS(s2n_hmac_digest_verify(conn->out.blob.data + 5 + bytes_written, 20, check_digest, 20));
+        EXPECT_SUCCESS(s2n_hmac_digest_verify(conn->out.blob.data + 5 + bytes_written, check_digest, 20));
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
@@ -314,7 +314,7 @@ int main(int argc, char **argv)
 
         uint8_t check_digest[20];
         EXPECT_SUCCESS(s2n_hmac_digest(&check_mac, check_digest, 20));
-        EXPECT_SUCCESS(s2n_hmac_digest_verify(conn->out.blob.data + 16 + 5 + bytes_written, 20, check_digest, 20));
+        EXPECT_SUCCESS(s2n_hmac_digest_verify(conn->out.blob.data + 16 + 5 + bytes_written, check_digest, 20));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));

--- a/tls/s2n_record_read.c
+++ b/tls/s2n_record_read.c
@@ -250,7 +250,7 @@ int s2n_record_parse(struct s2n_connection *conn)
         lte_check(mac_digest_size, sizeof(check_digest));
         GUARD(s2n_hmac_digest(mac, check_digest, mac_digest_size));
 
-        if (s2n_hmac_digest_verify(en.data + payload_length + offset, mac_digest_size, check_digest, mac_digest_size) < 0) {
+        if (s2n_hmac_digest_verify(en.data + payload_length + offset, check_digest, mac_digest_size) < 0) {
             GUARD(s2n_stuffer_wipe(&conn->in));
             S2N_ERROR(S2N_ERR_BAD_MESSAGE);
             return -1;


### PR DESCRIPTION
Nathan Collins reported that s2n_hmac_digest_verify() doesn't handle the case
correctly where digests of different length are passed in. This change updates
s2n_hmac_digest_verify() to take a single length parameter, instead of two.

This makes things simpler, by avoiding the sometimes confusing double-bang
operation (!!), and removes the issue by insisting that the caller use matching
lengths to begin with.

Closes: #205