### PR TITLE
Safer macros

### DIFF
--- a/error/s2n_errno.h
+++ b/error/s2n_errno.h
@@ -151,6 +151,6 @@ extern __thread const char *s2n_debug_str;
 #define STRING__LINE__ STRING_(__LINE__)
 
 #define _S2N_DEBUG_LINE     "Error encountered in " __FILE__ " line " STRING__LINE__
-#define _S2N_ERROR( x )     s2n_debug_str = _S2N_DEBUG_LINE; s2n_errno = ( x )
-#define S2N_ERROR( x )      _S2N_ERROR( ( x ) ); return -1
-#define S2N_ERROR_PTR( x )  _S2N_ERROR( ( x ) ); return NULL
+#define _S2N_ERROR( x )     do { s2n_debug_str = _S2N_DEBUG_LINE; s2n_errno = ( x ); } while (0)
+#define S2N_ERROR( x )      do { _S2N_ERROR( ( x ) ); return -1; } while (0)
+#define S2N_ERROR_PTR( x )  do { _S2N_ERROR( ( x ) ); return NULL; } while (0)

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -49,13 +49,13 @@ extern inline void* trace_memcpy_check(void *restrict to, const void *restrict f
 #define ne_check(a, b)  do { if ( (a) == (b) ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)
 #define inclusive_range_check( low, n, high )	\
   do  {						\
-    __typeof (n) __tmp_n = n;			\
+    __typeof( n ) __tmp_n = ( n );		\
     gte_check(__tmp_n, low);			\
     lte_check(__tmp_n, high);			\
   } while (0)
 #define exclusive_range_check( low, n, high )	\
   do {						\
-    __typeof (n) __tmp_n = n;			\
+    __typeof( n ) __tmp_n = ( n );		\
     gt_check(__tmp_n, low);			\
     lt_check(__tmp_n, high);			\
   } while (0)

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -37,23 +37,23 @@ extern inline void* trace_memcpy_check(void *restrict to, const void *restrict f
 
 /* Check memcpy and memset's arguments, if these are not right, log an error
  */
-#define memcpy_check( d, s, n )						\
-  do {									\
-    __typeof( n ) __tmp_n = ( n );					\
-    if ( __tmp_n ) {							\
+#define memcpy_check( d, s, n )                                             \
+  do {                                                                      \
+    __typeof( n ) __tmp_n = ( n );                                          \
+    if ( __tmp_n ) {                                                        \
       void *r = trace_memcpy_check( (d), (s) , (__tmp_n), _S2N_DEBUG_LINE); \
-      if (r == NULL) { return -1; }					\
-    }									\
+      if (r == NULL) { return -1; }                                         \
+    }                                                                       \
   } while(0)
 
-#define memset_check( d, c, n )			\
-  do {						\
-    __typeof( n ) __tmp_n = ( n );		\
-    if ( __tmp_n ) {				\
-      __typeof( d ) __tmp_d = ( d );		\
-      notnull_check( __tmp_d );			\
-      memset( __tmp_d, (c), __tmp_n);		\
-    }						\
+#define memset_check( d, c, n )                                             \
+  do {                                                                      \
+    __typeof( n ) __tmp_n = ( n );                                          \
+    if ( __tmp_n ) {                                                        \
+      __typeof( d ) __tmp_d = ( d );                                        \
+      notnull_check( __tmp_d );                                             \
+      memset( __tmp_d, (c), __tmp_n);                                       \
+    }                                                                       \
   } while(0)
 
 /* Range check a number */
@@ -63,17 +63,17 @@ extern inline void* trace_memcpy_check(void *restrict to, const void *restrict f
 #define lt_check(n, max)  do { if ( (n) >= max ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)
 #define eq_check(a, b)  do { if ( (a) != (b) ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)
 #define ne_check(a, b)  do { if ( (a) == (b) ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)
-#define inclusive_range_check( low, n, high )	\
-  do  {						\
-    __typeof( n ) __tmp_n = ( n );		\
-    gte_check(__tmp_n, low);			\
-    lte_check(__tmp_n, high);			\
+#define inclusive_range_check( low, n, high )   \
+  do  {                                         \
+    __typeof( n ) __tmp_n = ( n );              \
+    gte_check(__tmp_n, low);                    \
+    lte_check(__tmp_n, high);                   \
   } while (0)
-#define exclusive_range_check( low, n, high )	\
-  do {						\
-    __typeof( n ) __tmp_n = ( n );		\
-    gt_check(__tmp_n, low);			\
-    lt_check(__tmp_n, high);			\
+#define exclusive_range_check( low, n, high )   \
+  do {                                          \
+    __typeof( n ) __tmp_n = ( n );              \
+    gt_check(__tmp_n, low);                     \
+    lt_check(__tmp_n, high);                    \
   } while (0)
 
 #define GUARD( x )      if ( (x) < 0 ) return -1

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -37,8 +37,24 @@ extern inline void* trace_memcpy_check(void *restrict to, const void *restrict f
 
 /* Check memcpy and memset's arguments, if these are not right, log an error
  */
-#define memcpy_check( d, s, n )     do { if ( (n) ) { void *r = trace_memcpy_check( (d), (s) , (n), _S2N_DEBUG_LINE); if (r == NULL) { return -1; } } } while(0)
-#define memset_check( d, c, n )     do { if ( (n) ) { notnull_check( (d) ); memset( (d), (c), (n)); } } while(0)
+#define memcpy_check( d, s, n )						\
+  do {									\
+    __typeof( n ) __tmp_n = ( n );					\
+    if ( __tmp_n ) {							\
+      void *r = trace_memcpy_check( (d), (s) , (__tmp_n), _S2N_DEBUG_LINE); \
+      if (r == NULL) { return -1; }					\
+    }									\
+  } while(0)
+
+#define memset_check( d, c, n )			\
+  do {						\
+    __typeof( n ) __tmp_n = ( n );		\
+    if ( __tmp_n ) {				\
+      __typeof( d ) __tmp_d = ( d );		\
+      notnull_check( __tmp_d );			\
+      memset( __tmp_d, (c), __tmp_n);		\
+    }						\
+  } while(0)
 
 /* Range check a number */
 #define gte_check(n, min)  do { if ( (n) < min ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -47,8 +47,18 @@ extern inline void* trace_memcpy_check(void *restrict to, const void *restrict f
 #define lt_check(n, max)  do { if ( (n) >= max ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)
 #define eq_check(a, b)  do { if ( (a) != (b) ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)
 #define ne_check(a, b)  do { if ( (a) == (b) ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)
-#define inclusive_range_check( low, n, high )  gte_check(n, low); lte_check(n, high)
-#define exclusive_range_check( low, n, high )  gt_check(n, low); lt_check(n, high)
+#define inclusive_range_check( low, n, high )	\
+  do  {						\
+    __typeof (n) __tmp_n = n;			\
+    gte_check(__tmp_n, low);			\
+    lte_check(__tmp_n, high);			\
+  } while (0)
+#define exclusive_range_check( low, n, high )	\
+  do {						\
+    __typeof (n) __tmp_n = n;			\
+    gt_check(__tmp_n, low);			\
+    lt_check(__tmp_n, high);			\
+  } while (0)
 
 #define GUARD( x )      if ( (x) < 0 ) return -1
 #define GUARD_PTR( x )  if ( (x) < 0 ) return NULL


### PR DESCRIPTION
Several of the macros are not safe 

https://www.securecoding.cert.org/confluence/display/c/PRE10-C.+Wrap+multistatement+macros+in+a+do-while+loop
https://www.securecoding.cert.org/confluence/display/c/PRE12-C.+Do+not+define+unsafe+macros

This PR updates properly wraps them in do-while(0), and uses temp variables to avoid double evaluation.