### PR TITLE
Remove superfluous gte_check in s2n_record_parse

### DIFF
--- a/tls/s2n_record_read.c
+++ b/tls/s2n_record_read.c
@@ -145,7 +145,6 @@ int s2n_record_parse(struct s2n_connection *conn)
     uint8_t mac_digest_size;
     GUARD(s2n_hmac_digest_size(mac->alg, &mac_digest_size));
 
-    gte_check(mac_digest_size, 0);
     gte_check(payload_length, mac_digest_size);
     payload_length -= mac_digest_size;
 


### PR DESCRIPTION
This check is always true because we're checking if a uin8_t >= 0.
`gte_check(payload_length, mac_digest_size)` will catch actual
invalid input.