### PR TITLE
Remove implicit wipe from s2n_shutdown

### DIFF
--- a/tls/s2n_shutdown.c
+++ b/tls/s2n_shutdown.c
@@ -53,8 +53,5 @@ int s2n_shutdown(struct s2n_connection *conn, s2n_blocked_status * more)
     /* Fails with S2N_ERR_SHUTDOWN_RECORD_TYPE or S2N_ERR_ALERT on receipt of anything but a close_notify */
     GUARD(s2n_recv_close_notify(conn, more));
 
-    /* Wipe the connection */
-    GUARD(s2n_connection_wipe(conn));
-
     return 0;
 }


### PR DESCRIPTION
Reasons not to wipe in shutdown:
- Confusing behavior for users that are used to other SSL
  APIs. Users will probably expect s2n_connection_shutdown to just do a
  close at the TLS level.
- Applications may collect connection metadata _after_ shutting down a
  connection. Ex: cipher suite