### PR TITLE
Add dst/src overlap_check in memcpy_check

### DIFF
--- a/tests/unit/s2n_safety_test.c
+++ b/tests/unit/s2n_safety_test.c
@@ -111,6 +111,14 @@ static int failure_memcpy()
     return 0;
 }
 
+static int overlap_failure_memcpy()
+{
+    char src[1024]= {0};
+    memcpy_check(src + 512, src, 1024);
+
+    return 0;
+}
+
 static int success_inclusive_range()
 {
     inclusive_range_check(0, 0, 2);
@@ -179,6 +187,7 @@ int main(int argc, char **argv)
     EXPECT_FAILURE(failure_lt());
     EXPECT_FAILURE(failure_notnull());
     EXPECT_FAILURE(failure_memcpy());
+    EXPECT_FAILURE(overlap_failure_memcpy());
     EXPECT_FAILURE(failure_inclusive_range_too_high());
     EXPECT_FAILURE(failure_inclusive_range_too_low());
     EXPECT_FAILURE(failure_exclusive_range_too_high());

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -24,9 +24,17 @@
 /* NULL check a pointer */
 #define notnull_check( ptr )           do { if ( (ptr) == NULL ) { S2N_ERROR(S2N_ERR_NULL); } } while(0)
 
+/* Check memcpy destination and source do not overlap */
+extern inline int overlap_check(void *restrict to, const void *restrict from, size_t size)
+{
+	char *dst = to;
+	const char *src = from;
+	return (dst <= src && dst + size > src) || (src <= dst && src + size > dst);
+}
+
 extern inline void* trace_memcpy_check(void *restrict to, const void *restrict from, size_t size, const char *debug_str)
 {
-    if (to == NULL || from == NULL) {
+    if (to == NULL || from == NULL || overlap_check(to, from, size)) {
         s2n_errno = S2N_ERR_NULL;
         s2n_debug_str = debug_str;
         return NULL;


### PR DESCRIPTION
This PR is for the issue "memcpy in s2n_safety should check for dst/src overlap" [#397](https://github.com/awslabs/s2n/issues/397)

This PR checks for the overlap in addresses of dst and src by comparing the distance between the two based on the size of the copy.