### PR TITLE
More .travis.yml cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,6 @@ os:
   - osx
   - linux
 
-compiler:
-  - clang
-
 env:
   - BUILD_S2N=true TESTS=integration
   - LATEST_CLANG=true TESTS=fuzz
@@ -33,23 +30,8 @@ env:
   - TESTS=sawDRBG SAW=true
   - TESTS=sawHMACFailure SAW=true
 
-
 matrix:
   exclude:
-  - compiler: gcc
-    env: TESTS=sawHMAC SAW_HMAC_TEST=md5 SAW=true
-  - compiler: gcc
-    env: TESTS=sawHMAC SAW_HMAC_TEST=none SAW=true
-  - compiler: gcc
-    env: TESTS=sawHMAC SAW_HMAC_TEST=sha1 SAW=true
-  - compiler: gcc
-    env: TESTS=sawHMAC SAW_HMAC_TEST=sha224 SAW=true
-  - compiler: gcc
-    env: TESTS=sawHMAC SAW_HMAC_TEST=sha256 SAW=true
-  - compiler: gcc
-    env: TESTS=sawHMAC SAW_HMAC_TEST=sha384 SAW=true
-  - compiler: gcc
-    env: TESTS=sawHMAC SAW_HMAC_TEST=sha512 SAW=true
   - os: osx
     env: TESTS=sawHMAC SAW_HMAC_TEST=md5 SAW=true
   - os: osx
@@ -64,23 +46,14 @@ matrix:
     env: TESTS=sawHMAC SAW_HMAC_TEST=sha384 SAW=true
   - os: osx
     env: TESTS=sawHMAC SAW_HMAC_TEST=sha512 SAW=true
-  - compiler: gcc
-    env: LATEST_CLANG=true TESTS=fuzz
   - os: osx
     env: LATEST_CLANG=true TESTS=fuzz
   - os: osx
     env: TESTS=sawDRBG SAW=true
-  - compiler: gcc
-    env: TESTS=sawDRBG SAW=true
   - os: osx
-    env: TESTS=sawHMACFailure SAW=true
-  - compiler: gcc
     env: TESTS=sawHMACFailure SAW=true
   #This exception is because the test isn't finished yet, remove to turn on DRBG Saw tests
-  - compiler: clang
-    env: TESTS=sawDRBG SAW=true
-
-    
+  - env: TESTS=sawDRBG SAW=true
 
 before_install:
   # Install GCC 6 if on OSX

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,8 +62,7 @@ before_install:
   - alias gcc=$(which gcc-6)
   # Install latest version of clang, clang++, and llvm-symbolizer and add them to beginning of PATH. Needed for fuzzing.
   - if [[ "$LATEST_CLANG" == "true" ]]; then (.travis/install_clang.sh `pwd`/clang-download `pwd`/clang-latest $TRAVIS_OS_NAME) && export PATH=`pwd`/clang-latest/bin:$PATH ; fi
-
-  # Install SAW with Z3 on Linux only 
+  # Install SAW with Z3 on Linux only
   - if [[ "$SAW" == "true" ]]; then .travis/install_saw.sh ; fi
   - export PATH=$PATH:$PWD/saw-0.2-2016-11-02-Ubuntu14.04-64/bin:$PWD/z3
 
@@ -73,7 +72,7 @@ install:
   # Download and Install Openssl
   - .travis/install_openssl_1_1_0.sh `pwd`/libcrypto-build `pwd`/libcrypto-root $TRAVIS_OS_NAME > /dev/null
   # Install python linked with our compiled Openssl for integration tests
-  - if [[ "$BUILD_S2N" == "true" ]]; then mkdir python-build python && .travis/install_python.sh `pwd`/libcrypto-root `pwd`/python-build `pwd`/python > /dev/null && export PATH=`pwd`/python/bin:$PATH ; fi
+  - if [[ "$TESTS" == "integration" ]]; then mkdir python-build python && .travis/install_python.sh `pwd`/libcrypto-root `pwd`/python-build `pwd`/python > /dev/null && export PATH=`pwd`/python/bin:$PATH ; fi
   # Download and Install GnuTLS for integration tests
   - if [[ "$TESTS" == "integration" ]]; then mkdir gnutls gnutls-build && .travis/install_gnutls.sh `pwd`/gnutls-build `pwd`/gnutls $TRAVIS_OS_NAME > /dev/null && export PATH=`pwd`/gnutls/bin:$PATH ; fi
   # Install prlimit to set the memlock limit to unlimited for this process


### PR DESCRIPTION
- Removing the "compiler" directive since it's unused
- Only build python3 from source if we need to