### PR TITLE
Adding KWStyle Code Style Checker to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
         - g++-6
         - indent
         - cppcheck
+        - kwstyle
 
 osx_image: xcode8
 
@@ -79,6 +80,7 @@ install:
   - if [[ "$BUILD_S2N" == "true" ]]; then (test "$TRAVIS_OS_NAME" = "linux" && sudo "PATH=$PATH" .travis/install_prlimit.sh $PWD/.travis > /dev/null && sudo .travis/prlimit --pid "$$" --memlock=unlimited:unlimited) || true ; fi
   - if [[ "$BUILD_S2N" == "true" ]]; then mkdir -p .travis/checker && .travis/install_scan-build.sh .travis/checker && export PATH=$PATH:.travis/checker/bin ; fi
   - if [[ "$BUILD_S2N" == "true" ]]; then .travis/run_cppcheck.sh ; fi
+  - if [[ "$BUILD_S2N" == "true" && "$TRAVIS_OS_NAME" == "linux" ]]; then .travis/run_kwstyle.sh ; fi
 
 script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TESTS" == "integration" ]]; then make -j 8   ; fi

--- a/.travis/KWStyle.xml
+++ b/.travis/KWStyle.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+
+<!-- For list of supported features see: https://kitware.github.io/KWStyle/resources/features.html -->
+
+<Description>
+    <LineLength>177</LineLength>
+    <Functions>
+        <regex>[A-Za-z_]</regex>
+        <length>217</length>
+    </Functions>
+</Description>

--- a/.travis/run_kwstyle.sh
+++ b/.travis/run_kwstyle.sh
@@ -1,0 +1,22 @@
+#! /bin/bash
+
+S2N_FILES=`find $PWD -type f -name "s2n_*.[ch]" | grep -v "test"`
+
+FAILED=0
+
+for file in $S2N_FILES; do
+    ERROR_LIST=`KWStyle -gcc -v -xml .travis/KWStyle.xml "$file"`
+    if [ "$ERROR_LIST" != "" ] ;
+    then
+        echo "$ERROR_LIST"
+        FAILED=1
+    fi
+done
+
+if [ $FAILED == 1 ];
+then
+    printf "\033[31;1mFAILED kwstyle\033[0m\n"
+    exit -1
+else
+    printf "\033[32;1mPASSED kwstyle\033[0m\n"
+fi

--- a/.travis/run_kwstyle.sh
+++ b/.travis/run_kwstyle.sh
@@ -1,4 +1,17 @@
 #! /bin/bash
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
 
 S2N_FILES=`find $PWD -type f -name "s2n_*.[ch]" | grep -v "test"`
 


### PR DESCRIPTION
This change adds `KWStyle`, a C Code Style checker, that will check s2n source code for style violations during every build. Currently the coding style is defined in the Configuration File `.travis/KWStyle.xml `, and is purposefully set to be lax enough so that all existing code still passes style checks.

The intent is for future PR's to clean up existing code so that this Config File can be updated with stricter code style rules as the code is incrementally cleaned up. No attempt is made to clean up any existing code.

