### PR TITLE
Proof that codebalancing countermeasures are correctly implemented

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,14 @@ matrix:
   - env: TESTS=sawDRBG                      SAW=true
   include:
   - os : linux
+    env: TESTS=sidewinder
+    addons:
+      apt:
+        packages:
+          - clang-3.9
+          - llvm-3.9
+          - llvm-3.9-dev
+  - os : linux
     env : TESTS=sawHMAC SAW_HMAC_TEST=md5    SAW=true GCC6_REQUIRED=false
     addons: &sawaddons
       apt:
@@ -67,7 +75,7 @@ matrix:
     addons : *sawaddons    
   - os : linux
     env : TESTS=sawHMACFailure SAW=true
-    addons : *sawaddons    
+    addons : *sawaddons   
   allow_failures:
     - os: osx
     - env: S2N_LIBCRYPTO=openssl-1.1.x-master BUILD_S2N=true TESTS=integration GCC6_REQUIRED=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,12 +42,6 @@ matrix:
   include:
   - os : linux
     env: TESTS=sidewinder
-    addons:
-      apt:
-        packages:
-          - clang-3.9
-          - llvm-3.9
-          - llvm-3.9-dev
   - os : linux
     env : TESTS=sawHMAC SAW_HMAC_TEST=md5    SAW=true GCC6_REQUIRED=false
     addons: &sawaddons

