### PR TITLE
Use S2N_ERR_IO for all errors but EAGAIN

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -32,6 +32,7 @@ extern __thread int s2n_errno;
 
 typedef enum {
     S2N_ERR_OK,
+    S2N_ERR_IO,
     S2N_ERR_KEY_INIT,
     S2N_ERR_ENCRYPT,
     S2N_ERR_DECRYPT,

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -33,6 +33,7 @@ extern __thread int s2n_errno;
 typedef enum {
     S2N_ERR_OK,
     S2N_ERR_IO,
+    S2N_ERR_BLOCKED,
     S2N_ERR_KEY_INIT,
     S2N_ERR_ENCRYPT,
     S2N_ERR_DECRYPT,

--- a/error/s2n_errno.c
+++ b/error/s2n_errno.c
@@ -31,6 +31,7 @@ struct s2n_error_translation
 
 struct s2n_error_translation EN[] = { 
     { S2N_ERR_OK, "no error" },
+    { S2N_ERR_IO, "underlying I/O operation failed, check system errno" },
     { S2N_ERR_KEY_INIT, "error initializing encryption key" },
     { S2N_ERR_ENCRYPT, "error encrypting data" },
     { S2N_ERR_DECRYPT, "error decrypting data" },

--- a/error/s2n_errno.c
+++ b/error/s2n_errno.c
@@ -32,6 +32,7 @@ struct s2n_error_translation
 struct s2n_error_translation EN[] = { 
     { S2N_ERR_OK, "no error" },
     { S2N_ERR_IO, "underlying I/O operation failed, check system errno" },
+    { S2N_ERR_BLOCKED, "underlying I/O operation would block" },
     { S2N_ERR_KEY_INIT, "error initializing encryption key" },
     { S2N_ERR_ENCRYPT, "error encrypting data" },
     { S2N_ERR_DECRYPT, "error decrypting data" },

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -218,7 +218,7 @@ static int handshake_read_io(struct s2n_connection *conn)
             S2N_ERROR(S2N_ERR_CLOSED);
         }
         if (errno == EWOULDBLOCK) {
-            return -1;
+            S2N_ERROR(S2N_ERR_BLOCKED);
         }
         S2N_ERROR(S2N_ERR_IO);
     }

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -217,7 +217,10 @@ static int handshake_read_io(struct s2n_connection *conn)
             conn->closed = 1;
             S2N_ERROR(S2N_ERR_CLOSED);
         }
-        return -1;
+        if (errno == EWOULDBLOCK) {
+            return -1;
+        }
+        S2N_ERROR(S2N_ERR_IO);
     }
 
     if (isSSLv2) {

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -131,7 +131,7 @@ ssize_t s2n_recv(struct s2n_connection *conn, void *buf, ssize_t size, s2n_block
                 *blocked = S2N_NOT_BLOCKED;
                 return bytes_read;
             }
-            return -1;
+            S2N_ERROR(S2N_ERR_IO);
         }
     
         if (isSSLv2) {

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -123,7 +123,7 @@ ssize_t s2n_recv(struct s2n_connection *conn, void *buf, ssize_t size, s2n_block
                 if (bytes_read) {
                     return bytes_read;
                 }
-                return -1;
+                S2N_ERROR(S2N_ERR_BLOCKED);
             }
             if (r == -2) {
                 conn->closed = 1;

--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -42,7 +42,7 @@ int s2n_flush(struct s2n_connection *conn, s2n_blocked_status *blocked)
         w = s2n_stuffer_send_to_fd(&conn->out, conn->writefd, s2n_stuffer_data_available(&conn->out));
         if (w < 0) {
             if (errno == EWOULDBLOCK) {
-                return -1;
+                S2N_ERROR(S2N_ERR_BLOCKED);
             }
             S2N_ERROR(S2N_ERR_IO);
         }
@@ -138,7 +138,7 @@ ssize_t s2n_send(struct s2n_connection *conn, void *buf, ssize_t size, s2n_block
                     if (bytes_written) {
                         return bytes_written;
                     }
-                    return -1;
+                    S2N_ERROR(S2N_ERR_BLOCKED);
                 }
                 S2N_ERROR(S2N_ERR_IO);
             }


### PR DESCRIPTION
This changes all s2n I/O functions to set s2n_errno to S2N_ERR_IO
for failures in the underlying I/O syscalls. This does not include
EAGAIN for nonblocking fds. This simplifies caller error handling.
Previously multiple error causes returned without setting s2n_errno.


---

Should we also add something like S2N_ERR_BLOCKED for the blocked case? That way we can be consistent with setting s2n_errno for all -1 return values.