### PR TITLE
Use EVP interface for RC4 implementation

### DIFF
--- a/crypto/s2n_aead_cipher_aes_gcm.c
+++ b/crypto/s2n_aead_cipher_aes_gcm.c
@@ -30,7 +30,7 @@ static int s2n_aead_cipher_aes_gcm_encrypt(struct s2n_session_key *key, struct s
     eq_check(iv->size, S2N_TLS_GCM_IV_LEN);
 
     /* Initialize the IV */
-    if (EVP_EncryptInit_ex(&key->native_format.evp_cipher_ctx, NULL, NULL, NULL, iv->data) != 1) {
+    if (EVP_EncryptInit_ex(&key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) != 1) {
         S2N_ERROR(S2N_ERR_KEY_INIT);
     }
 
@@ -40,22 +40,22 @@ static int s2n_aead_cipher_aes_gcm_encrypt(struct s2n_session_key *key, struct s
 
     int out_len;
     /* Specify the AAD */
-    if (EVP_EncryptUpdate(&key->native_format.evp_cipher_ctx, NULL, &out_len, aad->data, aad->size) != 1) {
+    if (EVP_EncryptUpdate(&key->evp_cipher_ctx, NULL, &out_len, aad->data, aad->size) != 1) {
         S2N_ERROR(S2N_ERR_ENCRYPT);
     }
 
     /* Encrypt the data */
-    if (EVP_EncryptUpdate(&key->native_format.evp_cipher_ctx, out->data, &out_len, in->data, in_len) != 1) {
+    if (EVP_EncryptUpdate(&key->evp_cipher_ctx, out->data, &out_len, in->data, in_len) != 1) {
         S2N_ERROR(S2N_ERR_ENCRYPT);
     }
 
     /* Finalize */
-    if (EVP_EncryptFinal_ex(&key->native_format.evp_cipher_ctx, out->data, &out_len) != 1) {
+    if (EVP_EncryptFinal_ex(&key->evp_cipher_ctx, out->data, &out_len) != 1) {
         S2N_ERROR(S2N_ERR_ENCRYPT);
     }
 
     /* write the tag */
-    if (EVP_CIPHER_CTX_ctrl(&key->native_format.evp_cipher_ctx, EVP_CTRL_GCM_GET_TAG, S2N_TLS_GCM_TAG_LEN, tag_data) != 1) {
+    if (EVP_CIPHER_CTX_ctrl(&key->evp_cipher_ctx, EVP_CTRL_GCM_GET_TAG, S2N_TLS_GCM_TAG_LEN, tag_data) != 1) {
         S2N_ERROR(S2N_ERR_ENCRYPT);
     }
 
@@ -69,7 +69,7 @@ static int s2n_aead_cipher_aes_gcm_decrypt(struct s2n_session_key *key, struct s
     eq_check(iv->size, S2N_TLS_GCM_IV_LEN);
 
     /* Initialize the IV */
-    if (EVP_DecryptInit_ex(&key->native_format.evp_cipher_ctx, NULL, NULL, NULL, iv->data) != 1) {
+    if (EVP_DecryptInit_ex(&key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) != 1) {
         S2N_ERROR(S2N_ERR_KEY_INIT);
     }
 
@@ -78,23 +78,23 @@ static int s2n_aead_cipher_aes_gcm_decrypt(struct s2n_session_key *key, struct s
     uint8_t *tag_data = in->data + in->size - S2N_TLS_GCM_TAG_LEN;
 
     /* Set the TAG */
-    if (EVP_CIPHER_CTX_ctrl(&key->native_format.evp_cipher_ctx, EVP_CTRL_GCM_SET_TAG, S2N_TLS_GCM_TAG_LEN, tag_data) == 0) {
+    if (EVP_CIPHER_CTX_ctrl(&key->evp_cipher_ctx, EVP_CTRL_GCM_SET_TAG, S2N_TLS_GCM_TAG_LEN, tag_data) == 0) {
         S2N_ERROR(S2N_ERR_DECRYPT);
     }
 
     int out_len;
     /* Specify the AAD */
-    if (EVP_DecryptUpdate(&key->native_format.evp_cipher_ctx, NULL, &out_len, aad->data, aad->size) != 1) {
+    if (EVP_DecryptUpdate(&key->evp_cipher_ctx, NULL, &out_len, aad->data, aad->size) != 1) {
         S2N_ERROR(S2N_ERR_DECRYPT);
     }
 
     /* Decrypt the data */
-    if (EVP_DecryptUpdate(&key->native_format.evp_cipher_ctx, out->data, &out_len, in->data, in_len) != 1) {
+    if (EVP_DecryptUpdate(&key->evp_cipher_ctx, out->data, &out_len, in->data, in_len) != 1) {
         S2N_ERROR(S2N_ERR_DECRYPT);
     }
 
     /* Verify the tag */
-    if (EVP_DecryptFinal_ex(&key->native_format.evp_cipher_ctx, out->data, &out_len) != 1) {
+    if (EVP_DecryptFinal_ex(&key->evp_cipher_ctx, out->data, &out_len) != 1) {
         S2N_ERROR(S2N_ERR_DECRYPT);
     }
 
@@ -105,9 +105,9 @@ static int s2n_aead_cipher_aes128_gcm_get_encryption_key(struct s2n_session_key 
 {
     eq_check(in->size, 16);
 
-    EVP_EncryptInit_ex(&key->native_format.evp_cipher_ctx, EVP_aes_128_gcm(), NULL, NULL, NULL);
-    EVP_CIPHER_CTX_ctrl(&key->native_format.evp_cipher_ctx, EVP_CTRL_GCM_SET_IVLEN, S2N_TLS_GCM_IV_LEN, NULL);
-    EVP_EncryptInit_ex(&key->native_format.evp_cipher_ctx, NULL, NULL, in->data, NULL);
+    EVP_EncryptInit_ex(&key->evp_cipher_ctx, EVP_aes_128_gcm(), NULL, NULL, NULL);
+    EVP_CIPHER_CTX_ctrl(&key->evp_cipher_ctx, EVP_CTRL_GCM_SET_IVLEN, S2N_TLS_GCM_IV_LEN, NULL);
+    EVP_EncryptInit_ex(&key->evp_cipher_ctx, NULL, NULL, in->data, NULL);
 
     return 0;
 }
@@ -116,9 +116,9 @@ static int s2n_aead_cipher_aes256_gcm_get_encryption_key(struct s2n_session_key 
 {
     eq_check(in->size, 32);
 
-    EVP_EncryptInit_ex(&key->native_format.evp_cipher_ctx, EVP_aes_256_gcm(), NULL, NULL, NULL);
-    EVP_CIPHER_CTX_ctrl(&key->native_format.evp_cipher_ctx, EVP_CTRL_GCM_SET_IVLEN, S2N_TLS_GCM_IV_LEN, NULL);
-    EVP_EncryptInit_ex(&key->native_format.evp_cipher_ctx, NULL, NULL, in->data, NULL);
+    EVP_EncryptInit_ex(&key->evp_cipher_ctx, EVP_aes_256_gcm(), NULL, NULL, NULL);
+    EVP_CIPHER_CTX_ctrl(&key->evp_cipher_ctx, EVP_CTRL_GCM_SET_IVLEN, S2N_TLS_GCM_IV_LEN, NULL);
+    EVP_EncryptInit_ex(&key->evp_cipher_ctx, NULL, NULL, in->data, NULL);
 
     return 0;
 }
@@ -127,9 +127,9 @@ static int s2n_aead_cipher_aes128_gcm_get_decryption_key(struct s2n_session_key 
 {
     eq_check(in->size, 16);
 
-    EVP_DecryptInit_ex(&key->native_format.evp_cipher_ctx, EVP_aes_128_gcm(), NULL, NULL, NULL);
-    EVP_CIPHER_CTX_ctrl(&key->native_format.evp_cipher_ctx, EVP_CTRL_GCM_SET_IVLEN, S2N_TLS_GCM_IV_LEN, NULL);
-    EVP_DecryptInit_ex(&key->native_format.evp_cipher_ctx, NULL, NULL, in->data, NULL);
+    EVP_DecryptInit_ex(&key->evp_cipher_ctx, EVP_aes_128_gcm(), NULL, NULL, NULL);
+    EVP_CIPHER_CTX_ctrl(&key->evp_cipher_ctx, EVP_CTRL_GCM_SET_IVLEN, S2N_TLS_GCM_IV_LEN, NULL);
+    EVP_DecryptInit_ex(&key->evp_cipher_ctx, NULL, NULL, in->data, NULL);
 
     return 0;
 }
@@ -138,23 +138,23 @@ static int s2n_aead_cipher_aes256_gcm_get_decryption_key(struct s2n_session_key 
 {
     eq_check(in->size, 32);
 
-    EVP_DecryptInit_ex(&key->native_format.evp_cipher_ctx, EVP_aes_256_gcm(), NULL, NULL, NULL);
-    EVP_CIPHER_CTX_ctrl(&key->native_format.evp_cipher_ctx, EVP_CTRL_GCM_SET_IVLEN, S2N_TLS_GCM_IV_LEN, NULL);
-    EVP_DecryptInit_ex(&key->native_format.evp_cipher_ctx, NULL, NULL, in->data, NULL);
+    EVP_DecryptInit_ex(&key->evp_cipher_ctx, EVP_aes_256_gcm(), NULL, NULL, NULL);
+    EVP_CIPHER_CTX_ctrl(&key->evp_cipher_ctx, EVP_CTRL_GCM_SET_IVLEN, S2N_TLS_GCM_IV_LEN, NULL);
+    EVP_DecryptInit_ex(&key->evp_cipher_ctx, NULL, NULL, in->data, NULL);
 
     return 0;
 }
 
 static int s2n_aead_cipher_aes_gcm_init(struct s2n_session_key *key)
 {
-    EVP_CIPHER_CTX_init(&key->native_format.evp_cipher_ctx);
+    EVP_CIPHER_CTX_init(&key->evp_cipher_ctx);
 
     return 0;
 }
 
 static int s2n_aead_cipher_aes_gcm_destroy_key(struct s2n_session_key *key)
 {
-    EVP_CIPHER_CTX_cleanup(&key->native_format.evp_cipher_ctx);
+    EVP_CIPHER_CTX_cleanup(&key->evp_cipher_ctx);
 
     return 0;
 }

--- a/crypto/s2n_cbc_cipher_3des.c
+++ b/crypto/s2n_cbc_cipher_3des.c
@@ -26,12 +26,12 @@ static int s2n_cbc_cipher_3des_encrypt(struct s2n_session_key *key, struct s2n_b
 {
     gte_check(out->size, in->size);
 
-    if (EVP_EncryptInit_ex(&key->native_format.evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0) {
+    if (EVP_EncryptInit_ex(&key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0) {
         S2N_ERROR(S2N_ERR_KEY_INIT);
     }
 
     int len = out->size;
-    if (EVP_EncryptUpdate(&key->native_format.evp_cipher_ctx, out->data, &len, in->data, in->size) == 0) {
+    if (EVP_EncryptUpdate(&key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0) {
         S2N_ERROR(S2N_ERR_ENCRYPT);
     }
 
@@ -46,12 +46,12 @@ static int s2n_cbc_cipher_3des_decrypt(struct s2n_session_key *key, struct s2n_b
 {
     gte_check(out->size, in->size);
 
-    if (EVP_DecryptInit_ex(&key->native_format.evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0) {
+    if (EVP_DecryptInit_ex(&key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0) {
         S2N_ERROR(S2N_ERR_KEY_INIT);
     }
 
     int len = out->size;
-    if (EVP_DecryptUpdate(&key->native_format.evp_cipher_ctx, out->data, &len, in->data, in->size) == 0) {
+    if (EVP_DecryptUpdate(&key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0) {
         S2N_ERROR(S2N_ERR_DECRYPT);
     }
 
@@ -61,8 +61,8 @@ static int s2n_cbc_cipher_3des_decrypt(struct s2n_session_key *key, struct s2n_b
 static int s2n_cbc_cipher_3des_get_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
     eq_check(in->size, 192 / 8);
-    EVP_CIPHER_CTX_set_padding(&key->native_format.evp_cipher_ctx, EVP_CIPH_NO_PADDING);
-    EVP_DecryptInit_ex(&key->native_format.evp_cipher_ctx, EVP_des_ede3_cbc(), NULL, in->data, NULL);
+    EVP_CIPHER_CTX_set_padding(&key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
+    EVP_DecryptInit_ex(&key->evp_cipher_ctx, EVP_des_ede3_cbc(), NULL, in->data, NULL);
 
     return 0;
 }
@@ -70,22 +70,22 @@ static int s2n_cbc_cipher_3des_get_decryption_key(struct s2n_session_key *key, s
 static int s2n_cbc_cipher_3des_get_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
     eq_check(in->size, 192 / 8);
-    EVP_CIPHER_CTX_set_padding(&key->native_format.evp_cipher_ctx, EVP_CIPH_NO_PADDING);
-    EVP_EncryptInit_ex(&key->native_format.evp_cipher_ctx, EVP_des_ede3_cbc(), NULL, in->data, NULL);
+    EVP_CIPHER_CTX_set_padding(&key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
+    EVP_EncryptInit_ex(&key->evp_cipher_ctx, EVP_des_ede3_cbc(), NULL, in->data, NULL);
 
     return 0;
 }
 
 static int s2n_cbc_cipher_3des_init(struct s2n_session_key *key)
 {
-    EVP_CIPHER_CTX_init(&key->native_format.evp_cipher_ctx);
+    EVP_CIPHER_CTX_init(&key->evp_cipher_ctx);
 
     return 0;
 }
 
 static int s2n_cbc_cipher_3des_destroy_key(struct s2n_session_key *key)
 {
-    EVP_CIPHER_CTX_cleanup(&key->native_format.evp_cipher_ctx);
+    EVP_CIPHER_CTX_cleanup(&key->evp_cipher_ctx);
 
     return 0;
 }

--- a/crypto/s2n_cbc_cipher_aes.c
+++ b/crypto/s2n_cbc_cipher_aes.c
@@ -26,12 +26,12 @@ static int s2n_cbc_cipher_aes_encrypt(struct s2n_session_key *key, struct s2n_bl
 {
     gte_check(out->size, in->size);
 
-    if (EVP_EncryptInit_ex(&key->native_format.evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0) {
+    if (EVP_EncryptInit_ex(&key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0) {
         S2N_ERROR(S2N_ERR_KEY_INIT);
     }
 
     int len = out->size;
-    if (EVP_EncryptUpdate(&key->native_format.evp_cipher_ctx, out->data, &len, in->data, in->size) == 0) {
+    if (EVP_EncryptUpdate(&key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0) {
         S2N_ERROR(S2N_ERR_ENCRYPT);
     }
 
@@ -46,12 +46,12 @@ int s2n_cbc_cipher_aes_decrypt(struct s2n_session_key *key, struct s2n_blob *iv,
 {
     gte_check(out->size, in->size);
 
-    if (EVP_DecryptInit_ex(&key->native_format.evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0) {
+    if (EVP_DecryptInit_ex(&key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0) {
         S2N_ERROR(S2N_ERR_KEY_INIT);
     }
 
     int len = out->size;
-    if (EVP_DecryptUpdate(&key->native_format.evp_cipher_ctx, out->data, &len, in->data, in->size) == 0) {
+    if (EVP_DecryptUpdate(&key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0) {
         S2N_ERROR(S2N_ERR_DECRYPT);
     }
 
@@ -61,8 +61,8 @@ int s2n_cbc_cipher_aes_decrypt(struct s2n_session_key *key, struct s2n_blob *iv,
 int s2n_cbc_cipher_aes128_get_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
     eq_check(in->size, 128 / 8);
-    EVP_CIPHER_CTX_set_padding(&key->native_format.evp_cipher_ctx, EVP_CIPH_NO_PADDING);
-    EVP_DecryptInit_ex(&key->native_format.evp_cipher_ctx, EVP_aes_128_cbc(), NULL, in->data, NULL);
+    EVP_CIPHER_CTX_set_padding(&key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
+    EVP_DecryptInit_ex(&key->evp_cipher_ctx, EVP_aes_128_cbc(), NULL, in->data, NULL);
 
     return 0;
 }
@@ -70,8 +70,8 @@ int s2n_cbc_cipher_aes128_get_decryption_key(struct s2n_session_key *key, struct
 static int s2n_cbc_cipher_aes128_get_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
     eq_check(in->size, 128 / 8);
-    EVP_CIPHER_CTX_set_padding(&key->native_format.evp_cipher_ctx, EVP_CIPH_NO_PADDING);
-    EVP_EncryptInit_ex(&key->native_format.evp_cipher_ctx, EVP_aes_128_cbc(), NULL, in->data, NULL);
+    EVP_CIPHER_CTX_set_padding(&key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
+    EVP_EncryptInit_ex(&key->evp_cipher_ctx, EVP_aes_128_cbc(), NULL, in->data, NULL);
 
     return 0;
 }
@@ -79,8 +79,8 @@ static int s2n_cbc_cipher_aes128_get_encryption_key(struct s2n_session_key *key,
 static int s2n_cbc_cipher_aes256_get_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
     eq_check(in->size, 256 / 8);
-    EVP_CIPHER_CTX_set_padding(&key->native_format.evp_cipher_ctx, EVP_CIPH_NO_PADDING);
-    EVP_DecryptInit_ex(&key->native_format.evp_cipher_ctx, EVP_aes_256_cbc(), NULL, in->data, NULL);
+    EVP_CIPHER_CTX_set_padding(&key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
+    EVP_DecryptInit_ex(&key->evp_cipher_ctx, EVP_aes_256_cbc(), NULL, in->data, NULL);
 
     return 0;
 }
@@ -88,23 +88,23 @@ static int s2n_cbc_cipher_aes256_get_decryption_key(struct s2n_session_key *key,
 int s2n_cbc_cipher_aes256_get_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
     eq_check(in->size, 256 / 8);
-    EVP_CIPHER_CTX_init(&key->native_format.evp_cipher_ctx);
-    EVP_CIPHER_CTX_set_padding(&key->native_format.evp_cipher_ctx, EVP_CIPH_NO_PADDING);
-    EVP_EncryptInit_ex(&key->native_format.evp_cipher_ctx, EVP_aes_256_cbc(), NULL, in->data, NULL);
+    EVP_CIPHER_CTX_init(&key->evp_cipher_ctx);
+    EVP_CIPHER_CTX_set_padding(&key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
+    EVP_EncryptInit_ex(&key->evp_cipher_ctx, EVP_aes_256_cbc(), NULL, in->data, NULL);
 
     return 0;
 }
 
 static int s2n_cbc_cipher_aes_init(struct s2n_session_key *key)
 {
-    EVP_CIPHER_CTX_init(&key->native_format.evp_cipher_ctx);
+    EVP_CIPHER_CTX_init(&key->evp_cipher_ctx);
 
     return 0;
 }
 
 static int s2n_cbc_cipher_aes_destroy_key(struct s2n_session_key *key)
 {
-    EVP_CIPHER_CTX_cleanup(&key->native_format.evp_cipher_ctx);
+    EVP_CIPHER_CTX_cleanup(&key->evp_cipher_ctx);
 
     return 0;
 }

--- a/crypto/s2n_cipher.h
+++ b/crypto/s2n_cipher.h
@@ -27,15 +27,7 @@
 #include "utils/s2n_blob.h"
 
 struct s2n_session_key {
-    union {
-        RC4_KEY rc4;
-        struct {
-            DES_key_schedule dks1;
-            DES_key_schedule dks2;
-            DES_key_schedule dks3;
-        } des;
-        EVP_CIPHER_CTX evp_cipher_ctx;
-    } native_format;
+    EVP_CIPHER_CTX evp_cipher_ctx;
 };
 
 struct s2n_stream_cipher {

--- a/crypto/s2n_stream_cipher_rc4.c
+++ b/crypto/s2n_stream_cipher_rc4.c
@@ -20,27 +20,65 @@
 #include "utils/s2n_safety.h"
 #include "utils/s2n_blob.h"
 
-static int s2n_stream_cipher_rc4_endecrypt(struct s2n_session_key *key, struct s2n_blob *in, struct s2n_blob *out)
+static int s2n_stream_cipher_rc4_encrypt(struct s2n_session_key *key, struct s2n_blob *in, struct s2n_blob *out)
 {
     gte_check(out->size, in->size);
-    RC4(&key->native_format.rc4, out->size, in->data, out->data);
+
+    int len = out->size;
+    if (EVP_EncryptUpdate(&key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0) {
+        S2N_ERROR(S2N_ERR_ENCRYPT);
+    }
+
+    if (len != in->size) {
+        S2N_ERROR(S2N_ERR_ENCRYPT);
+    }
+
     return 0;
 }
 
-static int s2n_stream_cipher_rc4_get_key(struct s2n_session_key *key, struct s2n_blob *in)
+static int s2n_stream_cipher_rc4_decrypt(struct s2n_session_key *key, struct s2n_blob *in, struct s2n_blob *out)
+{
+    gte_check(out->size, in->size);
+
+    int len = out->size;
+    if (EVP_DecryptUpdate(&key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0) {
+        S2N_ERROR(S2N_ERR_ENCRYPT);
+    }
+
+    if (len != in->size) {
+        S2N_ERROR(S2N_ERR_ENCRYPT);
+    }
+
+    return 0;
+}
+
+static int s2n_stream_cipher_rc4_get_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
     eq_check(in->size, 16);
-    RC4_set_key(&key->native_format.rc4, in->size, in->data);
+    EVP_EncryptInit_ex(&key->evp_cipher_ctx, EVP_rc4(), NULL, in->data, NULL);
+
+    return 0;
+}
+
+static int s2n_stream_cipher_rc4_get_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
+{
+    eq_check(in->size, 16);
+    EVP_DecryptInit_ex(&key->evp_cipher_ctx, EVP_rc4(), NULL, in->data, NULL);
+
     return 0;
 }
 
 static int s2n_stream_cipher_rc4_init(struct s2n_session_key *key)
 {
+    EVP_CIPHER_CTX_init(&key->evp_cipher_ctx);
+
     return 0;
 }
 
 static int s2n_stream_cipher_rc4_destroy_key(struct s2n_session_key *key)
 {
+    EVP_CIPHER_CTX_cleanup(&key->evp_cipher_ctx);
+
     return 0;
 }
 
@@ -48,10 +86,10 @@ struct s2n_cipher s2n_rc4 = {
     .type = S2N_STREAM,
     .key_material_size = 16,
     .io.stream = {
-                  .decrypt = s2n_stream_cipher_rc4_endecrypt,
-                  .encrypt = s2n_stream_cipher_rc4_endecrypt},
+                  .decrypt = s2n_stream_cipher_rc4_decrypt,
+                  .encrypt = s2n_stream_cipher_rc4_encrypt},
     .init = s2n_stream_cipher_rc4_init,
-    .get_decryption_key = s2n_stream_cipher_rc4_get_key,
-    .get_encryption_key = s2n_stream_cipher_rc4_get_key,
+    .get_decryption_key = s2n_stream_cipher_rc4_get_decryption_key,
+    .get_encryption_key = s2n_stream_cipher_rc4_get_encryption_key,
     .destroy_key = s2n_stream_cipher_rc4_destroy_key,
 };

--- a/tests/unit/s2n_rc4_test.c
+++ b/tests/unit/s2n_rc4_test.c
@@ -46,6 +46,7 @@ int main(int argc, char **argv)
 
     /* Peer and we are in sync */
     conn->server = &conn->secure;
+    conn->client = &conn->secure;
 
     /* test the RC4 cipher with a SHA1 hash */
     conn->secure.cipher_suite->cipher = &s2n_rc4;


### PR DESCRIPTION
This changes direct use of the RC4 low-level crypto functions with
the high level EVP_* interface. The EVP interface is recommended as
it allows the underlying ENGINE to be overridden. Having all of our
ciphers use EVP_* results in cleaner code.