### PR TITLE
Append CFLAGS in s2n.mk

### DIFF
--- a/s2n.mk
+++ b/s2n.mk
@@ -45,7 +45,7 @@ ifneq ($(NO_STACK_PROTECTOR), 1)
 DEFAULT_CFLAGS += -Wstack-protector -fstack-protector-all
 endif
 
-CFLAGS = ${DEFAULT_CFLAGS}
+CFLAGS += ${DEFAULT_CFLAGS}
 
 DEBUG_CFLAGS = -g3 -ggdb -fno-omit-frame-pointer -fno-optimize-sibling-calls
 
@@ -57,7 +57,7 @@ ifeq ($(S2N_UNSAFE_FUZZING_MODE),1)
 
     # Turn on debugging and fuzzing flags when S2N_UNSAFE_FUZZING_MODE is enabled to give detailed stack traces in case
     # an error occurs while fuzzing.
-    CFLAGS = ${DEFAULT_CFLAGS} ${DEBUG_FLAGS} ${FUZZ_CFLAGS}
+    CFLAGS += ${DEFAULT_CFLAGS} ${DEBUG_FLAGS} ${FUZZ_CFLAGS}
 endif
 
 


### PR DESCRIPTION
This allows the user to provide their own CFLAGS when building s2n.
For example, a user can use CFLAGS="-g" to get symbols for debugging.

NOTE: LDFLAGS are already being appended