### PR TITLE
travis: Use cache for test dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 sudo: true
 language: c
+cache:
+    directories:
+        # Cache test dependencies that would normally be re-compiled for every build.
+        # This directory is unique for each entry of the build matrix per:
+        # https://docs.travis-ci.com/user/caching/#Caches-and-build-matrices
+        - test-deps
 
 addons:
     apt:
@@ -63,34 +69,55 @@ matrix:
   fast_finish: true
 
 before_install:
+  # Setup the cache directory paths
+  - if [[ ! -d test-deps ]]; then mkdir test-deps ; fi
+  - export PYTHON_INSTALL_DIR=`pwd`/test-deps/python
+  - export GNUTLS_INSTALL_DIR=`pwd`/test-deps/gnutls
+  - export PRLIMIT_INSTALL_DIR=`pwd`/test-deps/prlimit
+  - export SAW_INSTALL_DIR=`pwd`/test-deps/saw
+  - export Z3_INSTALL_DIR=`pwd`/test-deps/z3
+  - export OPENSSL_1_1_0_INSTALL_DIR=`pwd`/test-deps/openssl-1.1.0
   # Install GCC 6 if on OSX
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then   .travis/install_osx_dependencies.sh ; fi
   # Set GCC 6 as Default on both Ubuntu and OSX
   - alias gcc=$(which gcc-6)
   # Install latest version of clang, clang++, and llvm-symbolizer and add them to beginning of PATH. Needed for fuzzing.
   - if [[ "$LATEST_CLANG" == "true" ]]; then (.travis/install_clang.sh `pwd`/clang-download `pwd`/clang-latest $TRAVIS_OS_NAME) && export PATH=`pwd`/clang-latest/bin:$PATH ; fi
-  # Install SAW with Z3 on Linux only
-  - if [[ "$SAW" == "true" ]]; then .travis/install_saw.sh ; fi
-  - export PATH=$PATH:$PWD/saw-0.2-2016-11-02-Ubuntu14.04-64/bin:$PWD/z3
 
+# Install missing test dependencies. If the install directory already exists, cached artifacts will be used
+# for that dependency.
 install:
   # Download and Install LibFuzzer
   - if [[ "$TESTS" == "fuzz" ]]; then .travis/install_libFuzzer.sh `pwd`/fuzz_dependencies/libFuzzer-download `pwd`/fuzz_dependencies $TRAVIS_OS_NAME ; fi
-  # Download and Install Openssl
-  - .travis/install_openssl_1_1_0.sh `pwd`/libcrypto-build `pwd`/libcrypto-root $TRAVIS_OS_NAME > /dev/null
-  # Install python linked with our compiled Openssl for integration tests
-  - if [[ "$TESTS" == "integration" ]]; then mkdir python-build python && .travis/install_python.sh `pwd`/libcrypto-root `pwd`/python-build `pwd`/python > /dev/null && export PATH=`pwd`/python/bin:$PATH ; fi
+  # Download and Install Openssl 1.1.0
+  - if [[ ! -d "$OPENSSL_1_1_0_INSTALL_DIR" ]]; then .travis/install_openssl_1_1_0.sh /tmp $OPENSSL_1_1_0_INSTALL_DIR $TRAVIS_OS_NAME > /dev/null ; fi
+  # Install python linked with the latest Openssl for integration tests
+  - if [[ ! -d "$PYTHON_INSTALL_DIR" ]] && [[ "$TESTS" == "integration" ]]; then mkdir -p $PYTHON_INSTALL_DIR && .travis/install_python.sh $OPENSSL_1_1_0_INSTALL_DIR /tmp $PYTHON_INSTALL_DIR > /dev/null ; fi
   # Download and Install GnuTLS for integration tests
