### PR TITLE
Initialize map table with 0 in s2n_map_embiggen

### DIFF
--- a/utils/s2n_map.c
+++ b/utils/s2n_map.c
@@ -73,6 +73,7 @@ static int s2n_map_embiggen(struct s2n_map *map, uint32_t capacity)
     }
 
     GUARD(s2n_alloc(&mem, (capacity * sizeof(struct s2n_map_entry))));
+    GUARD(s2n_blob_zero(&mem));
 
     tmp.capacity = capacity;
     tmp.size = 0;
@@ -110,6 +111,7 @@ struct s2n_map *s2n_map_new()
 
     map = (void *) mem.data;
     map->capacity = 0;
+    map->size = 0;
     map->immutable = 0;
     map->table = NULL;
 


### PR DESCRIPTION
Found with overriding allocator to fill allocated memory with garbage and running unit tests.