### PR TITLE
Only wipe when returning 0 in s2n_recv

### DIFF
--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -108,6 +108,7 @@ ssize_t s2n_recv(struct s2n_connection *conn, void *buf, ssize_t size, s2n_block
     struct s2n_blob out = {.data = (uint8_t *) buf };
 
     if (conn->closed) {
+        GUARD(s2n_connection_wipe(conn));
         return 0;
     }
 
@@ -127,8 +128,10 @@ ssize_t s2n_recv(struct s2n_connection *conn, void *buf, ssize_t size, s2n_block
             }
             if (r == -2) {
                 conn->closed = 1;
-                GUARD(s2n_connection_wipe(conn));
                 *blocked = S2N_NOT_BLOCKED;
+                if (!bytes_read) {
+                    GUARD(s2n_connection_wipe(conn));
+                }
                 return bytes_read;
             }
             S2N_ERROR(S2N_ERR_IO);


### PR DESCRIPTION
Current code leaves open the possibility of wiping when "0" wasn't returned. The caller would just see a partial read and not know the struct was wiped. 


NOTE: I don't think bytes_read is ever non-zero in the closed code path because s2n_recv currently reads a single record and returns. However I think this change is more "defensive" to future changes.