### PR TITLE
Use Openssl 1.1.0 for TravisCI tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.o
 *.a
 *.dylib
+*.dSYM
 *.so
 *~
 libcrypto-build/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,8 @@ before_install:
 install:
   # Download and Install LibFuzzer
   - .travis/install_libFuzzer.sh `pwd`/fuzz_dependencies/libFuzzer-download `pwd`/fuzz_dependencies $TRAVIS_OS_NAME
-  # Download and Install Openssl
-  - .travis/install_openssl.sh `pwd`/libcrypto-build `pwd`/libcrypto-root $TRAVIS_OS_NAME > /dev/null
+  # Download and Install Openssl 1.1.0
+  - .travis/install_openssl_1_1_0.sh `pwd`/libcrypto-build `pwd`/libcrypto-root $TRAVIS_OS_NAME > /dev/null
   # Install python linked with our compiled Openssl for integration tests
   - sudo "PATH=$PATH" .travis/install_python.sh `pwd`/libcrypto-root > /dev/null
   # Install prlimit to set the memlock limit to unlimited for this process

--- a/.travis/install_openssl.sh
+++ b/.travis/install_openssl.sh
@@ -30,22 +30,26 @@ INSTALL_DIR=$2
 PLATFORM=$3
 
 cd $BUILD_DIR
-curl -L https://www.openssl.org/source/openssl-1.0.2-latest.tar.gz > openssl-1.0.2.tar.gz
-tar -xzvf openssl-1.0.2.tar.gz
-rm openssl-1.0.2.tar.gz
-cd openssl-1.0.2*
+curl -L https://www.openssl.org/source/openssl-1.1.0-latest.tar.gz > openssl-1.1.0.tar.gz
+tar -xzvf openssl-1.1.0.tar.gz
+rm openssl-1.1.0.tar.gz
+cd openssl-1.1.0*
 
 if [ "$PLATFORM" == "linux" ]; then
-	./config -fPIC no-shared no-libunbound no-gmp no-jpake no-krb5 no-md2 no-rc5 no-rfc3779 no-sctp no-ssl-trace \
-			 no-store no-zlib no-hw no-mdc2 no-seed no-idea enable-ec_nistp_64_gcc_128 no-camellia no-bf no-ripemd \
-			 no-dsa no-ssl2 no-capieng -DSSL_FORBID_ENULL -DOPENSSL_NO_DTLS1 -DOPENSSL_NO_HEARTBEATS \
-			 --prefix=$INSTALL_DIR
+	CONFIGURE="./config"
 elif [ "$PLATFORM" == "osx" ]; then
-	./Configure darwin64-x86_64-cc -fPIC --prefix=$INSTALL_DIR
+	CONFIGURE="./Configure darwin64-x86_64-cc"
 else
 	echo "Invalid platform! $PLATFORM"
 	usage
 fi
+
+$CONFIGURE -fPIC no-shared              \
+         no-md2 no-rc5 no-rfc3779 no-sctp no-ssl-trace no-zlib     \
+         no-hw no-mdc2 no-seed no-idea enable-ec_nistp_64_gcc_128 no-camellia\
+         no-bf no-ripemd no-dsa no-ssl2 no-ssl3 no-capieng                  \
+         -DSSL_FORBID_ENULL -DOPENSSL_NO_DTLS1 -DOPENSSL_NO_HEARTBEATS      \
+         --prefix=$INSTALL_DIR
 
 make depend
 make

--- a/.travis/install_openssl.sh
+++ b/.travis/install_openssl.sh
@@ -44,7 +44,8 @@ else
 	usage
 fi
 
-$CONFIGURE -fPIC no-shared              \
+# Use g3 to get debug symbols in libcrypto to chase memory leaks
+$CONFIGURE -g3 -fPIC no-shared              \
          no-md2 no-rc5 no-rfc3779 no-sctp no-ssl-trace no-zlib     \
          no-hw no-mdc2 no-seed no-idea enable-ec_nistp_64_gcc_128 no-camellia\
          no-bf no-ripemd no-dsa no-ssl2 no-ssl3 no-capieng                  \

