### PR TITLE
Track number of bytes in hash-blocks

### DIFF
--- a/.travis/install_saw.sh
+++ b/.travis/install_saw.sh
@@ -32,9 +32,7 @@ mkdir -p "$DOWNLOAD_DIR"
 cd "$DOWNLOAD_DIR"
 
 #download saw binaries
-##TODO: Post the SAW binary here once we've tested this
-#curl --retry 3 https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/saw-0.2-2017-07-27-Ubuntu14.04-64.tar.gz --output saw.tar.gz;
-curl https://saw.galois.com/builds/nightly/saw-0.2-2018-01-21-Ubuntu14.04-64.tar.gz > saw.tar.gz;
+curl --retry 3 https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/saw-0.2-2018-01-21-Ubuntu14.04-64.tar.gz --output saw.tar.gz;
 
 mkdir -p saw && tar -xzf saw.tar.gz --strip-components=1 -C saw
 mkdir -p "$INSTALL_DIR" && mv saw/* "$INSTALL_DIR"

--- a/.travis/install_saw.sh
+++ b/.travis/install_saw.sh
@@ -32,7 +32,9 @@ mkdir -p "$DOWNLOAD_DIR"
 cd "$DOWNLOAD_DIR"
 
 #download saw binaries
-curl --retry 3 https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/saw-0.2-2017-07-27-Ubuntu14.04-64.tar.gz --output saw.tar.gz;
+##TODO: Post the SAW binary here once we've tested this
+#curl --retry 3 https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/saw-0.2-2017-07-27-Ubuntu14.04-64.tar.gz --output saw.tar.gz;
+curl https://saw.galois.com/builds/nightly/saw-0.2-2018-01-21-Ubuntu14.04-64.tar.gz > saw.tar.gz;
 
 mkdir -p saw && tar -xzf saw.tar.gz --strip-components=1 -C saw
 mkdir -p "$INSTALL_DIR" && mv saw/* "$INSTALL_DIR"

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -38,6 +38,26 @@ int s2n_hash_digest_size(s2n_hash_algorithm alg, uint8_t *out)
     return 0;
 }
 
+/* NOTE: 2n_hash_get_currently_in_hash_block takes advantage of the fact that
+ * hash_block_size is a power of 2. This is true for all hashes we currently support
+ * If this ever becomes untrue, this would require fixing*/
+int s2n_hash_block_size(s2n_hash_algorithm alg, uint64_t *block_size)
+{
+    switch(alg) {
+    case S2N_HASH_NONE:       *block_size = 64;   break;
+    case S2N_HASH_MD5:        *block_size = 64;   break;
+    case S2N_HASH_SHA1:       *block_size = 64;   break;
+    case S2N_HASH_SHA224:     *block_size = 64;   break;
+    case S2N_HASH_SHA256:     *block_size = 64;   break;
+    case S2N_HASH_SHA384:     *block_size = 128;  break;
+    case S2N_HASH_SHA512:     *block_size = 128;  break;
+    case S2N_HASH_MD5_SHA1:   *block_size = 64;   break;
+    default:
+        S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
+    }
+    return 0;
+}
+
 /* Return 1 if hash algorithm is available, 0 otherwise. */
 int s2n_hash_is_available(s2n_hash_algorithm alg)
 {
@@ -63,11 +83,19 @@ int s2n_hash_is_available(s2n_hash_algorithm alg)
     return is_available;
 }
 
+int s2n_hash_is_ready_for_input(struct s2n_hash_state *state)
+{
+  return state->is_ready_for_input;
+}
+
 static int s2n_low_level_hash_new(struct s2n_hash_state *state)
 {
     /* s2n_hash_new will always call the corresponding implementation of the s2n_hash
      * being used. For the s2n_low_level_hash implementation, new is a no-op.
      */
+
+    state->is_ready_for_input = 0;
+    state->currently_in_hash = 0;
     return 0;
 }
 
@@ -110,12 +138,16 @@ static int s2n_low_level_hash_init(struct s2n_hash_state *state, s2n_hash_algori
     }
 
     state->alg = alg;
