### PR TITLE
FIX: Duplicate constants in s2n_hash.h and s2n_prf.h 

### DIFF
--- a/crypto/s2n_ecdsa.c
+++ b/crypto/s2n_ecdsa.c
@@ -33,9 +33,9 @@ int s2n_ecdsa_sign(const struct s2n_ecdsa_private_key *key, struct s2n_hash_stat
 {
     uint8_t digest_length;
     GUARD(s2n_hash_digest_size(digest->alg, &digest_length));
-    lte_check(digest_length, MAX_DIGEST_LENGTH);
+    lte_check(digest_length, S2N_MAX_DIGEST_LEN);
 
-    uint8_t digest_out[MAX_DIGEST_LENGTH];
+    uint8_t digest_out[S2N_MAX_DIGEST_LEN];
     GUARD(s2n_hash_digest(digest, digest_out, digest_length));
 
     unsigned int signature_size = signature->size;
@@ -56,9 +56,9 @@ int s2n_ecdsa_verify(const struct s2n_ecdsa_public_key *key, struct s2n_hash_sta
 {
     uint8_t digest_length;
     GUARD(s2n_hash_digest_size(digest->alg, &digest_length));
-    lte_check(digest_length, MAX_DIGEST_LENGTH);
+    lte_check(digest_length, S2N_MAX_DIGEST_LEN);
 
-    uint8_t digest_out[MAX_DIGEST_LENGTH];
+    uint8_t digest_out[S2N_MAX_DIGEST_LEN];
     GUARD(s2n_hash_digest(digest, digest_out, digest_length));
     
     /* ECDSA_verify ignores the first parameter */

--- a/crypto/s2n_hash.h
+++ b/crypto/s2n_hash.h
@@ -41,7 +41,7 @@
 
 #include <stdint.h>
 
-#define MAX_DIGEST_LENGTH SHA512_DIGEST_LENGTH
+#define S2N_MAX_DIGEST_LEN SHA512_DIGEST_LENGTH
 
 typedef enum {
     S2N_HASH_NONE,

--- a/crypto/s2n_rsa.c
+++ b/crypto/s2n_rsa.c
@@ -180,9 +180,9 @@ int s2n_rsa_sign(struct s2n_rsa_private_key *key, struct s2n_hash_state *digest,
     int NID_type;
     GUARD(s2n_hash_digest_size(digest->alg, &digest_length));
     GUARD(s2n_hash_NID_type(digest->alg, &NID_type));
-    lte_check(digest_length, MAX_DIGEST_LENGTH);
+    lte_check(digest_length, S2N_MAX_DIGEST_LEN);
 
-    uint8_t digest_out[MAX_DIGEST_LENGTH];
+    uint8_t digest_out[S2N_MAX_DIGEST_LEN];
     GUARD(s2n_hash_digest(digest, digest_out, digest_length));
 
     unsigned int signature_size = signature->size;
@@ -203,9 +203,9 @@ int s2n_rsa_verify(struct s2n_rsa_public_key *key, struct s2n_hash_state *digest
     int NID_type;
     GUARD(s2n_hash_digest_size(digest->alg, &digest_length));
     GUARD(s2n_hash_NID_type(digest->alg, &NID_type));
-    lte_check(digest_length, MAX_DIGEST_LENGTH);
+    lte_check(digest_length, S2N_MAX_DIGEST_LEN);
 
-    uint8_t digest_out[MAX_DIGEST_LENGTH];
+    uint8_t digest_out[S2N_MAX_DIGEST_LEN];
     GUARD(s2n_hash_digest(digest, digest_out, digest_length));
 
     if (RSA_verify(NID_type, digest_out, digest_length, signature->data, signature->size, key->rsa) == 0) {

--- a/tls/s2n_cbc.c
+++ b/tls/s2n_cbc.c
@@ -24,7 +24,6 @@
 #include "crypto/s2n_hmac.h"
 
 #include "tls/s2n_record.h"
-#include "tls/s2n_prf.h"
 
 /* A TLS CBC record looks like ..
  *

--- a/tls/s2n_prf.h
+++ b/tls/s2n_prf.h
@@ -23,8 +23,6 @@
 
 #include "utils/s2n_blob.h"
 
-#define S2N_MAX_DIGEST_LEN SHA512_DIGEST_LENGTH
-
 /* Enough to support TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384, 2*SHA384_DIGEST_LEN + 2*AES256_KEY_SIZE */
 #define S2N_MAX_KEY_BLOCK_LEN 160
 


### PR DESCRIPTION
As per https://github.com/awslabs/s2n/issues/587 the same #defined constant appears in two files under slightly different names.  Fixed it so it only appears in s2n_hash.h, renamed the uses as appropiate, removed a now unnecessary #include of s2n_prf.h.


