### PR TITLE
Use 1024 bit minimum DH prime size

### DIFF
--- a/crypto/s2n_dhe.c
+++ b/crypto/s2n_dhe.c
@@ -29,7 +29,7 @@
 #include "utils/s2n_blob.h"
 #include "utils/s2n_mem.h"
 
-#define S2N_MIN_DH_PRIME_SIZE_BYTES (2048 / 8)
+#define S2N_MIN_DH_PRIME_SIZE_BYTES (1024 / 8)
 
 /* Caller is not responsible for freeing values returned by these accessors
  * Per https://www.openssl.org/docs/man1.1.0/crypto/DH_get0_pqg.html

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -435,6 +435,19 @@ int s2n_config_add_dhparams(struct s2n_config *config,
 
 **s2n_config_add_dhparams** associates a set of Diffie-Hellman parameters with
 an **s2n_config** object. **dhparams_pem** should be PEM encoded DH parameters.
+Due to the [Logjam](https://weakdh.org/) attack, it is strongly recommended to
+use DH parameters >= 2048 bits. 
+
+Here is an example that generates DH params using Openssl:
+```sh
+openssl dhparam -out dhparams.pem 2048
+```
+
+*NOTE*: Certain versions of [Java](http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6521495)
+prior to [JDK8](http://bugs.java.com/bugdatabase/view_bug.do?bug_id=7044060) will not
+support DH params larger than 1024 bits. If your application requires interop with peers that use the affected Java
+versions, configure a [cipher preference list](#s2n\_config\_set\_cipher\_preferences) that has DHE ciphers disabled.
+The affected Java versions support ECDHE-based ciphers.
 
 ### s2n\_config\_set\_protocol\_preferences
 


### PR DESCRIPTION
The change relaxes our hardcoded restriction on dh param size from
2048 to 1024 bits. This change is required to support older Java[1]
implementations that will fail to negotiate if a server sends DH
params > 1024 bits. The bug was patched in JDK8[2].

This is not an impactful change to s2n for most use cases:
- Default cipher preferences removed DHE suites since 06/03/2015
- Recent (non-default) cipher preferences that support DHE suites
  have them at the bottom of the preference list.

[1] http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6521495
[2] https://docs.oracle.com/javase/8/docs/technotes/guides/security/enhancements-8.html