### PR TITLE
Print debug string on unit test failure

### DIFF
--- a/tests/s2n_test.h
+++ b/tests/s2n_test.h
@@ -51,10 +51,10 @@
 #define FAIL()      FAIL_MSG("");
 
 #define FAIL_MSG( msg ) { if (isatty(fileno(stdout))) { \
-                            fprintf(stdout, "\033[31;1mFAILED test %d\033[0m\n%s (%s line %d)\nError Message: '%s'\n", test_count, (msg),  __FILE__, __LINE__, s2n_strerror(s2n_errno, "EN")); \
+                            fprintf(stdout, "\033[31;1mFAILED test %d\033[0m\n%s (%s line %d)\nError Message: '%s'\n Debug String: '%s'\n", test_count, (msg), __FILE__, __LINE__, s2n_strerror(s2n_errno, "EN"), s2n_debug_str); \
                           } \
                           else { \
-                            fprintf(stdout, "FAILED test %d\n%s (%s line %d)\nError Message: '%s'\n", test_count, (msg), __FILE__, __LINE__, s2n_strerror(s2n_errno, "EN")); \
+                            fprintf(stdout, "FAILED test %d\n%s (%s line %d)\nError Message: '%s'\n Debug String: '%s'\n", test_count, (msg), __FILE__, __LINE__, s2n_strerror(s2n_errno, "EN"), s2n_debug_str); \
                           } \
                           exit(1);  \
                         }


### PR DESCRIPTION
Printing this by default for all test failures is useful for
development.