### PR TITLE
Silence output when building travis dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,21 +9,11 @@ compiler:
   - clang
 
 install:
-  - cd libcrypto-build
-  - curl -L https://www.openssl.org/source/openssl-1.0.2-latest.tar.gz > openssl-1.0.2.tar.gz
-  - tar -xzvf openssl-1.0.2.tar.gz
-  - rm openssl-1.0.2.tar.gz
-  - cd openssl-1.0.2*
-  - (test "$TRAVIS_OS_NAME" = "linux" && ./config -fPIC no-shared no-libunbound no-gmp no-jpake no-krb5 no-md2 no-rc5 no-rfc3779 no-sctp no-ssl-trace no-store no-zlib no-hw no-mdc2 no-seed no-idea enable-ec-nist_64_gcc_128 no-camellia no-bf no-ripemd no-dsa no-ssl2 no-capieng -DSSL_FORBID_ENULL -DOPENSSL_NO_DTLS1 -DOPENSSL_NO_HEARTBEATS --prefix=`pwd`/../../libcrypto-root/) || true
-  - (test "$TRAVIS_OS_NAME" = "osx" && ./Configure darwin64-x86_64-cc -fPIC --prefix=`pwd`/../../libcrypto-root/) || true
-  - make depend
-  - make
-  - make install
-  - cd ../../
+  - .travis/install_openssl.sh `pwd`/libcrypto-build `pwd`/libcrypto-root $TRAVIS_OS_NAME > /dev/null
   # Install python linked with our compiled Openssl for integration tests
-  - .travis/install_python.sh `pwd`/libcrypto-root
+  - .travis/install_python.sh `pwd`/libcrypto-root > /dev/null
   # Install prlimit to set the memlock limit to unlimited for this process 
-  - (test "$TRAVIS_OS_NAME" = "linux" && sudo .travis/install_prlimit.sh $PWD/.travis && sudo .travis/prlimit --pid "$$" --memlock=unlimited:unlimited) || true
+  - (test "$TRAVIS_OS_NAME" = "linux" && sudo .travis/install_prlimit.sh $PWD/.travis > /dev/null && sudo .travis/prlimit --pid "$$" --memlock=unlimited:unlimited) || true
 
 script:
   - make

--- a/.travis/install_openssl.sh
+++ b/.travis/install_openssl.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+set -e
+pushd `pwd`
+
+usage() {
+	echo "install_openssl.sh build_dir install_dir travis_platform"
+	exit 1
+}
+
+if [ "$#" -ne "3" ]; then
+	usage
+fi
+
+BUILD_DIR=$1
+INSTALL_DIR=$2
+PLATFORM=$3
+
+cd $BUILD_DIR
+curl -L https://www.openssl.org/source/openssl-1.0.2-latest.tar.gz > openssl-1.0.2.tar.gz
+tar -xzvf openssl-1.0.2.tar.gz
+rm openssl-1.0.2.tar.gz
+cd openssl-1.0.2*
+
+if [ "$PLATFORM" == "linux" ]; then
+	./config -fPIC no-shared no-libunbound no-gmp no-jpake no-krb5 no-md2 no-rc5 no-rfc3779 no-sctp no-ssl-trace \
+			 no-store no-zlib no-hw no-mdc2 no-seed no-idea enable-ec-nist_64_gcc_128 no-camellia no-bf no-ripemd \
+			 no-dsa no-ssl2 no-capieng -DSSL_FORBID_ENULL -DOPENSSL_NO_DTLS1 -DOPENSSL_NO_HEARTBEATS \
+			 --prefix=$INSTALL_DIR
+elif [ "$PLATFORM" == "osx" ]; then
+	./Configure darwin64-x86_64-cc -fPIC --prefix=$INSTALL_DIR
+else
+	echo "Invalid platform! $PLATFORM"
+	usage
+fi
+
+make depend
+make
+make install
+
+popd
+
+exit 0


### PR DESCRIPTION
Our build output log in TravisCI was being inflated by the output of
installing Openssl/Python/util-linux. Also added the install_openssl.sh
helper to make the .travis.yml cleaner.