### PR TITLE
Free I/O contexts allocated by s2n for managed IO

### DIFF
--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -414,6 +414,8 @@ int s2n_connection_free(struct s2n_connection *conn)
     GUARD(s2n_connection_reset_hmacs(conn));
     GUARD(s2n_connection_free_hmacs(conn));
 
+    GUARD(s2n_connection_free_io_contexts(conn));
+    
     GUARD(s2n_free(&conn->status_response));
     GUARD(s2n_stuffer_free(&conn->in));
     GUARD(s2n_stuffer_free(&conn->out));


### PR DESCRIPTION
The I/O contexts created for "managed I/O" (https://github.com/awslabs/s2n/blob/master/tls/s2n_connection.c#L655) were not freed as part of s2n_connection_free.

Tested by comparing valgrind reports for s2n_self_talk_test and s2n_self_talk_custom_io_test.