### PR TITLE
s2n_send: Return -1 on blocked and no records sent

### DIFF
--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -129,7 +129,10 @@ ssize_t s2n_send(struct s2n_connection *conn, void *buf, ssize_t size, s2n_block
             w = s2n_stuffer_send_to_fd(&conn->out, conn->writefd, s2n_stuffer_data_available(&conn->out));
             if (w < 0) {
                 if (errno == EWOULDBLOCK) {
-                    return bytes_written;
+                    if (bytes_written) {
+                        return bytes_written;
+                    }
+                    return -1;
                 }
                 return -1;
             }


### PR DESCRIPTION
This now matches the behavior of s2n_recv. Previously s2n_send never
returned -1 on an EAGAIN.