--- a/.travis/cppcheck_suppressions.txt
+++ b/.travis/cppcheck_suppressions.txt
@@ -9,3 +9,11 @@ variableScope:tests/unit/*
 // cppcheck Message: [tls/s2n_config.c:60]: (information:ConfigurationNotChecked) Skipping configuration 'CLOCK_MONOTONIC_RAW' since the value of 'CLOCK_MONOTONIC_RAW' is unknown. Use -D if you want to check it. You can use -U to skip it explicitly
 // Reason: There are many Config options that aren't checked by Cppcheck, and it warns for each. Ignore these so that they don't clutter the output.
 ConfigurationNotChecked:*
+
+// cppcheck Message:  [tests/sidewinder/working/s2n-cbc/cbc.c:69]: (style:unassignedVariable) Variable 'data' is not assigned a value.
+// Reason: Value deliveratly left nondeterministic for sidewinder test purposes
+unassignedVariable:tests/sidewinder/working/s2n-cbc/cbc.c
+
+//  cppcheck Message:  [tests/sidewinder/working/s2n-cbc/stubs/s2n_hash.c:71]: (style:unsignedPositive) Unsigned variable 'size' can't be negative so it is unnecessary to test it.
+// Reason: Boogie uses unsigned integers, so the test is indeed necessary (for sidewinder purposes)
+unsignedPositive:tests/sidewinder/working/s2n-cbc/stubs/s2n_hash.c

--- a/.travis/cppcheck_suppressions.txt
+++ b/.travis/cppcheck_suppressions.txt
@@ -9,11 +9,3 @@ variableScope:tests/unit/*
 // cppcheck Message: [tls/s2n_config.c:60]: (information:ConfigurationNotChecked) Skipping configuration 'CLOCK_MONOTONIC_RAW' since the value of 'CLOCK_MONOTONIC_RAW' is unknown. Use -D if you want to check it. You can use -U to skip it explicitly
 // Reason: There are many Config options that aren't checked by Cppcheck, and it warns for each. Ignore these so that they don't clutter the output.
 ConfigurationNotChecked:*
-
-// cppcheck Message:  [tests/sidewinder/working/s2n-cbc/cbc.c:69]: (style:unassignedVariable) Variable 'data' is not assigned a value.
-// Reason: Value deliveratly left nondeterministic for sidewinder test purposes
-unassignedVariable:tests/sidewinder/working/s2n-cbc/cbc.c
-
-//  cppcheck Message:  [tests/sidewinder/working/s2n-cbc/stubs/s2n_hash.c:71]: (style:unsignedPositive) Unsigned variable 'size' can't be negative so it is unnecessary to test it.
-// Reason: Boogie uses unsigned integers, so the test is indeed necessary (for sidewinder purposes)
-unsignedPositive:tests/sidewinder/working/s2n-cbc/stubs/s2n_hash.c

--- a/.travis/install_sidewinder.sh
+++ b/.travis/install_sidewinder.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+set -e
+set -x
+
+usage() {
+    echo "install_ctverif.sh install_dir"
+    exit 1
+}
+
+if [ "$#" -ne "1" ]; then
+    usage
+fi
+
+INSTALL_DIR=$1
+
+cd "$INSTALL_DIR"
+
+#install smack
+git clone https://github.com/danielsn/smack.git -b sidewinder-debug
+cd smack/bin
+
+clang --version
+which clang
+
+./build.sh
+
+# Disabling ShellCheck using https://github.com/koalaman/shellcheck/wiki/Directive
+# Turn of Warning in one line as https://github.com/koalaman/shellcheck/wiki/SC1090
+# shellcheck disable=SC1090
+source "$INSTALL_DIR"/smack.environment
+
+#install ctverif
+cd "$INSTALL_DIR"
+git clone --depth 1 https://github.com/imdea-software/verifying-constant-time.git -b test-automation
+

--- a/.travis/install_sidewinder_dependencies.sh
+++ b/.travis/install_sidewinder_dependencies.sh
@@ -14,37 +14,46 @@
 #
 
 set -e
+set -x
 
 #Figlet is required for ctverif printing
 sudo apt-get install -y figlet
 
 #Install boogieman
-sudo gem install --pre bam-bam-boogieman
+#sudo gem install --pre bam-bam-boogieman
+git clone https://github.com/Qthan/bam-bam-boogieman.git -b cost-modeling
+cd bam-bam-boogieman
+bundle update
+bundle exec rake install
+cd ..
+which bam
+
 
 #Install the apt-get dependencies from the smack build script: this way they will still be there
 #when we get things from cache
 DEPENDENCIES="git cmake python-yaml python-psutil unzip wget python3-yaml"
-DEPENDENCIES+=" clang-3.7 llvm-3.7 mono-complete libz-dev libedit-dev"
-
-# Adding LLVM repository
-sudo add-apt-repository "deb http://llvm-apt.ecranbleu.org/apt/trusty/ llvm-toolchain-trusty-3.7 main"
-wget --no-verbose -O - http://llvm-apt.ecranbleu.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
+DEPENDENCIES+=" mono-complete libz-dev libedit-dev"
 
 # Adding MONO repository
-sudo add-apt-repository "deb http://download.mono-project.com/repo/debian wheezy main"
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+echo "deb http://download.mono-project.com/repo/ubuntu trusty main" | sudo tee /etc/apt/sources.list.d/mono-official.list
 
-#    echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
 sudo apt-get update
 sudo apt-get install -y ${DEPENDENCIES}
-sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.7 20
-sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.7 20
-sudo update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-3.7 20
-sudo update-alternatives --install /usr/bin/llvm-link llvm-link /usr/bin/llvm-link-3.7 20
-sudo update-alternatives --install /usr/bin/llvm-dis llvm-dis /usr/bin/llvm-dis-3.7 20
 pip install pyyaml
+
+LLVM_SHORT_VERSION=3.9
+
+sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${LLVM_SHORT_VERSION} 30
+sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${LLVM_SHORT_VERSION} 30
+sudo update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-${LLVM_SHORT_VERSION} 30
+sudo update-alternatives --install /usr/bin/llvm-link llvm-link /usr/bin/llvm-link-${LLVM_SHORT_VERSION} 30
+sudo update-alternatives --install /usr/bin/llvm-dis llvm-dis /usr/bin/llvm-dis-${LLVM_SHORT_VERSION} 30
+
+
+clang --version
+clang-3.9 --version
 
 which python
 python --version
 pip install psutil
-

--- a/.travis/install_sidewinder_dependencies.sh
+++ b/.travis/install_sidewinder_dependencies.sh
@@ -33,6 +33,7 @@ which bam
 #when we get things from cache
 DEPENDENCIES="git cmake python-yaml python-psutil unzip wget python3-yaml"
 DEPENDENCIES+=" mono-complete libz-dev libedit-dev"
+DEPENDENCIES+=" clang-3.9 llvm-3.9 llvm-3.9-dev"
 
 # Adding MONO repository
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF

--- a/.travis/install_ubuntu_dependencies.sh
+++ b/.travis/install_ubuntu_dependencies.sh
@@ -36,3 +36,9 @@ if [[ "$TESTS" == "ctverif" || "$TESTS" == "ALL" ]] ; then
 
 if [[ "$TESTS" == "ctverif" || "$TESTS" == "ALL" ]] && [[ ! -d "$CTVERIF_INSTALL_DIR" ]]; then
     mkdir -p "$CTVERIF_INSTALL_DIR" && .travis/install_ctverif.sh "$CTVERIF_INSTALL_DIR" > /dev/null ; fi
+
+if [[ "$TESTS" == "sidewinder" || "$TESTS" == "ALL" ]] ; then
+    .travis/install_sidewinder_dependencies.sh ; fi
+
+if [[ "$TESTS" == "sidewinder" || "$TESTS" == "ALL" ]] && [[ ! -d "$SIDEWINDER_INSTALL_DIR" ]]; then
+    mkdir -p "$SIDEWINDER_INSTALL_DIR" && .travis/install_sidewinder.sh "$SIDEWINDER_INSTALL_DIR" > /dev/null ; fi

--- a/.travis/run_cppcheck.sh
+++ b/.travis/run_cppcheck.sh
@@ -30,7 +30,7 @@ CPPCHECK_EXECUTABLE=${INSTALL_DIR}/cppcheck/cppcheck
 
 FAILED=0
 $CPPCHECK_EXECUTABLE --version
-$CPPCHECK_EXECUTABLE --std=c99 --error-exitcode=-1 --quiet -j 8 --enable=all --template='[{file}:{line}]: ({severity}:{id}) {message}' --suppressions-list=.travis/cppcheck_suppressions.txt -I ./tests api bin crypto error stuffer tests tls utils || FAILED=1
+$CPPCHECK_EXECUTABLE --std=c99 --error-exitcode=-1 --quiet -j 8 --enable=all --template='[{file}:{line}]: ({severity}:{id}) {message}' --inline-suppr --suppressions-list=.travis/cppcheck_suppressions.txt -I ./tests api bin crypto error stuffer tests tls utils || FAILED=1
 
 if [ $FAILED == 1 ];
 then

--- a/.travis/run_sidewinder.sh
+++ b/.travis/run_sidewinder.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+set -e
+set -x
+
+usage() {
+    echo "run_ctverif.sh install_dir"
+    exit 1
+}
+
+if [ "$#" -ne "1" ]; then
+    usage
+fi
+
+INSTALL_DIR=$1
+SMACK_DIR="${1}/smack"
+
+#Put the dependencies are on the path
+
+# Disabling ShellCheck using https://github.com/koalaman/shellcheck/wiki/Directive
+# Turn of Warning in one line as https://github.com/koalaman/shellcheck/wiki/SC1090
+# shellcheck disable=SC1090
+source "${INSTALL_DIR}/smack.environment"
+export PATH="${SMACK_DIR}/bin:${SMACK_DIR}/build:${PATH}"
+#Test that they are really there
+which smack || echo "can't find smack"
+which boogie || echo "can't find z3"
+which llvm2bpl || echo "can't find llvm2bpl"
+which clang
+clang --version
+
+cd "${BASE_S2N_DIR}/tests/sidewinder/working/s2n-cbc"
+./copy_as_needed.sh
+make clean
+
+#run the test.  We expect both to pass, and none to fail
+FAILED=0
+EXPECTED_PASS=1
+EXPECTED_FAIL=0
+make 2>&1 | ../../count_success.pl $EXPECTED_PASS $EXPECTED_FAIL || FAILED=1
+
+if [ $FAILED == 1 ];
+then
+	printf "\\033[31;1mFAILED ctverif\\033[0m\\n"
+	exit -1
+else
+	printf "\\033[32;1mPASSED ctverif\\033[0m\\n"
+fi

--- a/.travis/s2n_setup_env.sh
+++ b/.travis/s2n_setup_env.sh
@@ -38,6 +38,7 @@
 : "${LIBRESSL_INSTALL_DIR:=$(pwd)/test-deps/libressl}"
 : "${CPPCHECK_INSTALL_DIR:=$(pwd)/test-deps/cppcheck}"
 : "${CTVERIF_INSTALL_DIR:=$(pwd)/test-deps/ctverif}"
+: "${SIDEWINDER_INSTALL_DIR:=$(pwd)/test-deps/sidewinder}"
 : "${FUZZ_TIMEOUT_SEC:=10}"
 
 # Openssl 1.1.x-master is not added to Travis cache because we want to build against the latest
@@ -72,6 +73,7 @@ export OPENSSL_1_0_2_FIPS_INSTALL_DIR
 export LIBRESSL_INSTALL_DIR
 export CPPCHECK_INSTALL_DIR
 export CTVERIF_INSTALL_DIR
+export SIDEWINDER_INSTALL_DIR
 export OPENSSL_1_1_X_MASTER_INSTALL_DIR
 export FUZZ_TIMEOUT_SEC
 export TRAVIS_OS_NAME

--- a/.travis/s2n_travis_build.sh
+++ b/.travis/s2n_travis_build.sh
@@ -51,4 +51,5 @@ if [[ "$TESTS" == "ALL" || "$TESTS" == "sawDRBG" ]]; then make -C tests/saw tmp/
 if [[ "$TESTS" == "ALL" || "$TESTS" == "tls" ]]; then make -C tests/saw tmp/handshake.log && make -C tests/saw tmp/cork-uncork.log ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "sawHMACFailure" ]]; then make -C tests/saw failure-tests ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "ctverif" ]]; then .travis/run_ctverif.sh "$CTVERIF_INSTALL_DIR" ; fi
+if [[ "$TESTS" == "ALL" || "$TESTS" == "sidewinder" ]]; then .travis/run_sidewinder.sh "$SIDEWINDER_INSTALL_DIR" ; fi
 

--- a/tests/sidewinder/Makefile
+++ b/tests/sidewinder/Makefile
@@ -1,0 +1,29 @@
+MAKEFILES = $(shell find examples -name Makefile -depth 2)
+EXAMPLES = $(patsubst %/,%,$(dir $(MAKEFILES)))
+
+logs = $(shell find . -name "*.log")
+attempts = $(shell grep "verifier version" $(logs) | wc -l | tr -d ' ')
+verified = $(shell grep "verifier finished .* [1-9][0-9]* verified" $(logs) | wc -l | tr -d ' ')
+errors = $(shell grep 'verifier finished .* [1-9][0-9]* error' $(logs) | wc -l | tr -d ' ')
+
+.PHONY: all %.target
+
+all: $(EXAMPLES:%=%.target)
+	@echo
+	@echo Results | figlet
+	@echo $(attempts) attempts
+	@echo $(verified) verified
+	@echo $(errors) errors
+
+clean: $(EXAMPLES:%=%.clean)
+
+%.target:
+	@echo
+	@echo Example | figlet
+	@echo $(notdir $*)
+	@cd $* && make
+
+%.clean:
+	@echo
+	@echo Cleaning $*
+	@cd $* && make clean

--- a/tests/sidewinder/README.md
+++ b/tests/sidewinder/README.md
@@ -1,0 +1,98 @@
+# Constant Time Verification Tests for s2n
+
+This repository contains tests which ensure that key s2n functions
+are not susceptible to timing attacks.
+
+For more details, see https://github.com/awslabs/s2n/issues/463
+
+
+## What are timing side channels
+
+Cryptographic protocols such as TLS are supposed to keep secret information secret.
+They do this by ensuring that WHICH bytes go over the wire is hidden using encryption.
+However, if the code is not carefully written, WHEN bytes go over the wire may depend
+on values that were supposed to remain secret.
+
+For example, if code checks a password as follows
+
+```
+for (i = 0; i < length; ++i) {
+  if password[i] != input[i] {
+    send("bad password");
+  }
+}
+```
+then the amount of time until the reply message is received will depend on which byte in the password
+is incorrect.  An attacker can simply guess
+  * a*******
+  * b*******
+  * c*******
+
+until the time to receive the error message changes, and then they know the first letter in the password.
+Repeating for the remaining characters turns an exponential guessing challenge into a linear one.
+
+A varient of this attack, called LUCKY13, has been demonstrated against some implementations the Cipher Block Chaining (CBC) mode of SSL/TLS. In this attack, the TLS server is tricked into treating a (secret) encrypted byte as a padding length field. A naive TLS implementation will remove the specified amount of padding, then calculate a hash on the remaining btyes in the packet. If the value in the secret byte was large, a small number of bytes will be hashed; if it was small, a larger number of bytes will be hashed, creating a timing difference, which in theory can reveal the value in the secret byte.
+
+For a detailed discussion of the LUCKY13 attack and how s2n mitigates against it, see [this blog post](https://aws.amazon.com/blogs/security/s2n-and-lucky-13/). 
+
+## s2n countermeasures against timing side channels
+
+s2n takes a belt and suspenders approach to preventing side-channel attacks.
+1. First of all, it uses code-balancing to ensure that the same number of hash compression rounds are processed, no matter the value in the secret byte.
+2. Second, it adds a delay of up to 10 seconds whenever any error is triggered, which increases by orders of magnitude the number of timing samples an attacker would need, even if they found a way around countermeasure 1. 
+
+## Why use formal methods to prove the correctness of s2n's countermeasures?
+Side channels are notoriously difficult to defend against, since code with a side-channel has the same functional behaviour as code that is side-channel free. Testing can find bugs, but it cannot prove their absence.  In order to prove the absence of a timing side-channel (up to a timing model of system execution), you need a formal proof.
+
+Formal proofs are also useful because they help prevent regressions.  If a code change causes a timing side-channel to be introduced, the proof will fail, and the developer will be notified before the bug goes to production.
+
+## How does Sidewinder prove the correctness of code blinding countermeasures
+
+### High level overview
+A program has a timing side channel if the amount of time needed to execute it depends on the value of a secret input to the program. Sidewinder take a program, annotates every instuction with its runtime cost, and then generates a mathematical formula which symbolically represents the cost of executing the program given an input.  Sidewinder then asks an automated theorem prover, called a Satisfiability Modulo Theories (SMT) solver, if there is a pair of secret inputs to the program that would take different amounts of time to process.  The SMT solver, using clever heuristics, exhaustively searches the state of all possible program inputs, and either returns a proof that there is no timing side-channel, or an example of a pair of inputs that lead to a timing channel, along with the estimated leakage.
+
+### The gory details
+
+Mathematically, a program `P(secret, public)` has runtime `Time(P(secret,public))`. A program has a timing side-channel of delta if `|Time(P(secret_1,public)) - Time(P(secret_2,public))| = delta`.  If we can represent `Time(P(secret,public))` as a mathematical formula, we can use a theorem prover to mathematically prove that the timing leakage of the program, for all choices of `secret_1, secret_2`, is less than `delta`. 
+
+Sidewinder proceedes in several steps:
+1. Compile the code to llvm bitcode - this allows Sidewinder to accuratly represent the effect of compiler optimizations on runtime
+2. Use LLVM's timing model to associate every bitcode operation with a timing cost
+3. Use SMACK to compile the annotated LLVM code to BoogiePL (this represents `(P(secret,public))` in the above formula
+4. Use bam-bam-boogieman to
+  * Add a timing cost variable to the program, generating `Time(P(secret,public))`
+  * Make two copies of the resulting program, one which has inputs `(secret_1, public)`, the other of which has inputs `(secret_2, public)`
+  * Assert that the difference in time between the two programs is less than `delta`
+5. Use boogie to prove (via the z3 theorem prover) that either
+  * The time is indeed less than `delta`
+  * or, the time is greater than `delta`, in which case the prover can emit a trace leading to the error
+
+
+## How to execute the tests
+
+### Install the dependencies
+Running these tests will require the following dependencies
+(tested on Ubuntu 14.04).  To see how to install this on a clean ubuntu machine, 
+take a look at the .travis scripts in this repo.
+
+- bam-bam-boogieman 
+- SMACK and all its dependencies
+  - The easiest way to get these is to use the build.sh in smack/bin
+  - Ensure that all of the installed depencies are on the $PATH
+  - source the smack.environment that the smack build script creates
+
+### Execute the test
+
+```
+cd tests/sidewinder/working/s2n-cbc
+./clean.sh
+./run.sh
+
+If the tests pass, you will see a message like: Boogie program verifier finished with 1 verified, 0 error
+
+If the tests fail, you will see a message like: Boogie program verifier finished with 0 verified, 1 error
+```
+
+
+## Questions?
+contact dsn@amazon.com

--- a/tests/sidewinder/README.md
+++ b/tests/sidewinder/README.md
@@ -31,7 +31,7 @@ is incorrect.  An attacker can simply guess
 until the time to receive the error message changes, and then they know the first letter in the password.
 Repeating for the remaining characters turns an exponential guessing challenge into a linear one.
 
-A varient of this attack, called LUCKY13, has been demonstrated against some implementations the Cipher Block Chaining (CBC) mode of SSL/TLS. In this attack, the TLS server is tricked into treating a (secret) encrypted byte as a padding length field. A naive TLS implementation will remove the specified amount of padding, then calculate a hash on the remaining btyes in the packet. If the value in the secret byte was large, a small number of bytes will be hashed; if it was small, a larger number of bytes will be hashed, creating a timing difference, which in theory can reveal the value in the secret byte.
+A variant of this attack, called LUCKY13, has been demonstrated against some implementations the Cipher Block Chaining (CBC) mode of SSL/TLS. In this attack, the TLS server is tricked into treating a (secret) encrypted byte as a padding length field. A naive TLS implementation will remove the specified amount of padding, then calculate a hash on the remaining bytes in the packet. If the value in the secret byte was large, a small number of bytes will be hashed; if it was small, a larger number of bytes will be hashed, creating a timing difference, which in theory can reveal the value in the secret byte.
 
 For a detailed discussion of the LUCKY13 attack and how s2n mitigates against it, see [this blog post](https://aws.amazon.com/blogs/security/s2n-and-lucky-13/). 
 
@@ -49,14 +49,21 @@ Formal proofs are also useful because they help prevent regressions.  If a code 
 ## How does Sidewinder prove the correctness of code blinding countermeasures
 
 ### High level overview
-A program has a timing side channel if the amount of time needed to execute it depends on the value of a secret input to the program. Sidewinder take a program, annotates every instuction with its runtime cost, and then generates a mathematical formula which symbolically represents the cost of executing the program given an input.  Sidewinder then asks an automated theorem prover, called a Satisfiability Modulo Theories (SMT) solver, if there is a pair of secret inputs to the program that would take different amounts of time to process.  The SMT solver, using clever heuristics, exhaustively searches the state of all possible program inputs, and either returns a proof that there is no timing side-channel, or an example of a pair of inputs that lead to a timing channel, along with the estimated leakage.
+A program has a timing side channel if the amount of time needed to execute it depends on the value of a secret input to the program. Sidewinder take a program, annotates every instruction with its runtime cost, and then generates a mathematical formula which symbolically represents the cost of executing the program given an input.  Sidewinder then asks an automated theorem prover, called a Satisfiability Modulo Theories (SMT) solver, if there is a pair of secret inputs to the program that would take different amounts of time to process.  The SMT solver, using clever heuristics, exhaustively searches the state of all possible program inputs, and either returns a proof that there is no timing side-channel, or an example of a pair of inputs that lead to a timing channel, along with the estimated leakage.
+
+### User annotations
+In addition to the standard assert()/assume()/ annotations supported through SMACK There are several annotations supported by Sidewinder, which allow the user to pass information to the Sidewinder proof
+1. __VERIFIER_ASSUME_LEAKAGE(arg): When the timing-modeling transformation encounters this call, it increments the leakage tracking variables by "arg"
+2. S2N_PUBLIC_INPUT(arg): the argument given here is taken to be public. All other variables are assumed private by default.
+3. S2N_INVARIENT(arg): asserts that the given argument is an invariant of the loop, and as such holds on each execution of the loop, and at loop exit.
+4. __VERIFIER_ASSERT_MAX_LEAKAGE(arg): asserts that the given function is time-balanced, with a leakage of less than "arg" time units. 
 
 ### The gory details
 
 Mathematically, a program `P(secret, public)` has runtime `Time(P(secret,public))`. A program has a timing side-channel of delta if `|Time(P(secret_1,public)) - Time(P(secret_2,public))| = delta`.  If we can represent `Time(P(secret,public))` as a mathematical formula, we can use a theorem prover to mathematically prove that the timing leakage of the program, for all choices of `secret_1, secret_2`, is less than `delta`. 
 
-Sidewinder proceedes in several steps:
-1. Compile the code to llvm bitcode - this allows Sidewinder to accuratly represent the effect of compiler optimizations on runtime
+Sidewinder proceeds in several steps:
+1. Compile the code to llvm bitcode - this allows Sidewinder to accurately represent the effect of compiler optimizations on runtime
 2. Use LLVM's timing model to associate every bitcode operation with a timing cost
 3. Use SMACK to compile the annotated LLVM code to BoogiePL (this represents `(P(secret,public))` in the above formula
 4. Use bam-bam-boogieman to
@@ -78,7 +85,7 @@ take a look at the .travis scripts in this repo.
 - bam-bam-boogieman 
 - SMACK and all its dependencies
   - The easiest way to get these is to use the build.sh in smack/bin
-  - Ensure that all of the installed depencies are on the $PATH
+  - Ensure that all of the installed dependencies are on the $PATH
   - source the smack.environment that the smack build script creates
 
 ### Execute the test

--- a/tests/sidewinder/bin/bpl_trace_to_c.py
+++ b/tests/sidewinder/bin/bpl_trace_to_c.py
@@ -1,0 +1,48 @@
+#! /usr/bin/python
+
+import sys
+import re
+from pprint import pprint
+
+args = sys.argv[1:]
+assert len(args) == 2, "usage is <bpl-file-name> <trace-to-convert>"
+print args
+
+def make_bpl_c_mapping(bpl_filename):
+    linenum = 0
+    bpl_c_mapping = {}
+    current_bb_line = -1
+    with open(bpl_filename) as bpl_file:
+        for line in bpl_file:
+            linenum += 1
+            if re.match(r'\$bb\d+', line):
+                current_bb_line = linenum
+                bpl_c_mapping[current_bb_line] = []
+
+            matchObj = re.match(r'  assume {:sourceloc "(.+)", (\d+), (\d+)} true;', line)
+            if matchObj:
+                matched_filename = matchObj.group(1)
+                matched_fileline = matchObj.group(2)
+                bpl_c_mapping[current_bb_line].append((matched_filename, matched_fileline))
+
+    return bpl_c_mapping
+
+def convert_trace_to_c(trace_filename, bpl_c_mapping):
+    with open(trace_filename) as tracefile:
+        for line in tracefile:
+            matchObj = re.match(r'.*\.bpl\((\d+),\d+\).*', line)
+            if matchObj:
+                bpl_line = int(matchObj.group(1))
+                if  bpl_line in bpl_c_mapping:
+                    mapping = bpl_c_mapping[bpl_line]
+                    if len(mapping) > 0:
+                        print mapping[0]
+                    else:
+                        print "No Source Loc"
+                else:
+                    print "unknown basic block"
+
+                print "\t\t", matchObj.group(0), matchObj.group(1)
+
+bpl_c_mapping = make_bpl_c_mapping(args[0])
+convert_trace_to_c(args[1], bpl_c_mapping)

--- a/tests/sidewinder/bin/ct-verif.rb
+++ b/tests/sidewinder/bin/ct-verif.rb
@@ -1,0 +1,222 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+require "open3"
+require 'date'
+require 'timeout'
+
+def run_command_with_heartbeat (beat_time, cmd)
+  start = Time.now
+  line = nil
+  puts "+ #{cmd}"
+  Open3.popen3(cmd) do |stdin, stdout, stderr, thread|    
+    loop do
+      begin
+        Timeout::timeout(beat_time) {line = stdout.gets}
+        break unless line
+        puts line
+      rescue Timeout::Error
+        STDERR.puts "+++++++ running for #{(Time.now - start).round} seconds"
+      end
+    end
+  end
+end
+
+def run_command cmd
+  puts cmd
+  puts `#{cmd}`
+end
+
+def get_parameters
+  params = {
+    shadowingArgs: nil,
+    sources: [],
+    entries: [],
+    dry: false,
+    compile: true,
+    product: true,
+    verify: true,
+    time: nil,
+    unroll: nil,
+    printModel: nil,
+    full_self_comp: nil,
+    a: 'a.bpl',
+    b: 'b.bpl',
+    clang_options: ["-I#{__dir__}/../include"]
+  }
+
+  OptionParser.new do |opts|
+    opts.banner = "Usage: #{File.basename $0} [options] FILE(s)"
+
+    opts.on("-h", "--help", "Show this message") do |v|
+      puts opts
+      exit
+    end
+
+    opts.on('-n', "--dry-run", "Just pretend.") do |d|
+      params[:dry] = d
+    end
+
+    opts.on('-e', '--shadowingArgs args', "The args to the shadowing pass.") do |p|
+      params[:shadowingArgs] = p
+    end
+    
+    opts.on('-e', '--entry-point PROC', "Entry-point procedures.") do |p|
+      params[:entries] << p
+    end
+
+    opts.on('--clang-options STRING', "Flags to pass to clang.") do |s|
+      params[:clang_options] << s unless s.empty?
+    end
+
+    opts.on('-t', '--time-limit SECONDS', "Time limit.") do |t|
+      params[:time] = t
+    end
+
+    opts.on('--print-model flag', "Print the Model.") do |u|
+      params[:printModel] = u
+    end
+
+    opts.on('--full-self-comp flag', "Perform full self composition.") do |u|
+      params[:full_self_comp] = u
+    end
+
+    opts.on('-u', '--unroll-limit NUMBER', "Unroll limit.") do |u|
+      params[:unroll] = u
+    end
+
+    opts.on('-l', '--loop-limit NUMBER', "Loop analysis limit.") do |l|
+      params[:loop] = l
+    end
+
+    opts.on('-a FILE', "Intermediate file after Boogie translation.") do |f|
+      params[:a] = f
+    end
+
+    opts.on('-b FILE', "Intermediate file after product construction.") do |f|
+      params[:b] = f
+    end
+
+    opts.separator ""
+    opts.separator "phase selection"
+
+    opts.on('--[no-]compile', "Compile the input program?") do |p|
+      params[:compile] = p
+    end
+
+    opts.on('--[no-]product', "Do the product construction?") do |p|
+      params[:product] = p
+    end
+
+    opts.on('--[no-]verify', "Do the verification?") do |p|
+      params[:verify] = p
+    end
+
+    opts.on('--timing-analysis', "Perform timing analysis") do |p|
+      params[:timing] = p
+    end
+
+
+  end.parse!
+  params[:sources] = ARGV
+
+  raise "Input FILES required; see --help." if params[:sources].empty?
+  params[:sources].each do |f|
+    raise "File #{f} not found." unless File.exists? f
+  end
+  if params[:compile]
+    raise "Entry-points PROCS required see --help." if params[:entries].empty?
+  else
+    raise "Too many input FILES given." if params[:sources].count > 1
+  end
+
+  params[:a] = params[:sources].first unless params[:compile]
+  params[:b] = params[:a] unless params[:product]
+
+  return params
+end
+
+begin
+  params = get_parameters
+  echo = params[:dry] ? "echo" : ""
+
+  inputs = params[:sources]
+  temp_files = []
+
+  SPECIAL_FUNCTIONS = [
+    "__SMACK",
+    "__VERIFIER",
+    "__builtin",
+    "llvm\.",
+    "public_in",
+    "public_out",
+    "declassified_out",
+    "public_invariant",
+    "benign",
+    "__disjoint_regions"
+  ]
+
+  INLINE_ASM_PATTERN = /\basm\b/
+  UNDEFINED_PATTERN = /\bdeclare\b .* @(?!(#{SPECIAL_FUNCTIONS * "|"}))([^(]*)/
+
+  if params[:compile]
+    flags = ["-t"]
+    flags << "--clang-options=\"#{params[:clang_options] * " "}\"" if params[:clang_options].any?
+    flags << "--loop-limit #{params[:loop]}" if params[:loop]
+    flags << "--verifier boogie"
+    flags << "--entry-points #{params[:entries] * ","}"
+    flags << "-ll #{params[:a]}.ll"
+    flags << "-bpl #{params[:a]}"
+    flags << "--timing-annotations" if params[:timing]
+    puts `which clang`
+    puts `which llvm-link`
+    puts `clang --version`
+    puts `llvm-link --version`
+    puts "#{flags * " "} #{params[:sources] * " "}"
+    puts `#{echo} smack #{flags * " "} #{params[:sources] * " "}`
+    raise "failed to compile #{params[:sources] * ", "}" unless $?.success?
+    warn "warning: module contains inline assembly" \
+      if File.readlines("#{params[:a]}.ll").grep(INLINE_ASM_PATTERN).any?
+
+    ufs = File.readlines("#{params[:a]}.ll")
+        .map{|s| s.match UNDEFINED_PATTERN}
+        .compact
+        .map{|m| m[2]}
+
+    warn "warning: module contains undefined functions: #{ufs * ", "}" if ufs.any?
+  end
+
+  if params[:product]
+    full = if params[:full_self_comp] then "full" else "selective" end
+    shadowingArgs = "self_comp_mode=#{full}"
+    shadowingArgs = "#{shadowingArgs},#{params[:shadowingArgs]}" if params[:shadowingArgs]
+    shadowingArgs.gsub(/\s+/, "") #remove whitespace from the args if necessary
+    flags = []
+    flags << "--cost-modeling" if params[:timing]
+    flags << "--shadowing #{shadowingArgs}"
+    flags << "--pruning"
+    puts `#{echo} bam -q -i #{params[:a]} #{flags * " "} -o #{params[:b]}`
+    raise "failed to construct product program" unless $?.success?
+  end
+
+  if params[:verify]
+    flags = []
+    flags << "/printModel 4" if params[:printModel]
+    flags << "/doModSetAnalysis"
+    flags << "/loopUnroll:#{params[:unroll]}" if params[:unroll]
+    flags << "/timeLimit:#{params[:time]}" if params[:time]
+    warn "warning: only unrolling up to #{params[:unroll]}" if params[:unroll]
+    run_command_with_heartbeat(30, "#{echo} boogie #{flags * " "} #{params[:b]}")
+    #raise "failed to process product program" unless $?.success?
+  end
+
+rescue Interrupt
+  puts "Got interrupt."
+
+rescue => e
+  puts "#{e}"
+  exit(-1)
+
+ensure
+
+end

--- a/tests/sidewinder/count_success.pl
+++ b/tests/sidewinder/count_success.pl
@@ -1,0 +1,64 @@
+#!/usr/bin/perl -w
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+# This script takes ct-verif output, and counts the number of successful
+# and failed tests.  If these match expected, it returns 0. Else it dies
+# with a non-zero exit code.
+
+use strict;
+use warnings;
+
+sub  trim { my $s = shift; $s =~ s/^\s+|\s+$//g; return $s };
+
+if (@ARGV != 2) {
+    die "usage: count_success.pl expected_success expected_failures";
+}
+
+my $expected_success = shift;
+my $expected_failure = shift;
+my @undefined_functions = ();
+my %allowed_undefined = ("__CONTRACT_invariant" => 1);
+
+my $verified = 0;
+my $errors = 0;
+while (my $line = <STDIN>){
+    print $line;
+    #Check if the code under test used unexpected functions
+    if ($line =~ /warning: module contains undefined functions:([a-zA-Z0-9_, ]+)/) {
+	print "found undefined\n\n";
+	for my $fns (split(",",$1)){
+	    my $trimmed = trim ($fns);
+	    unless ($allowed_undefined{$trimmed}) {
+		push @undefined_functions, $trimmed;
+	    }
+	}
+    }
+    
+    #Count the number of errors / successes
+    if ($line =~ /Boogie program verifier finished with (\d+) verified, (\d+) error/) {
+	$verified = $verified + $1;
+	$errors = $errors + $2;
+    }
+}
+
+if($verified == $expected_success and $errors == $expected_failure){
+   print "verified: $verified errors: $errors as expected\n";
+} else {
+    die "ERROR:\tExpected \tverified: $expected_success\terrors: $expected_failure.\n\tGot\t\tverified: $verified\terrors: $errors.\n";
+}
+
+if (@undefined_functions) {
+    die "Unable to prove that code was constant time due to the presence of external functions: @undefined_functions\n";
+}

--- a/tests/sidewinder/include/ct-verif.h
+++ b/tests/sidewinder/include/ct-verif.h
@@ -1,0 +1,54 @@
+#ifndef CT_VERIF_H
+#define CT_VERIF_H
+
+#ifndef COMPILE
+#include <smack.h>
+
+/*
+Security levels are the following.
+
+For inputs:
+- public - function requires (assumes) these to be equal.
+- private - no requirement (allowed to vary freely)
+
+For outputs (both by reference and return values):
+- public - function ensures these are equal
+           can be used on left-hand side of implications everywhere
+- private - no guarantee (allowed to vary freely)
+- declassified - we only analyse executions in which these
+                 possibly private values are fixed.
+
+We omit annotations for private since nothing needs to be generated
+ for them. We may need to add them back in for modular analyses.
+*/
+
+/* The abstract prototypes that form our annotation language */
+void public_in(smack_value_t);
+void public_out(smack_value_t);
+void declassified_out(smack_value_t);
+void public_invariant(smack_value_t);
+void benign(void);
+
+#define __disjoint_regions(addr1,len1,addr2,len2) \
+  assume(addr1 + len1 * sizeof(*addr1) < addr2 || \
+         addr2 + len2 * sizeof(*addr2) < addr1)
+
+#else /* COMPILE */
+
+#undef __SMACK_value
+
+#define __VERIFIER_assume(__a)
+#define __SMACK_value(__a)
+#define __SMACK_return_value(__a)
+#define __SMACK_values(__a,__b)
+#define __SMACK_return_values(__a)
+
+#define public_in(__a)
+#define public_out(__a)
+#define declassified_out(__a)
+#define public_invariant(__a)
+
+#define __disjoint_regions(addr1,len1,addr2,len2)
+
+#endif /* COMPILE */
+#endif /* CT_VERIF_H */

