### PR TITLE
Add 20170328 cipher prefs

### DIFF
--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -385,6 +385,7 @@ int s2n_config_set_cipher_preferences(struct s2n_config *config,
 |    version | SSLv3 | TLS1.0 | TLS1.1 | TLS1.2 | AES-CBC | ChaCha20-Poly1305 | AES-GCM | 3DES | RC4 | DHE | ECDHE |
 |------------|-------|--------|--------|--------|---------|-------------------|---------|------|-----|-----|-------|
 | "default"  |       |   X    |    X   |    X   |    X    |         X         |    X    |      |     |     |   X   |
+| "20170328" |       |   X    |    X   |    X   |    X    |                   |    X    |  X   |     |  X  |   X   |
 | "20170210" |       |   X    |    X   |    X   |    X    |         X         |    X    |      |     |     |   X   |
 | "20160824" |       |   X    |    X   |    X   |    X    |                   |    X    |      |     |     |   X   |
 | "20160804" |       |   X    |    X   |    X   |    X    |                   |    X    |  X   |     |     |   X   |

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -181,6 +181,35 @@ const struct s2n_cipher_preferences cipher_preferences_20170210 = {
     .minimum_protocol_version = S2N_TLS10
 };
 
+/* Preferences optimized for interop. DHE and 3DES are added(at the lowest preference). */
+struct s2n_cipher_suite *cipher_suites_20170328[] = {
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha,
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+    &s2n_rsa_with_aes_128_cbc_sha,
+    &s2n_rsa_with_aes_128_gcm_sha256,
+    &s2n_rsa_with_aes_256_gcm_sha384,
+    &s2n_rsa_with_aes_128_cbc_sha256,
+    &s2n_rsa_with_aes_256_cbc_sha,
+    &s2n_rsa_with_aes_256_cbc_sha256,
+    &s2n_rsa_with_3des_ede_cbc_sha,
+    &s2n_dhe_rsa_with_aes_128_cbc_sha,
+    &s2n_dhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_dhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_dhe_rsa_with_aes_128_cbc_sha256,
+    &s2n_dhe_rsa_with_aes_256_cbc_sha,
+    &s2n_dhe_rsa_with_aes_256_cbc_sha256,
+};
+
+const struct s2n_cipher_preferences cipher_preferences_20170328 = {
+    .count = sizeof(cipher_suites_20170328) / sizeof(cipher_suites_20170328[0]),
+    .suites = cipher_suites_20170328,
+    .minimum_protocol_version = S2N_TLS10
+};
+
 struct {
     const char *version;
     const struct s2n_cipher_preferences *preferences;
@@ -196,6 +225,7 @@ struct {
     "20160804", &cipher_preferences_20160804}, {
     "20160824", &cipher_preferences_20160824}, {
     "20170210", &cipher_preferences_20170210}, {
+    "20170328", &cipher_preferences_20170328}, {
     "test_all", &cipher_preferences_test_all}, {
     NULL, NULL}
 };

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -34,6 +34,7 @@ extern const struct s2n_cipher_preferences cipher_preferences_20160411;
 extern const struct s2n_cipher_preferences cipher_preferences_20160804;
 extern const struct s2n_cipher_preferences cipher_preferences_20160824;
 extern const struct s2n_cipher_preferences cipher_preferences_20170210;
+extern const struct s2n_cipher_preferences cipher_preferences_20170328;
 extern const struct s2n_cipher_preferences cipher_preferences_test_all;
 
 extern int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *version);


### PR DESCRIPTION
These preferences target endpoints that need to support legacy
clients. DHE and 3DES suites are readded at the bottom of the
preference list. The default cipher preference list will stay on
20170210.