### PR TITLE
cross-compile: build fixes to support cross compilation

### DIFF
--- a/bin/echo.c
+++ b/bin/echo.c
@@ -16,7 +16,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <netdb.h>
 
 #include <stdlib.h>

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -16,7 +16,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <netdb.h>
 
 #include <stdlib.h>

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -17,7 +17,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <netdb.h>
 
 #include <stdlib.h>

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -21,8 +21,8 @@ all: libs2n.a libs2n.so libs2n.dylib
 include ../s2n.mk
 
 libs2n.a: ${OBJS}
-	ar cru libs2n.a ${OBJS}
-	ranlib libs2n.a
+	$(AR) cru libs2n.a ${OBJS}
+	$(RANLIB) libs2n.a
 
 libs2n.so: ${OBJS}
 	${CC} -shared ${LIBS} -o libs2n.so ${OBJS}

--- a/s2n.mk
+++ b/s2n.mk
@@ -27,15 +27,25 @@ else
     CRYPTO_LIBS = -lcrypto
 endif
 
+CC	= $(CROSS_COMPILE)gcc
+AR	= $(CROSS_COMPILE)ar
+RANLIB	= $(CROSS_COMPILE)ranlib
+
 SOURCES = $(wildcard *.c *.h)
 CRUFT   = $(wildcard *.c~ *.h~ *.c.BAK *.h.BAK *.o *.a *.so *.dylib)
 INDENT  = $(shell (if indent --version 2>&1 | grep GNU > /dev/null; then echo indent ; elif gindent --version 2>&1 | grep GNU > /dev/null; then echo gindent; else echo true ; fi ))
 
 DEFAULT_CFLAGS = -pedantic -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-subscripts -Wuninitialized \
-                 -Wshadow -Wcast-qual -Wcast-align -Wwrite-strings -Wstack-protector -fPIC \
-                 -std=c99 -D_POSIX_C_SOURCE=200809L -fstack-protector-all -O2 -I$(LIBCRYPTO_ROOT)/include/ \
+                 -Wshadow -Wcast-qual -Wcast-align -Wwrite-strings -fPIC \
+                 -std=c99 -D_POSIX_C_SOURCE=200809L -O2 -I$(LIBCRYPTO_ROOT)/include/ \
                  -I../api/ -I../ -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security \
                  -D_FORTIFY_SOURCE=2
+
+# Add a flag to disable stack protector for alternative libcs without
+# libssp.
+ifneq ($(NO_STACK_PROTECTOR), 1)
+DEFAULT_CFLAGS += -Wstack-protector -fstack-protector-all
+endif
 
 CFLAGS = ${DEFAULT_CFLAGS}
 

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -25,7 +25,9 @@
 #include <string.h>
 #include <stdint.h>
 #include <errno.h>
+#if defined(__x86_64__)||defined(__i386__)
 #include <cpuid.h>
+#endif
 
 #include "stuffer/s2n_stuffer.h"
 


### PR DESCRIPTION
This patch contains miscellaneous fixes required to support cross
compilation with MUSL libc.  I have only tested arm64 as a target
but in theory, just about any architecture should work.

The bin tools are using wrong include path for poll.h which MUSL
is strict about.  The lib Makefile was also hard coding the ar and
ranlib utilities which should be accessed through a variable.

I also set a default value for CC, AR, and RANLIB in s2n.mak which
respects the CROSS_COMPILE variable.  Note that this still allows
override via make flags for each utility.

utils/s2n_random.c was also missing a guard around <cpuid.h>.

Finally, MUSL libc does not support libssp so I introduced a variable
called NO_STACK_PROTECTOR which can be used to disable this dependency.

To build for a cross MUSL compiler, use the following command:

  make CROSS_COMPILE=/path/to/musl- NO_STACK_PROTECTOR=1 bin

Signed-off-by: Anthony Liguori <aliguori@amazon.com>