### PR TITLE
Remove timestamp from server hello

### DIFF
--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -101,7 +101,6 @@ int s2n_server_hello_recv(struct s2n_connection *conn)
 
 int s2n_server_hello_send(struct s2n_connection *conn)
 {
-    uint32_t gmt_unix_time = time(NULL);
     struct s2n_stuffer *out = &conn->handshake.io;
     struct s2n_stuffer server_random;
     struct s2n_blob b, r;
@@ -112,10 +111,9 @@ int s2n_server_hello_send(struct s2n_connection *conn)
 
     /* Create the server random data */
     GUARD(s2n_stuffer_init(&server_random, &b));
-    GUARD(s2n_stuffer_write_uint32(&server_random, gmt_unix_time));
 
-    r.data = s2n_stuffer_raw_write(&server_random, S2N_TLS_RANDOM_DATA_LEN - 4);
-    r.size = S2N_TLS_RANDOM_DATA_LEN - 4;
+    r.data = s2n_stuffer_raw_write(&server_random, S2N_TLS_RANDOM_DATA_LEN);
+    r.size = S2N_TLS_RANDOM_DATA_LEN;
     notnull_check(r.data);
     GUARD(s2n_get_public_random_data(&r));
 


### PR DESCRIPTION
This change mirrors https://github.com/awslabs/s2n/pull/487 by removing the
timestamp from the server hello.

This isn't much of a security measure, in most cases the application protocol
(e.g. HTTP) leaks the time anyway, but this does make us more compatible with
OpenSSL's behavior and it removes a call to time() from our codebase.