### PR TITLE
Added some documentation for ALPN since the API is a bit different fr…

### DIFF
--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -492,8 +492,8 @@ preference, with most preferred protocol first, and of length
 **protocol_count**.  When acting as an **S2N_CLIENT** the protocol list is
 included in the Client Hello message as the ALPN extension.  As an
 **S2N_SERVER**, the list is used to negotiate a mutual application protocol
-with the client. After the negotiation for the connection has completed, the 
-agreed upon protocol will be stored in the application_protocol member of the s2n_connection object.
+with the client. After the negotiation for the connection has completed, the
+agreed upon protocol can be retrieved with [s2n_get_application_protocol](#s2n_get_application_protocol)
 
 ### s2n\_config\_set\_status\_request\_type
 

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -492,7 +492,8 @@ preference, with most preferred protocol first, and of length
 **protocol_count**.  When acting as an **S2N_CLIENT** the protocol list is
 included in the Client Hello message as the ALPN extension.  As an
 **S2N_SERVER**, the list is used to negotiate a mutual application protocol
-with the client.
+with the client. After the negotiation for the connection has completed, the 
+agreed upon protocol will be stored in the application_protocol member of the s2n_connection object.
 
 ### s2n\_config\_set\_status\_request\_type
 

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -188,6 +188,12 @@ struct s2n_connection {
 
     /* TLS extension data */
     char server_name[256];
+
+    /* The application protocol decided upon during the client hello.
+     * If ALPN is being used, then:
+     * In server mode, this will be set by the time client_hello_cb is invoked.
+     * In client mode, this will be set after is_handshake_complete(connection) is true.
+     */
     char application_protocol[256];
     /* s2n does not support renegotiation.
      * RFC5746 Section 4.3 suggests servers implement a minimal version of the


### PR DESCRIPTION
…om what OpenSSL users may be expecting.

I pulled down the code with the intention of making a PR for exposing the application protocol back to the user, similar to the OpenSSL ALPN callback. It took me a while of reading the code to figure out I just need to check the application_protocol in the s2n_connection object, after the negotiation is finished.

In my use case, I need to dynamically discover the protocol after the connection has been negotiated so I can set the channel up for either H2 or Http 1.1. I can't imagine anyone working with ALPN doesn't need to do the same thing, some doc updates may save the user some time.