### PR TITLE
Minimize required handshake hashes

### DIFF
--- a/crypto/s2n_hash.h
+++ b/crypto/s2n_hash.h
@@ -44,14 +44,16 @@
 #define S2N_MAX_DIGEST_LEN SHA512_DIGEST_LENGTH
 
 typedef enum {
-    S2N_HASH_NONE,
+    S2N_HASH_NONE=0,
     S2N_HASH_MD5,
     S2N_HASH_SHA1,
     S2N_HASH_SHA224,
     S2N_HASH_SHA256,
     S2N_HASH_SHA384,
     S2N_HASH_SHA512,
-    S2N_HASH_MD5_SHA1
+    S2N_HASH_MD5_SHA1,
+    /* Don't add any hash algorithms below S2N_HASH_SENTINEL */
+    S2N_HASH_SENTINEL
 } s2n_hash_algorithm;
 
 /* The low_level_digest stores all OpenSSL structs that are alg-specific to be used with OpenSSL's low-level hash API's. */

--- a/crypto/s2n_hmac.h
+++ b/crypto/s2n_hmac.h
@@ -52,6 +52,7 @@ struct s2n_hmac_state {
 
 extern int s2n_hmac_digest_size(s2n_hmac_algorithm alg, uint8_t *out);
 extern int s2n_hmac_is_available(s2n_hmac_algorithm alg);
+extern int s2n_hmac_hash_alg(s2n_hmac_algorithm hmac_alg, s2n_hash_algorithm *out);
 
 extern int s2n_hmac_new(struct s2n_hmac_state *state);
 extern int s2n_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm alg, const void *key, uint32_t klen);

--- a/tls/s2n_client_cert_verify.c
+++ b/tls/s2n_client_cert_verify.c
@@ -60,6 +60,9 @@ int s2n_client_cert_verify_recv(struct s2n_connection *conn)
         S2N_ERROR(S2N_ERR_INVALID_SIGNATURE_ALGORITHM);
     }
 
+    /* Client certificate has been verified. Minimize required handshake hash algs */
+    GUARD(s2n_conn_update_required_handshake_hashes(conn));
+
     return 0;
 }
 
@@ -97,6 +100,9 @@ int s2n_client_cert_verify_send(struct s2n_connection *conn)
     default:
         S2N_ERROR(S2N_ERR_INVALID_SIGNATURE_ALGORITHM);
     }
+
+    /* Client certificate has been verified. Minimize required handshake hash algs */
+    GUARD(s2n_conn_update_required_handshake_hashes(conn));
 
     return 0;
 }

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -21,6 +21,8 @@
 
 #include "error/s2n_errno.h"
 
+#include "crypto/s2n_hash.h"
+
 #include "tls/s2n_cipher_preferences.h"
 #include "tls/s2n_cipher_suites.h"
 #include "tls/s2n_connection.h"
@@ -120,6 +122,9 @@ int s2n_client_hello_recv(struct s2n_connection *conn)
 
     /* Set the handshake type */
     GUARD(s2n_conn_set_handshake_type(conn));
+
+    /* We've selected the cipher, update the required hashes for this connection */
+    GUARD(s2n_conn_update_required_handshake_hashes(conn));
 
     return 0;
 }

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -537,7 +537,7 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     GUARD(s2n_connection_init_hmacs(conn));
 
     /* Require all handshakes hashes. This set can be reduced as the handshake progresses. */
