### PR TITLE
Added api to associate connection with custom context

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -82,6 +82,9 @@ typedef enum { S2N_SERVER, S2N_CLIENT } s2n_mode;
 extern struct s2n_connection *s2n_connection_new(s2n_mode mode);
 extern int s2n_connection_set_config(struct s2n_connection *conn, struct s2n_config *config);
 
+extern int s2n_connection_set_ctx(struct s2n_connection *conn, void *ctx);
+extern void *s2n_connection_get_ctx(struct s2n_connection *conn);
+
 typedef int s2n_client_hello_fn(struct s2n_connection *conn, void *ctx);
 extern int s2n_config_set_client_hello_cb(struct s2n_config *config, s2n_client_hello_fn client_hello_callback, void *ctx);
 

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -615,6 +615,24 @@ int s2n_connection_set_config(struct s2n_connection *conn,
 **s2n_connection_set_config** Associates a configuration object with a
 connection. 
 
+### s2n\_connection\_set\_ctx
+
+```c
+int s2n_connection_set_ctx(struct s2n_connection *conn, void *ctx);
+```
+
+**s2n_connection_set_ctx** sets user defined context in **s2n_connection**
+object.
+
+### s2n\_connection\_get\_ctx
+
+```c
+void *s2n_connection_get_ctx(struct s2n_connection *conn);
+```
+
+**s2n_connection_get_ctx** gets user defined context from **s2n_connection**
+object.
+
 ### s2n\_connection\_set\_fd
 
 ```c

--- a/tests/unit/s2n_connection_context_test.c
+++ b/tests/unit/s2n_connection_context_test.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include <stdlib.h>
+#include <s2n.h>
+
+struct test_ctx {
+    int test;
+};
+
+int main(int argc, char **argv)
+{
+    struct s2n_connection *conn;
+    struct test_ctx ctx;
+
+    BEGIN_TEST();
+
+    EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+
+    /* Verify that we can set and get ctx */
+    EXPECT_SUCCESS(s2n_connection_set_ctx(conn, &ctx));
+    EXPECT_EQUAL(s2n_connection_get_ctx(conn), &ctx);
+
+    /* Verify that conext is cleaned up after wipe */
+    EXPECT_SUCCESS(s2n_connection_wipe(conn));
+    EXPECT_EQUAL(s2n_connection_get_ctx(conn), NULL);
+
+    EXPECT_SUCCESS(s2n_connection_free(conn));
+
+    END_TEST();
+}

--- a/tests/unit/s2n_connection_context_test.c
+++ b/tests/unit/s2n_connection_context_test.c
@@ -17,14 +17,10 @@
 #include <stdlib.h>
 #include <s2n.h>
 
-struct test_ctx {
-    int test;
-};
-
 int main(int argc, char **argv)
 {
     struct s2n_connection *conn;
-    struct test_ctx ctx;
+    int ctx;
 
     BEGIN_TEST();
 

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -129,6 +129,7 @@ struct s2n_connection *s2n_connection_new(s2n_mode mode)
     conn->recv_io_context = NULL;
     conn->managed_io = 0;
     conn->corked_io = 0;
+    conn->context = NULL;
 
     /* Allocate the fixed-size stuffers */
     blob.data = conn->alert_in_data;
@@ -304,6 +305,17 @@ int s2n_connection_set_config(struct s2n_connection *conn, struct s2n_config *co
     return 0;
 }
 
+int s2n_connection_set_ctx(struct s2n_connection *conn, void *ctx)
+{
+    conn->context = ctx;
+    return 0;
+}
+
+void *s2n_connection_get_ctx(struct s2n_connection *conn)
+{
+    return conn->context;
+}
+
 int s2n_connection_wipe(struct s2n_connection *conn)
 {
     /* First make a copy of everything we'd like to save, which isn't very much. */
@@ -342,6 +354,9 @@ int s2n_connection_wipe(struct s2n_connection *conn)
 
     /* Allocate memory for handling handshakes */
     GUARD(s2n_stuffer_resize(&conn->handshake.io, S2N_LARGE_RECORD_LENGTH));
+
+    /* Remove context associated with connection */
+    conn->context = NULL;
 
     /* Clone the stuffers */
     /* ignore gcc 4.7 address warnings because dest is allocated on the stack */

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -56,6 +56,9 @@ struct s2n_connection {
     /* The configuration (cert, key .. etc ) */
     struct s2n_config *config;
 
+    /* The user defined context associated with connection */
+    void *context;
+
     /* The send and receive callbacks don't have to be the same (e.g. two pipes) */
     s2n_send_fn *send;
     s2n_recv_fn *recv;


### PR DESCRIPTION
Can be used to get additional information about s2n connection in
callbacks, for example in client hello callback, which is set up by
s2n_config_set_client_hello_cb.