### PR TITLE
Add Debug flag to OpenSSL ./config scripts

### DIFF
--- a/.travis/install_openssl_1_0_2.sh
+++ b/.travis/install_openssl_1_0_2.sh
@@ -44,7 +44,7 @@ else
     usage
 fi
 
-$CONFIGURE -g3 -fPIC no-libunbound no-gmp no-jpake no-krb5 no-md2 no-rc5 no-rfc3779 no-sctp no-ssl-trace \
+$CONFIGURE -g3 -d -fPIC no-libunbound no-gmp no-jpake no-krb5 no-md2 no-rc5 no-rfc3779 no-sctp no-ssl-trace \
          no-store no-zlib no-hw no-mdc2 no-seed no-idea enable-ec_nistp_64_gcc_128 no-camellia no-bf no-ripemd \
          no-dsa no-ssl2 no-capieng -DSSL_FORBID_ENULL -DOPENSSL_NO_DTLS1 -DOPENSSL_NO_HEARTBEATS \
          --prefix=$INSTALL_DIR

--- a/.travis/install_openssl_1_1_0.sh
+++ b/.travis/install_openssl_1_1_0.sh
@@ -45,7 +45,7 @@ else
 fi
 
 # Use g3 to get debug symbols in libcrypto to chase memory leaks
-$CONFIGURE -g3 -fPIC              \
+$CONFIGURE -g3 -d -fPIC              \
          no-md2 no-rc5 no-rfc3779 no-sctp no-ssl-trace no-zlib     \
          no-hw no-mdc2 no-seed no-idea enable-ec_nistp_64_gcc_128 no-camellia\
          no-bf no-ripemd no-dsa no-ssl2 no-ssl3 no-capieng                  \


### PR DESCRIPTION
Adding `-d` flag to the `./config` script when building OpenSSL. This helps when debugging Fuzzing errors that occur in OpenSSL

Links:
 - http://www.cgicentral.net/400CS/Docs/openssl/INSTALL.openssl.html
 - http://stackoverflow.com/questions/11129826/build-openssl-on-linux-with-g-for-debugging