### PR TITLE
Make corked I/O optional

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -76,6 +76,7 @@ extern int s2n_connection_set_config(struct s2n_connection *conn, struct s2n_con
 extern int s2n_connection_set_fd(struct s2n_connection *conn, int fd);
 extern int s2n_connection_set_read_fd(struct s2n_connection *conn, int readfd);
 extern int s2n_connection_set_write_fd(struct s2n_connection *conn, int writefd);
+extern int s2n_connection_use_corked_io(struct s2n_connection *conn);
 
 typedef int s2n_recv_fn(void *io_context, uint8_t *buf, uint32_t len);
 typedef int s2n_send_fn(void *io_context, const uint8_t *buf, uint32_t len);

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -52,6 +52,11 @@ struct s2n_connection {
      * default socket-based I/O set by s2n */
     uint8_t managed_io;
 
+    /* Is this connection using CORK/SO_RCVLOWAT optimizations? Only valid when the connection is using
+     * managed_io
+     */
+    unsigned int corked_io:1;
+
     /* Is this connection a client or a server connection */
     s2n_mode mode;
 

--- a/utils/s2n_socket.c
+++ b/utils/s2n_socket.c
@@ -27,7 +27,7 @@
     #define S2N_CORK        TCP_CORK
     #define S2N_CORK_ON     1
     #define S2N_CORK_OFF    0
-#elif TCP_NOPUSH   
+#elif TCP_NOPUSH
     #define S2N_CORK        TCP_NOPUSH
     #define S2N_CORK_ON     1
     #define S2N_CORK_OFF    0
@@ -119,14 +119,14 @@ int s2n_socket_write_cork(struct s2n_connection *conn)
 {
 #ifdef S2N_CORK
     int optval = S2N_CORK_ON;
-    
+
     struct s2n_socket_write_io_context *w_io_ctx = (struct s2n_socket_write_io_context *) conn->send_io_context;
     notnull_check(w_io_ctx);
 
     /* Ignore the return value, if it fails it fails */
     setsockopt(w_io_ctx->fd, IPPROTO_TCP, S2N_CORK, &optval, sizeof(optval));
 #endif
-    
+
     return 0;
 }
 
@@ -134,14 +134,14 @@ int s2n_socket_write_uncork(struct s2n_connection *conn)
 {
 #ifdef S2N_CORK
     int optval = S2N_CORK_OFF;
-    
+
     struct s2n_socket_write_io_context *w_io_ctx = (struct s2n_socket_write_io_context *) conn->send_io_context;
     notnull_check(w_io_ctx);
 
     /* Ignore the return value, if it fails it fails */
     setsockopt(w_io_ctx->fd, IPPROTO_TCP, S2N_CORK, &optval, sizeof(optval));
 #endif
- 
+
     return 0;
 }
 


### PR DESCRIPTION
This change makes our I/O optimizations via TCP_CORK and SO_RCVLOWAT
optional. The optimizations can be explicitly enabled with
s2n_connection_use_optimized_io.