### PR TITLE
s/max_fragment_length/max_outgoing_fragment_length

### DIFF
--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -290,7 +290,7 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     conn->secure.cipher_suite = &s2n_null_cipher_suite;
     conn->server = &conn->initial;
     conn->client = &conn->initial;
-    conn->max_fragment_length = S2N_DEFAULT_FRAGMENT_LENGTH;
+    conn->max_outgoing_fragment_length = S2N_DEFAULT_FRAGMENT_LENGTH;
     conn->handshake.handshake_type = INITIAL;
     conn->handshake.message_number = 0;
     GUARD(s2n_hash_init(&conn->handshake.md5, S2N_HASH_MD5));
@@ -539,14 +539,14 @@ const uint8_t *s2n_connection_get_ocsp_response(struct s2n_connection *conn, uin
 
 int s2n_connection_prefer_throughput(struct s2n_connection *conn)
 {
-    conn->max_fragment_length = S2N_LARGE_FRAGMENT_LENGTH;
+    conn->max_outgoing_fragment_length = S2N_LARGE_FRAGMENT_LENGTH;
 
     return 0;
 }
 
 int s2n_connection_prefer_low_latency(struct s2n_connection *conn)
 {
-    conn->max_fragment_length = S2N_SMALL_FRAGMENT_LENGTH;
+    conn->max_outgoing_fragment_length = S2N_SMALL_FRAGMENT_LENGTH;
 
     return 0;
 }

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -130,7 +130,10 @@ struct s2n_connection {
     /* Our handshake state machine */
     struct s2n_handshake handshake;
 
-    uint16_t max_fragment_length;
+    /* Maximum outgoing fragment size for this connection. Does not limit
+     * incoming record size.
+     */
+    uint16_t max_outgoing_fragment_length;
 
     /* Keep some accounting on each connection */
     uint64_t wire_bytes_in;

--- a/tls/s2n_record_write.c
+++ b/tls/s2n_record_write.c
@@ -64,7 +64,7 @@ static uint16_t overhead(struct s2n_connection *conn)
 
 int s2n_record_max_write_payload_size(struct s2n_connection *conn)
 {
-    uint16_t max_fragment_size = conn->max_fragment_length;
+    uint16_t max_fragment_size = conn->max_outgoing_fragment_length;
     struct s2n_crypto_parameters *active = conn->server;
 
     if (conn->mode == S2N_CLIENT) {


### PR DESCRIPTION
Clarifies this value's meaning. We'll limit outgoing fragment
length, but the incoming maximum will never change for interop.