### PR TITLE
Include s2n_fips.c in SAW analysis

### DIFF
--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -18,7 +18,7 @@ OBJS=$(SRCS:.c=.o)
 
 BITCODE_DIR?=../tests/saw/bitcode/
 
-BCS_1=s2n_hmac.bc s2n_drbg.bc
+BCS_1=s2n_hmac.bc s2n_drbg.bc s2n_fips.bc
 BCS=$(addprefix $(BITCODE_DIR), $(BCS_1))
 
 .PHONY : all


### PR DESCRIPTION
This fixes a Travis failure when proving the correctness of HMAC with the MD5 hash algorithm.