### PR TITLE
api: Add s2n debug string getter

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -57,6 +57,7 @@ extern int s2n_config_free_dhparams(struct s2n_config *config);
 extern int s2n_config_free_cert_chain_and_key(struct s2n_config *config);
 extern int s2n_config_set_nanoseconds_since_epoch_callback(struct s2n_config *config, int (*nanoseconds_since_epoch)(void *, uint64_t *), void * data);
 extern const char *s2n_strerror(int error, const char *lang);
+extern const char *s2n_strerror_debug(int error, const char *lang);
 
 extern int s2n_config_set_cache_store_callback(struct s2n_config *config, int (*cache_store)(void *, uint64_t ttl_in_seconds, const void *key, uint64_t key_size, const void *value, uint64_t value_size), void *data);
 extern int s2n_config_set_cache_retrieve_callback(struct s2n_config *config, int (*cache_retrieve)(void *, const void *key, uint64_t key_size, void *value, uint64_t *value_size), void *data);

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -300,23 +300,29 @@ struct s2n_cert_public_key;
 
 ## Error handling
 
+```
+const char *s2n_strerror(int error, const char *lang);
+const char *s2n_strerror_debug(int error, const char *lang);
+````
+
 s2n functions that return 'int' return 0 to indicate success and -1 to indicate
 failure. s2n functions that return pointer types return NULL in the case of
 failure. When an s2n function returns a failure, s2n_errno will be set to a value
-corresponding to the error. This error value can be translated into a string 
-explaining the error in English by calling s2n_strerror(s2n_errno, "EN"); 
+corresponding to the error. This error value can be translated into a string
+explaining the error in English by calling s2n_strerror(s2n_errno, "EN");
+A string containing internal debug information, including filename and line number, can be generated with `s2n_strerror_debug`
+This string is useful to include when reporting issues to the s2n development team.
 
 Example:
 
 ```
 if (s2n_config_set_cipher_preferences(config, prefs) < 0) {
-    printf("Setting cipher prefs failed! %s", (s2n_strerror(s2n_errno, "EN"));
+    printf("Setting cipher prefs failed! %s : %s", s2n_strerror(s2n_errno, "EN"), s2n_strerror_debug(s2n_errno, "EN"));
     return -1;
 }
 ```
 
 **NOTE**: To avoid possible confusion, s2n_errno should be cleared after processing an error: `s2n_errno = S2N_ERR_T_OK`
-
 
 ### Error categories
 

--- a/error/s2n_errno.c
+++ b/error/s2n_errno.c
@@ -23,6 +23,9 @@
 __thread int s2n_errno;
 __thread const char *s2n_debug_str;
 
+static const char *no_such_language = "Language is not supported for error translation";
+static const char *no_such_error = "Internal s2n error";
+
 struct s2n_error_translation {
     int errno_value;
     const char *str;
@@ -142,7 +145,6 @@ const char *s2n_strerror(int error, const char *lang)
     }
 
     if (strcasecmp(lang, "EN")) {
-        const char *no_such_language = "Language is not supported for error translation";
         return no_such_language;
     }
 
@@ -152,8 +154,25 @@ const char *s2n_strerror(int error, const char *lang)
         }
     }
 
-    const char *no_such_error = "Internal s2n error";
     return no_such_error;
+}
+
+const char *s2n_strerror_debug(int error, const char *lang)
+{
+    if (lang == NULL) {
+        lang = "EN";
+    }
+
+    if (strcasecmp(lang, "EN")) {
+        return no_such_language;
+    }
+
+    /* No error, just return the no error string */
+    if (error == S2N_ERR_OK) {
+        return s2n_strerror(error, lang);
+    }
+
+    return s2n_debug_str;
 }
 
 int s2n_error_get_type(int error)


### PR DESCRIPTION
This change adds an accessor that returns a string containing the
file and line where the most recent error occurred.

This is helpful for debugging cases where the "s2n_strerror" output
isn't specific enough to determine where the error actually occurred.
For example, error values set by safety checks happen in many
different places, but will share the same error string.

Use of this function is optional, but it will helpful to debug any
problems found during external adoption.