### PR TITLE
Do not quote strings that should be subject to word splitting

### DIFF
--- a/.travis/install_ctverif_dependencies.sh
+++ b/.travis/install_ctverif_dependencies.sh
@@ -36,7 +36,7 @@ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328
 
 #    echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
 sudo apt-get update
-sudo apt-get install -y "${DEPENDENCIES}"
+sudo apt-get install -y ${DEPENDENCIES}
 sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.7 20
 sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.7 20
 sudo update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-3.7 20

--- a/.travis/install_ubuntu_dependencies.sh
+++ b/.travis/install_ubuntu_dependencies.sh
@@ -20,7 +20,7 @@ sudo apt-get update
 
 DEPENDENCIES="indent kwstyle"
 
-sudo apt-get install -y "${DEPENDENCIES}"
+sudo apt-get install -y ${DEPENDENCIES}
 
 if [[ "$GCC6_REQUIRED" == "true" ]]; then
     sudo apt-get -y install gcc-6;


### PR DESCRIPTION
These were false positives reported by shellcheck.

Follow-up to: 7f05280be5