### PR TITLE
Move s2n_{init,cleanup} to separate source file

### DIFF
--- a/utils/s2n_init.c
+++ b/utils/s2n_init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -13,14 +13,24 @@
  * permissions and limitations under the License.
  */
 
-#pragma once
+#include "tls/s2n_cipher_suites.h"
 
-#include "utils/s2n_blob.h"
+#include "utils/s2n_mem.h"
+#include "utils/s2n_random.h"
+#include "utils/s2n_safety.h"
 
-#include <stdint.h>
+int s2n_init(void)
+{
+	GUARD(s2n_mem_init());
+	GUARD(s2n_rand_init());
 
-int s2n_mem_init(void);
-int s2n_mem_cleanup(void);
-int s2n_alloc(struct s2n_blob *b, uint32_t size);
-int s2n_realloc(struct s2n_blob *b, uint32_t size);
-int s2n_free(struct s2n_blob *b);
+	return 0;
+}
+
+int s2n_cleanup(void)
+{
+	GUARD(s2n_rand_cleanup());
+	GUARD(s2n_mem_cleanup());
+
+	return 0;
+}

--- a/utils/s2n_init.h
+++ b/utils/s2n_init.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -15,12 +15,5 @@
 
 #pragma once
 
-#include "utils/s2n_blob.h"
-
-#include <stdint.h>
-
-int s2n_mem_init(void);
-int s2n_mem_cleanup(void);
-int s2n_alloc(struct s2n_blob *b, uint32_t size);
-int s2n_realloc(struct s2n_blob *b, uint32_t size);
-int s2n_free(struct s2n_blob *b);
+int s2n_init(void);
+int s2n_cleanup(void);

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -37,6 +37,13 @@ int s2n_mem_init(void)
     return 0;
 }
 
+int s2n_mem_cleanup(void)
+{
+    page_size = 4096;
+    use_mlock = 1;
+    return 0;
+}
+
 int s2n_alloc(struct s2n_blob *b, uint32_t size)
 {
     b->data = NULL;

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -223,10 +223,8 @@ RAND_METHOD s2n_openssl_rand_method = {
 };
 #endif
 
-int s2n_init(void)
+int s2n_rand_init(void)
 {
-    GUARD(s2n_mem_init());
-
   OPEN:
     entropy_fd = open(ENTROPY_SOURCE, O_RDONLY);
     if (entropy_fd == -1) {
@@ -274,7 +272,7 @@ int s2n_init(void)
     return 0;
 }
 
-int s2n_cleanup(void)
+int s2n_rand_cleanup(void)
 {
     if (entropy_fd == -1) {
         S2N_ERROR(S2N_ERR_NOT_INITIALIZED);

--- a/utils/s2n_random.h
+++ b/utils/s2n_random.h
@@ -17,6 +17,8 @@
 
 #include "utils/s2n_blob.h"
 
+extern int s2n_rand_init(void);
+extern int s2n_rand_cleanup(void);
 extern int s2n_get_public_random_data(struct s2n_blob *blob);
 extern int s2n_get_public_random_bytes_used(void);
 extern int s2n_get_private_random_data(struct s2n_blob *blob);


### PR DESCRIPTION
Functions were previously living in s2n_random.c. Makes more sense
to have them in a separate source. We'll be adding more library
init/cleanup functions in the future.

This change also resets use_mlock/page_size after s2n_cleanup
is called. This would be the least surprising behavior for the caller