### PR TITLE
Free allocated memory for the ECC Shared Secret in error case.

### DIFF
--- a/crypto/s2n_ecc.c
+++ b/crypto/s2n_ecc.c
@@ -269,6 +269,7 @@ static int s2n_ecc_compute_shared_secret(EC_KEY *own_key, const EC_POINT *peer_p
     GUARD(s2n_alloc(shared_secret, shared_secret_size));
 
     if (ECDH_compute_key(shared_secret->data, shared_secret_size, peer_public, own_key, NULL) != shared_secret_size) {
+        s2n_free(shared_secret);
         S2N_ERROR(S2N_ERR_ECDHE_SHARED_SECRET);
     }
 

--- a/crypto/s2n_ecc.c
+++ b/crypto/s2n_ecc.c
@@ -269,7 +269,7 @@ static int s2n_ecc_compute_shared_secret(EC_KEY *own_key, const EC_POINT *peer_p
     GUARD(s2n_alloc(shared_secret, shared_secret_size));
 
     if (ECDH_compute_key(shared_secret->data, shared_secret_size, peer_public, own_key, NULL) != shared_secret_size) {
-        s2n_free(shared_secret);
+        GUARD(s2n_free(shared_secret));
         S2N_ERROR(S2N_ERR_ECDHE_SHARED_SECRET);
     }
 


### PR DESCRIPTION
**s2n_alloc(shared_secret, shared_secret_size)** allocates memory for the ECC shared_secret on line 269, but this memory is not freed in the error case directly below the allocation. Found with LibFuzzer. From my tests this was a leak of 4096 bytes each time this code path was taken.