### PR TITLE
Make EVP_CIPHER_CTX usage opaque

### DIFF
--- a/crypto/s2n_aead_cipher_aes_gcm.c
+++ b/crypto/s2n_aead_cipher_aes_gcm.c
@@ -30,7 +30,7 @@ static int s2n_aead_cipher_aes_gcm_encrypt(struct s2n_session_key *key, struct s
     eq_check(iv->size, S2N_TLS_GCM_IV_LEN);
 
     /* Initialize the IV */
-    if (EVP_EncryptInit_ex(&key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) != 1) {
+    if (EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) != 1) {
         S2N_ERROR(S2N_ERR_KEY_INIT);
     }
 
@@ -40,22 +40,22 @@ static int s2n_aead_cipher_aes_gcm_encrypt(struct s2n_session_key *key, struct s
 
     int out_len;
     /* Specify the AAD */
-    if (EVP_EncryptUpdate(&key->evp_cipher_ctx, NULL, &out_len, aad->data, aad->size) != 1) {
+    if (EVP_EncryptUpdate(key->evp_cipher_ctx, NULL, &out_len, aad->data, aad->size) != 1) {
         S2N_ERROR(S2N_ERR_ENCRYPT);
     }
 
     /* Encrypt the data */
-    if (EVP_EncryptUpdate(&key->evp_cipher_ctx, out->data, &out_len, in->data, in_len) != 1) {
+    if (EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &out_len, in->data, in_len) != 1) {
         S2N_ERROR(S2N_ERR_ENCRYPT);
     }
 
     /* Finalize */
-    if (EVP_EncryptFinal_ex(&key->evp_cipher_ctx, out->data, &out_len) != 1) {
+    if (EVP_EncryptFinal_ex(key->evp_cipher_ctx, out->data, &out_len) != 1) {
         S2N_ERROR(S2N_ERR_ENCRYPT);
     }
 
     /* write the tag */
-    if (EVP_CIPHER_CTX_ctrl(&key->evp_cipher_ctx, EVP_CTRL_GCM_GET_TAG, S2N_TLS_GCM_TAG_LEN, tag_data) != 1) {
+    if (EVP_CIPHER_CTX_ctrl(key->evp_cipher_ctx, EVP_CTRL_GCM_GET_TAG, S2N_TLS_GCM_TAG_LEN, tag_data) != 1) {
         S2N_ERROR(S2N_ERR_ENCRYPT);
     }
 
@@ -69,7 +69,7 @@ static int s2n_aead_cipher_aes_gcm_decrypt(struct s2n_session_key *key, struct s
     eq_check(iv->size, S2N_TLS_GCM_IV_LEN);
 
     /* Initialize the IV */
-    if (EVP_DecryptInit_ex(&key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) != 1) {
+    if (EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) != 1) {
         S2N_ERROR(S2N_ERR_KEY_INIT);
     }
 
@@ -78,23 +78,23 @@ static int s2n_aead_cipher_aes_gcm_decrypt(struct s2n_session_key *key, struct s
     uint8_t *tag_data = in->data + in->size - S2N_TLS_GCM_TAG_LEN;
 
     /* Set the TAG */
-    if (EVP_CIPHER_CTX_ctrl(&key->evp_cipher_ctx, EVP_CTRL_GCM_SET_TAG, S2N_TLS_GCM_TAG_LEN, tag_data) == 0) {
+    if (EVP_CIPHER_CTX_ctrl(key->evp_cipher_ctx, EVP_CTRL_GCM_SET_TAG, S2N_TLS_GCM_TAG_LEN, tag_data) == 0) {
         S2N_ERROR(S2N_ERR_DECRYPT);
     }
 
     int out_len;
     /* Specify the AAD */
-    if (EVP_DecryptUpdate(&key->evp_cipher_ctx, NULL, &out_len, aad->data, aad->size) != 1) {
+    if (EVP_DecryptUpdate(key->evp_cipher_ctx, NULL, &out_len, aad->data, aad->size) != 1) {
         S2N_ERROR(S2N_ERR_DECRYPT);
     }
 
     /* Decrypt the data */
-    if (EVP_DecryptUpdate(&key->evp_cipher_ctx, out->data, &out_len, in->data, in_len) != 1) {
+    if (EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &out_len, in->data, in_len) != 1) {
         S2N_ERROR(S2N_ERR_DECRYPT);
     }
 
     /* Verify the tag */
-    if (EVP_DecryptFinal_ex(&key->evp_cipher_ctx, out->data, &out_len) != 1) {
+    if (EVP_DecryptFinal_ex(key->evp_cipher_ctx, out->data, &out_len) != 1) {
         S2N_ERROR(S2N_ERR_DECRYPT);
     }
 
@@ -105,9 +105,9 @@ static int s2n_aead_cipher_aes128_gcm_get_encryption_key(struct s2n_session_key 
 {
     eq_check(in->size, 16);
 
-    EVP_EncryptInit_ex(&key->evp_cipher_ctx, EVP_aes_128_gcm(), NULL, NULL, NULL);
-    EVP_CIPHER_CTX_ctrl(&key->evp_cipher_ctx, EVP_CTRL_GCM_SET_IVLEN, S2N_TLS_GCM_IV_LEN, NULL);
-    EVP_EncryptInit_ex(&key->evp_cipher_ctx, NULL, NULL, in->data, NULL);
+    EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_aes_128_gcm(), NULL, NULL, NULL);
+    EVP_CIPHER_CTX_ctrl(key->evp_cipher_ctx, EVP_CTRL_GCM_SET_IVLEN, S2N_TLS_GCM_IV_LEN, NULL);
+    EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, in->data, NULL);
 
     return 0;
 }
@@ -116,9 +116,9 @@ static int s2n_aead_cipher_aes256_gcm_get_encryption_key(struct s2n_session_key 
 {
     eq_check(in->size, 32);
 
-    EVP_EncryptInit_ex(&key->evp_cipher_ctx, EVP_aes_256_gcm(), NULL, NULL, NULL);
-    EVP_CIPHER_CTX_ctrl(&key->evp_cipher_ctx, EVP_CTRL_GCM_SET_IVLEN, S2N_TLS_GCM_IV_LEN, NULL);
-    EVP_EncryptInit_ex(&key->evp_cipher_ctx, NULL, NULL, in->data, NULL);
+    EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_aes_256_gcm(), NULL, NULL, NULL);
+    EVP_CIPHER_CTX_ctrl(key->evp_cipher_ctx, EVP_CTRL_GCM_SET_IVLEN, S2N_TLS_GCM_IV_LEN, NULL);
+    EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, in->data, NULL);
 
     return 0;
 }
@@ -127,9 +127,9 @@ static int s2n_aead_cipher_aes128_gcm_get_decryption_key(struct s2n_session_key 
 {
     eq_check(in->size, 16);
 
-    EVP_DecryptInit_ex(&key->evp_cipher_ctx, EVP_aes_128_gcm(), NULL, NULL, NULL);
-    EVP_CIPHER_CTX_ctrl(&key->evp_cipher_ctx, EVP_CTRL_GCM_SET_IVLEN, S2N_TLS_GCM_IV_LEN, NULL);
-    EVP_DecryptInit_ex(&key->evp_cipher_ctx, NULL, NULL, in->data, NULL);
+    EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_aes_128_gcm(), NULL, NULL, NULL);
+    EVP_CIPHER_CTX_ctrl(key->evp_cipher_ctx, EVP_CTRL_GCM_SET_IVLEN, S2N_TLS_GCM_IV_LEN, NULL);
+    EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, in->data, NULL);
 
     return 0;
 }
@@ -138,23 +138,23 @@ static int s2n_aead_cipher_aes256_gcm_get_decryption_key(struct s2n_session_key 
 {
     eq_check(in->size, 32);
 
-    EVP_DecryptInit_ex(&key->evp_cipher_ctx, EVP_aes_256_gcm(), NULL, NULL, NULL);
-    EVP_CIPHER_CTX_ctrl(&key->evp_cipher_ctx, EVP_CTRL_GCM_SET_IVLEN, S2N_TLS_GCM_IV_LEN, NULL);
-    EVP_DecryptInit_ex(&key->evp_cipher_ctx, NULL, NULL, in->data, NULL);
+    EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_aes_256_gcm(), NULL, NULL, NULL);
+    EVP_CIPHER_CTX_ctrl(key->evp_cipher_ctx, EVP_CTRL_GCM_SET_IVLEN, S2N_TLS_GCM_IV_LEN, NULL);
+    EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, in->data, NULL);
 
     return 0;
 }
 
 static int s2n_aead_cipher_aes_gcm_init(struct s2n_session_key *key)
 {
-    EVP_CIPHER_CTX_init(&key->evp_cipher_ctx);
+    EVP_CIPHER_CTX_init(key->evp_cipher_ctx);
 
     return 0;
 }
 
 static int s2n_aead_cipher_aes_gcm_destroy_key(struct s2n_session_key *key)
 {
-    EVP_CIPHER_CTX_cleanup(&key->evp_cipher_ctx);
+    EVP_CIPHER_CTX_cleanup(key->evp_cipher_ctx);
 
     return 0;
 }

--- a/crypto/s2n_cbc_cipher_3des.c
+++ b/crypto/s2n_cbc_cipher_3des.c
@@ -26,12 +26,12 @@ static int s2n_cbc_cipher_3des_encrypt(struct s2n_session_key *key, struct s2n_b
 {
     gte_check(out->size, in->size);
 
-    if (EVP_EncryptInit_ex(&key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0) {
+    if (EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0) {
         S2N_ERROR(S2N_ERR_KEY_INIT);
     }
 
     int len = out->size;
-    if (EVP_EncryptUpdate(&key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0) {
+    if (EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0) {
         S2N_ERROR(S2N_ERR_ENCRYPT);
     }
 
@@ -46,12 +46,12 @@ static int s2n_cbc_cipher_3des_decrypt(struct s2n_session_key *key, struct s2n_b
 {
     gte_check(out->size, in->size);
 
-    if (EVP_DecryptInit_ex(&key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0) {
+    if (EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0) {
         S2N_ERROR(S2N_ERR_KEY_INIT);
     }
 
     int len = out->size;
-    if (EVP_DecryptUpdate(&key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0) {
+    if (EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0) {
         S2N_ERROR(S2N_ERR_DECRYPT);
     }
 
@@ -61,8 +61,8 @@ static int s2n_cbc_cipher_3des_decrypt(struct s2n_session_key *key, struct s2n_b
 static int s2n_cbc_cipher_3des_get_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
     eq_check(in->size, 192 / 8);
-    EVP_CIPHER_CTX_set_padding(&key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
-    EVP_DecryptInit_ex(&key->evp_cipher_ctx, EVP_des_ede3_cbc(), NULL, in->data, NULL);
+    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
+    EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_des_ede3_cbc(), NULL, in->data, NULL);
 
     return 0;
 }
@@ -70,22 +70,22 @@ static int s2n_cbc_cipher_3des_get_decryption_key(struct s2n_session_key *key, s
 static int s2n_cbc_cipher_3des_get_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
     eq_check(in->size, 192 / 8);
-    EVP_CIPHER_CTX_set_padding(&key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
-    EVP_EncryptInit_ex(&key->evp_cipher_ctx, EVP_des_ede3_cbc(), NULL, in->data, NULL);
+    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
+    EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_des_ede3_cbc(), NULL, in->data, NULL);
 
     return 0;
 }
 
 static int s2n_cbc_cipher_3des_init(struct s2n_session_key *key)
 {
-    EVP_CIPHER_CTX_init(&key->evp_cipher_ctx);
+    EVP_CIPHER_CTX_init(key->evp_cipher_ctx);
 
     return 0;
 }
 
 static int s2n_cbc_cipher_3des_destroy_key(struct s2n_session_key *key)
 {
-    EVP_CIPHER_CTX_cleanup(&key->evp_cipher_ctx);
+    EVP_CIPHER_CTX_cleanup(key->evp_cipher_ctx);
 
     return 0;
 }

--- a/crypto/s2n_cbc_cipher_aes.c
+++ b/crypto/s2n_cbc_cipher_aes.c
@@ -26,12 +26,12 @@ static int s2n_cbc_cipher_aes_encrypt(struct s2n_session_key *key, struct s2n_bl
 {
     gte_check(out->size, in->size);
 
-    if (EVP_EncryptInit_ex(&key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0) {
+    if (EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0) {
         S2N_ERROR(S2N_ERR_KEY_INIT);
     }
 
     int len = out->size;
-    if (EVP_EncryptUpdate(&key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0) {
+    if (EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0) {
         S2N_ERROR(S2N_ERR_ENCRYPT);
     }
 
@@ -46,12 +46,12 @@ int s2n_cbc_cipher_aes_decrypt(struct s2n_session_key *key, struct s2n_blob *iv,
 {
     gte_check(out->size, in->size);
 
-    if (EVP_DecryptInit_ex(&key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0) {
+    if (EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0) {
         S2N_ERROR(S2N_ERR_KEY_INIT);
     }
 
     int len = out->size;
-    if (EVP_DecryptUpdate(&key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0) {
+    if (EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0) {
         S2N_ERROR(S2N_ERR_DECRYPT);
     }
 
@@ -61,8 +61,8 @@ int s2n_cbc_cipher_aes_decrypt(struct s2n_session_key *key, struct s2n_blob *iv,
 int s2n_cbc_cipher_aes128_get_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
     eq_check(in->size, 128 / 8);
-    EVP_CIPHER_CTX_set_padding(&key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
-    EVP_DecryptInit_ex(&key->evp_cipher_ctx, EVP_aes_128_cbc(), NULL, in->data, NULL);
+    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
+    EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_aes_128_cbc(), NULL, in->data, NULL);
 
     return 0;
 }
@@ -70,8 +70,8 @@ int s2n_cbc_cipher_aes128_get_decryption_key(struct s2n_session_key *key, struct
 static int s2n_cbc_cipher_aes128_get_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
     eq_check(in->size, 128 / 8);
-    EVP_CIPHER_CTX_set_padding(&key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
-    EVP_EncryptInit_ex(&key->evp_cipher_ctx, EVP_aes_128_cbc(), NULL, in->data, NULL);
+    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
+    EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_aes_128_cbc(), NULL, in->data, NULL);
 
     return 0;
 }
@@ -79,8 +79,8 @@ static int s2n_cbc_cipher_aes128_get_encryption_key(struct s2n_session_key *key,
 static int s2n_cbc_cipher_aes256_get_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
     eq_check(in->size, 256 / 8);
-    EVP_CIPHER_CTX_set_padding(&key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
-    EVP_DecryptInit_ex(&key->evp_cipher_ctx, EVP_aes_256_cbc(), NULL, in->data, NULL);
+    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
+    EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_aes_256_cbc(), NULL, in->data, NULL);
 
     return 0;
 }
@@ -88,23 +88,22 @@ static int s2n_cbc_cipher_aes256_get_decryption_key(struct s2n_session_key *key,
 int s2n_cbc_cipher_aes256_get_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
     eq_check(in->size, 256 / 8);
-    EVP_CIPHER_CTX_init(&key->evp_cipher_ctx);
-    EVP_CIPHER_CTX_set_padding(&key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
-    EVP_EncryptInit_ex(&key->evp_cipher_ctx, EVP_aes_256_cbc(), NULL, in->data, NULL);
+    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
+    EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_aes_256_cbc(), NULL, in->data, NULL);
 
     return 0;
 }
 
 static int s2n_cbc_cipher_aes_init(struct s2n_session_key *key)
 {
-    EVP_CIPHER_CTX_init(&key->evp_cipher_ctx);
+    EVP_CIPHER_CTX_init(key->evp_cipher_ctx);
 
     return 0;
 }
 
 static int s2n_cbc_cipher_aes_destroy_key(struct s2n_session_key *key)
 {
-    EVP_CIPHER_CTX_cleanup(&key->evp_cipher_ctx);
+    EVP_CIPHER_CTX_cleanup(key->evp_cipher_ctx);
 
     return 0;
 }

--- a/crypto/s2n_cipher.c
+++ b/crypto/s2n_cipher.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <openssl/evp.h>
+
+#include "crypto/s2n_cipher.h"
+
+#include "utils/s2n_safety.h"
+
+int s2n_session_key_alloc(struct s2n_session_key *key)
+{
+	eq_check(key->evp_cipher_ctx, NULL);
+	notnull_check(key->evp_cipher_ctx = EVP_CIPHER_CTX_new());
+
+	return 0;
+}
+
+int s2n_session_key_free(struct s2n_session_key *key)
+{
+	notnull_check(key->evp_cipher_ctx);
+    EVP_CIPHER_CTX_free(key->evp_cipher_ctx);
+    key->evp_cipher_ctx = NULL;
+
+    return 0;
+}

--- a/crypto/s2n_cipher.c
+++ b/crypto/s2n_cipher.c
@@ -21,15 +21,15 @@
 
 int s2n_session_key_alloc(struct s2n_session_key *key)
 {
-	eq_check(key->evp_cipher_ctx, NULL);
-	notnull_check(key->evp_cipher_ctx = EVP_CIPHER_CTX_new());
+    eq_check(key->evp_cipher_ctx, NULL);
+    notnull_check(key->evp_cipher_ctx = EVP_CIPHER_CTX_new());
 
-	return 0;
+    return 0;
 }
 
 int s2n_session_key_free(struct s2n_session_key *key)
 {
-	notnull_check(key->evp_cipher_ctx);
+    notnull_check(key->evp_cipher_ctx);
     EVP_CIPHER_CTX_free(key->evp_cipher_ctx);
     key->evp_cipher_ctx = NULL;
 

--- a/crypto/s2n_cipher.h
+++ b/crypto/s2n_cipher.h
@@ -27,7 +27,7 @@
 #include "utils/s2n_blob.h"
 
 struct s2n_session_key {
-    EVP_CIPHER_CTX evp_cipher_ctx;
+    EVP_CIPHER_CTX *evp_cipher_ctx;
 };
 
 struct s2n_stream_cipher {
@@ -63,6 +63,9 @@ struct s2n_cipher {
     int (*get_encryption_key) (struct s2n_session_key * key, struct s2n_blob * in);
     int (*destroy_key) (struct s2n_session_key * key);
 };
+
+extern int s2n_session_key_alloc(struct s2n_session_key *key);
+extern int s2n_session_key_free(struct s2n_session_key *key);
 
 extern struct s2n_cipher s2n_null_cipher;
 extern struct s2n_cipher s2n_rc4;

--- a/crypto/s2n_drbg.h
+++ b/crypto/s2n_drbg.h
@@ -32,7 +32,7 @@ struct s2n_drbg {
     /* Track how many bytes have been used */
     uint64_t bytes_used;
     
-    EVP_CIPHER_CTX ctx;
+    EVP_CIPHER_CTX *ctx;
 
     /* The current DRBG 'value' */
     uint8_t v[16];

--- a/crypto/s2n_stream_cipher_rc4.c
+++ b/crypto/s2n_stream_cipher_rc4.c
@@ -25,7 +25,7 @@ static int s2n_stream_cipher_rc4_encrypt(struct s2n_session_key *key, struct s2n
     gte_check(out->size, in->size);
 
     int len = out->size;
-    if (EVP_EncryptUpdate(&key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0) {
+    if (EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0) {
         S2N_ERROR(S2N_ERR_ENCRYPT);
     }
 
@@ -41,7 +41,7 @@ static int s2n_stream_cipher_rc4_decrypt(struct s2n_session_key *key, struct s2n
     gte_check(out->size, in->size);
 
     int len = out->size;
-    if (EVP_DecryptUpdate(&key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0) {
+    if (EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0) {
         S2N_ERROR(S2N_ERR_ENCRYPT);
     }
 
@@ -55,7 +55,7 @@ static int s2n_stream_cipher_rc4_decrypt(struct s2n_session_key *key, struct s2n
 static int s2n_stream_cipher_rc4_get_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
     eq_check(in->size, 16);
-    EVP_EncryptInit_ex(&key->evp_cipher_ctx, EVP_rc4(), NULL, in->data, NULL);
+    EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_rc4(), NULL, in->data, NULL);
 
     return 0;
 }
@@ -63,21 +63,21 @@ static int s2n_stream_cipher_rc4_get_encryption_key(struct s2n_session_key *key,
 static int s2n_stream_cipher_rc4_get_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
     eq_check(in->size, 16);
-    EVP_DecryptInit_ex(&key->evp_cipher_ctx, EVP_rc4(), NULL, in->data, NULL);
+    EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_rc4(), NULL, in->data, NULL);
 
     return 0;
 }
 
 static int s2n_stream_cipher_rc4_init(struct s2n_session_key *key)
 {
-    EVP_CIPHER_CTX_init(&key->evp_cipher_ctx);
+    EVP_CIPHER_CTX_init(key->evp_cipher_ctx);
 
     return 0;
 }
 
 static int s2n_stream_cipher_rc4_destroy_key(struct s2n_session_key *key)
 {
-    EVP_CIPHER_CTX_cleanup(&key->evp_cipher_ctx);
+    EVP_CIPHER_CTX_cleanup(key->evp_cipher_ctx);
 
     return 0;
 }

--- a/tests/unit/s2n_aes_test.c
+++ b/tests/unit/s2n_aes_test.c
@@ -53,6 +53,8 @@ int main(int argc, char **argv)
     /* test the AES128 cipher with a SHA1 hash */
     conn->secure.cipher_suite->cipher = &s2n_aes128;
     conn->secure.cipher_suite->hmac_alg = S2N_HMAC_SHA1;
+    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->init(&conn->secure.server_key));
+    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->init(&conn->secure.client_key));
     EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->get_encryption_key(&conn->secure.server_key, &aes128));
     EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->get_decryption_key(&conn->secure.client_key, &aes128));
     EXPECT_SUCCESS(s2n_hmac_init(&conn->secure.client_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
@@ -116,6 +118,8 @@ int main(int argc, char **argv)
     conn->client = &conn->secure;
     conn->secure.cipher_suite->cipher = &s2n_aes256;
     conn->secure.cipher_suite->hmac_alg = S2N_HMAC_SHA1;
+    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->init(&conn->secure.server_key));
+    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->init(&conn->secure.client_key));
     EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->get_encryption_key(&conn->secure.server_key, &aes256));
     EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->get_decryption_key(&conn->secure.client_key, &aes256));
     EXPECT_SUCCESS(s2n_hmac_init(&conn->secure.client_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));

--- a/tests/unit/s2n_record_size_test.c
+++ b/tests/unit/s2n_record_size_test.c
@@ -51,6 +51,8 @@ int main(int argc, char **argv)
     /* test the AES128 cipher with a SHA1 hash */
     conn->secure.cipher_suite->cipher = &s2n_aes128;
     conn->secure.cipher_suite->hmac_alg = S2N_HMAC_SHA1;
+    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->init(&conn->secure.server_key));
+    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->init(&conn->secure.client_key));
     EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->get_encryption_key(&conn->secure.server_key, &aes128));
     EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->get_decryption_key(&conn->secure.client_key, &aes128));
     EXPECT_SUCCESS(s2n_hmac_init(&conn->secure.client_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -90,6 +90,12 @@ struct s2n_connection *s2n_connection_new(s2n_mode mode)
     GUARD_PTR(s2n_stuffer_init(&conn->writer_alert_out, &blob));
     GUARD_PTR(s2n_stuffer_alloc(&conn->out, S2N_LARGE_RECORD_LENGTH));
 
+    /* Allocate long term key memory */
+    GUARD_PTR(s2n_session_key_alloc(&conn->secure.client_key));
+    GUARD_PTR(s2n_session_key_alloc(&conn->secure.server_key));
+    GUARD_PTR(s2n_session_key_alloc(&conn->initial.client_key));
+    GUARD_PTR(s2n_session_key_alloc(&conn->initial.server_key));
+
     /* Initialize the growable stuffers. Zero length at first, but the resize
      * in _wipe will fix that 
      */
@@ -107,6 +113,16 @@ struct s2n_connection *s2n_connection_new(s2n_mode mode)
 
 static int s2n_connection_free_keys(struct s2n_connection *conn)
 {
+    GUARD(s2n_session_key_free(&conn->secure.client_key));
+    GUARD(s2n_session_key_free(&conn->secure.server_key));
+    GUARD(s2n_session_key_free(&conn->initial.client_key));
+    GUARD(s2n_session_key_free(&conn->initial.server_key));
+
+    return 0;
+}
+
+static int s2n_connection_wipe_keys(struct s2n_connection *conn)
+{
     /* Destroy any keys - we call destroy on the object as that is where
      * keys are allocated. */
     if (conn->secure.cipher_suite && conn->secure.cipher_suite->cipher->destroy_key) {
@@ -121,8 +137,6 @@ static int s2n_connection_free_keys(struct s2n_connection *conn)
     GUARD(s2n_dh_params_free(&conn->secure.server_dh_params));
     GUARD(s2n_ecc_params_free(&conn->secure.server_ecc_params));
 
-    GUARD(s2n_free(&conn->status_response));
-
     return 0;
 }
 
@@ -130,8 +144,10 @@ int s2n_connection_free(struct s2n_connection *conn)
 {
     struct s2n_blob blob;
 
+    GUARD(s2n_connection_wipe_keys(conn));
     GUARD(s2n_connection_free_keys(conn));
 
+    GUARD(s2n_free(&conn->status_response));
     GUARD(s2n_stuffer_free(&conn->in));
     GUARD(s2n_stuffer_free(&conn->out));
     GUARD(s2n_stuffer_free(&conn->handshake.io));
@@ -163,9 +179,14 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     struct s2n_stuffer header_in;
     struct s2n_stuffer in;
     struct s2n_stuffer out;
+    /* Session keys will be wiped. Preserve structs to avoid reallocation */
+    struct s2n_session_key initial_client_key;
+    struct s2n_session_key initial_server_key;
+    struct s2n_session_key secure_client_key;
+    struct s2n_session_key secure_server_key;
 
     /* Wipe all of the sensitive stuff */
-    GUARD(s2n_connection_free_keys(conn));
+    GUARD(s2n_connection_wipe_keys(conn));
     GUARD(s2n_stuffer_wipe(&conn->alert_in));
     GUARD(s2n_stuffer_wipe(&conn->reader_alert_out));
     GUARD(s2n_stuffer_wipe(&conn->writer_alert_out));
@@ -173,6 +194,8 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     GUARD(s2n_stuffer_wipe(&conn->header_in));
     GUARD(s2n_stuffer_wipe(&conn->in));
     GUARD(s2n_stuffer_wipe(&conn->out));
+
+    GUARD(s2n_free(&conn->status_response));
 
     /* Allocate or resize to their original sizes */
     GUARD(s2n_stuffer_resize(&conn->in, S2N_LARGE_FRAGMENT_LENGTH));
@@ -194,6 +217,10 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     memcpy_check(&header_in, &conn->header_in, sizeof(struct s2n_stuffer));
     memcpy_check(&in, &conn->in, sizeof(struct s2n_stuffer));
     memcpy_check(&out, &conn->out, sizeof(struct s2n_stuffer));
+    memcpy_check(&initial_client_key, &conn->initial.client_key, sizeof(struct s2n_session_key));
+    memcpy_check(&initial_server_key, &conn->initial.server_key, sizeof(struct s2n_session_key));
+    memcpy_check(&secure_client_key, &conn->secure.client_key, sizeof(struct s2n_session_key));
+    memcpy_check(&secure_server_key, &conn->secure.server_key, sizeof(struct s2n_session_key));
 #if defined(__GNUC__) && GCC_VERSION >= 40600
 #pragma GCC diagnostic pop
 #endif
@@ -228,6 +255,10 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     memcpy_check(&conn->header_in, &header_in, sizeof(struct s2n_stuffer));
     memcpy_check(&conn->in, &in, sizeof(struct s2n_stuffer));
     memcpy_check(&conn->out, &out, sizeof(struct s2n_stuffer));
+    memcpy_check(&conn->initial.client_key, &initial_client_key, sizeof(struct s2n_session_key));
+    memcpy_check(&conn->initial.server_key, &initial_server_key, sizeof(struct s2n_session_key));
+    memcpy_check(&conn->secure.client_key, &secure_client_key, sizeof(struct s2n_session_key));
+    memcpy_check(&conn->secure.server_key, &secure_server_key, sizeof(struct s2n_session_key));
 
     if (conn->mode == S2N_SERVER) {
         conn->server_protocol_version = s2n_highest_protocol_version;


### PR DESCRIPTION
This changes our EVP_CIPHER_CTX memory to be managed by Openssl via
EVP_CIPHER_CTX_{new,free}. It also adds a distinction between
s2n_session_key wiping and freeing. EVP_CIPHER_CTXs are allocated
in s2n_connection_new, wiped for reuse in s2n_connection_wipe, and
freed in s2n_connection_free.

The motivation for this change is the EVP_CIPHER_CTX struct is
opaque starting in Openssl 1.1.0[1]. The new approach is backwards
compatible with Openssl 1.0.1/1.0.2.

[1] https://www.openssl.org/docs/manmaster/crypto/EVP_EncryptInit.html