### PR TITLE
Disable DRBG override for FIPS libcrypto

### DIFF
--- a/tests/unit/s2n_override_openssl_random_test.c
+++ b/tests/unit/s2n_override_openssl_random_test.c
@@ -24,7 +24,7 @@
 #include <openssl/dh.h>
 #include <s2n.h>
 
-#if !defined(OPENSSL_IS_BORINGSSL)
+#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_FIPS)
 
 static uint8_t dhparams[] =
     "-----BEGIN DH PARAMETERS-----\n"
@@ -41,7 +41,6 @@ int main(int argc, char **argv)
     struct s2n_blob b;
 
     BEGIN_TEST();
-
 
     EXPECT_EQUAL(s2n_get_private_random_bytes_used(), 0);
 

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -155,7 +155,7 @@ int64_t s2n_public_random(int64_t max)
     return -1;
 }
 
-#ifndef OPENSSL_IS_BORINGSSL
+#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_FIPS)
 
 int s2n_openssl_compat_rand(unsigned char *buf, int num)
 {
@@ -218,7 +218,7 @@ int s2n_init(void)
 
     GUARD(s2n_defend_if_forked());
 
-#ifndef OPENSSL_IS_BORINGSSL
+#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_FIPS)
     /* Create an engine */
     ENGINE *e = ENGINE_new();
     if (e == NULL ||


### PR DESCRIPTION
To maintain FIPS compliance we should not override any
functions provided by the "Openssl FIPS module". A FIPS
compliant libcrypto is linked with this module.

The module provides FIPS 140-2 compliant random number
generation via FIPS_rand_*. The default algorithm used
in FIPS mode is based on 256-bit CTR AES[1].

[1] https://wiki.openssl.org/index.php/Random_Numbers#FIPS_Mode