### PR TITLE
Init SHA224/SHA512 hashes in s2n_connection_wipe

### DIFF
--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -296,8 +296,10 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     conn->handshake.message_number = 0;
     GUARD(s2n_hash_init(&conn->handshake.md5, S2N_HASH_MD5));
     GUARD(s2n_hash_init(&conn->handshake.sha1, S2N_HASH_SHA1));
+    GUARD(s2n_hash_init(&conn->handshake.sha224, S2N_HASH_SHA224));
     GUARD(s2n_hash_init(&conn->handshake.sha256, S2N_HASH_SHA256));
     GUARD(s2n_hash_init(&conn->handshake.sha384, S2N_HASH_SHA384));
+    GUARD(s2n_hash_init(&conn->handshake.sha512, S2N_HASH_SHA512));
     GUARD(s2n_hmac_init(&conn->client->client_record_mac, S2N_HMAC_NONE, NULL, 0));
     GUARD(s2n_hmac_init(&conn->server->server_record_mac, S2N_HMAC_NONE, NULL, 0));
 


### PR DESCRIPTION
To match the behavior of the other hashes. It doesn't appear to be
causing issues, but there's no coverage here at the moment. SHA224
and SHA512 aren't used in the TLS PRF.