### PR TITLE
Fix forward declaration of accept_all_rsa_certs

### DIFF
--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -59,7 +59,7 @@ void usage()
 extern void print_s2n_error(const char *app_error);
 extern int echo(struct s2n_connection *conn, int sockfd);
 extern int negotiate(struct s2n_connection *conn);
-extern int accept_all_rsa_certs(struct s2n_connection *conn, uint8_t *cert_chain_in, uint32_t cert_chain_len, struct s2n_cert_public_key *public_key_out, void *context);
+extern s2n_cert_validation_code accept_all_rsa_certs(struct s2n_connection *conn, uint8_t *cert_chain_in, uint32_t cert_chain_len, struct s2n_cert_public_key *public_key_out, void *context);
 
 int main(int argc, char *const *argv)
 {

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -230,7 +230,7 @@ int cache_delete(void *ctx, const void *key, uint64_t key_size)
 extern void print_s2n_error(const char *app_error);
 extern int echo(struct s2n_connection *conn, int sockfd);
 extern int negotiate(struct s2n_connection *conn);
-extern int accept_all_rsa_certs(struct s2n_connection *conn, uint8_t *cert_chain_in, uint32_t cert_chain_len, struct s2n_cert_public_key *public_key_out, void *context);
+extern s2n_cert_validation_code accept_all_rsa_certs(struct s2n_connection *conn, uint8_t *cert_chain_in, uint32_t cert_chain_len, struct s2n_cert_public_key *public_key_out, void *context);
 
 /* Caller is expected to free the memory returned. */
 static char *load_file_to_cstring(const char *path)


### PR DESCRIPTION
Cleanup to make more type-sensitive compilers like goto-cc happy.