### PR TITLE
Add missing GUARD(), GUARD_PTR(), and notnull_check() calls

### DIFF
--- a/crypto/s2n_ecc.c
+++ b/crypto/s2n_ecc.c
@@ -95,6 +95,8 @@ int s2n_ecc_read_ecc_params(struct s2n_ecc_params *server_ecc_params, struct s2n
         S2N_ERROR(S2N_ERR_BAD_MESSAGE);
     }
     curve_blob.data = s2n_stuffer_raw_read(in, 2);
+    notnull_check(curve_blob.data);
+
     curve_blob.size = 2;
     /* Verify that the client supports the server curve */
     if (s2n_ecc_find_supported_curve(&curve_blob, &server_ecc_params->negotiated_curve) != 0) {

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -88,6 +88,7 @@ int s2n_client_hello_recv(struct s2n_connection *conn)
         struct s2n_blob extensions;
         extensions.size = extensions_size;
         extensions.data = s2n_stuffer_raw_read(in, extensions.size);
+        notnull_check(extensions.data);
 
         GUARD(s2n_client_extensions_recv(conn, &extensions));
     }

--- a/tls/s2n_client_key_exchange.c
+++ b/tls/s2n_client_key_exchange.c
@@ -55,7 +55,7 @@ static int s2n_rsa_client_key_recv(struct s2n_connection *conn)
 
     encrypted.size = s2n_stuffer_data_available(in);
     encrypted.data = s2n_stuffer_raw_read(in, length);
-
+    notnull_check(encrypted.data);
     gt_check(encrypted.size, 0);
 
     /* First: use a random pre-master secret */

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -58,7 +58,7 @@ struct s2n_connection *s2n_connection_new(s2n_mode mode)
          * variable is required to be set for the client mode to work.
          */
         if (getenv("S2N_ENABLE_CLIENT_MODE") == NULL) {
-            s2n_free(&blob);
+            GUARD_PTR(s2n_free(&blob));
             S2N_ERROR_PTR(S2N_ERR_CLIENT_MODE_DISABLED);
         }
     }

--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -53,7 +53,7 @@ int s2n_flush(struct s2n_connection *conn, s2n_blocked_status *blocked)
         conn->closed = 1;
         /* Delay wiping for close_notify. s2n_shutdown() needs to wait for peer's close_notify */
         if (!conn->close_notify_queued) {
-            s2n_connection_wipe(conn);
+            GUARD(s2n_connection_wipe(conn));
         }
     }
     GUARD(s2n_stuffer_rewrite(&conn->out));

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -96,6 +96,7 @@ int s2n_server_hello_recv(struct s2n_connection *conn)
     struct s2n_blob extensions;
     extensions.size = extensions_size;
     extensions.data = s2n_stuffer_raw_read(in, extensions.size);
+    notnull_check(extensions.data);
 
     GUARD(s2n_server_extensions_recv(conn, &extensions));
 


### PR DESCRIPTION
I went through the s2n code base and tried to find any spots that were missing `GUARD()`, `GUARD_PTR()`, or `notnull_check()` calls. 

There was one case in **s2n_ecc.c** where we were not checking `s2n_stuffer_data_available()` to ensure that there was enough data in the stuffer, which may have resulted in `curve_blob.data` containing a null pointer which could have caused a null pointer dereference.

`s2n_stuffer_raw_read()` can return null if trying to read more data than the stuffer contains. For all but the one case in **s2n_ecc.c** where `notnull_check()` was added, there were already `s2n_stuffer_data_available()` checks above the raw stuffer reads that check for attempts to read more data than what is available, so in theory most of these new `notnull_check()`'s are redundant. Having said that, I still think every call to `s2n_stuffer_raw_read()` should be followed with a `notnull_check()` for good coding style since `s2n_stuffer_raw_read()` is allowed to return null in some cases.