### PR TITLE
Add s2n_config_set_extension_data method to add/change TLS extension data

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -72,8 +72,6 @@ typedef struct {
   uint32_t length;
 } s2n_tls_extension;
 
-extern int s2n_config_add_cert_chain_and_key_with_extensions(struct s2n_config *config, const char *cert_chain_pem,
-        const char *private_key_pem, s2n_tls_extension *extensions, uint16_t num_extensions);
 extern int s2n_config_add_cert_chain_and_key(struct s2n_config *config, const char *cert_chain_pem, const char *private_key_pem);
 
 extern int s2n_config_add_dhparams(struct s2n_config *config, const char *dhparams_pem);

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -66,12 +66,6 @@ typedef enum {
     S2N_EXTENSION_CERTIFICATE_TRANSPARENCY = 18,
 } s2n_tls_extension_type;
 
-typedef struct {
-  s2n_tls_extension_type type;
-  uint8_t *data;
-  uint32_t length;
-} s2n_tls_extension;
-
 extern int s2n_config_add_cert_chain_and_key(struct s2n_config *config, const char *cert_chain_pem, const char *private_key_pem);
 
 extern int s2n_config_add_dhparams(struct s2n_config *config, const char *dhparams_pem);
@@ -81,7 +75,7 @@ typedef enum { S2N_STATUS_REQUEST_NONE = 0, S2N_STATUS_REQUEST_OCSP = 1 } s2n_st
 extern int s2n_config_set_status_request_type(struct s2n_config *config, s2n_status_request_type type);
 typedef enum { S2N_CT_SUPPORT_NONE = 0, S2N_CT_SUPPORT_REQUEST = 1 } s2n_ct_support_level;
 extern int s2n_config_set_ct_support_level(struct s2n_config *config, s2n_ct_support_level level);
