### PR TITLE
Make RSA usage opaque

### DIFF
--- a/crypto/s2n_rsa.c
+++ b/crypto/s2n_rsa.c
@@ -93,23 +93,25 @@ int s2n_rsa_private_key_free(struct s2n_rsa_private_key *key)
     return 0;
 }
 
-static BIGNUM *s2n_rsa_get_modulus(RSA *rsa)
+static int s2n_rsa_modulus_check(RSA *rsa)
 {
     /* RSA was made opaque starting in Openssl 1.1.0 */
     #if OPENSSL_VERSION_NUMBER < 0x10100000L
-        return rsa->n;
+        notnull_check(rsa->n);
     #else
         BIGNUM *n = NULL;
         /* RSA still owns the memory for n */
         RSA_get0_key(rsa, &n, NULL, NULL);
-        return n;
+        notnull_check(n);
     #endif
+
+    return 0;
 }
 
 int s2n_rsa_public_encrypted_size(struct s2n_rsa_public_key *key)
 {
     notnull_check(key->rsa);
-    notnull_check(s2n_rsa_get_modulus(key->rsa));
+    GUARD(s2n_rsa_modulus_check(key->rsa));
 
     return RSA_size(key->rsa);
 }
@@ -117,7 +119,7 @@ int s2n_rsa_public_encrypted_size(struct s2n_rsa_public_key *key)
 int s2n_rsa_private_encrypted_size(struct s2n_rsa_private_key *key)
 {
     notnull_check(key->rsa);
-    notnull_check(s2n_rsa_get_modulus(key->rsa));
+    GUARD(s2n_rsa_modulus_check(key->rsa));
 
     return RSA_size(key->rsa);
 }


### PR DESCRIPTION
This changes all of our interaction with RSA objects to be opaque.

We were previously looking into the RSA object for our defensive modulus checks.
There were two choices to get around this:

- Remove the nonull modulus check
- Make a portable check that depends on the OPENSSL_VERSION macro

I went for the second option. See https://www.openssl.org/docs/manmaster/crypto/RSA_get0_key.html
for the new RSA accessor API.

-----

Open to suggestions on a cleaner way to handle Openssl API changes. I don't think we can avoid macros. We'll need to be selective in where we put them.