### PR TITLE
Use xcode8 osx_image in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ addons:
         - indent
         - cppcheck
 
+osx_image: xcode8
+
 os:
   - osx
   - linux


### PR DESCRIPTION
This change fixes Travis OSX lack of output build failures by
upgrading the OSX version to 10.11(El Capitan).
The homebrew tap we are using for gcc6 removed bottle support for
Mavericks[1], causing builds to compile gcc from source.

Note: xcode8 corresponds to El Capitan in the TravisCI world[2].

[1] https://github.com/Homebrew/homebrew-versions/commit/f48a10726ffa92ad7ddc3f5e86fa13f343452a4f
[2] https://docs.travis-ci.com/user/languages/objective-c/#Supported-Xcode-versions