### PR TITLE
Initialize s2n_cert_chain_and_key members to NULL

### DIFF
--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -215,6 +215,8 @@ int s2n_config_add_cert_chain_and_key(struct s2n_config *config, const char *cer
     /* Allocate the memory for the chain and key struct */
     GUARD(s2n_alloc(&mem, sizeof(struct s2n_cert_chain_and_key)));
     config->cert_and_key_pairs = (struct s2n_cert_chain_and_key *)(void *)mem.data;
+    config->cert_and_key_pairs->head = NULL;
+    config->cert_and_key_pairs->private_key.rsa = NULL;
     config->cert_and_key_pairs->ocsp_status.data = NULL;
     config->cert_and_key_pairs->ocsp_status.size = 0;
     config->cert_and_key_pairs->sct_list.data = NULL;


### PR DESCRIPTION
This will more gracefully handle the case when we call s2n_config_add_cert_chain_and_key with an invalid cert or key.