### PR TITLE
Fix three bugs in OCSP stapling

### DIFF
--- a/tests/unit/s2n_client_extensions_test.c
+++ b/tests/unit/s2n_client_extensions_test.c
@@ -693,6 +693,7 @@ int main(int argc, char **argv)
         struct s2n_connection *server_conn;
         struct s2n_config *server_config;
         struct s2n_config *client_config;
+        const uint8_t *server_ocsp_reply;
         int server_to_client[2];
         int client_to_server[2];
         uint32_t length;
@@ -730,9 +731,13 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
-        /* Verify that the client didn't receive an OCSP response. */
-        EXPECT_NULL(s2n_connection_get_ocsp_response(client_conn, &length));
-        EXPECT_EQUAL(length, 0);
+        /* Verify that the client received an OCSP response. */
+        EXPECT_NOT_NULL(server_ocsp_reply = s2n_connection_get_ocsp_response(client_conn, &length));
+        EXPECT_EQUAL(length, sizeof(server_ocsp_status));
+
+        for (int i = 0; i < sizeof(server_ocsp_status); i++) {
+            EXPECT_EQUAL(server_ocsp_reply[i], server_ocsp_status[i]);
+        }
 
         EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
 

--- a/tls/s2n_client_extensions.c
+++ b/tls/s2n_client_extensions.c
@@ -365,9 +365,7 @@ static int s2n_recv_client_alpn(struct s2n_connection *conn, struct s2n_stuffer 
 
 static int s2n_recv_client_status_request(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
-    uint16_t size_of_all;
-    GUARD(s2n_stuffer_read_uint16(extension, &size_of_all));
-    if (size_of_all > s2n_stuffer_data_available(extension) || size_of_all < 5) {
+    if (s2n_stuffer_data_available(extension) < 5) {
         /* Malformed length, ignore the extension */
         return 0;
     }

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -216,7 +216,7 @@ int s2n_conn_set_handshake_type(struct s2n_connection *conn)
         conn->handshake.handshake_type |= PERFECT_FORWARD_SECRECY;
     }
 
-    if (s2n_server_can_send_ocsp(conn)) {
+    if (s2n_server_can_send_ocsp(conn) || s2n_server_sent_ocsp(conn)) {
         conn->handshake.handshake_type |= OCSP_STATUS;
     }
 

--- a/tls/s2n_ocsp_stapling.c
+++ b/tls/s2n_ocsp_stapling.c
@@ -26,9 +26,6 @@
 
 int s2n_server_status_send(struct s2n_connection *conn)
 {
-    uint32_t length = conn->config->cert_and_key_pairs->ocsp_status.size + 4;
-    GUARD(s2n_stuffer_write_uint24(&conn->handshake.io, length));
-
     GUARD(s2n_stuffer_write_uint8(&conn->handshake.io, (uint8_t) S2N_STATUS_REQUEST_OCSP));
     GUARD(s2n_stuffer_write_uint24(&conn->handshake.io, conn->config->cert_and_key_pairs->ocsp_status.size));
     GUARD(s2n_stuffer_write(&conn->handshake.io, &conn->config->cert_and_key_pairs->ocsp_status));

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -96,6 +96,10 @@ int s2n_server_hello_recv(struct s2n_connection *conn)
 
     GUARD(s2n_server_extensions_recv(conn, &extensions));
 
+    if (conn->mode == S2N_CLIENT && conn->status_type == S2N_STATUS_REQUEST_OCSP) {
+        conn->handshake.handshake_type |= OCSP_STATUS;
+    }
+
     return 0;
 }
 

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -72,32 +72,25 @@ int s2n_server_hello_recv(struct s2n_connection *conn)
         S2N_ERROR(S2N_ERR_BAD_MESSAGE);
     }
 
+    if (s2n_stuffer_data_available(in) >= 2) {
+        GUARD(s2n_stuffer_read_uint16(in, &extensions_size));
+
+        if (extensions_size > s2n_stuffer_data_available(in)) {
+            S2N_ERROR(S2N_ERR_BAD_MESSAGE);
+        }
+
+        struct s2n_blob extensions;
+        extensions.size = extensions_size;
+        extensions.data = s2n_stuffer_raw_read(in, extensions.size);
+        notnull_check(extensions.data);
+
+        GUARD(s2n_server_extensions_recv(conn, &extensions));
+    }
+
     GUARD(s2n_conn_set_handshake_type(conn));
 
     if (IS_RESUMPTION_HANDSHAKE(conn->handshake.handshake_type)) {
         GUARD(s2n_prf_key_expansion(conn));
-    }
-
-    if (s2n_stuffer_data_available(in) < 2) {
-        /* No extensions */
-        return 0;
-    }
-
-    GUARD(s2n_stuffer_read_uint16(in, &extensions_size));
-
-    if (extensions_size > s2n_stuffer_data_available(in)) {
-        S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-    }
-
-    struct s2n_blob extensions;
-    extensions.size = extensions_size;
-    extensions.data = s2n_stuffer_raw_read(in, extensions.size);
-    notnull_check(extensions.data);
-
-    GUARD(s2n_server_extensions_recv(conn, &extensions));
-
-    if (conn->mode == S2N_CLIENT && conn->status_type == S2N_STATUS_REQUEST_OCSP) {
-        conn->handshake.handshake_type |= OCSP_STATUS;
     }
 
     return 0;

--- a/tls/s2n_tls.h
+++ b/tls/s2n_tls.h
@@ -64,6 +64,9 @@ extern int s2n_server_extensions_recv(struct s2n_connection *conn, struct s2n_bl
         (conn)->config->cert_and_key_pairs && \
         (conn)->config->cert_and_key_pairs->ocsp_status.size > 0)
 
+#define s2n_server_sent_ocsp(conn) ((conn)->mode == S2N_CLIENT && \
+        (conn)->status_type == S2N_STATUS_REQUEST_OCSP)
+
 #define s2n_server_can_send_sct_list(conn) ((conn)->ct_level_requested == S2N_CT_SUPPORT_REQUEST && \
         (conn)->config->cert_and_key_pairs && \
         (conn)->config->cert_and_key_pairs->sct_list.size > 0)


