### PR TITLE
Use MIN/MAX macros to avoid in-code branches

### DIFF
--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -194,7 +194,7 @@ int s2n_stuffer_skip_write(struct s2n_stuffer *stuffer, const uint32_t n)
     if (s2n_stuffer_space_remaining(stuffer) < n) {
         if (stuffer->growable) {
             /* Always grow a stuffer by at least 1k */
-            uint32_t growth = MAX(n, 1024);
+            uint32_t growth = MIN(n, 1024);
 
             GUARD(s2n_stuffer_resize(stuffer, stuffer->blob.size + growth));
         } else {

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -102,7 +102,7 @@ int s2n_stuffer_resize(struct s2n_stuffer *stuffer, const uint32_t size)
 int s2n_stuffer_rewrite(struct s2n_stuffer *stuffer)
 {
     stuffer->write_cursor = 0;
-    stuffer->read_cursor = MIN(stuffer->read_cursor, stuffer->write_cursor);
+    stuffer->read_cursor = 0;
 
     return 0;
 }
@@ -194,7 +194,7 @@ int s2n_stuffer_skip_write(struct s2n_stuffer *stuffer, const uint32_t n)
     if (s2n_stuffer_space_remaining(stuffer) < n) {
         if (stuffer->growable) {
             /* Always grow a stuffer by at least 1k */
-            uint32_t growth = MIN(n, 1024);
+            uint32_t growth = MAX(n, 1024);
 
             GUARD(s2n_stuffer_resize(stuffer, stuffer->blob.size + growth));
         } else {

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -112,10 +112,9 @@ static int handshake_write_io(struct s2n_connection *conn)
     /* Write the handshake data to records in fragment sized chunks */
     struct s2n_blob out;
     while(s2n_stuffer_data_available(&conn->handshake.io) > 0) {
-        out.size = s2n_stuffer_data_available(&conn->handshake.io);
 
         GUARD((max_payload_size = s2n_record_max_write_payload_size(conn)));
-        out.size = MIN(out.size, max_payload_size);
+        out.size = MIN(s2n_stuffer_data_available(&conn->handshake.io), max_payload_size);
 
         out.data = s2n_stuffer_raw_read(&conn->handshake.io, out.size);
         notnull_check(out.data);

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+#include <sys/param.h>
+
 #include <errno.h>
 #include <s2n.h>
 
@@ -113,9 +115,7 @@ static int handshake_write_io(struct s2n_connection *conn)
         out.size = s2n_stuffer_data_available(&conn->handshake.io);
 
         GUARD((max_payload_size = s2n_record_max_write_payload_size(conn)));
-        if (out.size > max_payload_size) {
-            out.size = max_payload_size;
-        }
+        out.size = MIN(out.size, max_payload_size);
 
         out.data = s2n_stuffer_raw_read(&conn->handshake.io, out.size);
         notnull_check(out.data);

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 
+#include <sys/param.h>
 #include <openssl/md5.h>
 #include <openssl/sha.h>
 #include <string.h>
@@ -62,10 +63,7 @@ static int s2n_sslv3_prf(union s2n_prf_working_space *ws, struct s2n_blob *secre
         GUARD(s2n_hash_update(md5, ws->ssl3.sha1_digest, sizeof(ws->ssl3.sha1_digest)));
         GUARD(s2n_hash_digest(md5, ws->ssl3.md5_digest, sizeof(ws->ssl3.md5_digest)));
 
-        uint32_t bytes_to_copy = outputlen;
-        if (bytes_to_copy > sizeof(ws->ssl3.md5_digest)) {
-            bytes_to_copy = sizeof(ws->ssl3.md5_digest);
-        }
+        uint32_t bytes_to_copy = MIN(outputlen, sizeof(ws->ssl3.md5_digest));
 
         memcpy_check(output, ws->ssl3.md5_digest, bytes_to_copy);
 
@@ -112,10 +110,7 @@ static int s2n_p_hash(union s2n_prf_working_space *ws, s2n_hmac_algorithm alg, s
         }
         GUARD(s2n_hmac_digest(hmac, ws->tls.digest1, digest_size));
 
-        uint32_t bytes_to_xor = outputlen;
-        if (bytes_to_xor > digest_size) {
-            bytes_to_xor = digest_size;
-        }
+        uint32_t bytes_to_xor = MIN(outputlen, digest_size);
 
         for (int i = 0; i < bytes_to_xor; i++) {
             *output ^= ws->tls.digest1[i];

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+#include <sys/param.h>
+
 /* Use usleep */
 #define _XOPEN_SOURCE 500
 #include <unistd.h>
@@ -150,10 +152,7 @@ ssize_t s2n_recv(struct s2n_connection *conn, void *buf, ssize_t size, s2n_block
             continue;
         }
 
-        out.size = size;
-        if (out.size > s2n_stuffer_data_available(&conn->in)) {
-            out.size = s2n_stuffer_data_available(&conn->in);
-        }
+        out.size = MIN(size, s2n_stuffer_data_available(&conn->in));
 
         GUARD(s2n_stuffer_erase_and_read(&conn->in, &out));
         bytes_read += out.size;

--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 
+#include <sys/param.h>
 #include <errno.h>
 #include <s2n.h>
 
@@ -105,10 +106,7 @@ ssize_t s2n_send(struct s2n_connection *conn, void *buf, ssize_t size, s2n_block
 
     /* Now write the data we were asked to send this round */
     while (size) {
-        in.size = size;
-        if (in.size > max_payload_size) {
-            in.size = max_payload_size;
-        }
+        in.size = MIN(size, max_payload_size);
 
         if (conn->actual_protocol_version < S2N_TLS11 && conn->active.cipher_suite->cipher->type == S2N_CBC) {
             if (in.size > 1 && cbcHackUsed == 0) {

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+#include <sys/param.h>
+
 #include <s2n.h>
 #include <time.h>
 
@@ -122,9 +124,7 @@ int s2n_server_hello_send(struct s2n_connection *conn)
     notnull_check(r.data);
     GUARD(s2n_get_public_random_data(&r));
 
-    if (conn->client_protocol_version < conn->server_protocol_version) {
-        conn->actual_protocol_version = conn->client_protocol_version;
-    }
+    conn->actual_protocol_version = MIN(conn->client_protocol_version, conn->server_protocol_version);
 
     protocol_version[0] = conn->actual_protocol_version / 10;
     protocol_version[1] = conn->actual_protocol_version % 10;


### PR DESCRIPTION
This change removes code by using simple MIN/MAX macros where possible.
Those places identified by Ernie Cohen.