### PR TITLE
[Part 1 - FIPS Integ Tests] Fix PRF hash state names for hashes used when copying

### DIFF
--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -56,9 +56,9 @@ static int s2n_connection_new_hashes(struct s2n_connection *conn)
     GUARD(s2n_hash_new(&conn->handshake.sha384));
     GUARD(s2n_hash_new(&conn->handshake.sha512));
     GUARD(s2n_hash_new(&conn->handshake.md5_sha1));
-    GUARD(s2n_hash_new(&conn->handshake.sslv3_md5_copy));
-    GUARD(s2n_hash_new(&conn->handshake.sslv3_sha1_copy));
-    GUARD(s2n_hash_new(&conn->handshake.tls_hash_copy));
+    GUARD(s2n_hash_new(&conn->handshake.prf_md5_hash_copy));
+    GUARD(s2n_hash_new(&conn->handshake.prf_sha1_hash_copy));
+    GUARD(s2n_hash_new(&conn->handshake.prf_tls12_hash_copy));
     GUARD(s2n_hash_new(&conn->prf_space.ssl3.md5));
     GUARD(s2n_hash_new(&conn->prf_space.ssl3.sha1));
     GUARD(s2n_hash_new(&conn->initial.signature_hash));
@@ -74,7 +74,7 @@ static int s2n_connection_init_hashes(struct s2n_connection *conn)
     if (s2n_hash_is_available(S2N_HASH_MD5)) {
         /* Only initialize hashes that use MD5 if available. */
         GUARD(s2n_hash_init(&conn->handshake.md5, S2N_HASH_MD5));
-        GUARD(s2n_hash_init(&conn->handshake.sslv3_md5_copy, S2N_HASH_MD5));
+        GUARD(s2n_hash_init(&conn->handshake.prf_md5_hash_copy, S2N_HASH_MD5));
         GUARD(s2n_hash_init(&conn->prf_space.ssl3.md5, S2N_HASH_MD5));
     }
 
@@ -88,8 +88,8 @@ static int s2n_connection_init_hashes(struct s2n_connection *conn)
     GUARD(s2n_hash_init(&conn->handshake.sha256, S2N_HASH_SHA256));
     GUARD(s2n_hash_init(&conn->handshake.sha384, S2N_HASH_SHA384));
     GUARD(s2n_hash_init(&conn->handshake.sha512, S2N_HASH_SHA512));
-    GUARD(s2n_hash_init(&conn->handshake.tls_hash_copy, S2N_HASH_NONE));
-    GUARD(s2n_hash_init(&conn->handshake.sslv3_sha1_copy, S2N_HASH_SHA1));
+    GUARD(s2n_hash_init(&conn->handshake.prf_tls12_hash_copy, S2N_HASH_NONE));
+    GUARD(s2n_hash_init(&conn->handshake.prf_sha1_hash_copy, S2N_HASH_SHA1));
     GUARD(s2n_hash_init(&conn->prf_space.ssl3.sha1, S2N_HASH_SHA1));
     GUARD(s2n_hash_init(&conn->initial.signature_hash, S2N_HASH_NONE));
     GUARD(s2n_hash_init(&conn->secure.signature_hash, S2N_HASH_NONE));
@@ -292,9 +292,9 @@ static int s2n_connection_reset_hashes(struct s2n_connection *conn)
     GUARD(s2n_hash_reset(&conn->handshake.sha384));
     GUARD(s2n_hash_reset(&conn->handshake.sha512));
     GUARD(s2n_hash_reset(&conn->handshake.md5_sha1));
-    GUARD(s2n_hash_reset(&conn->handshake.sslv3_md5_copy));
-    GUARD(s2n_hash_reset(&conn->handshake.sslv3_sha1_copy));
-    GUARD(s2n_hash_reset(&conn->handshake.tls_hash_copy));
+    GUARD(s2n_hash_reset(&conn->handshake.prf_md5_hash_copy));
+    GUARD(s2n_hash_reset(&conn->handshake.prf_sha1_hash_copy));
+    GUARD(s2n_hash_reset(&conn->handshake.prf_tls12_hash_copy));
     GUARD(s2n_hash_reset(&conn->prf_space.ssl3.md5));
     GUARD(s2n_hash_reset(&conn->prf_space.ssl3.sha1));
     GUARD(s2n_hash_reset(&conn->initial.signature_hash));
@@ -369,9 +369,9 @@ static int s2n_connection_free_hashes(struct s2n_connection *conn)
     GUARD(s2n_hash_free(&conn->handshake.sha384));
     GUARD(s2n_hash_free(&conn->handshake.sha512));
     GUARD(s2n_hash_free(&conn->handshake.md5_sha1));
