### PR TITLE
Set LIBCRYPTO_ROOT for saw tests

### DIFF
--- a/s2n.mk
+++ b/s2n.mk
@@ -63,7 +63,7 @@ ifeq ($(S2N_UNSAFE_FUZZING_MODE),1)
 endif
 
 
-CFLAGS_LLVM = -emit-llvm -I../libcrypto-root/include -I../api -I.. $(OPENSSL_INC) -c
+CFLAGS_LLVM = ${DEFAULT_CFLAGS} -emit-llvm -c
 
 $(BITCODE_DIR)%.bc: %.c
 	clang $(CFLAGS_LLVM) -o $@ $< 

--- a/tests/saw/Makefile
+++ b/tests/saw/Makefile
@@ -22,6 +22,7 @@ SCRIPTS = $(wildcard *.saw)
 #A log file will be created for each test in the temp dir
 LOGS=$(patsubst %.saw,tmp/%.log,$(SCRIPTS))
 SHELL:=/bin/bash 
+export LIBCRYPTO_ROOT:=$(shell pwd)/../../libcrypto-root
 
 .PHONY : all
 all:


### PR DESCRIPTION
Previously was defaulting to system Openssl.