### PR TITLE
travis: Add build dimension for Openssl master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ env:
   # Force libcrypto to use "software only" crypto implementations for AES and AES-GCM. Verify s2n can gracefully use
   # unoptimized routines. See https://www.openssl.org/docs/man1.1.0/crypto/OPENSSL_ia32cap.html
   - S2N_LIBCRYPTO=openssl-1.1.0 OPENSSL_ia32cap="~0x200000200000000" BUILD_S2N=true TESTS=integration GCC6_REQUIRED=true
+  - S2N_LIBCRYPTO=openssl-1.1.x-master BUILD_S2N=true TESTS=integration GCC6_REQUIRED=true
   - S2N_LIBCRYPTO=openssl-1.1.0 LATEST_CLANG=true TESTS=fuzz
   - TESTS=sawHMAC SAW_HMAC_TEST=md5    SAW=true GCC6_REQUIRED=false
   - TESTS=sawHMAC SAW_HMAC_TEST=sha1   SAW=true GCC6_REQUIRED=false
@@ -62,14 +63,18 @@ matrix:
     env: TESTS=sawDRBG                      SAW=true  GCC6_REQUIRED=false
   - os: osx
     env: TESTS=sawHMACFailure               SAW=true
+  - os: osx
+    env: S2N_LIBCRYPTO=openssl-1.1.x-master BUILD_S2N=true TESTS=integration GCC6_REQUIRED=true
   #This exception is because the test isn't finished yet, remove to turn on DRBG Saw tests
   - env: TESTS=sawDRBG                      SAW=true
   allow_failures:
     - os: osx
+    - env: S2N_LIBCRYPTO=openssl-1.1.x-master BUILD_S2N=true TESTS=integration GCC6_REQUIRED=true
   fast_finish: true
 
 before_install:
-  # Setup the cache directory paths
+  # Setup the cache directory paths. Openssl 1.1.x-master is skipped because we want to build against the latest
+  # revision.
   - if [[ ! -d test-deps ]]; then mkdir test-deps ; fi
   - export BASE_S2N_DIR=`pwd`
   - export PYTHON_INSTALL_DIR=`pwd`/test-deps/python
@@ -85,6 +90,8 @@ before_install:
   - export LIBRESSL_INSTALL_DIR=`pwd`/test-deps/libressl
   - export CPPCHECK_INSTALL_DIR=`pwd`/test-deps/cppcheck
   - export CTVERIF_INSTALL_DIR=`pwd`/test-deps/ctverif
+  # Keep this out of test-deps so that we always build the latest master
+  - export OPENSSL_1_1_X_MASTER_INSTALL_DIR=`mktemp -d`
 
 # Install missing test dependencies. If the install directory already exists, cached artifacts will be used
 # for that dependency.
@@ -100,9 +107,10 @@ before_script:
   # integration tests.
   - export PATH=$PYTHON_INSTALL_DIR/bin:$OPENSSL_1_1_0_INSTALL_DIR/bin:$GNUTLS_INSTALL_DIR/bin:$SAW_INSTALL_DIR/bin:$Z3_INSTALL_DIR/bin:$SCAN_BUILD_INSTALL_DIR/bin:$PATH
   - export LD_LIBRARY_PATH=$OPENSSL_1_1_0_INSTALL_DIR/lib:$LD_LIBRARY_PATH; export DYLD_LIBRARY_PATH=$OPENSSL_1_1_0_INSTALL_DIR/lib:$LD_LIBRARY_PATH;
-  # Select the libcrypto to build s2n against. If this is unset, default to the latest(Openssl 1.1.0)
+  # Select the libcrypto to build s2n against. If this is unset, default to the latest stable version(Openssl 1.1.0)
   - if [[ -z $S2N_LIBCRYPTO ]]; then export LIBCRYPTO_ROOT=$OPENSSL_1_1_0_INSTALL_DIR ; fi
   - if [[ "$S2N_LIBCRYPTO" == "openssl-1.1.0" ]]; then export LIBCRYPTO_ROOT=$OPENSSL_1_1_0_INSTALL_DIR ; fi
