### PR TITLE
Make gcm crypto functions more general

### DIFF
--- a/crypto/s2n_aead_cipher_aes_gcm.c
+++ b/crypto/s2n_aead_cipher_aes_gcm.c
@@ -25,10 +25,9 @@
 
 static int s2n_aead_cipher_aes_gcm_encrypt(struct s2n_session_key *key, struct s2n_blob *iv, struct s2n_blob *aad, struct s2n_blob *in, struct s2n_blob *out)
 {
-    gte_check(in->size, S2N_TLS_GCM_TAG_LEN + S2N_TLS_GCM_EXPLICIT_IV_LEN);
+    gte_check(in->size, S2N_TLS_GCM_TAG_LEN);
     gte_check(out->size, in->size);
     eq_check(iv->size, S2N_TLS_GCM_IV_LEN);
-    eq_check(aad->size, S2N_TLS_GCM_AAD_LEN);
 
     /* Initialize the IV */
     if (EVP_EncryptInit_ex(&key->native_format.evp_cipher_ctx, NULL, NULL, NULL, iv->data) != 1) {
@@ -36,9 +35,7 @@ static int s2n_aead_cipher_aes_gcm_encrypt(struct s2n_session_key *key, struct s
     }
 
     /* Adjust our buffer pointers to account for the explicit IV and TAG lengths */
-    int in_len = in->size - (S2N_TLS_GCM_EXPLICIT_IV_LEN + S2N_TLS_GCM_TAG_LEN);
-    uint8_t *in_data = in->data + S2N_TLS_GCM_EXPLICIT_IV_LEN;
-    uint8_t *out_data = out->data + S2N_TLS_GCM_EXPLICIT_IV_LEN;
+    int in_len = in->size - S2N_TLS_GCM_TAG_LEN;
     uint8_t *tag_data = out->data + out->size - S2N_TLS_GCM_TAG_LEN;
 
     int out_len;
@@ -48,12 +45,12 @@ static int s2n_aead_cipher_aes_gcm_encrypt(struct s2n_session_key *key, struct s
     }
 
     /* Encrypt the data */
-    if (EVP_EncryptUpdate(&key->native_format.evp_cipher_ctx, out_data, &out_len, in_data, in_len) != 1) {
+    if (EVP_EncryptUpdate(&key->native_format.evp_cipher_ctx, out->data, &out_len, in->data, in_len) != 1) {
         S2N_ERROR(S2N_ERR_ENCRYPT);
     }
 
     /* Finalize */
-    if (EVP_EncryptFinal_ex(&key->native_format.evp_cipher_ctx, out_data, &out_len) != 1) {
+    if (EVP_EncryptFinal_ex(&key->native_format.evp_cipher_ctx, out->data, &out_len) != 1) {
         S2N_ERROR(S2N_ERR_ENCRYPT);
     }
 
@@ -67,10 +64,9 @@ static int s2n_aead_cipher_aes_gcm_encrypt(struct s2n_session_key *key, struct s
 
 static int s2n_aead_cipher_aes_gcm_decrypt(struct s2n_session_key *key, struct s2n_blob *iv, struct s2n_blob *aad, struct s2n_blob *in, struct s2n_blob *out)
 {
-    gte_check(in->size, S2N_TLS_GCM_TAG_LEN + S2N_TLS_GCM_EXPLICIT_IV_LEN);
+    gte_check(in->size, S2N_TLS_GCM_TAG_LEN);
     gte_check(out->size, in->size);
     eq_check(iv->size, S2N_TLS_GCM_IV_LEN);
-    eq_check(aad->size, S2N_TLS_GCM_AAD_LEN);
 
     /* Initialize the IV */
     if (EVP_DecryptInit_ex(&key->native_format.evp_cipher_ctx, NULL, NULL, NULL, iv->data) != 1) {
@@ -78,9 +74,7 @@ static int s2n_aead_cipher_aes_gcm_decrypt(struct s2n_session_key *key, struct s
     }
 
     /* Adjust our buffer pointers to account for the explicit IV and TAG lengths */
-    int in_len = in->size - (S2N_TLS_GCM_EXPLICIT_IV_LEN + S2N_TLS_GCM_TAG_LEN);
-    uint8_t *in_data = in->data + S2N_TLS_GCM_EXPLICIT_IV_LEN;
-    uint8_t *out_data = out->data + S2N_TLS_GCM_EXPLICIT_IV_LEN;
+    int in_len = in->size - S2N_TLS_GCM_TAG_LEN;
     uint8_t *tag_data = in->data + in->size - S2N_TLS_GCM_TAG_LEN;
 
     /* Set the TAG */
@@ -95,12 +89,12 @@ static int s2n_aead_cipher_aes_gcm_decrypt(struct s2n_session_key *key, struct s
     }
 
     /* Decrypt the data */
-    if (EVP_DecryptUpdate(&key->native_format.evp_cipher_ctx, out_data, &out_len, in_data, in_len) != 1) {
+    if (EVP_DecryptUpdate(&key->native_format.evp_cipher_ctx, out->data, &out_len, in->data, in_len) != 1) {
         S2N_ERROR(S2N_ERR_DECRYPT);
     }
 
     /* Verify the tag */
-    if (EVP_DecryptFinal_ex(&key->native_format.evp_cipher_ctx, out_data, &out_len) != 1) {
+    if (EVP_DecryptFinal_ex(&key->native_format.evp_cipher_ctx, out->data, &out_len) != 1) {
         S2N_ERROR(S2N_ERR_DECRYPT);
     }
 

--- a/tls/s2n_record_write.c
+++ b/tls/s2n_record_write.c
@@ -214,7 +214,7 @@ int s2n_record_write(struct s2n_connection *conn, uint8_t content_type, struct s
     uint16_t encrypted_length = data_bytes_to_take + mac_digest_size;
 
     if (cipher_suite->cipher->type == S2N_AEAD) {
-        encrypted_length += cipher_suite->cipher->io.aead.record_iv_size;
+        GUARD(s2n_stuffer_skip_write(&conn->out, cipher_suite->cipher->io.aead.record_iv_size));
         encrypted_length += cipher_suite->cipher->io.aead.tag_size;
     }
 


### PR DESCRIPTION
    Move the iv byte skipping outside of the general AEAD AES GCM
    encryption and decryption functions. The record read and write
    functions now take care of skipping the iv. In addition, the
    AAD is not required to be a specific size (< 2^64 bits and a
    multiple of 8). This also allows us to add more data to the
    AAD for authenticating session tickets.