### PR TITLE
Fix the potential arithmetic overflow on s2n_realloc() and s2n_connection_get_delay()

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -81,7 +81,7 @@ extern int s2n_connection_prefer_low_latency(struct s2n_connection *conn);
 
 typedef enum { S2N_BUILT_IN_BLINDING, S2N_SELF_SERVICE_BLINDING } s2n_blinding;
 extern int s2n_connection_set_blinding(struct s2n_connection *conn, s2n_blinding blinding);
-extern int64_t s2n_connection_get_delay(struct s2n_connection *conn);
+extern uint64_t s2n_connection_get_delay(struct s2n_connection *conn);
 
 extern int s2n_set_server_name(struct s2n_connection *conn, const char *server_name);
 extern const char *s2n_get_server_name(struct s2n_connection *conn);

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -347,7 +347,7 @@ int s2n_connection_set_blinding(struct s2n_connection *conn, s2n_blinding blindi
 #define ONE_S  INT64_C(1000000000)
 #define TEN_S  INT64_C(10000000000)
 
-int64_t s2n_connection_get_delay(struct s2n_connection * conn)
+uint64_t s2n_connection_get_delay(struct s2n_connection * conn)
 {
     if (!conn->delay) {
         return 0;

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -58,7 +58,7 @@ int s2n_realloc(struct s2n_blob *b, uint32_t size)
         return 0;
     }
 
-    uint32_t allocate = page_size * ((size + (page_size - 1)) / page_size);
+    uint32_t allocate = page_size * (((size - 1) / page_size) + 1);
 
     void *data;
     if (posix_memalign(&data, page_size, allocate)) {


### PR DESCRIPTION
The changes fix two potential arithmetic overflows:

 1) the inconsistent return type of s2n_connection_get_delay(), which is int64_t, however the returning variable has type uint64_t.

2) if the variable "size" in s2n_realloc() contain a huge value, (size + (page_size - 1)) could cause a unsigned overflow. Although it may not happen in the normal usage, it could be a potential risk.  