--- a/tests/sidewinder/lib/ct-verif.mk
+++ b/tests/sidewinder/lib/ct-verif.mk
@@ -1,0 +1,72 @@
+
+# HACK to get the directory of this file
+mydir = $(dir $(realpath $(word 2, $(MAKEFILE_LIST))))
+
+entrypoint = $(word 1, $(subst @, ,$1))
+sourcefile = $(word 2, $(subst @, ,$1))
+
+ctverif := $(mydir)../bin/ct-verif.rb
+
+goals   ?=
+unroll	?=
+looplim ?=
+time	?=
+cflags  ?=
+extras  ?=
+prereqs ?=
+secure  ?= true
+timing  ?=
+printModel ?=
+full_self_comp ?=
+shadowingArgs ?=
+
+flags = $(strip \
+	$(if $(strip $(printModel)),--print-model $(printModel)) \
+	$(if $(strip $(full_self_comp)),--full-self-comp $(full_self_comp)) \
+	$(if $(strip $(unroll)),--unroll-limit $(unroll)) \
+	$(if $(strip $(looplim)),--loop-limit $(looplim)) \
+	$(if $(strip $(time)),--time-limit $(time)) \
+	$(if $(strip $(timing)),--timing) \
+	$(if $(strip $(cflags)),--clang-options="$(cflags)") \
+	$(if $(strip $(pruneBefore)),--prune-before) \
+	$(if $(strip $(pruneAfter)),--prune-after) \
+	$(if $(strip $(shadowingArgs)),--shadowingArgs="$(strip $(shadowingArgs))") \
+)
+
+c = compiled.bpl
+p = product.bpl
+v = verified
+
+.PRECIOUS: %.$(c) %.$(p)
+.PHONY: %.$(v) clean
+
+.SECONDEXPANSION:
+%.$(c): $$(call sourcefile,$$*) $$(extras) $(prereqs)
+	@echo
+	@echo Compile | figlet
+	@echo $*
+	@echo
+	@mkdir -p $(dir $@)
+	@$(ctverif) $(flags) -a $@ --no-product --no-verify -e $(call entrypoint,$*) $(call sourcefile,$*) $(extras)
+
+%.$(p): %.$(c)
+	@echo
+	@echo Product | figlet
+	@echo $*
+	@echo
+	@$(ctverif) $(flags) -b $@ --no-compile --no-verify $<
+
+%.$(v): %.$(p)
+	@echo
+	@echo Verify | figlet
+	@echo $*
+	@echo
+	@$(ctverif) $(flags) --no-compile --no-product $< | tee $*.log
+#	@$(secure) || [ -z "$$(grep " 0 errors" $*.log)" ]
+#	@not $(secure) || [ -n "$$(grep " 0 errors" $*.log)" ]
+
+all: $$(patsubst %,%.$(v),$$(goals))
+
+clean:
+	@echo Removing intermediate files
+	@rm -vrf $$(find . -name "*@*")

