### PR TITLE
Improving support for TLS_FALLBACK_SCSV (RFC 7507)

### DIFF
--- a/tls/s2n_tls_parameters.h
+++ b/tls/s2n_tls_parameters.h
@@ -44,7 +44,7 @@
 #define TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256    0xC0, 0x2F
 #define TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384    0xC0, 0x30
 
-/* From https://tools.ietf.org/html/draft-ietf-tls-downgrade-scsv-03 */
+/* From https://tools.ietf.org/html/rfc7507 */
 #define TLS_FALLBACK_SCSV                   0x56, 0x00
 
 /* TLS extensions from https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml */


### PR DESCRIPTION
Improving support for RFC 7507. This change allows s2n to properly detect TLS downgrade attacks as described in the RFC and close the connection if such an attack is detected. 

This PR does not include the extra changes needed to send a TLS alert to the client so they can renegotiate the connection, I'll be sending another PR to fix that soon, but I don't think that should block this PR.