### PR TITLE
Update Curl download commands to retry up to 3 times

### DIFF
--- a/.travis/install_gnutls.sh
+++ b/.travis/install_gnutls.sh
@@ -44,7 +44,7 @@ cd "$GNUTLS_BUILD_DIR"
 
 # libnettle is a dependency of GnuTLS
 # Originally from: https://ftp.gnu.org/gnu/nettle/nettle-3.3.tar.gz
-curl https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/2017-08-29_nettle-3.3.tar.gz > nettle-3.3.tar.gz
+curl --retry 3 https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/2017-08-29_nettle-3.3.tar.gz --output nettle-3.3.tar.gz
 tar -xzf nettle-3.3.tar.gz
 cd nettle-3.3
 ./configure --prefix="$GNUTLS_INSTALL_DIR"/nettle
@@ -54,7 +54,7 @@ cd ..
 
 # Install GnuTLS
 # Originally from: ftp://ftp.gnutls.org/gcrypt/gnutls/v3.5/gnutls-3.5.5.tar.xz
-curl https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/2017-08-29_gnutls-3.5.5.tar.xz > gnutls-3.5.5.tar.xz
+curl --retry 3 https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/2017-08-29_gnutls-3.5.5.tar.xz --output gnutls-3.5.5.tar.xz
 tar -xJf gnutls-3.5.5.tar.xz
 cd gnutls-3.5.5
 ./configure LD_FLAGS="-R$GNUTLS_INSTALL_DIR/nettle/lib -L$GNUTLS_INSTALL_DIR/nettle/lib -lnettle -lhogweed" \

--- a/.travis/install_libressl.sh
+++ b/.travis/install_libressl.sh
@@ -29,7 +29,7 @@ INSTALL_DIR=$2
 
 cd "$BUILD_DIR"
 # Originally from: https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.5.1.tar.gz
-curl https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/2017-08-29_libressl-2.5.1.tar.gz > libressl-2.5.1.tar.gz
+curl --retry 3 https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/2017-08-29_libressl-2.5.1.tar.gz --output libressl-2.5.1.tar.gz
 tar -xzvf libressl-2.5.1.tar.gz
 cd libressl-2.5.1
 ./configure --prefix="$INSTALL_DIR"

--- a/.travis/install_openssl_1_0_2.sh
+++ b/.travis/install_openssl_1_0_2.sh
@@ -30,7 +30,7 @@ INSTALL_DIR=$2
 PLATFORM=$3
 
 cd "$BUILD_DIR"
-curl -L https://www.openssl.org/source/openssl-1.0.2-latest.tar.gz > openssl-1.0.2.tar.gz
+curl --retry 3 -L https://www.openssl.org/source/openssl-1.0.2-latest.tar.gz --output openssl-1.0.2.tar.gz
 tar -xzvf openssl-1.0.2.tar.gz
 rm openssl-1.0.2.tar.gz
 cd openssl-1.0.2*

--- a/.travis/install_openssl_1_0_2_fips.sh
+++ b/.travis/install_openssl_1_0_2_fips.sh
@@ -48,7 +48,7 @@ fi
 # There is no 'latest' download URL for the FIPS object modules
 cd "$BUILD_DIR"
 # Originally from: http://www.openssl.org/source/openssl-fips-2.0.13.tar.gz
-curl https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/2017-08-31_openssl-fips-2.0.13.tar.gz > openssl-fips-2.0.13.tar.gz
+curl --retry 3 https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/2017-08-31_openssl-fips-2.0.13.tar.gz --output openssl-fips-2.0.13.tar.gz
 gunzip -c openssl-fips-2.0.13.tar.gz | tar xf -
 rm openssl-fips-2.0.13.tar.gz
 cd openssl-fips-2.0.13
@@ -61,7 +61,7 @@ make
 sudo make install
 
 cd "$BUILD_DIR"
-curl -L https://www.openssl.org/source/openssl-1.0.2-latest.tar.gz > openssl-1.0.2.tar.gz
+curl --retry 3 -L https://www.openssl.org/source/openssl-1.0.2-latest.tar.gz --output openssl-1.0.2.tar.gz
 tar -xzvf openssl-1.0.2.tar.gz
 rm openssl-1.0.2.tar.gz
 cd openssl-1.0.2*

--- a/.travis/install_openssl_1_1_0.sh
+++ b/.travis/install_openssl_1_1_0.sh
@@ -30,7 +30,7 @@ INSTALL_DIR=$2
 PLATFORM=$3
 
 cd "$BUILD_DIR"