--- a/tests/sidewinder/working/s2n-cbc/Makefile
+++ b/tests/sidewinder/working/s2n-cbc/Makefile
@@ -1,0 +1,17 @@
+include ../../lib/ct-verif.mk
+
+cflags +=-D__TIMING_CONTRACTS__
+#the overriden .h
+cflags += -I$(CURDIR)
+#original .h
+cflags += -I$(CURDIR)/../../../../
+#/api .h that haven't fixed that
+cflags += -I$(CURDIR)/../../../../api/
+cflags += -fPIC -std=c99 -fgnu89-inline
+extras += crypto/s2n_hmac.c  crypto/s2n_hash.c utils/s2n_safety.c tls/s2n_cbc.c
+goals  += simple_cbc_wrapper@cbc.c
+full_self_comp += true
+smtlog += p.smt2
+shadowingArgs += "self_comp_mode=full,branchcond_assertion=assert_never,memory_assertion=assert_never"
+timing += true
+#printModel += true

--- a/tests/sidewinder/working/s2n-cbc/cbc.c
+++ b/tests/sidewinder/working/s2n-cbc/cbc.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <sys/param.h>
+#include <stdint.h>
+
+#include "crypto/s2n_hmac.h"
+
+#include "tls/s2n_record.h"
+#include "tls/s2n_prf.h"
+#include "tls/s2n_connection.h"
+
+#include <smack.h>
+#include <smack-contracts.h>
+#include "ct-verif.h"
+#include "sidewinder.h"
+
+int simple_cbc_wrapper(int currently_in_hash_block, int mlocked, int size, int *xor_pad, int * digest_pad)
+{
+
+  __VERIFIER_ASSERT_MAX_LEAKAGE(68);
+
+  public_in(__SMACK_value(currently_in_hash_block));
+  __VERIFIER_assume(currently_in_hash_block >= 0);
+  __VERIFIER_assume(currently_in_hash_block < BLOCK_SIZE);
+
+  public_in(__SMACK_value(mlocked));
+
+  struct s2n_hmac_state hmac = {
+    .alg = S2N_HMAC_SHA1,
+    .hash_block_size = BLOCK_SIZE,
+    .currently_in_hash_block = 0,
+    .digest_size = SHA_DIGEST_LENGTH,
+    .xor_pad_size = BLOCK_SIZE,
+    .inner.alg = S2N_HASH_SHA1,
+    .inner.currently_in_hash_block = 0,
+    .inner_just_key.alg = S2N_HASH_SHA1,
+    .inner_just_key.currently_in_hash_block = 0,
+    .outer.alg = S2N_HASH_SHA1,
+    .outer.currently_in_hash_block = 0,
+    .outer_just_key.alg = S2N_HASH_SHA1,
+    .outer_just_key.currently_in_hash_block = 0,
+     .xor_pad = *xor_pad,
+    //xor_pad is an array
+    .digest_pad = *digest_pad
+  };
+
+
+  struct s2n_crypto_parameters client;
+  struct s2n_connection conn = {
+    .client = &client,
+    .mode = S2N_SERVER
+  };
+  
+  //struct s2n_hmac_state hmac_copy;
+
+  int data[MAX_SIZE];
+  public_in(__SMACK_value(size));
+  __VERIFIER_assume(size >= 0);
+  __VERIFIER_assume(size <= MAX_SIZE);
+
+  struct s2n_blob decrypted = {
+    .data = data,
+    .size = size,
+    .allocated = 1,
+    .mlocked = mlocked
+  };
+
+  return s2n_verify_cbc(&conn, &hmac, &decrypted);
+}

