### PR TITLE
Add "is_available" method to s2n_cipher

### DIFF
--- a/crypto/s2n_aead_cipher_aes_gcm.c
+++ b/crypto/s2n_aead_cipher_aes_gcm.c
@@ -23,6 +23,16 @@
 #include "utils/s2n_safety.h"
 #include "utils/s2n_blob.h"
 
+static uint8_t s2n_aead_cipher_aes128_gcm_available()
+{
+    return (EVP_aes_128_gcm() ? 1 : 0);
+}
+
+static uint8_t s2n_aead_cipher_aes256_gcm_available()
+{
+    return (EVP_aes_256_gcm() ? 1 : 0);
+}
+
 static int s2n_aead_cipher_aes_gcm_encrypt(struct s2n_session_key *key, struct s2n_blob *iv, struct s2n_blob *aad, struct s2n_blob *in, struct s2n_blob *out)
 {
     gte_check(in->size, S2N_TLS_GCM_TAG_LEN);
@@ -192,6 +202,7 @@ struct s2n_cipher s2n_aes128_gcm = {
                 .tag_size = S2N_TLS_GCM_TAG_LEN,
                 .decrypt = s2n_aead_cipher_aes_gcm_decrypt,
                 .encrypt = s2n_aead_cipher_aes_gcm_encrypt},
+    .is_available = s2n_aead_cipher_aes128_gcm_available,
     .init = s2n_aead_cipher_aes_gcm_init,
     .set_encryption_key = s2n_aead_cipher_aes128_gcm_set_encryption_key,
     .set_decryption_key = s2n_aead_cipher_aes128_gcm_set_decryption_key,
@@ -207,6 +218,7 @@ struct s2n_cipher s2n_aes256_gcm = {
                 .tag_size = S2N_TLS_GCM_TAG_LEN,
                 .decrypt = s2n_aead_cipher_aes_gcm_decrypt,
                 .encrypt = s2n_aead_cipher_aes_gcm_encrypt},
+    .is_available = s2n_aead_cipher_aes256_gcm_available,
     .init = s2n_aead_cipher_aes_gcm_init,
     .set_encryption_key = s2n_aead_cipher_aes256_gcm_set_encryption_key,
     .set_decryption_key = s2n_aead_cipher_aes256_gcm_set_decryption_key,

--- a/crypto/s2n_cbc_cipher_3des.c
+++ b/crypto/s2n_cbc_cipher_3des.c
@@ -22,6 +22,11 @@
 #include "utils/s2n_safety.h"
 #include "utils/s2n_blob.h"
 
+static uint8_t s2n_cbc_cipher_3des_available()
+{
+    return (EVP_des_ede3_cbc() ? 1 : 0);
+}
+
 static int s2n_cbc_cipher_3des_encrypt(struct s2n_session_key *key, struct s2n_blob *iv, struct s2n_blob *in, struct s2n_blob *out)
 {
     gte_check(out->size, in->size);
@@ -104,6 +109,7 @@ struct s2n_cipher s2n_3des = {
                .record_iv_size = 8,
                .decrypt = s2n_cbc_cipher_3des_decrypt,
                .encrypt = s2n_cbc_cipher_3des_encrypt},
+    .is_available = s2n_cbc_cipher_3des_available,
     .init = s2n_cbc_cipher_3des_init,
     .set_decryption_key = s2n_cbc_cipher_3des_set_decryption_key,
     .set_encryption_key = s2n_cbc_cipher_3des_set_encryption_key,

--- a/crypto/s2n_cbc_cipher_aes.c
+++ b/crypto/s2n_cbc_cipher_aes.c
@@ -22,6 +22,16 @@
 #include "utils/s2n_safety.h"
 #include "utils/s2n_blob.h"
 
+static uint8_t s2n_cbc_cipher_aes128_avilable()
+{
+    return (EVP_aes_128_cbc() ? 1 : 0);
+}
+
+static uint8_t s2n_cbc_cipher_aes256_avilable()
+{
+    return (EVP_aes_256_cbc() ? 1 : 0);
+}
+
 static int s2n_cbc_cipher_aes_encrypt(struct s2n_session_key *key, struct s2n_blob *iv, struct s2n_blob *in, struct s2n_blob *out)
 {
     gte_check(out->size, in->size);
@@ -129,6 +139,7 @@ struct s2n_cipher s2n_aes128 = {
                .record_iv_size = 16,
                .decrypt = s2n_cbc_cipher_aes_decrypt,
                .encrypt = s2n_cbc_cipher_aes_encrypt},
+    .is_available = s2n_cbc_cipher_aes128_avilable,
     .init = s2n_cbc_cipher_aes_init,
     .set_decryption_key = s2n_cbc_cipher_aes128_set_decryption_key,
     .set_encryption_key = s2n_cbc_cipher_aes128_set_encryption_key,
@@ -143,6 +154,7 @@ struct s2n_cipher s2n_aes256 = {
                .record_iv_size = 16,
                .decrypt = s2n_cbc_cipher_aes_decrypt,
                .encrypt = s2n_cbc_cipher_aes_encrypt},
+    .is_available = s2n_cbc_cipher_aes256_avilable,
     .init = s2n_cbc_cipher_aes_init,
     .set_decryption_key = s2n_cbc_cipher_aes256_set_decryption_key,
     .set_encryption_key = s2n_cbc_cipher_aes256_set_encryption_key,

--- a/crypto/s2n_cipher.h
+++ b/crypto/s2n_cipher.h
@@ -70,16 +70,15 @@ struct s2n_cipher {
         struct s2n_composite_cipher comp;
     } io;
     uint8_t key_material_size;
-    int (*init) (struct s2n_session_key *key);
-    int (*set_decryption_key) (struct s2n_session_key *key, struct s2n_blob *in);
-    int (*set_encryption_key) (struct s2n_session_key *key, struct s2n_blob *in);
-    int (*destroy_key) (struct s2n_session_key *key);
+    uint8_t (*is_available) (void);
+    int     (*init) (struct s2n_session_key *key);
+    int     (*set_decryption_key) (struct s2n_session_key *key, struct s2n_blob *in);
+    int     (*set_encryption_key) (struct s2n_session_key *key, struct s2n_blob *in);
+    int     (*destroy_key) (struct s2n_session_key *key);
 };
 
 extern int s2n_session_key_alloc(struct s2n_session_key *key);
 extern int s2n_session_key_free(struct s2n_session_key *key);
-
-extern int s2n_composite_ciphers_supported();
 
 extern struct s2n_cipher s2n_null_cipher;
 extern struct s2n_cipher s2n_rc4;

--- a/crypto/s2n_composite_cipher_aes_sha.c
+++ b/crypto/s2n_composite_cipher_aes_sha.c
@@ -18,6 +18,7 @@
 #include <openssl/sha.h>
 
 #include "crypto/s2n_cipher.h"
+#include "crypto/s2n_openssl.h"
 
 #include "tls/s2n_crypto.h"
 
@@ -31,7 +32,7 @@ static const EVP_CIPHER *s2n_evp_aes_128_cbc_hmac_sha1(void)
      * See https://www.openssl.org/news/cl101.txt. LibreSSL defines OPENSSL_VERSION_NUMBER to be
      * 0x20000000L but AES-SHA1-CBC is in LibreSSL since first major release(2.0.0).
      */
-    #if OPENSSL_VERSION_NUMBER > 0x10000FFFL
+    #if S2N_OPENSSL_VERSION_AT_LEAST(1,0,1)
         return EVP_aes_128_cbc_hmac_sha1();
     #else
         return NULL;
@@ -40,7 +41,7 @@ static const EVP_CIPHER *s2n_evp_aes_128_cbc_hmac_sha1(void)
 
 static const EVP_CIPHER *s2n_evp_aes_256_cbc_hmac_sha1(void)
 {
-    #if OPENSSL_VERSION_NUMBER > 0x10000FFFL
+    #if S2N_OPENSSL_VERSION_AT_LEAST(1,0,1)
         return EVP_aes_256_cbc_hmac_sha1();
     #else
         return NULL;

--- a/crypto/s2n_openssl.h
+++ b/crypto/s2n_openssl.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/* Per https://wiki.openssl.org/index.php/Manual:OPENSSL_VERSION_NUMBER(3)
+ * OPENSSL_VERSION_NUMBER in hex is: MNNFFRBB major minor fix final beta/patch.
+ * bitwise: MMMMNNNNNNNNFFFFFFFFRRRRBBBBBBBB
+ * For our purposes we're only concerned about major/minor/fix. Patch versions don't usually introduce
+ * features.
+ */
+#define S2N_OPENSSL_VERSION_AT_LEAST(major, minor, fix) \
+    (OPENSSL_VERSION_NUMBER >= ((major << 28) + (minor << 20) + (fix << 12)))
+

--- a/crypto/s2n_rsa.c
+++ b/crypto/s2n_rsa.c
@@ -22,6 +22,7 @@
 #include "stuffer/s2n_stuffer.h"
 
 #include "crypto/s2n_hash.h"
+#include "crypto/s2n_openssl.h"
 #include "crypto/s2n_rsa.h"
 
 #include "utils/s2n_random.h"
@@ -100,15 +101,14 @@ int s2n_rsa_private_key_free(struct s2n_rsa_private_key *key)
 static int s2n_rsa_modulus_check(RSA *rsa)
 {
     /* RSA was made opaque starting in Openssl 1.1.0 */
-    #if OPENSSL_VERSION_NUMBER < 0x10100000L || defined LIBRESSL_VERSION_NUMBER
-        notnull_check(rsa->n);
-    #else
+    #if S2N_OPENSSL_VERSION_AT_LEAST(1,1,0) && !defined(LIBRESSL_VERSION_NUMBER)
         const BIGNUM *n = NULL;
         /* RSA still owns the memory for n */
         RSA_get0_key(rsa, &n, NULL, NULL);
         notnull_check(n);
+    #else
+        notnull_check(rsa->n);
     #endif
-
     return 0;
 }
 

--- a/crypto/s2n_stream_cipher_null.c
+++ b/crypto/s2n_stream_cipher_null.c
@@ -20,6 +20,11 @@
 #include "utils/s2n_safety.h"
 #include "utils/s2n_blob.h"
 
+static uint8_t s2n_stream_cipher_null_avilable()
+{
+    return 1;
+}
+
 static int s2n_stream_cipher_null_endecrypt(struct s2n_session_key *key, struct s2n_blob *in, struct s2n_blob *out)
 {
     if (out->data < in->data) {
@@ -53,6 +58,7 @@ struct s2n_cipher s2n_null_cipher = {
     .io.stream = {
                   .decrypt = s2n_stream_cipher_null_endecrypt,
                   .encrypt = s2n_stream_cipher_null_endecrypt},
+    .is_available = s2n_stream_cipher_null_avilable,
     .init = s2n_stream_cipher_null_init,
     .set_encryption_key = s2n_stream_cipher_null_get_key,
     .set_decryption_key = s2n_stream_cipher_null_get_key,

--- a/crypto/s2n_stream_cipher_rc4.c
+++ b/crypto/s2n_stream_cipher_rc4.c
@@ -20,6 +20,11 @@
 #include "utils/s2n_safety.h"
 #include "utils/s2n_blob.h"
 
+static uint8_t s2n_stream_cipher_rc4_avilable()
+{
+    return (EVP_rc4() ? 1 : 0);
+}
+
 static int s2n_stream_cipher_rc4_encrypt(struct s2n_session_key *key, struct s2n_blob *in, struct s2n_blob *out)
 {
     gte_check(out->size, in->size);
@@ -92,6 +97,7 @@ struct s2n_cipher s2n_rc4 = {
     .io.stream = {
                   .decrypt = s2n_stream_cipher_rc4_decrypt,
                   .encrypt = s2n_stream_cipher_rc4_encrypt},
+    .is_available = s2n_stream_cipher_rc4_avilable,
     .init = s2n_stream_cipher_rc4_init,
     .set_decryption_key = s2n_stream_cipher_rc4_set_decryption_key,
     .set_encryption_key = s2n_stream_cipher_rc4_set_encryption_key,

--- a/tests/unit/s2n_aes_sha_composite_test.c
+++ b/tests/unit/s2n_aes_sha_composite_test.c
@@ -45,8 +45,8 @@ int main(int argc, char **argv)
 
     BEGIN_TEST();
 
-    /* Skip the test if we don't have the implementations for composite ciphers available */
-    if (!s2n_composite_ciphers_supported()) {
+    /* Skip test if we can't use the ciphers */
+    if (!s2n_aes128_sha.is_available() || !s2n_aes256_sha.is_available()) {
         END_TEST();
     }
 


### PR DESCRIPTION
The intention of this change is to allow us to query the availability
of a cipher before using it for TLS cipher_suite implementation. For
example there are certain optimized ciphers in the EVP_* interface
that are only available if the host CPU supports Intel AES-NI.

We'll also use this for compatibility with different versions of
libcrypto. As we add more ciphers(i.e. ChaCha20-Poly1305), we'll
need to still operate correctly when compiled against libcrypto 1.0.x

Currently, the only logic we're using to determine availability is
the EVP_* return value. We can harden the logic in the future.

To be added later:
- Cipher suite implementation selection based on the "is_available"
  return value of ciphers.