### PR TITLE
Remove the limit on static libcrypto.

### DIFF
--- a/s2n.mk
+++ b/s2n.mk
@@ -23,7 +23,7 @@ else
     LIBS = -lpthread -ldl -lrt
 endif
 
-CRYPTO_LIBS = -lcrypto
+CRYPTO_LIBS = -Wl,-rpath=${LIBCRYPTO_ROOT}/lib -lcrypto
 
 CC	:= $(CROSS_COMPILE)$(CC)
 AR	= $(CROSS_COMPILE)ar


### PR DESCRIPTION
**Issue # (if available):** 

**Description of changes:** 
This enhancement can avoid the confusion when linking to the dynamic libcrypto.
Using dynamic libcrypto is a requirement for the OpenSSL dynamic engine.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