+  - if [[ "$S2N_LIBCRYPTO" == "openssl-1.1.x-master" ]]; then export LIBCRYPTO_ROOT=$OPENSSL_1_1_X_MASTER_INSTALL_DIR ; fi
   - if [[ "$S2N_LIBCRYPTO" == "openssl-1.0.2" ]]; then export LIBCRYPTO_ROOT=$OPENSSL_1_0_2_INSTALL_DIR ; fi
   - if [[ "$S2N_LIBCRYPTO" == "libressl" ]]; then export LIBCRYPTO_ROOT=$LIBRESSL_INSTALL_DIR ; fi
   # Set the libfuzzer to use for fuzz tests

--- a/.travis/install_default_dependencies.sh
+++ b/.travis/install_default_dependencies.sh
@@ -17,37 +17,63 @@ set -e
 
  # Install latest version of clang, clang++, and llvm-symbolizer. Needed for fuzzing.
 if [[ "$TESTS" == "fuzz" ]]                  && [[ ! -d "$LATEST_CLANG_INSTALL_DIR" ]]; then
-    .travis/install_clang.sh `mktemp -d` $LATEST_CLANG_INSTALL_DIR $TRAVIS_OS_NAME > /dev/null ; fi
+    mkdir -p $LATEST_CLANG_INSTALL_DIR;
+    .travis/install_clang.sh `mktemp -d` $LATEST_CLANG_INSTALL_DIR $TRAVIS_OS_NAME > /dev/null ;
+fi
 
 # Download and Install LibFuzzer with latest clang
 if [[ "$TESTS" == "fuzz" ]]                  && [[ ! -d "$LIBFUZZER_INSTALL_DIR" ]]; then
-    PATH=$LATEST_CLANG_INSTALL_DIR/bin:$PATH .travis/install_libFuzzer.sh `mktemp -d` $LIBFUZZER_INSTALL_DIR $TRAVIS_OS_NAME > /dev/null ; fi
+    mkdir -p $LIBFUZZER_INSTALL_DIR;
+    PATH=$LATEST_CLANG_INSTALL_DIR/bin:$PATH .travis/install_libFuzzer.sh `mktemp -d` $LIBFUZZER_INSTALL_DIR $TRAVIS_OS_NAME > /dev/null ;
+fi
 
 # Download and Install Openssl 1.1.0
 if [[ "$TESTS" == "integration" ]]        && [[ ! -d "$OPENSSL_1_1_0_INSTALL_DIR" ]]; then
-    .travis/install_openssl_1_1_0.sh `mktemp -d` $OPENSSL_1_1_0_INSTALL_DIR $TRAVIS_OS_NAME > /dev/null ; fi
+    mkdir -p $OPENSSL_1_1_0_INSTALL_DIR;
+    .travis/install_openssl_1_1_0.sh `mktemp -d` $OPENSSL_1_1_0_INSTALL_DIR $TRAVIS_OS_NAME > /dev/null ;
+fi
 
 # Download and Install Openssl 1.0.2
 if [[ "$S2N_LIBCRYPTO" == "openssl-1.0.2" ]] && [[ ! -d "$OPENSSL_1_0_2_INSTALL_DIR" ]]; then
-    .travis/install_openssl_1_0_2.sh `mktemp -d` $OPENSSL_1_0_2_INSTALL_DIR $TRAVIS_OS_NAME > /dev/null ; fi
+    mkdir -p $OPENSSL_1_0_2_INSTALL_DIR;
+    .travis/install_openssl_1_0_2.sh `mktemp -d` $OPENSSL_1_0_2_INSTALL_DIR $TRAVIS_OS_NAME > /dev/null ;
+fi
 
 # Download and Install CppCheck
 if [[ "$BUILD_S2N" == "true" ]]              && [[ ! -d "$CPPCHECK_INSTALL_DIR" ]]; then
-    mkdir -p $CPPCHECK_INSTALL_DIR && .travis/install_cppcheck.sh $CPPCHECK_INSTALL_DIR > /dev/null ; fi
+    mkdir -p $CPPCHECK_INSTALL_DIR;
+    .travis/install_cppcheck.sh $CPPCHECK_INSTALL_DIR > /dev/null ;
+fi
 
 # Download and Install LibreSSL
 if [[ "$S2N_LIBCRYPTO" == "libressl" ]]      && [[ ! -d "$LIBRESSL_INSTALL_DIR" ]]; then