-    GUARD(s2n_handshake_require_all_hashes(conn));
+    GUARD(s2n_handshake_require_all_hashes(&conn->handshake));
 
     if (conn->mode == S2N_SERVER) {
         /* Start with the highest protocol version so that the highest common protocol version can be selected */

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -536,6 +536,9 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     GUARD(s2n_connection_init_hashes(conn));
     GUARD(s2n_connection_init_hmacs(conn));
 
+    /* Require all handshakes hashes. This set can be reduced as the handshake progresses. */
+    GUARD(s2n_handshake_require_all_hashes(conn));
+
     if (conn->mode == S2N_SERVER) {
         /* Start with the highest protocol version so that the highest common protocol version can be selected */
         /* during handshake. */

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@
 
 /* This is the list of message types that we support */
 typedef enum {
-    CLIENT_HELLO,
+    CLIENT_HELLO=0,
     SERVER_HELLO,
     SERVER_CERT,
     SERVER_NEW_SESSION_TICKET,
@@ -61,9 +61,13 @@ struct s2n_handshake {
     /*Used for TLS 1.2 PRF */
     struct s2n_hash_state prf_tls12_hash_copy;
 
+    /* Hash algorithms required for this handshake. The set of required hashes can be reduced as session parameters are
+     * negotiated, i.e. cipher suite and protocol version.
+     */
+    uint8_t required_hash_algs[S2N_HASH_SENTINEL];
+
     uint8_t server_finished[S2N_SSL_FINISHED_LEN];
     uint8_t client_finished[S2N_SSL_FINISHED_LEN];
-
 
     /* Handshake type is a bitset, with the following
        bit positions */
@@ -99,4 +103,7 @@ struct s2n_handshake {
 
 extern message_type_t s2n_conn_get_current_message_type(struct s2n_connection *conn);
 extern int s2n_conn_set_handshake_type(struct s2n_connection *conn);
+extern int s2n_handshake_require_all_hashes(struct s2n_connection *conn);
+extern uint8_t s2n_handshake_is_hash_required(struct s2n_handshake *handshake, s2n_hash_algorithm hash_alg);
+extern int s2n_conn_update_required_handshake_hashes(struct s2n_connection *conn);
 extern int s2n_handshake_get_hash_state(struct s2n_connection *conn, s2n_hash_algorithm hash_alg, struct s2n_hash_state *hash_state);

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -103,7 +103,7 @@ struct s2n_handshake {
 
 extern message_type_t s2n_conn_get_current_message_type(struct s2n_connection *conn);
 extern int s2n_conn_set_handshake_type(struct s2n_connection *conn);
-extern int s2n_handshake_require_all_hashes(struct s2n_connection *conn);
+extern int s2n_handshake_require_all_hashes(struct s2n_handshake *handshake);
 extern uint8_t s2n_handshake_is_hash_required(struct s2n_handshake *handshake, s2n_hash_algorithm hash_alg);
 extern int s2n_conn_update_required_handshake_hashes(struct s2n_connection *conn);
 extern int s2n_handshake_get_hash_state(struct s2n_connection *conn, s2n_hash_algorithm hash_alg, struct s2n_hash_state *hash_state);

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -306,24 +306,40 @@ int s2n_conn_set_handshake_type(struct s2n_connection *conn)
 
 static int s2n_conn_update_handshake_hashes(struct s2n_connection *conn, struct s2n_blob *data)
 {
-    /* The handshake MD5 hash state will fail the s2n_hash_is_available() check
-     * since MD5 is not permitted in FIPS mode. This check will not be used as
-     * the handshake MD5 hash state is specifically used by the TLS 1.0 and TLS 1.1
-     * PRF, which is required to comply with the TLS 1.0 and 1.1 RFCs and is approved
-     * as per NIST Special Publication 800-52 Revision 1.
-     */
-    GUARD(s2n_hash_update(&conn->handshake.md5, data->data, data->size));
+    if (s2n_handshake_is_hash_required(&conn->handshake, S2N_HASH_MD5)) {
+        /* The handshake MD5 hash state will fail the s2n_hash_is_available() check
+         * since MD5 is not permitted in FIPS mode. This check will not be used as
+         * the handshake MD5 hash state is specifically used by the TLS 1.0 and TLS 1.1
+         * PRF, which is required to comply with the TLS 1.0 and 1.1 RFCs and is approved
+         * as per NIST Special Publication 800-52 Revision 1.
+         */
+        GUARD(s2n_hash_update(&conn->handshake.md5, data->data, data->size));
+    }
 
-    if (s2n_hash_is_available(S2N_HASH_MD5_SHA1)) {
-        /* The MD5_SHA1 hash cannot be initialized when FIPS mode is set. */
+    if (s2n_handshake_is_hash_required(&conn->handshake, S2N_HASH_SHA1)) {
+        GUARD(s2n_hash_update(&conn->handshake.sha1, data->data, data->size));
+    }
+
+    if (s2n_handshake_is_hash_required(&conn->handshake, S2N_HASH_MD5) &&
+        s2n_handshake_is_hash_required(&conn->handshake, S2N_HASH_SHA1)) {
         GUARD(s2n_hash_update(&conn->handshake.md5_sha1, data->data, data->size));
     }
 
-    GUARD(s2n_hash_update(&conn->handshake.sha1, data->data, data->size));
-    GUARD(s2n_hash_update(&conn->handshake.sha224, data->data, data->size));
-    GUARD(s2n_hash_update(&conn->handshake.sha256, data->data, data->size));
-    GUARD(s2n_hash_update(&conn->handshake.sha384, data->data, data->size));
-    GUARD(s2n_hash_update(&conn->handshake.sha512, data->data, data->size));
+    if (s2n_handshake_is_hash_required(&conn->handshake, S2N_HASH_SHA224)) {
+        GUARD(s2n_hash_update(&conn->handshake.sha224, data->data, data->size));
+    }
+
+    if (s2n_handshake_is_hash_required(&conn->handshake, S2N_HASH_SHA256)) {
+        GUARD(s2n_hash_update(&conn->handshake.sha256, data->data, data->size));
+    }
+
+    if (s2n_handshake_is_hash_required(&conn->handshake, S2N_HASH_SHA384)) {
+        GUARD(s2n_hash_update(&conn->handshake.sha384, data->data, data->size));
+    }
+
+    if (s2n_handshake_is_hash_required(&conn->handshake, S2N_HASH_SHA512)) {
+        GUARD(s2n_hash_update(&conn->handshake.sha512, data->data, data->size));
+    }
 
     return 0;
 }
@@ -560,7 +576,7 @@ static int handshake_read_io(struct s2n_connection *conn)
 
         /* Don't update handshake hashes until after the handler has executed since some handlers need to read the
          * hash values before they are updated. */
-        s2n_handshake_conn_update_hashes(conn);
+        GUARD(s2n_handshake_conn_update_hashes(conn));
 
         GUARD(s2n_stuffer_wipe(&conn->handshake.io));
 

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -320,8 +320,11 @@ static int s2n_conn_update_handshake_hashes(struct s2n_connection *conn, struct 
         GUARD(s2n_hash_update(&conn->handshake.sha1, data->data, data->size));
     }
 
-    if (s2n_handshake_is_hash_required(&conn->handshake, S2N_HASH_MD5) &&
-        s2n_handshake_is_hash_required(&conn->handshake, S2N_HASH_SHA1)) {
+    const uint8_t md5_sha1_required = (s2n_handshake_is_hash_required(&conn->handshake, S2N_HASH_MD5) &&
+                                       s2n_handshake_is_hash_required(&conn->handshake, S2N_HASH_SHA1));
+
+    if (md5_sha1_required && s2n_hash_is_available(S2N_HASH_MD5_SHA1)) {
+        /* The MD5_SHA1 hash cannot be initialized when FIPS mode is set. */
         GUARD(s2n_hash_update(&conn->handshake.md5_sha1, data->data, data->size));
     }
 

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -93,6 +93,9 @@ int s2n_server_hello_recv(struct s2n_connection *conn)
         GUARD(s2n_prf_key_expansion(conn));
     }
 
+    /* We've selected the cipher, update the required hashes for this connection */
+    GUARD(s2n_conn_update_required_handshake_hashes(conn));
+
     return 0;
 }
 


### PR DESCRIPTION
Previously s2n kept a running hash of handshake messages for *every*
supported hash algorithm. The handshake hash is used in the PRF and
the optional CertificateVerify message.

This change disables all unneeded hash algorithms after the
{Client, Server}Hello is received [1]. On my test system, this change
reduced handshake processing time by ~5%. In practice, most handshake
time is spent waiting on network round trips and not on-CPU processing.
This change is unlikely to have a significant performance impact
outside of low latency networks.

closes #234

[1] When client authentication is required we delay minimizing handshake
    hashes until the CertificateVerify message is processed.