--- a/.travis/install_openssl_1_0_2.sh
+++ b/.travis/install_openssl_1_0_2.sh
@@ -51,7 +51,7 @@ $CONFIGURE -g3 -fPIC no-shared no-libunbound no-gmp no-jpake no-krb5 no-md2 no-r
 
 make depend
 make
-make install
+make install_sw
 
 popd
 

--- a/.travis/install_openssl_1_0_2.sh
+++ b/.travis/install_openssl_1_0_2.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+set -e
+pushd `pwd`
+
+usage() {
+    echo "install_openssl.sh build_dir install_dir travis_platform"
+    exit 1
+}
+
+if [ "$#" -ne "3" ]; then
+    usage
+fi
+
+BUILD_DIR=$1
+INSTALL_DIR=$2
+PLATFORM=$3
+
+cd $BUILD_DIR
+curl -L https://www.openssl.org/source/openssl-1.0.2-latest.tar.gz > openssl-1.0.2.tar.gz
+tar -xzvf openssl-1.0.2.tar.gz
+rm openssl-1.0.2.tar.gz
+cd openssl-1.0.2*
+
+if [ "$PLATFORM" == "linux" ]; then
+    CONFIGURE="./config"
+elif [ "$PLATFORM" == "osx" ]; then
+    CONFIGURE="./Configure darwin64-x86_64-cc"
+else
+    echo "Invalid platform! $PLATFORM"
+    usage
+fi
+
+$CONFIGURE -g3 -fPIC no-shared no-libunbound no-gmp no-jpake no-krb5 no-md2 no-rc5 no-rfc3779 no-sctp no-ssl-trace \
+         no-store no-zlib no-hw no-mdc2 no-seed no-idea enable-ec_nistp_64_gcc_128 no-camellia no-bf no-ripemd \
+         no-dsa no-ssl2 no-capieng -DSSL_FORBID_ENULL -DOPENSSL_NO_DTLS1 -DOPENSSL_NO_HEARTBEATS \
+         --prefix=$INSTALL_DIR
+
+make depend
+make
+make install
+
+popd
+
+exit 0

--- a/.travis/install_openssl_1_0_2.sh
+++ b/.travis/install_openssl_1_0_2.sh
@@ -17,7 +17,7 @@ set -e
 pushd `pwd`
 
 usage() {
-    echo "install_openssl.sh build_dir install_dir travis_platform"
+    echo "install_openssl_1_0_2.sh build_dir install_dir travis_platform"
     exit 1
 }
 

--- a/.travis/install_openssl_1_1_0.sh
+++ b/.travis/install_openssl_1_1_0.sh
@@ -54,7 +54,7 @@ $CONFIGURE -g3 -fPIC no-shared              \
 
 make depend
 make
-make install
+make install_sw
 
 popd
 

--- a/.travis/install_openssl_1_1_0.sh
+++ b/.travis/install_openssl_1_1_0.sh
@@ -17,12 +17,12 @@ set -e
 pushd `pwd`
 
 usage() {
-	echo "install_openssl.sh build_dir install_dir travis_platform"
-	exit 1
+    echo "install_openssl.sh build_dir install_dir travis_platform"
+    exit 1
 }
 
 if [ "$#" -ne "3" ]; then
-	usage
+    usage
 fi
 
 BUILD_DIR=$1
@@ -36,12 +36,12 @@ rm openssl-1.1.0.tar.gz
 cd openssl-1.1.0*
 
 if [ "$PLATFORM" == "linux" ]; then
-	CONFIGURE="./config"
+    CONFIGURE="./config"
 elif [ "$PLATFORM" == "osx" ]; then
-	CONFIGURE="./Configure darwin64-x86_64-cc"
+    CONFIGURE="./Configure darwin64-x86_64-cc"
 else
-	echo "Invalid platform! $PLATFORM"
-	usage
+    echo "Invalid platform! $PLATFORM"
+    usage
 fi
 
 # Use g3 to get debug symbols in libcrypto to chase memory leaks

--- a/.travis/install_openssl_1_1_0.sh
+++ b/.travis/install_openssl_1_1_0.sh
@@ -17,7 +17,7 @@ set -e
 pushd `pwd`
 
 usage() {
-    echo "install_openssl.sh build_dir install_dir travis_platform"
+    echo "install_openssl_1_1_0.sh build_dir install_dir travis_platform"
     exit 1
 }
 

