### PR TITLE
Prefer dynamic linking with libcrypto

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
   # Download and Install Openssl 1.1.0
   - .travis/install_openssl_1_1_0.sh `pwd`/libcrypto-build `pwd`/libcrypto-root $TRAVIS_OS_NAME > /dev/null
   # Install python linked with our compiled Openssl for integration tests
-  - mkdir python-build python && CC=`which gcc-6` .travis/install_python.sh `pwd`/libcrypto-root `pwd`/python-build `pwd`/python && export PATH=`pwd`/python/bin:$PATH
+  - mkdir python-build python && .travis/install_python.sh `pwd`/libcrypto-root `pwd`/python-build `pwd`/python && export PATH=`pwd`/python/bin:$PATH
   # Download and Install GnuTLS for integration tests
   - mkdir gnutls gnutls-build && .travis/install_gnutls.sh `pwd`/gnutls-build `pwd`/gnutls $TRAVIS_OS_NAME > /dev/null && export PATH=`pwd`/gnutls/bin:$PATH
   # Install prlimit to set the memlock limit to unlimited for this process

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
   # Download and Install Openssl 1.1.0
   - .travis/install_openssl_1_1_0.sh `pwd`/libcrypto-build `pwd`/libcrypto-root $TRAVIS_OS_NAME > /dev/null
   # Install python linked with our compiled Openssl for integration tests
-  - sudo "PATH=$PATH" .travis/install_python.sh `pwd`/libcrypto-root > /dev/null
+  - mkdir python-build python && CC=`which gcc-6` .travis/install_python.sh `pwd`/libcrypto-root `pwd`/python-build `pwd`/python && export PATH=`pwd`/python/bin:$PATH
   # Download and Install GnuTLS for integration tests
   - mkdir gnutls gnutls-build && .travis/install_gnutls.sh `pwd`/gnutls-build `pwd`/gnutls $TRAVIS_OS_NAME > /dev/null && export PATH=`pwd`/gnutls/bin:$PATH
   # Install prlimit to set the memlock limit to unlimited for this process

--- a/.travis/install_openssl_1_0_2.sh
+++ b/.travis/install_openssl_1_0_2.sh
@@ -44,7 +44,7 @@ else
     usage
 fi
 
-$CONFIGURE -g3 -fPIC no-shared no-libunbound no-gmp no-jpake no-krb5 no-md2 no-rc5 no-rfc3779 no-sctp no-ssl-trace \
+$CONFIGURE -g3 -fPIC no-libunbound no-gmp no-jpake no-krb5 no-md2 no-rc5 no-rfc3779 no-sctp no-ssl-trace \
          no-store no-zlib no-hw no-mdc2 no-seed no-idea enable-ec_nistp_64_gcc_128 no-camellia no-bf no-ripemd \
          no-dsa no-ssl2 no-capieng -DSSL_FORBID_ENULL -DOPENSSL_NO_DTLS1 -DOPENSSL_NO_HEARTBEATS \
          --prefix=$INSTALL_DIR

--- a/.travis/install_openssl_1_1_0.sh
+++ b/.travis/install_openssl_1_1_0.sh
@@ -45,7 +45,7 @@ else
 fi
 
 # Use g3 to get debug symbols in libcrypto to chase memory leaks
-$CONFIGURE -g3 -fPIC no-shared              \
+$CONFIGURE -g3 -fPIC              \
          no-md2 no-rc5 no-rfc3779 no-sctp no-ssl-trace no-zlib     \
          no-hw no-mdc2 no-seed no-idea enable-ec_nistp_64_gcc_128 no-camellia\
          no-bf no-ripemd no-dsa no-ssl2 no-ssl3 no-capieng                  \

--- a/.travis/install_python.sh
+++ b/.travis/install_python.sh
@@ -14,11 +14,22 @@
 #
 #!/bin/bash
 
-LIBCRYPTO_ROOT=$1
+set -e
 
+if [ "$#" -ne 3 ]; then
+	echo "install_python.sh libcrypto_root build_dir install_dir"
+	exit 1
+fi
+
+LIBCRYPTO_ROOT=$1
+BUILD_DIR=$2
+INSTALL_DIR=$3
+
+cd $BUILD_DIR
 wget https://www.python.org/ftp/python/3.6.0/Python-3.6.0b1.tgz
 tar xzf Python-3.6.0b1.tgz
 cd Python-3.6.0b1
