### PR TITLE
Added overrides for realloc/posix_memalign in unit

### DIFF
--- a/tests/LD_PRELOAD/Makefile
+++ b/tests/LD_PRELOAD/Makefile
@@ -1,0 +1,29 @@
+#
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+SRCS=$(wildcard *.c)
+OVERRIDES=$(SRCS:.c=)
+
+.PHONY : all
+all : $(OVERRIDES)
+
+include ../../s2n.mk
+
+CRUFT += $(wildcard *.so)
+
+LD_PRELOAD_CFLAGS = -Wno-unreachable-code -O0
+
+$(OVERRIDES)::
+	${CC} ${DEFAULT_CFLAGS} ${DEBUG_CFLAGS} ${LD_PRELOAD_CFLAGS} -shared -fPIC $@.c -o $@.so -ldl

--- a/tests/LD_PRELOAD/allocator_overrides.c
+++ b/tests/LD_PRELOAD/allocator_overrides.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#define _GNU_SOURCE
+
+#include <dlfcn.h>
+#include <string.h>
+#include <malloc.h>
+
+typedef int (*posix_memalign_fn)(void **memptr, size_t alignment, size_t size);
+typedef void *(*realloc_fn)(void *ptr, size_t size);
+
+posix_memalign_fn orig_posix_memalign = NULL;
+realloc_fn orig_realloc = NULL;
+
+int posix_memalign(void **memptr, size_t alignment, size_t size)
+{
+    /* Override original posix_memalign to fill allocated memory with some data
+     * to catch errors due to missing initialization */
+    int rc;
+
+    if (orig_posix_memalign == NULL) {
+        /* C99 forbids converting void * to function pointers, so direct
+         * assignemnt fails with -pedantic. Yet dlsym is still used to return
+         * function pointers in standard library, despite that it returns
+         * void *. Casting function pointer to void ** and dereferencing it
+         * allows to bypass compiler warnings. */
+        *(void **) &orig_posix_memalign = dlsym(RTLD_NEXT, "posix_memalign");
+    }
+
+    rc = orig_posix_memalign(memptr, alignment, size);
+
+    memset(*memptr, 0xff, size);
+
+    return rc;
+}
+
+void *realloc(void *ptr, size_t size)
+{
+    /* Override original realloc to fill allocated memory with some data to
+     * catch errors due to missing initialization */
+    void *p;
+    size_t ptr_alloc_size;
+
+    if (orig_realloc == NULL) {
+        /* C99 forbids converting void * to function pointers, so direct
+         * assignemnt fails with -pedantic. Yet dlsym is still used to return
+         * function pointers in standard library, despite that it returns
+         * void *. Casting function pointer to void ** and dereferencing it
+         * allows to bypass compiler warnings. */
+        *(void **) &orig_realloc = dlsym(RTLD_NEXT, "realloc");
+    }
+
+    ptr_alloc_size = malloc_usable_size(ptr);
+    p = orig_realloc(ptr, size);
+
+    /* If call succeeded and we're enlarging memory, fill the extension with
+     * some random data */
+    if (p && size > ptr_alloc_size) {
+        memset((char *) p + ptr_alloc_size, 0xff, size - ptr_alloc_size);
+    }
+
+    return p;
+}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -23,6 +23,7 @@ endif
 .PHONY : all
 all:
 	${MAKE} -C testlib
+	${MAKE} -C LD_PRELOAD
 	${MAKE} -C unit
 	@echo "\033[1m ${COMPILE_INFO} \033[0;39m"
 
@@ -39,6 +40,7 @@ include ../s2n.mk
 .PHONY : clean
 clean:
 	${MAKE} -C testlib decruft
+	${MAKE} -C LD_PRELOAD decruft
 	${MAKE} -C unit decruft
 	${MAKE} -C fuzz decruft
 	${MAKE} -C saw decruft

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -45,6 +45,7 @@ run_tests:: $(TESTS)
 	  (\
 	    DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" \
 	    LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
+	    LD_PRELOAD="../LD_PRELOAD/allocator_overrides.so" \
 	    ./$$test; \
 	  ) & \
 	  done; wait)


### PR DESCRIPTION
Override original allocators to fill allocated memory with some data to catch errors due to missing initialization in unit tests (f.e. PR #515).