### PR TITLE
Add partial acknowledgement to non-blocking s2n_send calls

### DIFF
--- a/tests/unit/s2n_self_talk_nonblocking_test.c
+++ b/tests/unit/s2n_self_talk_nonblocking_test.c
@@ -72,7 +72,7 @@ int mock_client(int writefd, int readfd, uint8_t *expected_data, uint32_t size)
 
     for (int i = 0; i < size; i++) {
         if (buffer[i] != expected_data[i]) {
-        return 1;
+            return 1;
         }
     }
 
@@ -171,18 +171,19 @@ int main(int argc, char **argv)
         int r = s2n_send(conn, ptr, remaining, &blocked);
         if (r < 0) {
             if (blocked) {
-                /* We reached a blocked state */
+                /* We reached a blocked state and made no forward progress last call */
                 break;
             }
             continue;
         }
-        
+        EXPECT_TRUE(r > 0);
         remaining -= r;
         ptr += r;
     }
-        
-    /* Remaining shouldn't have progressed at all */
-    EXPECT_EQUAL(remaining, data_size);
+
+    /* Remaining should be between data_size and 0 */
+    EXPECT_TRUE(remaining < data_size);
+    EXPECT_TRUE(remaining > 0);
 
     /* Wake the child process by sending it SIGCONT */
     EXPECT_SUCCESS(kill(pid, SIGCONT));
@@ -197,7 +198,7 @@ int main(int argc, char **argv)
         if (r < 0) {
             continue;
         }
-        
+        EXPECT_TRUE(r > 0);
         remaining -= r;
         ptr += r;
     }

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -122,7 +122,8 @@ struct s2n_connection {
     enum { ENCRYPTED, PLAINTEXT } in_status;
 
     /* How much of the current user buffer have we already
-     * encrypted and have pending for the wire.
+     * encrypted and sent or have pending for the wire but have
+     * not acknowledged to the user.
      */
     ssize_t current_user_data_consumed;
 


### PR DESCRIPTION
This commit changes s2n_send to return the user data successfully flushed
on the wire even if the entire input buffer is not consumed.  This allows
applications to garbage collect the sent part of the buffer.  Errors other
than blocked write calls take priority over partial acknowledgement and
still return -1.