--- a/tests/sidewinder/working/s2n-cbc/clean.sh
+++ b/tests/sidewinder/working/s2n-cbc/clean.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+make clean
+rm -r crypto
+rm -r tls
+rm -r utils

--- a/tests/sidewinder/working/s2n-cbc/copy_as_needed.sh
+++ b/tests/sidewinder/working/s2n-cbc/copy_as_needed.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+set -x 
+BASEDIR=$(pwd)
+echo $BASEDIR
+S2N_BASE="$BASEDIR/../../../.."
+echo $S2N_BASE
+
+cd $BASEDIR
+mkdir -p crypto
+#The hmac should be based off the old hmac, so just apply the patches to add the invarients
+cp $S2N_BASE/crypto/s2n_hmac.c crypto/
+cp $S2N_BASE/crypto/s2n_hmac.h crypto/
+patch -p5 < patches/hmac.patch
+
+#the hash uses my stubs for now, so replace the file
+cp stubs/s2n_hash.c crypto/
+cp stubs/s2n_hash.h crypto/
+
+mkdir -p tls
+#add invariants etc needed for the proof to the s2n_cbc code
+cp $S2N_BASE/tls/s2n_cbc.c tls/
+patch -p5 < patches/cbc.patch
+
+mkdir -p utils
+cp $S2N_BASE/utils/s2n_safety.c utils/
+cp $S2N_BASE/utils/s2n_safety.h utils/
+patch -p5 < patches/safety.patch
+
+cp stubs/s2n_annotations.h utils/
+

