### PR TITLE
Avoid data-dependent shift distances

### DIFF
--- a/utils/s2n_safety.c
+++ b/utils/s2n_safety.c
@@ -49,7 +49,7 @@ int s2n_constant_time_equals(const uint8_t * a, const uint8_t * b, uint32_t len)
 
 int s2n_constant_time_copy_or_dont(uint8_t * a, const uint8_t * b, uint32_t len, uint8_t dont)
 {
-    uint8_t mask = ~(0xff << ((!dont) * 8));
+    uint8_t mask = ((uint_fast16_t)((uint_fast16_t)(dont) - 1)) >> 8;
 
     /* dont = 0 : mask = 0xff */
     /* dont > 0 : mask = 0x00 */


### PR DESCRIPTION
On CPUs without barrel shifters, integer shifts take time dependent on
the distance being shifted.  As a result, it is important to avoid
using such operations in cryptographic code, where they might leak
sensitive information via a timing side channel.

The most recent CPU with which I'm personally familiar on which this
is a problem is the Intel 80286; but while the transistor footprint of
even a 64-bit barrel shifter is insignificant on modern general
purpose CPUs, it is conceivable that some embedded systems will have
sufficiently limited transistor budgets that they shave a few square
microns by using bit-per-cycle shifters.

Since extracting the high bits of a 16+ bit value x - 1 is in any event
a simpler and faster way of mapping bytes 0 -> 255, 1--255 -> 0, use
that rather than the hypothetically dangerous variable shift.