### PR TITLE
Simplify read I/O error handling

### DIFF
--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -267,17 +267,7 @@ static int handshake_read_io(struct s2n_connection *conn)
     uint8_t record_type;
     int isSSLv2;
 
-    int r = s2n_read_full_record(conn, &record_type, &isSSLv2);
-    if (r < 0) {
-        if (r == -2) {
-            conn->closed = 1;
-            S2N_ERROR(S2N_ERR_CLOSED);
-        }
-        if (errno == EWOULDBLOCK) {
-            S2N_ERROR(S2N_ERR_BLOCKED);
-        }
-        S2N_ERROR(S2N_ERR_IO);
-    }
+    GUARD(s2n_read_full_record(conn, &record_type, &isSSLv2));
 
     if (isSSLv2) {
         if (ACTIVE_MESSAGE(conn) != CLIENT_HELLO) {
@@ -345,6 +335,7 @@ static int handshake_read_io(struct s2n_connection *conn)
 
     /* Record is a handshake message */
     while (s2n_stuffer_data_available(&conn->in)) {
+        int r;
         uint8_t handshake_message_type;
         GUARD((r = read_full_handshake_message(conn, &handshake_message_type)));
 


### PR DESCRIPTION
This changes the high level I/O functions to not depend on special
error values returned by s2n_read_full_record. s2n_read_full_record
will now set s2n_errno properly, so errors can be propagated using
the GUARD macro.

---

s2n_recv has to do some mangling of s2n_errno because we return 0 for EOF instead of -1 with s2n_errno == S2N_ERR_CLOSED.