### PR TITLE
Use urandom much less without rdrand

### DIFF
--- a/crypto/s2n_drbg.c
+++ b/crypto/s2n_drbg.c
@@ -147,7 +147,13 @@ int s2n_drbg_generate(struct s2n_drbg *drbg, struct s2n_blob *blob)
         S2N_ERROR(S2N_ERR_DRBG_REQUEST_SIZE);
     }
 
-    GUARD(s2n_drbg_seed(drbg, &zeros));
+    /* If either the entropy generator is set, for prediction resistance,
+     * or if we reach the definitely-need-to-reseed limit, then reseed.
+     */
+    if (drbg->entropy_generator || drbg->bytes_used + blob->size + S2N_DRBG_BLOCK_SIZE >= S2N_DRBG_RESEED_LIMIT) {
+        GUARD(s2n_drbg_seed(drbg, &zeros));
+    }
+
     GUARD(s2n_drbg_bits(drbg, blob));
     GUARD(s2n_drbg_update(drbg, &zeros));
 

--- a/crypto/s2n_drbg.h
+++ b/crypto/s2n_drbg.h
@@ -25,6 +25,9 @@
 /* The maximum size of any one request: from NIST SP800-90A 10.2.1 Table 3 */
 #define S2N_DRBG_GENERATE_LIMIT 8192
 
+/* We reseed after 2^35 bytes have been generated: from NIST SP800-90A 10.2.1 Table 3 */
+#define S2N_DRBG_RESEED_LIMIT   34359738368
+
 struct s2n_drbg {
     EVP_CIPHER_CTX ctx;
 

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -25,6 +25,8 @@
 #include <string.h>
 #include <stdint.h>
 #include <errno.h>
+#include <time.h>
+
 #if defined(__x86_64__)||defined(__i386__)
 #include <cpuid.h>
 #endif
@@ -45,6 +47,9 @@
 
 /* See https://en.wikipedia.org/wiki/CPUID */
 #define RDRAND_ECX_FLAG     0x40000000
+
+/* One second in nanoseconds */
+#define ONE_S  INT64_C(1000000000)
 
 static int entropy_fd = -1;
 
@@ -112,15 +117,39 @@ int s2n_get_urandom_data(struct s2n_blob *blob)
 {
     uint32_t n = blob->size;
     uint8_t *data = blob->data;
-
-    if (entropy_fd == -1) {
-        S2N_ERROR(S2N_ERR_RANDOM_UNITIALIZED);
-    }
+    struct timespec sleep_time = {.tv_sec = 0, .tv_nsec = 0 };
+    long backoff = 1;
 
     while (n) {
         int r = read(entropy_fd, data, n);
         if (r <= 0) {
-            sleep(1);
+            /*
+             * A non-blocking read() on /dev/urandom should "never" fail,
+             * except for EINTR. If it does, briefly pause and use
+             * exponential backoff to avoid creating a tight spinning loop.
+             *
+             * iteration          delay
+             * ---------    -----------------
+             *    1         10          nsec
+             *    2         100         nsec
+             *    3         1,000       nsec
+             *    4         10,000      nsec
+             *    5         100,000     nsec
+             *    6         1,000,000   nsec
+             *    7         10,000,000  nsec
+             *    8         99,999,999  nsec
+             *    9         99,999,999  nsec
+             *    ...
+             */
+            if (errno != EINTR) {
+                backoff = MIN(backoff * 10, ONE_S - 1);
+                sleep_time.tv_nsec = backoff;
+                do {
+                    r = nanosleep(&sleep_time, &sleep_time);
+                }
+                while (r != 0);
+            }
+
             continue;
         }
 


### PR DESCRIPTION
Our measurements indicate that reading from /dev/urandom is simply
too slow when doing it from multiple threads. Thankfully rdrand is
available on modern instance types, but let's save the older ones.

This change also removes the sleep() delay for any cases where reading
from /dev/urandom results in EINTR. Instead we immediately retry.
For other cases, we now do exponential backoff. From 10ns to 1s,
and then keep trying at 1s if we get that far.