### PR TITLE
Make ct-verif test fail if undefined functions are used

### DIFF
--- a/.travis/run_ctverif.sh
+++ b/.travis/run_ctverif.sh
@@ -45,7 +45,7 @@ make clean
 FAILED=0
 EXPECTED_PASS=2
 EXPECTED_FAIL=0
-make | ./count_success.pl $EXPECTED_PASS $EXPECTED_FAIL || FAILED=1
+make 2>&1 | ./count_success.pl $EXPECTED_PASS $EXPECTED_FAIL || FAILED=1
 
 if [ $FAILED == 1 ];
 then

--- a/tests/ctverif/README.md
+++ b/tests/ctverif/README.md
@@ -92,7 +92,7 @@ cp ../../utils/s2n_safety.c .
 make clean
 EXPECTED_PASS=2
 EXPECTED_FAIL=0
-make | ./count_success.pl $EXPECTED_PASS $EXPECTED_FAIL
+make 2>&1 | ./count_success.pl $EXPECTED_PASS $EXPECTED_FAIL
 ```
 
 If both tests pass, you will see

--- a/tests/ctverif/count_success.pl
+++ b/tests/ctverif/count_success.pl
@@ -40,7 +40,6 @@ while (my $line = <STDIN>){
 	for my $fns (split(",",$1)){
 	    my $trimmed = trim ($fns);
 	    push @undefined_functions, $trimmed;
-	    print "found some !!!!!\n";
 	}
     }
     

--- a/tests/ctverif/count_success.pl
+++ b/tests/ctverif/count_success.pl
@@ -20,18 +20,32 @@
 use strict;
 use warnings;
 
+sub  trim { my $s = shift; $s =~ s/^\s+|\s+$//g; return $s };
+
+
 if (@ARGV != 2) {
     die "usage: count_success.pl expected_success expected_failures";
 }
 
 my $expected_success = shift;
 my $expected_failure = shift;
+my @undefined_functions = ();
 
 my $verified = 0;
 my $errors = 0;
 while (my $line = <STDIN>){
     print $line;
-    if ($line =~ /Boogie program verifier finished with (\d+) verified, (\d+) errors/) {
+    #Check if the code under test used unexpected functions
+    if ($line =~ /warning: module contains undefined functions:([a-zA-Z0-9_, ]+)/) {
+	for my $fns (split(",",$1)){
+	    my $trimmed = trim ($fns);
+	    push @undefined_functions, $trimmed;
+	    print "found some !!!!!\n";
+	}
+    }
+    
+    #Count the number of errors / successes
+    if ($line =~ /Boogie program verifier finished with (\d+) verified, (\d+) error/) {
 	$verified = $verified + $1;
 	$errors = $errors + $2;
     }
@@ -41,4 +55,8 @@ if($verified == $expected_success and $errors == $expected_failure){
    print "verified: $verified errors: $errors as expected\n";
 } else {
     die "ERROR:\tExpected \tverified: $expected_success\terrors: $expected_failure.\n\tGot\t\tverified: $verified\terrors: $errors.\n";
+}
+
+if (@undefined_functions) {
+    die "Unable to prove that code was constant time due to the presence of external functions: @undefined_functions\n";
 }


### PR DESCRIPTION
Change the constant-time proof so that it alarms if it detects that unknown external code is called.   

https://github.com/awslabs/s2n/issues/463