### PR TITLE
Add documentation around the modulu fudge

### DIFF
--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -174,16 +174,26 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
 {
     /* Keep track of how much of the current hash block is full
      *
-     * Why the 4294967040 constant in this code? 4294967040 is the highest 32-bit
-     * value that is congruent to 0 modulo all of our HMAC block sizes. It
-     * therefore has no effect on the mathematical result.
+     * Why the 4294949760 constant in this code? 4294949760 is the highest 32-bit
+     * value that is congruent to 0 modulo all of our HMAC block sizes, that is also
+     * at least 16k smaller than 2^32. It therefore has no effect on the mathematical
+     * result, and no valid record size can cause it to overflow.
+     * 
+     * The value was found with the following python code;
+     * 
+     * x = (2 ** 32) - (2 ** 14)
+     * while True:
+     *   if x % 40 | x % 48 | x % 64 | x % 128 == 0:
+     *     break
+     *   x -= 1
+     * print x
      *
      * What it does do however is ensure that the mod operation takes a
      * constant number of instruction cycles, regardless of the size of the
      * input. On some platforms, including Intel, the operation can take a
      * smaller number of cycles if the input is "small".
      */
-    state->currently_in_hash_block += (4294967040 + size) % state->hash_block_size;
+    state->currently_in_hash_block += (4294949760 + size) % state->hash_block_size;
     state->currently_in_hash_block %= state->block_size;
 
     return s2n_hash_update(&state->inner, in, size);


### PR DESCRIPTION
This change adds a verbose comment explaining why we add a seemingly
redundant constant to the size of a record before calculating its
modulus.

This change also updates this value to be as far as possible into the
32-bit range.