-./configure CPPFLAGS="-I$LIBCRYPTO_ROOT/include" LDFLAGS="-L$LIBCRYPTO_ROOT/lib"
+ CPPFLAGS="-I$LIBCRYPTO_ROOT/include" LDFLAGS="-Wl,-R$LIBCRYPTO_ROOT/lib -L$LIBCRYPTO_ROOT/lib" ./configure --prefix="$INSTALL_DIR"
 make
 make install
+

--- a/.travis/install_python.sh
+++ b/.travis/install_python.sh
@@ -29,7 +29,7 @@ cd $BUILD_DIR
 wget https://www.python.org/ftp/python/3.6.0/Python-3.6.0b1.tgz
 tar xzf Python-3.6.0b1.tgz
 cd Python-3.6.0b1
- CPPFLAGS="-I$LIBCRYPTO_ROOT/include" LDFLAGS="-Wl,-R$LIBCRYPTO_ROOT/lib -L$LIBCRYPTO_ROOT/lib" ./configure --prefix="$INSTALL_DIR"
+ CPPFLAGS="-I$LIBCRYPTO_ROOT/include" LDFLAGS="-Wl,-rpath,$LIBCRYPTO_ROOT/lib -L$LIBCRYPTO_ROOT/lib" ./configure --prefix="$INSTALL_DIR"
 make
 make install
 

--- a/bin/Makefile
+++ b/bin/Makefile
@@ -17,7 +17,7 @@
 all: s2nc s2nd
 include ../s2n.mk
 
-LDFLAGS += -L../lib/ -ls2n ${LIBS} ${CRYPTO_LIBS}
+LDFLAGS += -L../lib/ -L${LIBCRYPTO_ROOT}/lib -ls2n ${LIBS} ${CRYPTO_LIBS}
 CRUFT += s2nc s2nd
 
 s2nc: s2nc.c echo.c

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -13,7 +13,7 @@
 # permissions and limitations under the License.
 #
 
-OBJS = $(wildcard ../utils/*.o ../stuffer/*.o ../tls/*.o ../iana/*.o ../crypto/*.o ../error/*.o $(LIBCRYPTO_ROOT)/lib/libcrypto.a)
+OBJS = $(wildcard ../utils/*.o ../stuffer/*.o ../tls/*.o ../iana/*.o ../crypto/*.o ../error/*.o)
 
 .PHONY : all
 all: libs2n.a libs2n.so libs2n.dylib
@@ -25,7 +25,7 @@ libs2n.a: ${OBJS}
 	$(RANLIB) libs2n.a
 
 libs2n.so: ${OBJS}
-	${CC} -shared ${LIBS} -o libs2n.so ${OBJS}
+	${CC} -shared  ${LIBS} -L${LIBCRYPTO_ROOT}/lib ${CRYPTO_LIBS} -o libs2n.so ${OBJS}
 
 libs2n.dylib: ${OBJS}
-	test ! -f /usr/lib/libSystem.dylib || libtool -dynamic ${LIBS} -o libs2n.dylib ${OBJS}
+	test ! -f /usr/lib/libSystem.dylib || libtool -dynamic  ${LIBS} -L${LIBCRYPTO_ROOT}/lib ${CRYPTO_LIBS} -o libs2n.dylib ${OBJS}

--- a/s2n.mk
+++ b/s2n.mk
@@ -15,17 +15,15 @@
 
 ifeq ($(PLATFORM),Darwin)
     LIBS = -lc -lpthread
-    CRYPTO_LIBS =
 else ifeq ($(PLATFORM),FreeBSD)
     LIBS = -lthr
-    CRYPTO_LIBS = -lcrypto
 else ifeq ($(PLATFORM),NetBSD)
     LIBS = -lpthread
-    CRYPTO_LIBS = -lcrypto
 else
     LIBS = -lpthread -ldl -lrt
-    CRYPTO_LIBS = -lcrypto
 endif
+
+CRYPTO_LIBS = -lcrypto
 
 CC	= $(CROSS_COMPILE)gcc
 AR	= $(CROSS_COMPILE)ar


### PR DESCRIPTION
This changes libs2n to default to dynamic linking of libcrypto.
Previously we were trying to force static linking by referencing
libcrypto.a directly.

The intention here is to avoid subtle issues that arise when
an application links against both libs2n and libcrypto. One failure
mode I've found is CRYPTO lock corruption.