### PR TITLE
Reset the hash after finalizing it

### DIFF
--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -295,6 +295,9 @@ int s2n_hmac_digest_two_compression_rounds(struct s2n_hmac_state *state, void *o
         return 0;
     }
 
+    /* Can't reuse a hash after it has been finalized, so reset and push another block in */
+    GUARD(s2n_hash_reset(&state->inner));
+
     /* No-op s2n_hash_update to normalize timing and guard against Lucky13. This does not affect the value of *out. */
     return s2n_hash_update(&state->inner, state->xor_pad, state->hash_block_size);
 }


### PR DESCRIPTION
The previous fix for https://github.com/awslabs/s2n/issues/634 got rolled back. This is a simpler fix, which simply reinitializes the hash, rather than creating a temporary hash object, and copying the state before finalization.  

The documentation was unclear about whether reset is allowed after final. The documentation for reset suggests yes:

```
EVP_MD_CTX_reset() resets the digest context ctx. This can be used to reuse an already existing context.
```

But the documentation for final is less clear

```
EVP_DigestFinal_ex() retrieves the digest value from ctx and places it in md. If the s parameter is not NULL then the number of bytes of data written (i.e. the length of the digest) will be written to the integer at s, at most EVP_MAX_MD_SIZE bytes will be written. After calling EVP_DigestFinal_ex() no additional calls to EVP_DigestUpdate() can be made, but EVP_DigestInit_ex() can be called to initialize a new digest operation.
```

