### PR TITLE
Fix s2n_hmac variable naming, mixup between block_size and hash_block_size, and add comments

### DIFF
--- a/crypto/s2n_hmac.h
+++ b/crypto/s2n_hmac.h
@@ -36,7 +36,7 @@ struct s2n_hmac_state {
 
     uint16_t hash_block_size;
     uint32_t currently_in_hash_block;
-    uint16_t block_size;
+    uint16_t xor_pad_size;
     uint8_t digest_size;
 
     struct s2n_hash_state inner;

--- a/tests/saw/failure_tests/sha_bad_magic_mod.patch
+++ b/tests/saw/failure_tests/sha_bad_magic_mod.patch
@@ -7,7 +7,7 @@ diff -r -u s2n/crypto/s2n_hmac.c s2n_break/crypto/s2n_hmac.c
       */
 -    state->currently_in_hash_block += (4294949760 + size) % state->hash_block_size;
 +    state->currently_in_hash_block += (4294949761 + size) % state->hash_block_size;
-     state->currently_in_hash_block %= state->block_size;
+     state->currently_in_hash_block %= state->hash_block_size;
 
      return s2n_hash_update(&state->inner, in, size);
 Binary files s2n/.git/index and s2n_break/.git/index differ


### PR DESCRIPTION
In developing a new automated side channel analysis tool Daniel Schwartz-Narbonne (@danielsn) found an impractical to exploit timing side channel in s2n that occurs when using SSLv3. Note that SSLv3 is disabled by default in s2n, and usage of SSLv3 is strongly discouraged, as the SSLv3 protocol itself is considered insecure. 

This timing side channel was due to a timing normalization function that was not invoked for SSLv3 connections due to a mix up between the variables `block_size` and `hash_block_size`. These variables contain equal values in TLS 1.0, 1.1, and 1.2, but their values differ only in SSLv3. This timing normalization is used for all of s2n's TLS 1.0, 1.1, and 1.2 connections. This change renames `block_size` to `xor_pad_size` and corrects the mix up between those variables.

A later change will include a regression test based on the new tool. 