-    .travis/install_libressl.sh `mktemp -d` $LIBRESSL_INSTALL_DIR > /dev/null ; fi
+    mkdir -p $LIBRESSL_INSTALL_DIR;
+    .travis/install_libressl.sh `mktemp -d` $LIBRESSL_INSTALL_DIR > /dev/null ;
+fi
+
+# Download and Install Openssl master. Don't use the cache so the latest revision is used
+if [[ "$S2N_LIBCRYPTO" == "openssl-1.1.x-master" ]]; then
+    mkdir -p $OPENSSL_1_1_X_MASTER_INSTALL_DIR;
+    .travis/install_openssl_1_1_x_master.sh `mktemp -d` $OPENSSL_1_1_X_MASTER_INSTALL_DIR $TRAVIS_OS_NAME  ;
+fi
 
 # Install python linked with the latest Openssl for integration tests
 if [[ "$TESTS" == "integration" ]]           && [[ ! -d "$PYTHON_INSTALL_DIR" ]]; then
-    mkdir -p $PYTHON_INSTALL_DIR && .travis/install_python.sh $OPENSSL_1_1_0_INSTALL_DIR `mktemp -d` $PYTHON_INSTALL_DIR > /dev/null ; fi
+    mkdir -p $PYTHON_INSTALL_DIR;
+    .travis/install_python.sh $OPENSSL_1_1_0_INSTALL_DIR `mktemp -d` $PYTHON_INSTALL_DIR > /dev/null ;
+fi
 
 # Download and Install GnuTLS for integration tests
-if [[ "$TESTS" == "integration" ]]           && [[ ! -d "$GNUTLS_INSTALL_DIR" ]]; then mkdir -p $GNUTLS_INSTALL_DIR && .travis/install_gnutls.sh `mktemp -d` $GNUTLS_INSTALL_DIR $TRAVIS_OS_NAME > /dev/null ; fi
+if [[ "$TESTS" == "integration" ]]           && [[ ! -d "$GNUTLS_INSTALL_DIR" ]]; then
+    mkdir -p $GNUTLS_INSTALL_DIR;
+    .travis/install_gnutls.sh `mktemp -d` $GNUTLS_INSTALL_DIR $TRAVIS_OS_NAME > /dev/null ;
+fi
 
 # Install SAW, Z3, and Yices for formal verification
 if [[ "$SAW" == "true" ]]                    && [[ ! -d "$SAW_INSTALL_DIR" ]]; then
-    mkdir -p $SAW_INSTALL_DIR && .travis/install_saw.sh `mktemp -d` $SAW_INSTALL_DIR > /dev/null ; fi
+    mkdir -p $SAW_INSTALL_DIR;
+    .travis/install_saw.sh `mktemp -d` $SAW_INSTALL_DIR > /dev/null ;
+fi
+
 if [[ "$SAW" == "true" ]]                    && [[ ! -d "$Z3_INSTALL_DIR" ]]; then
     mkdir -p $Z3_INSTALL_DIR && .travis/install_z3_yices.sh `mktemp -d` $Z3_INSTALL_DIR > /dev/null ; fi

--- a/.travis/install_openssl_1_1_x_master.sh
+++ b/.travis/install_openssl_1_1_x_master.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+set -e
+pushd `pwd`
+
+usage() {
+    echo "install_openssl_1_1_x_master.sh build_dir install_dir travis_platform"
+    exit 1
+}
+
+if [ "$#" -ne "3" ]; then
+    usage
+fi
+
+BUILD_DIR=$1
+INSTALL_DIR=$2
+PLATFORM=$3
+
+cd $BUILD_DIR
+
+git clone https://github.com/openssl/openssl.git
+
+cd openssl
+
+if [ "$PLATFORM" == "linux" ]; then
+    CONFIGURE="./config -d"
+elif [ "$PLATFORM" == "osx" ]; then
+    CONFIGURE="./Configure darwin64-x86_64-cc"
+else
+    echo "Invalid platform! $PLATFORM"
+    usage
+fi
+
+# Use g3 to get debug symbols in libcrypto to chase memory leaks
+$CONFIGURE -g3 -fPIC              \
+         no-md2 no-rc5 no-rfc3779 no-sctp no-ssl-trace no-zlib     \
+         no-hw no-mdc2 no-seed no-idea enable-ec_nistp_64_gcc_128 no-camellia\
+         no-bf no-ripemd no-dsa no-ssl2 no-ssl3 no-capieng                  \
+         -DSSL_FORBID_ENULL -DOPENSSL_NO_DTLS1 -DOPENSSL_NO_HEARTBEATS      \
+         --prefix=$INSTALL_DIR
+
+make depend
+make
+make install_sw
+
+popd
+
+exit 0

