### PR TITLE
Code style change

### DIFF
--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -374,8 +374,8 @@ static int handshake_write_io(struct s2n_connection *conn)
     /* Write the handshake data to records in fragment sized chunks */
     struct s2n_blob out;
     while (s2n_stuffer_data_available(&conn->handshake.io) > 0) {
-        int max_payload_size;
-        GUARD((max_payload_size = s2n_record_max_write_payload_size(conn)));
+        int max_payload_size = s2n_record_max_write_payload_size(conn);
+        GUARD(max_payload_size);
         out.size = MIN(s2n_stuffer_data_available(&conn->handshake.io), max_payload_size);
 
         out.data = s2n_stuffer_raw_read(&conn->handshake.io, out.size);


### PR DESCRIPTION
Isolating the assignment from the function call. It is just to make explicit that the assignment expression has the value of the left operand after the assignment.