### PR TITLE
Use uin32_t for current_user_data_consumed

### DIFF
--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -98,7 +98,7 @@ struct s2n_connection {
     /* How much of the current user buffer have we already
      * encrypted and have pending for the wire.
      */
-    uint16_t current_user_data_consumed;
+    uint32_t current_user_data_consumed;
 
     /* An alert may be fragmented across multiple records,
      * this stuffer is used to re-assemble.


### PR DESCRIPTION
Amount of pending user data is not bounded by
2^16 - 1 bytes.