### PR DESCRIPTION
While attempting to use server OCSP stapling, I discovered that the current implementation doesn't work. The s2n_client_extensions_test seems to prove that it doesn't.

There were three bugs I needed to address to make this implementation work:

- s2n_recv_client_status_request was reading an extra uint16 off the front of the client status request, thus causing it to skip all client status requests as malformed. According to https://tools.ietf.org/html/rfc6066#section-8, the first element in the client status request is a 1-byte type enum.
- s2n_server_status_send was sending the total length of a server OCSP response a second time. s2n_handshake_finish_header actually takes care of sending the length, so s2n_server_status_send doesn't need to.
- Client handshake type did not have the OCSP_STATUS bit set after reading OCSP extension from server hello.

I've fixed the happy path unit test for OCSP, and I've manually tested with openssl :

```
]$ openssl s_client -connect 127.0.0.1:8080 -CAfile /tmp/test-79wal1AAr1/issuer.crt -tlsextdebug -status 2>&1 > ocsp_test.out
CONNECTED(00000003)
TLS server extension "EC point formats" (id=11), len=2
0000 - 01                                                .
0002 - <SPACES/NULS>
TLS server extension "renegotiation info" (id=65281), len=1
0001 - <SPACES/NULS>
TLS server extension "status request" (id=5), len=0
OCSP response: 
======================================
OCSP Response Data:
    OCSP Response Status: successful (0x0)
    Response Type: Basic OCSP Response
    Version: 1 (0x0)
    Responder Id: CN = issuer
    Produced At: May 23 16:35:22 2017 GMT
    Responses:
    Certificate ID:
      Hash Algorithm: sha1
      Issuer Name Hash: 6E09B43BE90D6C3967C8DB1656D260EC12E93123
      Issuer Key Hash: BC6C23A31C34157354D586705A2655BE36003EAF
      Serial Number: 1000
    Cert Status: good
    This Update: May 23 16:35:22 2017 GMT
    Next Update: May 26 16:35:22 2017 GMT

    Response Extensions:
        OCSP Nonce: 
            0410CB4C06C5AB52565E392BBF65CFAC6155
    Signature Algorithm: sha1WithRSAEncryption
         ac:de:e5:16:6f:3e:0d:0d:e9:02:f4:95:22:0a:cd:fc:60:44:
         82:91:38:f9:95:70:18:1a:47:86:4d:33:73:63:e8:71:73:32:
         65:74:b8:0c:8e:3c:0d:18:11:47:68:fd:de:4c:93:6a:7e:78:
         d6:56:ad:7c:a4:f6:b6:9b:cd:fa:55:a9:49:07:d0:18:a4:c5:
         85:c4:ec:a8:51:c1:d3:70:ae:01:cb:cd:da:5e:f5:7e:58:c7:
         9f:e8:e4:00:e4:64:8a:c5:27:6b:20:6f:f3:07:e5:81:dd:cf:
         44:d4:42:ca:3c:6a:61:fa:25:0b:6d:09:91:60:eb:7e:4a:d4:
         09:ef
Certificate:
    Data:
        Version: 1 (0x0)
        Serial Number: 12995275762243689983 (0xb4587e742ec75dff)
    Signature Algorithm: sha1WithRSAEncryption
        Issuer: CN=issuer
        Validity
            Not Before: May 23 16:35:22 2017 GMT
            Not After : Jun 22 16:35:22 2017 GMT
        Subject: CN=issuer
        Subject Public Key Info:
            Public Key Algorithm: rsaEncryption
                Public-Key: (1024 bit)
                Modulus:
                    00:dc:59:54:19:d6:14:48:81:62:59:f6:97:49:fc:
                    56:e5:2f:7a:8b:c2:8c:45:8f:84:46:1b:96:e9:93:
                    fa:c1:3f:ea:7d:3e:a3:98:fc:5c:7e:e6:50:03:41:
                    e1:56:fc:46:24:15:96:05:e6:13:bb:78:16:4f:62:
                    e9:1b:3e:c6:69:2d:32:62:de:d2:f5:d8:6c:39:1d:
                    13:b0:85:46:43:04:29:94:4a:12:d3:ce:12:6b:f3:
                    21:16:8c:32:20:1a:9e:55:0f:b2:90:22:05:82:51:
                    31:d7:a8:9e:a8:93:4e:25:03:cf:54:c0:08:49:b8:
                    67:cd:15:24:eb:0b:5f:92:89
                Exponent: 65537 (0x10001)
    Signature Algorithm: sha1WithRSAEncryption
         5a:3e:f2:0a:bc:db:e6:d9:66:ef:8f:50:80:1d:0c:9d:7a:f2:
         d7:3e:b5:b1:48:9d:3e:b0:25:fd:b5:9b:61:b8:e0:72:54:cc:
         2c:ba:65:ef:f2:62:2f:78:f3:c7:fe:8f:f8:4b:1a:73:68:16:
         6f:89:38:72:d8:25:98:79:b5:33:04:f5:54:d3:cc:04:0d:93:
         39:47:9c:80:2f:5d:89:4b:d1:f3:69:16:fe:73:c3:31:92:37:
         29:c5:c4:7d:06:84:8e:02:57:3c:fc:9d:8c:13:05:04:ac:9f:
         cb:e2:a0:c1:b3:f6:09:c7:70:cd:ed:5b:85:49:ba:c8:aa:63:
         4f:c8
-----BEGIN CERTIFICATE-----
MIIBmTCCAQICCQC0WH50Lsdd/zANBgkqhkiG9w0BAQUFADARMQ8wDQYDVQQDDAZp
c3N1ZXIwHhcNMTcwNTIzMTYzNTIyWhcNMTcwNjIyMTYzNTIyWjARMQ8wDQYDVQQD
DAZpc3N1ZXIwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBANxZVBnWFEiBYln2
l0n8VuUveovCjEWPhEYblumT+sE/6n0+o5j8XH7mUANB4Vb8RiQVlgXmE7t4Fk9i
6Rs+xmktMmLe0vXYbDkdE7CFRkMEKZRKEtPOEmvzIRaMMiAanlUPspAiBYJRMdeo
nqiTTiUDz1TACEm4Z80VJOsLX5KJAgMBAAEwDQYJKoZIhvcNAQEFBQADgYEAWj7y
Crzb5tlm749QgB0MnXry1z61sUidPrAl/bWbYbjgclTMLLpl7/JiL3jzx/6P+Esa
c2gWb4k4ctglmHm1MwT1VNPMBA2TOUecgC9diUvR82kW/nPDMZI3KcXEfQaEjgJX
PPydjBMFBKyfy+KgwbP2Ccdwze1bhUm6yKpjT8g=
-----END CERTIFICATE-----
======================================
---
Certificate chain
 0 s:/CN=signed
   i:/CN=issuer
---
Server certificate
-----BEGIN CERTIFICATE-----
MIIBkTCB+wICEAAwDQYJKoZIhvcNAQEFBQAwETEPMA0GA1UEAwwGaXNzdWVyMB4X
DTE3MDUyMzE2MzUyMloXDTE3MDUyNjE2MzUyMlowETEPMA0GA1UEAwwGc2lnbmVk
MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCjHW0kPQXhP53Bo6Bf0nWRsLI9
s933c7eHVa7LY7hjhJIYK/ufPOyGWHi6icrqZgkBw7TMPe0uKzqktzgK0ljbZemW
mqjY1sAx6h4Tc479fhMdyvi1tTF7i/Mm33F3nLZVlLxicmPBln5F8cIZIGJohZxl
7NAupgP9n8QFYjmJDwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAAd68v6OflynDq4R
xvZUNtB0AQ0P2n5jpjncMaEsTqJmiemOz+Ass2WG7mAsOyTjokWOJmcsLA7vPL4s
ymS8bVSUklXSG/Nl8DpJRDUb5ff+5p/NfT6UQPCu1zxjykgFeyoJ/OETb0vJwtLk
GpvaXrQT9y57kUsZ0X9X3FW3HtO7
-----END CERTIFICATE-----
subject=/CN=signed
issuer=/CN=issuer
---
No client certificate CA names sent
Server Temp Key: ECDH, prime256v1, 256 bits
---
SSL handshake has read 1550 bytes and written 384 bytes
---
New, TLSv1/SSLv3, Cipher is ECDHE-RSA-AES128-GCM-SHA256
Server public key is 1024 bit
Secure Renegotiation IS supported
Compression: NONE
Expansion: NONE
SSL-Session:
    Protocol  : TLSv1.2
    Cipher    : ECDHE-RSA-AES128-GCM-SHA256
    Session-ID: 
    Session-ID-ctx: 
    Master-Key: BEF226548D6D5483D720D4F43BD735FBFFFA096D0C5F933B85D091BCA724B0DFE6023DD5D546F9A7AD1E0CEDC9926C62
    Key-Arg   : None
    Krb5 Principal: None
    PSK identity: None
    PSK identity hint: None
    Start Time: 1495639468
    Timeout   : 300 (sec)
    Verify return code: 0 (ok)
---

```