### PR TITLE
Don't use cpuid.h for GCC < 4.3

### DIFF
--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -32,16 +32,13 @@
 
 #include "crypto/s2n_cipher.h"
 
+#include "utils/s2n_compiler.h"
 #include "utils/s2n_random.h"
 #include "utils/s2n_safety.h"
 #include "utils/s2n_socket.h"
 #include "utils/s2n_timer.h"
 #include "utils/s2n_blob.h"
 #include "utils/s2n_mem.h"
-
-#define GCC_VERSION (__GNUC__ * 10000 \
-                     + __GNUC_MINOR__ * 100 \
-                     + __GNUC_PATCHLEVEL__)
 
 struct s2n_connection *s2n_connection_new(s2n_mode mode)
 {
@@ -98,7 +95,7 @@ struct s2n_connection *s2n_connection_new(s2n_mode mode)
     GUARD_PTR(s2n_session_key_alloc(&conn->initial.server_key));
 
     /* Initialize the growable stuffers. Zero length at first, but the resize
-     * in _wipe will fix that 
+     * in _wipe will fix that
      */
     blob.data = conn->header_in_data;
     blob.size = S2N_TLS_RECORD_HEADER_LENGTH;
@@ -210,7 +207,7 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     /* Clone the stuffers */
     /* ignore gcc 4.7 address warnings because dest is allocated on the stack */
     /* pragma gcc diagnostic was added in gcc 4.6 */
-#if defined(__GNUC__) && GCC_VERSION >= 40600
+#if S2N_GCC_VERSION_AT_LEAST(4,6,0)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Waddress"
 #endif
@@ -225,7 +222,7 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     memcpy_check(&initial_server_key, &conn->initial.server_key, sizeof(struct s2n_session_key));
     memcpy_check(&secure_client_key, &conn->secure.client_key, sizeof(struct s2n_session_key));
     memcpy_check(&secure_server_key, &conn->secure.server_key, sizeof(struct s2n_session_key));
-#if defined(__GNUC__) && GCC_VERSION >= 40600
+#if S2N_GCC_VERSION_AT_LEAST(4,6,0)
 #pragma GCC diagnostic pop
 #endif
 

--- a/utils/s2n_compiler.h
+++ b/utils/s2n_compiler.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#define S2N_GCC_VERSION (__GNUC__ * 10000 \
+                     + __GNUC_MINOR__ * 100 \
+                     + __GNUC_PATCHLEVEL__)
+
+#define S2N_GCC_VERSION_AT_LEAST(major, minor, patch_level) \
+    ((S2N_GCC_VERSION) >= ((major) * 10000 + (minor) * 100 + (patch_level)))
+

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -27,7 +27,10 @@
 #include <errno.h>
 #include <time.h>
 
-#if defined(__x86_64__)||defined(__i386__)
+#include "utils/s2n_compiler.h"
+
+/* clang can define gcc version to be < 4.3, but cpuid.h exists for most releases */
+#if ((defined(__x86_64__) || defined(__i386__)) && (defined(__clang__) || S2N_GCC_VERSION_AT_LEAST(4,3,0)))
 #include <cpuid.h>
 #endif
 
@@ -298,7 +301,7 @@ int s2n_cleanup(void)
 
 int s2n_cpu_supports_rdrand()
 {
-#if defined(__x86_64__)||defined(__i386__)
+#if ((defined(__x86_64__) || defined(__i386__)) && (defined(__clang__) || S2N_GCC_VERSION_AT_LEAST(4,3,0)))
     uint32_t eax, ebx, ecx, edx;
     if (!__get_cpuid(1, &eax, &ebx, &ecx, &edx)) {
         return 0;
@@ -323,7 +326,7 @@ int s2n_cpu_supports_rdrand()
 int s2n_get_rdrand_data(struct s2n_blob *out)
 {
 
-#if defined(__x86_64__)||defined(__i386__)
+#if defined(__x86_64__) || defined(__i386__)
     int space_remaining = 0;
     struct s2n_stuffer stuffer;
     union {


### PR DESCRIPTION
Unfortunately, there are folks still using gcc < 4.3 to build s2n.