### PR TITLE
Support builds with existing libcrypto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@
 PLATFORM := $(shell uname)
 MAKEFLAGS += PLATFORM=$(PLATFORM)
 
+ifndef LIBCRYPTO_ROOT
+	export LIBCRYPTO_ROOT = $(shell echo "`pwd`/libcrypto-root")
+endif
+
 DIRS=$(wildcard */)
 SRCS=$(wildcard *.c)
 OBJS=$(SRCS:.c=.o)

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -8,7 +8,14 @@ git clone https://github.com/awslabs/s2n.git
 cd s2n
 ```
 
-s2n depends on a local copy of libcrypto for certain ciphers.
+## Building s2n with existing libcrypto
+
+To build s2n with an existing libcrypto installation, store its root folder in the
+`LIBCRYPTO_ROOT` environment variable.
+```shell
+# /usr/local/ssl/lib should contain libcrypto.a
+LIBCRYPTO_ROOT=/usr/local/ssl make
+```
 
 ## Building s2n with LibreSSL
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -13,7 +13,7 @@
 # permissions and limitations under the License.
 #
 
-OBJS = $(wildcard ../utils/*.o ../stuffer/*.o ../tls/*.o ../iana/*.o ../crypto/*.o ../error/*.o ../libcrypto-root/lib/libcrypto.a)
+OBJS = $(wildcard ../utils/*.o ../stuffer/*.o ../tls/*.o ../iana/*.o ../crypto/*.o ../error/*.o $(LIBCRYPTO_ROOT)/lib/libcrypto.a)
 
 .PHONY : all
 all: libs2n.a libs2n.so libs2n.dylib

--- a/s2n.mk
+++ b/s2n.mk
@@ -33,7 +33,7 @@ INDENT  = $(shell (if indent --version 2>&1 | grep GNU > /dev/null; then echo in
 
 CFLAGS = -pedantic -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-subscripts -Wuninitialized \
          -Wshadow -Wcast-qual -Wcast-align -Wwrite-strings -Wstack-protector -fPIC \
-         -std=c99 -D_POSIX_C_SOURCE=200112L -fstack-protector-all -O2 -I../libcrypto-root/include/ \
+         -std=c99 -D_POSIX_C_SOURCE=200112L -fstack-protector-all -O2 -I$(LIBCRYPTO_ROOT)/include/ \
          -I../api/ -I../ -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security \
          -D_FORTIFY_SOURCE=2
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,7 +13,7 @@
 # permissions and limitations under the License.
 #
 
-OPENSSL_VERSION=$(shell ../libcrypto-root/bin/openssl version 2> /dev/null || echo 1)
+OPENSSL_VERSION=$(shell $(LIBCRYPTO_ROOT)/bin/openssl version 2> /dev/null || echo 1)
 ifeq (${OPENSSL_VERSION}, 1)
 	COMPILE_INFO=Compiled with the missing version of openssl
 else

--- a/tests/testlib/Makefile
+++ b/tests/testlib/Makefile
@@ -15,14 +15,14 @@
 
 SRCS=$(wildcard *.c)
 OBJS=$(SRCS:.c=.o)
-CRYPTO_LDFLAGS = -L../../libcrypto-root/lib
+CRYPTO_LDFLAGS = -L$(LIBCRYPTO_ROOT)/lib
 
 .PHONY : all
 all: libtests2n.so libtests2n.dylib
 
 include ../../s2n.mk
 
-CFLAGS += -I../../ -I../../api/ -I../../libcrypto-root/include/
+CFLAGS += -I../../ -I../../api/ -I$(LIBCRYPTO_ROOT)/include/
 LDFLAGS += -L../../lib/ ${CRYPTO_LDFLAGS} -lcrypto -lpthread -ls2n
 
 libtests2n.so: ${OBJS}

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -17,7 +17,7 @@ SRCS=$(wildcard *.c)
 OBJS=$(SRCS:.c=.o)
 TESTS=$(SRCS:.c=)
 VALGRIND_TESTS=$(SRCS:.c=_valgrind)
-CRYPTO_LDFLAGS = -L../../libcrypto-root/lib
+CRYPTO_LDFLAGS = -L$(LIBCRYPTO_ROOT)/lib
 
 .PHONY : all
 all: $(TESTS)
@@ -29,12 +29,12 @@ LIBS += -lm
 
 # Suppress the unreachable code warning, because tests involve what should be
 # unreachable code
-CFLAGS += -Wno-unreachable-code -I../../libcrypto-root/include/ -I../../ -I../../api/
+CFLAGS += -Wno-unreachable-code -I$(LIBCRYPTO_ROOT)/include/ -I../../ -I../../api/
 LDFLAGS += -L../../lib/ ${CRYPTO_LDFLAGS} -L../testlib/ -ltests2n -ls2n ${LIBS} ${CRYPTO_LIBS}
 
 $(TESTS)::
 	@${CC} ${CFLAGS} -o $@ $@.c ${LDFLAGS} 2>&1
-	@DYLD_LIBRARY_PATH="../../lib/:../testlib/:$$DYLD_LIBRARY_PATH" LD_LIBRARY_PATH="../../lib/:../testlib/:$$LD_LIBRARY_PATH" ./$@
+	@DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" ./$@
 
 .PHONY : valgrind
 valgrind: $(TESTS)


### PR DESCRIPTION
This change allows users to build s2n with an arbitrary
libcrypto. Users should supply their install directory
in the "LIBCRYPTO_ROOT" environment variable before
building s2n.

closes #77 