-    GUARD(s2n_hash_free(&conn->handshake.sslv3_md5_copy));
-    GUARD(s2n_hash_free(&conn->handshake.sslv3_sha1_copy));
-    GUARD(s2n_hash_free(&conn->handshake.tls_hash_copy));
+    GUARD(s2n_hash_free(&conn->handshake.prf_md5_hash_copy));
+    GUARD(s2n_hash_free(&conn->handshake.prf_sha1_hash_copy));
+    GUARD(s2n_hash_free(&conn->handshake.prf_tls12_hash_copy));
     GUARD(s2n_hash_free(&conn->prf_space.ssl3.md5));
     GUARD(s2n_hash_free(&conn->prf_space.ssl3.sha1));
     GUARD(s2n_hash_free(&conn->initial.signature_hash));

--- a/tls/s2n_connection_evp_digests.c
+++ b/tls/s2n_connection_evp_digests.c
@@ -46,9 +46,9 @@ int s2n_connection_save_hash_state(struct s2n_connection_hash_handles *hash_hand
     hash_handles->sha384 = conn->handshake.sha384.digest.high_level;
     hash_handles->sha512 = conn->handshake.sha512.digest.high_level;
     hash_handles->md5_sha1 = conn->handshake.md5_sha1.digest.high_level;
-    hash_handles->sslv3_md5_copy = conn->handshake.sslv3_md5_copy.digest.high_level;
-    hash_handles->sslv3_sha1_copy = conn->handshake.sslv3_sha1_copy.digest.high_level;
-    hash_handles->tls_hash_copy = conn->handshake.tls_hash_copy.digest.high_level;
+    hash_handles->prf_md5_hash_copy = conn->handshake.prf_md5_hash_copy.digest.high_level;
+    hash_handles->prf_sha1_hash_copy = conn->handshake.prf_sha1_hash_copy.digest.high_level;
+    hash_handles->prf_tls12_hash_copy = conn->handshake.prf_tls12_hash_copy.digest.high_level;
 
     /* Preserve only the handlers for SSLv3 PRF hash state pointers to avoid re-allocation */
     hash_handles->prf_md5 = conn->prf_space.ssl3.md5.digest.high_level;
@@ -131,9 +131,9 @@ int s2n_connection_restore_hash_state(struct s2n_connection *conn, struct s2n_co
     conn->handshake.sha384.digest.high_level = hash_handles->sha384;
     conn->handshake.sha512.digest.high_level = hash_handles->sha512;
     conn->handshake.md5_sha1.digest.high_level = hash_handles->md5_sha1;
-    conn->handshake.sslv3_md5_copy.digest.high_level = hash_handles->sslv3_md5_copy;
-    conn->handshake.sslv3_sha1_copy.digest.high_level = hash_handles->sslv3_sha1_copy;
-    conn->handshake.tls_hash_copy.digest.high_level = hash_handles->tls_hash_copy;
+    conn->handshake.prf_md5_hash_copy.digest.high_level = hash_handles->prf_md5_hash_copy;
+    conn->handshake.prf_sha1_hash_copy.digest.high_level = hash_handles->prf_sha1_hash_copy;
+    conn->handshake.prf_tls12_hash_copy.digest.high_level = hash_handles->prf_tls12_hash_copy;
 
     /* Restore s2n_connection handlers for SSLv3 PRF hash states */
     conn->prf_space.ssl3.md5.digest.high_level = hash_handles->prf_md5;

--- a/tls/s2n_connection_evp_digests.h
+++ b/tls/s2n_connection_evp_digests.h
@@ -40,9 +40,9 @@ struct s2n_connection_hash_handles {
     struct s2n_hash_evp_digest sha384;
     struct s2n_hash_evp_digest sha512;
     struct s2n_hash_evp_digest md5_sha1;
-    struct s2n_hash_evp_digest sslv3_md5_copy;
-    struct s2n_hash_evp_digest sslv3_sha1_copy;
-    struct s2n_hash_evp_digest tls_hash_copy;
+    struct s2n_hash_evp_digest prf_md5_hash_copy;
+    struct s2n_hash_evp_digest prf_sha1_hash_copy;
+    struct s2n_hash_evp_digest prf_tls12_hash_copy;
     struct s2n_hash_evp_digest prf_md5;
 
     /* SSLv3 PRF hash states */

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -55,11 +55,11 @@ struct s2n_handshake {
     struct s2n_hash_state sha512;
     struct s2n_hash_state md5_sha1;
 
-    /* Used for SSLv3 PRF */
-    struct s2n_hash_state sslv3_md5_copy;
-    struct s2n_hash_state sslv3_sha1_copy;
-    /*Used for TLS PRF */
-    struct s2n_hash_state tls_hash_copy;
+    /* Used for SSLv3, TLS 1.0, and TLS 1.1 PRFs */
+    struct s2n_hash_state prf_md5_hash_copy;
+    struct s2n_hash_state prf_sha1_hash_copy;
+    /*Used for TLS 1.2 PRF */
+    struct s2n_hash_state prf_tls12_hash_copy;
 
     uint8_t server_finished[S2N_SSL_FINISHED_LEN];
     uint8_t client_finished[S2N_SSL_FINISHED_LEN];


### PR DESCRIPTION
The PRF hash states used for hash copying are not named correctly.
The MD5 and SHA1 hash states are used for SSLv3, TLS 1.0, and TLS 1.1
but are currently named to imply that they are only used for SSLv3.