### PR TITLE
Fix Fuzz Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ env:
   # unoptimized routines. See https://www.openssl.org/docs/man1.1.0/crypto/OPENSSL_ia32cap.html
   - S2N_LIBCRYPTO=openssl-1.1.0 OPENSSL_ia32cap="~0x200000200000000" BUILD_S2N=true TESTS=integration GCC6_REQUIRED=true
   - S2N_LIBCRYPTO=openssl-1.1.x-master BUILD_S2N=true TESTS=integration GCC6_REQUIRED=true
-  - S2N_LIBCRYPTO=openssl-1.1.0 LATEST_CLANG=true TESTS=fuzz
-  - S2N_LIBCRYPTO=openssl-1.0.2-fips LATEST_CLANG=true TESTS=fuzz
+  - S2N_LIBCRYPTO=openssl-1.1.0 LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=120
+  - S2N_LIBCRYPTO=openssl-1.0.2-fips LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=120
 
 matrix:
   exclude:

--- a/.travis/install_libFuzzer.sh
+++ b/.travis/install_libFuzzer.sh
@@ -31,6 +31,9 @@ mkdir -p "$LIBFUZZER_DOWNLOAD_DIR"
 cd "$LIBFUZZER_DOWNLOAD_DIR"
 
 git clone https://chromium.googlesource.com/chromium/llvm-project/llvm/lib/Fuzzer
+cd Fuzzer
+git checkout 651ead
+cd ..
 
 echo "Compiling LibFuzzer..."
 clang++ -c -g -v -O2 -lstdc++ -std=c++11 Fuzzer/*.cpp -IFuzzer


### PR DESCRIPTION
Looks like our Fuzz Tests have been broken for a couple of weeks since the repo at https://chromium.googlesource.com/chromium/llvm-project/llvm/lib/Fuzzer changed their build. Updated the LibFuzzer install script to use a commit from a few weeks ago .

I also added the `-x` flag to all bash scripts to aid debuggability.