### PR TITLE
Add a FIPS compliant cipher suite preference list

### DIFF
--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -386,6 +386,7 @@ int s2n_config_set_cipher_preferences(struct s2n_config *config,
 |------------|-------|--------|--------|--------|---------|-------------------|---------|------|-----|-----|-------|
 | "default"  |       |   X    |    X   |    X   |    X    |         X         |    X    |      |     |     |   X   |
 | "20170328" |       |   X    |    X   |    X   |    X    |                   |    X    |  X   |     |  X  |   X   |
+| "20170405" |       |   X    |    X   |    X   |    X    |                   |    X    |  X   |     |     |   X   |
 | "20170210" |       |   X    |    X   |    X   |    X    |         X         |    X    |      |     |     |   X   |
 | "20160824" |       |   X    |    X   |    X   |    X    |                   |    X    |      |     |     |   X   |
 | "20160804" |       |   X    |    X   |    X   |    X    |                   |    X    |  X   |     |     |   X   |
@@ -399,6 +400,8 @@ int s2n_config_set_cipher_preferences(struct s2n_config *config,
 The "default" version is special in that it will be updated with future s2n changes and ciphersuites and protocol versions may be added and removed, or their internal order of preference might change. Numbered versions are fixed and will never change. 
 
 "20160411" follows the same general preference order as "default". The main difference is it has a CBC cipher suite at the top. This is to accomodate certain Java clients that have poor GCM implementations. Users of s2n who have found GCM to be hurting performance for their clients should consider this version.
+
+"20170405" is a FIPS compliant cipher suite preference list based on approved algorithms in the [FIPS 140-2 Annex A](http://csrc.nist.gov/publications/fips/fips140-2/fips1402annexa.pdf). Similarly to "20160411", this perference list has CBC cipher suites at the top to accomodate certain Java clients. Users of s2n who plan to enable FIPS mode should consider this version.
 
 s2n does not expose an API to control the order of preference for each ciphersuite or protocol version. s2n follows the following order:
 

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -210,6 +210,27 @@ const struct s2n_cipher_preferences cipher_preferences_20170328 = {
     .minimum_protocol_version = S2N_TLS10
 };
 
+/* Preferences optimized for FIPS compatibility. */
+struct s2n_cipher_suite *cipher_suites_20170405[] = {
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_rsa_with_aes_128_cbc_sha,
+    &s2n_rsa_with_aes_128_gcm_sha256,
+    &s2n_rsa_with_aes_256_gcm_sha384,
+    &s2n_rsa_with_aes_128_cbc_sha256,
+    &s2n_rsa_with_aes_256_cbc_sha,
+    &s2n_rsa_with_aes_256_cbc_sha256,
+    &s2n_rsa_with_3des_ede_cbc_sha,
+};
+
+const struct s2n_cipher_preferences cipher_preferences_20170405 = {
+    .count = sizeof(cipher_suites_20170405) / sizeof(cipher_suites_20170405[0]),
+    .suites = cipher_suites_20170405,
+    .minimum_protocol_version = S2N_TLS10
+};
+
 struct {
     const char *version;
     const struct s2n_cipher_preferences *preferences;
@@ -226,6 +247,7 @@ struct {
     "20160824", &cipher_preferences_20160824}, {
     "20170210", &cipher_preferences_20170210}, {
     "20170328", &cipher_preferences_20170328}, {
+    "20170405", &cipher_preferences_20170405}, {
     "test_all", &cipher_preferences_test_all}, {
     NULL, NULL}
 };

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -35,6 +35,7 @@ extern const struct s2n_cipher_preferences cipher_preferences_20160804;
 extern const struct s2n_cipher_preferences cipher_preferences_20160824;
 extern const struct s2n_cipher_preferences cipher_preferences_20170210;
 extern const struct s2n_cipher_preferences cipher_preferences_20170328;
+extern const struct s2n_cipher_preferences cipher_preferences_20170405;
 extern const struct s2n_cipher_preferences cipher_preferences_test_all;
 
 extern int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *version);


### PR DESCRIPTION
See Issue #482.

Add a cipher suite preference list that complies with the approved
algorithms in the FIPS 140-2 Annex A. Prefer CBC over GCM for
compatibility with legacy Java clients with poor GCM implementations.