+    state->is_ready_for_input = 1;
+    state->currently_in_hash = 0;
 
     return 0;
 }
 
 static int s2n_low_level_hash_update(struct s2n_hash_state *state, const void *data, uint32_t size)
 {
+    S2N_ERROR_UNLESS(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
+
     int r;
     switch (state->alg) {
     case S2N_HASH_NONE:
@@ -151,11 +183,15 @@ static int s2n_low_level_hash_update(struct s2n_hash_state *state, const void *d
         S2N_ERROR(S2N_ERR_HASH_UPDATE_FAILED);
     }
 
+    state->currently_in_hash += size;
+
     return 0;
 }
 
 static int s2n_low_level_hash_digest(struct s2n_hash_state *state, void *out, uint32_t size)
 {
+    S2N_ERROR_UNLESS(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
+
     int r;
     switch (state->alg) {
     case S2N_HASH_NONE:
@@ -198,6 +234,8 @@ static int s2n_low_level_hash_digest(struct s2n_hash_state *state, void *out, ui
         S2N_ERROR(S2N_ERR_HASH_DIGEST_FAILED);
     }
 
+    state->currently_in_hash = 0;
+    state->is_ready_for_input = 0;
     return 0;
 }
 
@@ -209,6 +247,7 @@ static int s2n_low_level_hash_copy(struct s2n_hash_state *to, struct s2n_hash_st
 
 static int s2n_low_level_hash_reset(struct s2n_hash_state *state)
 {
+    /* hash_init resets the ready_for_input and currently_in_hash fields */
     return s2n_low_level_hash_init(state, state->alg);
 }
 
@@ -217,6 +256,7 @@ static int s2n_low_level_hash_free(struct s2n_hash_state *state)
     /* s2n_hash_free will always call the corresponding implementation of the s2n_hash
      * being used. For the s2n_low_level_hash implementation, free is a no-op.
      */
+    state->is_ready_for_input = 0;
     return 0;
 }
 
@@ -224,6 +264,8 @@ static int s2n_evp_hash_new(struct s2n_hash_state *state)
 {
     notnull_check(state->digest.high_level.evp.ctx = S2N_EVP_MD_CTX_NEW());
     notnull_check(state->digest.high_level.evp_md5_secondary.ctx = S2N_EVP_MD_CTX_NEW());
+    state->is_ready_for_input = 0;
+    state->currently_in_hash = 0;
 
     return 0;
 }
@@ -276,12 +318,16 @@ static int s2n_evp_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm al
     }
 
     state->alg = alg;
+    state->is_ready_for_input = 1;
+    state->currently_in_hash = 0;
 
     return 0;
 }
 
 static int s2n_evp_hash_update(struct s2n_hash_state *state, const void *data, uint32_t size)
 {
+    S2N_ERROR_UNLESS(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
+
     int r;
     switch (state->alg) {
     case S2N_HASH_NONE:
@@ -307,11 +353,15 @@ static int s2n_evp_hash_update(struct s2n_hash_state *state, const void *data, u
         S2N_ERROR(S2N_ERR_HASH_UPDATE_FAILED);
     }
 
+    state->currently_in_hash += size;
+
     return 0;
 }
 
 static int s2n_evp_hash_digest(struct s2n_hash_state *state, void *out, uint32_t size)
 {
+    S2N_ERROR_UNLESS(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
+
     int r;
     unsigned int digest_size = size;
     uint8_t expected_digest_size;
@@ -351,6 +401,8 @@ static int s2n_evp_hash_digest(struct s2n_hash_state *state, void *out, uint32_t
         S2N_ERROR(S2N_ERR_HASH_DIGEST_FAILED);
     }
 
+    state->currently_in_hash = 0;
+    state->is_ready_for_input = 0;
     return 0;
 }
 
@@ -388,6 +440,8 @@ static int s2n_evp_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *f
     }
     to->hash_impl = from->hash_impl;
     to->alg = from->alg;
+    to->is_ready_for_input = from->is_ready_for_input;
+    to->currently_in_hash = from->currently_in_hash;
 
     return 0;
 }
@@ -414,6 +468,7 @@ static int s2n_evp_hash_reset(struct s2n_hash_state *state)
         GUARD(s2n_hash_allow_md5_for_fips(state));
     }
 
+    /* hash_init resets the ready_for_input and currently_in_hash fields */
     return s2n_evp_hash_init(state, state->alg);
 }
 
@@ -423,7 +478,7 @@ static int s2n_evp_hash_free(struct s2n_hash_state *state)
     S2N_EVP_MD_CTX_FREE(state->digest.high_level.evp_md5_secondary.ctx);
     state->digest.high_level.evp.ctx = NULL;
     state->digest.high_level.evp_md5_secondary.ctx = NULL;
-
+    state->is_ready_for_input = 0;
     return 0;
 }
 
@@ -543,4 +598,26 @@ int s2n_hash_free(struct s2n_hash_state *state)
     notnull_check(state->hash_impl->free);
 
     return state->hash_impl->free(state);
