### PR TITLE
Fix TLS version negotiation

### DIFF
--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -50,7 +50,7 @@ int s2n_client_hello_recv(struct s2n_connection *conn)
     GUARD(s2n_stuffer_read_uint8(in, &conn->session_id_len));
 
     conn->client_protocol_version = (client_protocol_version[0] * 10) + client_protocol_version[1];
-    if (conn->client_protocol_version < conn->config->cipher_preferences->minimum_protocol_version || conn->client_protocol_version > S2N_TLS12) {
+    if (conn->client_protocol_version < conn->config->cipher_preferences->minimum_protocol_version || conn->client_protocol_version > conn->server_protocol_version) {
         GUARD(s2n_queue_reader_unsupported_protocol_version_alert(conn));
         S2N_ERROR(S2N_ERR_BAD_MESSAGE);
     }
@@ -153,7 +153,7 @@ int s2n_sslv2_client_hello_recv(struct s2n_connection *conn)
     uint16_t challenge_length;
     uint8_t *cipher_suites;
 
-    if (conn->client_protocol_version < conn->config->cipher_preferences->minimum_protocol_version || conn->client_protocol_version > S2N_TLS12) {
+    if (conn->client_protocol_version < conn->config->cipher_preferences->minimum_protocol_version || conn->client_protocol_version > conn->server_protocol_version) {
         GUARD(s2n_queue_reader_unsupported_protocol_version_alert(conn));
         S2N_ERROR(S2N_ERR_BAD_MESSAGE);
     }

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -212,7 +212,7 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     conn->server = &conn->initial;
     conn->client = &conn->initial;
     conn->max_fragment_length = S2N_SMALL_FRAGMENT_LENGTH;
-    conn->handshake.handshake_type = 0;
+    conn->handshake.handshake_type = INITIAL;
     conn->handshake.message_number = 0;
     GUARD(s2n_hash_init(&conn->handshake.md5, S2N_HASH_MD5));
     GUARD(s2n_hash_init(&conn->handshake.sha1, S2N_HASH_SHA1));

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -46,17 +46,12 @@ int s2n_server_hello_recv(struct s2n_connection *conn)
 
     conn->server_protocol_version = (protocol_version[0] * 10) + protocol_version[1];
 
-    if (conn->server_protocol_version > conn->actual_protocol_version) {
+    if (conn->server_protocol_version < conn->config->cipher_preferences->minimum_protocol_version || conn->server_protocol_version > conn->client_protocol_version) {
         GUARD(s2n_queue_reader_unsupported_protocol_version_alert(conn));
         S2N_ERROR(S2N_ERR_BAD_MESSAGE);
     }
-    conn->actual_protocol_version = conn->server_protocol_version;
+    conn->actual_protocol_version = MIN(conn->server_protocol_version, conn->client_protocol_version);
     conn->actual_protocol_version_established = 1;
-
-    /* Verify that the protocol version is sane */
-    if (conn->actual_protocol_version < S2N_SSLv3 || conn->actual_protocol_version > S2N_TLS12) {
-        S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-    }
 
     conn->secure.signature_digest_alg = S2N_HASH_MD5_SHA1;
     if (conn->actual_protocol_version == S2N_TLS12) {


### PR DESCRIPTION
This change fixes s2n's client-side TLS version negotiation to use the
highest version of TLS/SSL supported by both sides.