### PR TITLE
Client hello fuzz test bug fix

### DIFF
--- a/tests/fuzz/runFuzzTest.sh
+++ b/tests/fuzz/runFuzzTest.sh
@@ -27,6 +27,7 @@ fi
 TEST_NAME=$1
 FUZZ_TIMEOUT_SEC=$2
 MIN_TEST_PER_SEC="1000"
+MIN_BRANCHES_COVERED="100"
 
 if [[ $TEST_NAME == *_negative_test ]];
 then
@@ -70,10 +71,13 @@ then
     else
        if [ "$TESTS_PER_SEC" -lt $MIN_TEST_PER_SEC ]; then
             printf "\033[31;1mWARNING!\033[0m ${TEST_NAME} is only ${TESTS_PER_SEC} tests/sec, which is below ${MIN_TEST_PER_SEC}/sec! Fuzz tests are more effective at higher rates.\n\n"
-        fi
+       fi
+
+       if [ "$BRANCH_COVERAGE" -lt $MIN_BRANCHES_COVERED ]; then
+            printf "\033[31;1mWARNING!\033[0m ${TEST_NAME} only covers ${BRANCH_COVERAGE} branches, which is below ${MIN_BRANCHES_COVERED} branches! This is likely a bug.\n"
+            exit -1;
+       fi
     fi
-    
-    
     
 else
     cat ${TEST_NAME}_output.txt

--- a/tests/fuzz/s2n_client_hello_recv_fuzz_test.c
+++ b/tests/fuzz/s2n_client_hello_recv_fuzz_test.c
@@ -24,7 +24,7 @@ static const uint8_t TLS_VERSIONS[] = {S2N_TLS10, S2N_TLS11, S2N_TLS12};
 
 int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
 {
-    for(int version = 0; version < (sizeof(TLS_VERSIONS) / TLS_VERSIONS[0]); version++){
+    for(int version = 0; version < (sizeof(TLS_VERSIONS) / sizeof(TLS_VERSIONS[0])); version++){
         /* Setup */
         struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
         notnull_check(server_conn);


### PR DESCRIPTION
Found a silly bug in the Client Hello Fuzz Test that completely skips the fuzz tests. This was discovered when I noticed that the number of branches covered was only 5 when it should have been much higher.

I've fixed the bug, and added a check in `runFuzzTest.sh` to enforce a minimum branch coverage for positive fuzz tests so that it doesn't happen again.