### PR TITLE
Fix all issues found by cppcheck 1.75, and add cppcheck as a build requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,8 @@ addons:
       packages:
         - gcc-6
         - g++-6
-<<<<<<< HEAD
         - indent
-=======
         - cppcheck
->>>>>>> Add cppcheck for every build
 
 os:
   - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,11 @@ addons:
       packages:
         - gcc-6
         - g++-6
+<<<<<<< HEAD
         - indent
+=======
+        - cppcheck
+>>>>>>> Add cppcheck for every build
 
 os:
   - osx
@@ -24,6 +28,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then   brew tap homebrew/versions ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then   brew install gcc6          ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then   brew install gnu-indent    ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then   brew install cppcheck      ; fi
   # Set GCC 6 as Default on both Ubuntu and OSX
   - alias gcc=$(which gcc-6)
   # Install latest version of clang, clang++, and llvm-symbolizer and add them to beginning of PATH. Needed for fuzzing.
@@ -38,6 +43,7 @@ install:
   # Install prlimit to set the memlock limit to unlimited for this process
   - (test "$TRAVIS_OS_NAME" = "linux" && sudo "PATH=$PATH" .travis/install_prlimit.sh $PWD/.travis > /dev/null && sudo .travis/prlimit --pid "$$" --memlock=unlimited:unlimited) || true
   - mkdir -p .travis/checker && .travis/install_scan-build.sh .travis/checker && export PATH=$PATH:.travis/checker/bin
+  - .travis/run_cppcheck.sh
 
 script:
   - (test "$TRAVIS_OS_NAME" = "linux" && make -j8) || true

--- a/.travis/cppcheck_suppressions.txt
+++ b/.travis/cppcheck_suppressions.txt
@@ -1,0 +1,3 @@
+// cppcheck Message: [utils/s2n_random.c:291]: (style) union member 'Anonymous0::u64' is never used.
+// Reason for Suppression: output.u64 is used inside raw __asm__  instructions which cppcheck isn't able to detect
+*:utils/s2n_random.c:291

--- a/.travis/run_cppcheck.sh
+++ b/.travis/run_cppcheck.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+set -e
+
+FAILED=0
+
+cppcheck --std=c99 --error-exitcode=-1 --quiet -j 8 --enable=style,performance,portability,information,missingInclude -I ./tests api bin crypto error stuffer tests tls utils || FAILED=1
+
+if [ $FAILED == 1 ];
+then
+	printf "\033[31;1mFAILED cppcheck\033[0m\n"
+	exit -1
+else
+	printf "\033[32;1mPASSED cppcheck\033[0m\n"
+fi

--- a/.travis/run_cppcheck.sh
+++ b/.travis/run_cppcheck.sh
@@ -16,8 +16,8 @@
 set -e
 
 FAILED=0
-
-cppcheck --std=c99 --error-exitcode=-1 --quiet -j 8 --enable=style,performance,portability,information,missingInclude -I ./tests api bin crypto error stuffer tests tls utils || FAILED=1
+cppcheck --version
+cppcheck --std=c99 --error-exitcode=-1 --quiet -j 8 --enable=style,performance,portability,information,missingInclude --suppressions-list=.travis/cppcheck_suppressions.txt -I ./tests api bin crypto error stuffer tests tls utils || FAILED=1
 
 if [ $FAILED == 1 ];
 then

--- a/crypto/s2n_hkdf.c
+++ b/crypto/s2n_hkdf.c
@@ -51,15 +51,14 @@ static int s2n_hkdf_expand(s2n_hmac_algorithm alg, const struct s2n_blob *pseudo
         total_rounds++;
     }
 
