### PR TITLE
Don't mask unit test failure

### DIFF
--- a/tests/LD_PRELOAD/allocator_overrides.c
+++ b/tests/LD_PRELOAD/allocator_overrides.c
@@ -70,16 +70,19 @@ void *realloc(void *ptr, size_t size)
         *(void **) &orig_realloc = dlsym(RTLD_NEXT, "realloc");
     }
 
+
+#ifdef HAVE_MALLOC_USABLE_SIZE
+    /* If malloc_usable_size is available, we can get the size of previously
+     * allocated buffer, to find out how many new bytes we've allocated.
+     * Get the usable size for ptr before we call realloc, because realloc may call
+     * free() on the original pointer. */
+    size_t ptr_alloc_size = malloc_usable_size(ptr);
+#endif
+
     p = orig_realloc(ptr, size);
 
 #ifdef HAVE_MALLOC_USABLE_SIZE
-    /* If malloc_usable_size is availible, we can get the size of previously
-     * allocated buffer, to find out how many new bytes we've allocated */
-    size_t ptr_alloc_size;
-    size_t p_alloc_size;
-
-    ptr_alloc_size = malloc_usable_size(ptr);
-    p_alloc_size = malloc_usable_size(p);
+    size_t p_alloc_size = malloc_usable_size(p);
 
     /* If call succeeded and we're enlarging memory, fill the extension with
      * non-zero data */

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -22,8 +22,6 @@ CRYPTO_LDFLAGS = -L$(LIBCRYPTO_ROOT)/lib
 # Users can specify a subset of tests to be run, otherwise run all tests.
 ifeq (,$(strip ${UNIT_TESTS}))
 	UNIT_TESTS := ${TESTS}
-else
-	UNIT_TESTS := $(strip ${UNIT_TESTS})
 endif
 
 .PHONY : all

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -19,9 +19,17 @@ TESTS=$(SRCS:.c=)
 VALGRIND_TESTS=$(SRCS:.c=_valgrind)
 CRYPTO_LDFLAGS = -L$(LIBCRYPTO_ROOT)/lib
 
+# Users can specify a subset of tests to be run, otherwise run all tests.
+ifeq (,$(strip ${UNIT_TESTS}))
+	UNIT_TESTS := ${TESTS}
+else
+	UNIT_TESTS := $(strip ${UNIT_TESTS})
+endif
+
 .PHONY : all
 .PRECIOUS : $(TESTS)
-all: run_tests
+
+all: $(UNIT_TESTS)
 
 include ../../s2n.mk
 
@@ -33,22 +41,12 @@ LIBS += -lm
 CFLAGS += -Wno-unreachable-code -I$(LIBCRYPTO_ROOT)/include/ -I../../ -I../../api/
 LDFLAGS += -L../../lib/ ${CRYPTO_LDFLAGS} -L../testlib/ -ltests2n -ls2n ${LIBS} ${CRYPTO_LIBS}
 
-ifeq (,$(strip ${UNIT_TESTS}))
-	UNIT_TESTS=${TESTS}
-endif
-
-$(TESTS)::
+$(UNIT_TESTS)::
 	@${CC} ${CFLAGS} -o $@ $@.c ${LDFLAGS} 2>&1
-
-run_tests:: $(TESTS)
-	@(for test in ${UNIT_TESTS} ; do\
-	  (\
-	    DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" \
-	    LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
-	    LD_PRELOAD="../LD_PRELOAD/allocator_overrides.so" \
-	    ./$$test; \
-	  ) & \
-	  done; wait)
+	@DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" \
+	LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
+	LD_PRELOAD="../LD_PRELOAD/allocator_overrides.so" \
+	./$@
 
 .PHONY : valgrind
 valgrind: $(TESTS)


### PR DESCRIPTION
Previously we were using the `wait` bash builtin after spinning up
a subprocess for every unit test. The caused only the last process'
exit value to be used for the `make` exit value [1], other unit tests
would be ignored.

[1] Per `man bash`: "...the return status is the exit status of the last
                     process or job waited for."