### PR TITLE
Add remaining test deps to cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,37 +76,42 @@ before_install:
   - export PRLIMIT_INSTALL_DIR=`pwd`/test-deps/prlimit
   - export SAW_INSTALL_DIR=`pwd`/test-deps/saw
   - export Z3_INSTALL_DIR=`pwd`/test-deps/z3
+  - export LIBFUZZER_INSTALL_DIR=`pwd`/test-deps/libfuzzer
+  - export LATEST_CLANG_INSTALL_DIR=`pwd`/test-deps/clang
+  - export SCAN_BUILD_INSTALL_DIR=`pwd`/test-deps/scan-build
   - export OPENSSL_1_1_0_INSTALL_DIR=`pwd`/test-deps/openssl-1.1.0
   # Install GCC 6 if on OSX
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then   .travis/install_osx_dependencies.sh ; fi
   # Set GCC 6 as Default on both Ubuntu and OSX
   - alias gcc=$(which gcc-6)
-  # Install latest version of clang, clang++, and llvm-symbolizer and add them to beginning of PATH. Needed for fuzzing.
-  - if [[ "$LATEST_CLANG" == "true" ]]; then (.travis/install_clang.sh `pwd`/clang-download `pwd`/clang-latest $TRAVIS_OS_NAME) && export PATH=`pwd`/clang-latest/bin:$PATH ; fi
+  # Install latest version of clang, clang++, and llvm-symbolizer. Needed for fuzzing.
+  - if [[ ! -d "$LATEST_CLANG_INSTALL_DIR" ]]; then .travis/install_clang.sh `mktemp -d` $LATEST_CLANG_INSTALL_DIR $TRAVIS_OS_NAME > /dev/null ; fi
 
 # Install missing test dependencies. If the install directory already exists, cached artifacts will be used
 # for that dependency.
 install:
-  # Download and Install LibFuzzer
-  - if [[ "$TESTS" == "fuzz" ]]; then .travis/install_libFuzzer.sh `pwd`/fuzz_dependencies/libFuzzer-download `pwd`/fuzz_dependencies $TRAVIS_OS_NAME ; fi
+  # Download and Install LibFuzzer with latest clang
+  - if [[ ! -d "$LIBFUZZER_INSTALL_DIR" ]]; then PATH=$LATEST_CLANG_INSTALL_DIR/bin:$PATH .travis/install_libFuzzer.sh `mktemp -d` $LIBFUZZER_INSTALL_DIR $TRAVIS_OS_NAME > /dev/null ; fi
   # Download and Install Openssl 1.1.0
-  - if [[ ! -d "$OPENSSL_1_1_0_INSTALL_DIR" ]]; then .travis/install_openssl_1_1_0.sh /tmp $OPENSSL_1_1_0_INSTALL_DIR $TRAVIS_OS_NAME > /dev/null ; fi
+  - if [[ ! -d "$OPENSSL_1_1_0_INSTALL_DIR" ]]; then .travis/install_openssl_1_1_0.sh `mktemp -d` $OPENSSL_1_1_0_INSTALL_DIR $TRAVIS_OS_NAME > /dev/null ; fi
   # Install python linked with the latest Openssl for integration tests
-  - if [[ ! -d "$PYTHON_INSTALL_DIR" ]]; then mkdir -p $PYTHON_INSTALL_DIR && .travis/install_python.sh $OPENSSL_1_1_0_INSTALL_DIR /tmp $PYTHON_INSTALL_DIR > /dev/null ; fi
+  - if [[ ! -d "$PYTHON_INSTALL_DIR" ]]; then mkdir -p $PYTHON_INSTALL_DIR && .travis/install_python.sh $OPENSSL_1_1_0_INSTALL_DIR `mktemp -d` $PYTHON_INSTALL_DIR > /dev/null ; fi
   # Download and Install GnuTLS for integration tests
