### PR TITLE
Add ability to run a subset of tests

### DIFF
--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -21,7 +21,7 @@ CRYPTO_LDFLAGS = -L$(LIBCRYPTO_ROOT)/lib
 
 .PHONY : all
 .PRECIOUS : $(TESTS)
-all: $(TESTS)
+all: run_tests
 
 include ../../s2n.mk
 
@@ -33,9 +33,15 @@ LIBS += -lm
 CFLAGS += -Wno-unreachable-code -I$(LIBCRYPTO_ROOT)/include/ -I../../ -I../../api/
 LDFLAGS += -L../../lib/ ${CRYPTO_LDFLAGS} -L../testlib/ -ltests2n -ls2n ${LIBS} ${CRYPTO_LIBS}
 
+ifeq (,$(strip ${TEST_FILES}))
+	TEST_FILES=${TESTS}
+endif
+
 $(TESTS)::
 	@${CC} ${CFLAGS} -o $@ $@.c ${LDFLAGS} 2>&1
-	@DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" ./$@
+
+run_tests: $(TESTS)
+	@(for test in ${TEST_FILES} ; do DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" ./$$test; done )
 
 .PHONY : valgrind
 valgrind: $(TESTS)

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -33,15 +33,15 @@ LIBS += -lm
 CFLAGS += -Wno-unreachable-code -I$(LIBCRYPTO_ROOT)/include/ -I../../ -I../../api/
 LDFLAGS += -L../../lib/ ${CRYPTO_LDFLAGS} -L../testlib/ -ltests2n -ls2n ${LIBS} ${CRYPTO_LIBS}
 
-ifeq (,$(strip ${TEST_FILES}))
-	TEST_FILES=${TESTS}
+ifeq (,$(strip ${UNIT_TESTS}))
+	UNIT_TESTS=${TESTS}
 endif
 
 $(TESTS)::
 	@${CC} ${CFLAGS} -o $@ $@.c ${LDFLAGS} 2>&1
 
 run_tests: $(TESTS)
-	@(for test in ${TEST_FILES} ; do DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" ./$$test; done )
+	@(for test in ${UNIT_TESTS} ; do DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" ./$$test; done )
 
 .PHONY : valgrind
 valgrind: $(TESTS)


### PR DESCRIPTION
Closes #399

To run a subset of tests, set the environment variable `UNIT_TESTS` to
the full name of the tests you wish to run, for example:

````
UNIT_TESTS=“s2n_aes_test s2n_map_test” make
...
/Library/Developer/CommandLineTools/usr/bin/make -C unit
Running s2n_aes_test.c                                     ... PASSED     307117 tests
Running s2n_map_test.c                                     ... PASSED      57418 tests
 Compiled with OpenSSL 1.0.2k  26 Jan 2017.
````

By default, all tests are run if the variable is unset.