### PR TITLE
Disable 1/n-1 CBC message split in server mode

### DIFF
--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -122,7 +122,11 @@ ssize_t s2n_send(struct s2n_connection *conn, void *buf, ssize_t size, s2n_block
     while (size) {
         in.size = MIN(size, max_payload_size);
 
-        if (conn->actual_protocol_version < S2N_TLS11 && writer->cipher_suite->cipher->type == S2N_CBC) {
+        /* Don't split messages in server mode for interoperability with naive clients.
+         * Some clients may have expectations based on the amount of content in the first record.
+         */
+        if (conn->actual_protocol_version < S2N_TLS11 && writer->cipher_suite->cipher->type == S2N_CBC
+                                                      && conn->mode != S2N_SERVER) {
             if (in.size > 1 && cbcHackUsed == 0) {
                 in.size = 1;
                 cbcHackUsed = 1;


### PR DESCRIPTION
This changes s2n_send to not split CBC messages into 1 byte
and n-1 byte records in server mode. The 1/n-1 split was
identified as a mitigation for the BEAST attack on SSLv3/TLS
1.0 CBC cipher suites.
The motivation for disabling is interoperability. Google Chrome
found that many sites were broken when 1/n-1 splitting was rolled
out [1]. Clients that place strong expectations on the amount/value
of data in the first TLS record received can be broken.

[1] https://www.imperialviolet.org/2012/01/15/beastfollowup.html