### PR TITLE
Skip ciphers that clients shouldn't support

### DIFF
--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -131,6 +131,11 @@ static int s2n_set_cipher_as_server(struct s2n_connection *conn, uint8_t *wire, 
                     continue;
                 }
 
+                /* Don't choose a suite the client shouldn't be able support */
+                if (conn->client_protocol_version < match->minimum_required_tls_version) {
+                    continue;
+                }
+
                 conn->pending.cipher_suite = match;
                 return 0;
             }


### PR DESCRIPTION
When selecting ciphers using server preference, skip any cipher
that's defined in a later version than the client supports.
Technically clients shouldn't even have these "newer" ciphers in
their client hello.

----

I suppose we could immediately fail the handshake if we encounter this case, but I don't think it's a reasonable attack vector to just move to the next cipher suite. Thoughts? Openssl opts to just move on as well: https://github.com/openssl/openssl/blob/8f09ba471c256020f8147c421e32b4d5fc162960/ssl/s3_lib.c#L3599 (took me way too long to figure this out)