### PR TITLE
Disable DRBG override for LibreSSL

### DIFF
--- a/tests/unit/s2n_override_openssl_random_test.c
+++ b/tests/unit/s2n_override_openssl_random_test.c
@@ -24,7 +24,7 @@
 #include <openssl/dh.h>
 #include <s2n.h>
 
-#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_FIPS)
+#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_FIPS) && !defined(LIBRESSL_VERSION_NUMBER)
 
 static uint8_t dhparams[] =
     "-----BEGIN DH PARAMETERS-----\n"

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -155,7 +155,7 @@ int64_t s2n_public_random(int64_t max)
     return -1;
 }
 
-#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_FIPS)
+#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_FIPS) && !defined(LIBRESSL_VERSION_NUMBER)
 
 int s2n_openssl_compat_rand(unsigned char *buf, int num)
 {
@@ -218,7 +218,7 @@ int s2n_init(void)
 
     GUARD(s2n_defend_if_forked());
 
-#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_FIPS)
+#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_FIPS) && !defined(LIBRESSL_VERSION_NUMBER)
     /* Create an engine */
     ENGINE *e = ENGINE_new();
     if (e == NULL ||


### PR DESCRIPTION
It looks like our ENGINE setup succeeds, but
the code isn't actually run. LibreSSL will always
use the default generator(arc4random)[1]

[1] https://github.com/libressl-portable/openbsd/issues/36

closes #97 