-curl -L https://www.openssl.org/source/openssl-1.1.0-latest.tar.gz > openssl-1.1.0.tar.gz
+curl --retry 3 -L https://www.openssl.org/source/openssl-1.1.0-latest.tar.gz --output openssl-1.1.0.tar.gz
 tar -xzvf openssl-1.1.0.tar.gz
 rm openssl-1.1.0.tar.gz
 cd openssl-1.1.0*

--- a/.travis/install_prlimit.sh
+++ b/.travis/install_prlimit.sh
@@ -30,7 +30,7 @@ NUM_CORES=$(nproc)
 
 cd "$BUILD_DIR"
 # Originally from: https://www.kernel.org/pub/linux/utils/util-linux/v2.25/util-linux-2.25.2.tar.gz
-curl https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/2017-08-29_util-linux-2.25.2.tar.gz > util-linux-2.25.2.tar.gz
+curl --retry 3 https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/2017-08-29_util-linux-2.25.2.tar.gz --output util-linux-2.25.2.tar.gz
 tar -xzvf util-linux-2.25.2.tar.gz
 cd util-linux-2.25.2
 ./configure ADJTIME_PATH=/var/lib/hwclock/adjtime \

--- a/.travis/install_python.sh
+++ b/.travis/install_python.sh
@@ -27,7 +27,7 @@ INSTALL_DIR=$3
 
 cd "$BUILD_DIR"
 # Originally from: https://www.python.org/ftp/python/3.6.0/Python-3.6.0.tgz
-curl https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/2017-08-29_Python-3.6.0.tgz > Python-3.6.0.tgz
+curl --retry 3 https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/2017-08-29_Python-3.6.0.tgz --output Python-3.6.0.tgz
 tar xzf Python-3.6.0.tgz
 cd Python-3.6.0
  CPPFLAGS="-I$LIBCRYPTO_ROOT/include" LDFLAGS="-Wl,-rpath,$LIBCRYPTO_ROOT/lib -L$LIBCRYPTO_ROOT/lib" ./configure --prefix="$INSTALL_DIR"

--- a/.travis/install_saw.sh
+++ b/.travis/install_saw.sh
@@ -32,7 +32,7 @@ mkdir -p "$DOWNLOAD_DIR"
 cd "$DOWNLOAD_DIR"
 
 #download saw binaries
-curl https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/saw-0.2-2017-07-27-Ubuntu14.04-64.tar.gz > saw.tar.gz;
+curl --retry 3 https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/saw-0.2-2017-07-27-Ubuntu14.04-64.tar.gz --output saw.tar.gz;
 
 mkdir -p saw && tar -xzf saw.tar.gz --strip-components=1 -C saw
 mkdir -p "$INSTALL_DIR" && mv saw/* "$INSTALL_DIR"

--- a/.travis/install_scan-build.sh
+++ b/.travis/install_scan-build.sh
@@ -25,5 +25,5 @@ if [ "$#" -ne "1" ]; then
 fi
 INSTALL_DIR=$1
 # Originally from: http://clang-analyzer.llvm.org/downloads/checker-278.tar.bz2
-curl https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/2017-08-29_clang-analyzer_checker.tar.bz2 > checker-278.tar.bz2
+curl --retry 3 https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/2017-08-29_clang-analyzer_checker.tar.bz2 --output checker-278.tar.bz2
 mkdir -p "$INSTALL_DIR" && tar jxf checker-278.tar.bz2 --strip-components=1 -C "$INSTALL_DIR"

--- a/.travis/install_z3_yices.sh
+++ b/.travis/install_z3_yices.sh
@@ -31,8 +31,8 @@ mkdir -p "$DOWNLOAD_DIR"
 cd "$DOWNLOAD_DIR"
 
 #download z3 and yices
-curl https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/z3-2017-04-04-Ubuntu14.04-64 > z3
-curl https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/yices_smt2-linux-static-2017-06-21 > yices-smt2
+curl --retry 3 https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/z3-2017-04-04-Ubuntu14.04-64 --output z3
+curl --retry 3 https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/yices_smt2-linux-static-2017-06-21 --output yices-smt2
 sudo chmod +x z3
 sudo chmod +x yices-smt2
 mkdir -p "$INSTALL_DIR"/bin


### PR DESCRIPTION
We had what looks like an intermittent download error here: https://travis-ci.org/awslabs/s2n/jobs/305452648#L2855

This should allow curl to retry failed downloads up to 3 times.