### PR TITLE
Cleanup s2n_connection_evp_digests

### DIFF
--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -339,3 +339,23 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
 
     return 0;
 }
+
+
+/* Preserve the handlers for hmac state pointers to avoid re-allocation 
+ * Only valid if the HMAC is in EVP mode
+ */
+int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac)
+{
+    backup->inner = hmac->inner.digest.high_level;
+    backup->inner_just_key = hmac->inner_just_key.digest.high_level;
+    backup->outer = hmac->outer.digest.high_level;
+    return 0;
+}
+
+int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac)
+{
+    hmac->inner.digest.high_level = backup->inner;
+    hmac->inner_just_key.digest.high_level = backup->inner_just_key;
+    hmac->outer.digest.high_level = backup->outer;
+    return 0;
+}

--- a/crypto/s2n_hmac.h
+++ b/crypto/s2n_hmac.h
@@ -50,6 +50,12 @@ struct s2n_hmac_state {
     uint8_t digest_pad[SHA512_DIGEST_LENGTH];
 };
 
+struct s2n_hmac_evp_backup {
+    struct s2n_hash_evp_digest inner;
+    struct s2n_hash_evp_digest inner_just_key;
+    struct s2n_hash_evp_digest outer;
+};
+
 extern int s2n_hmac_digest_size(s2n_hmac_algorithm alg, uint8_t *out);
 extern int s2n_hmac_is_available(s2n_hmac_algorithm alg);
 extern int s2n_hmac_hash_alg(s2n_hmac_algorithm hmac_alg, s2n_hash_algorithm *out);
@@ -63,3 +69,6 @@ extern int s2n_hmac_digest_verify(const void *a, const void *b, uint32_t len);
 extern int s2n_hmac_free(struct s2n_hmac_state *state);
 extern int s2n_hmac_reset(struct s2n_hmac_state *state);
 extern int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from);
+extern int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac);
+extern int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac);
+

--- a/tls/s2n_connection_evp_digests.h
+++ b/tls/s2n_connection_evp_digests.h
@@ -22,9 +22,7 @@
 
 struct s2n_connection_prf_handles {
     /* TLS PRF HMAC p_hash */
-    struct s2n_hash_evp_digest p_hash_s2n_hmac_inner;
-    struct s2n_hash_evp_digest p_hash_s2n_hmac_inner_just_key;
-    struct s2n_hash_evp_digest p_hash_s2n_hmac_outer;
+    struct s2n_hmac_evp_backup p_hash_s2n_hmac;
 
     /* TLS PRF EVP p_hash */
     struct s2n_evp_hmac_state p_hash_evp_hmac;
@@ -52,37 +50,14 @@ struct s2n_connection_hash_handles {
     struct s2n_hash_evp_digest secure_signature_hash;
 };
 
-/* s2n hmac state components from hash states within each hmac */
+/* Allocationg new EVP structs is expensive, so we back them up here and reuse them */
 struct s2n_connection_hmac_handles {
-    /* Initial client mac hmac states */
-    struct s2n_hash_evp_digest initial_client_mac_inner;
-    struct s2n_hash_evp_digest initial_client_mac_inner_just_key;
-    struct s2n_hash_evp_digest initial_client_mac_outer;
-
-    /* Initial client mac copy hmac states */
-    struct s2n_hash_evp_digest initial_client_mac_copy_inner;
-    struct s2n_hash_evp_digest initial_client_mac_copy_inner_just_key;
-    struct s2n_hash_evp_digest initial_client_mac_copy_outer;
-
-    /* Initial server mac hmac states */
-    struct s2n_hash_evp_digest initial_server_mac_inner;
-    struct s2n_hash_evp_digest initial_server_mac_inner_just_key;
-    struct s2n_hash_evp_digest initial_server_mac_outer;
-
-    /* Secure client mac hmac states */
-    struct s2n_hash_evp_digest secure_client_mac_inner;
-    struct s2n_hash_evp_digest secure_client_mac_inner_just_key;
-    struct s2n_hash_evp_digest secure_client_mac_outer;
-
-    /* Secure client mac copy hmac states */
-    struct s2n_hash_evp_digest secure_client_mac_copy_inner;
-    struct s2n_hash_evp_digest secure_client_mac_copy_inner_just_key;
-    struct s2n_hash_evp_digest secure_client_mac_copy_outer;
-
-    /* Secure server mac hmac states */
-    struct s2n_hash_evp_digest secure_server_mac_inner;
-    struct s2n_hash_evp_digest secure_server_mac_inner_just_key;
-    struct s2n_hash_evp_digest secure_server_mac_outer;
+    struct s2n_hmac_evp_backup initial_client;
+    struct s2n_hmac_evp_backup initial_client_copy;
+    struct s2n_hmac_evp_backup initial_server;
+    struct s2n_hmac_evp_backup secure_client;
+    struct s2n_hmac_evp_backup secure_client_copy;
+    struct s2n_hmac_evp_backup secure_server;
 };
 
 extern int s2n_connection_save_prf_state(struct s2n_connection_prf_handles *prf_handles, struct s2n_connection *conn);


### PR DESCRIPTION
Currently, s2n_connection_evp_digests.c has several functions that back up evp pointers from hmac structures, to allow them to be reused instead of wasting time deallocating and reallocating them. These functions have several problems
1. They break encapsulation of the hmac_state structure 
2. They have a significant amount of repeated code
3. They have deep dereference chains that make it hard to read / audit that there are no typos / missing fields.

This PR fixes this by creating a proper save/restore set of functions on the hmac.c API.