### PR TITLE
Run s2n unit tests in FIPS mode when S2N_ENTER_FIPS_MODE is defined

### DIFF
--- a/s2n.mk
+++ b/s2n.mk
@@ -45,6 +45,11 @@ ifneq ($(NO_STACK_PROTECTOR), 1)
 DEFAULT_CFLAGS += -Wstack-protector -fstack-protector-all
 endif
 
+# Define S2N_TEST_IN_FIPS_MODE - to be used for testing when present.
+ifdef S2N_TEST_IN_FIPS_MODE
+    DEFAULT_CFLAGS += -DS2N_TEST_IN_FIPS_MODE
+endif
+
 CFLAGS += ${DEFAULT_CFLAGS}
 
 DEBUG_CFLAGS = -g3 -ggdb -fno-omit-frame-pointer -fno-optimize-sibling-calls

--- a/tests/s2n_test.h
+++ b/tests/s2n_test.h
@@ -20,6 +20,8 @@
 #include <string.h>
 #include <stdio.h>
 
+#include <openssl/crypto.h>
+
 #include "error/s2n_errno.h"
 
 /* Macro definitions for calls that occur within BEGIN_TEST() and END_TEST() to preserve the SKIPPED test behavior
@@ -35,7 +37,12 @@
  * This is a very basic, but functional unit testing framework. All testing should
  * happen in main() and start with a BEGIN_TEST() and end with an END_TEST();
  */
+#ifdef S2N_TEST_IN_FIPS_MODE
+#define BEGIN_TEST() int test_count = 0; EXPECT_NOT_EQUAL_WITHOUT_COUNT(FIPS_mode_set(1), 0); EXPECT_SUCCESS_WITHOUT_COUNT(s2n_init());\
+                            { fprintf(stdout, "Running FIPS test %-50s ... ", __FILE__); }
+#else
 #define BEGIN_TEST() int test_count = 0; EXPECT_SUCCESS_WITHOUT_COUNT(s2n_init()); { fprintf(stdout, "Running %-50s ... ", __FILE__); }
+#endif
 #define END_TEST()   EXPECT_SUCCESS_WITHOUT_COUNT(s2n_cleanup()); { if (isatty(fileno(stdout))) { \
                             if (test_count) { \
                                 fprintf(stdout, "\033[32;1mPASSED\033[0m %10d tests\n", test_count ); \


### PR DESCRIPTION
Currently, s2n unit tests will fail when [`FIPS_mode`](https://wiki.openssl.org/index.php/FIPS_mode()) is entered. Merging PR #529 and resolving Issue #483 will allow all s2n unit tests to pass in FIPS mode. This change [enters FIPS_mode](https://wiki.openssl.org/index.php/FIPS_mode_set()) during the `BEGIN_TEST()` initialization for each unit test. This PR resolves Issue #484.

----Commit Message----

If S2N_ENTER_FIPS_MODE is defined, each s2n unit test using
BEGIN_TEST() will attempt to enter FIPS mode before executing.
The test output will clearly state that unit tests are running in
FIPS mode.

Ex: S2N_ENTER_FIPS_MODE=1 make -j

This can be used for integration tests and fuzz tests in the future.