### PR TITLE
Introduce s2n_record_algorithm

### DIFF
--- a/tests/unit/s2n_3des_test.c
+++ b/tests/unit/s2n_3des_test.c
@@ -49,12 +49,11 @@ int main(int argc, char **argv)
     conn->client = &conn->secure;
 
     /* test the 3des cipher with a SHA1 hash */
-    conn->secure.cipher_suite->cipher = &s2n_3des;
-    conn->secure.cipher_suite->hmac_alg = S2N_HMAC_SHA1;
-    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->init(&conn->secure.server_key));
-    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->init(&conn->secure.client_key));
-    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->set_encryption_key(&conn->secure.server_key, &des3));
-    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->set_decryption_key(&conn->secure.client_key, &des3));
+    conn->secure.cipher_suite->record_alg = &s2n_record_alg_3des_sha;
+    EXPECT_SUCCESS(conn->secure.cipher_suite->record_alg->cipher->init(&conn->secure.server_key));
+    EXPECT_SUCCESS(conn->secure.cipher_suite->record_alg->cipher->init(&conn->secure.client_key));
+    EXPECT_SUCCESS(conn->secure.cipher_suite->record_alg->cipher->set_encryption_key(&conn->secure.server_key, &des3));
+    EXPECT_SUCCESS(conn->secure.cipher_suite->record_alg->cipher->set_decryption_key(&conn->secure.client_key, &des3));
     EXPECT_SUCCESS(s2n_hmac_init(&conn->secure.client_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
     EXPECT_SUCCESS(s2n_hmac_init(&conn->secure.server_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
     conn->actual_protocol_version = S2N_TLS11;
@@ -106,8 +105,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
     }
 
-    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->destroy_key(&conn->secure.server_key));
-    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->destroy_key(&conn->secure.client_key));
+    EXPECT_SUCCESS(conn->secure.cipher_suite->record_alg->cipher->destroy_key(&conn->secure.server_key));
+    EXPECT_SUCCESS(conn->secure.cipher_suite->record_alg->cipher->destroy_key(&conn->secure.client_key));
     EXPECT_SUCCESS(s2n_connection_free(conn));
 
     END_TEST();

--- a/tests/unit/s2n_aes_sha_composite_test.c
+++ b/tests/unit/s2n_aes_sha_composite_test.c
@@ -61,8 +61,7 @@ int main(int argc, char **argv)
     uint8_t proto_versions[3] = { S2N_TLS10, S2N_TLS11, S2N_TLS12 };
 
     /* test the composite AES128_SHA1 cipher  */
-    conn->initial.cipher_suite->cipher = &s2n_aes128_sha;
-    conn->initial.cipher_suite->hmac_alg = S2N_HMAC_NONE;
+    conn->initial.cipher_suite->record_alg = &s2n_record_alg_aes128_sha_composite;
 
     /* It's important to verify all TLS versions for the composite implementation.
      * There are a few gotchas with respect to explicit IV length and payload length
@@ -74,10 +73,10 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
 
-            EXPECT_SUCCESS(conn->initial.cipher_suite->cipher->set_encryption_key(&conn->initial.server_key, &aes128));
-            EXPECT_SUCCESS(conn->initial.cipher_suite->cipher->set_decryption_key(&conn->initial.client_key, &aes128));
-            EXPECT_SUCCESS(conn->initial.cipher_suite->cipher->io.comp.set_mac_write_key(&conn->initial.server_key, mac_key_sha, sizeof(mac_key_sha)));
-            EXPECT_SUCCESS(conn->initial.cipher_suite->cipher->io.comp.set_mac_write_key(&conn->initial.client_key, mac_key_sha, sizeof(mac_key_sha)));
+            EXPECT_SUCCESS(conn->initial.cipher_suite->record_alg->cipher->set_encryption_key(&conn->initial.server_key, &aes128));
+            EXPECT_SUCCESS(conn->initial.cipher_suite->record_alg->cipher->set_decryption_key(&conn->initial.client_key, &aes128));
+            EXPECT_SUCCESS(conn->initial.cipher_suite->record_alg->cipher->io.comp.set_mac_write_key(&conn->initial.server_key, mac_key_sha, sizeof(mac_key_sha)));
+            EXPECT_SUCCESS(conn->initial.cipher_suite->record_alg->cipher->io.comp.set_mac_write_key(&conn->initial.client_key, mac_key_sha, sizeof(mac_key_sha)));
 
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
             conn->actual_protocol_version = proto_versions[j];
@@ -131,8 +130,7 @@ int main(int argc, char **argv)
     }
 
     /* test the composite AES256_SHA1 cipher  */
-    conn->initial.cipher_suite->cipher = &s2n_aes256_sha;
-    conn->initial.cipher_suite->hmac_alg = S2N_HMAC_NONE;
+    conn->initial.cipher_suite->record_alg = &s2n_record_alg_aes256_sha_composite;
     for (int j = 0; j < 3; j++ ) {
         for (int i = 0; i < max_aligned_fragment; i++) {
             struct s2n_blob in = {.data = random_data,.size = i };
@@ -140,10 +138,10 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
 
-            EXPECT_SUCCESS(conn->initial.cipher_suite->cipher->set_encryption_key(&conn->initial.server_key, &aes256));
-            EXPECT_SUCCESS(conn->initial.cipher_suite->cipher->set_decryption_key(&conn->initial.client_key, &aes256));
-            EXPECT_SUCCESS(conn->initial.cipher_suite->cipher->io.comp.set_mac_write_key(&conn->initial.server_key, mac_key_sha, sizeof(mac_key_sha)));
-            EXPECT_SUCCESS(conn->initial.cipher_suite->cipher->io.comp.set_mac_write_key(&conn->initial.client_key, mac_key_sha, sizeof(mac_key_sha)));
+            EXPECT_SUCCESS(conn->initial.cipher_suite->record_alg->cipher->set_encryption_key(&conn->initial.server_key, &aes256));
+            EXPECT_SUCCESS(conn->initial.cipher_suite->record_alg->cipher->set_decryption_key(&conn->initial.client_key, &aes256));
+            EXPECT_SUCCESS(conn->initial.cipher_suite->record_alg->cipher->io.comp.set_mac_write_key(&conn->initial.server_key, mac_key_sha, sizeof(mac_key_sha)));
+            EXPECT_SUCCESS(conn->initial.cipher_suite->record_alg->cipher->io.comp.set_mac_write_key(&conn->initial.client_key, mac_key_sha, sizeof(mac_key_sha)));
 
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
             conn->actual_protocol_version = proto_versions[j];

--- a/tests/unit/s2n_aes_test.c
+++ b/tests/unit/s2n_aes_test.c
@@ -51,12 +51,11 @@ int main(int argc, char **argv)
     conn->client = &conn->secure;
 
     /* test the AES128 cipher with a SHA1 hash */
-    conn->secure.cipher_suite->cipher = &s2n_aes128;
-    conn->secure.cipher_suite->hmac_alg = S2N_HMAC_SHA1;
-    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->init(&conn->secure.server_key));
-    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->init(&conn->secure.client_key));
-    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->set_encryption_key(&conn->secure.server_key, &aes128));
-    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->set_decryption_key(&conn->secure.client_key, &aes128));
+    conn->secure.cipher_suite->record_alg = &s2n_record_alg_aes128_sha;
+    EXPECT_SUCCESS(conn->secure.cipher_suite->record_alg->cipher->init(&conn->secure.server_key));
+    EXPECT_SUCCESS(conn->secure.cipher_suite->record_alg->cipher->init(&conn->secure.client_key));
+    EXPECT_SUCCESS(conn->secure.cipher_suite->record_alg->cipher->set_encryption_key(&conn->secure.server_key, &aes128));
+    EXPECT_SUCCESS(conn->secure.cipher_suite->record_alg->cipher->set_decryption_key(&conn->secure.client_key, &aes128));
     EXPECT_SUCCESS(s2n_hmac_init(&conn->secure.client_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
     EXPECT_SUCCESS(s2n_hmac_init(&conn->secure.server_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
     conn->actual_protocol_version = S2N_TLS11;
@@ -108,20 +107,19 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
     }
 
-    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->destroy_key(&conn->secure.server_key));
-    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->destroy_key(&conn->secure.client_key));
+    EXPECT_SUCCESS(conn->secure.cipher_suite->record_alg->cipher->destroy_key(&conn->secure.server_key));
+    EXPECT_SUCCESS(conn->secure.cipher_suite->record_alg->cipher->destroy_key(&conn->secure.client_key));
     EXPECT_SUCCESS(s2n_connection_free(conn));
 
     /* test the AES256 cipher with a SHA1 hash */
     EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
     conn->server = &conn->secure;
     conn->client = &conn->secure;
-    conn->secure.cipher_suite->cipher = &s2n_aes256;
-    conn->secure.cipher_suite->hmac_alg = S2N_HMAC_SHA1;
-    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->init(&conn->secure.server_key));
-    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->init(&conn->secure.client_key));
-    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->set_encryption_key(&conn->secure.server_key, &aes256));
-    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->set_decryption_key(&conn->secure.client_key, &aes256));
+    conn->secure.cipher_suite->record_alg = &s2n_record_alg_aes256_sha;
+    EXPECT_SUCCESS(conn->secure.cipher_suite->record_alg->cipher->init(&conn->secure.server_key));
+    EXPECT_SUCCESS(conn->secure.cipher_suite->record_alg->cipher->init(&conn->secure.client_key));
+    EXPECT_SUCCESS(conn->secure.cipher_suite->record_alg->cipher->set_encryption_key(&conn->secure.server_key, &aes256));
+    EXPECT_SUCCESS(conn->secure.cipher_suite->record_alg->cipher->set_decryption_key(&conn->secure.client_key, &aes256));
     EXPECT_SUCCESS(s2n_hmac_init(&conn->secure.client_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
     EXPECT_SUCCESS(s2n_hmac_init(&conn->secure.server_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
     conn->actual_protocol_version = S2N_TLS11;
@@ -173,8 +171,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
     }
 
-    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->destroy_key(&conn->secure.server_key));
-    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->destroy_key(&conn->secure.client_key));
+    EXPECT_SUCCESS(conn->secure.cipher_suite->record_alg->cipher->destroy_key(&conn->secure.server_key));
+    EXPECT_SUCCESS(conn->secure.cipher_suite->record_alg->cipher->destroy_key(&conn->secure.client_key));
     EXPECT_SUCCESS(s2n_connection_free(conn));
 
     END_TEST();

--- a/tests/unit/s2n_rc4_test.c
+++ b/tests/unit/s2n_rc4_test.c
@@ -49,12 +49,11 @@ int main(int argc, char **argv)
     conn->client = &conn->secure;
 
     /* test the RC4 cipher with a SHA1 hash */
-    conn->secure.cipher_suite->cipher = &s2n_rc4;
-    conn->secure.cipher_suite->hmac_alg = S2N_HMAC_SHA1;
-    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->init(&conn->secure.server_key));
-    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->init(&conn->secure.client_key));
-    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->set_decryption_key(&conn->secure.client_key, &key_iv));
-    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->set_encryption_key(&conn->secure.server_key, &key_iv));
+    conn->secure.cipher_suite->record_alg = &s2n_record_alg_rc4_sha;
+    EXPECT_SUCCESS(conn->secure.cipher_suite->record_alg->cipher->init(&conn->secure.server_key));
+    EXPECT_SUCCESS(conn->secure.cipher_suite->record_alg->cipher->init(&conn->secure.client_key));
+    EXPECT_SUCCESS(conn->secure.cipher_suite->record_alg->cipher->set_decryption_key(&conn->secure.client_key, &key_iv));
+    EXPECT_SUCCESS(conn->secure.cipher_suite->record_alg->cipher->set_encryption_key(&conn->secure.server_key, &key_iv));
     EXPECT_SUCCESS(s2n_hmac_init(&conn->secure.client_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
     EXPECT_SUCCESS(s2n_hmac_init(&conn->secure.server_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
     conn->actual_protocol_version = S2N_TLS11;
@@ -105,8 +104,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
     }
 
-    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->destroy_key(&conn->secure.server_key));
-    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->destroy_key(&conn->secure.client_key));
+    EXPECT_SUCCESS(conn->secure.cipher_suite->record_alg->cipher->destroy_key(&conn->secure.server_key));
+    EXPECT_SUCCESS(conn->secure.cipher_suite->record_alg->cipher->destroy_key(&conn->secure.client_key));
     EXPECT_SUCCESS(s2n_connection_free(conn));
 
     END_TEST();

--- a/tests/unit/s2n_record_size_test.c
+++ b/tests/unit/s2n_record_size_test.c
@@ -49,12 +49,11 @@ int main(int argc, char **argv)
     conn->client = &conn->secure;
 
     /* test the AES128 cipher with a SHA1 hash */
-    conn->secure.cipher_suite->cipher = &s2n_aes128;
-    conn->secure.cipher_suite->hmac_alg = S2N_HMAC_SHA1;
-    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->init(&conn->secure.server_key));
-    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->init(&conn->secure.client_key));
-    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->set_encryption_key(&conn->secure.server_key, &aes128));
-    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->set_decryption_key(&conn->secure.client_key, &aes128));
+    conn->secure.cipher_suite->record_alg = &s2n_record_alg_aes128_sha;
+    EXPECT_SUCCESS(conn->secure.cipher_suite->record_alg->cipher->init(&conn->secure.server_key));
+    EXPECT_SUCCESS(conn->secure.cipher_suite->record_alg->cipher->init(&conn->secure.client_key));
+    EXPECT_SUCCESS(conn->secure.cipher_suite->record_alg->cipher->set_encryption_key(&conn->secure.server_key, &aes128));
+    EXPECT_SUCCESS(conn->secure.cipher_suite->record_alg->cipher->set_decryption_key(&conn->secure.client_key, &aes128));
     EXPECT_SUCCESS(s2n_hmac_init(&conn->secure.client_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
     EXPECT_SUCCESS(s2n_hmac_init(&conn->secure.server_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
     conn->actual_protocol_version = S2N_TLS11;
@@ -85,10 +84,10 @@ int main(int argc, char **argv)
     EXPECT_EQUAL(bytes_written, large_aligned_payload);
 
     /* Clean up */
-    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->destroy_key(&conn->secure.server_key));
-    EXPECT_SUCCESS(conn->secure.cipher_suite->cipher->destroy_key(&conn->secure.client_key));
+    EXPECT_SUCCESS(conn->secure.cipher_suite->record_alg->cipher->destroy_key(&conn->secure.server_key));
+    EXPECT_SUCCESS(conn->secure.cipher_suite->record_alg->cipher->destroy_key(&conn->secure.client_key));
     EXPECT_SUCCESS(s2n_connection_free(conn));
     EXPECT_SUCCESS(s2n_hmac_init(&conn->secure.server_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
-    
+
     END_TEST();
 }

--- a/tests/unit/s2n_record_test.c
+++ b/tests/unit/s2n_record_test.c
@@ -49,12 +49,22 @@ struct s2n_cipher mock_block_cipher = {
     .destroy_key = NULL,
 };
 
-struct s2n_cipher_suite mock_block_cipher_suite = {
-    .name = "TLS_MOCK_CBC",
-    .value = {0x12, 0x34},
-    .key_exchange_alg = &s2n_rsa,
+struct s2n_record_algorithm mock_block_record_alg = {
     .cipher = &mock_block_cipher,
-    .hmac_alg = S2N_HMAC_SHA1
+    .hmac_alg = S2N_HMAC_SHA1,
+};
+
+struct s2n_cipher_suite mock_block_cipher_suite = {
+    .available = 1,
+    .name = "TLS_MOCK_CBC",
+    .iana_value = {0x12, 0x34},
+    .key_exchange_alg = &s2n_rsa,
+    .record_alg = &mock_block_record_alg,
+};
+
+struct s2n_record_algorithm mock_null_sha1_record_alg = {
+    .cipher = &s2n_null_cipher,
+    .hmac_alg = S2N_HMAC_SHA1,
 };
 
 int main(int argc, char **argv)
@@ -114,7 +124,7 @@ int main(int argc, char **argv)
     }
 
     /* test a fake streaming cipher with a MAC */
-    conn->initial.cipher_suite->hmac_alg = S2N_HMAC_SHA1;
+    conn->initial.cipher_suite->record_alg = &mock_null_sha1_record_alg;
     EXPECT_SUCCESS(s2n_hmac_init(&conn->initial.client_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
     EXPECT_SUCCESS(s2n_hmac_init(&conn->initial.server_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
     conn->initial.cipher_suite = &s2n_null_cipher_suite;
@@ -263,7 +273,6 @@ int main(int argc, char **argv)
     }
 
     /* Test a mock block cipher with a mac - in TLS1.1+ mode */
-    conn->initial.cipher_suite->hmac_alg = S2N_HMAC_SHA1;
     EXPECT_SUCCESS(s2n_hmac_init(&conn->initial.client_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
     EXPECT_SUCCESS(s2n_hmac_init(&conn->initial.server_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
     conn->actual_protocol_version = S2N_TLS11;

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -17,6 +17,8 @@
 
 #include "error/s2n_errno.h"
 
+#include "crypto/s2n_cipher.h"
+
 #include "tls/s2n_cipher_suites.h"
 #include "tls/s2n_connection.h"
 #include "utils/s2n_safety.h"
@@ -33,48 +35,422 @@ const struct s2n_key_exchange_algorithm s2n_ecdhe = {
     .flags = S2N_KEY_EXCHANGE_DH | S2N_KEY_EXCHANGE_EPH | S2N_KEY_EXCHANGE_ECC,
 };
 
-/* All of the cipher suites that s2n negotiates, in order of value */
-struct s2n_cipher_suite s2n_all_cipher_suites[] = {
-    {"RC4-MD5", {TLS_RSA_WITH_RC4_128_MD5}, &s2n_rsa, &s2n_rc4, S2N_HMAC_MD5, S2N_HMAC_SHA256, S2N_SSLv3},  /* 0x00,0x04 */
-    {"RC4-SHA", {TLS_RSA_WITH_RC4_128_SHA}, &s2n_rsa, &s2n_rc4, S2N_HMAC_SHA1, S2N_HMAC_SHA256, S2N_SSLv3}, /* 0x00,0x05 */
-    {"DES-CBC3-SHA", {TLS_RSA_WITH_3DES_EDE_CBC_SHA}, &s2n_rsa, &s2n_3des, S2N_HMAC_SHA1, S2N_HMAC_SHA256, S2N_SSLv3},  /* 0x00,0x0A */
-    {"EDH-RSA-DES-CBC3-SHA", {TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA}, &s2n_dhe, &s2n_3des, S2N_HMAC_SHA1, S2N_HMAC_SHA256, S2N_SSLv3},  /* 0x00,0x16 */
-    {"AES128-SHA", {TLS_RSA_WITH_AES_128_CBC_SHA}, &s2n_rsa, &s2n_aes128, S2N_HMAC_SHA1, S2N_HMAC_SHA256, S2N_TLS10},   /* 0x00,0x2F */
-    {"DHE-RSA-AES128-SHA", {TLS_DHE_RSA_WITH_AES_128_CBC_SHA}, &s2n_dhe, &s2n_aes128, S2N_HMAC_SHA1, S2N_HMAC_SHA256, S2N_TLS10},   /* 0x00,0x33 */
-    {"AES256-SHA", {TLS_RSA_WITH_AES_256_CBC_SHA}, &s2n_rsa, &s2n_aes256, S2N_HMAC_SHA1, S2N_HMAC_SHA256, S2N_TLS10},   /* 0x00,0x35 */
-    {"DHE-RSA-AES256-SHA", {TLS_DHE_RSA_WITH_AES_256_CBC_SHA}, &s2n_dhe, &s2n_aes256, S2N_HMAC_SHA1, S2N_HMAC_SHA256, S2N_TLS10},   /* 0x00,0x39 */
-    {"AES128-SHA256", {TLS_RSA_WITH_AES_128_CBC_SHA256}, &s2n_rsa, &s2n_aes128, S2N_HMAC_SHA256, S2N_HMAC_SHA256, S2N_TLS12},   /* 0x00,0x3C */
-    {"AES256-SHA256", {TLS_RSA_WITH_AES_256_CBC_SHA256}, &s2n_rsa, &s2n_aes256, S2N_HMAC_SHA256, S2N_HMAC_SHA256, S2N_TLS12},   /* 0x00,0x3D */
-    {"DHE-RSA-AES128-SHA256", {TLS_DHE_RSA_WITH_AES_128_CBC_SHA256}, &s2n_dhe, &s2n_aes128, S2N_HMAC_SHA256, S2N_HMAC_SHA256, S2N_TLS12},   /* 0x00,0x67 */
-    {"DHE-RSA-AES256-SHA256", {TLS_DHE_RSA_WITH_AES_256_CBC_SHA256}, &s2n_dhe, &s2n_aes256, S2N_HMAC_SHA256, S2N_HMAC_SHA256, S2N_TLS12},   /* 0x00,0x6B */
-    {"AES128-GCM-SHA256", {TLS_RSA_WITH_AES_128_GCM_SHA256}, &s2n_rsa, &s2n_aes128_gcm, S2N_HMAC_NONE, S2N_HMAC_SHA256, S2N_TLS12}, /* 0x00,0x9C */
-    {"AES256-GCM-SHA384", {TLS_RSA_WITH_AES_256_GCM_SHA384}, &s2n_rsa, &s2n_aes256_gcm, S2N_HMAC_NONE, S2N_HMAC_SHA384, S2N_TLS12}, /* 0x00,0x9D */
-    {"DHE-RSA-AES128-GCM-SHA256", {TLS_DHE_RSA_WITH_AES_128_GCM_SHA256}, &s2n_dhe, &s2n_aes128_gcm, S2N_HMAC_NONE, S2N_HMAC_SHA256, S2N_TLS12}, /* 0x00,0x9E */
-    {"ECDHE-RSA-DES-CBC3-SHA", {TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA}, &s2n_ecdhe, &s2n_3des, S2N_HMAC_SHA1, S2N_HMAC_SHA256, S2N_TLS10},    /* 0xC0,0x12 */
-    {"ECDHE-RSA-AES128-SHA", {TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA}, &s2n_ecdhe, &s2n_aes128, S2N_HMAC_SHA1, S2N_HMAC_SHA256, S2N_TLS10}, /* 0xC0,0x13 */
-    {"ECDHE-RSA-AES256-SHA", {TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA}, &s2n_ecdhe, &s2n_aes256, S2N_HMAC_SHA1, S2N_HMAC_SHA256, S2N_TLS10}, /* 0xC0,0x14 */
-    {"ECDHE-RSA-AES128-SHA256", {TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256}, &s2n_ecdhe, &s2n_aes128, S2N_HMAC_SHA256, S2N_HMAC_SHA256, S2N_TLS12}, /* 0xC0,0x27 */
-    {"ECDHE-RSA-AES256-SHA384", {TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384}, &s2n_ecdhe, &s2n_aes256, S2N_HMAC_SHA384, S2N_HMAC_SHA384, S2N_TLS12}, /* 0xC0,0x28 */
-    {"ECDHE-RSA-AES128-GCM-SHA256", {TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256}, &s2n_ecdhe, &s2n_aes128_gcm, S2N_HMAC_NONE, S2N_HMAC_SHA256, S2N_TLS12},   /* 0xC0,0x2F */
-    {"ECDHE-RSA-AES256-GCM-SHA384", {TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384}, &s2n_ecdhe, &s2n_aes256_gcm, S2N_HMAC_NONE, S2N_HMAC_SHA384, S2N_TLS12},   /* 0xC0,0x30 */
+const struct s2n_record_algorithm s2n_record_alg_null = {
+    .cipher = &s2n_null_cipher,
+    .hmac_alg = S2N_HMAC_NONE,
+};
+
+const struct s2n_record_algorithm s2n_record_alg_rc4_md5 = {
+    .cipher = &s2n_rc4,
+    .hmac_alg = S2N_HMAC_MD5,
+};
+
+const struct s2n_record_algorithm s2n_record_alg_rc4_sha = {
+    .cipher = &s2n_rc4,
+    .hmac_alg = S2N_HMAC_SHA1,
+};
+
+const struct s2n_record_algorithm s2n_record_alg_3des_sha = {
+    .cipher = &s2n_3des,
+    .hmac_alg = S2N_HMAC_SHA1,
+};
+
+const struct s2n_record_algorithm s2n_record_alg_aes128_sha = {
+    .cipher = &s2n_aes128,
+    .hmac_alg = S2N_HMAC_SHA1,
+};
+
+const struct s2n_record_algorithm s2n_record_alg_aes128_sha_composite = {
+    .cipher = &s2n_aes128_sha,
+    .hmac_alg = S2N_HMAC_NONE,
+};
+
+const struct s2n_record_algorithm s2n_record_alg_aes128_sha256 = {
+    .cipher = &s2n_aes128,
+    .hmac_alg = S2N_HMAC_SHA256,
+};
+
+const struct s2n_record_algorithm s2n_record_alg_aes256_sha = {
+    .cipher = &s2n_aes256,
+    .hmac_alg = S2N_HMAC_SHA1,
+};
+
+const struct s2n_record_algorithm s2n_record_alg_aes256_sha_composite = {
+    .cipher = &s2n_aes256_sha,
+    .hmac_alg = S2N_HMAC_NONE,
+};
+
+const struct s2n_record_algorithm s2n_record_alg_aes256_sha256 = {
+    .cipher = &s2n_aes256,
+    .hmac_alg = S2N_HMAC_SHA256,
+};
+
+const struct s2n_record_algorithm s2n_record_alg_aes256_sha384 = {
+    .cipher = &s2n_aes256,
+    .hmac_alg = S2N_HMAC_SHA384,
+};
+
+const struct s2n_record_algorithm s2n_record_alg_aes128_gcm = {
+    .cipher = &s2n_aes128_gcm,
+    .hmac_alg = S2N_HMAC_NONE,
+};
+
+const struct s2n_record_algorithm s2n_record_alg_aes256_gcm = {
+    .cipher = &s2n_aes256_gcm,
+    .hmac_alg = S2N_HMAC_NONE,
 };
 
 /* This is the initial cipher suite, but is never negotiated */
-struct s2n_cipher_suite s2n_null_cipher_suite = { "TLS_NULL_WITH_NULL_NULL", {TLS_NULL_WITH_NULL_NULL}, &s2n_rsa, &s2n_null_cipher, S2N_HMAC_NONE };
+struct s2n_cipher_suite s2n_null_cipher_suite = {
+    .available = 1,
+    .name = "TLS_NULL_WITH_NULL_NULL",
+    .iana_value = { TLS_NULL_WITH_NULL_NULL },
+    .key_exchange_alg = &s2n_rsa,
+    .record_alg = &s2n_record_alg_null,
+};
+
+struct s2n_cipher_suite s2n_rsa_with_rc4_128_md5 = /* 0x00,0x04 */ {
+    .available = 0,
+    .name = "RC4-MD5",
+    .iana_value = { TLS_RSA_WITH_RC4_128_MD5 },
+    .key_exchange_alg = &s2n_rsa,
+    .record_alg = NULL,
+    .all_record_algs = { &s2n_record_alg_rc4_md5 },
+    .num_record_algs = 1,
+    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .minimum_required_tls_version = S2N_SSLv3,
+};
+
+struct s2n_cipher_suite s2n_rsa_with_rc4_128_sha = /* 0x00,0x05 */ {
+    .available = 0,
+    .name = "RC4-SHA",
+    .iana_value = { TLS_RSA_WITH_RC4_128_SHA },
+    .key_exchange_alg = &s2n_rsa,
+    .record_alg = NULL,
+    .all_record_algs = { &s2n_record_alg_rc4_sha },
+    .num_record_algs = 1,
+    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .minimum_required_tls_version = S2N_SSLv3,
+};
+
+struct s2n_cipher_suite s2n_rsa_with_3des_ede_cbc_sha = /* 0x00,0x0A */ {
+    .available = 0,
+    .name = "DES-CBC3-SHA",
+    .iana_value = { TLS_RSA_WITH_3DES_EDE_CBC_SHA },
+    .key_exchange_alg = &s2n_rsa,
+    .record_alg = NULL,
+    .all_record_algs = { &s2n_record_alg_3des_sha },
+    .num_record_algs = 1,
+    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .minimum_required_tls_version = S2N_SSLv3,
+};
+
+struct s2n_cipher_suite s2n_dhe_rsa_with_3des_ede_cbc_sha = /* 0x00,0x16 */ {
+    .available = 0,
+    .name = "EDH-RSA-DES-CBC3-SHA",
+    .iana_value = { TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA },
+    .key_exchange_alg = &s2n_dhe,
+    .record_alg = NULL,
+    .all_record_algs = { &s2n_record_alg_3des_sha },
+    .num_record_algs = 1,
+    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .minimum_required_tls_version = S2N_SSLv3,
+};
+
+struct s2n_cipher_suite s2n_rsa_with_aes_128_cbc_sha = /* 0x00,0x2F */ {
+    .available = 0,
+    .name = "AES128-SHA",
+    .iana_value = { TLS_RSA_WITH_AES_128_CBC_SHA },
+    .key_exchange_alg = &s2n_rsa,
+    .record_alg = NULL,
+    .all_record_algs = { &s2n_record_alg_aes128_sha_composite, &s2n_record_alg_aes128_sha },
+    .num_record_algs = 2,
+    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .minimum_required_tls_version = S2N_SSLv3,
+};
+
+struct s2n_cipher_suite s2n_dhe_rsa_with_aes_128_cbc_sha = /* 0x00,0x33 */ {
+    .available = 0,
+    .name = "DHE-RSA-AES128-SHA",
+    .iana_value = { TLS_DHE_RSA_WITH_AES_128_CBC_SHA },
+    .key_exchange_alg = &s2n_dhe,
+    .record_alg = NULL,
+    .all_record_algs = { &s2n_record_alg_aes128_sha_composite, &s2n_record_alg_aes128_sha },
+    .num_record_algs = 2,
+    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .minimum_required_tls_version = S2N_SSLv3,
+};
+
+struct s2n_cipher_suite s2n_rsa_with_aes_256_cbc_sha = /* 0x00,0x35 */ {
+    .available = 0,
+    .name = "AES256-SHA",
+    .iana_value = { TLS_RSA_WITH_AES_256_CBC_SHA },
+    .key_exchange_alg = &s2n_rsa,
+    .record_alg = NULL,
+    .all_record_algs = { &s2n_record_alg_aes256_sha_composite , &s2n_record_alg_aes256_sha },
+    .num_record_algs = 2,
+    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .minimum_required_tls_version = S2N_SSLv3,
+};
+
+struct s2n_cipher_suite s2n_dhe_rsa_with_aes_256_cbc_sha = /* 0x00,0x39 */ {
+    .available = 0,
+    .name = "DHE-RSA-AES256-SHA",
+    .iana_value = { TLS_DHE_RSA_WITH_AES_256_CBC_SHA },
+    .key_exchange_alg = &s2n_dhe,
+    .record_alg = NULL,
+    .all_record_algs = { &s2n_record_alg_aes256_sha_composite , &s2n_record_alg_aes256_sha },
+    .num_record_algs = 2,
+    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .minimum_required_tls_version = S2N_SSLv3,
+};
+
+struct s2n_cipher_suite s2n_rsa_with_aes_128_cbc_sha256 = /* 0x00,0x3C */ {
+    .available = 0,
+    .name = "AES128-SHA256",
+    .iana_value = { TLS_RSA_WITH_AES_128_CBC_SHA256 },
+    .key_exchange_alg = &s2n_rsa,
+    .record_alg = NULL,
+    .all_record_algs = { &s2n_record_alg_aes128_sha256 },
+    .num_record_algs = 1,
+    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .minimum_required_tls_version = S2N_TLS12,
+};
+
+struct s2n_cipher_suite s2n_rsa_with_aes_256_cbc_sha256 = /* 0x00,0x3D */ {
+    .available = 0,
+    .name = "AES256-SHA256",
+    .iana_value = { TLS_RSA_WITH_AES_256_CBC_SHA256 },
+    .key_exchange_alg = &s2n_rsa,
+    .record_alg = NULL,
+    .all_record_algs = { &s2n_record_alg_aes256_sha256 },
+    .num_record_algs = 1,
+    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .minimum_required_tls_version = S2N_TLS12,
+};
+
+struct s2n_cipher_suite s2n_dhe_rsa_with_aes_128_cbc_sha256 = /* 0x00,0x67 */ {
+    .available = 0,
+    .name = "DHE-RSA-AES128-SHA256",
+    .iana_value = { TLS_DHE_RSA_WITH_AES_128_CBC_SHA256 },
+    .key_exchange_alg = &s2n_dhe,
+    .record_alg = NULL,
+    .all_record_algs = { &s2n_record_alg_aes128_sha256 },
+    .num_record_algs = 1,
+    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .minimum_required_tls_version = S2N_TLS12,
+};
+
+struct s2n_cipher_suite s2n_dhe_rsa_with_aes_256_cbc_sha256 = /* 0x00,0x6B */ {
+    .available = 0,
+    .name = "DHE-RSA-AES256-SHA256",
+    .iana_value = { TLS_DHE_RSA_WITH_AES_256_CBC_SHA256 },
+    .key_exchange_alg = &s2n_dhe,
+    .record_alg = NULL,
+    .all_record_algs = { &s2n_record_alg_aes256_sha256 },
+    .num_record_algs = 1,
+    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .minimum_required_tls_version = S2N_TLS12,
+};
+
+struct s2n_cipher_suite s2n_rsa_with_aes_128_gcm_sha256 = /* 0x00,0x9C */ {
+    .available = 0,
+    .name = "AES128-GCM-SHA256",
+    .iana_value = { TLS_RSA_WITH_AES_128_GCM_SHA256 },
+    .key_exchange_alg = &s2n_rsa,
+    .record_alg = NULL,
+    .all_record_algs = { &s2n_record_alg_aes128_gcm },
+    .num_record_algs = 1,
+    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .minimum_required_tls_version = S2N_TLS12,
+};
+
+struct s2n_cipher_suite s2n_rsa_with_aes_256_gcm_sha384 = /* 0x00,0x9D */ {
+    .available = 0,
+    .name = "AES256-GCM-SHA384",
+    .iana_value = { TLS_RSA_WITH_AES_256_GCM_SHA384 },
+    .key_exchange_alg = &s2n_rsa,
+    .record_alg = NULL,
+    .all_record_algs = { &s2n_record_alg_aes256_gcm },
+    .num_record_algs = 1,
+    .tls12_prf_alg = S2N_HMAC_SHA384,
+    .minimum_required_tls_version = S2N_TLS12,
+};
+
+struct s2n_cipher_suite s2n_dhe_rsa_with_aes_128_gcm_sha256 = /* 0x00,0x9E */ {
+    .available = 0,
+    .name = "DHE-RSA-AES128-GCM-SHA256",
+    .iana_value = { TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 },
+    .key_exchange_alg = &s2n_dhe,
+    .record_alg = NULL,
+    .all_record_algs = { &s2n_record_alg_aes128_gcm },
+    .num_record_algs = 1,
+    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .minimum_required_tls_version = S2N_TLS12,
+};
+
+struct s2n_cipher_suite s2n_ecdhe_rsa_with_3des_ede_cbc_sha = /* 0xC0,0x12 */ {
+    .available = 0,
+    .name = "ECDHE-RSA-DES-CBC3-SHA",
+    .iana_value = { TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA },
+    .key_exchange_alg = &s2n_ecdhe,
+    .record_alg = NULL,
+    .all_record_algs = { &s2n_record_alg_3des_sha },
+    .num_record_algs = 1,
+    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .minimum_required_tls_version = S2N_TLS10,
+};
+
+struct s2n_cipher_suite s2n_ecdhe_rsa_with_aes_128_cbc_sha = /* 0xC0,0x13 */ {
+    .available = 0,
+    .name = "ECDHE-RSA-AES128-SHA",
+    .iana_value = { TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA },
+    .key_exchange_alg = &s2n_ecdhe,
+    .record_alg = NULL,
+    .all_record_algs = { &s2n_record_alg_aes128_sha_composite, &s2n_record_alg_aes128_sha },
+    .num_record_algs = 2,
+    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .minimum_required_tls_version = S2N_TLS10,
+};
+
+struct s2n_cipher_suite s2n_ecdhe_rsa_with_aes_256_cbc_sha = /* 0xC0,0x14 */ {
+    .available = 0,
+    .name = "ECDHE-RSA-AES256-SHA",
+    .iana_value = { TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA },
+    .key_exchange_alg = &s2n_ecdhe,
+    .record_alg = NULL,
+    .all_record_algs = { &s2n_record_alg_aes256_sha_composite , &s2n_record_alg_aes256_sha },
+    .num_record_algs = 2,
+    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .minimum_required_tls_version = S2N_TLS10,
+};
+
+struct s2n_cipher_suite s2n_ecdhe_rsa_with_aes_128_cbc_sha256 = /* 0xC0,0x27 */ {
+    .available = 0,
+    .name = "ECDHE-RSA-AES128-SHA256",
+    .iana_value = { TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 },
+    .key_exchange_alg = &s2n_ecdhe,
+    .record_alg = NULL,
+    .all_record_algs = { &s2n_record_alg_aes128_sha256 },
+    .num_record_algs = 1,
+    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .minimum_required_tls_version = S2N_TLS12,
+};
+
+struct s2n_cipher_suite s2n_ecdhe_rsa_with_aes_256_cbc_sha384 = /* 0xC0,0x28 */ {
+    .available = 0,
+    .name = "ECDHE-RSA-AES256-SHA384",
+    .iana_value = { TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384 },
+    .key_exchange_alg = &s2n_ecdhe,
+    .record_alg = NULL,
+    .all_record_algs = { &s2n_record_alg_aes256_sha384 },
+    .num_record_algs = 1,
+    .tls12_prf_alg = S2N_HMAC_SHA384,
+    .minimum_required_tls_version = S2N_TLS12,
+};
+
+struct s2n_cipher_suite s2n_ecdhe_rsa_with_aes_128_gcm_sha256 = /* 0xC0,0x2F */ {
+    .available = 0,
+    .name = "ECDHE-RSA-AES128-GCM-SHA256",
+    .iana_value = { TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 },
+    .key_exchange_alg = &s2n_ecdhe,
+    .record_alg = NULL,
+    .all_record_algs = { &s2n_record_alg_aes128_gcm },
+    .num_record_algs = 1,
+    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .minimum_required_tls_version = S2N_TLS12,
+};
+
+struct s2n_cipher_suite s2n_ecdhe_rsa_with_aes_256_gcm_sha384 = /* 0xC0,0x30 */ {
+    .available = 0,
+    .name = "ECDHE-RSA-AES256-GCM-SHA384",
+    .iana_value = { TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 },
+    .key_exchange_alg = &s2n_ecdhe,
+    .record_alg = NULL,
+    .all_record_algs = { &s2n_record_alg_aes256_gcm },
+    .num_record_algs = 1,
+    .tls12_prf_alg = S2N_HMAC_SHA384,
+    .minimum_required_tls_version = S2N_TLS12,
+};
+
+/* All of the cipher suites that s2n negotiates, in order of IANA value */
+struct s2n_cipher_suite *s2n_all_cipher_suites[] = {
+    &s2n_rsa_with_rc4_128_md5,                /* 0x00,0x04 */
+    &s2n_rsa_with_rc4_128_sha,                /* 0x00,0x05 */
+    &s2n_rsa_with_3des_ede_cbc_sha,           /* 0x00,0x0A */
+    &s2n_dhe_rsa_with_3des_ede_cbc_sha,       /* 0x00,0x16 */
+    &s2n_rsa_with_aes_128_cbc_sha,            /* 0x00,0x2F */
+    &s2n_dhe_rsa_with_aes_128_cbc_sha,        /* 0x00,0x33 */
+    &s2n_rsa_with_aes_256_cbc_sha,            /* 0x00,0x35 */
+    &s2n_dhe_rsa_with_aes_256_cbc_sha,        /* 0x00,0x39 */
+    &s2n_rsa_with_aes_128_cbc_sha256,         /* 0x00,0x3C */
+    &s2n_rsa_with_aes_256_cbc_sha256,         /* 0x00,0x3D */
+    &s2n_dhe_rsa_with_aes_128_cbc_sha256,     /* 0x00,0x67 */
+    &s2n_dhe_rsa_with_aes_256_cbc_sha256,     /* 0x00,0x6B */
+    &s2n_rsa_with_aes_128_gcm_sha256,         /* 0x00,0x9C */
+    &s2n_rsa_with_aes_256_gcm_sha384,         /* 0x00,0x9D */
+    &s2n_dhe_rsa_with_aes_128_gcm_sha256,     /* 0x00,0x9E */
+    &s2n_ecdhe_rsa_with_3des_ede_cbc_sha,     /* 0xC0,0x12 */
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha,      /* 0xC0,0x13 */
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha,      /* 0xC0,0x14 */
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,   /* 0xC0,0x27 */
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,   /* 0xC0,0x28 */
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,   /* 0xC0,0x2F */
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,   /* 0xC0,0x30 */
+};
+
+/* Determines cipher suite availability and selects record algorithms */
+int s2n_cipher_suites_init(void)
+{
+    const int num_cipher_suites = sizeof(s2n_all_cipher_suites) / sizeof(struct s2n_cipher_suite*);
+    for (int i = 0; i < num_cipher_suites; i++) {
+        struct s2n_cipher_suite *cur_suite = s2n_all_cipher_suites[i];
+        cur_suite->available = 0;
+        cur_suite->record_alg = NULL;
+
+        /* Find the highest priority supported record algorithm */
+        for (int j = 0; j < cur_suite->num_record_algs; j++) {
+            /* Can we use the record algorithm's cipher? Won't be available if the system CPU architechure
+             * doesn't support it or if the libcrypto lacks the feature. All hmac_algs are supported.
+             */
+            if (cur_suite->all_record_algs[j]->cipher->is_available()) {
+                /* Found a supported record algorithm. Use it. */
+                cur_suite->available = 1;
+                cur_suite->record_alg = cur_suite->all_record_algs[j];
+                break;
+            }
+        }
+    }
+
+    return 0;
+}
+
+/* Reset any selected record algorithms */
+int s2n_cipher_suites_cleanup(void)
+{
+    const int num_cipher_suites = sizeof(s2n_all_cipher_suites) / sizeof(struct s2n_cipher_suite*);
+    for (int i = 0; i < num_cipher_suites; i++) {
+        struct s2n_cipher_suite *cur_suite = s2n_all_cipher_suites[i];
+        cur_suite->available = 0;
+        cur_suite->record_alg = NULL;
+    }
+
+    return 0;
+}
 
 struct s2n_cipher_suite *s2n_cipher_suite_match(uint8_t cipher_suite[S2N_TLS_CIPHER_SUITE_LEN])
 {
     int low = 0;
-    int top = (sizeof(s2n_all_cipher_suites) / sizeof(struct s2n_cipher_suite)) - 1;
+    int top = (sizeof(s2n_all_cipher_suites) / sizeof(struct s2n_cipher_suite*)) - 1;
 
     /* Perform a textbook binary search */
     while (low <= top) {
         /* Check in the middle */
         int mid = low + ((top - low) / 2);
-        int m = memcmp(s2n_all_cipher_suites[mid].value, cipher_suite, 2);
+        int m = memcmp(s2n_all_cipher_suites[mid]->iana_value, cipher_suite, 2);
 
         if (m == 0) {
-            return &s2n_all_cipher_suites[mid];
+            return s2n_all_cipher_suites[mid];
         } else if (m > 0) {
             top = mid - 1;
         } else if (m < 0) {
@@ -142,6 +518,11 @@ static int s2n_set_cipher_as_server(struct s2n_connection *conn, uint8_t * wire,
             /* This should never happen */
             if (match == NULL) {
                 S2N_ERROR(S2N_ERR_CIPHER_NOT_SUPPORTED);
+            }
+
+            /* Skip the suite if we don't have an available implementation */
+            if (!match->available) {
+                continue;
             }
 
             /* Don't choose DHE key exchange if it's not configured. */

--- a/tls/s2n_cipher_suites.h
+++ b/tls/s2n_cipher_suites.h
@@ -38,22 +38,56 @@ struct s2n_key_exchange_algorithm {
     /* OR'ed S2N_KEY_EXCHANGE_* flags */
     uint16_t flags;
 };
+
 extern const struct s2n_key_exchange_algorithm s2n_rsa;
 extern const struct s2n_key_exchange_algorithm s2n_dhe;
 extern const struct s2n_key_exchange_algorithm s2n_ecdhe;
 
-struct s2n_cipher_suite {
-    const char *name;
-    uint8_t value[2];
-    const struct s2n_key_exchange_algorithm *key_exchange_alg;
-    /* Cipher name in Openssl format */
-    struct s2n_cipher *cipher;
+#define S2N_MAX_POSSIBLE_RECORD_ALGS  2
+
+struct s2n_record_algorithm {
+    const struct s2n_cipher *cipher;
     s2n_hmac_algorithm hmac_alg;
+};
+
+/* Verbose names to avoid confusion with s2n_cipher. Exposed for unit tests */
+extern const struct s2n_record_algorithm s2n_record_alg_null;
+extern const struct s2n_record_algorithm s2n_record_alg_rc4_md5;
+extern const struct s2n_record_algorithm s2n_record_alg_rc4_sha;
+extern const struct s2n_record_algorithm s2n_record_alg_3des_sha;
+extern const struct s2n_record_algorithm s2n_record_alg_aes128_sha;
+extern const struct s2n_record_algorithm s2n_record_alg_aes128_sha_composite;
+extern const struct s2n_record_algorithm s2n_record_alg_aes128_sha256;
+extern const struct s2n_record_algorithm s2n_record_alg_aes256_sha;
+extern const struct s2n_record_algorithm s2n_record_alg_aes256_sha_composite;
+extern const struct s2n_record_algorithm s2n_record_alg_aes256_sha256;
+extern const struct s2n_record_algorithm s2n_record_alg_aes256_sha384;
+extern const struct s2n_record_algorithm s2n_record_alg_aes128_gcm;
+extern const struct s2n_record_algorithm s2n_record_alg_aes256_gcm;
+
+struct s2n_cipher_suite {
+    /* Is there an implementation available? Set in s2n_cipher_suites_init() */
+    unsigned int available:1;
+
+    /* Cipher name in Openssl format */
+    const char *name;
+    const uint8_t iana_value[2];
+
+    const struct s2n_key_exchange_algorithm *key_exchange_alg;
+
+    /* Algorithms used for per-record security. Set in s2n_cipher_suites_init() */
+    const struct s2n_record_algorithm *record_alg;
+
+    /* List of all possible record alg implementations in descending priority */
+    const struct s2n_record_algorithm *all_record_algs[S2N_MAX_POSSIBLE_RECORD_ALGS];
+    const uint8_t num_record_algs;
+
     /* RFC 5426(TLS1.2) allows cipher suite defined PRFs. Cipher suites defined in and before TLS1.2 will use
      * P_hash with SHA256 when TLS1.2 is negotiated.
      */
-    s2n_hmac_algorithm tls12_prf_alg;
-    uint8_t minimum_required_tls_version;
+    const s2n_hmac_algorithm tls12_prf_alg;
+
+    const uint8_t minimum_required_tls_version;
 };
 
 extern struct s2n_cipher_suite s2n_null_cipher_suite;
@@ -63,6 +97,8 @@ extern struct s2n_cipher_preferences *s2n_cipher_preferences_20150214;
 extern struct s2n_cipher_preferences *s2n_cipher_preferences_20150306;
 extern struct s2n_cipher_preferences *s2n_cipher_preferences_default;
 
+extern int s2n_cipher_suites_init(void);
+extern int s2n_cipher_suites_cleanup(void);
 extern int s2n_set_cipher_as_client(struct s2n_connection *conn, uint8_t wire[S2N_TLS_CIPHER_SUITE_LEN]);
 extern int s2n_set_cipher_as_sslv2_server(struct s2n_connection *conn, uint8_t * wire, uint16_t count);
 extern int s2n_set_cipher_as_tls_server(struct s2n_connection *conn, uint8_t * wire, uint16_t count);

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -123,9 +123,9 @@ static int s2n_connection_wipe_keys(struct s2n_connection *conn)
 {
     /* Destroy any keys - we call destroy on the object as that is where
      * keys are allocated. */
-    if (conn->secure.cipher_suite && conn->secure.cipher_suite->cipher->destroy_key) {
-        GUARD(conn->secure.cipher_suite->cipher->destroy_key(&conn->secure.client_key));
-        GUARD(conn->secure.cipher_suite->cipher->destroy_key(&conn->secure.server_key));
+    if (conn->secure.cipher_suite && conn->secure.cipher_suite->record_alg->cipher->destroy_key) {
+        GUARD(conn->secure.cipher_suite->record_alg->cipher->destroy_key(&conn->secure.client_key));
+        GUARD(conn->secure.cipher_suite->record_alg->cipher->destroy_key(&conn->secure.server_key));
     }
 
     /* Free any server key received (we may not have completed a

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -42,7 +42,7 @@ static int s2n_serialize_resumption_state(struct s2n_connection *conn, struct s2
     /* Write the entry */
     GUARD(s2n_stuffer_write_uint8(to, S2N_SERIALIZED_FORMAT_VERSION));
     GUARD(s2n_stuffer_write_uint8(to, conn->actual_protocol_version));
-    GUARD(s2n_stuffer_write_bytes(to, conn->secure.cipher_suite->value, S2N_TLS_CIPHER_SUITE_LEN));
+    GUARD(s2n_stuffer_write_bytes(to, conn->secure.cipher_suite->iana_value, S2N_TLS_CIPHER_SUITE_LEN));
     GUARD(s2n_stuffer_write_uint64(to, now));
     GUARD(s2n_stuffer_write_bytes(to, conn->secure.master_secret, S2N_TLS_SECRET_LEN));
 
@@ -71,7 +71,7 @@ static int s2n_deserialize_resumption_state(struct s2n_connection *conn, struct 
     }
 
     GUARD(s2n_stuffer_read_bytes(from, cipher_suite, S2N_TLS_CIPHER_SUITE_LEN));
-    if (memcmp(conn->secure.cipher_suite->value, cipher_suite, S2N_TLS_CIPHER_SUITE_LEN)) {
+    if (memcmp(conn->secure.cipher_suite->iana_value, cipher_suite, S2N_TLS_CIPHER_SUITE_LEN)) {
         return -1;
     }
 

--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -129,7 +129,7 @@ ssize_t s2n_send(struct s2n_connection * conn, const void *buf, ssize_t size, s2
         /* Don't split messages in server mode for interoperability with naive clients.
          * Some clients may have expectations based on the amount of content in the first record.
          */
-        if (conn->actual_protocol_version < S2N_TLS11 && writer->cipher_suite->cipher->type == S2N_CBC && conn->mode != S2N_SERVER) {
+        if (conn->actual_protocol_version < S2N_TLS11 && writer->cipher_suite->record_alg->cipher->type == S2N_CBC && conn->mode != S2N_SERVER) {
             if (in.size > 1 && cbcHackUsed == 0) {
                 in.size = 1;
                 cbcHackUsed = 1;

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -126,7 +126,7 @@ int s2n_server_hello_send(struct s2n_connection *conn)
     GUARD(s2n_stuffer_write_bytes(out, conn->secure.server_random, S2N_TLS_RANDOM_DATA_LEN));
     GUARD(s2n_stuffer_write_uint8(out, conn->session_id_len));
     GUARD(s2n_stuffer_write_bytes(out, conn->session_id, conn->session_id_len));
-    GUARD(s2n_stuffer_write_bytes(out, conn->secure.cipher_suite->value, S2N_TLS_CIPHER_SUITE_LEN));
+    GUARD(s2n_stuffer_write_bytes(out, conn->secure.cipher_suite->iana_value, S2N_TLS_CIPHER_SUITE_LEN));
     GUARD(s2n_stuffer_write_uint8(out, S2N_TLS_COMPRESSION_METHOD_NULL));
 
     GUARD(s2n_server_extensions_send(conn, out));

--- a/utils/s2n_init.c
+++ b/utils/s2n_init.c
@@ -23,12 +23,14 @@ int s2n_init(void)
 {
 	GUARD(s2n_mem_init());
 	GUARD(s2n_rand_init());
+	GUARD(s2n_cipher_suites_init());
 
 	return 0;
 }
 
 int s2n_cleanup(void)
 {
+	GUARD(s2n_cipher_suites_cleanup());
 	GUARD(s2n_rand_cleanup());
 	GUARD(s2n_mem_cleanup());
 


### PR DESCRIPTION
This change adds a wrapper around cipher/hmac_alg in s2n_cipher_suite.
Logic is also added to select an "s2n_record_algorithm" for every cipher
suite during s2n_init().

What do we gain?
- Selection of optimal cipher suite implementation. For example, we'll
  prefer to use composite ciphers for AES-CBC suites.
- Seamless fallback to less performant implementations.
- Disable cipher suites when no implementations are available. This
  allows us to add code for new suites(i.e. ChaCha20-based suites)
  without breaking compatibility when s2n is built with an older
  libcrypto.
- Foundation for divorcing TLS-specific parameters from core crypto
  code(I'm looking at you s2n_aead_aes_gcm.c).
- Foundation to add more cipher suite implementations. All of our
  current implementations are libcrypto-based, but this needn't
  always be true.

What sucks?
- Dynamic state(record_alg) is added and must be initialized at runtime.
  Previously all s2n_cipher_suite fields were basically constant.
- A new layer of abstraction is added:
  - Compare cipher_suite->record_alg->cipher vs cipher_suite->cipher
- More verbose accessors for cipher/hmac