-  - if [[ ! -d "$GNUTLS_INSTALL_DIR" ]]; then mkdir -p $GNUTLS_INSTALL_DIR && .travis/install_gnutls.sh /tmp $GNUTLS_INSTALL_DIR $TRAVIS_OS_NAME > /dev/null ; fi
-  - if [[ ! -d "$PRLIMIT_INSTALL_DIR" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then mkdir -p $PRLIMIT_INSTALL_DIR && .travis/install_prlimit.sh /tmp $PRLIMIT_INSTALL_DIR > /dev/null ; fi
-  - if [[ "$BUILD_S2N" == "true" ]]; then mkdir -p .travis/checker && .travis/install_scan-build.sh .travis/checker && export PATH=$PATH:.travis/checker/bin ; fi
+  - if [[ ! -d "$GNUTLS_INSTALL_DIR" ]]; then mkdir -p $GNUTLS_INSTALL_DIR && .travis/install_gnutls.sh `mktemp -d` $GNUTLS_INSTALL_DIR $TRAVIS_OS_NAME > /dev/null ; fi
+  - if [[ ! -d "$PRLIMIT_INSTALL_DIR" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then mkdir -p $PRLIMIT_INSTALL_DIR && .travis/install_prlimit.sh `mktemp -d` $PRLIMIT_INSTALL_DIR > /dev/null ; fi
+  - if [[ ! -d "$SCAN_BUILD_INSTALL_DIR" ]] && [[ "$TRAVIS_OS_NAME" == "osx" ]]; then .travis/install_scan-build.sh $SCAN_BUILD_INSTALL_DIR; fi
   # Install SAW and Z3 for formal verification
-  - if [[ ! -d "$SAW_INSTALL_DIR" ]]; then mkdir -p $SAW_INSTALL_DIR && .travis/install_saw.sh /tmp $SAW_INSTALL_DIR > /dev/null ; fi
-  - if [[ ! -d "$Z3_INSTALL_DIR" ]]; then mkdir -p $Z3_INSTALL_DIR && .travis/install_z3.sh /tmp $Z3_INSTALL_DIR > /dev/null ; fi
+  - if [[ ! -d "$SAW_INSTALL_DIR" ]]; then mkdir -p $SAW_INSTALL_DIR && .travis/install_saw.sh `mktemp -d` $SAW_INSTALL_DIR > /dev/null ; fi
+  - if [[ ! -d "$Z3_INSTALL_DIR" ]]; then mkdir -p $Z3_INSTALL_DIR && .travis/install_z3.sh `mktemp -d` $Z3_INSTALL_DIR > /dev/null ; fi
 
 before_script:
   # Add all of our test dependencies to the PATH
-  - export PATH=$PYTHON_INSTALL_DIR/bin:$LIBCRYPTO_ROOT/bin:$GNUTLS_INSTALL_DIR/bin:$SAW_INSTALL_DIR/bin:$Z3_INSTALL_DIR/bin:$PATH
+  - export PATH=$PYTHON_INSTALL_DIR/bin:$LIBCRYPTO_ROOT/bin:$GNUTLS_INSTALL_DIR/bin:$SAW_INSTALL_DIR/bin:$Z3_INSTALL_DIR/bin:$SCAN_BUILD_INSTALL_DIR/bin:$PATH
   # Select the libcrypto to build s2n against. This can be a TravisCI build variable in the future to gain coverage
   # against older versions(1.0.1, 1.0.2) and forks(LibreSSL).
   - export LIBCRYPTO_ROOT=$OPENSSL_1_1_0_INSTALL_DIR
+  # Set the libfuzzer to use for fuzz tests
+  - export LIBFUZZER_ROOT=$LIBFUZZER_INSTALL_DIR
   # Create a link to the selected libcrypto. This shouldn't be needed when LIBCRYPTO_ROOT is set, but some tests
   # have the "libcrypto-root" directory path hardcoded.
   - rm -rf libcrypto-root && ln -s $LIBCRYPTO_ROOT libcrypto-root
@@ -120,7 +125,7 @@ script:
   # Build and run unit tests with scan-build for osx. scan-build bundle isn't available for linux
   - if [[ "$TRAVIS_OS_NAME" == "osx" && "$TESTS" == "integration" ]]; then   scan-build --status-bugs -o /tmp/scan-build make -j8; STATUS=$?; test $STATUS -ne 0 && cat /tmp/scan-build/*/* ; [ "$STATUS" -eq "0" ] ; fi
   - if [[ "$TESTS" == "integration" ]]; then make clean; make integration ; fi
-  - if [[ "$TESTS" == "fuzz" ]]; then make clean && make fuzz ; fi
+  - if [[ "$TESTS" == "fuzz" ]]; then export PATH=$LATEST_CLANG_INSTALL_DIR/bin:$PATH && make clean && make fuzz ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TESTS" == "sawHMAC" ]]; then make -C tests/saw/ tmp/verify_s2n_hmac_$SAW_HMAC_TEST.log ; fi
   - if [[ "$TESTS" == "sawDRBG" ]]; then make -C tests/saw tmp/spec/DRBG/DRBG.log ; fi
   - if [[ "$TESTS" == "sawHMACFailure" ]]; then make -C tests/saw failure-tests ; fi

--- a/.travis/install_clang.sh
+++ b/.travis/install_clang.sh
@@ -58,5 +58,5 @@ mv ../third_party $CLANG_DOWNLOAD_DIR
 echo "Installed Clang Version: "
 $CLANG_DOWNLOAD_DIR/third_party/llvm-build/Release+Asserts/bin/clang --version
 
-ln -s $CLANG_DOWNLOAD_DIR/third_party/llvm-build/Release+Asserts/ $CLANG_INSTALL_DIR
+mkdir -p $CLANG_INSTALL_DIR && cp -rf $CLANG_DOWNLOAD_DIR/third_party/llvm-build/Release+Asserts/* $CLANG_INSTALL_DIR
 

--- a/.travis/install_libFuzzer.sh
+++ b/.travis/install_libFuzzer.sh
@@ -37,4 +37,5 @@ clang++ -c -g -v -O2 -lstdc++ -std=c++11 Fuzzer/*.cpp -IFuzzer
 ar ruv libFuzzer.a Fuzzer*.o
 
 echo "Copying libFuzzer.a to $LIBFUZZER_INSTALL_DIR"
-cp libFuzzer.a $LIBFUZZER_INSTALL_DIR
+mkdir -p $LIBFUZZER_INSTALL_DIR/lib && cp libFuzzer.a $LIBFUZZER_INSTALL_DIR/lib
+

--- a/.travis/install_scan-build.sh
+++ b/.travis/install_scan-build.sh
@@ -15,9 +15,16 @@
 
 set -e
 
-pushd `pwd`
+usage() {
+    echo "install_scan-build.sh install_dir"
+    exit 1
+}
 
+if [ "$#" -ne "1" ]; then
+    usage
+fi
 INSTALL_DIR=$1
 
 wget http://clang-analyzer.llvm.org/downloads/checker-278.tar.bz2
-tar jxf checker-278.tar.bz2 --strip-components=1 -C $INSTALL_DIR
+mkdir -p $INSTALL_DIR && tar jxf checker-278.tar.bz2 --strip-components=1 -C $INSTALL_DIR
+

--- a/tests/fuzz/Makefile
+++ b/tests/fuzz/Makefile
@@ -18,6 +18,11 @@ OBJS=$(SRCS:.c=.o)
 TESTS=$(SRCS:.c=)
 CRYPTO_LDFLAGS = -L$(LIBCRYPTO_ROOT)/lib
 
+ifndef LIBFUZZER_ROOT
+    export LIBFUZZER_ROOT = $(shell echo "../../fuzz_dependencies")
+endif
+
+
 .PHONY : all
 all : ld-preload
 all : $(TESTS)
@@ -28,7 +33,7 @@ CRUFT += $(wildcard *_test) $(wildcard fuzz-*.log) $(wildcard *_test_output.txt)
 LIBS += -lm
 
 CFLAGS += -Wno-unreachable-code -O0 -I$(LIBCRYPTO_ROOT)/include/ -I../../ -I../../api/
-LDFLAGS += ../../fuzz_dependencies/libFuzzer.a -lstdc++ -L../../lib/ ${CRYPTO_LDFLAGS} -L../testlib/ -ls2n ${LIBS} ${CRYPTO_LIBS}
+LDFLAGS += $(LIBFUZZER_ROOT)/lib/libFuzzer.a -lstdc++ -L../../lib/ ${CRYPTO_LDFLAGS} -L../testlib/ -ls2n ${LIBS} ${CRYPTO_LIBS}
 
 DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH"
 LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH"


### PR DESCRIPTION
Adds scan-build, clang, and libfuzzer build artifacts to the TravisCI
cache. A few workarounds were required to force the correct clang
version for libfuzzer and saw.