### PR TITLE
Pass s2n_connection to verify_cert_trust_chain_fn

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -173,7 +173,7 @@ extern int s2n_cert_public_key_set_cert_type(struct s2n_cert_public_key *cert_pu
 extern int s2n_cert_public_key_get_rsa(struct s2n_cert_public_key *cert_pub_key, struct s2n_rsa_public_key **rsa);
 
 /* Not intended for general consumption. Use at your own risk. */
-typedef s2n_cert_validation_code verify_cert_trust_chain_fn(uint8_t *der_cert_chain_in, uint32_t cert_chain_len, struct s2n_cert_public_key *public_key_out, void *context);
+typedef s2n_cert_validation_code verify_cert_trust_chain_fn(struct s2n_connection *conn, uint8_t *der_cert_chain_in, uint32_t cert_chain_len, struct s2n_cert_public_key *public_key_out, void *context);
 
 extern int s2n_config_set_verify_cert_chain_cb(struct s2n_config *config, verify_cert_trust_chain_fn *callback, void *context);
 

--- a/bin/echo.c
+++ b/bin/echo.c
@@ -31,7 +31,7 @@
 #include <openssl/x509.h>
 
 /* Accept all RSA Certificates is unsafe and is only used in the s2n Client */
-s2n_cert_validation_code accept_all_rsa_certs(uint8_t *cert_chain_in, uint32_t cert_chain_len, struct s2n_cert_public_key *public_key_out, void *context)
+s2n_cert_validation_code accept_all_rsa_certs(struct s2n_connection *conn, uint8_t *cert_chain_in, uint32_t cert_chain_len, struct s2n_cert_public_key *public_key_out, void *context)
 {
     uint32_t bytes_read = 0;
     uint32_t certificate_count = 0;

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -58,7 +58,7 @@ void usage()
 
 extern int echo(struct s2n_connection *conn, int sockfd);
 extern int negotiate(struct s2n_connection *conn);
-extern int accept_all_rsa_certs(uint8_t *cert_chain_in, uint32_t cert_chain_len, struct s2n_cert_public_key *public_key_out, void *context);
+extern int accept_all_rsa_certs(struct s2n_connection *conn, uint8_t *cert_chain_in, uint32_t cert_chain_len, struct s2n_cert_public_key *public_key_out, void *context);
 
 int main(int argc, char *const *argv)
 {

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -222,7 +222,7 @@ int cache_delete(void *ctx, const void *key, uint64_t key_size)
 
 extern int echo(struct s2n_connection *conn, int sockfd);
 extern int negotiate(struct s2n_connection *conn);
-extern int accept_all_rsa_certs(uint8_t *cert_chain_in, uint32_t cert_chain_len, struct s2n_cert_public_key *public_key_out, void *context);
+extern int accept_all_rsa_certs(struct s2n_connection *conn, uint8_t *cert_chain_in, uint32_t cert_chain_len, struct s2n_cert_public_key *public_key_out, void *context);
 
 void usage()
 {

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -591,7 +591,7 @@ default is for s2n to accept all RSA Certs on the client side, and deny all cert
 ```c
 int verify_cert_trust_chain(struct s2n_connection *conn, uint8_t *der_cert_chain_in, uint32_t cert_chain_len, struct s2n_cert_public_key *public_key_out, void *context);
 ```
- - **conn** The connection certificate chain is validated for
+ - **conn** The connection the certificate chain is validated for
  - **der_cert_chain_in** The DER encoded full chain of certificates recieved
  - **cert_chain_len** The length in bytes of the DER encoded Cert Chain
  - **public_key_out** The public key that should be updated with the key extracted from the first certificate in the chain (the leaf Cert)

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -589,8 +589,9 @@ default is for s2n to accept all RSA Certs on the client side, and deny all cert
 ### verify_cert_trust_chain_fn
 
 ```c
-int verify_cert_trust_chain(uint8_t *der_cert_chain_in, uint32_t cert_chain_len, struct s2n_cert_public_key *public_key_out, void *context);
+int verify_cert_trust_chain(struct s2n_connection *conn, uint8_t *der_cert_chain_in, uint32_t cert_chain_len, struct s2n_cert_public_key *public_key_out, void *context);
 ```
+ - **conn** The connection certificate chain is validated for
  - **der_cert_chain_in** The DER encoded full chain of certificates recieved
  - **cert_chain_len** The length in bytes of the DER encoded Cert Chain
  - **public_key_out** The public key that should be updated with the key extracted from the first certificate in the chain (the leaf Cert)
@@ -599,7 +600,6 @@ int verify_cert_trust_chain(uint8_t *der_cert_chain_in, uint32_t cert_chain_len,
 
 **verify_cert_trust_chain_fn** defines a Callback Function Signature intended to be used only in special circumstances, and may be removed in a later release.
 Implementations should Verify the Certificate Chain of trust, and place the leaf Certificate's Public Key in the public_key_out parameter.
-They should not not perform any hostname validation, which is still needed in order to completely validate a Certificate.
 
 ### Public Key API's
 ```c

--- a/tls/s2n_client_cert.c
+++ b/tls/s2n_client_cert.c
@@ -45,7 +45,7 @@ int s2n_client_cert_recv(struct s2n_connection *conn)
     struct s2n_cert_public_key cert_public_key;
 
     /* Determine the Cert Type, Verify the Cert, and extract the Public Key */
-    const s2n_cert_validation_code rc = conn->config->verify_cert_chain_cb(client_cert_chain.data, client_cert_chain.size, &cert_public_key, conn->config->verify_cert_context);
+    const s2n_cert_validation_code rc = conn->config->verify_cert_chain_cb(conn, client_cert_chain.data, client_cert_chain.size, &cert_public_key, conn->config->verify_cert_context);
 
     if (rc != S2N_CERT_OK) {
         /* Don't use GUARD for verify_cert_chain_cb so that s2n_errno is set. */

--- a/tls/s2n_client_cert.c
+++ b/tls/s2n_client_cert.c
@@ -45,7 +45,8 @@ int s2n_client_cert_recv(struct s2n_connection *conn)
     struct s2n_cert_public_key cert_public_key;
 
     /* Determine the Cert Type, Verify the Cert, and extract the Public Key */
-    const s2n_cert_validation_code rc = conn->config->verify_cert_chain_cb(conn, client_cert_chain.data, client_cert_chain.size, &cert_public_key, conn->config->verify_cert_context);
+    const s2n_cert_validation_code rc = conn->config->verify_cert_chain_cb(conn, client_cert_chain.data, client_cert_chain.size,
+            &cert_public_key, conn->config->verify_cert_context);
 
     if (rc != S2N_CERT_OK) {
         /* Don't use GUARD for verify_cert_chain_cb so that s2n_errno is set. */

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -70,13 +70,13 @@ int get_nanoseconds_since_epoch(void *data, uint64_t * nanoseconds)
 
 #endif
 
-int deny_all_certs(uint8_t *cert_chain_in, uint32_t cert_chain_len, struct s2n_cert_public_key *public_key, void *context)
+int deny_all_certs(struct s2n_connection *conn, uint8_t *cert_chain_in, uint32_t cert_chain_len, struct s2n_cert_public_key *public_key, void *context)
 {
     S2N_ERROR(S2N_ERR_CERT_UNTRUSTED);
 }
 
 /* Accept all RSA Certificates is unsafe and is only used in the s2n Client for testing purposes */
-s2n_cert_validation_code accept_all_rsa_certs(uint8_t *cert_chain_in, uint32_t cert_chain_len, struct s2n_cert_public_key *public_key_out, void *context)
+s2n_cert_validation_code accept_all_rsa_certs(struct s2n_connection *conn, uint8_t *cert_chain_in, uint32_t cert_chain_len, struct s2n_cert_public_key *public_key_out, void *context)
 {
     struct s2n_blob cert_chain_blob = { .data = cert_chain_in, .size = cert_chain_len};
     struct s2n_stuffer cert_chain_in_stuffer;

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -76,7 +76,11 @@ int deny_all_certs(struct s2n_connection *conn, uint8_t *cert_chain_in, uint32_t
 }
 
 /* Accept all RSA Certificates is unsafe and is only used in the s2n Client for testing purposes */
-s2n_cert_validation_code accept_all_rsa_certs(struct s2n_connection *conn, uint8_t *cert_chain_in, uint32_t cert_chain_len, struct s2n_cert_public_key *public_key_out, void *context)
+s2n_cert_validation_code accept_all_rsa_certs(struct s2n_connection *conn,
+                                              uint8_t *cert_chain_in,
+                                              uint32_t cert_chain_len,
+                                              struct s2n_cert_public_key *public_key_out,
+                                              void *context)
 {
     struct s2n_blob cert_chain_blob = { .data = cert_chain_in, .size = cert_chain_len};
     struct s2n_stuffer cert_chain_in_stuffer;

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -61,5 +61,5 @@ extern struct s2n_config s2n_default_config;
 extern struct s2n_config s2n_default_fips_config;
 extern struct s2n_config s2n_unsafe_client_testing_config;
 
-int accept_all_rsa_certs(uint8_t *cert_chain_in, uint32_t cert_chain_len, struct s2n_cert_public_key *public_key_out, void *context);
-int deny_all_certs(uint8_t *cert_chain_in, uint32_t cert_chain_len, struct s2n_cert_public_key *public_key, void *context);
+int accept_all_rsa_certs(struct s2n_connection *conn, uint8_t *cert_chain_in, uint32_t cert_chain_len, struct s2n_cert_public_key *public_key_out, void *context);
+int deny_all_certs(struct s2n_connection *conn, uint8_t *cert_chain_in, uint32_t cert_chain_len, struct s2n_cert_public_key *public_key, void *context);

--- a/tls/s2n_server_cert.c
+++ b/tls/s2n_server_cert.c
@@ -42,7 +42,7 @@ int s2n_server_cert_recv(struct s2n_connection *conn)
     cert_chain.data = s2n_stuffer_raw_read(&conn->handshake.io, size_of_all_certificates);
     cert_chain.size = size_of_all_certificates;
 
-    const s2n_cert_validation_code rc = conn->config->verify_cert_chain_cb(cert_chain.data, cert_chain.size, &public_key, conn->config->verify_cert_context);
+    const s2n_cert_validation_code rc = conn->config->verify_cert_chain_cb(conn, cert_chain.data, cert_chain.size, &public_key, conn->config->verify_cert_context);
 
     if (rc != S2N_CERT_OK) {
         S2N_ERROR(S2N_ERR_CERT_UNTRUSTED);


### PR DESCRIPTION
s2n_connection in verify_cert_trust_chain_fn callback allows consumer to
perform addional connection-specific checks, like performing hostname
validation.