### PR TITLE
Cppcheck fixes

### DIFF
--- a/crypto/s2n_dhe.c
+++ b/crypto/s2n_dhe.c
@@ -36,7 +36,7 @@
  */
 static const BIGNUM *s2n_get_Ys_dh_param(struct s2n_dh_params *dh_params)
 {
-    const BIGNUM *Ys = NULL;
+    const BIGNUM *Ys;
 
     /* DH made opaque in Openssl 1.1.0 */
     #if S2N_OPENSSL_VERSION_AT_LEAST(1,1,0) && !defined(LIBRESSL_VERSION_NUMBER)
@@ -50,7 +50,7 @@ static const BIGNUM *s2n_get_Ys_dh_param(struct s2n_dh_params *dh_params)
 
 static const BIGNUM *s2n_get_p_dh_param(struct s2n_dh_params *dh_params)
 {
-    const BIGNUM *p = NULL;
+    const BIGNUM *p;
     #if S2N_OPENSSL_VERSION_AT_LEAST(1,1,0) && !defined(LIBRESSL_VERSION_NUMBER)
         DH_get0_pqg(dh_params->dh, &p, NULL, NULL);
     #else
@@ -62,7 +62,7 @@ static const BIGNUM *s2n_get_p_dh_param(struct s2n_dh_params *dh_params)
 
 static const BIGNUM *s2n_get_g_dh_param(struct s2n_dh_params *dh_params)
 {
-    const BIGNUM *g = NULL;
+    const BIGNUM *g;
     #if S2N_OPENSSL_VERSION_AT_LEAST(1,1,0) && !defined(LIBRESSL_VERSION_NUMBER)
         DH_get0_pqg(dh_params->dh, NULL, NULL, &g);
     #else

--- a/tests/fuzz/LD_PRELOAD/s2n_server_fuzz_test_overrides.c
+++ b/tests/fuzz/LD_PRELOAD/s2n_server_fuzz_test_overrides.c
@@ -44,7 +44,7 @@ int s2n_constant_time_equals(const uint8_t *a, const uint8_t *b, uint32_t len)
     /* Allow all signatures checked with s2n_constant_time_equals to always pass verification even if they are invalid
      * in order to aid code coverage with server fuzz test.
      */
-    return !0;
+    return 1;
 }
 
 int s2n_rsa_client_key_recv(struct s2n_connection *conn)


### PR DESCRIPTION
Conditions for the cppcheck style checks have changed in the new version. I've adhered to the style guide rather than put in additional suppressions. For the NULL assignment of local variables, it shouldn't matter since these variables are assigned in all branches immediately after. The NULL assignment is probably considered safer though, so I can put in a suppression rule instead if desired.