--- a/tests/sidewinder/working/s2n-cbc/heat.rb
+++ b/tests/sidewinder/working/s2n-cbc/heat.rb
@@ -1,0 +1,35 @@
+require 'nyaplot'
+require 'nyaplot3d'
+
+colors = Nyaplot::Colors.qual
+
+f = File.open(ARGV[0], "r")
+x=[]
+y=[]
+x_s=[]
+y_s=[]
+f.each_line do |li|
+  m = /\$l.shadow@(.*) -> (.*)/.match(li)
+  if m
+    x.push(Integer(m[1]))
+    y.push(Integer(m[2]))
+  end
+  m = /\$l@(.*) -> (.*)/.match(li)
+  if m
+    x_s.push(Integer(m[1]))
+    y_s.push(Integer(m[2]))
+  end
+
+end
+#puts x
+
+plot1 = Nyaplot::Plot.new
+sc1 = plot1.add(:scatter, x, y)
+plot2 = Nyaplot::Plot.new
+sc2 = plot2.add(:scatter, x_s, y_s)
+
+
+frame = Nyaplot::Frame.new
+frame.add(plot1)
+frame.add(plot2)
+frame.export_html("multiple_pane.html")

--- a/tests/sidewinder/working/s2n-cbc/patches/cbc.patch
+++ b/tests/sidewinder/working/s2n-cbc/patches/cbc.patch
@@ -1,0 +1,86 @@
+diff --git a/tests/sidewinder/working/s2n-cbc/tls/s2n_cbc.c b/tests/sidewinder/working/s2n-cbc/tls/s2n_cbc.c
+index b37efb0..077d214 100644
+--- a/tests/sidewinder/working/s2n-cbc/tls/s2n_cbc.c
++++ b/tests/sidewinder/working/s2n-cbc/tls/s2n_cbc.c
+@@ -25,6 +25,28 @@
+ 
+ #include "tls/s2n_record.h"
+ 
++#include <smack.h>
++#include <smack-contracts.h>
++#include "ct-verif.h"
++#include "sidewinder.h"
++
++/* Because of a bug in SMACK, when we try to specify the invarients for this loop in the main function, 
++ * SMACK crashes. Moving the code (unmodified) to this function sidesteps the bug. Michael Emmi has promissed
++ * a fix soon
++ */
++int double_loop(int old_mismatches, struct s2n_blob *decrypted, int check, int cutoff, int padding_length) {
++  __VERIFIER_assert(decrypted->size >= 0);
++  __VERIFIER_assert(decrypted->size <= 1024);
++  int mismatches = old_mismatches;
++  for (int i = 0, j = decrypted->size - 1 - check; i < check && j < decrypted->size; i++, j++) {
++    invariant(i <= check);
++    invariant(j == i + decrypted->size - check - 1);
++    uint8_t mask = ~(0xff << ((i >= cutoff) * 8));
++    mismatches |= (decrypted->data[j] ^ padding_length) & mask;
++  }
++  return mismatches;
++}
++
+ /* A TLS CBC record looks like ..
+  *
+  * [ Payload data ] [ HMAC ] [ Padding ] [ Padding length byte ]
+@@ -53,17 +75,20 @@ int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, str
+        copy = &conn->server->record_mac_copy_workspace;
+     }
+     
+-    uint8_t mac_digest_size;
+-    GUARD(s2n_hmac_digest_size(hmac->alg, &mac_digest_size));
++    uint8_t mac_digest_size = DIGEST_SIZE;;
++    //GUARD(s2n_hmac_digest_size(hmac->alg, &mac_digest_size));
+ 
+     /* The record has to be at least big enough to contain the MAC,
+      * plus the padding length byte */
+     gt_check(decrypted->size, mac_digest_size);
+ 
+     int payload_and_padding_size = decrypted->size - mac_digest_size;
++    __VERIFIER_assert(payload_and_padding_size <= MAX_SIZE - 20);
+ 
+     /* Determine what the padding length is */
+     uint8_t padding_length = decrypted->data[decrypted->size - 1];
++    __VERIFIER_assume(padding_length >= 0);
++    __VERIFIER_assume(padding_length <  256);
+ 
+     int payload_length = MAX(payload_and_padding_size - padding_length - 1, 0);
+ 
+@@ -82,20 +107,21 @@ int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, str
+     GUARD(s2n_hmac_update(copy, decrypted->data + payload_length + mac_digest_size, decrypted->size - payload_length - mac_digest_size - 1));
+ 
+     /* SSLv3 doesn't specify what the padding should actually be */
+-    if (conn->actual_protocol_version == S2N_SSLv3) {
+-        return 0 - mismatches;
+-    }
++    /* if (conn->actual_protocol_version == S2N_SSLv3) { */
++    /*     return 0 - mismatches; */
++    /* } */
+ 
+     /* Check the maximum amount that could theoretically be padding */
+     int check = MIN(255, (payload_and_padding_size - 1));
+ 
+     int cutoff = check - padding_length;
+-    for (int i = 0, j = decrypted->size - 1 - check; i < check && j < decrypted->size; i++, j++) {
+-        uint8_t mask = ~(0xff << ((i >= cutoff) * 8));
+-        mismatches |= (decrypted->data[j] ^ padding_length) & mask;
+-    }
++    mismatches = double_loop(mismatches, decrypted, check, cutoff, padding_length);
++    /* for (int i = 0, j = decrypted->size - 1 - check; i < check && j < decrypted->size; i++, j++) { */
++    /*     uint8_t mask = ~(0xff << ((i >= cutoff) * 8)); */
++    /*     mismatches |= (decrypted->data[j] ^ padding_length) & mask; */
++    /* } */
+ 
+-    GUARD(s2n_hmac_reset(copy));
++    /* GUARD(s2n_hmac_reset(copy)); */
+ 
+     if (mismatches) {
+         S2N_ERROR(S2N_ERR_CBC_VERIFY);

--- a/tests/sidewinder/working/s2n-cbc/patches/cbc.patch
+++ b/tests/sidewinder/working/s2n-cbc/patches/cbc.patch
@@ -17,7 +17,7 @@ index b37efb0..077d214 100644
 + */
 +int double_loop(int old_mismatches, struct s2n_blob *decrypted, int check, int cutoff, int padding_length) {
 +  __VERIFIER_assert(decrypted->size >= 0);
-+  __VERIFIER_assert(decrypted->size <= 1024);
++  __VERIFIER_assert(decrypted->size <= MAX_SIZE);
 +  int mismatches = old_mismatches;
 +  for (int i = 0, j = decrypted->size - 1 - check; i < check && j < decrypted->size; i++, j++) {
 +    invariant(i <= check);

--- a/tests/sidewinder/working/s2n-cbc/patches/hmac.patch
+++ b/tests/sidewinder/working/s2n-cbc/patches/hmac.patch
@@ -1,0 +1,109 @@
+diff --git a/tests/sidewinder/working/s2n-cbc/crypto/s2n_hmac.c b/tests/sidewinder/working/s2n-cbc/crypto/s2n_hmac.c
+index 3405781..3beeacf 100644
+--- a/tests/sidewinder/working/s2n-cbc/crypto/s2n_hmac.c
++++ b/tests/sidewinder/working/s2n-cbc/crypto/s2n_hmac.c
+@@ -26,6 +26,9 @@
+ #include "utils/s2n_blob.h"
+ #include "utils/s2n_mem.h"
+ 
++#include "smack.h"
++#include "sidewinder.h"
++
+ int s2n_hmac_hash_alg(s2n_hmac_algorithm hmac_alg, s2n_hash_algorithm *out)
+ {
+     switch(hmac_alg) {
+@@ -235,7 +238,7 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
+      * input. On some platforms, including Intel, the operation can take a
+      * smaller number of cycles if the input is "small".
+      */
+-    state->currently_in_hash_block += (4294949760 + size) % state->hash_block_size;
++    state->currently_in_hash_block += (size) % state->hash_block_size;
+     state->currently_in_hash_block %= state->hash_block_size;
+ 
+     return s2n_hash_update(&state->inner, in, size);
+@@ -311,30 +314,30 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
+     GUARD(s2n_hash_copy(&to->outer_just_key, &from->outer_just_key));
+ 
+ 
+-    memcpy_check(to->xor_pad, from->xor_pad, sizeof(to->xor_pad));
+-    memcpy_check(to->digest_pad, from->digest_pad, sizeof(to->digest_pad));
++    //memcpy_check(to->xor_pad, from->xor_pad, sizeof(to->xor_pad));
++    //memcpy_check(to->digest_pad, from->digest_pad, sizeof(to->digest_pad));
+ 
+     return 0;
+ }
+ 
+ 
+-/* Preserve the handlers for hmac state pointers to avoid re-allocation 
+- * Only valid if the HMAC is in EVP mode
+- */
+-int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac)
+-{
+-    backup->inner = hmac->inner.digest.high_level;
+-    backup->inner_just_key = hmac->inner_just_key.digest.high_level;
+-    backup->outer = hmac->outer.digest.high_level;
+-    backup->outer_just_key = hmac->outer_just_key.digest.high_level;
+-    return 0;
+-}
+-
+-int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac)
+-{
+-    hmac->inner.digest.high_level = backup->inner;
+-    hmac->inner_just_key.digest.high_level = backup->inner_just_key;
+-    hmac->outer.digest.high_level = backup->outer;
+-    hmac->outer_just_key.digest.high_level = backup->outer_just_key;
+-    return 0;
+-}
++/* /\* Preserve the handlers for hmac state pointers to avoid re-allocation  */
++/*  * Only valid if the HMAC is in EVP mode */
++/*  *\/ */
++/* int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac) */
++/* { */
++/*     backup->inner = hmac->inner.digest.high_level; */
++/*     backup->inner_just_key = hmac->inner_just_key.digest.high_level; */
++/*     backup->outer = hmac->outer.digest.high_level; */
++/*     backup->outer_just_key = hmac->outer_just_key.digest.high_level; */
++/*     return 0; */
++/* } */
++
++/* int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac) */
++/* { */
++/*     hmac->inner.digest.high_level = backup->inner; */
++/*     hmac->inner_just_key.digest.high_level = backup->inner_just_key; */
++/*     hmac->outer.digest.high_level = backup->outer; */
++/*     hmac->outer_just_key.digest.high_level = backup->outer_just_key; */
++/*     return 0; */
++/* } */
+diff --git a/tests/sidewinder/working/s2n-cbc/crypto/s2n_hmac.h b/tests/sidewinder/working/s2n-cbc/crypto/s2n_hmac.h
+index 7af7e61..e6382ce 100644
+--- a/tests/sidewinder/working/s2n-cbc/crypto/s2n_hmac.h
++++ b/tests/sidewinder/working/s2n-cbc/crypto/s2n_hmac.h
+@@ -52,12 +52,12 @@ struct s2n_hmac_state {
+     uint8_t digest_pad[SHA512_DIGEST_LENGTH];
+ };
+ 
+-struct s2n_hmac_evp_backup {
+-    struct s2n_hash_evp_digest inner;
+-    struct s2n_hash_evp_digest inner_just_key;
+-    struct s2n_hash_evp_digest outer;
+-    struct s2n_hash_evp_digest outer_just_key;
+-};
++/* struct s2n_hmac_evp_backup { */
++/*     struct s2n_hash_evp_digest inner; */
++/*     struct s2n_hash_evp_digest inner_just_key; */
++/*     struct s2n_hash_evp_digest outer; */
++/*     struct s2n_hash_evp_digest outer_just_key; */
++/* }; */
+ 
+ extern int s2n_hmac_digest_size(s2n_hmac_algorithm alg, uint8_t *out);
+ extern int s2n_hmac_is_available(s2n_hmac_algorithm alg);
+@@ -72,7 +72,7 @@ extern int s2n_hmac_digest_verify(const void *a, const void *b, uint32_t len);
+ extern int s2n_hmac_free(struct s2n_hmac_state *state);
+ extern int s2n_hmac_reset(struct s2n_hmac_state *state);
+ extern int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from);
+-extern int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac);
+-extern int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac);
++//extern int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac);
++//extern int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac);
+ 
+ 

