### PR TITLE
Fix reference of uninitialized values

### DIFF
--- a/crypto/s2n_rsa.c
+++ b/crypto/s2n_rsa.c
@@ -181,7 +181,7 @@ static int s2n_rsa_decrypt(const struct s2n_pkey *priv, struct s2n_blob *in, str
 
 static int s2n_rsa_keys_match(const struct s2n_pkey *pub, const struct s2n_pkey *priv)
 {
-    uint8_t plain_inpad[36], plain_outpad[36], encpad[8192];
+    uint8_t plain_inpad[36] = {0}, plain_outpad[36] = {0}, encpad[8192];
     struct s2n_blob plain_in, plain_out, enc;
 
     const s2n_rsa_public_key *pub_key = &pub->key.rsa_key;

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -165,8 +165,7 @@ struct s2n_config *s2n_config_new(void)
     new_config = (struct s2n_config *)(void *)allocator.data;
     new_config->cert_and_key_pairs = NULL;
     new_config->dhparams = NULL;
-    new_config->application_protocols.data = NULL;
-    new_config->application_protocols.size = 0;
+    memset(&new_config->application_protocols, 0, sizeof(new_config->application_protocols));
     new_config->status_request_type = S2N_STATUS_REQUEST_NONE;
     new_config->nanoseconds_since_epoch = get_nanoseconds_since_epoch;
     new_config->client_hello_cb = NULL;
@@ -346,10 +345,8 @@ int s2n_config_add_cert_chain_and_key(struct s2n_config *config, const char *cer
     config->cert_and_key_pairs = (struct s2n_cert_chain_and_key *)(void *)mem.data;
     
     config->cert_and_key_pairs->head = NULL;
-    config->cert_and_key_pairs->ocsp_status.data = NULL;
-    config->cert_and_key_pairs->ocsp_status.size = 0;
-    config->cert_and_key_pairs->sct_list.data = NULL;
-    config->cert_and_key_pairs->sct_list.size = 0;
+    memset(&config->cert_and_key_pairs->ocsp_status, 0, sizeof(config->cert_and_key_pairs->ocsp_status));
+    memset(&config->cert_and_key_pairs->sct_list, 0, sizeof(config->cert_and_key_pairs->sct_list));
     GUARD(s2n_pkey_zero_init(&config->cert_and_key_pairs->private_key));
 
     /* Put the private key pem in a stuffer */
@@ -426,7 +423,7 @@ int s2n_config_add_cert_chain_and_key(struct s2n_config *config, const char *cer
 int s2n_config_add_dhparams(struct s2n_config *config, const char *dhparams_pem)
 {
     struct s2n_stuffer dhparams_in_stuffer, dhparams_out_stuffer;
-    struct s2n_blob dhparams_blob;
+    struct s2n_blob dhparams_blob = {0};
     struct s2n_blob mem;
 
     /* Allocate the memory for the chain and key struct */

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -326,8 +326,8 @@ static int s2n_connection_free_io_contexts(struct s2n_connection *conn)
         return 0;
     }
 
-    struct s2n_blob send_io_blob;
-    struct s2n_blob recv_io_blob;
+    struct s2n_blob send_io_blob = {0};
+    struct s2n_blob recv_io_blob = {0};
 
     if (conn->send_io_context) {
         send_io_blob.data = (uint8_t *)conn->send_io_context;
@@ -398,7 +398,7 @@ static int s2n_connection_free_hmacs(struct s2n_connection *conn)
 
 int s2n_connection_free(struct s2n_connection *conn)
 {
-    struct s2n_blob blob;
+    struct s2n_blob blob = {0};
 
     GUARD(s2n_connection_wipe_keys(conn));
     GUARD(s2n_connection_free_keys(conn));


### PR DESCRIPTION
This commit zeroes out structures that valgrind complained were
referenced before initialization.

s2n_free looks at the value of 'mlocked' which isn't initialized
in a number of locations.

s2n_rsa_keys_match also complained about an invalid memcmp.

This may not be the optimal way to solve these problems, but zeroing
out as indicated allows our application to run without valgrind errors.