### PR TITLE
Add ECDSA signature functions

### DIFF
--- a/crypto/s2n_ecdsa.c
+++ b/crypto/s2n_ecdsa.c
@@ -46,6 +46,7 @@ int s2n_ecdsa_sign(const struct s2n_ecdsa_private_key *key, struct s2n_hash_stat
         S2N_ERROR(S2N_ERR_SIZE_MISMATCH);
     }
     signature->size = signature_size;
+    
     return 0;
 }
 
@@ -58,7 +59,7 @@ int s2n_ecdsa_verify(const struct s2n_ecdsa_public_key *key, struct s2n_hash_sta
     uint8_t digest_out[MAX_DIGEST_LENGTH];
     GUARD(s2n_hash_digest(digest, digest_out, digest_length));
     
-    // ECDSA_verify ignores the first parameter
+    /* ECDSA_verify ignores the first parameter */
     if (ECDSA_verify(0, digest_out, digest_length, signature->data, signature->size, key->eckey) == 0) {
         S2N_ERROR(S2N_ERR_VERIFY_SIGNATURE);
     }

--- a/crypto/s2n_ecdsa.c
+++ b/crypto/s2n_ecdsa.c
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <openssl/ec.h>
+#include <openssl/ecdsa.h>
+#include <openssl/x509.h>
+
+#include "stuffer/s2n_stuffer.h"
+
+#include "error/s2n_errno.h"
+#include "utils/s2n_safety.h"
+#include "utils/s2n_blob.h"
+#include "utils/s2n_mem.h"
+
+#include "crypto/s2n_ecdsa.h"
+#include "crypto/s2n_hash.h"
+#include "crypto/s2n_openssl.h"
+
+int s2n_ecdsa_sign(const struct s2n_ecdsa_private_key *key, struct s2n_hash_state *digest, struct s2n_blob *signature)
+{
+    uint8_t digest_length;
+    GUARD(s2n_hash_digest_size(digest->alg, &digest_length));
+    lte_check(digest_length, MAX_DIGEST_LENGTH);
+
+    uint8_t digest_out[MAX_DIGEST_LENGTH];
+    GUARD(s2n_hash_digest(digest, digest_out, digest_length));
+
+    unsigned int signature_size = signature->size;
+    if (ECDSA_sign(0, digest_out, digest_length, signature->data, &signature_size, key->eckey) == 0) {
+        S2N_ERROR(S2N_ERR_SIGN);
+    }
+    if (signature_size > signature->size) {
+        S2N_ERROR(S2N_ERR_SIZE_MISMATCH);
+    }
+    signature->size = signature_size;
+    return 0;
+}
+
+int s2n_ecdsa_verify(const struct s2n_ecdsa_public_key *key, struct s2n_hash_state *digest, struct s2n_blob *signature)
+{
+    uint8_t digest_length;
+    GUARD(s2n_hash_digest_size(digest->alg, &digest_length));
+    lte_check(digest_length, MAX_DIGEST_LENGTH);
+
+    uint8_t digest_out[MAX_DIGEST_LENGTH];
+    GUARD(s2n_hash_digest(digest, digest_out, digest_length));
+    
+    // ECDSA_verify ignores the first parameter
+    if (ECDSA_verify(0, digest_out, digest_length, signature->data, signature->size, key->eckey) == 0) {
+        S2N_ERROR(S2N_ERR_VERIFY_SIGNATURE);
+    }
+    
+    return 0;
+}
+
+int s2n_asn1der_to_ecdsa_public_key(struct s2n_ecdsa_public_key *key, struct s2n_blob *asn1der)
+{
+    uint8_t *cert_to_parse = asn1der->data;
+    X509 *cert = d2i_X509(NULL, (const unsigned char **)(void *)&cert_to_parse, asn1der->size);
+    if (cert == NULL) {
+        S2N_ERROR(S2N_ERR_DECODE_CERTIFICATE);
+    }
+    /* If cert parsing is successful, d2i_X509 increments *cert_to_parse to the byte following the parsed data */
+    uint32_t parsed_len = cert_to_parse - asn1der->data;
+
+    if (parsed_len != asn1der->size) {
+        X509_free(cert);
+        S2N_ERROR(S2N_ERR_DECODE_CERTIFICATE);
+    }
+
+    EVP_PKEY *public_key = X509_get_pubkey(cert);
+    X509_free(cert);
+
+    if (public_key == NULL) {
+        S2N_ERROR(S2N_ERR_DECODE_CERTIFICATE);
+    }
+
+    if (EVP_PKEY_base_id(public_key) != EVP_PKEY_EC) {
+        EVP_PKEY_free(public_key);
+        S2N_ERROR(S2N_ERR_DECODE_CERTIFICATE);
+    }
+
+    key->eckey = EVP_PKEY_get1_EC_KEY(public_key);
+    if (key->eckey == NULL) {
+        EVP_PKEY_free(public_key);
+        S2N_ERROR(S2N_ERR_DECODE_CERTIFICATE);
+    }
+
+    EVP_PKEY_free(public_key);
+
+    return 0;
+}
+
+int s2n_asn1der_to_ecdsa_private_key(struct s2n_ecdsa_private_key *key, struct s2n_blob *asn1der)
+{
+    uint8_t *key_to_parse = asn1der->data;
+
+    EVP_PKEY *pkey = d2i_PrivateKey(EVP_PKEY_EC, NULL, (const unsigned char **)(void *)&key_to_parse, asn1der->size);
+    if (pkey == NULL) {
+        S2N_ERROR(S2N_ERR_DECODE_PRIVATE_KEY);
+    }
+    
+    EC_KEY *ec_key = EVP_PKEY_get1_EC_KEY(pkey);
+    EVP_PKEY_free(pkey);
+    if (ec_key == NULL) {
+        S2N_ERROR(S2N_ERR_DECODE_PRIVATE_KEY);
+    }
+
+    /* If key parsing is successful, d2i_PrivateKey increments *key_to_parse to the byte following the parsed data */
+    uint32_t parsed_len = key_to_parse - asn1der->data;
+    if (parsed_len != asn1der->size) {
+        S2N_ERROR(S2N_ERR_DECODE_PRIVATE_KEY);
+    }
+
+    if (!EC_KEY_check_key(ec_key)) {
+        S2N_ERROR(S2N_ERR_PRIVATE_KEY_CHECK);
+    }
+
+    key->eckey = ec_key;
+
+    return 0;
+
+}
+
+int s2n_ecdsa_public_key_free(struct s2n_ecdsa_public_key *key)
+{
+    EC_KEY_free(key->eckey);
+    key->eckey = NULL;
+    return 0;
+}
+
+int s2n_ecdsa_private_key_free(struct s2n_ecdsa_private_key *key)
+{
+    EC_KEY_free(key->eckey);
+    key->eckey = NULL;
+    return 0;
+}
+
+int s2n_ecdsa_signature_size(const struct s2n_ecdsa_private_key *key)
+{
+    notnull_check(key->eckey);
+
+    return ECDSA_size(key->eckey);
+}
+
+int s2n_ecdsa_keys_match(const struct s2n_ecdsa_public_key *pub_key, const struct s2n_ecdsa_private_key *priv_key) 
+{
+    uint8_t input[] = "keys match!";
+    struct s2n_hash_state state_in, state_out;
+    struct s2n_blob signature;
+
+    GUARD(s2n_hash_init(&state_in, S2N_HASH_SHA1));
+    GUARD(s2n_hash_init(&state_out, S2N_HASH_SHA1));
+    GUARD(s2n_hash_update(&state_in, input, sizeof(input)));
+    GUARD(s2n_hash_update(&state_out, input, sizeof(input)));
+
+    GUARD(s2n_alloc(&signature, s2n_ecdsa_signature_size(priv_key)));
+    
+    GUARD(s2n_ecdsa_sign(priv_key, &state_in, &signature));
+    GUARD(s2n_ecdsa_verify(pub_key, &state_out, &signature));
+
+    return 0;
+}

--- a/crypto/s2n_ecdsa.c
+++ b/crypto/s2n_ecdsa.c
@@ -20,9 +20,10 @@
 #include "stuffer/s2n_stuffer.h"
 
 #include "error/s2n_errno.h"
-#include "utils/s2n_safety.h"
 #include "utils/s2n_blob.h"
 #include "utils/s2n_mem.h"
+#include "utils/s2n_random.h"
+#include "utils/s2n_safety.h"
 
 #include "crypto/s2n_ecdsa.h"
 #include "crypto/s2n_hash.h"
@@ -157,9 +158,14 @@ int s2n_ecdsa_signature_size(const struct s2n_ecdsa_private_key *key)
 
 int s2n_ecdsa_keys_match(const struct s2n_ecdsa_public_key *pub_key, const struct s2n_ecdsa_private_key *priv_key) 
 {
-    uint8_t input[] = "keys match!";
+    uint8_t input[16];
+    struct s2n_blob random_input;
     struct s2n_hash_state state_in, state_out;
     struct s2n_blob signature;
+
+    random_input.data = input;
+    random_input.size = sizeof(input);
+    GUARD(s2n_get_public_random_data(&random_input));
 
     GUARD(s2n_hash_init(&state_in, S2N_HASH_SHA1));
     GUARD(s2n_hash_init(&state_out, S2N_HASH_SHA1));

--- a/crypto/s2n_ecdsa.h
+++ b/crypto/s2n_ecdsa.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include <openssl/ecdsa.h>
+#include <stdint.h>
+
+#include "stuffer/s2n_stuffer.h"
+
+#include "crypto/s2n_hash.h"
+
+#include "utils/s2n_blob.h"
+
+struct s2n_ecdsa_public_key {
+    EC_KEY *eckey;
+};
+
+struct s2n_ecdsa_private_key {
+    EC_KEY *eckey;
+};
+
+extern int s2n_asn1der_to_ecdsa_public_key(struct s2n_ecdsa_public_key *key, struct s2n_blob *asn1der);
+extern int s2n_asn1der_to_ecdsa_private_key(struct s2n_ecdsa_private_key *key, struct s2n_blob *asn1der);
+extern int s2n_ecdsa_public_key_free(struct s2n_ecdsa_public_key *key);
+extern int s2n_ecdsa_private_key_free(struct s2n_ecdsa_private_key *key);
+
+extern int s2n_ecdsa_sign(const struct s2n_ecdsa_private_key *key, struct s2n_hash_state *digest, struct s2n_blob *signature);
+extern int s2n_ecdsa_verify(const struct s2n_ecdsa_public_key *key, struct s2n_hash_state *digest, struct s2n_blob *signature);
+
+extern int s2n_ecdsa_signature_size(const struct s2n_ecdsa_private_key *key);
+
+extern int s2n_ecdsa_keys_match(const struct s2n_ecdsa_public_key *pub_key, const struct s2n_ecdsa_private_key *priv_key); 

--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -109,6 +109,9 @@ extern int s2n_stuffer_alloc_ro_from_string(struct s2n_stuffer *stuffer, const c
 /* Read an RSA private key from a PEM encoded stuffer to an ASN1/DER encoded one */
 extern int s2n_stuffer_rsa_private_key_from_pem(struct s2n_stuffer *pem, struct s2n_stuffer *asn1);
 
+/* Read an EC private key from a PEM encoded stuffer to an ASN1/DER encoded one */
+extern int s2n_stuffer_ec_private_key_from_pem(struct s2n_stuffer *pem, struct s2n_stuffer *asn1);
+
 /* Read a certificate  from a PEM encoded stuffer to an ASN1/DER encoded one */
 extern int s2n_stuffer_certificate_from_pem(struct s2n_stuffer *pem, struct s2n_stuffer *asn1);
 

--- a/stuffer/s2n_stuffer_pem.c
+++ b/stuffer/s2n_stuffer_pem.c
@@ -108,6 +108,18 @@ int s2n_stuffer_rsa_private_key_from_pem(struct s2n_stuffer *pem, struct s2n_stu
     return s2n_stuffer_data_from_pem(pem, asn1, "PRIVATE KEY");
 }
 
+int s2n_stuffer_ec_private_key_from_pem(struct s2n_stuffer *pem, struct s2n_stuffer *asn1)
+{
+    const int rc = s2n_stuffer_data_from_pem(pem, asn1, "EC PRIVATE KEY");
+    if(!rc) {
+        return 0;
+    }
+    /* PEM may be using the PKCS#8 format. Retry with "PRIVATE KEY" */
+    s2n_stuffer_reread(pem);
+    s2n_stuffer_reread(asn1);
+    return s2n_stuffer_data_from_pem(pem, asn1, "PRIVATE KEY");
+}
+
 int s2n_stuffer_certificate_from_pem(struct s2n_stuffer *pem, struct s2n_stuffer *asn1)
 {
     return s2n_stuffer_data_from_pem(pem, asn1, "CERTIFICATE");

--- a/tests/unit/s2n_ecdsa_test.c
+++ b/tests/unit/s2n_ecdsa_test.c
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "stuffer/s2n_stuffer.h"
+#include "tls/s2n_connection.h"
+#include "tls/s2n_config.h"
+#include "crypto/s2n_ecdsa.h"
+#include "crypto/s2n_ecc.h"
+
+static uint8_t certificate[] =
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIID/DCCA4KgAwIBAgIJAKQlR7g6yRc2MAkGByqGSM49BAEwWTELMAkGA1UEBhMC\n"  
+    "QVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNVBAoTGEludGVybmV0IFdpZGdp\n"
+    "dHMgUHR5IEx0ZDESMBAGA1UEAxMJbG9jYWxob3N0MB4XDTE3MDQyMDIyMTY1NloX\n"
+    "DTI3MDQxODIyMTY1NlowWTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3Rh\n"
+    "dGUxITAfBgNVBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDESMBAGA1UEAxMJ\n"
+    "bG9jYWxob3N0MIIBzDCCAWQGByqGSM49AgEwggFXAgEBMDwGByqGSM49AQECMQD/\n"
+    "/////////////////////////////////////////v////8AAAAAAAAAAP////8w\n"
+    "ewQw//////////////////////////////////////////7/////AAAAAAAAAAD/\n"
+    "///8BDCzMS+n4j7n5JiOBWvj+C0ZGB2cbv6BQRIDFAiPUBOHWsZWOY2KLtGdKoXI\n"
+    "7dPsKu8DFQCjNZJqoxmieh0AiWpnc6SCes2scwRhBKqHyiK+iwU3jrHHHvMgrXRu\n"
+    "HTtii6ebmFn3QeCCVCo4VQLyXb9VKWw6VF44cnYKtzYX3kqWJixvXZ6Yv5KS3Cn4\n"
+    "9B29KJoUfOnaMRO18LjACmCxzh1+gZ16Qx18kOoOXwIxAP//////////////////\n"
+    "/////////////8djTYH0Ny3fWBoNskiwp3rs7BlqzMUpcwIBAQNiAATuRnqVT+re\n"
+    "o/6EEEW/pwLNDa7GrOZsTIRchHqjwrDrlnjtT7IcuWy5ALxEFGP0K0Xfh5kuBf4G\n"
+    "ebxhSZ690eYEVapsi8QDtvhu7V7jSgv8QQQRb4advo9CpsUWNFDHHGKjgb4wgbsw\n"
+    "HQYDVR0OBBYEFCTKHbjWPdLJjMlv3v5fH/vBTyWtMIGLBgNVHSMEgYMwgYCAFCTK\n"
+    "HbjWPdLJjMlv3v5fH/vBTyWtoV2kWzBZMQswCQYDVQQGEwJBVTETMBEGA1UECBMK\n"
+    "U29tZS1TdGF0ZTEhMB8GA1UEChMYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMRIw\n"
+    "EAYDVQQDEwlsb2NhbGhvc3SCCQCkJUe4OskXNjAMBgNVHRMEBTADAQH/MAkGByqG\n"
+    "SM49BAEDaQAwZgIxAJG5Ql52qUo+x9w7bJ3EZWpgt4jdblRkBvzpB1uX780h/6Wh\n"
+    "suQU36012pTQ6wTiNQIxAMJWqVLBmOJv3DSe4jsCeWwvWhWeItOy0fZ8fxW9w8VE\n"
+    "sXf3HEogY/fhiv5EUr+lcg==\n"
+    "-----END CERTIFICATE-----\n";
+
+static uint8_t private_key[] =
+    "-----BEGIN EC PRIVATE KEY-----\n"
+    "MIIB+gIBAQQwSJMrJhDMDa3hihWBYV/yyG7FLGPFxDhi+D6ZK6cXh/lzGdLztWmR\n" 
+    "UInVQV7mkO1RoIIBWzCCAVcCAQEwPAYHKoZIzj0BAQIxAP//////////////////\n"
+    "///////////////////////+/////wAAAAAAAAAA/////zB7BDD/////////////\n"
+    "/////////////////////////////v////8AAAAAAAAAAP////wEMLMxL6fiPufk\n"
+    "mI4Fa+P4LRkYHZxu/oFBEgMUCI9QE4daxlY5jYou0Z0qhcjt0+wq7wMVAKM1kmqj\n"
+    "GaJ6HQCJamdzpIJ6zaxzBGEEqofKIr6LBTeOscce8yCtdG4dO2KLp5uYWfdB4IJU\n"
+    "KjhVAvJdv1UpbDpUXjhydgq3NhfeSpYmLG9dnpi/kpLcKfj0Hb0omhR86doxE7Xw\n"
+    "uMAKYLHOHX6BnXpDHXyQ6g5fAjEA////////////////////////////////x2NN\n"
+    "gfQ3Ld9YGg2ySLCneuzsGWrMxSlzAgEBoWQDYgAE7kZ6lU/q3qP+hBBFv6cCzQ2u\n"
+    "xqzmbEyEXIR6o8Kw65Z47U+yHLlsuQC8RBRj9CtF34eZLgX+Bnm8YUmevdHmBFWq\n"
+    "bIvEA7b4bu1e40oL/EEEEW+Gnb6PQqbFFjRQxxxi\n"
+    "-----END EC PRIVATE KEY-----\n";
+
+static uint8_t unmatched_private_key[] =
+    "-----BEGIN EC PRIVATE KEY-----\n"
+    "MIIB+gIBAQQwuenHFMJsDm5tCQgthH8kGXQ1dHkKACmHH3ZqIGteoghhGow6vGmr\n" 
+    "xzA8gAdD2bJ0oIIBWzCCAVcCAQEwPAYHKoZIzj0BAQIxAP//////////////////\n"
+    "///////////////////////+/////wAAAAAAAAAA/////zB7BDD/////////////\n"
+    "/////////////////////////////v////8AAAAAAAAAAP////wEMLMxL6fiPufk\n"
+    "mI4Fa+P4LRkYHZxu/oFBEgMUCI9QE4daxlY5jYou0Z0qhcjt0+wq7wMVAKM1kmqj\n"
+    "GaJ6HQCJamdzpIJ6zaxzBGEEqofKIr6LBTeOscce8yCtdG4dO2KLp5uYWfdB4IJU\n"
+    "KjhVAvJdv1UpbDpUXjhydgq3NhfeSpYmLG9dnpi/kpLcKfj0Hb0omhR86doxE7Xw\n"
+    "uMAKYLHOHX6BnXpDHXyQ6g5fAjEA////////////////////////////////x2NN\n"
+    "gfQ3Ld9YGg2ySLCneuzsGWrMxSlzAgEBoWQDYgAE8oYPSRINnKlr5ZBHWacYEq4Y\n"
+    "j18l5f9yoMhBhpl7qvzf7uNFQ1SHzgHu0/v662d8Z0Pc0ujIms3/9uYxXVUY73vm\n"
+    "iwVevOxBJ1GL0usqhWNqOKoNp048H4rCmfyMN97E\n"
+    "-----END EC PRIVATE KEY-----\n";
+
+int main(int argc, char **argv)
+{
+    struct s2n_stuffer certificate_in, certificate_out;
+    struct s2n_stuffer ecdsa_key_in, ecdsa_key_out;
+    struct s2n_stuffer unmatched_ecdsa_key_in, unmatched_ecdsa_key_out;
+    struct s2n_blob b;
+
+    BEGIN_TEST();
+
+    EXPECT_SUCCESS(s2n_stuffer_alloc(&certificate_in, sizeof(certificate)));
+    EXPECT_SUCCESS(s2n_stuffer_alloc(&certificate_out, sizeof(certificate)));
+    EXPECT_SUCCESS(s2n_stuffer_alloc(&ecdsa_key_in, sizeof(private_key)));
+    EXPECT_SUCCESS(s2n_stuffer_alloc(&ecdsa_key_out, sizeof(private_key)));
+    EXPECT_SUCCESS(s2n_stuffer_alloc(&unmatched_ecdsa_key_in, sizeof(unmatched_private_key)));
+    EXPECT_SUCCESS(s2n_stuffer_alloc(&unmatched_ecdsa_key_out, sizeof(unmatched_private_key)));
+
+    b.data = certificate;
+    b.size = sizeof(certificate);
+    EXPECT_SUCCESS(s2n_stuffer_write(&certificate_in, &b));
+
+    b.data = private_key;
+    b.size = sizeof(private_key);
+    EXPECT_SUCCESS(s2n_stuffer_write(&ecdsa_key_in, &b));
+
+    b.data = unmatched_private_key;
+    b.size = sizeof(unmatched_private_key);
+    EXPECT_SUCCESS(s2n_stuffer_write(&unmatched_ecdsa_key_in, &b));
+
+    EXPECT_SUCCESS(s2n_stuffer_certificate_from_pem(&certificate_in, &certificate_out));
+    EXPECT_SUCCESS(s2n_stuffer_ec_private_key_from_pem(&ecdsa_key_in, &ecdsa_key_out));
+    EXPECT_SUCCESS(s2n_stuffer_ec_private_key_from_pem(&unmatched_ecdsa_key_in, &unmatched_ecdsa_key_out));
+
+    struct s2n_ecdsa_public_key pub_key;
+    struct s2n_ecdsa_private_key priv_key;
+    struct s2n_ecdsa_private_key unmatched_priv_key;
+
+    b.size = s2n_stuffer_data_available(&certificate_out);
+    b.data = s2n_stuffer_raw_read(&certificate_out, b.size);
+    EXPECT_SUCCESS(s2n_asn1der_to_ecdsa_public_key(&pub_key, &b));
+
+    b.size = s2n_stuffer_data_available(&ecdsa_key_out);
+    b.data = s2n_stuffer_raw_read(&ecdsa_key_out, b.size);
+    EXPECT_SUCCESS(s2n_asn1der_to_ecdsa_private_key(&priv_key, &b));
+    
+    b.size = s2n_stuffer_data_available(&unmatched_ecdsa_key_out);
+    b.data = s2n_stuffer_raw_read(&unmatched_ecdsa_key_out, b.size);
+    EXPECT_SUCCESS(s2n_asn1der_to_ecdsa_private_key(&unmatched_priv_key, &b));
+
+    /* Verify that the public/private key pair match */
+    EXPECT_SUCCESS(s2n_ecdsa_keys_match(&pub_key, &priv_key));
+
+    /* Try signing and verification with ECDSA */
+    uint8_t inputpad[] = "Hello world!";
+    struct s2n_blob signature, bad_signature;
+    struct s2n_hash_state tls10_one, tls10_two, tls12_one, tls12_two;
+
+    EXPECT_SUCCESS(s2n_hash_init(&tls10_one, S2N_HASH_MD5_SHA1));
+    EXPECT_SUCCESS(s2n_hash_init(&tls10_two, S2N_HASH_MD5_SHA1));
+    EXPECT_SUCCESS(s2n_hash_init(&tls12_one, S2N_HASH_SHA1));
+    EXPECT_SUCCESS(s2n_hash_init(&tls12_two, S2N_HASH_SHA1));
+
+    EXPECT_SUCCESS(s2n_alloc(&signature, s2n_ecdsa_signature_size(&priv_key)));
+
+    EXPECT_SUCCESS(s2n_hash_update(&tls10_one, inputpad, sizeof(inputpad)));
+    EXPECT_SUCCESS(s2n_hash_update(&tls10_two, inputpad, sizeof(inputpad)));
+    EXPECT_SUCCESS(s2n_ecdsa_sign(&priv_key, &tls10_one, &signature));
+    EXPECT_SUCCESS(s2n_ecdsa_verify(&pub_key, &tls10_two, &signature));
+
+    EXPECT_SUCCESS(s2n_hash_update(&tls12_one, inputpad, sizeof(inputpad)));
+    EXPECT_SUCCESS(s2n_hash_update(&tls12_two, inputpad, sizeof(inputpad)));
+    EXPECT_SUCCESS(s2n_ecdsa_sign(&priv_key, &tls12_one, &signature));
+    EXPECT_SUCCESS(s2n_ecdsa_verify(&pub_key, &tls12_two, &signature));
+
+    /* Mismatched public/private key should fail verification */
+    EXPECT_SUCCESS(s2n_alloc(&bad_signature, s2n_ecdsa_signature_size(&unmatched_priv_key)));
+
+    EXPECT_FAILURE(s2n_ecdsa_keys_match(&pub_key, &unmatched_priv_key));
+
+    EXPECT_SUCCESS(s2n_ecdsa_sign(&unmatched_priv_key, &tls12_one, &bad_signature));
+    EXPECT_FAILURE(s2n_ecdsa_verify(&pub_key, &tls12_two, &bad_signature));
+
+    EXPECT_SUCCESS(s2n_free(&signature));
+    EXPECT_SUCCESS(s2n_free(&bad_signature));
+    EXPECT_SUCCESS(s2n_ecdsa_public_key_free(&pub_key));
+    EXPECT_SUCCESS(s2n_ecdsa_private_key_free(&priv_key));
+    EXPECT_SUCCESS(s2n_ecdsa_private_key_free(&unmatched_priv_key));
+    EXPECT_SUCCESS(s2n_stuffer_free(&certificate_in));
+    EXPECT_SUCCESS(s2n_stuffer_free(&certificate_out));
+    EXPECT_SUCCESS(s2n_stuffer_free(&ecdsa_key_in));
+    EXPECT_SUCCESS(s2n_stuffer_free(&ecdsa_key_out));
+    EXPECT_SUCCESS(s2n_stuffer_free(&unmatched_ecdsa_key_in));
+    EXPECT_SUCCESS(s2n_stuffer_free(&unmatched_ecdsa_key_out));
+
+    END_TEST();
+}
+


### PR DESCRIPTION
Adding ECDSA functions to sign/verify, and parse keys. They are currently modeled after the equivalent RSA functions and use a mixture of the EVP and low-level OpenSSL APIs. Once the EVP refactoring in #478 has been completed for s2n_hash, these can switch over as well.