### PR TITLE
Add scan-build to TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,11 @@ install:
   - .travis/install_openssl.sh `pwd`/libcrypto-build `pwd`/libcrypto-root $TRAVIS_OS_NAME > /dev/null
   # Install python linked with our compiled Openssl for integration tests
   - .travis/install_python.sh `pwd`/libcrypto-root > /dev/null
-  # Install prlimit to set the memlock limit to unlimited for this process 
+  # Install prlimit to set the memlock limit to unlimited for this process
   - (test "$TRAVIS_OS_NAME" = "linux" && sudo .travis/install_prlimit.sh $PWD/.travis > /dev/null && sudo .travis/prlimit --pid "$$" --memlock=unlimited:unlimited) || true
-
+  - mkdir -p .travis/checker && .travis/install_scan-build.sh .travis/checker && export PATH=$PATH:.travis/checker/bin
 script:
   - make -j8
+  # Bundled scan-build is only available for OSX but running on a single platform should be sufficient
+  - (test "$TRAVIS_OS_NAME" = "osx" && make clean && scan-build make bin) || true
   - make integration

--- a/.travis/install_scan-build.sh
+++ b/.travis/install_scan-build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+set -e
+
+pushd `pwd`
+
+INSTALL_DIR=$1
+
+wget http://clang-analyzer.llvm.org/downloads/checker-278.tar.bz2
+tar jxf checker-278.tar.bz2 --strip-components=1 -C $INSTALL_DIR


### PR DESCRIPTION
For convenience, scan-build only runs on the
OSX instance of TravisCI. This is because scan-build
bundles aren't distributed for linux which would require
us to compile yet another dependency from source.