### PR TITLE
Mock time for our timer tests

### DIFF
--- a/tests/unit/s2n_timer_test.c
+++ b/tests/unit/s2n_timer_test.c
@@ -18,29 +18,45 @@
 
 #include "tls/s2n_config.h"
 
+
+
+int mock_clock(void *in, uint64_t *out)
+{
+    *out = *(uint64_t *)in;
+
+    return 0;
+}
+
 int main(int argc, char **argv)
 {
     struct s2n_config *config;
     struct s2n_timer timer;
     uint64_t nanoseconds;
+    uint64_t mock_time;
 
     BEGIN_TEST();
 
     EXPECT_NOT_NULL(config = s2n_config_new());
-    /* First: Perform some tests using the real clock */
+    EXPECT_SUCCESS(s2n_config_set_nanoseconds_since_epoch_callback(config, mock_clock, &mock_time));
+
+    mock_time = 0;
     EXPECT_SUCCESS(s2n_timer_start(config, &timer));
+
+    mock_time = 10;
     EXPECT_SUCCESS(s2n_timer_reset(config, &timer, &nanoseconds));
-    EXPECT_TRUE(nanoseconds < 1000000000);
+    EXPECT_EQUAL(nanoseconds, 10);
+
+    mock_time = 20;
     EXPECT_SUCCESS(s2n_timer_elapsed(config, &timer, &nanoseconds));
-    EXPECT_TRUE(nanoseconds < 1000000000);
-    EXPECT_SUCCESS(sleep(1));
+    EXPECT_EQUAL(nanoseconds, 10);
+
+    mock_time = 30;
     EXPECT_SUCCESS(s2n_timer_reset(config, &timer, &nanoseconds));
-    EXPECT_TRUE(nanoseconds > 1000000000);
-    EXPECT_TRUE(nanoseconds < 2000000000);
-    EXPECT_SUCCESS(sleep(1));
+    EXPECT_EQUAL(nanoseconds, 20);
+
+    mock_time = 40;
     EXPECT_SUCCESS(s2n_timer_elapsed(config, &timer, &nanoseconds));
-    EXPECT_TRUE(nanoseconds > 1000000000);
-    EXPECT_TRUE(nanoseconds < 2000000000);
+    EXPECT_EQUAL(nanoseconds, 10);
 
     END_TEST();
 }


### PR DESCRIPTION
This change updates the s2n timer tests to use a mocked out wall clock
time. This should avoid false negative unit test failures due to
inaccurate system clocks and slow test servers.