### PR TITLE
build: Use fgnu89-inline

### DIFF
--- a/s2n.mk
+++ b/s2n.mk
@@ -37,7 +37,7 @@ DEFAULT_CFLAGS = -pedantic -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-su
                  -Wshadow -Wcast-qual -Wcast-align -Wwrite-strings -fPIC \
                  -std=c99 -D_POSIX_C_SOURCE=200809L -O2 -I$(LIBCRYPTO_ROOT)/include/ \
                  -I../api/ -I../ -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security \
-                 -D_FORTIFY_SOURCE=2
+                 -D_FORTIFY_SOURCE=2 -fgnu89-inline
 
 # Add a flag to disable stack protector for alternative libcs without
 # libssp.


### PR DESCRIPTION
This flags fixes a build compatibility issue with older glibc headers.
The problem is related to gcc's handling of "extern inline" [1][2][3][4]
Forcing GNU inline semantics allows compilation with the incompatible
headers.

[1] https://stackoverflow.com/questions/32325334/error-symbol-pread64-is-already-defined
[2] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=37384
[3] http://lifecs.likai.org/2009/06/multiple-definition-of-extern-inline.html
[4] https://llvm.org/bugs/show_bug.cgi?id=5960