### PR TITLE
Properly display skipped unit tests

### DIFF
--- a/tests/s2n_test.h
+++ b/tests/s2n_test.h
@@ -22,14 +22,21 @@
 
 #include "error/s2n_errno.h"
 
+/* Macro definitions for calls that occur within BEGIN_TEST() and END_TEST() to preserve the SKIPPED test behavior
+ * by ignoring the test_count, keeping it as 0 to indicate that a test was skipped. */
+#define EXPECT_TRUE_WITHOUT_COUNT( condition )    { if ( !(condition) ) { FAIL_MSG( #condition " is not true "); } }
+#define EXPECT_FALSE_WITHOUT_COUNT( condition )   EXPECT_TRUE_WITHOUT_COUNT( !(condition) )
+
+#define EXPECT_NOT_EQUAL_WITHOUT_COUNT( p1, p2 )  EXPECT_FALSE_WITHOUT_COUNT( (p1) == (p2) )
+
+#define EXPECT_SUCCESS_WITHOUT_COUNT( function_call )  EXPECT_NOT_EQUAL_WITHOUT_COUNT( (function_call) ,  -1 )
+
 /**
  * This is a very basic, but functional unit testing framework. All testing should
  * happen in main() and start with a BEGIN_TEST() and end with an END_TEST();
- *
  */
-
-#define BEGIN_TEST() int test_count = 0; EXPECT_SUCCESS(s2n_init()); { fprintf(stdout, "Running %-50s ... ", __FILE__); }
-#define END_TEST()   EXPECT_SUCCESS(s2n_cleanup()); { if (isatty(fileno(stdout))) { \
+#define BEGIN_TEST() int test_count = 0; EXPECT_SUCCESS_WITHOUT_COUNT(s2n_init()); { fprintf(stdout, "Running %-50s ... ", __FILE__); }
+#define END_TEST()   EXPECT_SUCCESS_WITHOUT_COUNT(s2n_cleanup()); { if (isatty(fileno(stdout))) { \
                             if (test_count) { \
                                 fprintf(stdout, "\033[32;1mPASSED\033[0m %10d tests\n", test_count ); \
                             }\


### PR DESCRIPTION
Add _WITHOUT_COUNT macros for EXPECT macro checks that are used
during BEGIN_TEST and END_TEST. The _WITHOUT_COUNT macros do not
increment test_count, as test_count is initialized to 0 and using
the existing EXPECT macros increment the test_count, thus breaking
the logic for determining if tests were skipped.

It is expected that as further checks are added to BEGIN_TEST and
END_TEST, _WITHOUT_COUNT macros are added as needed to preserve
the SKIPPED test behavior.