--- a/tests/integration/s2n_handshake_test_gnutls.py
+++ b/tests/integration/s2n_handshake_test_gnutls.py
@@ -111,7 +111,7 @@ def main():
     parser = argparse.ArgumentParser(description='Runs TLS server integration tests against s2nd using gnutls-cli')
     parser.add_argument('host', help='The host for s2nd to bind to')
     parser.add_argument('port', type=int, help='The port for s2nd to bind to')
-    parser.add_argument('--libcrypto', default='openssl-1.1.0', choices=['openssl-1.0.2', 'openssl-1.1.0', 'libressl'],
+    parser.add_argument('--libcrypto', default='openssl-1.1.0', choices=['openssl-1.0.2', 'openssl-1.1.0', 'openssl-1.1.x-master', 'libressl'],
             help="""The Libcrypto that s2n was built with. s2n supports different cipher suites depending on
                     libcrypto version. Defaults to openssl-1.1.0.""")
     args = parser.parse_args()

--- a/tests/integration/s2n_handshake_test_s_client.py
+++ b/tests/integration/s2n_handshake_test_s_client.py
@@ -256,7 +256,7 @@ def resume_test(host, port, test_ciphers):
     return failed
 
 supported_sigs = ["RSA+SHA1", "RSA+SHA224", "RSA+SHA256", "RSA+SHA384", "RSA+SHA512"]
-unsupported_sigs = ["ECDSA+SHA256", "DSA+SHA384", "ECDSA+SHA512", "DSA+SHA1"]
+unsupported_sigs = ["ECDSA+SHA256", "ECDSA+SHA512"]
 
 def run_sigalg_test(host, port, cipher, ssl_version, permutation, use_client_auth):
     # Put some unsupported algs in front to make sure we gracefully skip them

--- a/tests/integration/s2n_handshake_test_s_client.py
+++ b/tests/integration/s2n_handshake_test_s_client.py
@@ -374,7 +374,7 @@ def main():
     parser = argparse.ArgumentParser(description='Runs TLS server integration tests against s2nd using Openssl s_client')
     parser.add_argument('host', help='The host for s2nd to bind to')
     parser.add_argument('port', type=int, help='The port for s2nd to bind to')
-    parser.add_argument('--libcrypto', default='openssl-1.1.0', choices=['openssl-1.0.2', 'openssl-1.1.0', 'libressl'],
+    parser.add_argument('--libcrypto', default='openssl-1.1.0', choices=['openssl-1.0.2', 'openssl-1.1.0', 'openssl-1.1.x-master', 'libressl'],
             help="""The Libcrypto that s2n was built with. s2n supports different cipher suites depending on
                     libcrypto version. Defaults to openssl-1.1.0.""")
     args = parser.parse_args()

--- a/tests/integration/s2n_test_constants.py
+++ b/tests/integration/s2n_test_constants.py
@@ -70,9 +70,10 @@ LIBRESSL_TEST_CIPHERS = list(filter(lambda x: x.openssl_name != "ECDHE-RSA-CHACH
 # Dictionary to look up ciphers to use by libcrypto s2n is built with.
 # Libcrypto string will be an argument to test scripts.
 S2N_LIBCRYPTO_TO_TEST_CIPHERS = {
-    "openssl-1.1.0" : OPENSSL_1_1_0_TEST_CIPHERS,
-    "openssl-1.0.2" : OPENSSL_1_0_2_TEST_CIPHERS,
-    "libressl"      : LIBRESSL_TEST_CIPHERS,
+    "openssl-1.1.x-master"  : OPENSSL_1_1_0_TEST_CIPHERS,
+    "openssl-1.1.0"         : OPENSSL_1_1_0_TEST_CIPHERS,
+    "openssl-1.0.2"         : OPENSSL_1_0_2_TEST_CIPHERS,
+    "libressl"              : LIBRESSL_TEST_CIPHERS,
 }
 
 S2N_PROTO_VERS_TO_STR = {


### PR DESCRIPTION
The intention of this build dimension is to catch build regressions
before they are "officially" released. I expect this build to be
unstable, so it's added to the "allow_failures" section.