-extern int s2n_config_set_extension_data(struct s2n_config *config, const s2n_tls_extension *extension);
+extern int s2n_config_set_extension_data(struct s2n_config *config, s2n_tls_extension_type type, const uint8_t *data, uint32_t length);
 
 struct s2n_connection;
 typedef enum { S2N_SERVER, S2N_CLIENT } s2n_mode;

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -61,7 +61,10 @@ extern int s2n_config_set_cache_store_callback(struct s2n_config *config, int (*
 extern int s2n_config_set_cache_retrieve_callback(struct s2n_config *config, int (*cache_retrieve)(void *, const void *key, uint64_t key_size, void *value, uint64_t *value_size), void *data);
 extern int s2n_config_set_cache_delete_callback(struct s2n_config *config, int (*cache_delete)(void *, const void *key, uint64_t key_size), void *data);
 
-typedef enum { S2N_EXTENSION_OCSP_STAPLING, S2N_EXTENSION_CERTIFICATE_TRANSPARENCY } s2n_tls_extension_type;
+typedef enum {
+    S2N_EXTENSION_OCSP_STAPLING = 5,
+    S2N_EXTENSION_CERTIFICATE_TRANSPARENCY = 18,
+} s2n_tls_extension_type;
 
 typedef struct {
   s2n_tls_extension_type type;
@@ -73,8 +76,6 @@ extern int s2n_config_add_cert_chain_and_key_with_extensions(struct s2n_config *
         const char *private_key_pem, s2n_tls_extension *extensions, uint16_t num_extensions);
 extern int s2n_config_add_cert_chain_and_key(struct s2n_config *config, const char *cert_chain_pem, const char *private_key_pem);
 
-extern int s2n_config_add_cert_chain_and_key_with_status(struct s2n_config *config,
-        const char *cert_chain_pem, const char *private_key_pem, const uint8_t *status, uint32_t length);
 extern int s2n_config_add_dhparams(struct s2n_config *config, const char *dhparams_pem);
 extern int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *version);
 extern int s2n_config_set_protocol_preferences(struct s2n_config *config, const char * const *protocols, int protocol_count);
@@ -82,6 +83,7 @@ typedef enum { S2N_STATUS_REQUEST_NONE = 0, S2N_STATUS_REQUEST_OCSP = 1 } s2n_st
 extern int s2n_config_set_status_request_type(struct s2n_config *config, s2n_status_request_type type);
 typedef enum { S2N_CT_SUPPORT_NONE = 0, S2N_CT_SUPPORT_REQUEST = 1 } s2n_ct_support_level;
 extern int s2n_config_set_ct_support_level(struct s2n_config *config, s2n_ct_support_level level);
+extern int s2n_config_set_extension_data(struct s2n_config *config, const s2n_tls_extension *extension);
 
 struct s2n_connection;
 typedef enum { S2N_SERVER, S2N_CLIENT } s2n_mode;

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -219,9 +219,6 @@ int cache_delete(void *ctx, const void *key, uint64_t key_size)
     return 0;
 }
 
-static uint8_t sct_list[] = {
-    0xff, 0xff, 0xff, 0xff, // bogus test data
-};
 
 extern int echo(struct s2n_connection *conn, int sockfd);
 extern int negotiate(struct s2n_connection *conn);
@@ -252,8 +249,6 @@ int main(int argc, char *const *argv)
 {
     struct addrinfo hints, *ai;
     int r, sockfd = 0;
-    s2n_tls_extension sct_ext = { .type = S2N_EXTENSION_CERTIFICATE_TRANSPARENCY,
-                                  .length = sizeof(sct_list), .data = sct_list };
 
     /* required args */
     const char *host = NULL;
@@ -376,7 +371,7 @@ int main(int argc, char *const *argv)
         exit(1);
     }
 
-    if (s2n_config_add_cert_chain_and_key_with_extensions(config, certificate_chain, private_key, &sct_ext, 1) < 0) {
+    if (s2n_config_add_cert_chain_and_key(config, certificate_chain, private_key) < 0) {
         fprintf(stderr, "Error getting certificate/key: '%s'\n", s2n_strerror(s2n_errno, "EN"));
         exit(1);
     }

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -460,24 +460,22 @@ S2N_STATUS_REQUEST_NONE, no status request is made.
 ### s2n\_config\_set\_extension\_data
 
 ```c
-int s2n_config_set_extension_data(struct s2n_config *config, const s2n_tls_extension *extension);
+int s2n_config_set_extension_data(struct s2n_config *config, s2n_tls_extension_type type, const uint8_t *data, uint32_t length);
 ```
 
 **s2n_config_set_extension_data** Sets the extension data in the **s2n_config**
 object for the specified extension.  This method will clear any existing data
-that is set.   If the data and length members of the **s2n_tls_extension**
-parameter are set to NULL, no new data is set in the **s2n_config** object,
-effectively clearing existing data.
+that is set.   If the data and length parameters are set to NULL, no new data
+is set in the **s2n_config** object, effectively clearing existing data.
 
-`s2n_tls_extension` is defined as:
+`s2n_tls_extension_type` is defined as:
 
-    typedef enum { S2N_EXTENSION_OCSP_STAPLING = 5,
-                   S2N_EXTENSION_CERTIFICATE_TRANSPARENCY = 18 } s2n_tls_extension_type;
-    typedef struct {
-      s2n_tls_extension_type type;
-      uint8_t *data;
-      uint32_t length;
-    } s2n_tls_extension;
+```c
+    typedef enum {
+      S2N_EXTENSION_OCSP_STAPLING = 5,
+      S2N_EXTENSION_CERTIFICATE_TRANSPARENCY = 18
+    } s2n_tls_extension_type;
+```
 
 At this time the following extensions are supported:
 

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -421,43 +421,6 @@ certificate-chain/key pair may be associated with a config.
 certificate in the chain being your servers certificate. **private_key_pem**
 should be a PEM encoded private key corresponding to the server certificate.
 
-### s2n\_config\_add\_cert\_chain\_and\_key\_with\_extensions
-
-```c
-int s2n_config_add_cert_chain_and_key_with_extensions(struct s2n_config *config,
-                                                      const char *cert_chain_pem,
-                                                      const char *private_key_pem,
-                                                      s2n_tls_extension *extensions,
-                                                      uint16_t num_extensions);
-```
-
-**s2n_config_add_cert_chain_and_key_with_extensions** performs the same function
-as s2n_config_add_cert_chain_and_key, and associates data for TLS extensions
-with the server certificate.
-
-`s2n_tls_extension` is defined as:
-
-    typedef enum { S2N_EXTENSION_OCSP_STAPLING = 5,
-                   S2N_EXTENSION_CERTIFICATE_TRANSPARENCY = 18 } s2n_tls_extension_type;
-    typedef struct {
-      s2n_tls_extension_type type;
-      uint8_t *data;
-      uint32_t length;
-    } s2n_tls_extension;
-
-At this time the following extensions are supported:
-
-`S2N_EXTENSION_OCSP_STAPLING` - If a client requests the OCSP status of the server
-certificate, this is the response used in the CertificateStatus handshake
-message.
-
-`S2N_EXTENSION_CERTIFICATE_TRANSPARENCY` - If a client supports receiving SCTs
-via the TLS extension (section 3.3.1 of RFC6962) this data is returned within
-the extension response during the handshake.  The format of this data is the
-SignedCertificateTimestampList structure defined in that document.  See
-http://www.certificate-transparency.org/ for more information about Certificate
-Transparency.
-
 ### s2n\_config\_add\_dhparams
 
 ```c
@@ -505,6 +468,29 @@ object for the specified extension.  This method will clear any existing data
 that is set.   If the data and length members of the **s2n_tls_extension**
 parameter are set to NULL, no new data is set in the **s2n_config** object,
 effectively clearing existing data.
+
+`s2n_tls_extension` is defined as:
+
+    typedef enum { S2N_EXTENSION_OCSP_STAPLING = 5,
+                   S2N_EXTENSION_CERTIFICATE_TRANSPARENCY = 18 } s2n_tls_extension_type;
+    typedef struct {
+      s2n_tls_extension_type type;
+      uint8_t *data;
+      uint32_t length;
+    } s2n_tls_extension;
+
+At this time the following extensions are supported:
+
+`S2N_EXTENSION_OCSP_STAPLING` - If a client requests the OCSP status of the server
+certificate, this is the response used in the CertificateStatus handshake
+message.
+
+`S2N_EXTENSION_CERTIFICATE_TRANSPARENCY` - If a client supports receiving SCTs
+via the TLS extension (section 3.3.1 of RFC6962) this data is returned within
+the extension response during the handshake.  The format of this data is the
+SignedCertificateTimestampList structure defined in that document.  See
+http://www.certificate-transparency.org/ for more information about Certificate
+Transparency.
 
 ### s2n\_config\_set\_nanoseconds\_since\_epoch\_callback
 

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -437,8 +437,8 @@ with the server certificate.
 
 `s2n_tls_extension` is defined as:
 
-    typedef enum { S2N_EXTENSION_OCSP_STAPLING,
-                   S2N_EXTENSION_CERTIFICATE_TRANSPARENCY } s2n_tls_extension_type;
+    typedef enum { S2N_EXTENSION_OCSP_STAPLING = 5,
+                   S2N_EXTENSION_CERTIFICATE_TRANSPARENCY = 18 } s2n_tls_extension_type;
     typedef struct {
       s2n_tls_extension_type type;
       uint8_t *data;
@@ -493,6 +493,18 @@ int s2n_config_set_status_request_type(struct s2n_config *config, s2n_status_req
 **s2n_config_set_status_request_type** Sets up an S2N_CLIENT to request the
 server certificate status during an SSL handshake.  If set to
 S2N_STATUS_REQUEST_NONE, no status request is made.
+
+### s2n\_config\_set\_extension\_data
+
+```c
+int s2n_config_set_extension_data(struct s2n_config *config, const s2n_tls_extension *extension);
+```
+
+**s2n_config_set_extension_data** Sets the extension data in the **s2n_config**
+object for the specified extension.  This method will clear any existing data
+that is set.   If the data and length members of the **s2n_tls_extension**
+parameter are set to NULL, no new data is set in the **s2n_config** object,
+effectively clearing existing data.
 
 ### s2n\_config\_set\_nanoseconds\_since\_epoch\_callback
 

--- a/tests/unit/s2n_client_extensions_test.c
+++ b/tests/unit/s2n_client_extensions_test.c
@@ -606,7 +606,8 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         s2n_tls_extension ocsp_ext = { .type = S2N_EXTENSION_OCSP_STAPLING,
                                       .length = sizeof(server_ocsp_status), .data = server_ocsp_status };
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_with_extensions(server_config, certificate, private_key, &ocsp_ext, 1));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key(server_config, certificate, private_key));
+        EXPECT_SUCCESS(s2n_config_set_extension_data(server_config, &ocsp_ext));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
@@ -727,7 +728,8 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         s2n_tls_extension ocsp_ext = { .type = S2N_EXTENSION_OCSP_STAPLING,
                                       .length = sizeof(server_ocsp_status), .data = server_ocsp_status };
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_with_extensions(server_config, certificate, private_key, &ocsp_ext, 1));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key(server_config, certificate, private_key));
+        EXPECT_SUCCESS(s2n_config_set_extension_data(server_config, &ocsp_ext));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
@@ -785,8 +787,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_with_extensions(server_config, certificate, private_key,
-                                                                         &sct_ext, 1));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key(server_config, certificate, private_key));
+        EXPECT_SUCCESS(s2n_config_set_extension_data(server_config, &sct_ext));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
@@ -848,8 +850,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_with_extensions(server_config, certificate, private_key,
-                                                                         &sct_ext, 1));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key(server_config, certificate, private_key));
+        EXPECT_SUCCESS(s2n_config_set_extension_data(server_config, &sct_ext));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
@@ -928,44 +930,6 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(close(server_to_client[i]));
             EXPECT_SUCCESS(close(client_to_server[i]));
         }
-    }
-
-    /* Client provides bad SCT list */
-    {
-        struct s2n_config *server_config;
-        s2n_tls_extension sct_ext = { .type = S2N_EXTENSION_CERTIFICATE_TRANSPARENCY,
-                                      .length = 0, .data = NULL };
-
-        EXPECT_NOT_NULL(server_config = s2n_config_new());
-        EXPECT_FAILURE(s2n_config_add_cert_chain_and_key_with_extensions(server_config, certificate, private_key,
-                                                                         &sct_ext, 1));
-        EXPECT_SUCCESS(s2n_config_free(server_config));
-    }
-
-    /* Client provides bad OCSP response */
-    {
-        struct s2n_config *server_config;
-        s2n_tls_extension ocsp_ext = { .type = S2N_EXTENSION_OCSP_STAPLING,
-                                       .length = 0, .data = NULL };
-
-        EXPECT_NOT_NULL(server_config = s2n_config_new());
-        EXPECT_FAILURE(s2n_config_add_cert_chain_and_key_with_extensions(server_config, certificate, private_key,
-                                                                         &ocsp_ext, 1));
-        EXPECT_SUCCESS(s2n_config_free(server_config));
-    }
-
-    /* Client provides duplicate SCT list */
-    {
-        struct s2n_config *server_config;
-        s2n_tls_extension sct_ext[] = {
-            { .type = S2N_EXTENSION_CERTIFICATE_TRANSPARENCY, .length = sizeof(sct_list), .data = sct_list },
-            { .type = S2N_EXTENSION_CERTIFICATE_TRANSPARENCY, .length = sizeof(sct_list), .data = sct_list },
-        };
-
-        EXPECT_NOT_NULL(server_config = s2n_config_new());
-        EXPECT_FAILURE(s2n_config_add_cert_chain_and_key_with_extensions(server_config, certificate, private_key,
-                                                                         sct_ext, 2));
-        EXPECT_SUCCESS(s2n_config_free(server_config));
     }
 
     END_TEST();

--- a/tests/unit/s2n_client_extensions_test.c
+++ b/tests/unit/s2n_client_extensions_test.c
@@ -604,10 +604,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
-        s2n_tls_extension ocsp_ext = { .type = S2N_EXTENSION_OCSP_STAPLING,
-                                      .length = sizeof(server_ocsp_status), .data = server_ocsp_status };
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key(server_config, certificate, private_key));
-        EXPECT_SUCCESS(s2n_config_set_extension_data(server_config, &ocsp_ext));
+        EXPECT_SUCCESS(s2n_config_set_extension_data(server_config, S2N_EXTENSION_OCSP_STAPLING, server_ocsp_status, sizeof(server_ocsp_status)));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
@@ -726,10 +724,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
-        s2n_tls_extension ocsp_ext = { .type = S2N_EXTENSION_OCSP_STAPLING,
-                                      .length = sizeof(server_ocsp_status), .data = server_ocsp_status };
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key(server_config, certificate, private_key));
-        EXPECT_SUCCESS(s2n_config_set_extension_data(server_config, &ocsp_ext));
+        EXPECT_SUCCESS(s2n_config_set_extension_data(server_config, S2N_EXTENSION_OCSP_STAPLING, server_ocsp_status, sizeof(server_ocsp_status)));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
@@ -760,8 +756,6 @@ int main(int argc, char **argv)
         int server_to_client[2];
         int client_to_server[2];
 
-        s2n_tls_extension sct_ext = { .type = S2N_EXTENSION_CERTIFICATE_TRANSPARENCY,
-                                      .length = sizeof(sct_list), .data = sct_list };
         uint32_t length;
 
         /* Create nonblocking pipes */
@@ -788,7 +782,7 @@ int main(int argc, char **argv)
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key(server_config, certificate, private_key));
-        EXPECT_SUCCESS(s2n_config_set_extension_data(server_config, &sct_ext));
+        EXPECT_SUCCESS(s2n_config_set_extension_data(server_config, S2N_EXTENSION_CERTIFICATE_TRANSPARENCY, sct_list, sizeof(sct_list)));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
@@ -818,8 +812,6 @@ int main(int argc, char **argv)
         int server_to_client[2];
         int client_to_server[2];
 
-        s2n_tls_extension sct_ext = { .type = S2N_EXTENSION_CERTIFICATE_TRANSPARENCY,
-                                      .length = sizeof(sct_list), .data = sct_list };
         uint32_t length;
 
         /* Create nonblocking pipes */
@@ -851,7 +843,7 @@ int main(int argc, char **argv)
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key(server_config, certificate, private_key));
-        EXPECT_SUCCESS(s2n_config_set_extension_data(server_config, &sct_ext));
+        EXPECT_SUCCESS(s2n_config_set_extension_data(server_config, S2N_EXTENSION_CERTIFICATE_TRANSPARENCY, sct_list, sizeof(sct_list)));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));

--- a/tests/unit/s2n_client_extensions_test.c
+++ b/tests/unit/s2n_client_extensions_test.c
@@ -604,7 +604,9 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_with_status(server_config, certificate, private_key, server_ocsp_status, sizeof(server_ocsp_status)));
+        s2n_tls_extension ocsp_ext = { .type = S2N_EXTENSION_OCSP_STAPLING,
+                                      .length = sizeof(server_ocsp_status), .data = server_ocsp_status };
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_with_extensions(server_config, certificate, private_key, &ocsp_ext, 1));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
@@ -723,7 +725,9 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_with_status(server_config, certificate, private_key, server_ocsp_status, sizeof(server_ocsp_status)));
+        s2n_tls_extension ocsp_ext = { .type = S2N_EXTENSION_OCSP_STAPLING,
+                                      .length = sizeof(server_ocsp_status), .data = server_ocsp_status };
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_with_extensions(server_config, certificate, private_key, &ocsp_ext, 1));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -524,28 +524,27 @@ int s2n_config_set_cache_delete_callback(struct s2n_config *config, int (*cache_
     return 0;
 }
 
-int s2n_config_set_extension_data(struct s2n_config *config, const s2n_tls_extension *extension)
+int s2n_config_set_extension_data(struct s2n_config *config, s2n_tls_extension_type type, const uint8_t *data, uint32_t length)
 {
     notnull_check(config);
-    notnull_check(extension);
 
-    switch (extension->type) {
+    switch (type) {
         case S2N_EXTENSION_CERTIFICATE_TRANSPARENCY:
             {
                 GUARD(s2n_free(&config->cert_and_key_pairs->sct_list));
 
-                if (extension->data && extension->length) {
-                    GUARD(s2n_alloc(&config->cert_and_key_pairs->sct_list, extension->length));
-                    memcpy_check(config->cert_and_key_pairs->sct_list.data, extension->data, extension->length);
+                if (data && length) {
+                    GUARD(s2n_alloc(&config->cert_and_key_pairs->sct_list, length));
+                    memcpy_check(config->cert_and_key_pairs->sct_list.data, data, length);
                 }
             } break;
         case S2N_EXTENSION_OCSP_STAPLING:
             {
                 GUARD(s2n_free(&config->cert_and_key_pairs->ocsp_status));
 
-                if (extension->data && extension->length) {
-                    GUARD(s2n_alloc(&config->cert_and_key_pairs->ocsp_status, extension->length));
-                    memcpy_check(config->cert_and_key_pairs->ocsp_status.data, extension->data, extension->length);
+                if (data && length) {
+                    GUARD(s2n_alloc(&config->cert_and_key_pairs->ocsp_status, length));
+                    memcpy_check(config->cert_and_key_pairs->ocsp_status.data, data, length);
                 }
             } break;
         default:


### PR DESCRIPTION
Add s2n_config_set_extension_data method to add/change TLS extension data after creating the initial configuration.

This is useful for extensions such as OCSP where the data needs to be refreshed over time, if the OCSP status expires or is updated, for example.

Closes #461