### PR TITLE
Make our outputs precious

### DIFF
--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -20,6 +20,7 @@ VALGRIND_TESTS=$(SRCS:.c=_valgrind)
 CRYPTO_LDFLAGS = -L$(LIBCRYPTO_ROOT)/lib
 
 .PHONY : all
+.PRECIOUS : $(TESTS)
 all: $(TESTS)
 
 include ../../s2n.mk


### PR DESCRIPTION
This change marks our compiled tests as "Precious" which means they
won't be deleted when a test fails. This makes it much easier to
re-run the test by hand inside gdb/lldb.