### PR TITLE
Unify accept_all_rsa_certs/deny_all_certs declarations

### DIFF
--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -59,7 +59,12 @@ void usage()
 extern void print_s2n_error(const char *app_error);
 extern int echo(struct s2n_connection *conn, int sockfd);
 extern int negotiate(struct s2n_connection *conn);
-extern s2n_cert_validation_code accept_all_rsa_certs(struct s2n_connection *conn, uint8_t *cert_chain_in, uint32_t cert_chain_len, s2n_cert_type *cert_type_out, s2n_cert_public_key *public_key_out, void *context);
+extern s2n_cert_validation_code accept_all_rsa_certs(struct s2n_connection *conn,
+        uint8_t *cert_chain_in,
+        uint32_t cert_chain_len,
+        s2n_cert_type *cert_type_out,
+        s2n_cert_public_key *public_key_out,
+        void *context);
 
 int main(int argc, char *const *argv)
 {

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -230,7 +230,12 @@ int cache_delete(void *ctx, const void *key, uint64_t key_size)
 extern void print_s2n_error(const char *app_error);
 extern int echo(struct s2n_connection *conn, int sockfd);
 extern int negotiate(struct s2n_connection *conn);
-extern s2n_cert_validation_code accept_all_rsa_certs(struct s2n_connection *conn, uint8_t *cert_chain_in, uint32_t cert_chain_len, s2n_cert_type *cert_type_out, s2n_cert_public_key *public_key_out, void *context);
+extern s2n_cert_validation_code accept_all_rsa_certs(struct s2n_connection *conn,
+        uint8_t *cert_chain_in,
+        uint32_t cert_chain_len,
+        s2n_cert_type *cert_type_out,
+        s2n_cert_public_key *public_key_out,
+        void *context);
 
 /* Caller is expected to free the memory returned. */
 static char *load_file_to_cstring(const char *path)
@@ -583,6 +588,7 @@ int main(int argc, char *const *argv)
 
     if (mutual_auth) {
         s2n_config_set_client_auth_type(config, S2N_CERT_AUTH_REQUIRED);
+        /* Use an unsafe verification function until we support default x509 verification */
         s2n_config_set_verify_cert_chain_cb(config, &accept_all_rsa_certs, NULL);
     }
 

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -70,19 +70,23 @@ int get_nanoseconds_since_epoch(void *data, uint64_t * nanoseconds)
 
 #endif
 
-int deny_all_certs(struct s2n_connection *conn, uint8_t *cert_chain_in, uint32_t cert_chain_len, s2n_cert_type *cert_type, 
-                   s2n_cert_public_key *public_key, void *context)
+s2n_cert_validation_code deny_all_certs(struct s2n_connection *conn,
+        uint8_t *cert_chain_in,
+        uint32_t cert_chain_len,
+        s2n_cert_type *cert_type_out,
+        s2n_cert_public_key *public_key_out,
+        void *context)
 {
     S2N_ERROR(S2N_ERR_CERT_UNTRUSTED);
 }
 
-/* Accept all RSA Certificates is unsafe and is only used in the s2n Client for testing purposes */
+/* Accept all RSA Certificates is unsafe and is only used in the s2n client for testing purposes */
 s2n_cert_validation_code accept_all_rsa_certs(struct s2n_connection *conn,
-                                              uint8_t *cert_chain_in,
-                                              uint32_t cert_chain_len,
-                                              s2n_cert_type *cert_type_out,
-                                              s2n_cert_public_key *public_key_out,
-                                              void *context)
+        uint8_t *cert_chain_in,
+        uint32_t cert_chain_len,
+        s2n_cert_type *cert_type_out,
+        s2n_cert_public_key *public_key_out,
+        void *context)
 {
     struct s2n_blob cert_chain_blob = { .data = cert_chain_in, .size = cert_chain_len};
     struct s2n_stuffer cert_chain_in_stuffer;

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -60,16 +60,16 @@ extern struct s2n_config s2n_default_config;
 extern struct s2n_config s2n_default_fips_config;
 extern struct s2n_config s2n_unsafe_client_testing_config;
 
-int accept_all_rsa_certs(struct s2n_connection *conn,
-                            uint8_t *cert_chain_in,
-                            uint32_t cert_chain_len,
-                            s2n_cert_type *cert_type,
-                            s2n_cert_public_key *public_key_out,
-                            void *context);
+s2n_cert_validation_code accept_all_rsa_certs(struct s2n_connection *conn,
+        uint8_t *cert_chain_in,
+        uint32_t cert_chain_len,
+        s2n_cert_type *cert_type_out,
+        s2n_cert_public_key *public_key_out,
+        void *context);
 
-int deny_all_certs(struct s2n_connection *conn,
-                        uint8_t *cert_chain_in,
-                        uint32_t cert_chain_len,
-                        s2n_cert_type *cert_type,
-                        s2n_cert_public_key *public_key,
-                        void *context);
+s2n_cert_validation_code deny_all_certs(struct s2n_connection *conn,
+        uint8_t *cert_chain_in,
+        uint32_t cert_chain_len,
+        s2n_cert_type *cert_type_out,
+        s2n_cert_public_key *public_key_out,
+        void *context);


### PR DESCRIPTION
Previously these functions were defined with different signatures in
multiple places.

See #650