--- a/tests/sidewinder/working/s2n-cbc/patches/safety.patch
+++ b/tests/sidewinder/working/s2n-cbc/patches/safety.patch
@@ -1,0 +1,48 @@
+diff --git a/tests/sidewinder/working/s2n-cbc/utils/s2n_safety.c b/tests/sidewinder/working/s2n-cbc/utils/s2n_safety.c
+index 3af0262..261285a 100644
+--- a/tests/sidewinder/working/s2n-cbc/utils/s2n_safety.c
++++ b/tests/sidewinder/working/s2n-cbc/utils/s2n_safety.c
+@@ -55,8 +55,8 @@ pid_t s2n_actual_getpid()
+  */
+ int s2n_constant_time_equals(const uint8_t * a, const uint8_t * b, uint32_t len)
+ {
+-    S2N_PUBLIC_INPUT(a);
+-    S2N_PUBLIC_INPUT(b);
++  //S2N_PUBLIC_INPUT(a);
++  //S2N_PUBLIC_INPUT(b);
+     S2N_PUBLIC_INPUT(len);
+     
+     uint8_t xor = 0;
+diff --git a/tests/sidewinder/working/s2n-cbc/utils/s2n_safety.h b/tests/sidewinder/working/s2n-cbc/utils/s2n_safety.h
+index 704bb63..dc44360 100644
+--- a/tests/sidewinder/working/s2n-cbc/utils/s2n_safety.h
++++ b/tests/sidewinder/working/s2n-cbc/utils/s2n_safety.h
+@@ -21,6 +21,8 @@
+ 
+ #include "error/s2n_errno.h"
+ 
++void __VERIFIER_assume(int);
++
+ /* NULL check a pointer */
+ #define notnull_check( ptr )           do { if ( (ptr) == NULL ) { S2N_ERROR(S2N_ERR_NULL); } } while(0)
+ 
+@@ -58,8 +60,8 @@ static inline void* trace_memcpy_check(void *restrict to, const void *restrict f
+ 
+ /* Range check a number */
+ #define gte_check(n, min)  do { if ( (n) < min ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)
+-#define lte_check(n, max)  do { if ( (n) > max ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)
+-#define gt_check(n, min)  do { if ( (n) <= min ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)
++#define lte_check(n, max)  __VERIFIER_assume( (n) <= (max) )
++#define gt_check(n, min)   __VERIFIER_assume( (n) >  (min) )
+ #define lt_check(n, max)  do { if ( (n) >= max ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)
+ #define eq_check(a, b)  do { if ( (a) != (b) ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)
+ #define ne_check(a, b)  do { if ( (a) == (b) ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)
+@@ -76,7 +78,7 @@ static inline void* trace_memcpy_check(void *restrict to, const void *restrict f
+     lt_check(__tmp_n, high);                    \
+   } while (0)
+ 
+-#define GUARD( x )      if ( (x) < 0 ) return -1
++#define GUARD( x ) __VERIFIER_assume( (x) >= 0 )
+ #define GUARD_PTR( x )  if ( (x) < 0 ) return NULL
+ 
+ /**

--- a/tests/sidewinder/working/s2n-cbc/run.sh
+++ b/tests/sidewinder/working/s2n-cbc/run.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+
+./copy_as_needed.sh
+make clean
+time make

--- a/tests/sidewinder/working/s2n-cbc/sidewinder.h
+++ b/tests/sidewinder/working/s2n-cbc/sidewinder.h
@@ -1,0 +1,7 @@
+#pragma once
+
+void __VERIFIER_ASSERT_MAX_LEAKAGE(int max);
+void __VERIFIER_ASSUME_LEAKAGE(int assumedLeakage);
+void benign();
+#define BENIGN benign()
+//#define BENIGN

--- a/tests/sidewinder/working/s2n-cbc/sidewinder.h
+++ b/tests/sidewinder/working/s2n-cbc/sidewinder.h
@@ -4,4 +4,3 @@ void __VERIFIER_ASSERT_MAX_LEAKAGE(int max);
 void __VERIFIER_ASSUME_LEAKAGE(int assumedLeakage);
 void benign();
 #define BENIGN benign()
-//#define BENIGN

--- a/tests/sidewinder/working/s2n-cbc/stubs/s2n_annotations.h
+++ b/tests/sidewinder/working/s2n-cbc/stubs/s2n_annotations.h
@@ -12,8 +12,11 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
 #pragma once
 
-//For compilation purposes, these annotations are no-ops 
-#define S2N_PUBLIC_INPUT(__a)
-#define S2N_INVARIENT(__a)
+#include <smack-contracts.h>
+#include "ct-verif.h"
+
+#define S2N_PUBLIC_INPUT( __a )  public_in(__SMACK_value( __a ))
+#define S2N_INVARIENT( __a ) invariant ( __a )

--- a/tests/sidewinder/working/s2n-cbc/stubs/s2n_hash.c
+++ b/tests/sidewinder/working/s2n-cbc/stubs/s2n_hash.c
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+#include "s2n_hash.h"
+#include "../error/s2n_errno.h"
+#include <smack.h>
+#include "ct-verif.h"
+#include "../sidewinder.h"
+
+int s2n_hash_digest_size(s2n_hash_algorithm alg, uint8_t *out)
+{
+    switch (alg) {
+    case S2N_HASH_NONE:     *out = 0;                    break;
+    case S2N_HASH_MD5:      *out = MD5_DIGEST_LENGTH;    break;
+    case S2N_HASH_SHA1:     *out = 20;    break;
+      //    case S2N_HASH_SHA1:     *out = SHA_DIGEST_LENGTH;    break;
+    case S2N_HASH_SHA224:   *out = SHA224_DIGEST_LENGTH; break;
+    case S2N_HASH_SHA256:   *out = SHA256_DIGEST_LENGTH; break;
+    case S2N_HASH_SHA384:   *out = SHA384_DIGEST_LENGTH; break;
+    case S2N_HASH_SHA512:   *out = SHA512_DIGEST_LENGTH; break;
+    case S2N_HASH_MD5_SHA1: *out = MD5_DIGEST_LENGTH + SHA_DIGEST_LENGTH; break;
+    default:
+        S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
+    }
+    return 0;
+}
+
+int s2n_hash_new(struct s2n_hash_state *state)
+{
+  return SUCCESS;
+}
+
+int s2n_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm alg)
+{
+  __VERIFIER_ASSUME_LEAKAGE(0);
+  state->alg = alg;
+  state->currently_in_hash_block = 0;
+  return SUCCESS;
+}
+
+int num_blocks(int numBytes) {
+  __VERIFIER_ASSUME_LEAKAGE(0);
+  if (numBytes <  1*BLOCK_SIZE) {BENIGN;return 0;}
+  if (numBytes <  2*BLOCK_SIZE) return 1;
+  if (numBytes <  3*BLOCK_SIZE) return 2;
+  if (numBytes <  4*BLOCK_SIZE) return 3;
+  if (numBytes <  5*BLOCK_SIZE) return 4;
+  if (numBytes <  6*BLOCK_SIZE) return 5;
+  if (numBytes <  7*BLOCK_SIZE) return 6;
+  if (numBytes <  8*BLOCK_SIZE) return 7;
+  if (numBytes <  9*BLOCK_SIZE) return 8;
+  if (numBytes < 10*BLOCK_SIZE) return 9;
+  if (numBytes < 11*BLOCK_SIZE) return 10;
+  if (numBytes < 12*BLOCK_SIZE) return 11;
+  if (numBytes < 13*BLOCK_SIZE) return 12;
+  if (numBytes < 14*BLOCK_SIZE) return 13;
+  if (numBytes < 15*BLOCK_SIZE) return 14;
+  if (numBytes < 16*BLOCK_SIZE) return 15;
+  if (numBytes < 17*BLOCK_SIZE) return 16;
+  if (numBytes == 1088) return 17;
+  __VERIFIER_assert(numBytes <= 1088);
+  //return -1;
+}
+
+int s2n_hash_update(struct s2n_hash_state *state, const void *data, uint32_t size)
+{
+
+  /* The __VERIFIER_assert statements give better performance but don't add to our current spec.
+   *  The proof should hold in their absense.
+   */
+
+   __VERIFIER_assert(size >= 0);
+   __VERIFIER_assert(size <= 1024);
+   __VERIFIER_assert(state->currently_in_hash_block < BLOCK_SIZE);
+   __VERIFIER_ASSUME_LEAKAGE(PER_BYTE_COST * size);
+
+   state->currently_in_hash_block += size;
+   int num_filled_blocks = num_blocks(state->currently_in_hash_block);
+   __VERIFIER_ASSUME_LEAKAGE(num_filled_blocks * PER_BLOCK_COST);
+
+   state->currently_in_hash_block = state->currently_in_hash_block - num_filled_blocks*BLOCK_SIZE;
+   __VERIFIER_assert(state->currently_in_hash_block < BLOCK_SIZE);
+
+   return SUCCESS;
+}
+
+int s2n_hash_digest(struct s2n_hash_state *state, void *out, uint32_t size)
+{
+  __VERIFIER_ASSUME_LEAKAGE(0);
+  // All the leakage comes from the hash_update we do once we've updated the size fields
+
+  const int MARKER_BYTE_LENGTH = 1;
+  // append the bit '1' to the message e.g. by adding 0x80 if message length is a multiple of 8 bits.
+  uint32_t min_bytes_to_add = MARKER_BYTE_LENGTH;
+  min_bytes_to_add += LENGTH_FIELD_SIZE;
+
+  int bytes_to_add;
+  if(state->currently_in_hash_block + min_bytes_to_add <= BLOCK_SIZE){
+    BENIGN;
+    bytes_to_add = BLOCK_SIZE - state->currently_in_hash_block;
+  } else {
+    bytes_to_add = BLOCK_SIZE + (BLOCK_SIZE - state->currently_in_hash_block);
+  }
+
+  s2n_hash_update(state, NULL, bytes_to_add);
+  return SUCCESS;
+}
+
+int s2n_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *from)
+{
+  __VERIFIER_ASSUME_LEAKAGE(0);
+  to->alg = from->alg;
+  to->currently_in_hash_block = from->currently_in_hash_block;
+  return SUCCESS;
+}
+
+int s2n_hash_reset(struct s2n_hash_state *state)
+{
+  __VERIFIER_ASSUME_LEAKAGE(0);
+  state->currently_in_hash_block = 0;
+  return SUCCESS;
+}
+
+int s2n_hash_free(struct s2n_hash_state *state)
+{
+  return SUCCESS;
+}

