### PR TITLE
Disable drbg speedup check if no rdrand

### DIFF
--- a/tests/unit/s2n_drbg_test.c
+++ b/tests/unit/s2n_drbg_test.c
@@ -233,8 +233,10 @@ int main(int argc, char **argv)
     }
     EXPECT_SUCCESS(s2n_timer_reset(config, &timer, &urandom_nanoseconds));
 
-    /* Confirm that the DRBG is faster than urandom */
-    EXPECT_TRUE(drbg_nanoseconds < urandom_nanoseconds);
+    /* Confirm that the DRBG is faster than urandom when rdrand is enabled */
+    if (s2n_cpu_supports_rdrand()) {
+        EXPECT_TRUE(drbg_nanoseconds < urandom_nanoseconds);
+    }
 
     /* NOTE: s2n_random_test also includes monobit tests for this DRBG */
 


### PR DESCRIPTION
With the prediction resistance change our drbg will fall back to
calling urandom for every drbg_generate call. So let's keep the unit
test on for when we have rdrand(and expect to be faster) and turn
it off without rdrand.