### PR TITLE
Speed up unit tests by turning off blinding in tests that cause a delay.

### DIFF
--- a/tests/unit/s2n_malformed_handshake_test.c
+++ b/tests/unit/s2n_malformed_handshake_test.c
@@ -269,7 +269,9 @@ int main(int argc, char **argv)
     /* This is the parent process, close the write end of the pipe */
     EXPECT_SUCCESS(close(p[1]));
 
-    /* Negotiate the handshake. This will fail due to EOF, but that's ok. */
+    /* Negotiate the handshake. This will fail due to EOF, but that's ok. Turn off Blinding before negotiation so that
+     * server doesn't delay its response and test finishes quickly. */
+    EXPECT_SUCCESS(s2n_connection_set_blinding(conn, S2N_SELF_SERVICE_BLINDING));
     EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
     /* Verify that the data is as we expect it */
@@ -312,7 +314,9 @@ int main(int argc, char **argv)
     /* This is the parent process, close the write end of the pipe */
     EXPECT_SUCCESS(close(p[1]));
 
-    /* Negotiate the handshake. This will fail due to EOF, but that's ok. */
+    /* Negotiate the handshake. This will fail due to EOF, but that's ok. Turn off Blinding before negotiation so that
+     * server doesn't delay its response and test finishes quickly. */
+    EXPECT_SUCCESS(s2n_connection_set_blinding(conn, S2N_SELF_SERVICE_BLINDING));
     EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
     /* Verify that the data is as we expect it */
@@ -355,7 +359,9 @@ int main(int argc, char **argv)
     /* This is the parent process, close the write end of the pipe */
     EXPECT_SUCCESS(close(p[1]));
 
-    /* Negotiate the handshake. This will fail due to EOF, but that's ok. */
+    /* Negotiate the handshake. This will fail due to EOF, but that's ok. Turn off Blinding before negotiation so that
+     * server doesn't delay its response and test finishes quickly. */
+    EXPECT_SUCCESS(s2n_connection_set_blinding(conn, S2N_SELF_SERVICE_BLINDING));
     EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
     /* Verify that the data is as we expect it */
@@ -398,7 +404,9 @@ int main(int argc, char **argv)
     /* This is the parent process, close the write end of the pipe */
     EXPECT_SUCCESS(close(p[1]));
 
-    /* Negotiate the handshake. This will fail due to EOF, but that's ok. */
+    /* Negotiate the handshake. This will fail due to EOF, but that's ok. Turn off Blinding before negotiation so that
+     * server doesn't delay its response and test finishes quickly. */
+    EXPECT_SUCCESS(s2n_connection_set_blinding(conn, S2N_SELF_SERVICE_BLINDING));
     EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
     /* Verify that the data is as we expect it */
@@ -441,7 +449,9 @@ int main(int argc, char **argv)
     /* This is the parent process, close the write end of the pipe */
     EXPECT_SUCCESS(close(p[1]));
 
-    /* Negotiate the handshake. This will fail due to EOF, but that's ok. */
+    /* Negotiate the handshake. This will fail due to EOF, but that's ok. Turn off Blinding before negotiation so that
+     * server doesn't delay its response and test finishes quickly. */
+    EXPECT_SUCCESS(s2n_connection_set_blinding(conn, S2N_SELF_SERVICE_BLINDING));
     EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
     /* Verify that the data is as we expect it */
@@ -484,7 +494,9 @@ int main(int argc, char **argv)
     /* This is the parent process, close the write end of the pipe */
     EXPECT_SUCCESS(close(p[1]));
 
-    /* Negotiate the handshake. This will fail due to EOF, but that's ok. */
+    /* Negotiate the handshake. This will fail due to EOF, but that's ok. Turn off Blinding before negotiation so that
+     * server doesn't delay its response and test finishes quickly. */
+    EXPECT_SUCCESS(s2n_connection_set_blinding(conn, S2N_SELF_SERVICE_BLINDING));
     EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
     /* Verify that the data is as we expect it */


### PR DESCRIPTION
Currently **s2n_malformed_handshake_test** results in 4 blinding delays, each randomly between 10-30 seconds. Turning off blinding in this test reduces the time it takes unit tests to complete by on average 80 seconds. I've verified that this is the only unit test that causes a blinding delay. This change should significantly reduce the edit-compile-test cycle for everyone working on s2n.

As an example, on my i7 Ubuntu desktop, this reduced the time for "make" to complete from 2+ minutes to ~37 seconds. 
- Before: 21.02s user 5.90s system 19% cpu **2:20.36** total
- After: 21.03s user 6.01s system 73% cpu **36.788** total