--- a/tests/sidewinder/working/s2n-cbc/stubs/s2n_hash.h
+++ b/tests/sidewinder/working/s2n-cbc/stubs/s2n_hash.h
@@ -41,7 +41,15 @@ struct s2n_hash_state {
   int currently_in_hash_block;
 };
 
-//SHA1
+/* SHA1
+ * These fields were determined from the SHA specification, augmented by
+ * analyzing SHA implementations. 
+ * PER_BLOCK_COST is the cost of a compression round.  Pessimistically assume 
+ * it is 1000 cycles/block, which is worse than real implementations (larger
+ * numbers here make lucky13 leakages look worse), and hence large is safer.
+ * PER_BYTE_COST is the cost of memcopy one byte that is already in cache,
+ * to a location already in cache.
+ */
 enum {
   PER_BLOCK_COST = 1000,
   PER_BYTE_COST = 1,

--- a/tests/sidewinder/working/s2n-cbc/stubs/s2n_hash.h
+++ b/tests/sidewinder/working/s2n-cbc/stubs/s2n_hash.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <openssl/sha.h>
+#include <openssl/md5.h>
+
+#include "crypto/s2n_evp.h"
+
+#define S2N_MAX_DIGEST_LEN SHA512_DIGEST_LENGTH
+
+typedef enum {
+    S2N_HASH_NONE,
+    S2N_HASH_MD5,
+    S2N_HASH_SHA1,
+    S2N_HASH_SHA224,
+    S2N_HASH_SHA256,
+    S2N_HASH_SHA384,
+    S2N_HASH_SHA512,
+    S2N_HASH_MD5_SHA1,
+    /* Don't add any hash algorithms below S2N_HASH_SENTINEL */
+    S2N_HASH_SENTINEL
+} s2n_hash_algorithm;
+
+struct s2n_hash_state {
+  s2n_hash_algorithm alg;
+  int currently_in_hash_block;
+};
+
+//SHA1
+enum {
+  PER_BLOCK_COST = 1000,
+  PER_BYTE_COST = 1,
+  BLOCK_SIZE = 64,          
+  LENGTH_FIELD_SIZE = 8,
+  DIGEST_SIZE = 20
+};
+
+#define MAX_SIZE 1024
+
+enum {
+  SUCCESS = 0,
+  FAILURE = -1
+};
+
+extern int s2n_hash_digest_size(s2n_hash_algorithm alg, uint8_t *out);
+extern int s2n_hash_new(struct s2n_hash_state *state);
+extern int s2n_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm alg);
+extern int s2n_hash_update(struct s2n_hash_state *state, const void *data, uint32_t size);
+extern int s2n_hash_digest(struct s2n_hash_state *state, void *out, uint32_t size);
+extern int s2n_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *from);
+extern int s2n_hash_reset(struct s2n_hash_state *state);
+extern int s2n_hash_free(struct s2n_hash_state *state);
+
+

--- a/utils/s2n_safety.c
+++ b/utils/s2n_safety.c
@@ -61,6 +61,8 @@ int s2n_constant_time_equals(const uint8_t * a, const uint8_t * b, uint32_t len)
     
     uint8_t xor = 0;
     for (int i = 0; i < len; i++) {
+        /* Invariants must hold for each execution of the loop
+	 * and at loop exit, hence the <= */ 
         S2N_INVARIENT(i <= len);
         xor |= a[i] ^ b[i];
     }

--- a/utils/s2n_safety.c
+++ b/utils/s2n_safety.c
@@ -61,6 +61,7 @@ int s2n_constant_time_equals(const uint8_t * a, const uint8_t * b, uint32_t len)
     
     uint8_t xor = 0;
     for (int i = 0; i < len; i++) {
+        S2N_INVARIENT(i <= len);
         xor |= a[i] ^ b[i];
     }
 


### PR DESCRIPTION
This PR integrates a new tool Sidewinder, which checks the correctness of code-balancing countermeasures against side-channel attacks.

A program has a timing side channel if the amount of time needed to execute it depends on the value of a secret input to the program. Sidewinder take a program, annotates every instuction with its runtime cost, and then generates a mathematical formula which symbolically represents the cost of executing the program given an input. Sidewinder then asks an automated theorem prover, called a Satisfiability Modulo Theories (SMT) solver, if there is a pair of secret inputs to the program that would take different amounts of time to process. The SMT solver, using clever heuristics, exhaustively searches the state of all possible program inputs, and either returns a proof that there is no timing side-channel, or an example of a pair of inputs that lead to a timing channel, along with the estimated leakage.

 More detail is available at: https://github.com/danielsn/s2n/blob/sidewinder-travis-pr/tests/sidewinder/README.md

A CI run showing that this tool catches the lucky microseconds issue is at https://travis-ci.org/danielsn/s2n/builds/315433471