+}
+
+int s2n_hash_get_currently_in_hash_total(struct s2n_hash_state *state, uint64_t *out)
+{
+    S2N_ERROR_UNLESS(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
+
+    *out = state->currently_in_hash;
+    return 0;
+}
+
+
+/* Calculate, in constant time, the number of bytes currently in the hash_block */
+int s2n_hash_get_currently_in_hash_block(struct s2n_hash_state *state, uint64_t *out)
+{
+    S2N_ERROR_UNLESS(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
+    uint64_t hash_block_size;
+    GUARD(s2n_hash_block_size(state->alg, &hash_block_size));
+
+    /* Requires that hash_block_size is a power of 2. This is true for all hashes we currently support
+     * If this ever becomes untrue, this would require fixing this*/
+    *out = state->currently_in_hash & (hash_block_size - 1);
+    return 0;
 }

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -38,7 +38,7 @@ int s2n_hash_digest_size(s2n_hash_algorithm alg, uint8_t *out)
     return 0;
 }
 
-/* NOTE: 2n_hash_get_currently_in_hash_block takes advantage of the fact that
+/* NOTE: s2n_hash_const_time_get_currently_in_hash_block takes advantage of the fact that
  * hash_block_size is a power of 2. This is true for all hashes we currently support
  * If this ever becomes untrue, this would require fixing*/
 int s2n_hash_block_size(s2n_hash_algorithm alg, uint64_t *block_size)
@@ -146,7 +146,7 @@ static int s2n_low_level_hash_init(struct s2n_hash_state *state, s2n_hash_algori
 
 static int s2n_low_level_hash_update(struct s2n_hash_state *state, const void *data, uint32_t size)
 {
-    S2N_ERROR_UNLESS(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
+    S2N_ERROR_IF(!state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
 
     int r;
     switch (state->alg) {
@@ -190,7 +190,7 @@ static int s2n_low_level_hash_update(struct s2n_hash_state *state, const void *d
 
 static int s2n_low_level_hash_digest(struct s2n_hash_state *state, void *out, uint32_t size)
 {
-    S2N_ERROR_UNLESS(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
+    S2N_ERROR_IF(!state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
 
     int r;
     switch (state->alg) {
@@ -326,7 +326,7 @@ static int s2n_evp_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm al
 
 static int s2n_evp_hash_update(struct s2n_hash_state *state, const void *data, uint32_t size)
 {
-    S2N_ERROR_UNLESS(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
+    S2N_ERROR_IF(!state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
 
     int r;
     switch (state->alg) {
@@ -360,7 +360,7 @@ static int s2n_evp_hash_update(struct s2n_hash_state *state, const void *data, u
 
 static int s2n_evp_hash_digest(struct s2n_hash_state *state, void *out, uint32_t size)
 {
-    S2N_ERROR_UNLESS(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
+    S2N_ERROR_IF(!state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
 
     int r;
     unsigned int digest_size = size;
@@ -602,7 +602,7 @@ int s2n_hash_free(struct s2n_hash_state *state)
 
 int s2n_hash_get_currently_in_hash_total(struct s2n_hash_state *state, uint64_t *out)
 {
-    S2N_ERROR_UNLESS(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
+    S2N_ERROR_IF(!state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
 
     *out = state->currently_in_hash;
     return 0;
@@ -610,9 +610,9 @@ int s2n_hash_get_currently_in_hash_total(struct s2n_hash_state *state, uint64_t 
 
 
 /* Calculate, in constant time, the number of bytes currently in the hash_block */
-int s2n_hash_get_currently_in_hash_block(struct s2n_hash_state *state, uint64_t *out)
+int s2n_hash_const_time_get_currently_in_hash_block(struct s2n_hash_state *state, uint64_t *out)
 {
-    S2N_ERROR_UNLESS(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
+    S2N_ERROR_IF(!state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
     uint64_t hash_block_size;
     GUARD(s2n_hash_block_size(state->alg, &hash_block_size));
 

--- a/crypto/s2n_hash.h
+++ b/crypto/s2n_hash.h
@@ -118,4 +118,4 @@ extern int s2n_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *from)
 extern int s2n_hash_reset(struct s2n_hash_state *state);
 extern int s2n_hash_free(struct s2n_hash_state *state);
 extern int s2n_hash_get_currently_in_hash_total(struct s2n_hash_state *state, uint64_t *out);
-extern int s2n_hash_get_currently_in_hash_block(struct s2n_hash_state *state, uint64_t *out);
+extern int s2n_hash_const_time_get_currently_in_hash_block(struct s2n_hash_state *state, uint64_t *out);

--- a/crypto/s2n_hash.h
+++ b/crypto/s2n_hash.h
@@ -83,6 +83,8 @@ struct s2n_hash_evp_digest {
 struct s2n_hash_state {
     const struct s2n_hash *hash_impl;
     s2n_hash_algorithm alg;
+    uint8_t is_ready_for_input;
+    uint64_t currently_in_hash;
     union {
         union s2n_hash_low_level_digest low_level;
         struct s2n_hash_evp_digest high_level;
@@ -104,7 +106,9 @@ struct s2n_hash {
 };
 
 extern int s2n_hash_digest_size(s2n_hash_algorithm alg, uint8_t *out);
+extern int s2n_hash_block_size(s2n_hash_algorithm alg, uint64_t *block_size);
 extern int s2n_hash_is_available(s2n_hash_algorithm alg);
+extern int s2n_hash_is_ready_for_input(struct s2n_hash_state *state);
 extern int s2n_hash_new(struct s2n_hash_state *state);
 extern int s2n_hash_allow_md5_for_fips(struct s2n_hash_state *state);
 extern int s2n_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm alg);
@@ -113,3 +117,5 @@ extern int s2n_hash_digest(struct s2n_hash_state *state, void *out, uint32_t siz
 extern int s2n_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *from);
 extern int s2n_hash_reset(struct s2n_hash_state *state);
 extern int s2n_hash_free(struct s2n_hash_state *state);
+extern int s2n_hash_get_currently_in_hash_total(struct s2n_hash_state *state, uint64_t *out);
+extern int s2n_hash_get_currently_in_hash_block(struct s2n_hash_state *state, uint64_t *out);

--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -26,6 +26,9 @@
 #include "utils/s2n_blob.h"
 #include "utils/s2n_mem.h"
 
+#include <inttypes.h>
+
+
 int s2n_hmac_hash_alg(s2n_hmac_algorithm hmac_alg, s2n_hash_algorithm *out)
 {
     switch(hmac_alg) {
@@ -284,8 +287,16 @@ int s2n_hmac_free(struct s2n_hmac_state *state)
 
 int s2n_hmac_reset(struct s2n_hmac_state *state)
 {
-    state->currently_in_hash_block = 0;
     GUARD(s2n_hash_copy(&state->inner, &state->inner_just_key));
+    
+    uint64_t bytes_in_hash;
+    GUARD(s2n_hash_get_currently_in_hash_total(&state->inner, &bytes_in_hash));
+    /* The length of the key is not private, so don't need to do tricky match here */
+    state->currently_in_hash_block = bytes_in_hash % state->hash_block_size;
+    /* if( state->currently_in_hash_block != 0) { */
+    /*   fprintf(stderr,"\ncurrently in: %" PRId64 "\n", bytes_in_hash); */
+    /*   S2N_ERROR(S2N_ERR_KEY_MISMATCH); */
+    /* } */
     return 0;
 }
 

--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -291,12 +291,8 @@ int s2n_hmac_reset(struct s2n_hmac_state *state)
     
     uint64_t bytes_in_hash;
     GUARD(s2n_hash_get_currently_in_hash_total(&state->inner, &bytes_in_hash));
-    /* The length of the key is not private, so don't need to do tricky match here */
+    /* The length of the key is not private, so don't need to do tricky math here */
     state->currently_in_hash_block = bytes_in_hash % state->hash_block_size;
-    /* if( state->currently_in_hash_block != 0) { */
-    /*   fprintf(stderr,"\ncurrently in: %" PRId64 "\n", bytes_in_hash); */
-    /*   S2N_ERROR(S2N_ERR_KEY_MISMATCH); */
-    /* } */
     return 0;
 }
 

--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -26,7 +26,7 @@
 #include "utils/s2n_blob.h"
 #include "utils/s2n_mem.h"
 
-#include <inttypes.h>
+#include <stdint.h>
 
 
 int s2n_hmac_hash_alg(s2n_hmac_algorithm hmac_alg, s2n_hash_algorithm *out)

--- a/error/s2n_errno.c
+++ b/error/s2n_errno.c
@@ -75,6 +75,7 @@ struct s2n_error_translation EN[] = {
     {S2N_ERR_HASH_UPDATE_FAILED, "error updating hash"},
     {S2N_ERR_HASH_COPY_FAILED, "error copying hash"},
     {S2N_ERR_HASH_WIPE_FAILED, "error wiping hash"},
+    {S2N_ERR_HASH_NOT_READY, "hash not in a valid state for the attempted operation"},
     {S2N_ERR_ALLOW_MD5_FOR_FIPS_FAILED, "error allowing MD5 to be used when in FIPS mode"},
     {S2N_ERR_HMAC_INVALID_ALGORITHM, "invalid HMAC algorithm"},
     {S2N_ERR_HKDF_OUTPUT_SIZE, "invalid HKDF output size"},

--- a/error/s2n_errno.h
+++ b/error/s2n_errno.h
@@ -167,4 +167,3 @@ extern __thread const char *s2n_debug_str;
 #define S2N_ERROR( x )      do { _S2N_ERROR( ( x ) ); return -1; } while (0)
 #define S2N_ERROR_PTR( x )  do { _S2N_ERROR( ( x ) ); return NULL; } while (0)
 #define S2N_ERROR_IF( cond , x ) do { if ( cond ) { S2N_ERROR( x ); }} while (0)
-#define S2N_ERROR_UNLESS( cond , x ) S2N_ERROR_IF( !( cond ), x)

--- a/error/s2n_errno.h
+++ b/error/s2n_errno.h
@@ -68,6 +68,7 @@ typedef enum {
     S2N_ERR_HASH_UPDATE_FAILED,
     S2N_ERR_HASH_COPY_FAILED,
     S2N_ERR_HASH_WIPE_FAILED,
+    S2N_ERR_HASH_NOT_READY,
     S2N_ERR_ALLOW_MD5_FOR_FIPS_FAILED,
     S2N_ERR_DECODE_CERTIFICATE,
     S2N_ERR_DECODE_PRIVATE_KEY,
@@ -165,3 +166,5 @@ extern __thread const char *s2n_debug_str;
 #define _S2N_ERROR( x )     do { s2n_debug_str = _S2N_DEBUG_LINE; s2n_errno = ( x ); } while (0)
 #define S2N_ERROR( x )      do { _S2N_ERROR( ( x ) ); return -1; } while (0)
 #define S2N_ERROR_PTR( x )  do { _S2N_ERROR( ( x ) ); return NULL; } while (0)
+#define S2N_ERROR_IF( cond , x ) do { if ( cond ) { S2N_ERROR( x ); }} while (0)
+#define S2N_ERROR_UNLESS( cond , x ) S2N_ERROR_IF( !( cond ), x)

--- a/tests/saw/spec/HMAC.saw
+++ b/tests/saw/spec/HMAC.saw
@@ -49,7 +49,7 @@ let yices_hash_unint =
 //
 
 let hash_state_inner pstate =
-    crucible_elem (crucible_elem (crucible_elem pstate 2) 0) 0;
+    crucible_elem (crucible_elem (crucible_elem pstate 4) 0) 0;
 
 let setup_hash_state pstate = do {
     alg0 <- crucible_fresh_var "alg" (llvm_int 32);
@@ -58,12 +58,16 @@ let setup_hash_state pstate = do {
     Nh0 <- crucible_fresh_var "Nh" (llvm_int 64);
     u0 <- crucible_fresh_var "u" (llvm_array 16 (llvm_int 64));
     num0 <- crucible_fresh_var "num" (llvm_int 32);
+    is_ready_for_input0 <- crucible_fresh_var "is_ready_for_input" (llvm_int 8);
+    currently_in_hash0 <- crucible_fresh_var "currently_in_hash" (llvm_int 64);
     md_len0 <- crucible_fresh_var "md_len" (llvm_int 32);
     (_, pimpl) <- ptr_to_fresh "impl" (llvm_struct "struct.s2n_hash");
     crucible_points_to pstate
       (crucible_struct
         [ pimpl
         , crucible_term alg0
+        , crucible_term is_ready_for_input0
+        , crucible_term currently_in_hash0
         , crucible_struct
           [ crucible_struct
             [ crucible_struct
@@ -86,7 +90,7 @@ let setup_hash_state pstate = do {
       , md_len = md_len0
       }
     }};
-    return st;
+    return (st, currently_in_hash0);
 };
 
 let update_hash_state pstate st = do {
@@ -100,7 +104,7 @@ let update_hash_state pstate st = do {
 
 let hash_init_spec = do {
     pstate <- crucible_alloc (llvm_struct "struct.s2n_hash_state");
-    st0 <- setup_hash_state pstate;
+    (st0, _) <- setup_hash_state pstate;
     alg <- crucible_fresh_var "alg" (llvm_int 32);
     crucible_execute_func [pstate, crucible_term alg];
     // We need to pass in the starting state since many of the bits in
@@ -112,7 +116,7 @@ let hash_init_spec = do {
 
 let hash_reset_spec = do {
     pstate <- crucible_alloc (llvm_struct "struct.s2n_hash_state");
-    st0 <- setup_hash_state pstate;
+    (st0, _) <- setup_hash_state pstate;
     crucible_execute_func [pstate];
     let st1 = {{ hash_init_c_state st0 }};
     update_hash_state pstate st1;
@@ -122,8 +126,8 @@ let hash_reset_spec = do {
 let hash_copy_spec = do {
     pstate1 <- crucible_alloc (llvm_struct "struct.s2n_hash_state");
     pstate2 <- crucible_alloc (llvm_struct "struct.s2n_hash_state");
-    st1 <- setup_hash_state pstate1;
-    st2 <- setup_hash_state pstate2;
+    (st1, _) <- setup_hash_state pstate1;
+    (st2, _) <- setup_hash_state pstate2;
     crucible_execute_func [pstate1, pstate2];
     update_hash_state pstate1 st2;
     crucible_return (crucible_term {{ 0 : [32] }});
@@ -132,7 +136,7 @@ let hash_copy_spec = do {
 let hash_update_spec msg_size = do {
     pstate <- crucible_alloc (llvm_struct "struct.s2n_hash_state");
     (msg, pmsg) <- ptr_to_fresh "msg" (llvm_array msg_size (llvm_int 8));
-    st0 <- setup_hash_state pstate;
+    (st0, _) <- setup_hash_state pstate;
     let size = crucible_term {{ `msg_size : [32] }};
     crucible_execute_func [pstate, pmsg, size];
     let st1 = {{ hash_update_c_state`{msg_size=msg_size} st0 msg }};
@@ -143,11 +147,20 @@ let hash_update_spec msg_size = do {
 let hash_digest_spec digest_size = do {
     pstate <- crucible_alloc (llvm_struct "struct.s2n_hash_state");
     (dgst, pdgst) <- ptr_to_fresh "out" (llvm_array digest_size (llvm_int 8));
-    st0 <- setup_hash_state pstate;
+    (st0, _) <- setup_hash_state pstate;
     size <- crucible_fresh_var "size" (llvm_int 32);
     crucible_execute_func [pstate, pdgst, crucible_term size];
     let out1 = {{ hash_digest_c_state`{digest_size=digest_size} st0 }};
     crucible_points_to pdgst (crucible_term out1);
+    crucible_return (crucible_term {{ 0 : [32] }});
+};
+
+let hash_get_currently_in_hash_total_spec = do {
+    pstate <- crucible_alloc (llvm_struct "struct.s2n_hash_state");
+    pout <- crucible_alloc (llvm_int 64);
+    (st0, currently_in_hash) <- setup_hash_state pstate;
+    crucible_execute_func [pstate, pout];
+    crucible_points_to pout (crucible_term {{zero: [64]}} );
     crucible_return (crucible_term {{ 0 : [32] }});
 };
 

--- a/tests/saw/spec/HMAC.saw
+++ b/tests/saw/spec/HMAC.saw
@@ -179,10 +179,10 @@ let setup_hmac_state alg0 hash_block_size0 block_size0 digest_size0 = do {
     crucible_points_to (crucible_field pstate "currently_in_hash_block") (crucible_term currently_in_hash_block0);
     crucible_points_to (crucible_field pstate "xor_pad_size") (crucible_term block_size0);
     crucible_points_to (crucible_field pstate "digest_size") (crucible_term digest_size0);
-    inner0 <- setup_hash_state (crucible_field pstate "inner");
-    inner_just_key0 <- setup_hash_state (crucible_field pstate "inner_just_key");
-    outer_just_key0 <- setup_hash_state (crucible_field pstate "outer_just_key");
-    outer0 <- setup_hash_state (crucible_field pstate "outer");
+    (inner0, _) <- setup_hash_state (crucible_field pstate "inner");
+    (inner_just_key0, _) <- setup_hash_state (crucible_field pstate "inner_just_key");
+    (outer_just_key0, _) <- setup_hash_state (crucible_field pstate "outer_just_key");
+    (outer0, _) <- setup_hash_state (crucible_field pstate "outer");
     crucible_points_to (crucible_field pstate "xor_pad") (crucible_term xor_pad0);
     crucible_points_to (crucible_field pstate "digest_pad") (crucible_term digest_pad0);
 

--- a/tests/saw/spec/HMAC_driver.saw
+++ b/tests/saw/spec/HMAC_driver.saw
@@ -118,6 +118,11 @@ let verify_s2n_hmac
 
   print_json "s2n_hmac_digest_size" cfg t key_size msg_size hmac_digest_size_ov;
 
+  (t, hash_get_currently_in_hash_total_ov) <- with_time (crucible_llvm_unsafe_assume_spec m "s2n_hash_get_currently_in_hash_total" (hash_get_currently_in_hash_total_spec));
+
+  print_json "hash_get_currently_in_hash_total" cfg t key_size msg_size hash_get_currently_in_hash_total_ov;
+
+
   let hash_ovs =
     [ hash_init_ov
     , hash_update_key_size_ov
@@ -128,6 +133,7 @@ let verify_s2n_hmac
     , hash_copy_ov
     , hash_reset_ov
     , hmac_digest_size_ov
+    , hash_get_currently_in_hash_total_ov
     ];
 
   (t, hmac_init_ov) <-

--- a/tests/sidewinder/working/s2n-cbc/stubs/s2n_hash.c
+++ b/tests/sidewinder/working/s2n-cbc/stubs/s2n_hash.c
@@ -155,3 +155,10 @@ int s2n_hash_free(struct s2n_hash_state *state)
 {
   return SUCCESS;
 }
+
+int s2n_hash_get_currently_in_hash_total(struct s2n_hash_state *state, uint64_t *out)
+{
+  *out = state->currently_in_hash_block;
+  return SUCCESS;
+}
+

--- a/tests/sidewinder/working/s2n-cbc/stubs/s2n_hash.h
+++ b/tests/sidewinder/working/s2n-cbc/stubs/s2n_hash.h
@@ -73,5 +73,6 @@ extern int s2n_hash_digest(struct s2n_hash_state *state, void *out, uint32_t siz
 extern int s2n_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *from);
 extern int s2n_hash_reset(struct s2n_hash_state *state);
 extern int s2n_hash_free(struct s2n_hash_state *state);
+extern int s2n_hash_get_currently_in_hash_total(struct s2n_hash_state *state, uint64_t *out);
 
 

--- a/tests/unit/s2n_hash_test.c
+++ b/tests/unit/s2n_hash_test.c
@@ -34,11 +34,16 @@ int main(int argc, char **argv)
     struct s2n_stuffer output;
     struct s2n_hash_state hash, copy;
     struct s2n_blob out = {.data = output_pad,.size = sizeof(output_pad) };
+    uint64_t bytes_in_hash;
 
     BEGIN_TEST();
 
     GUARD(s2n_hash_new(&hash));
+    EXPECT_FALSE(s2n_hash_is_ready_for_input(&hash));
+    EXPECT_FAILURE(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
     GUARD(s2n_hash_new(&copy));
+    EXPECT_FALSE(s2n_hash_is_ready_for_input(&copy));
+    EXPECT_FAILURE(s2n_hash_get_currently_in_hash_total(&copy, &bytes_in_hash));
 
     if (s2n_hash_is_available(S2N_HASH_MD5)) {
         /* Try MD5 */
@@ -46,8 +51,18 @@ int main(int argc, char **argv)
         GUARD(s2n_hash_digest_size(S2N_HASH_MD5, &md5_digest_size));
         EXPECT_EQUAL(md5_digest_size, 16);
         EXPECT_SUCCESS(s2n_hash_init(&hash, S2N_HASH_MD5));
+	EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));
+	EXPECT_SUCCESS(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
+	EXPECT_EQUAL(bytes_in_hash, 0);
+
         EXPECT_SUCCESS(s2n_hash_update(&hash, hello, strlen((char *)hello)));
+	EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));
+	EXPECT_SUCCESS(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
+	EXPECT_EQUAL(bytes_in_hash, 13);
+
         EXPECT_SUCCESS(s2n_hash_digest(&hash, digest_pad, MD5_DIGEST_LENGTH));
+	EXPECT_FALSE(s2n_hash_is_ready_for_input(&hash));
+	EXPECT_FAILURE(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
 
         EXPECT_SUCCESS(s2n_stuffer_init(&output, &out));
         for (int i = 0; i < 16; i++) {
@@ -58,6 +73,9 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(memcmp(output_pad, "59ca0efa9f5633cb0371bbc0355478d8", 16 * 2), 0);
 
         GUARD(s2n_hash_reset(&hash));
+	EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));
+	EXPECT_SUCCESS(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
+	EXPECT_EQUAL(bytes_in_hash, 0);
     }
 
     /* Try SHA1 */
@@ -65,9 +83,27 @@ int main(int argc, char **argv)
     GUARD(s2n_hash_digest_size(S2N_HASH_SHA1, &sha1_digest_size));
     EXPECT_EQUAL(sha1_digest_size, 20);
     EXPECT_SUCCESS(s2n_hash_init(&hash, S2N_HASH_SHA1));
+    EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));
+    EXPECT_SUCCESS(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
+    EXPECT_EQUAL(bytes_in_hash, 0);
+
     EXPECT_SUCCESS(s2n_hash_update(&hash, hello, strlen((char *)hello)));
+    EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));
+    EXPECT_SUCCESS(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
+    EXPECT_EQUAL(bytes_in_hash, 13);
+
     EXPECT_SUCCESS(s2n_hash_copy(&copy, &hash));
+    EXPECT_TRUE(s2n_hash_is_ready_for_input(&copy));
+    EXPECT_SUCCESS(s2n_hash_get_currently_in_hash_total(&copy, &bytes_in_hash));
+    EXPECT_EQUAL(bytes_in_hash, 13);
+
+    EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));
+    EXPECT_SUCCESS(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
+    EXPECT_EQUAL(bytes_in_hash, 13);
+
     EXPECT_SUCCESS(s2n_hash_digest(&hash, digest_pad, SHA_DIGEST_LENGTH));
+    EXPECT_FALSE(s2n_hash_is_ready_for_input(&hash));
+    EXPECT_FAILURE(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
 
     EXPECT_SUCCESS(s2n_stuffer_init(&output, &out));
     for (int i = 0; i < 20; i++) {
@@ -79,6 +115,8 @@ int main(int argc, char **argv)
 
     /* Check the copy */
     EXPECT_SUCCESS(s2n_hash_digest(&copy, digest_pad, SHA_DIGEST_LENGTH));
+    EXPECT_FALSE(s2n_hash_is_ready_for_input(&copy));
+    EXPECT_FAILURE(s2n_hash_get_currently_in_hash_total(&copy, &bytes_in_hash));
 
     EXPECT_SUCCESS(s2n_stuffer_init(&output, &out));
     for (int i = 0; i < 20; i++) {
@@ -89,13 +127,39 @@ int main(int argc, char **argv)
     EXPECT_EQUAL(memcmp(output_pad, "47a013e660d408619d894b20806b1d5086aab03b", 20 * 2), 0);
 
     EXPECT_SUCCESS(s2n_hash_reset(&hash));
+    EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));
+    EXPECT_SUCCESS(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
+    EXPECT_EQUAL(bytes_in_hash, 0);
+
     EXPECT_SUCCESS(s2n_hash_reset(&copy));
+    EXPECT_TRUE(s2n_hash_is_ready_for_input(&copy));
+    EXPECT_SUCCESS(s2n_hash_get_currently_in_hash_total(&copy, &bytes_in_hash));
+    EXPECT_EQUAL(bytes_in_hash, 0);
+
 
     /* Test that a multi-update works */
     EXPECT_SUCCESS(s2n_hash_update(&hash, string1, strlen((char *)string1)));
+    EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));
+    EXPECT_SUCCESS(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
+    EXPECT_EQUAL(bytes_in_hash, 9);
+
     EXPECT_SUCCESS(s2n_hash_copy(&copy, &hash));
+    EXPECT_TRUE(s2n_hash_is_ready_for_input(&copy));
+    EXPECT_SUCCESS(s2n_hash_get_currently_in_hash_total(&copy, &bytes_in_hash));
+    EXPECT_EQUAL(bytes_in_hash, 9);
+
+    EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));
+    EXPECT_SUCCESS(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
+    EXPECT_EQUAL(bytes_in_hash, 9);
+
     EXPECT_SUCCESS(s2n_hash_update(&hash, string2, strlen((char *)string2)));
+    EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));
+    EXPECT_SUCCESS(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
+    EXPECT_EQUAL(bytes_in_hash, 22);
+
     EXPECT_SUCCESS(s2n_hash_digest(&hash, digest_pad, SHA_DIGEST_LENGTH));
+    EXPECT_FALSE(s2n_hash_is_ready_for_input(&hash));
+    EXPECT_FAILURE(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
 
     EXPECT_SUCCESS(s2n_stuffer_init(&output, &out));
     for (int i = 0; i < 20; i++) {
@@ -107,9 +171,17 @@ int main(int argc, char **argv)
 
     /* Test that a copy-update works */
     EXPECT_SUCCESS(s2n_hash_update(&copy, string2, strlen((char *)string2)));
+    EXPECT_TRUE(s2n_hash_is_ready_for_input(&copy));
+    EXPECT_SUCCESS(s2n_hash_get_currently_in_hash_total(&copy, &bytes_in_hash));
+    EXPECT_EQUAL(bytes_in_hash, 22);
+
     EXPECT_SUCCESS(s2n_hash_digest(&copy, digest_pad, SHA_DIGEST_LENGTH));
+    EXPECT_FALSE(s2n_hash_is_ready_for_input(&copy));
+    EXPECT_FAILURE(s2n_hash_get_currently_in_hash_total(&copy, &bytes_in_hash));
 
     EXPECT_SUCCESS(s2n_hash_free(&copy));
+    EXPECT_FALSE(s2n_hash_is_ready_for_input(&copy));
+    EXPECT_FAILURE(s2n_hash_get_currently_in_hash_total(&copy, &bytes_in_hash));
 
     EXPECT_SUCCESS(s2n_stuffer_init(&output, &out));
     for (int i = 0; i < 20; i++) {
@@ -120,16 +192,32 @@ int main(int argc, char **argv)
     EXPECT_EQUAL(memcmp(output_pad, "4afd618f797f0c6bd85b2035338bb26c62ab0dbc", 20 * 2), 0);
 
     GUARD(s2n_hash_reset(&hash));
+    EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));
+    EXPECT_SUCCESS(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
+    EXPECT_EQUAL(bytes_in_hash, 0);
+
 
     /* Try SHA224 and test s2n_hash_free */
     uint8_t sha224_digest_size;
     GUARD(s2n_hash_digest_size(S2N_HASH_SHA224, &sha224_digest_size));
     EXPECT_EQUAL(sha224_digest_size, 28);
     EXPECT_SUCCESS(s2n_hash_init(&hash, S2N_HASH_SHA224));
+    EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));
+    EXPECT_SUCCESS(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
+    EXPECT_EQUAL(bytes_in_hash, 0);
+
     EXPECT_SUCCESS(s2n_hash_update(&hash, hello, strlen((char *)hello)));
+    EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));
+    EXPECT_SUCCESS(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
+    EXPECT_EQUAL(bytes_in_hash, 13);
+
     EXPECT_SUCCESS(s2n_hash_digest(&hash, digest_pad, SHA224_DIGEST_LENGTH));
+    EXPECT_FALSE(s2n_hash_is_ready_for_input(&hash));
+    EXPECT_FAILURE(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
 
     EXPECT_SUCCESS(s2n_hash_free(&hash));
+    EXPECT_FALSE(s2n_hash_is_ready_for_input(&hash));
+    EXPECT_FAILURE(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
 
     EXPECT_SUCCESS(s2n_stuffer_init(&output, &out));
     for (int i = 0; i < 28; i++) {
@@ -141,13 +229,25 @@ int main(int argc, char **argv)
 
     /* Try SHA256 using a freed hash state */
     GUARD(s2n_hash_new(&hash));
+    EXPECT_FALSE(s2n_hash_is_ready_for_input(&hash));
+    EXPECT_FAILURE(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
 
     uint8_t sha256_digest_size;
     GUARD(s2n_hash_digest_size(S2N_HASH_SHA256, &sha256_digest_size));
     EXPECT_EQUAL(sha256_digest_size, 32);
     EXPECT_SUCCESS(s2n_hash_init(&hash, S2N_HASH_SHA256));
+    EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));
+    EXPECT_SUCCESS(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
+    EXPECT_EQUAL(bytes_in_hash, 0);
+
     EXPECT_SUCCESS(s2n_hash_update(&hash, hello, strlen((char *)hello)));
+    EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));
+    EXPECT_SUCCESS(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
+    EXPECT_EQUAL(bytes_in_hash, 13);
+
     EXPECT_SUCCESS(s2n_hash_digest(&hash, digest_pad, SHA256_DIGEST_LENGTH));
+    EXPECT_FALSE(s2n_hash_is_ready_for_input(&hash));
+    EXPECT_FAILURE(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
 
     EXPECT_SUCCESS(s2n_stuffer_init(&output, &out));
     for (int i = 0; i < 32; i++) {
@@ -158,38 +258,68 @@ int main(int argc, char **argv)
     EXPECT_EQUAL(memcmp(output_pad, "0ba904eae8773b70c75333db4de2f3ac45a8ad4ddba1b242f0b3cfc199391dd8", 32 * 2), 0);
 
     GUARD(s2n_hash_reset(&hash));
+    EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));
+    EXPECT_SUCCESS(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
+    EXPECT_EQUAL(bytes_in_hash, 0);
+
 
     /* Try SHA384 */
     uint8_t sha384_digest_size;
     GUARD(s2n_hash_digest_size(S2N_HASH_SHA384, &sha384_digest_size));
     EXPECT_EQUAL(sha384_digest_size, 48);
     EXPECT_SUCCESS(s2n_hash_init(&hash, S2N_HASH_SHA384));
+    EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));
+    EXPECT_SUCCESS(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
+    EXPECT_EQUAL(bytes_in_hash, 0);
+
     EXPECT_SUCCESS(s2n_hash_update(&hash, hello, strlen((char *)hello)));
+    EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));
+    EXPECT_SUCCESS(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
+    EXPECT_EQUAL(bytes_in_hash, 13);
+
     EXPECT_SUCCESS(s2n_hash_digest(&hash, digest_pad, SHA384_DIGEST_LENGTH));
+    EXPECT_FALSE(s2n_hash_is_ready_for_input(&hash));
+    EXPECT_FAILURE(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
 
     EXPECT_SUCCESS(s2n_stuffer_init(&output, &out));
     for (int i = 0; i < 48; i++) {
-        EXPECT_SUCCESS(s2n_stuffer_write_uint8_hex(&output, digest_pad[i]));
+      EXPECT_SUCCESS(s2n_stuffer_write_uint8_hex(&output, digest_pad[i]));
     }
 
     /* Reference value from command line sha384sum */
     EXPECT_EQUAL(memcmp(output_pad, "f7f8f1b9d5a9a61742eeda26c20990282ac08dabda14e70376fcb4c8b46198a9959ea9d7d194b38520eed5397ffe6d8e", 48 * 2), 0);
 
     GUARD(s2n_hash_reset(&hash));
+    EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));
+    EXPECT_SUCCESS(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
+    EXPECT_EQUAL(bytes_in_hash, 0);
+
 
     /* Try SHA512 */
     uint8_t sha512_digest_size;
     GUARD(s2n_hash_digest_size(S2N_HASH_SHA512, &sha512_digest_size));
     EXPECT_EQUAL(sha512_digest_size, 64);
     EXPECT_SUCCESS(s2n_hash_init(&hash, S2N_HASH_SHA512));
+    EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));
+    EXPECT_SUCCESS(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
+    EXPECT_EQUAL(bytes_in_hash, 0);
+
     EXPECT_SUCCESS(s2n_hash_update(&hash, hello, strlen((char *)hello)));
+    EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));
+    EXPECT_SUCCESS(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
+    EXPECT_EQUAL(bytes_in_hash, 13);
+
     EXPECT_SUCCESS(s2n_hash_digest(&hash, digest_pad, SHA512_DIGEST_LENGTH));
+    EXPECT_FALSE(s2n_hash_is_ready_for_input(&hash));
+    EXPECT_FAILURE(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
 
     EXPECT_SUCCESS(s2n_hash_free(&hash));
+    EXPECT_FALSE(s2n_hash_is_ready_for_input(&hash));
+    EXPECT_FAILURE(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
 
     EXPECT_SUCCESS(s2n_stuffer_init(&output, &out));
     for (int i = 0; i < 64; i++) {
-        EXPECT_SUCCESS(s2n_stuffer_write_uint8_hex(&output, digest_pad[i]));
+      EXPECT_SUCCESS(s2n_stuffer_write_uint8_hex(&output, digest_pad[i]));
     }
 
     /* Reference value from command line sha512sum */


### PR DESCRIPTION
**Description of changes:** 
In developing a new automated side channel analysis tool I found an impractical to exploit timing side channel in s2n that occurs when using SSLv3. Note that SSLv3 is disabled by default in s2n, and usage of SSLv3 is strongly discouraged, as the SSLv3 protocol itself is considered insecure.

This timing side channel was due to a an irregularity in the SSLv3 HMAC:
 in sha1 mode, the key is 4 blocks short of the hash block size 
https://www.randombit.net/bitbashing/2003/01/11/ssl3mac.html 
https://tools.ietf.org/html/rfc6101#page-55 

This means that the value of currently_in_hash_block should actually have been set to 60 in that mode. 

The fix is simple: keep track of how many bytes are in the hash, and update the hmac state accordingly.  

While I was in there, I also added some error checking to the hash functions, and updated the unit tests to cover the new functionality.  

SAW and Sidewinder proofs have been updated to match.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