--- a/.travis/install_python.sh
+++ b/.travis/install_python.sh
@@ -16,9 +16,9 @@
 
 LIBCRYPTO_ROOT=$1
 
-wget https://www.python.org/ftp/python/3.5.1/Python-3.5.1.tgz
-tar xzf Python-3.5.1.tgz
-cd Python-3.5.1
+wget https://www.python.org/ftp/python/3.6.0/Python-3.6.0b1.tgz
+tar xzf Python-3.6.0b1.tgz
+cd Python-3.6.0b1
 ./configure CPPFLAGS="-I$LIBCRYPTO_ROOT/include" LDFLAGS="-L$LIBCRYPTO_ROOT/lib"
 make
 make install

--- a/tests/fuzz/s2n_server_fuzz_test.c
+++ b/tests/fuzz/s2n_server_fuzz_test.c
@@ -130,9 +130,15 @@ static char dhparams[] =
 
 static int MAX_NEGOTIATION_ATTEMPTS = 10;
 
+static void s2n_server_fuzz_atexit()
+{
+    s2n_cleanup();
+}
+
 int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
 {
     GUARD(s2n_init());
+    GUARD(atexit(s2n_server_fuzz_atexit));
     GUARD(setenv("S2N_ENABLE_CLIENT_MODE", "1", 0));
     return 0;
 }

--- a/tests/integration/s2n_handshake_test.py
+++ b/tests/integration/s2n_handshake_test.py
@@ -13,43 +13,21 @@
 # permissions and limitations under the License.
 #
 
+"""
+Simple handshake tests using the Python ssl module.
+"""
+
 import sys
 import ssl
 import socket
 import subprocess
+from s2n_test_constants import *
 
