### PR TITLE
Allow Unit tests to be run in parallel again

### DIFF
--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -40,8 +40,14 @@ endif
 $(TESTS)::
 	@${CC} ${CFLAGS} -o $@ $@.c ${LDFLAGS} 2>&1
 
-run_tests: $(TESTS)
-	@(for test in ${UNIT_TESTS} ; do DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" ./$$test; done )
+run_tests:: $(TESTS)
+	@(for test in ${UNIT_TESTS} ; do\
+	  (\
+	    DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" \
+	    LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
+	    ./$$test; \
+	  ) & \
+	  done; wait)
 
 .PHONY : valgrind
 valgrind: $(TESTS)


### PR DESCRIPTION
Looks like https://github.com/awslabs/s2n/pull/445 broke the ability to run `make -j 32` and have it be faster than a normal `make`. This change makes the for loop start each test as a background thread and `wait` for all background threads to complete. `make -j $NUM` still works as expected. 