### PR TITLE
CMake support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,18 +137,18 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 if(BUILD_SHARED_LIBS)
-    target_include_directories(s2nShared PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include>)
+    target_include_directories(s2nShared PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
     target_include_directories(s2nShared PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api> $<INSTALL_INTERFACE:include>)
 endif()
 
-target_include_directories(s2nStatic PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include>)
+target_include_directories(s2nStatic PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 target_include_directories(s2nStatic PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api> $<INSTALL_INTERFACE:include>)
 
 file(GLOB TESTLIB_SRC "tests/testlib/*.c")
 file(GLOB TESTLIB_HEADERS "tests/testlib/*.h")
 
 add_library(testss2n STATIC ${TESTLIB_HEADERS} ${TESTLIB_SRC})
-target_include_directories(testss2n PUBLIC tests)
+target_include_directories(testss2n PRIVATE tests)
 target_link_libraries(testss2n PUBLIC s2nStatic)
 
 #run unit tests
@@ -182,12 +182,8 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 #install the s2n files
-install (FILES ${API_HEADERS} DESTINATION "include/s2n/api")
-install (FILES ${CRYPTO_HEADERS} DESTINATION "include/s2n/crypto")
-install (FILES ${ERROR_HEADERS} DESTINATION "include/s2n/error")
-install (FILES ${STUFFER_HEADERS} DESTINATION "include/s2n/stuffer")
-install (FILES ${TLS_HEADERS} DESTINATION "include/s2n/tls")
-install (FILES ${UTILS_HEADERS} DESTINATION "include/s2n/utils")
+install (FILES ${API_HEADERS} DESTINATION "include/")
+
 install (
          TARGETS ${export_targets}
          EXPORT "${PROJECT_NAME}-config"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ file(GLOB ERROR_SRC
     "error/*.c"
 )
 
-file(GLOB STUFFER_SOURCE
+file(GLOB STUFFER_SRC
     "stuffer/*.c"
 )
 
@@ -89,6 +89,10 @@ file(GLOB S2N_HEADERS
     ${TLS_SRC}
     ${UTILS_SRC}
  )
+
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
  
 add_library(s2nStatic STATIC ${S2N_HEADERS} ${S2N_SRC})
 add_library(s2nShared SHARED ${S2N_HEADERS} ${S2N_SRC})
@@ -107,8 +111,8 @@ target_compile_options(s2nShared PRIVATE -std=c99 -pedantic -Wall -Werror -Wimpl
 target_compile_definitions(s2nStatic PRIVATE -D_POSIX_C_SOURCE=200809L -D_FORTIFY_SOURCE=2)
 target_compile_definitions(s2nShared PRIVATE -D_POSIX_C_SOURCE=200809L -D_FORTIFY_SOURCE=2)
 
-target_compile_options(s2nStatic PUBLIC -fPIC -fgnu89-inline)    
-target_compile_options(s2nShared PUBLIC -fPIC -fgnu89-inline)
+target_compile_options(s2nStatic PUBLIC -fPIC)    
+target_compile_options(s2nShared PUBLIC -fPIC)
 
 if(NO_STACK_PROTECTOR)
     target_compile_options(s2nStatic PRIVATE -Wstack-protector -fstack-protector-all)
@@ -124,14 +128,14 @@ if(NOT LIBCRYPTO_ROOT)
     find_package(OpenSSL)   
     target_include_directories(s2nStatic PRIVATE ${OPENSSL_INCLUDE_DIR})
     target_include_directories(s2nShared PRIVATE ${OPENSSL_INCLUDE_DIR})
-    target_link_libraries(s2nStatic PRIVATE ${OS_LIBS} OpenSSL::Crypto)
-    target_link_libraries(s2nShared PRIVATE ${OS_LIBS} OpenSSL::Crypto)
+    target_link_libraries(s2nStatic PRIVATE ${OS_LIBS} PRIVATE OpenSSL::Crypto)
+    target_link_libraries(s2nShared PRIVATE ${OS_LIBS} PRIVATE OpenSSL::Crypto)
 else()
     target_include_directories(s2nStatic PRIVATE ${LIBCRYPTO_ROOT}/include)
     target_include_directories(s2nShared PRIVATE ${LIBCRYPTO_ROOT}/include)
     link_directories(${LIBCRYPTO_ROOT})
-    target_link_libraries(s2nStatic PRIVATE ${OS_LIBS} crypto)
-    target_link_libraries(s2nShared PRIVATE ${OS_LIBS} crypto)
+    target_link_libraries(s2nStatic PRIVATE ${OS_LIBS} PRIVATE crypto)
+    target_link_libraries(s2nShared PRIVATE ${OS_LIBS} PRIVATE crypto)
 endif()
 
 target_include_directories(s2nStatic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
@@ -146,28 +150,31 @@ file(GLOB TESTLIB_HEADERS "tests/testlib/*.h")
 
 add_library(testss2n SHARED ${TESTLIB_HEADERS} ${TESTLIB_SRC})
 target_include_directories(testss2n PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-target_link_libraries(testss2n PRIVATE s2nShared)
-# file(GLOB TEST_HDRS "tests/*.h")
-# file(GLOB TESTS ${TEST_HDRS} ${TEST_SRC})
-   
-# include_directories(${CMAKE_CURRENT_SOURCE_DIR}/tests)
-# add_executable(aws-io-tests ${TESTS} tests/event_loop_test.c)
-# target_link_libraries(aws-io-tests aws-io)
-# set_target_properties(aws-io-tests PROPERTIES LINKER_LANGUAGE C)
-# set_property(TARGET aws-io-tests PROPERTY C_STANDARD 99)
+target_link_libraries(testss2n PUBLIC s2nShared)
 
-#add_custom_command(TARGET aws-io-tests PRE_BUILD
-#        COMMAND ${CMAKE_COMMAND} -E copy_directory
-#        ${CMAKE_CURRENT_SOURCE_DIR}/tests/resources ${CMAKE_CURRENT_BINARY_DIR})
- 
-# include(CTest)
-# enable_testing()
- 
-# install (FILES ${AWS_IO_HEADERS} DESTINATION "include/aws/io")
-# install (
- #         TARGETS ${PROJECT_NAME}
- #         EXPORT "${PROJECT_NAME}-targets"
- #         ARCHIVE DESTINATION lib
- #         LIBRARY DESTINATION lib
- #         COMPONENT library     
- #)
+file (GLOB TEST_LD_PRELOAD "tests/LD_PRELOAD/*.c")
+add_library(allocator_overrides SHARED ${TEST_LD_PRELOAD})
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/tests/pems
+        DESTINATION ${CMAKE_BINARY_DIR})
+
+include(CTest)
+enable_testing()
+
+file(GLOB UNITTESTS_SRC "tests/unit/*.c")
+    foreach(test_case ${UNITTESTS_SRC})
+    string(REGEX REPLACE ".+\\/(.+)\\.c" "\\1" test_case_name ${test_case})
+    add_executable(${test_case_name} ${test_case})
+    target_link_libraries(${test_case_name} PRIVATE testss2n PRIVATE m pthread)
+    target_include_directories(${test_case_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/api)
+    target_include_directories(${test_case_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+    target_include_directories(${test_case_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+    add_test(NAME ${test_case_name} COMMAND $<TARGET_FILE:${test_case_name}> WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+   
+    set_property(
+    TEST
+        ${test_case_name}
+    PROPERTY
+        ENVIRONMENT LD_PRELOAD=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/liballocator_overrides.so)
+
+endforeach(test_case)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,68 +88,39 @@ file(GLOB S2N_HEADERS
     ${TLS_SRC}
     ${UTILS_SRC}
  )
- 
-if(BUILD_SHARED_LIBS)
-    add_library(s2nShared SHARED ${S2N_HEADERS} ${S2N_SRC})
-    set_target_properties(s2nShared PROPERTIES OUTPUT_NAME s2n)
-    set_target_properties(s2nShared PROPERTIES LINKER_LANGUAGE C) 
-endif()
 
-add_library(s2nStatic STATIC ${S2N_HEADERS} ${S2N_SRC})
-set_target_properties(s2nStatic PROPERTIES OUTPUT_NAME s2n)
-set_target_properties(s2nStatic PROPERTIES LINKER_LANGUAGE C)
+add_library(s2n ${S2N_HEADERS} ${S2N_SRC})
+set_target_properties(s2n PROPERTIES LINKER_LANGUAGE C)
 
 set(CMAKE_C_FLAGS_DEBUGOPT "")
 
-if(BUILD_SHARED_LIBS)
-    target_compile_options(s2nShared PRIVATE -std=c99 -pedantic -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-subscripts -Wuninitialized -Wshadow -Wcast-qual -Wcast-align -Wwrite-strings -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security)
-    target_compile_definitions(s2nShared PRIVATE -D_POSIX_C_SOURCE=200809L -D_FORTIFY_SOURCE=2)
-    target_compile_options(s2nShared PUBLIC -fPIC)
-endif()
-
-target_compile_options(s2nStatic PRIVATE -std=c99 -pedantic -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-subscripts -Wuninitialized -Wshadow -Wcast-qual -Wcast-align -Wwrite-strings -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security)
-target_compile_definitions(s2nStatic PRIVATE -D_POSIX_C_SOURCE=200809L -D_FORTIFY_SOURCE=2)
-target_compile_options(s2nStatic PUBLIC -fPIC)    
+target_compile_options(s2n PRIVATE -pedantic -std=c99 -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-subscripts -Wuninitialized -Wshadow -Wcast-qual -Wcast-align -Wwrite-strings -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security)
+target_compile_definitions(s2n PRIVATE -D_POSIX_C_SOURCE=200809L -D_FORTIFY_SOURCE=2)
+target_compile_options(s2n PUBLIC -fPIC)    
 
 if(NO_STACK_PROTECTOR)
-    target_compile_options(s2nStatic PRIVATE -Wstack-protector -fstack-protector-all)
-
-    if(BUILD_SHARED_LIBS)
-        target_compile_options(s2nShared PRIVATE -Wstack-protector -fstack-protector-all)
-    endif()
+    target_compile_options(s2n PRIVATE -Wstack-protector -fstack-protector-all)
 endif()
 
 if(S2N_UNSAFE_FUZZING_MODE)
-    target_compile_options(s2nStatic PRIVATE -fsanitize-coverage=trace-pc-guard -fsanitize=address,undefined,leak)
-
-    if(BUILD_SHARED_LIBS)
-        target_compile_options(s2nShared PRIVATE -fsanitize-coverage=trace-pc-guard -fsanitize=address,undefined,leak)
-    endif()
+    target_compile_options(s2n PRIVATE -fsanitize-coverage=trace-pc-guard -fsanitize=address,undefined,leak)
 endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 
 find_package(LibCrypto REQUIRED)
-target_link_libraries(s2nStatic PRIVATE LibCrypto::Crypto PRIVATE ${OS_LIBS})
+target_link_libraries(s2n PRIVATE LibCrypto::Crypto PRIVATE ${OS_LIBS})
 
-if(BUILD_SHARED_LIBS)
-    target_link_libraries(s2nShared PRIVATE LibCrypto::Crypto PRIVATE ${OS_LIBS})
-endif()
-
-if(BUILD_SHARED_LIBS)
-    target_include_directories(s2nShared PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
-    target_include_directories(s2nShared PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api> $<INSTALL_INTERFACE:include>)
-endif()
-
-target_include_directories(s2nStatic PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
-target_include_directories(s2nStatic PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api> $<INSTALL_INTERFACE:include>)
+target_include_directories(s2n PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+target_include_directories(s2n PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api> $<INSTALL_INTERFACE:include>)
 
 file(GLOB TESTLIB_SRC "tests/testlib/*.c")
 file(GLOB TESTLIB_HEADERS "tests/testlib/*.h")
 
-add_library(testss2n STATIC ${TESTLIB_HEADERS} ${TESTLIB_SRC})
+add_library(testss2n ${TESTLIB_HEADERS} ${TESTLIB_SRC})
 target_include_directories(testss2n PRIVATE tests)
-target_link_libraries(testss2n PUBLIC s2nStatic)
+target_compile_options(testss2n PRIVATE -std=c99)
+target_link_libraries(testss2n PUBLIC s2n)
 
 #run unit tests
 file (GLOB TEST_LD_PRELOAD "tests/LD_PRELOAD/*.c")
@@ -166,6 +137,7 @@ file(GLOB UNITTESTS_SRC "tests/unit/*.c")
     target_include_directories(${test_case_name} PRIVATE api)
     target_include_directories(${test_case_name} PRIVATE ./)
     target_include_directories(${test_case_name} PRIVATE tests)
+    target_compile_options(${test_case_name} PRIVATE -Wno-implicit-function-declaration -std=c99)
     add_test(NAME ${test_case_name} COMMAND $<TARGET_FILE:${test_case_name}> WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit)
    
     set_property(
@@ -176,16 +148,11 @@ file(GLOB UNITTESTS_SRC "tests/unit/*.c")
 
 endforeach(test_case)
 
-set(export_targets s2nStatic)
-if(BUILD_SHARED_LIBS)
-    set(export_targets s2nStatic s2nShared)
-endif()
-
 #install the s2n files
 install (FILES ${API_HEADERS} DESTINATION "include/")
 
 install (
-         TARGETS ${export_targets}
+         TARGETS s2n
          EXPORT "${PROJECT_NAME}-config"
          ARCHIVE DESTINATION lib
          LIBRARY DESTINATION lib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,10 +89,6 @@ file(GLOB S2N_HEADERS
     ${TLS_SRC}
     ${UTILS_SRC}
  )
-
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
  
 add_library(s2nStatic STATIC ${S2N_HEADERS} ${S2N_SRC})
 add_library(s2nShared SHARED ${S2N_HEADERS} ${S2N_SRC})
@@ -138,10 +134,10 @@ else()
     target_link_libraries(s2nShared PRIVATE ${OS_LIBS} PRIVATE crypto)
 endif()
 
-target_include_directories(s2nStatic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_include_directories(s2nShared PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_include_directories(s2nStatic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/api)
-target_include_directories(s2nShared PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/api)
+target_include_directories(s2nStatic PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include>)
+target_include_directories(s2nShared PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include>)
+target_include_directories(s2nStatic PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api> $<INSTALL_INTERFACE:include>)
+target_include_directories(s2nShared PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api> $<INSTALL_INTERFACE:include>)
 target_link_libraries(s2nStatic PRIVATE ${OS_LIBS} OpenSSL::Crypto)
 target_link_libraries(s2nShared PRIVATE ${OS_LIBS} OpenSSL::Crypto) 
 
@@ -149,14 +145,12 @@ file(GLOB TESTLIB_SRC "tests/testlib/*.c")
 file(GLOB TESTLIB_HEADERS "tests/testlib/*.h")
 
 add_library(testss2n SHARED ${TESTLIB_HEADERS} ${TESTLIB_SRC})
-target_include_directories(testss2n PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+target_include_directories(testss2n PUBLIC tests)
 target_link_libraries(testss2n PUBLIC s2nShared)
 
+#run unit tests
 file (GLOB TEST_LD_PRELOAD "tests/LD_PRELOAD/*.c")
 add_library(allocator_overrides SHARED ${TEST_LD_PRELOAD})
-
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/tests/pems
-        DESTINATION ${CMAKE_BINARY_DIR})
 
 include(CTest)
 enable_testing()
@@ -166,15 +160,34 @@ file(GLOB UNITTESTS_SRC "tests/unit/*.c")
     string(REGEX REPLACE ".+\\/(.+)\\.c" "\\1" test_case_name ${test_case})
     add_executable(${test_case_name} ${test_case})
     target_link_libraries(${test_case_name} PRIVATE testss2n PRIVATE m pthread)
-    target_include_directories(${test_case_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/api)
-    target_include_directories(${test_case_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-    target_include_directories(${test_case_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-    add_test(NAME ${test_case_name} COMMAND $<TARGET_FILE:${test_case_name}> WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+    target_include_directories(${test_case_name} PRIVATE api)
+    target_include_directories(${test_case_name} PRIVATE ./})
+    target_include_directories(${test_case_name} PRIVATE tests)
+    add_test(NAME ${test_case_name} COMMAND $<TARGET_FILE:${test_case_name}> WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit)
    
     set_property(
     TEST
         ${test_case_name}
     PROPERTY
-        ENVIRONMENT LD_PRELOAD=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/liballocator_overrides.so)
+        ENVIRONMENT LD_PRELOAD=$<TARGET_FILE:allocator_overrides>)
 
 endforeach(test_case)
+
+#install the s2n files
+install (FILES ${API_HEADERS} DESTINATION "include/s2n/api")
+install (FILES ${CRYPTO_HEADERS} DESTINATION "include/s2n/crypto")
+install (FILES ${ERROR_HEADERS} DESTINATION "include/s2n/error")
+install (FILES ${STUFFER_HEADERS} DESTINATION "include/s2n/stuffer")
+install (FILES ${TLS_HEADERS} DESTINATION "include/s2n/tls")
+install (FILES ${UTILS_HEADERS} DESTINATION "include/s2n/utils")
+install (
+         TARGETS s2nStatic s2nShared
+         EXPORT "${PROJECT_NAME}-config"
+         ARCHIVE DESTINATION lib
+         LIBRARY DESTINATION lib
+         COMPONENT library     
+)
+
+export(TARGETS s2nStatic s2nShared FILE "s2n-config.cmake")
+#install the cmake finder
+install(EXPORT s2n-config DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/s2n/cmake/")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,173 @@
+cmake_minimum_required (VERSION 3.0)
+project (s2n)
+
+##header files
+file(GLOB API_HEADERS
+     "api/*.h"
+)
+
+file(GLOB CRYPTO_HEADERS
+    "crypto/*.h"
+)
+
+file(GLOB ERROR_HEADERS
+    "error/*.h"
+)
+
+file(GLOB STUFFER_HEADERS
+    "stuffer/*.h"
+)
+
+file(GLOB TLS_HEADERS
+    "tls/*.h"
+)
+
+file(GLOB UTILS_HEADERS
+    "utils/*.h"
+)
+ 
+ ##source files
+ file(GLOB CRYPTO_SRC
+     "crypto/*.c"
+ )
+
+file(GLOB ERROR_SRC
+    "error/*.c"
+)
+
+file(GLOB STUFFER_SOURCE
+    "stuffer/*.c"
+)
+
+file(GLOB TLS_SRC
+    "tls/*.c"
+)
+
+file(GLOB UTILS_SRC
+    "utils/*.c"
+)
+
+##be nice to visutal studio users
+if(MSVC)
+    source_group("Header Files\\s2n\\api" FILES ${API_HEADERS})
+    source_group("Header Files\\s2n\\crypto" FILES ${CRYPTO_HEADERS})
+    source_group("Header Files\\s2n\\error" FILES ${ERROR_HEADERS})
+    source_group("Header Files\\s2n\\stuffer" FILES ${STUFFER_HEADERS})
+    source_group("Header Files\\s2n\\tls" FILES ${TLS_HEADERS})
+    source_group("Header Files\\s2n\\utils" FILES ${UTILS_HEADERS})
+
+    source_group("Source Files\\crypto" FILES ${CRYPTO_SRC})
+    source_group("Source Files\\error" FILES ${ERROR_SRC})
+    source_group("Source Files\\stuffer" FILES ${STUFFER_SRC})
+    source_group("Source Files\\tls" FILES ${TLS_SRC})
+    source_group("Source Files\\utils" FILES ${UTILS_SRC})
+endif()
+
+if(APPLE)
+    set(OS_LIBS c pthread)        
+elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+    set(OS_LIBS thr)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "NetBSD")
+    set(OS_LIBS pthread)
+else()
+    set(OS_LIBS pthread dl rt)
+endif()
+ 
+file(GLOB S2N_HEADERS
+    ${API_HEADERS}
+    ${CRYPTO_HEADERS}
+    ${ERROR_HEADERS}
+    ${STUFFER_HEADERS}
+    ${TLS_HEADERS}
+    ${UTILS_HEADERS}
+ )
+ 
+ file(GLOB S2N_SRC
+    ${CRYPTO_SRC}
+    ${ERROR_SRC}
+    ${STUFFER_SRC}
+    ${TLS_SRC}
+    ${UTILS_SRC}
+ )
+ 
+add_library(s2nStatic STATIC ${S2N_HEADERS} ${S2N_SRC})
+add_library(s2nShared SHARED ${S2N_HEADERS} ${S2N_SRC})
+set_target_properties(s2nStatic PROPERTIES OUTPUT_NAME s2n)
+set_target_properties(s2nShared PROPERTIES OUTPUT_NAME s2n)
+
+set_target_properties(s2nStatic PROPERTIES LINKER_LANGUAGE C)
+set_target_properties(s2nShared PROPERTIES LINKER_LANGUAGE C) 
+
+set(CMAKE_C_FLAGS_DEBUGOPT "")
+
+target_compile_options(s2nStatic PRIVATE -std=c99 -pedantic -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-subscripts -Wuninitialized -Wshadow -Wcast-qual -Wcast-align -Wwrite-strings -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security)
+
+target_compile_options(s2nShared PRIVATE -std=c99 -pedantic -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-subscripts -Wuninitialized -Wshadow -Wcast-qual -Wcast-align -Wwrite-strings -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security)
+
+target_compile_definitions(s2nStatic PRIVATE -D_POSIX_C_SOURCE=200809L -D_FORTIFY_SOURCE=2)
+target_compile_definitions(s2nShared PRIVATE -D_POSIX_C_SOURCE=200809L -D_FORTIFY_SOURCE=2)
+
+target_compile_options(s2nStatic PUBLIC -fPIC -fgnu89-inline)    
+target_compile_options(s2nShared PUBLIC -fPIC -fgnu89-inline)
+
+if(NO_STACK_PROTECTOR)
+    target_compile_options(s2nStatic PRIVATE -Wstack-protector -fstack-protector-all)
+    target_compile_options(s2nShared PRIVATE -Wstack-protector -fstack-protector-all)
+endif()
+
+if(S2N_UNSAFE_FUZZING_MODE)
+    target_compile_options(s2nStatic PRIVATE -fsanitize-coverage=trace-pc-guard -fsanitize=address,undefined,leak)
+    target_compile_options(s2nShared PRIVATE -fsanitize-coverage=trace-pc-guard -fsanitize=address,undefined,leak)
+endif()
+
+if(NOT LIBCRYPTO_ROOT)
+    find_package(OpenSSL)   
+    target_include_directories(s2nStatic PRIVATE ${OPENSSL_INCLUDE_DIR})
+    target_include_directories(s2nShared PRIVATE ${OPENSSL_INCLUDE_DIR})
+    target_link_libraries(s2nStatic PRIVATE ${OS_LIBS} OpenSSL::Crypto)
+    target_link_libraries(s2nShared PRIVATE ${OS_LIBS} OpenSSL::Crypto)
+else()
+    target_include_directories(s2nStatic PRIVATE ${LIBCRYPTO_ROOT}/include)
+    target_include_directories(s2nShared PRIVATE ${LIBCRYPTO_ROOT}/include)
+    link_directories(${LIBCRYPTO_ROOT})
+    target_link_libraries(s2nStatic PRIVATE ${OS_LIBS} crypto)
+    target_link_libraries(s2nShared PRIVATE ${OS_LIBS} crypto)
+endif()
+
+target_include_directories(s2nStatic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(s2nShared PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(s2nStatic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/api)
+target_include_directories(s2nShared PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/api)
+target_link_libraries(s2nStatic PRIVATE ${OS_LIBS} OpenSSL::Crypto)
+target_link_libraries(s2nShared PRIVATE ${OS_LIBS} OpenSSL::Crypto) 
+
+file(GLOB TESTLIB_SRC "tests/testlib/*.c")
+file(GLOB TESTLIB_HEADERS "tests/testlib/*.h")
+
+add_library(testss2n SHARED ${TESTLIB_HEADERS} ${TESTLIB_SRC})
+target_include_directories(testss2n PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+target_link_libraries(testss2n PRIVATE s2nShared)
+# file(GLOB TEST_HDRS "tests/*.h")
+# file(GLOB TESTS ${TEST_HDRS} ${TEST_SRC})
+   
+# include_directories(${CMAKE_CURRENT_SOURCE_DIR}/tests)
+# add_executable(aws-io-tests ${TESTS} tests/event_loop_test.c)
+# target_link_libraries(aws-io-tests aws-io)
+# set_target_properties(aws-io-tests PROPERTIES LINKER_LANGUAGE C)
+# set_property(TARGET aws-io-tests PROPERTY C_STANDARD 99)
+
+#add_custom_command(TARGET aws-io-tests PRE_BUILD
+#        COMMAND ${CMAKE_COMMAND} -E copy_directory
+#        ${CMAKE_CURRENT_SOURCE_DIR}/tests/resources ${CMAKE_CURRENT_BINARY_DIR})
+ 
+# include(CTest)
+# enable_testing()
+ 
+# install (FILES ${AWS_IO_HEADERS} DESTINATION "include/aws/io")
+# install (
+ #         TARGETS ${PROJECT_NAME}
+ #         EXPORT "${PROJECT_NAME}-targets"
+ #         ARCHIVE DESTINATION lib
+ #         LIBRARY DESTINATION lib
+ #         COMPONENT library     
+ #)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required (VERSION 3.0)
 project (s2n)
-
 ##header files
 file(GLOB API_HEADERS
      "api/*.h"
@@ -47,7 +46,7 @@ file(GLOB UTILS_SRC
     "utils/*.c"
 )
 
-##be nice to visutal studio users
+##be nice to visual studio users
 if(MSVC)
     source_group("Header Files\\s2n\\api" FILES ${API_HEADERS})
     source_group("Header Files\\s2n\\crypto" FILES ${CRYPTO_HEADERS})
@@ -90,63 +89,67 @@ file(GLOB S2N_HEADERS
     ${UTILS_SRC}
  )
  
-add_library(s2nStatic STATIC ${S2N_HEADERS} ${S2N_SRC})
-add_library(s2nShared SHARED ${S2N_HEADERS} ${S2N_SRC})
-set_target_properties(s2nStatic PROPERTIES OUTPUT_NAME s2n)
-set_target_properties(s2nShared PROPERTIES OUTPUT_NAME s2n)
+if(BUILD_SHARED_LIBS)
+    add_library(s2nShared SHARED ${S2N_HEADERS} ${S2N_SRC})
+    set_target_properties(s2nShared PROPERTIES OUTPUT_NAME s2n)
+    set_target_properties(s2nShared PROPERTIES LINKER_LANGUAGE C) 
+endif()
 
+add_library(s2nStatic STATIC ${S2N_HEADERS} ${S2N_SRC})
+set_target_properties(s2nStatic PROPERTIES OUTPUT_NAME s2n)
 set_target_properties(s2nStatic PROPERTIES LINKER_LANGUAGE C)
-set_target_properties(s2nShared PROPERTIES LINKER_LANGUAGE C) 
 
 set(CMAKE_C_FLAGS_DEBUGOPT "")
 
+if(BUILD_SHARED_LIBS)
+    target_compile_options(s2nShared PRIVATE -std=c99 -pedantic -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-subscripts -Wuninitialized -Wshadow -Wcast-qual -Wcast-align -Wwrite-strings -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security)
+    target_compile_definitions(s2nShared PRIVATE -D_POSIX_C_SOURCE=200809L -D_FORTIFY_SOURCE=2)
+    target_compile_options(s2nShared PUBLIC -fPIC)
+endif()
+
 target_compile_options(s2nStatic PRIVATE -std=c99 -pedantic -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-subscripts -Wuninitialized -Wshadow -Wcast-qual -Wcast-align -Wwrite-strings -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security)
-
-target_compile_options(s2nShared PRIVATE -std=c99 -pedantic -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-subscripts -Wuninitialized -Wshadow -Wcast-qual -Wcast-align -Wwrite-strings -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security)
-
 target_compile_definitions(s2nStatic PRIVATE -D_POSIX_C_SOURCE=200809L -D_FORTIFY_SOURCE=2)
-target_compile_definitions(s2nShared PRIVATE -D_POSIX_C_SOURCE=200809L -D_FORTIFY_SOURCE=2)
-
 target_compile_options(s2nStatic PUBLIC -fPIC)    
-target_compile_options(s2nShared PUBLIC -fPIC)
 
 if(NO_STACK_PROTECTOR)
     target_compile_options(s2nStatic PRIVATE -Wstack-protector -fstack-protector-all)
-    target_compile_options(s2nShared PRIVATE -Wstack-protector -fstack-protector-all)
+
+    if(BUILD_SHARED_LIBS)
+        target_compile_options(s2nShared PRIVATE -Wstack-protector -fstack-protector-all)
+    endif()
 endif()
 
 if(S2N_UNSAFE_FUZZING_MODE)
     target_compile_options(s2nStatic PRIVATE -fsanitize-coverage=trace-pc-guard -fsanitize=address,undefined,leak)
-    target_compile_options(s2nShared PRIVATE -fsanitize-coverage=trace-pc-guard -fsanitize=address,undefined,leak)
+
+    if(BUILD_SHARED_LIBS)
+        target_compile_options(s2nShared PRIVATE -fsanitize-coverage=trace-pc-guard -fsanitize=address,undefined,leak)
+    endif()
 endif()
 
-if(NOT LIBCRYPTO_ROOT)
-    find_package(OpenSSL)   
-    target_include_directories(s2nStatic PRIVATE ${OPENSSL_INCLUDE_DIR})
-    target_include_directories(s2nShared PRIVATE ${OPENSSL_INCLUDE_DIR})
-    target_link_libraries(s2nStatic PRIVATE ${OS_LIBS} PRIVATE OpenSSL::Crypto)
-    target_link_libraries(s2nShared PRIVATE ${OS_LIBS} PRIVATE OpenSSL::Crypto)
-else()
-    target_include_directories(s2nStatic PRIVATE ${LIBCRYPTO_ROOT}/include)
-    target_include_directories(s2nShared PRIVATE ${LIBCRYPTO_ROOT}/include)
-    link_directories(${LIBCRYPTO_ROOT})
-    target_link_libraries(s2nStatic PRIVATE ${OS_LIBS} PRIVATE crypto)
-    target_link_libraries(s2nShared PRIVATE ${OS_LIBS} PRIVATE crypto)
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
+
+find_package(LibCrypto REQUIRED)
+target_link_libraries(s2nStatic PRIVATE LibCrypto::Crypto PRIVATE ${OS_LIBS})
+
+if(BUILD_SHARED_LIBS)
+    target_link_libraries(s2nShared PRIVATE LibCrypto::Crypto PRIVATE ${OS_LIBS})
+endif()
+
+if(BUILD_SHARED_LIBS)
+    target_include_directories(s2nShared PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include>)
+    target_include_directories(s2nShared PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api> $<INSTALL_INTERFACE:include>)
 endif()
 
 target_include_directories(s2nStatic PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include>)
-target_include_directories(s2nShared PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include>)
 target_include_directories(s2nStatic PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api> $<INSTALL_INTERFACE:include>)
-target_include_directories(s2nShared PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api> $<INSTALL_INTERFACE:include>)
-target_link_libraries(s2nStatic PRIVATE ${OS_LIBS} OpenSSL::Crypto)
-target_link_libraries(s2nShared PRIVATE ${OS_LIBS} OpenSSL::Crypto) 
 
 file(GLOB TESTLIB_SRC "tests/testlib/*.c")
 file(GLOB TESTLIB_HEADERS "tests/testlib/*.h")
 
-add_library(testss2n SHARED ${TESTLIB_HEADERS} ${TESTLIB_SRC})
+add_library(testss2n STATIC ${TESTLIB_HEADERS} ${TESTLIB_SRC})
 target_include_directories(testss2n PUBLIC tests)
-target_link_libraries(testss2n PUBLIC s2nShared)
+target_link_libraries(testss2n PUBLIC s2nStatic)
 
 #run unit tests
 file (GLOB TEST_LD_PRELOAD "tests/LD_PRELOAD/*.c")
@@ -161,7 +164,7 @@ file(GLOB UNITTESTS_SRC "tests/unit/*.c")
     add_executable(${test_case_name} ${test_case})
     target_link_libraries(${test_case_name} PRIVATE testss2n PRIVATE m pthread)
     target_include_directories(${test_case_name} PRIVATE api)
-    target_include_directories(${test_case_name} PRIVATE ./})
+    target_include_directories(${test_case_name} PRIVATE ./)
     target_include_directories(${test_case_name} PRIVATE tests)
     add_test(NAME ${test_case_name} COMMAND $<TARGET_FILE:${test_case_name}> WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit)
    
@@ -173,6 +176,11 @@ file(GLOB UNITTESTS_SRC "tests/unit/*.c")
 
 endforeach(test_case)
 
+set(export_targets s2nStatic)
+if(BUILD_SHARED_LIBS)
+    set(export_targets s2nStatic s2nShared)
+endif()
+
 #install the s2n files
 install (FILES ${API_HEADERS} DESTINATION "include/s2n/api")
 install (FILES ${CRYPTO_HEADERS} DESTINATION "include/s2n/crypto")
@@ -181,13 +189,13 @@ install (FILES ${STUFFER_HEADERS} DESTINATION "include/s2n/stuffer")
 install (FILES ${TLS_HEADERS} DESTINATION "include/s2n/tls")
 install (FILES ${UTILS_HEADERS} DESTINATION "include/s2n/utils")
 install (
-         TARGETS s2nStatic s2nShared
+         TARGETS ${export_targets}
          EXPORT "${PROJECT_NAME}-config"
          ARCHIVE DESTINATION lib
          LIBRARY DESTINATION lib
          COMPONENT library     
 )
 
-export(TARGETS s2nStatic s2nShared FILE "s2n-config.cmake")
+export(TARGETS ${export_targets} FILE "s2n-config.cmake")
 #install the cmake finder
 install(EXPORT s2n-config DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/s2n/cmake/")

--- a/cmake/modules/FindLibCrypto.cmake
+++ b/cmake/modules/FindLibCrypto.cmake
@@ -1,0 +1,62 @@
+# - Try to find boringssl include dirs and libraries
+#
+# Usage of this module as follows:
+#
+#     find_package(LibCrypto)
+#
+# Variables used by this module, they can change the default behaviour and need
+# to be set before calling find_package:
+#
+#  LibCrypto_ROOT_DIR        Set this variable to the root installation of
+#                            anything using libcrypto if the module has problems finding the
+#                            proper installation path.
+#
+# Variables defined by this module:
+#
+#  LibCrypto_FOUND             System has libcrypto, include and library dirs found
+#  LibCrypto_INCLUDE_DIR       The crypto include directories.
+#  LibCrypto_LIBRARY    The crypto library.
+
+find_path(LibCrypto_ROOT_DIR
+        NAMES include/openssl/crypto.h 
+        HINTS ${LibCrypto_ROOT_DIR}
+        )
+
+find_path(LibCrypto_INCLUDE_DIR
+        NAMES openssl/crypto.h
+        HINTS ${LibCrypto_ROOT_DIR}/include
+        )
+
+find_library(LibCrypto_LIBRARY
+        NAMES libcrypto.a libcrypto.so
+        HINTS ${LibCrypto_ROOT_DIR}/build/crypto
+        ${LibCrypto_ROOT_DIR}/build
+        ${LibCrypto_ROOT_DIR}
+        ${LibCrypto_ROOT_DIR}/lib 
+       )
+
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LibCrypto DEFAULT_MSG
+        LibCrypto_LIBRARY
+        LibCrypto_INCLUDE_DIR
+        )
+
+mark_as_advanced(
+        LibCrypto_ROOT_DIR
+        LibCrypto_INCLUDE_DIR
+        LibCrypto_LIBRARY
+)
+
+if(LibCrypto_FOUND)
+  if(NOT TARGET LibCrypto::Crypto AND
+      (EXISTS "${LibCrypto_LIBRARY}")
+      )
+    add_library(LibCrypto::Crypto UNKNOWN IMPORTED)
+    set_target_properties(LibCrypto::Crypto PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${LibCrypto_INCLUDE_DIR}")
+    set_target_properties(LibCrypto::Crypto PROPERTIES
+        IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+        IMPORTED_LOCATION "${LibCrypto_LIBRARY}")
+  endif()
+endif()

--- a/cmake/modules/FindLibCrypto.cmake
+++ b/cmake/modules/FindLibCrypto.cmake
@@ -1,4 +1,4 @@
-# - Try to find boringssl include dirs and libraries
+# - Try to find LibCrypto include dirs and libraries
 #
 # Usage of this module as follows:
 #

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -9,14 +9,75 @@ cd s2n
 ```
 
 ## Building s2n with existing libcrypto
-
+### make Instructions
 To build s2n with an existing libcrypto installation, store its root folder in the
 `LIBCRYPTO_ROOT` environment variable.
 ```shell
 # /usr/local/ssl/lib should contain libcrypto.a
 LIBCRYPTO_ROOT=/usr/local/ssl make
 ```
+### CMake Instructions
 
+Throughout this document, there are instructions for setting a `LIBCRYPTO_ROOT` environment variable, or setting install prefixes to `s2n/lib-crypto-root`. If you 
+are using CMake that step is unnecessary. Just follow the instructions here to use any build of libcrypto.
+
+(Required): You need at least CMake version 3.0 to fully benefit from Modern CMake. See [this](https://www.youtube.com/watch?v=bsXLMQ6WgIk) for more information.
+
+(Optional): Set the CMake variable `LIBCRYPTO_ROOT_DIR` to any libcrypto build on your machine. If you do not,
+the default installation on your machine will be used.
+
+(Optional): Set the CMake variable `BUILD_SHARED_LIBS=ON` to build shared libraries. The default is static.
+ 
+We recommend an out-of-source build. Suppose you have a directory `s2n` which contains the s2n source code. At the same level
+we can create a directory called `s2n-build`
+
+For example, we can build and install shared libs using ninja as our build system, and the system libcrypto implementation.
+
+````shell
+mkdir s2n-build
+cd s2n-build
+cmake ../s2n -DBUILD_SHARED_LIBS=ON -GNinja
+ninja
+ninja test 
+sudo ninja install
+````
+
+For another example, we can prepare an Xcode project using static libs using a libcrypto implementation in the directory `$HOME/s2n-user/builds/libcrypto-impl`.
+
+````shell
+mkdir s2n-build
+cd s2n-build
+cmake ../s2n -DLIBCRYPTO_ROOT_DIR=$HOME/s2n-user/builds/libcrypto-impl -G "Xcode"
+# now open the project in Xcode and build from there, or use the Xcode CLI
+````
+
+Or, for unix style vanilla builds:
+
+````shell
+mkdir s2n-build
+cd s2n-build
+cmake ../s2n
+make
+make test
+sudo make install
+````
+
+### Consuming s2n via. CMake
+s2n ships with modern CMake finder scripts if CMake is used for the build. To take advantage of this from your CMake script, all you need to do to compile and link against s2n in your project is:
+
+````shell
+find_package(s2n)
+
+....
+
+target_link_libraries(yourExecutableOrLibrary s2n)
+````
+
+And when invoking CMake for your project, do one of three things:
+ 1. Append the `CMAKE_PREFIX_PATH` variable with the path to your s2n build.
+ 2. Set the `s2n_DIR` CMake variable
+ 3. If you have globally installed s2n, do nothing, it will automatically be found.
+ 
 ## Building s2n with OpenSSL-1.1.0
 
 To build s2n with OpenSSL-1.1.0, do the following:

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -24,7 +24,7 @@
 /* NULL check a pointer */
 #define notnull_check( ptr )           do { if ( (ptr) == NULL ) { S2N_ERROR(S2N_ERR_NULL); } } while(0)
 
-extern inline void* trace_memcpy_check(void *restrict to, const void *restrict from, size_t size, const char *debug_str)
+static inline void* trace_memcpy_check(void *restrict to, const void *restrict from, size_t size, const char *debug_str)
 {
     if (to == NULL || from == NULL) {
         s2n_errno = S2N_ERR_NULL;


### PR DESCRIPTION
This has several nice benefits. 
First, we can use this as part of a CMake build.

Second, we can use find_package to import the target into another build. 

Third we can use any build system CMake supports, so, for example we can use Ninja instead of Make.

Fourth, the build is out of source (which is more ideal)

Fifth, the cflags interface is clean. ABI changing flags are the only ones exported to the user.

Sixth, the dependency map is clean. Only linker flags the customer needs to know about end up in the user's dependency closure.

Seventh, the LIB_CRYPTO_ROOT stuff can go away completely, and the user can use CMAKE_PREFIX_PATH to inject the correct location and the build can pick it up. This isn't implemented yet, but it will be on my next pass.

Eighth, the project will just load in most IDE's ready to use (and already compiling). Visual Studio, CLion, etc...

I haven't implemented fuzz or integration tests yet. This can't replace make yet, simply because internal builds need to be updated as well.

To test on your end:

after cloning the code to a folder named s2n,

    mkdir s2n-build
    cd s2n-build
    cmake ../s2n -G "Ninja" ##if you do this without -G, it will just use make
    ninja
    ninja test
    sudo ninja install

or alternatively:

    mkdir s2n-build
    cd s2n-build
    cmake ../s2n 
    make
    make test
    sudo make install
