### PR TITLE
Add Ability to run subset of Fuzz Tests with customizable Timeout

### DIFF
--- a/tests/fuzz/Makefile
+++ b/tests/fuzz/Makefile
@@ -26,10 +26,14 @@ ifndef FUZZ_TIMEOUT_SEC
     export FUZZ_TIMEOUT_SEC=120
 endif
 
+ifndef FUZZ_TESTS
+    export FUZZ_TESTS=${TESTS}
+endif
+
 
 .PHONY : all
 all : ld-preload
-all : $(TESTS)
+all : run_tests
 
 include ../../s2n.mk
 
@@ -47,11 +51,13 @@ ld-preload :
 
 $(TESTS)::
 	@${CC} ${CFLAGS} $@.c -o $@  ${LDFLAGS} > /dev/null
-	@( \
+
+run_tests: $(TESTS)
+	@( for test_name in ${FUZZ_TESTS} ; do \
 	export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}; \
 	export DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}; \
 	export LIBCRYPTO_ROOT=${LIBCRYPTO_ROOT}; \
-	./runFuzzTest.sh $@ ${FUZZ_TIMEOUT_SEC}; \
+	./runFuzzTest.sh $${test_name} ${FUZZ_TIMEOUT_SEC}; done\
 	)
 
 .PHONY : clean

--- a/tests/fuzz/Makefile
+++ b/tests/fuzz/Makefile
@@ -32,7 +32,6 @@ endif
 
 
 .PHONY : all
-all : ld-preload
 all : run_tests
 
 include ../../s2n.mk
@@ -52,7 +51,7 @@ ld-preload :
 $(TESTS)::
 	@${CC} ${CFLAGS} $@.c -o $@  ${LDFLAGS} > /dev/null
 
-run_tests: $(TESTS)
+run_tests:: $(TESTS) ld-preload
 	@( for test_name in ${FUZZ_TESTS} ; do \
 	export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}; \
 	export DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}; \

--- a/tests/fuzz/Makefile
+++ b/tests/fuzz/Makefile
@@ -22,6 +22,10 @@ ifndef LIBFUZZER_ROOT
     export LIBFUZZER_ROOT = $(shell echo "../../fuzz_dependencies")
 endif
 
+ifndef FUZZ_TIMEOUT_SEC
+    export FUZZ_TIMEOUT_SEC=120
+endif
+
 
 .PHONY : all
 all : ld-preload
@@ -37,8 +41,6 @@ LDFLAGS += $(LIBFUZZER_ROOT)/lib/libFuzzer.a -lstdc++ -L../../lib/ ${CRYPTO_LDFL
 
 DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH"
 LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH"
-
-FUZZ_TIMEOUT_SEC=120
 
 ld-preload :
 	${MAKE} -C LD_PRELOAD


### PR DESCRIPTION
Allows faster debugging of Fuzz Tests by allowing devs to run a subset of the Fuzz Tests with a custom timeout.

To use, just run: `export FUZZ_TIMEOUT_SEC=5; export FUZZ_TESTS="s2n_server_fuzz_test"; make fuzz`