### PR TITLE
Fail Travis fuzz job on any single fuzz test failure

### DIFF
--- a/tests/fuzz/Makefile
+++ b/tests/fuzz/Makefile
@@ -52,11 +52,12 @@ $(TESTS)::
 	@${CC} ${CFLAGS} $@.c -o $@  ${LDFLAGS} > /dev/null
 
 run_tests:: $(TESTS) ld-preload
-	@( for test_name in ${FUZZ_TESTS} ; do \
+	@( fail_count=0; for test_name in ${FUZZ_TESTS} ; do \
 	export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}; \
 	export DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}; \
 	export LIBCRYPTO_ROOT=${LIBCRYPTO_ROOT}; \
-	./runFuzzTest.sh $${test_name} ${FUZZ_TIMEOUT_SEC}; done\
+	./runFuzzTest.sh $${test_name} ${FUZZ_TIMEOUT_SEC} || fail_count=`expr $$fail_count + 1`; done; \
+	exit $${fail_count}; \
 	)
 
 .PHONY : clean


### PR DESCRIPTION
Currently, Travis' job status for fuzz tests is based on the return code of the final fuzz test (see Issue #554). With this change, the fuzz tests will count the number of failures, ensuring that all fuzz tests are run, and will exit with a return code of the failure count. Any single fuzz test failure will cause the job to fail.