### PR TITLE
Handle EAGAIN

### DIFF
--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -56,7 +56,7 @@ int s2n_read_full_record(struct s2n_connection *conn, uint8_t * record_type, int
             conn->closed = 1;
             S2N_ERROR(S2N_ERR_CLOSED);
         } else if (r < 0) {
-            if (errno == EWOULDBLOCK) {
+            if (errno == EWOULDBLOCK || errno == EAGAIN) {
                 S2N_ERROR(S2N_ERR_BLOCKED);
             }
             S2N_ERROR(S2N_ERR_IO);
@@ -88,7 +88,7 @@ int s2n_read_full_record(struct s2n_connection *conn, uint8_t * record_type, int
             conn->closed = 1;
             S2N_ERROR(S2N_ERR_CLOSED);
         } else if (r < 0) {
-            if (errno == EWOULDBLOCK) {
+            if (errno == EWOULDBLOCK || errno == EAGAIN) {
                 S2N_ERROR(S2N_ERR_BLOCKED);
             }
             S2N_ERROR(S2N_ERR_IO);

--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -42,7 +42,7 @@ int s2n_flush(struct s2n_connection *conn, s2n_blocked_status * blocked)
     while (s2n_stuffer_data_available(&conn->out)) {
         w = s2n_stuffer_send_to_fd(&conn->out, conn->writefd, s2n_stuffer_data_available(&conn->out));
         if (w < 0) {
-            if (errno == EWOULDBLOCK) {
+            if (errno == EWOULDBLOCK || errno == EAGAIN) {
                 S2N_ERROR(S2N_ERR_BLOCKED);
             }
             S2N_ERROR(S2N_ERR_IO);


### PR DESCRIPTION
This change updates s2n to tread EAGAIN as it would EWOULDBLOCK, to handle
systems on which these two constants are not the same value.