-  - if [[ "$TESTS" == "integration" ]]; then mkdir gnutls gnutls-build && .travis/install_gnutls.sh `pwd`/gnutls-build `pwd`/gnutls $TRAVIS_OS_NAME > /dev/null && export PATH=`pwd`/gnutls/bin:$PATH ; fi
-  # Install prlimit to set the memlock limit to unlimited for this process
-  - if [[ "$BUILD_S2N" == "true" ]]; then (test "$TRAVIS_OS_NAME" = "linux" && sudo "PATH=$PATH" .travis/install_prlimit.sh $PWD/.travis > /dev/null && sudo .travis/prlimit --pid "$$" --memlock=unlimited:unlimited) || true ; fi
+  - if [[ ! -d "$GNUTLS_INSTALL_DIR" ]] && [[ "$TESTS" == "integration" ]]; then mkdir -p $GNUTLS_INSTALL_DIR && .travis/install_gnutls.sh /tmp $GNUTLS_INSTALL_DIR $TRAVIS_OS_NAME > /dev/null ; fi
+  - if [[ ! -d "$PRLIMIT_INSTALL_DIR" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then mkdir -p $PRLIMIT_INSTALL_DIR && .travis/install_prlimit.sh /tmp $PRLIMIT_INSTALL_DIR > /dev/null ; fi
   - if [[ "$BUILD_S2N" == "true" ]]; then mkdir -p .travis/checker && .travis/install_scan-build.sh .travis/checker && export PATH=$PATH:.travis/checker/bin ; fi
-  - if [[ "$BUILD_S2N" == "true" ]]; then .travis/run_cppcheck.sh ; fi
-  - if [[ "$BUILD_S2N" == "true" && "$TRAVIS_OS_NAME" == "linux" ]]; then .travis/run_kwstyle.sh ; fi
+  # Install SAW and Z3 for formal verification
+  - if [[ ! -d "$SAW_INSTALL_DIR" ]] && [[ "$SAW" == "true" ]]; then mkdir -p $SAW_INSTALL_DIR && .travis/install_saw.sh /tmp $SAW_INSTALL_DIR > /dev/null ; fi
+  - if [[ ! -d "$Z3_INSTALL_DIR" ]] && [[ "$SAW" == "true" ]]; then mkdir -p $Z3_INSTALL_DIR && .travis/install_z3.sh /tmp $Z3_INSTALL_DIR > /dev/null ; fi
+
+before_script:
+  # Add all of our test dependencies to the PATH
+  - export PATH=$PYTHON_INSTALL_DIR/bin:$LIBCRYPTO_ROOT/bin:$GNUTLS_INSTALL_DIR/bin:$SAW_INSTALL_DIR/bin:$Z3_INSTALL_DIR/bin:$PATH
+  # Select the libcrypto to build s2n against. This can be a TravisCI build variable in the future to gain coverage
+  # against older versions(1.0.1, 1.0.2) and forks(LibreSSL).
+  - export LIBCRYPTO_ROOT=$OPENSSL_1_1_0_INSTALL_DIR
+  # Create a link to the selected libcrypto. This shouldn't be needed when LIBCRYPTO_ROOT is set, but some tests
+  # have the "libcrypto-root" directory path hardcoded.
+  - rm -rf libcrypto-root && ln -s $LIBCRYPTO_ROOT libcrypto-root
+  # Use prlimit to set the memlock limit to unlimited for linux. OSX is unlimited by default
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo -E $PRLIMIT_INSTALL_DIR/bin/prlimit --pid "$$" --memlock=unlimited:unlimited ; fi
 
 script:
+  - if [[ "$BUILD_S2N" == "true" ]]; then .travis/run_cppcheck.sh ; fi
+  - if [[ "$BUILD_S2N" == "true" && "$TRAVIS_OS_NAME" == "linux" ]]; then .travis/run_kwstyle.sh ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TESTS" == "integration" ]]; then make -j 8   ; fi
-  # Build and run integration tests with scan-build for osx. scan-build bundle isn't available for linux
+  # Build and run unit tests with scan-build for osx. scan-build bundle isn't available for linux
   - if [[ "$TRAVIS_OS_NAME" == "osx" && "$TESTS" == "integration" ]]; then   scan-build --status-bugs -o /tmp/scan-build make -j8; STATUS=$?; test $STATUS -ne 0 && cat /tmp/scan-build/*/* ; [ "$STATUS" -eq "0" ] ; fi
   - if [[ "$TESTS" == "integration" ]]; then make integration ; fi
   - if [[ "$TESTS" == "fuzz" ]]; then make clean && make fuzz ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,14 +92,14 @@ install:
   # Download and Install Openssl 1.1.0
   - if [[ ! -d "$OPENSSL_1_1_0_INSTALL_DIR" ]]; then .travis/install_openssl_1_1_0.sh /tmp $OPENSSL_1_1_0_INSTALL_DIR $TRAVIS_OS_NAME > /dev/null ; fi
   # Install python linked with the latest Openssl for integration tests
-  - if [[ ! -d "$PYTHON_INSTALL_DIR" ]] && [[ "$TESTS" == "integration" ]]; then mkdir -p $PYTHON_INSTALL_DIR && .travis/install_python.sh $OPENSSL_1_1_0_INSTALL_DIR /tmp $PYTHON_INSTALL_DIR > /dev/null ; fi
+  - if [[ ! -d "$PYTHON_INSTALL_DIR" ]]; then mkdir -p $PYTHON_INSTALL_DIR && .travis/install_python.sh $OPENSSL_1_1_0_INSTALL_DIR /tmp $PYTHON_INSTALL_DIR > /dev/null ; fi
   # Download and Install GnuTLS for integration tests
-  - if [[ ! -d "$GNUTLS_INSTALL_DIR" ]] && [[ "$TESTS" == "integration" ]]; then mkdir -p $GNUTLS_INSTALL_DIR && .travis/install_gnutls.sh /tmp $GNUTLS_INSTALL_DIR $TRAVIS_OS_NAME > /dev/null ; fi
+  - if [[ ! -d "$GNUTLS_INSTALL_DIR" ]]; then mkdir -p $GNUTLS_INSTALL_DIR && .travis/install_gnutls.sh /tmp $GNUTLS_INSTALL_DIR $TRAVIS_OS_NAME > /dev/null ; fi
   - if [[ ! -d "$PRLIMIT_INSTALL_DIR" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then mkdir -p $PRLIMIT_INSTALL_DIR && .travis/install_prlimit.sh /tmp $PRLIMIT_INSTALL_DIR > /dev/null ; fi
   - if [[ "$BUILD_S2N" == "true" ]]; then mkdir -p .travis/checker && .travis/install_scan-build.sh .travis/checker && export PATH=$PATH:.travis/checker/bin ; fi
   # Install SAW and Z3 for formal verification
-  - if [[ ! -d "$SAW_INSTALL_DIR" ]] && [[ "$SAW" == "true" ]]; then mkdir -p $SAW_INSTALL_DIR && .travis/install_saw.sh /tmp $SAW_INSTALL_DIR > /dev/null ; fi
-  - if [[ ! -d "$Z3_INSTALL_DIR" ]] && [[ "$SAW" == "true" ]]; then mkdir -p $Z3_INSTALL_DIR && .travis/install_z3.sh /tmp $Z3_INSTALL_DIR > /dev/null ; fi
+  - if [[ ! -d "$SAW_INSTALL_DIR" ]]; then mkdir -p $SAW_INSTALL_DIR && .travis/install_saw.sh /tmp $SAW_INSTALL_DIR > /dev/null ; fi
+  - if [[ ! -d "$Z3_INSTALL_DIR" ]]; then mkdir -p $Z3_INSTALL_DIR && .travis/install_z3.sh /tmp $Z3_INSTALL_DIR > /dev/null ; fi
 
 before_script:
   # Add all of our test dependencies to the PATH

--- a/.travis/install_prlimit.sh
+++ b/.travis/install_prlimit.sh
@@ -15,8 +15,18 @@
 
 set -e
 
+usage() {
+    echo "install_prlimit.sh download_dir install_dir"
+    exit 1
+}
+
+if [ "$#" -ne "2" ]; then
+    usage
+fi
+
 BUILD_DIR=$1
 INSTALL_DIR=$2
+NUM_CORES=`nproc`
 
 cd $BUILD_DIR
 wget https://www.kernel.org/pub/linux/utils/util-linux/v2.25/util-linux-2.25.2.tar.gz
@@ -38,6 +48,6 @@ cd util-linux-2.25.2
     --without-ncurses \
     --prefix=$INSTALL_DIR || cat config.log
 
-make -j `grep -c ^processor /proc/cpuinfo`
+make -j $NUM_CORES
 make install
 

--- a/.travis/install_prlimit.sh
+++ b/.travis/install_prlimit.sh
@@ -15,17 +15,29 @@
 
 set -e
 
-OUT_DIR=$1
+BUILD_DIR=$1
+INSTALL_DIR=$2
 
-pushd $PWD
-
+cd $BUILD_DIR
 wget https://www.kernel.org/pub/linux/utils/util-linux/v2.25/util-linux-2.25.2.tar.gz
 tar -xzvf util-linux-2.25.2.tar.gz
 cd util-linux-2.25.2
-./configure ADJTIME_PATH=/var/lib/hwclock/adjtime --disable-chfn-chsh --disable-login --disable-nologin --disable-su --disable-setpriv --disable-runuser --disable-pylibmount --disable-static --without-python --without-systemd --without-systemdsystemunitdir --without-ncurses || cat config.log
+./configure ADJTIME_PATH=/var/lib/hwclock/adjtime \
+    --disable-chfn-chsh \
+    --disable-login \
+    --disable-nologin \
+    --disable-su \
+    --disable-setpriv \
+    --disable-runuser \
+    --disable-pylibmount \
+    --disable-static \
+    --without-python \
+    --without-systemd \
+    --disable-makeinstall-chown \
+    --without-systemdsystemunitdir \
+    --without-ncurses \
+    --prefix=$INSTALL_DIR || cat config.log
 
-# only compile prlimit
-make prlimit
-mv ./prlimit $OUT_DIR
+make -j `grep -c ^processor /proc/cpuinfo`
+make install
 
-popd

--- a/.travis/install_saw.sh
+++ b/.travis/install_saw.sh
@@ -1,9 +1,25 @@
 #!/bin/bash
 
-#download saw binaries
-curl http://saw.galois.com/builds/nightly/saw-0.2-2016-11-02-Ubuntu14.04-64.tar.gz > \
-     saw.tar.gz; tar -xzvf saw.tar.gz
+set -xe
 
-#download z3
-mkdir z3; curl http://saw.galois.com/builds/z3/z3 > z3/z3
-sudo chmod +x z3/z3
+usage() {
+	echo "install_saw.sh download_dir install_dir"
+	exit 1
+}
+
+if [ "$#" -ne "2" ]; then
+	usage
+fi
+
+DOWNLOAD_DIR=$1
+INSTALL_DIR=$2
+
+mkdir -p $DOWNLOAD_DIR
+cd $DOWNLOAD_DIR
+
+#download saw binaries
+curl http://saw.galois.com/builds/nightly/saw-0.2-2016-11-02-Ubuntu14.04-64.tar.gz > saw.tar.gz;
+
+mkdir -p saw && tar -xzf saw.tar.gz --strip-components=1 -C saw
+mkdir -p $INSTALL_DIR && mv saw/* $INSTALL_DIR
+

--- a/.travis/install_z3.sh
+++ b/.travis/install_z3.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+set -e
+
+usage() {
+	echo "install_z3.sh download_dir install_dir"
+	exit 1
+}
+
+if [ "$#" -ne "2" ]; then
+	usage
+fi
+
+DOWNLOAD_DIR=$1
+INSTALL_DIR=$2
+
+mkdir -p $DOWNLOAD_DIR
+cd $DOWNLOAD_DIR
+
+#download z3
+curl http://saw.galois.com/builds/z3/z3 > z3
+sudo chmod +x z3
+mkdir -p $INSTALL_DIR/bin && mv z3 $INSTALL_DIR/bin
+


### PR DESCRIPTION
This change uses Travis' builtin caching to speedup our builds
up to 3x. We benefit from caching because our main test
dependencies were being compiled from source on every build.

There is less benefit to cache dependencies that we were already
fetching in binary format. However we still see a speedup since
Travis is fetching the entire cache in a single call to S3. Having
the dependencies centrally stored in Travis(S3) may also increase the
reliability of our builds.

The downside of this change is that the cache must be manually
flushed to update any depedencies. Most of our dependencies should
not require frequent updates.
See https://docs.travis-ci.com/user/caching/#Clearing-Caches

Dependencies cached(with time saved):
- Openssl (125s)
- GnuTLS (203s)
- Python (142s)
- Saw/Z3 (26s)
- prlimit (15s)

Skipped:
- scan-build (14s)
- clang (2s)
- libfuzzer (18s)

closes #406