-# All supported ciphers
-S2N_CIPHERS= [
-    ("RC4-MD5", ssl.PROTOCOL_SSLv3),
-    ("RC4-SHA", ssl.PROTOCOL_SSLv3),
-    ("DES-CBC3-SHA", ssl.PROTOCOL_SSLv3),
-    ("EDH-RSA-DES-CBC3-SHA", ssl.PROTOCOL_SSLv3),
-    ("AES128-SHA", ssl.PROTOCOL_TLSv1),
-    ("DHE-RSA-AES128-SHA", ssl.PROTOCOL_TLSv1),
-    ("AES256-SHA", ssl.PROTOCOL_TLSv1),
-    ("DHE-RSA-AES256-SHA", ssl.PROTOCOL_TLSv1),
-    ("AES128-SHA256", ssl.PROTOCOL_TLSv1_2),
-    ("AES256-SHA256", ssl.PROTOCOL_TLSv1_2),
-    ("DHE-RSA-AES128-SHA256", ssl.PROTOCOL_TLSv1_2),
-    ("DHE-RSA-AES256-SHA256", ssl.PROTOCOL_TLSv1_2),
-    ("AES128-GCM-SHA256", ssl.PROTOCOL_TLSv1_2),
-    ("AES256-GCM-SHA384", ssl.PROTOCOL_TLSv1_2),
-    ("DHE-RSA-AES128-GCM-SHA256", ssl.PROTOCOL_TLSv1_2),
-    ("ECDHE-RSA-DES-CBC3-SHA", ssl.PROTOCOL_TLSv1),
-    ("ECDHE-RSA-AES128-SHA", ssl.PROTOCOL_TLSv1),
-    ("ECDHE-RSA-AES256-SHA", ssl.PROTOCOL_TLSv1),
-    ("ECDHE-RSA-AES128-SHA256", ssl.PROTOCOL_TLSv1_2),
-    ("ECDHE-RSA-AES256-SHA384", ssl.PROTOCOL_TLSv1_2),
-    ("ECDHE-RSA-AES128-GCM-SHA256", ssl.PROTOCOL_TLSv1_2),
-    ("ECDHE-RSA-AES256-GCM-SHA384", ssl.PROTOCOL_TLSv1_2),
+S2N_PYTHON_VERSIONS = [
+    (S2N_TLS10, ssl.PROTOCOL_TLSv1),
+    (S2N_TLS11, ssl.PROTOCOL_TLSv1_1),
+    (S2N_TLS12, ssl.PROTOCOL_TLSv1_2),
 ]
-
-PROTO_VERS_TO_STR = {
-    ssl.PROTOCOL_SSLv3 : "SSlv3",
-    ssl.PROTOCOL_TLSv1 : "TLSv1.0",
-    ssl.PROTOCOL_TLSv1_1 : "TLSv1.1",
-    ssl.PROTOCOL_TLSv1_2 : "TLSv1.2",
-}
 
 def try_handshake(endpoint, port, cipher, ssl_version):
     # Fire up s2nd
@@ -114,17 +92,17 @@ def main(argv):
 
     print("\nRunning handshake tests with: " + str(ssl.OPENSSL_VERSION))
     failed = 0
-    for ssl_version in [ssl.PROTOCOL_SSLv3, ssl.PROTOCOL_TLSv1, ssl.PROTOCOL_TLSv1_1, ssl.PROTOCOL_TLSv1_2]:
-        print("\n\tTesting ciphers using client version: " + PROTO_VERS_TO_STR[ssl_version])
+    for s2n_tls_vers, python_tls_vers in S2N_PYTHON_VERSIONS:
+        print("\n\tTesting ciphers using client version: " + S2N_PROTO_VERS_TO_STR[s2n_tls_vers])
         for cipher in S2N_CIPHERS:
             cipher_name = cipher[0]
             cipher_vers = cipher[1]
 
-            if ssl_version < cipher_vers:
+            if s2n_tls_vers < cipher_vers:
                 continue
 
-            ret = try_handshake(argv[0], int(argv[1]), cipher_name, ssl_version)
-            print("Cipher: %-30s Vers: %-10s ... " % (cipher_name, PROTO_VERS_TO_STR[ssl_version]), end='')
+            ret = try_handshake(argv[0], int(argv[1]), cipher_name, python_tls_vers)
+            print("Cipher: %-30s Vers: %-10s ... " % (cipher_name, S2N_PROTO_VERS_TO_STR[s2n_tls_vers]), end='')
             if ret == 0:
                 if sys.stdout.isatty():
                     print("\033[32;1mPASSED\033[0m")

--- a/tests/integration/s2n_test_constants.py
+++ b/tests/integration/s2n_test_constants.py
@@ -1,0 +1,47 @@
+#
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+S2N_SSLv3 = 30
+S2N_TLS10 = 31
+S2N_TLS11 = 32
+S2N_TLS12 = 33
+
+# All supported s2n ciphers by (cipher_name, min_proto_vers). 
+S2N_CIPHERS= [
+    ("AES128-SHA", S2N_TLS10),
+    ("DHE-RSA-AES128-SHA", S2N_TLS10),
+    ("AES256-SHA", S2N_TLS10),
+    ("DHE-RSA-AES256-SHA", S2N_TLS10),
+    ("AES128-SHA256", S2N_TLS12),
+    ("AES256-SHA256", S2N_TLS12),
+    ("DHE-RSA-AES128-SHA256", S2N_TLS12),
+    ("DHE-RSA-AES256-SHA256", S2N_TLS12),
+    ("AES128-GCM-SHA256", S2N_TLS12),
+    ("AES256-GCM-SHA384", S2N_TLS12),
+    ("DHE-RSA-AES128-GCM-SHA256", S2N_TLS12),
+    ("ECDHE-RSA-AES128-SHA", S2N_TLS10),
+    ("ECDHE-RSA-AES256-SHA", S2N_TLS10),
+    ("ECDHE-RSA-AES128-SHA256", S2N_TLS12),
+    ("ECDHE-RSA-AES256-SHA384", S2N_TLS12),
+    ("ECDHE-RSA-AES128-GCM-SHA256", S2N_TLS12),
+    ("ECDHE-RSA-AES256-GCM-SHA384", S2N_TLS12),
+]
+
+S2N_PROTO_VERS_TO_STR = {
+    S2N_SSLv3 : "SSLv3",
+    S2N_TLS10 : "TLSv1.0",
+    S2N_TLS11 : "TLSv1.1",
+    S2N_TLS12 : "TLSv1.2",
+}


### PR DESCRIPTION
In the future, we way want to construct a build matrix that
uses a 1.0.2/1.0.1 libcrypto to check for regressions in that
version.
