### PR TITLE
Use S2N_TLS12_AAD_LEN for composite ciphers

### DIFF
--- a/crypto/s2n_composite_cipher_aes_sha.c
+++ b/crypto/s2n_composite_cipher_aes_sha.c
@@ -35,8 +35,8 @@ int s2n_composite_ciphers_supported()
 static int s2n_composite_cipher_aes_sha_initial_hmac(struct s2n_session_key *key, uint8_t *sequence_number, uint8_t content_type,
                                                      uint16_t protocol_version, uint16_t payload_and_eiv_len, int *extra)
 {
-    uint8_t ctrl_buf[EVP_AEAD_TLS1_AAD_LEN];
-    struct s2n_blob ctrl_blob = { .data = ctrl_buf, .size = EVP_AEAD_TLS1_AAD_LEN };
+    uint8_t ctrl_buf[S2N_TLS12_AAD_LEN];
+    struct s2n_blob ctrl_blob = { .data = ctrl_buf, .size = S2N_TLS12_AAD_LEN };
     struct s2n_stuffer ctrl_stuffer;
     GUARD(s2n_stuffer_init(&ctrl_stuffer, &ctrl_blob));
 
@@ -51,7 +51,7 @@ static int s2n_composite_cipher_aes_sha_initial_hmac(struct s2n_session_key *key
      * See https://github.com/openssl/openssl/blob/master/crypto/evp/e_aes_cbc_hmac_sha1.c#L814
      * and https://github.com/openssl/openssl/blob/4f0c475719defd7c051964ef9964cc6e5b3a63bf/ssl/record/ssl3_record.c#L743
      */
-    int ctrl_ret = EVP_CIPHER_CTX_ctrl(key->evp_cipher_ctx, EVP_CTRL_AEAD_TLS1_AAD, EVP_AEAD_TLS1_AAD_LEN, ctrl_buf);
+    int ctrl_ret = EVP_CIPHER_CTX_ctrl(key->evp_cipher_ctx, EVP_CTRL_AEAD_TLS1_AAD, S2N_TLS12_AAD_LEN, ctrl_buf);
 
     if (ctrl_ret < 0) {
         S2N_ERROR(S2N_ERR_INITIAL_HMAC);

--- a/tls/s2n_crypto.h
+++ b/tls/s2n_crypto.h
@@ -33,8 +33,9 @@
 #define S2N_SSL_FINISHED_LEN           36
 #define S2N_TLS_MAX_IV_LEN             16
 
-#define S2N_TLS_GCM_AAD_LEN            13
-#define S2N_TLS_MAX_AAD_LEN            S2N_TLS_GCM_AAD_LEN
+/* From RFC 5246 6.2.3.3 */
+#define S2N_TLS12_AAD_LEN              13
+#define S2N_TLS_MAX_AAD_LEN            S2N_TLS12_AAD_LEN
 #define S2N_TLS_GCM_FIXED_IV_LEN        4
 #define S2N_TLS_GCM_EXPLICIT_IV_LEN     8
 #define S2N_TLS_GCM_IV_LEN            (S2N_TLS_GCM_FIXED_IV_LEN + S2N_TLS_GCM_EXPLICIT_IV_LEN)


### PR DESCRIPTION
This fixes the build for Libressl(again). Previously we were using
EVP_AEAD_TLS1_AAD_LEN which is not defined in Libressl. It's set to
13 bytes per: https://github.com/openssl/openssl/blob/6f0ac0e2f27d9240516edb9a23b7863e7ad02898/include/openssl/evp.h#L345
Makes sense since the input is always the non-payload parts of the
MAC (seq_num || content_type || version || payload_length).