### PR TITLE
Add init function to s2n_cipher

### DIFF
--- a/crypto/s2n_aead_cipher_aes_gcm.c
+++ b/crypto/s2n_aead_cipher_aes_gcm.c
@@ -111,7 +111,6 @@ static int s2n_aead_cipher_aes128_gcm_get_encryption_key(struct s2n_session_key 
 {
     eq_check(in->size, 16);
 
-    EVP_CIPHER_CTX_init(&key->native_format.evp_cipher_ctx);
     EVP_EncryptInit_ex(&key->native_format.evp_cipher_ctx, EVP_aes_128_gcm(), NULL, NULL, NULL);
     EVP_CIPHER_CTX_ctrl(&key->native_format.evp_cipher_ctx, EVP_CTRL_GCM_SET_IVLEN, S2N_TLS_GCM_IV_LEN, NULL);
     EVP_EncryptInit_ex(&key->native_format.evp_cipher_ctx, NULL, NULL, in->data, NULL);
@@ -123,7 +122,6 @@ static int s2n_aead_cipher_aes256_gcm_get_encryption_key(struct s2n_session_key 
 {
     eq_check(in->size, 32);
 
-    EVP_CIPHER_CTX_init(&key->native_format.evp_cipher_ctx);
     EVP_EncryptInit_ex(&key->native_format.evp_cipher_ctx, EVP_aes_256_gcm(), NULL, NULL, NULL);
     EVP_CIPHER_CTX_ctrl(&key->native_format.evp_cipher_ctx, EVP_CTRL_GCM_SET_IVLEN, S2N_TLS_GCM_IV_LEN, NULL);
     EVP_EncryptInit_ex(&key->native_format.evp_cipher_ctx, NULL, NULL, in->data, NULL);
@@ -135,7 +133,6 @@ static int s2n_aead_cipher_aes128_gcm_get_decryption_key(struct s2n_session_key 
 {
     eq_check(in->size, 16);
 
-    EVP_CIPHER_CTX_init(&key->native_format.evp_cipher_ctx);
     EVP_DecryptInit_ex(&key->native_format.evp_cipher_ctx, EVP_aes_128_gcm(), NULL, NULL, NULL);
     EVP_CIPHER_CTX_ctrl(&key->native_format.evp_cipher_ctx, EVP_CTRL_GCM_SET_IVLEN, S2N_TLS_GCM_IV_LEN, NULL);
     EVP_DecryptInit_ex(&key->native_format.evp_cipher_ctx, NULL, NULL, in->data, NULL);
@@ -147,10 +144,16 @@ static int s2n_aead_cipher_aes256_gcm_get_decryption_key(struct s2n_session_key 
 {
     eq_check(in->size, 32);
 
-    EVP_CIPHER_CTX_init(&key->native_format.evp_cipher_ctx);
     EVP_DecryptInit_ex(&key->native_format.evp_cipher_ctx, EVP_aes_256_gcm(), NULL, NULL, NULL);
     EVP_CIPHER_CTX_ctrl(&key->native_format.evp_cipher_ctx, EVP_CTRL_GCM_SET_IVLEN, S2N_TLS_GCM_IV_LEN, NULL);
     EVP_DecryptInit_ex(&key->native_format.evp_cipher_ctx, NULL, NULL, in->data, NULL);
+
+    return 0;
+}
+
+static int s2n_aead_cipher_aes_gcm_init(struct s2n_session_key *key)
+{
+    EVP_CIPHER_CTX_init(&key->native_format.evp_cipher_ctx);
 
     return 0;
 }
@@ -171,6 +174,7 @@ struct s2n_cipher s2n_aes128_gcm = {
                 .tag_size = S2N_TLS_GCM_TAG_LEN,
                 .decrypt = s2n_aead_cipher_aes_gcm_decrypt,
                 .encrypt = s2n_aead_cipher_aes_gcm_encrypt},
+    .init = s2n_aead_cipher_aes_gcm_init,
     .get_encryption_key = s2n_aead_cipher_aes128_gcm_get_encryption_key,
     .get_decryption_key = s2n_aead_cipher_aes128_gcm_get_decryption_key,
     .destroy_key = s2n_aead_cipher_aes_gcm_destroy_key,
@@ -185,6 +189,7 @@ struct s2n_cipher s2n_aes256_gcm = {
                 .tag_size = S2N_TLS_GCM_TAG_LEN,
                 .decrypt = s2n_aead_cipher_aes_gcm_decrypt,
                 .encrypt = s2n_aead_cipher_aes_gcm_encrypt},
+    .init = s2n_aead_cipher_aes_gcm_init,
     .get_encryption_key = s2n_aead_cipher_aes256_gcm_get_encryption_key,
     .get_decryption_key = s2n_aead_cipher_aes256_gcm_get_decryption_key,
     .destroy_key = s2n_aead_cipher_aes_gcm_destroy_key,

--- a/crypto/s2n_cbc_cipher_3des.c
+++ b/crypto/s2n_cbc_cipher_3des.c
@@ -42,7 +42,7 @@ static int s2n_cbc_cipher_3des_encrypt(struct s2n_session_key *key, struct s2n_b
     return 0;
 }
 
-int s2n_cbc_cipher_3des_decrypt(struct s2n_session_key *key, struct s2n_blob *iv, struct s2n_blob *in, struct s2n_blob *out)
+static int s2n_cbc_cipher_3des_decrypt(struct s2n_session_key *key, struct s2n_blob *iv, struct s2n_blob *in, struct s2n_blob *out)
 {
     gte_check(out->size, in->size);
 
@@ -58,22 +58,27 @@ int s2n_cbc_cipher_3des_decrypt(struct s2n_session_key *key, struct s2n_blob *iv
     return 0;
 }
 
-int s2n_cbc_cipher_3des_get_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
+static int s2n_cbc_cipher_3des_get_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
     eq_check(in->size, 192 / 8);
-    EVP_CIPHER_CTX_init(&key->native_format.evp_cipher_ctx);
     EVP_CIPHER_CTX_set_padding(&key->native_format.evp_cipher_ctx, EVP_CIPH_NO_PADDING);
     EVP_DecryptInit_ex(&key->native_format.evp_cipher_ctx, EVP_des_ede3_cbc(), NULL, in->data, NULL);
 
     return 0;
 }
 
-int s2n_cbc_cipher_3des_get_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
+static int s2n_cbc_cipher_3des_get_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
     eq_check(in->size, 192 / 8);
-    EVP_CIPHER_CTX_init(&key->native_format.evp_cipher_ctx);
     EVP_CIPHER_CTX_set_padding(&key->native_format.evp_cipher_ctx, EVP_CIPH_NO_PADDING);
     EVP_EncryptInit_ex(&key->native_format.evp_cipher_ctx, EVP_des_ede3_cbc(), NULL, in->data, NULL);
+
+    return 0;
+}
+
+static int s2n_cbc_cipher_3des_init(struct s2n_session_key *key)
+{
+    EVP_CIPHER_CTX_init(&key->native_format.evp_cipher_ctx);
 
     return 0;
 }
@@ -93,6 +98,7 @@ struct s2n_cipher s2n_3des = {
                .record_iv_size = 8,
                .decrypt = s2n_cbc_cipher_3des_decrypt,
                .encrypt = s2n_cbc_cipher_3des_encrypt},
+    .init = s2n_cbc_cipher_3des_init,
     .get_decryption_key = s2n_cbc_cipher_3des_get_decryption_key,
     .get_encryption_key = s2n_cbc_cipher_3des_get_encryption_key,
     .destroy_key = s2n_cbc_cipher_3des_destroy_key,

--- a/crypto/s2n_cbc_cipher_aes.c
+++ b/crypto/s2n_cbc_cipher_aes.c
@@ -61,27 +61,24 @@ int s2n_cbc_cipher_aes_decrypt(struct s2n_session_key *key, struct s2n_blob *iv,
 int s2n_cbc_cipher_aes128_get_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
     eq_check(in->size, 128 / 8);
-    EVP_CIPHER_CTX_init(&key->native_format.evp_cipher_ctx);
     EVP_CIPHER_CTX_set_padding(&key->native_format.evp_cipher_ctx, EVP_CIPH_NO_PADDING);
     EVP_DecryptInit_ex(&key->native_format.evp_cipher_ctx, EVP_aes_128_cbc(), NULL, in->data, NULL);
 
     return 0;
 }
 
-int s2n_cbc_cipher_aes128_get_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
+static int s2n_cbc_cipher_aes128_get_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
     eq_check(in->size, 128 / 8);
-    EVP_CIPHER_CTX_init(&key->native_format.evp_cipher_ctx);
     EVP_CIPHER_CTX_set_padding(&key->native_format.evp_cipher_ctx, EVP_CIPH_NO_PADDING);
     EVP_EncryptInit_ex(&key->native_format.evp_cipher_ctx, EVP_aes_128_cbc(), NULL, in->data, NULL);
 
     return 0;
 }
 
-int s2n_cbc_cipher_aes256_get_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
+static int s2n_cbc_cipher_aes256_get_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
     eq_check(in->size, 256 / 8);
-    EVP_CIPHER_CTX_init(&key->native_format.evp_cipher_ctx);
     EVP_CIPHER_CTX_set_padding(&key->native_format.evp_cipher_ctx, EVP_CIPH_NO_PADDING);
     EVP_DecryptInit_ex(&key->native_format.evp_cipher_ctx, EVP_aes_256_cbc(), NULL, in->data, NULL);
 
@@ -94,6 +91,13 @@ int s2n_cbc_cipher_aes256_get_encryption_key(struct s2n_session_key *key, struct
     EVP_CIPHER_CTX_init(&key->native_format.evp_cipher_ctx);
     EVP_CIPHER_CTX_set_padding(&key->native_format.evp_cipher_ctx, EVP_CIPH_NO_PADDING);
     EVP_EncryptInit_ex(&key->native_format.evp_cipher_ctx, EVP_aes_256_cbc(), NULL, in->data, NULL);
+
+    return 0;
+}
+
+static int s2n_cbc_cipher_aes_init(struct s2n_session_key *key)
+{
+    EVP_CIPHER_CTX_init(&key->native_format.evp_cipher_ctx);
 
     return 0;
 }
@@ -113,6 +117,7 @@ struct s2n_cipher s2n_aes128 = {
                .record_iv_size = 16,
                .decrypt = s2n_cbc_cipher_aes_decrypt,
                .encrypt = s2n_cbc_cipher_aes_encrypt},
+    .init = s2n_cbc_cipher_aes_init,
     .get_decryption_key = s2n_cbc_cipher_aes128_get_decryption_key,
     .get_encryption_key = s2n_cbc_cipher_aes128_get_encryption_key,
     .destroy_key = s2n_cbc_cipher_aes_destroy_key,
@@ -126,6 +131,7 @@ struct s2n_cipher s2n_aes256 = {
                .record_iv_size = 16,
                .decrypt = s2n_cbc_cipher_aes_decrypt,
                .encrypt = s2n_cbc_cipher_aes_encrypt},
+    .init = s2n_cbc_cipher_aes_init,
     .get_decryption_key = s2n_cbc_cipher_aes256_get_decryption_key,
     .get_encryption_key = s2n_cbc_cipher_aes256_get_encryption_key,
     .destroy_key = s2n_cbc_cipher_aes_destroy_key,

--- a/crypto/s2n_cipher.h
+++ b/crypto/s2n_cipher.h
@@ -66,6 +66,7 @@ struct s2n_cipher {
         struct s2n_cbc_cipher cbc;
     } io;
     uint8_t key_material_size;
+    int (*init) (struct s2n_session_key *key);
     int (*get_decryption_key) (struct s2n_session_key *key, struct s2n_blob *in);
     int (*get_encryption_key) (struct s2n_session_key *key, struct s2n_blob *in);
     int (*destroy_key) (struct s2n_session_key *key);

--- a/crypto/s2n_stream_cipher_null.c
+++ b/crypto/s2n_stream_cipher_null.c
@@ -20,7 +20,7 @@
 #include "utils/s2n_safety.h"
 #include "utils/s2n_blob.h"
 
-int s2n_stream_cipher_null_endecrypt(struct s2n_session_key *key, struct s2n_blob *in, struct s2n_blob *out)
+static int s2n_stream_cipher_null_endecrypt(struct s2n_session_key *key, struct s2n_blob *in, struct s2n_blob *out)
 {
     if (out->data < in->data) {
         S2N_ERROR(S2N_ERR_SIZE_MISMATCH);
@@ -32,12 +32,17 @@ int s2n_stream_cipher_null_endecrypt(struct s2n_session_key *key, struct s2n_blo
     return 0;
 }
 
-int s2n_stream_cipher_null_get_key(struct s2n_session_key *key, struct s2n_blob *in)
+static int s2n_stream_cipher_null_get_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
     return 0;
 }
 
-int s2n_stream_cipher_null_destroy_key(struct s2n_session_key *key)
+static int s2n_stream_cipher_null_destroy_key(struct s2n_session_key *key)
+{
+    return 0;
+}
+
+static int s2n_stream_cipher_null_init(struct s2n_session_key *key)
 {
     return 0;
 }
@@ -48,6 +53,7 @@ struct s2n_cipher s2n_null_cipher = {
     .io.stream = {
                   .decrypt = s2n_stream_cipher_null_endecrypt,
                   .encrypt = s2n_stream_cipher_null_endecrypt},
+    .init = s2n_stream_cipher_null_init,
     .get_encryption_key = s2n_stream_cipher_null_get_key,
     .get_decryption_key = s2n_stream_cipher_null_get_key,
     .destroy_key = s2n_stream_cipher_null_destroy_key,

--- a/crypto/s2n_stream_cipher_rc4.c
+++ b/crypto/s2n_stream_cipher_rc4.c
@@ -20,21 +20,26 @@
 #include "utils/s2n_safety.h"
 #include "utils/s2n_blob.h"
 
-int s2n_stream_cipher_rc4_endecrypt(struct s2n_session_key *key, struct s2n_blob *in, struct s2n_blob *out)
+static int s2n_stream_cipher_rc4_endecrypt(struct s2n_session_key *key, struct s2n_blob *in, struct s2n_blob *out)
 {
     gte_check(out->size, in->size);
     RC4(&key->native_format.rc4, out->size, in->data, out->data);
     return 0;
 }
 
-int s2n_stream_cipher_rc4_get_key(struct s2n_session_key *key, struct s2n_blob *in)
+static int s2n_stream_cipher_rc4_get_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
     eq_check(in->size, 16);
     RC4_set_key(&key->native_format.rc4, in->size, in->data);
     return 0;
 }
 
-int s2n_stream_cipher_rc4_destroy_key(struct s2n_session_key *key)
+static int s2n_stream_cipher_rc4_init(struct s2n_session_key *key)
+{
+    return 0;
+}
+
+static int s2n_stream_cipher_rc4_destroy_key(struct s2n_session_key *key)
 {
     return 0;
 }
@@ -45,6 +50,7 @@ struct s2n_cipher s2n_rc4 = {
     .io.stream = {
                   .decrypt = s2n_stream_cipher_rc4_endecrypt,
                   .encrypt = s2n_stream_cipher_rc4_endecrypt},
+    .init = s2n_stream_cipher_rc4_init,
     .get_decryption_key = s2n_stream_cipher_rc4_get_key,
     .get_encryption_key = s2n_stream_cipher_rc4_get_key,
     .destroy_key = s2n_stream_cipher_rc4_destroy_key,

--- a/tests/unit/s2n_3des_test.c
+++ b/tests/unit/s2n_3des_test.c
@@ -51,6 +51,8 @@ int main(int argc, char **argv)
     /* test the 3des cipher with a SHA1 hash */
     conn->active.cipher_suite->cipher = &s2n_3des;
     conn->active.cipher_suite->hmac_alg = S2N_HMAC_SHA1;
+    EXPECT_SUCCESS(conn->active.cipher_suite->cipher->init(&conn->active.server_key));
+    EXPECT_SUCCESS(conn->active.cipher_suite->cipher->init(&conn->active.client_key));
     EXPECT_SUCCESS(conn->active.cipher_suite->cipher->get_encryption_key(&conn->active.server_key, &des3));
     EXPECT_SUCCESS(conn->active.cipher_suite->cipher->get_decryption_key(&conn->active.client_key, &des3));
     EXPECT_SUCCESS(s2n_hmac_init(&conn->active.client_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));

--- a/tests/unit/s2n_aead_aes_test.c
+++ b/tests/unit/s2n_aead_aes_test.c
@@ -26,9 +26,20 @@
 #include "stuffer/s2n_stuffer.h"
 #include "crypto/s2n_cipher.h"
 #include "utils/s2n_random.h"
+#include "utils/s2n_safety.h"
 #include "crypto/s2n_hmac.h"
 #include "tls/s2n_record.h"
 #include "tls/s2n_prf.h"
+
+static int setup_server_keys(struct s2n_connection *server_conn, struct s2n_blob *key)
+{
+    GUARD(server_conn->active.cipher_suite->cipher->init(&server_conn->active.server_key));
+    GUARD(server_conn->active.cipher_suite->cipher->init(&server_conn->active.client_key));
+    GUARD(server_conn->active.cipher_suite->cipher->get_encryption_key(&server_conn->active.server_key, key));
+    GUARD(server_conn->active.cipher_suite->cipher->get_decryption_key(&server_conn->active.client_key, key));
+
+    return 0;
+}
 
 int main(int argc, char **argv)
 {
@@ -53,8 +64,7 @@ int main(int argc, char **argv)
     /* test the AES128 cipher with a SHA1 hash */
     conn->active.cipher_suite->cipher = &s2n_aes128_gcm;
     conn->active.cipher_suite->hmac_alg = S2N_HMAC_SHA1;
-    EXPECT_SUCCESS(conn->active.cipher_suite->cipher->get_encryption_key(&conn->active.server_key, &aes128));
-    EXPECT_SUCCESS(conn->active.cipher_suite->cipher->get_decryption_key(&conn->active.client_key, &aes128));
+    EXPECT_SUCCESS(setup_server_keys(conn, &aes128));
     EXPECT_SUCCESS(s2n_hmac_init(&conn->active.client_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
     EXPECT_SUCCESS(s2n_hmac_init(&conn->active.server_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
     conn->actual_protocol_version = S2N_TLS12;
@@ -65,8 +75,7 @@ int main(int argc, char **argv)
         int bytes_written;
 
         EXPECT_SUCCESS(s2n_connection_wipe(conn));
-        EXPECT_SUCCESS(conn->active.cipher_suite->cipher->get_encryption_key(&conn->active.server_key, &aes128));
-        EXPECT_SUCCESS(conn->active.cipher_suite->cipher->get_decryption_key(&conn->active.client_key, &aes128));
+        EXPECT_SUCCESS(setup_server_keys(conn, &aes128));
         EXPECT_SUCCESS(s2n_hmac_init(&conn->active.client_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
         EXPECT_SUCCESS(s2n_hmac_init(&conn->active.server_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
         EXPECT_SUCCESS(bytes_written = s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
@@ -114,8 +123,7 @@ int main(int argc, char **argv)
 
         /* Start over */
         EXPECT_SUCCESS(s2n_connection_wipe(conn));
-        EXPECT_SUCCESS(conn->active.cipher_suite->cipher->get_encryption_key(&conn->active.server_key, &aes128));
-        EXPECT_SUCCESS(conn->active.cipher_suite->cipher->get_decryption_key(&conn->active.client_key, &aes128));
+        EXPECT_SUCCESS(setup_server_keys(conn, &aes128));
         EXPECT_SUCCESS(s2n_hmac_init(&conn->active.client_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
         EXPECT_SUCCESS(s2n_hmac_init(&conn->active.server_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
         EXPECT_SUCCESS(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
@@ -139,8 +147,7 @@ int main(int argc, char **argv)
         /* Tamper with the IV and ensure decryption fails */
         for (int j = 0; j < S2N_TLS_GCM_IV_LEN; j++) {
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
-            EXPECT_SUCCESS(conn->active.cipher_suite->cipher->get_encryption_key(&conn->active.server_key, &aes128));
-            EXPECT_SUCCESS(conn->active.cipher_suite->cipher->get_decryption_key(&conn->active.client_key, &aes128));
+            EXPECT_SUCCESS(setup_server_keys(conn, &aes128));
             EXPECT_SUCCESS(s2n_hmac_init(&conn->active.client_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
             EXPECT_SUCCESS(s2n_hmac_init(&conn->active.server_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
             EXPECT_SUCCESS(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
@@ -162,8 +169,7 @@ int main(int argc, char **argv)
         /* Tamper with the TAG and ensure decryption fails */
         for (int j = 0; j < S2N_TLS_GCM_TAG_LEN; j++) {
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
-            EXPECT_SUCCESS(conn->active.cipher_suite->cipher->get_encryption_key(&conn->active.server_key, &aes128));
-            EXPECT_SUCCESS(conn->active.cipher_suite->cipher->get_decryption_key(&conn->active.client_key, &aes128));
+            EXPECT_SUCCESS(setup_server_keys(conn, &aes128));
             EXPECT_SUCCESS(s2n_hmac_init(&conn->active.client_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
             EXPECT_SUCCESS(s2n_hmac_init(&conn->active.server_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
             EXPECT_SUCCESS(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
@@ -185,8 +191,7 @@ int main(int argc, char **argv)
         /* Tamper with the ciphertext and ensure decryption fails */
         for (int j = 0; j < i - S2N_TLS_GCM_TAG_LEN; j++) {
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
-            EXPECT_SUCCESS(conn->active.cipher_suite->cipher->get_encryption_key(&conn->active.server_key, &aes128));
-            EXPECT_SUCCESS(conn->active.cipher_suite->cipher->get_decryption_key(&conn->active.client_key, &aes128));
+            EXPECT_SUCCESS(setup_server_keys(conn, &aes128));
             EXPECT_SUCCESS(s2n_hmac_init(&conn->active.client_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
             EXPECT_SUCCESS(s2n_hmac_init(&conn->active.server_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
             EXPECT_SUCCESS(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
@@ -213,8 +218,7 @@ int main(int argc, char **argv)
     EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
     conn->active.cipher_suite->cipher = &s2n_aes256_gcm;
     conn->active.cipher_suite->hmac_alg = S2N_HMAC_SHA1;
-    EXPECT_SUCCESS(conn->active.cipher_suite->cipher->get_encryption_key(&conn->active.server_key, &aes256));
-    EXPECT_SUCCESS(conn->active.cipher_suite->cipher->get_decryption_key(&conn->active.client_key, &aes256));
+    EXPECT_SUCCESS(setup_server_keys(conn, &aes256));
     EXPECT_SUCCESS(s2n_hmac_init(&conn->active.client_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
     EXPECT_SUCCESS(s2n_hmac_init(&conn->active.server_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
     conn->actual_protocol_version = S2N_TLS12;
@@ -225,9 +229,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_wipe(conn));
         conn->active.cipher_suite->cipher = &s2n_aes256_gcm;
-        conn->active.cipher_suite->cipher = &s2n_aes256_gcm;
-        EXPECT_SUCCESS(conn->active.cipher_suite->cipher->get_encryption_key(&conn->active.server_key, &aes256));
-        EXPECT_SUCCESS(conn->active.cipher_suite->cipher->get_decryption_key(&conn->active.client_key, &aes256));
+        EXPECT_SUCCESS(setup_server_keys(conn, &aes256));
         EXPECT_SUCCESS(s2n_hmac_init(&conn->active.client_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
         EXPECT_SUCCESS(s2n_hmac_init(&conn->active.server_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
         conn->actual_protocol_version = S2N_TLS12;
@@ -276,9 +278,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_wipe(conn));
         conn->active.cipher_suite->cipher = &s2n_aes256_gcm;
-        conn->active.cipher_suite->cipher = &s2n_aes256_gcm;
-        EXPECT_SUCCESS(conn->active.cipher_suite->cipher->get_encryption_key(&conn->active.server_key, &aes256));
-        EXPECT_SUCCESS(conn->active.cipher_suite->cipher->get_decryption_key(&conn->active.client_key, &aes256));
+        EXPECT_SUCCESS(setup_server_keys(conn, &aes256));
         EXPECT_SUCCESS(s2n_hmac_init(&conn->active.client_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
         EXPECT_SUCCESS(s2n_hmac_init(&conn->active.server_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
         conn->actual_protocol_version = S2N_TLS12;
@@ -304,9 +304,7 @@ int main(int argc, char **argv)
         for (int j = 0; j < S2N_TLS_GCM_IV_LEN; j++) {
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
             conn->active.cipher_suite->cipher = &s2n_aes256_gcm;
-            conn->active.cipher_suite->cipher = &s2n_aes256_gcm;
-            EXPECT_SUCCESS(conn->active.cipher_suite->cipher->get_encryption_key(&conn->active.server_key, &aes256));
-            EXPECT_SUCCESS(conn->active.cipher_suite->cipher->get_decryption_key(&conn->active.client_key, &aes256));
+            EXPECT_SUCCESS(setup_server_keys(conn, &aes256));
             EXPECT_SUCCESS(s2n_hmac_init(&conn->active.client_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
             EXPECT_SUCCESS(s2n_hmac_init(&conn->active.server_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
             conn->actual_protocol_version = S2N_TLS12;
@@ -330,9 +328,7 @@ int main(int argc, char **argv)
         for (int j = 0; j < S2N_TLS_GCM_TAG_LEN; j++) {
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
             conn->active.cipher_suite->cipher = &s2n_aes256_gcm;
-            conn->active.cipher_suite->cipher = &s2n_aes256_gcm;
-            EXPECT_SUCCESS(conn->active.cipher_suite->cipher->get_encryption_key(&conn->active.server_key, &aes256));
-            EXPECT_SUCCESS(conn->active.cipher_suite->cipher->get_decryption_key(&conn->active.client_key, &aes256));
+            EXPECT_SUCCESS(setup_server_keys(conn, &aes256));
             EXPECT_SUCCESS(s2n_hmac_init(&conn->active.client_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
             EXPECT_SUCCESS(s2n_hmac_init(&conn->active.server_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
             conn->actual_protocol_version = S2N_TLS12;
@@ -356,9 +352,7 @@ int main(int argc, char **argv)
         for (int j = S2N_TLS_GCM_IV_LEN; j < i - S2N_TLS_GCM_TAG_LEN; j++) {
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
             conn->active.cipher_suite->cipher = &s2n_aes256_gcm;
-            conn->active.cipher_suite->cipher = &s2n_aes256_gcm;
-            EXPECT_SUCCESS(conn->active.cipher_suite->cipher->get_encryption_key(&conn->active.server_key, &aes256));
-            EXPECT_SUCCESS(conn->active.cipher_suite->cipher->get_decryption_key(&conn->active.client_key, &aes256));
+            EXPECT_SUCCESS(setup_server_keys(conn, &aes256));
             EXPECT_SUCCESS(s2n_hmac_init(&conn->active.client_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
             EXPECT_SUCCESS(s2n_hmac_init(&conn->active.server_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
             conn->actual_protocol_version = S2N_TLS12;

--- a/tests/unit/s2n_rc4_test.c
+++ b/tests/unit/s2n_rc4_test.c
@@ -50,6 +50,8 @@ int main(int argc, char **argv)
     /* test the RC4 cipher with a SHA1 hash */
     conn->active.cipher_suite->cipher = &s2n_rc4;
     conn->active.cipher_suite->hmac_alg = S2N_HMAC_SHA1;
+    EXPECT_SUCCESS(conn->active.cipher_suite->cipher->init(&conn->active.server_key));
+    EXPECT_SUCCESS(conn->active.cipher_suite->cipher->init(&conn->active.client_key));
     EXPECT_SUCCESS(conn->active.cipher_suite->cipher->get_decryption_key(&conn->active.client_key, &key_iv));
     EXPECT_SUCCESS(conn->active.cipher_suite->cipher->get_encryption_key(&conn->active.server_key, &key_iv));
     EXPECT_SUCCESS(s2n_hmac_init(&conn->active.client_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
@@ -102,6 +104,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
     }
 
+    EXPECT_SUCCESS(conn->active.cipher_suite->cipher->destroy_key(&conn->active.server_key));
+    EXPECT_SUCCESS(conn->active.cipher_suite->cipher->destroy_key(&conn->active.client_key));
     EXPECT_SUCCESS(s2n_connection_free(conn));
 
     END_TEST();

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -365,6 +365,9 @@ int s2n_prf_key_expansion(struct s2n_connection *conn)
     GUARD(s2n_stuffer_init(&key_material, &out));
     GUARD(s2n_stuffer_write(&key_material, &out));
 
+    GUARD(conn->pending.cipher_suite->cipher->init(&conn->pending.client_key));
+    GUARD(conn->pending.cipher_suite->cipher->init(&conn->pending.server_key));
+
     /* What's our hmac algorithm? */
     s2n_hmac_algorithm hmac_alg = conn->pending.cipher_suite->hmac_alg;
     if (conn->actual_protocol_version == S2N_SSLv3) {


### PR DESCRIPTION
Previously we were implicitly calling EVP_CIPHER_CTX_init in
get_encryption_key.

----

Also prepares us for Openssl 1.1.0 where EVP_CIPHER_CTX is opaque.