### PR TITLE
Change linking order for libs2n.so

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -25,7 +25,7 @@ libs2n.a: ${OBJS}
 	$(RANLIB) libs2n.a
 
 libs2n.so: ${OBJS}
-	${CC} -shared  ${LIBS} -L${LIBCRYPTO_ROOT}/lib ${CRYPTO_LIBS} -o libs2n.so ${OBJS}
+	${CC} -shared -o libs2n.so ${OBJS} ${LIBS} -L${LIBCRYPTO_ROOT}/lib ${CRYPTO_LIBS}
 
 libs2n.dylib: ${OBJS}
 	test ! -f /usr/lib/libSystem.dylib || libtool -dynamic  ${LIBS} -L${LIBCRYPTO_ROOT}/lib ${CRYPTO_LIBS} -o libs2n.dylib ${OBJS}


### PR DESCRIPTION
GNU linker on some platfroms defaults to --as-needed, which causes
linker not to link library if it's not needed at the point of linking.
Since linking happens from left to right, libraries which were specified
before the actual libs2n objects will be skipped with --as-needed, as at
that point of linking nothing reference to symbols from them.

This change moves linking libraries to the end of compilation chain.

Build on ubuntu before the change:

% ldd libs2n.so
	linux-vdso.so.1 =>  (0x00007ffe87160000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f480f901000)
	/lib64/ld-linux-x86-64.so.2 (0x00005608be110000)

After the change:

% ldd libs2n.so
	linux-vdso.so.1 =>  (0x00007fffc33bf000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fefe4651000)
	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007fefe4449000)
	libcrypto.so.1.0.0 => /lib/x86_64-linux-gnu/libcrypto.so.1.0.0 (0x00007fefe4004000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fefe3c3b000)
	/lib64/ld-linux-x86-64.so.2 (0x0000563e793c4000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fefe3a37000)