### PR TITLE
Use types with necessary range in stuffer tests

### DIFF
--- a/tests/unit/s2n_stuffer_hex_test.c
+++ b/tests/unit/s2n_stuffer_hex_test.c
@@ -35,14 +35,14 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_stuffer_init(&stuffer, &b));
 
     /* Try to write 51 1-byte ints bytes */
-    for (int i = 0; i < 50; i++) {
+    for (uint8_t i = 0; i < 50; i++) {
         uint8_t value = i * (0xff / 50);
         EXPECT_SUCCESS(s2n_stuffer_write_uint8_hex(&stuffer, value));
     }
     EXPECT_FAILURE(s2n_stuffer_write_uint8_hex(&stuffer, 1));
 
     /* Read those back, and expect the same results */
-    for (int i = 0; i < 50; i++) {
+    for (int8_t i = 0; i < 50; i++) {
         uint8_t value = i * (0xff / 50);
         EXPECT_SUCCESS(s2n_stuffer_read_uint8_hex(&stuffer, &u8));
         EXPECT_EQUAL(u8, value);
@@ -51,14 +51,14 @@ int main(int argc, char **argv)
 
     /* Try to write 26 2-byte ints bytes */
     EXPECT_SUCCESS(s2n_stuffer_wipe(&stuffer));
-    for (int i = 0; i < 25; i++) {
+    for (uint16_t i = 0; i < 25; i++) {
         uint16_t value = i * (0xffff / 25);
         EXPECT_SUCCESS(s2n_stuffer_write_uint16_hex(&stuffer, value));
     }
     EXPECT_FAILURE(s2n_stuffer_write_uint16_hex(&stuffer, 1));
 
     /* Read those back, and expect the same results */
-    for (int i = 0; i < 25; i++) {
+    for (uint16_t i = 0; i < 25; i++) {
         uint16_t value = i * (0xffff / 25);
         EXPECT_SUCCESS(s2n_stuffer_read_uint16_hex(&stuffer, &u16));
         EXPECT_EQUAL(value, u16);
@@ -68,14 +68,14 @@ int main(int argc, char **argv)
     /* Try to write 13 4-byte ints bytes */
     EXPECT_SUCCESS(s2n_stuffer_wipe(&stuffer));
     EXPECT_SUCCESS(s2n_stuffer_init(&stuffer, &b));
-    for (int i = 0; i < 12; i++) {
+    for (uint32_t i = 0; i < 12; i++) {
         uint32_t value = i * (0xffffffff / 12);
         EXPECT_SUCCESS(s2n_stuffer_write_uint32_hex(&stuffer, value));
     }
     EXPECT_FAILURE(s2n_stuffer_write_uint32_hex(&stuffer, 1));
 
     /* Read those back, and expect the same results */
-    for (int i = 0; i < 12; i++) {
+    for (uint32_t i = 0; i < 12; i++) {
         uint32_t value = i * (0xffffffff / 12);
         EXPECT_SUCCESS(s2n_stuffer_read_uint32_hex(&stuffer, &u32));
         EXPECT_EQUAL(value, u32);
@@ -84,14 +84,14 @@ int main(int argc, char **argv)
 
     /* Try to write 7 8-byte ints bytes */
     EXPECT_SUCCESS(s2n_stuffer_wipe(&stuffer));
-    for (int i = 0; i < 6; i++) {
+    for (uint64_t i = 0; i < 6; i++) {
         uint64_t value = i * (0xffffffffffffffff / 6);
         EXPECT_SUCCESS(s2n_stuffer_write_uint64_hex(&stuffer, value));
     }
     EXPECT_FAILURE(s2n_stuffer_write_uint64_hex(&stuffer, 1));
 
     /* Read those back, and expect the same results */
-    for (int i = 0; i < 6; i++) {
+    for (uint64_t i = 0; i < 6; i++) {
         uint64_t value = i * (0xffffffffffffffff / 6);
         EXPECT_SUCCESS(s2n_stuffer_read_uint64_hex(&stuffer, &u64));
         EXPECT_EQUAL(value, u64);

--- a/tests/unit/s2n_stuffer_test.c
+++ b/tests/unit/s2n_stuffer_test.c
@@ -37,14 +37,14 @@ int main(int argc, char **argv)
     EXPECT_FAILURE(s2n_stuffer_write(&stuffer, &in));
 
     /* Try to write 101 1-byte ints bytes */
-    for (int i = 0; i < 100; i++) {
+    for (uint64_t i = 0; i < 100; i++) {
         uint64_t value = i * (0xff / 100);
         EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, value));
     }
     EXPECT_FAILURE(s2n_stuffer_write_uint8(&stuffer, 1));
 
     /* Read those back, and expect the same results */
-    for (int i = 0; i < 100; i++) {
+    for (uint64_t i = 0; i < 100; i++) {
         uint64_t value = i * (0xff / 100);
         EXPECT_SUCCESS(s2n_stuffer_read_uint8(&stuffer, &u8));
         EXPECT_EQUAL(value, u8);
@@ -53,14 +53,14 @@ int main(int argc, char **argv)
 
     /* Try to write 51 2-byte ints bytes */
     EXPECT_SUCCESS(s2n_stuffer_wipe(&stuffer));
-    for (int i = 0; i < 50; i++) {
+    for (uint64_t i = 0; i < 50; i++) {
         uint64_t value = i * (0xffff / 50);
         EXPECT_SUCCESS(s2n_stuffer_write_uint16(&stuffer, value));
     }
     EXPECT_FAILURE(s2n_stuffer_write_uint16(&stuffer, 1));
 
     /* Read those back, and expect the same results */
-    for (int i = 0; i < 50; i++) {
+    for (uint64_t i = 0; i < 50; i++) {
         uint64_t value = i * (0xffff / 50);
         EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &u16));
         EXPECT_EQUAL(value, u16);
@@ -69,14 +69,14 @@ int main(int argc, char **argv)
 
     /* Try to write 34 3-byte ints bytes */
     EXPECT_SUCCESS(s2n_stuffer_wipe(&stuffer));
-    for (int i = 0; i < 33; i++) {
+    for (uint64_t i = 0; i < 33; i++) {
         uint64_t value = i * (0xffffff / 33);
         EXPECT_SUCCESS(s2n_stuffer_write_uint24(&stuffer, value));
     }
     EXPECT_FAILURE(s2n_stuffer_write_uint24(&stuffer, 1));
 
     /* Read those back, and expect the same results */
-    for (int i = 0; i < 33; i++) {
+    for (uint64_t i = 0; i < 33; i++) {
         uint64_t value = i * (0xffffff / 33);
         EXPECT_SUCCESS(s2n_stuffer_read_uint24(&stuffer, &u32));
         EXPECT_EQUAL(value, u32);
@@ -85,14 +85,14 @@ int main(int argc, char **argv)
 
     /* Try to write 26 4-byte ints bytes */
     EXPECT_SUCCESS(s2n_stuffer_wipe(&stuffer));
-    for (int i = 0; i < 25; i++) {
+    for (uint64_t i = 0; i < 25; i++) {
         uint64_t value = i * (0xffffffff / 25);
         EXPECT_SUCCESS(s2n_stuffer_write_uint32(&stuffer, value));
     }
     EXPECT_FAILURE(s2n_stuffer_write_uint32(&stuffer, 1));
 
     /* Read those back, and expect the same results */
-    for (int i = 0; i < 25; i++) {
+    for (uint64_t i = 0; i < 25; i++) {
         uint64_t value = i * (0xffffffff / 25);
         EXPECT_SUCCESS(s2n_stuffer_read_uint32(&stuffer, &u32));
         EXPECT_EQUAL(value, u32);


### PR DESCRIPTION
bryongloden pointed out that our stuffer tests could have undefined
behavior when promoting a an int to uint32_t. This changes "i" to
use an unsigned type of appropriate size.

closes #251
----

```
f45c89a6a0bf% ./cppcheck ../s2n/tests
Checking ../s2n/tests/testlib/s2n_print_connection.c...
1/34 files checked 0% done
Checking ../s2n/tests/testlib/s2n_stuffer_hex.c...
2/34 files checked 0% done
Checking ../s2n/tests/unit/s2n_3des_test.c...
3/34 files checked 4% done
Checking ../s2n/tests/unit/s2n_aead_aes_test.c...
4/34 files checked 7% done
Checking ../s2n/tests/unit/s2n_aes_test.c...
5/34 files checked 10% done
Checking ../s2n/tests/unit/s2n_cbc_verify_test.c...
6/34 files checked 13% done
Checking ../s2n/tests/unit/s2n_cipher_suite_match_test.c...
7/34 files checked 16% done
Checking ../s2n/tests/unit/s2n_client_disabled_test.c...
8/34 files checked 19% done
Checking ../s2n/tests/unit/s2n_client_extensions_test.c...
9/34 files checked 22% done
Checking ../s2n/tests/unit/s2n_drbg_test.c...
10/34 files checked 25% done
Checking ../s2n/tests/unit/s2n_ecc_test.c...
11/34 files checked 28% done
Checking ../s2n/tests/unit/s2n_error_type_test.c...
12/34 files checked 31% done
Checking ../s2n/tests/unit/s2n_fragmentation_coalescing_test.c...
13/34 files checked 34% done
Checking ../s2n/tests/unit/s2n_handshake_test.c...
14/34 files checked 38% done
Checking ../s2n/tests/unit/s2n_hash_test.c...
15/34 files checked 41% done
Checking ../s2n/tests/unit/s2n_hmac_test.c...
16/34 files checked 44% done
Checking ../s2n/tests/unit/s2n_malformed_handshake_test.c...
17/34 files checked 47% done
Checking ../s2n/tests/unit/s2n_override_openssl_random_test.c...
18/34 files checked 50% done
Checking ../s2n/tests/unit/s2n_pem_rsa_dhe_test.c...
19/34 files checked 53% done
Checking ../s2n/tests/unit/s2n_random_test.c...
20/34 files checked 56% done
Checking ../s2n/tests/unit/s2n_rc4_test.c...
21/34 files checked 59% done
Checking ../s2n/tests/unit/s2n_record_size_test.c...
22/34 files checked 62% done
Checking ../s2n/tests/unit/s2n_record_test.c...
23/34 files checked 65% done
Checking ../s2n/tests/unit/s2n_safety_test.c...
24/34 files checked 69% done
Checking ../s2n/tests/unit/s2n_self_talk_alpn_test.c...
25/34 files checked 72% done
Checking ../s2n/tests/unit/s2n_self_talk_test.c...
26/34 files checked 75% done
Checking ../s2n/tests/unit/s2n_ssl_prf_test.c...
27/34 files checked 78% done
Checking ../s2n/tests/unit/s2n_stuffer_base64_test.c...
28/34 files checked 81% done
Checking ../s2n/tests/unit/s2n_stuffer_hex_test.c...
29/34 files checked 84% done
Checking ../s2n/tests/unit/s2n_stuffer_test.c...
30/34 files checked 87% done
Checking ../s2n/tests/unit/s2n_stuffer_text_test.c...
31/34 files checked 90% done
Checking ../s2n/tests/unit/s2n_timer_test.c...
32/34 files checked 93% done
Checking ../s2n/tests/unit/s2n_tls_prf_test.c...
33/34 files checked 96% done
Checking ../s2n/tests/unit/s2n_tls_record_stuffer_test.c...
34/34 files checked 100% done
f45c89a6a0bf%
```