### PR TITLE
Make our CBC memcpy conditional

### DIFF
--- a/tls/s2n_record_read.c
+++ b/tls/s2n_record_read.c
@@ -189,11 +189,15 @@ int s2n_record_parse(struct s2n_connection *conn)
         eq_check(en.size % iv.size, 0);
 
         /* Copy the last encrypted block to be the next IV */
-        memcpy_check(ivpad, en.data + en.size - iv.size, iv.size);
+        if (conn->actual_protocol_version < S2N_TLS11) {
+            memcpy_check(ivpad, en.data + en.size - iv.size, iv.size);
+        }
 
         GUARD(cipher_suite->cipher->io.cbc.decrypt(session_key, &iv, &en, &en));
 
-        memcpy_check(implicit_iv, ivpad, iv.size);
+        if (conn->actual_protocol_version < S2N_TLS11) {
+            memcpy_check(implicit_iv, ivpad, iv.size);
+        }
         break;
     case S2N_AEAD:
         /* Skip explicit IV for decryption */

--- a/tls/s2n_record_write.c
+++ b/tls/s2n_record_write.c
@@ -241,8 +241,10 @@ int s2n_record_write(struct s2n_connection *conn, uint8_t content_type, struct s
         GUARD(cipher_suite->cipher->io.cbc.encrypt(session_key, &iv, &en, &en));
 
         /* Copy the last encrypted block to be the next IV */
-        gte_check(en.size, block_size);
-        memcpy_check(implicit_iv, en.data + en.size - block_size, block_size);
+        if (conn->actual_protocol_version < S2N_TLS11) {
+            gte_check(en.size, block_size);
+            memcpy_check(implicit_iv, en.data + en.size - block_size, block_size);
+        }
         break;
     case S2N_AEAD:
         GUARD(cipher_suite->cipher->io.aead.encrypt(session_key, &iv, &aad, &en, &en));


### PR DESCRIPTION
For CBC encryption prior to TLS1.1 we need to copy the last block
of each record to use as an IV in the next record. This change
makes this memcpy conditional and avoids for TLS1.1/1.2.