-    if (total_rounds > MAX_HKDF_ROUNDS || total_rounds <= 0) {
+    if (total_rounds > MAX_HKDF_ROUNDS || total_rounds == 0) {
         S2N_ERROR(S2N_ERR_HKDF_OUTPUT_SIZE);
     }
 
     struct s2n_hmac_state hmac;
 
-    uint32_t cat_len;
     for (uint32_t curr_round = 1; curr_round <= total_rounds; curr_round++) {
-
+        uint32_t cat_len;
         GUARD(s2n_hmac_init(&hmac, alg, pseudo_rand_key->data, pseudo_rand_key->size));
         if (curr_round != 1) {
             GUARD(s2n_hmac_update(&hmac, prev, hash_len));

--- a/error/s2n_errno.c
+++ b/error/s2n_errno.c
@@ -109,14 +109,12 @@ struct s2n_error_translation EN[] = {
 
 const char *s2n_strerror(int error, const char *lang)
 {
-    const char *no_such_language = "Language is not supported for error translation";
-    const char *no_such_error = "Internal s2n error";
-
     if (lang == NULL) {
         lang = "EN";
     }
 
     if (strcasecmp(lang, "EN")) {
+        const char *no_such_language = "Language is not supported for error translation";
         return no_such_language;
     }
 
@@ -126,6 +124,7 @@ const char *s2n_strerror(int error, const char *lang)
         }
     }
 
+    const char *no_such_error = "Internal s2n error";
     return no_such_error;
 }
 

--- a/tests/testlib/s2n_stuffer_hex.c
+++ b/tests/testlib/s2n_stuffer_hex.c
@@ -32,7 +32,7 @@ static uint8_t hex[16] = {
  */
 static int s2n_stuffer_read_n_bits_hex(struct s2n_stuffer *stuffer, uint8_t n, uint64_t *u)
 {
-    uint8_t hex_data[16];
+    uint8_t hex_data[16] = {0};
     struct s2n_blob b = { .data = hex_data, .size = n / 4 };
 
     GUARD(s2n_stuffer_read(stuffer, &b));

--- a/tests/unit/s2n_drbg_test.c
+++ b/tests/unit/s2n_drbg_test.c
@@ -182,7 +182,7 @@ int main(int argc, char **argv)
 
     /* Check everything against the NIST vectors */
     for (int i = 0; i < 14; i++) {
-        uint8_t ps[32];
+        uint8_t ps[32] = {0};
         struct s2n_drbg nist_drbg = { .entropy_generator = nist_fake_urandom_data };
         struct s2n_blob personalization_string = {.data = ps, .size = 32};
         /* Read the next personalization string */

--- a/tests/unit/s2n_safety_test.c
+++ b/tests/unit/s2n_safety_test.c
@@ -94,7 +94,7 @@ static int failure_notnull()
 static int success_memcpy()
 {
     char dst[1024];
-    char src[1024];
+    char src[1024] = {0};
 
     memcpy_check(dst, src, 1024);
 

--- a/tests/unit/s2n_self_talk_alpn_test.c
+++ b/tests/unit/s2n_self_talk_alpn_test.c
@@ -208,10 +208,10 @@ int main(int argc, char **argv)
 
     for (int i = 1; i < 0xffff; i += 100) {
         char * ptr = buffer;
-        int bytes_read = 0;
         int size = i;
 
         do {
+            int bytes_read = 0;
             EXPECT_SUCCESS(bytes_read = s2n_recv(conn, ptr, size, &blocked));
 
             size -= bytes_read;
@@ -266,10 +266,10 @@ int main(int argc, char **argv)
 
     for (int i = 1; i < 0xffff; i += 100) {
         char * ptr = buffer;
-        int bytes_read = 0;
         int size = i;
 
         do {
+            int bytes_read = 0;
             EXPECT_SUCCESS(bytes_read = s2n_recv(conn, ptr, size, &blocked));
 
             size -= bytes_read;
@@ -321,10 +321,10 @@ int main(int argc, char **argv)
 
     for (int i = 1; i < 0xffff; i += 100) {
         char * ptr = buffer;
-        int bytes_read = 0;
         int size = i;
 
         do {
+            int bytes_read = 0;
             EXPECT_SUCCESS(bytes_read = s2n_recv(conn, ptr, size, &blocked));
 
             size -= bytes_read;

--- a/tests/unit/s2n_self_talk_test.c
+++ b/tests/unit/s2n_self_talk_test.c
@@ -179,10 +179,10 @@ int main(int argc, char **argv)
         char buffer[0xffff];
         for (int i = 1; i < 0xffff; i += 100) {
             char * ptr = buffer;
-            int bytes_read = 0;
             int size = i;
 
             do {
+                int bytes_read = 0;
                 EXPECT_SUCCESS(bytes_read = s2n_recv(conn, ptr, size, &blocked));
 
                 size -= bytes_read;

--- a/tests/unit/s2n_stuffer_test.c
+++ b/tests/unit/s2n_stuffer_test.c
@@ -21,7 +21,7 @@
 
 int main(int argc, char **argv)
 {
-    uint8_t entropy[2048];
+    uint8_t entropy[2048] = {0};
     struct s2n_stuffer stuffer;
     uint8_t u8;
     uint16_t u16;

--- a/tests/unit/s2n_timer_test.c
+++ b/tests/unit/s2n_timer_test.c
@@ -57,6 +57,7 @@ int main(int argc, char **argv)
     mock_time = 40;
     EXPECT_SUCCESS(s2n_timer_elapsed(config, &timer, &nanoseconds));
     EXPECT_EQUAL(nanoseconds, 10);
+    EXPECT_EQUAL(mock_time, 40); /* Work-around for cppcheck complaining that mock_time is never read after being set */
 
     END_TEST();
 }

--- a/tls/s2n_alerts.c
+++ b/tls/s2n_alerts.c
@@ -98,15 +98,15 @@ int s2n_process_alert_fragment(struct s2n_connection *conn)
 int s2n_queue_writer_close_alert_warning(struct s2n_connection *conn)
 {
     uint8_t alert[2];
+    alert[0] = S2N_TLS_ALERT_LEVEL_WARNING;
+    alert[1] = S2N_TLS_ALERT_CLOSE_NOTIFY;
+
     struct s2n_blob out = {.data = alert,.size = sizeof(alert) };
 
     /* If there is an alert pending or we've already sent a close_notify, do nothing */
     if (s2n_stuffer_data_available(&conn->writer_alert_out) || conn->close_notify_queued) {
         return 0;
     }
-
-    alert[0] = S2N_TLS_ALERT_LEVEL_WARNING;
-    alert[1] = S2N_TLS_ALERT_CLOSE_NOTIFY;
 
     GUARD(s2n_stuffer_write(&conn->writer_alert_out, &out));
     conn->close_notify_queued = 1;
@@ -117,15 +117,15 @@ int s2n_queue_writer_close_alert_warning(struct s2n_connection *conn)
 int s2n_queue_reader_unsupported_protocol_version_alert(struct s2n_connection *conn)
 {
     uint8_t alert[2];
+    alert[0] = S2N_TLS_ALERT_LEVEL_FATAL;
+    alert[1] = S2N_TLS_ALERT_PROTOCOL_VERSION;
+
     struct s2n_blob out = {.data = alert,.size = sizeof(alert) };
 
     /* If there is an alert pending, do nothing */
     if (s2n_stuffer_data_available(&conn->reader_alert_out)) {
         return 0;
     }
-
-    alert[0] = S2N_TLS_ALERT_LEVEL_FATAL;
-    alert[1] = S2N_TLS_ALERT_PROTOCOL_VERSION;
 
     GUARD(s2n_stuffer_write(&conn->reader_alert_out, &out));
 

--- a/tls/s2n_client_extensions.c
+++ b/tls/s2n_client_extensions.c
@@ -290,7 +290,6 @@ static int s2n_recv_client_alpn(struct s2n_connection *conn, struct s2n_stuffer 
 
         while (s2n_stuffer_data_available(&client_protos)) {
             uint8_t client_length;
-            uint8_t client_protocol[255];
             GUARD(s2n_stuffer_read_uint8(&client_protos, &client_length));
             if (client_length > s2n_stuffer_data_available(&client_protos)) {
                 S2N_ERROR(S2N_ERR_BAD_MESSAGE);
@@ -298,6 +297,7 @@ static int s2n_recv_client_alpn(struct s2n_connection *conn, struct s2n_stuffer 
             if (client_length != length) {
                 GUARD(s2n_stuffer_skip_read(&client_protos, client_length));
             } else {
+                uint8_t client_protocol[255];
                 GUARD(s2n_stuffer_read_bytes(&client_protos, client_protocol, client_length));
                 if (memcmp(client_protocol, protocol, client_length) == 0) {
                     memcpy_check(conn->application_protocol, client_protocol, client_length);

--- a/tls/s2n_client_key_exchange.c
+++ b/tls/s2n_client_key_exchange.c
@@ -65,7 +65,7 @@ static int s2n_rsa_client_key_recv(struct s2n_connection *conn)
     conn->secure.rsa_premaster_secret[1] = client_protocol_version[1];
 
     /* Set rsa_failed to 1 if s2n_rsa_decrypt returns anything other than zero */
-    conn->handshake.rsa_failed = ! !s2n_rsa_decrypt(&conn->config->cert_and_key_pairs->private_key, &encrypted, &pms);
+    conn->handshake.rsa_failed = !!s2n_rsa_decrypt(&conn->config->cert_and_key_pairs->private_key, &encrypted, &pms);
 
     /* Set rsa_failed to 1, if it isn't already, if the protocol version isn't what we expect */
     conn->handshake.rsa_failed |= !s2n_constant_time_equals(client_protocol_version, pms.data, S2N_TLS_PROTOCOL_VERSION_LEN);

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -168,7 +168,6 @@ static int handshake_write_io(struct s2n_connection *conn)
 {
     uint8_t record_type = ACTIVE_STATE(conn).record_type;
     s2n_blocked_status blocked = S2N_NOT_BLOCKED;
-    int max_payload_size;
 
     /* Populate handshake.io with header/payload for the current state, once.
      * Check wiped instead of s2n_stuffer_data_available to differentiate between the initial call
@@ -187,7 +186,7 @@ static int handshake_write_io(struct s2n_connection *conn)
     /* Write the handshake data to records in fragment sized chunks */
     struct s2n_blob out;
     while (s2n_stuffer_data_available(&conn->handshake.io) > 0) {
-
+        int max_payload_size;
         GUARD((max_payload_size = s2n_record_max_write_payload_size(conn)));
         out.size = MIN(s2n_stuffer_data_available(&conn->handshake.io), max_payload_size);
 

--- a/tls/s2n_record_read.c
+++ b/tls/s2n_record_read.c
@@ -240,7 +240,6 @@ int s2n_record_parse(struct s2n_connection *conn)
         if (s2n_verify_cbc(conn, mac, &en) < 0) {
             GUARD(s2n_stuffer_wipe(&conn->in));
             S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-            return -1;
         }
     } else {
         /* MAC check for streaming ciphers - no padding */
@@ -253,7 +252,6 @@ int s2n_record_parse(struct s2n_connection *conn)
         if (s2n_hmac_digest_verify(en.data + payload_length + offset, check_digest, mac_digest_size) < 0) {
             GUARD(s2n_stuffer_wipe(&conn->in));
             S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-            return -1;
         }
     }
 

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -93,7 +93,7 @@ static int s2n_deserialize_resumption_state(struct s2n_connection *conn, struct 
 
 int s2n_resume_from_cache(struct s2n_connection *conn)
 {
-    uint8_t data[S2N_STATE_SIZE_IN_BYTES];
+    uint8_t data[S2N_STATE_SIZE_IN_BYTES] = { 0 };
     struct s2n_blob entry = {.data = data,.size = S2N_STATE_SIZE_IN_BYTES };
     struct s2n_stuffer from;
     uint64_t size;
@@ -122,7 +122,7 @@ int s2n_resume_from_cache(struct s2n_connection *conn)
 
 int s2n_store_to_cache(struct s2n_connection *conn)
 {
-    uint8_t data[S2N_STATE_SIZE_IN_BYTES];
+    uint8_t data[S2N_STATE_SIZE_IN_BYTES] = { 0 };
     struct s2n_blob entry = {.data = data,.size = S2N_STATE_SIZE_IN_BYTES };
     struct s2n_stuffer to;
 


### PR DESCRIPTION
The latest of version of cppcheck finds one or more instances of:

- Possible uninitialized memory use in s2n
- Instances of variables whose scope unnecessarily large, and can be reduced
- Greater than Zero checks on unsigned integers that expand to throw errors when being checked for `<= 0`, when it is impossible for unsigned integers to be less than 0. (The `< 0` is impossible to be reached, even though the `= 0` is possible)
- Unreachable `return -1` statements that occur after a S2N_ERROR which internally already return -1


These changes fix all issues found by cppcheck v1.75 (released August 6th, 2016), and adds it as a build requirement.