### PR TITLE
Allow osx failure in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,8 @@ matrix:
     env: TESTS=sawHMACFailure SAW=true
   #This exception is because the test isn't finished yet, remove to turn on DRBG Saw tests
   - env: TESTS=sawDRBG SAW=true
+  allow_failures:
+    - os: osx
 
 before_install:
   # Install GCC 6 if on OSX


### PR DESCRIPTION
Issue #402 

travis is having issues fetching SAW, but I confirmed that the build now lists OSX builds under "allowed failures"

https://travis-ci.org/aghour/s2n/builds/207263725