### PR TITLE
Use "{0}" instead of "{ {0} }" for struct init

### DIFF
--- a/crypto/s2n_drbg.h
+++ b/crypto/s2n_drbg.h
@@ -29,13 +29,13 @@
 #define S2N_DRBG_RESEED_LIMIT   34359738368
 
 struct s2n_drbg {
+    /* Track how many bytes have been used */
+    uint64_t bytes_used;
+    
     EVP_CIPHER_CTX ctx;
 
     /* The current DRBG 'value' */
     uint8_t v[16];
-
-    /* Track how many bytes have been used */
-    uint64_t bytes_used;
 
     /* Function pointer to the entropy generating function. If it's NULL, then
      * s2n_get_urandom_data() will be used. This function pointer is intended

--- a/tests/unit/s2n_drbg_test.c
+++ b/tests/unit/s2n_drbg_test.c
@@ -156,8 +156,8 @@ int nist_fake_urandom_data(struct s2n_blob *blob)
 
 int main(int argc, char **argv)
 {
-    uint8_t data[256] = { 0 };
-    struct s2n_drbg drbg = {{ 0 }};
+    uint8_t data[256] = {0};
+    struct s2n_drbg drbg = {0};
     struct s2n_blob blob = {.data = data, .size = 64 };
     struct s2n_timer timer;
     uint64_t drbg_nanoseconds;

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -53,8 +53,8 @@
 
 static int entropy_fd = -1;
 
-static __thread struct s2n_drbg per_thread_private_drbg = { {0} };
-static __thread struct s2n_drbg per_thread_public_drbg = { {0} };
+static __thread struct s2n_drbg per_thread_private_drbg = {0};
+static __thread struct s2n_drbg per_thread_public_drbg = {0};
 
 #if !defined(MAP_INHERIT_ZERO)
 static __thread int zero_if_forked = 0;


### PR DESCRIPTION
Clang gives "error: braces around scalar initializer [-Werror,-Wbraced-scalar-init]"
for the previous approach.