### PR TITLE
Add ability to automatically run Fuzz Tests until no new inputs are generated

### DIFF
--- a/.travis/maximize_fuzz_corpus.sh
+++ b/.travis/maximize_fuzz_corpus.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+set -e
+
+ALL_FUZZ_TEST_FILES=""
+
+for dir in $( ls ./tests/fuzz/corpus ); do
+    ALL_FUZZ_TEST_FILES="$ALL_FUZZ_TEST_FILES $dir"
+done
+
+echo "$ALL_FUZZ_TEST_FILES"
+
+export FUZZ_TESTS="$ALL_FUZZ_TEST_FILES"
+
+DONE=0
+while [ $DONE -ne 1 ]; do
+    make fuzz;
+    NEW_CORPUS_FILES=`git ls-files --others --exclude-standard | grep "tests/fuzz/corpus"`
+    
+    if [[ -n "$NEW_CORPUS_FILES" ]]; then
+        file_count=0
+        for file in $NEW_CORPUS_FILES; do
+            printf "\033[32;1mFound new Corpus Input:\033[0m $file\n"
+            file_count=$((file_count+1))
+            git add "$file"
+        done
+        
+        FUZZ_TESTS_TO_RERUN=`echo "$NEW_CORPUS_FILES" | awk -F'/' '{print $4}' | sort | uniq`
+        
+        export FUZZ_TESTS=""
+        for test in $FUZZ_TESTS_TO_RERUN; do 
+            export FUZZ_TESTS="$FUZZ_TESTS $test"
+        done
+        
+        printf "Found \033[32;1m $file_count \033[0m new corpus inputs for Fuzz Tests: $FUZZ_TESTS\n"
+    else
+        printf "\033[32;1mCorpus Maximized.\033[0m\n"
+        DONE=1
+    fi
+done

--- a/.travis/maximize_fuzz_corpus.sh
+++ b/.travis/maximize_fuzz_corpus.sh
@@ -28,8 +28,8 @@ export FUZZ_TESTS="$ALL_FUZZ_TEST_FILES"
 DONE=0
 while [ $DONE -ne 1 ]; do
     make fuzz;
-    NEW_CORPUS_FILES=`git ls-files --others --exclude-standard | grep "tests/fuzz/corpus"`
-    
+    NEW_CORPUS_FILES=`git ls-files --others --exclude-standard | (grep "tests/fuzz/corpus" || echo "")`
+
     if [[ -n "$NEW_CORPUS_FILES" ]]; then
         file_count=0
         for file in $NEW_CORPUS_FILES; do
@@ -37,15 +37,15 @@ while [ $DONE -ne 1 ]; do
             file_count=$((file_count+1))
             git add "$file"
         done
-        
+
         FUZZ_TESTS_TO_RERUN=`echo "$NEW_CORPUS_FILES" | awk -F'/' '{print $4}' | sort | uniq`
-        
+
         export FUZZ_TESTS=""
-        for test in $FUZZ_TESTS_TO_RERUN; do 
+        for test in $FUZZ_TESTS_TO_RERUN; do
             export FUZZ_TESTS="$FUZZ_TESTS $test"
         done
-        
-        printf "Found \033[32;1m $file_count \033[0m new corpus inputs for Fuzz Tests: $FUZZ_TESTS\n"
+
+        printf "Found \033[32;1m$file_count\033[0m new corpus inputs for Fuzz Tests: $FUZZ_TESTS\n"
     else
         printf "\033[32;1mCorpus Maximized.\033[0m\n"
         DONE=1


### PR DESCRIPTION
Closes https://github.com/awslabs/s2n/issues/448

Running `export FUZZ_TIMEOUT_SEC=600; ./.travis/maximize_fuzz_corpus.sh` will run each fuzz test for 10 minutes at a time until each test has not generated new corpus inputs.

This script is intelligent in that it will run _**every**_ fuzz test on the first iteration, and progressively remove fuzz tests on each iteration that did not produce new corpus inputs during the previous 10 minute iteration so that time is not wasted running fuzz tests that are already maximized.