### PR TITLE
Client Hello Callback is called after all Client Extensions are parsed - Issue 697

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -69,7 +69,9 @@ extern int s2n_config_set_cache_retrieve_callback(struct s2n_config *config, int
 extern int s2n_config_set_cache_delete_callback(struct s2n_config *config, int (*cache_delete)(void *, const void *key, uint64_t key_size), void *data);
 
 typedef enum {
+    S2N_EXTENSION_SERVER_NAME = 0,
     S2N_EXTENSION_OCSP_STAPLING = 5,
+    S2N_EXTENSION_ALPN = 16,
     S2N_EXTENSION_CERTIFICATE_TRANSPARENCY = 18,
 } s2n_tls_extension_type;
 
@@ -120,6 +122,8 @@ extern uint32_t s2n_client_hello_get_cipher_suites_length(struct s2n_client_hell
 extern uint32_t s2n_client_hello_get_cipher_suites(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);
 extern uint32_t s2n_client_hello_get_extensions_length(struct s2n_client_hello *ch);
 extern uint32_t s2n_client_hello_get_extensions(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);
+extern uint32_t s2n_client_hello_get_extension_length(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type);
+extern uint32_t s2n_client_hello_get_extension_by_id(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type, uint8_t *out, uint32_t max_length);
 
 extern int s2n_connection_set_fd(struct s2n_connection *conn, int fd);
 extern int s2n_connection_set_read_fd(struct s2n_connection *conn, int readfd);

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -70,8 +70,14 @@ extern int s2n_config_set_cache_delete_callback(struct s2n_config *config, int (
 
 typedef enum {
     S2N_EXTENSION_SERVER_NAME = 0,
+    S2N_EXTENSION_MAX_FRAG_LEN = 1,
     S2N_EXTENSION_OCSP_STAPLING = 5,
+    S2N_EXTENSION_ELLIPTIC_CURVES = 10,
+    S2N_EXTENSION_EC_POINT_FORMATS = 11,
+    S2N_EXTENSION_SIGNATURE_ALGORITHMS = 13,
+    S2N_EXTENSION_ALPN = 16,
     S2N_EXTENSION_CERTIFICATE_TRANSPARENCY = 18,
+    S2N_EXTENSION_RENEGOTIATION_INFO = 65281,
 } s2n_tls_extension_type;
 
 typedef enum {
@@ -121,8 +127,8 @@ extern uint32_t s2n_client_hello_get_cipher_suites_length(struct s2n_client_hell
 extern uint32_t s2n_client_hello_get_cipher_suites(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);
 extern uint32_t s2n_client_hello_get_extensions_length(struct s2n_client_hello *ch);
 extern uint32_t s2n_client_hello_get_extensions(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);
-extern uint32_t s2n_client_hello_get_extension_length(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type);
-extern uint32_t s2n_client_hello_get_extension_by_id(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type, uint8_t *out, uint32_t max_length);
+extern int s2n_client_hello_get_extension_length(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type);
+extern int s2n_client_hello_get_extension_by_id(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type, uint8_t *out, uint32_t max_length);
 
 extern int s2n_connection_set_fd(struct s2n_connection *conn, int fd);
 extern int s2n_connection_set_read_fd(struct s2n_connection *conn, int readfd);

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -71,7 +71,6 @@ extern int s2n_config_set_cache_delete_callback(struct s2n_config *config, int (
 typedef enum {
     S2N_EXTENSION_SERVER_NAME = 0,
     S2N_EXTENSION_OCSP_STAPLING = 5,
-    S2N_EXTENSION_ALPN = 16,
     S2N_EXTENSION_CERTIFICATE_TRANSPARENCY = 18,
 } s2n_tls_extension_type;
 

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -581,8 +581,15 @@ is set in the **s2n_config** object, effectively clearing existing data.
 
 ```c
     typedef enum {
+      S2N_EXTENSION_SERVER_NAME = 0,
+      S2N_EXTENSION_MAX_FRAG_LEN = 1,
       S2N_EXTENSION_OCSP_STAPLING = 5,
-      S2N_EXTENSION_CERTIFICATE_TRANSPARENCY = 18
+      S2N_EXTENSION_ELLIPTIC_CURVES = 10,
+      S2N_EXTENSION_EC_POINT_FORMATS = 11,
+      S2N_EXTENSION_SIGNATURE_ALGORITHMS = 13,
+      S2N_EXTENSION_ALPN = 16,
+      S2N_EXTENSION_CERTIFICATE_TRANSPARENCY = 18,
+      S2N_EXTENSION_RENEGOTIATION_INFO = 65281,
     } s2n_tls_extension_type;
 ```
 
@@ -1000,7 +1007,7 @@ uint32_t s2n_client_hello_get_cipher_suites(struct s2n_client_hello *ch, uint8_t
 ### s2n\_client\_hello\_get\_extensions
 
 ```c
-uint32_t s2n_client_hello_get_extensions_length(struct s2n_client_hello *ch);
+uint32_t  _length(struct s2n_client_hello *ch);
 uint32_t s2n_client_hello_get_extensions(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);
 ```
 
@@ -1010,6 +1017,21 @@ uint32_t s2n_client_hello_get_extensions(struct s2n_client_hello *ch, uint8_t *o
 
 **s2n_client_hello_get_extensions_length** returns the number of bytes the extensions take on the ClientHello message received by the server; it can be used to allocate the **out** buffer.
 **s2n_client_hello_get_extensions** copies into the **out** buffer **max_length** bytes of the extensions on the ClienthHello and returns the number of bytes that were copied.
+
+### s2n\_client\_hello\_get\_extension
+
+```c
+int _length(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type);
+int _by_id(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type, uint8_t *out, uint32_t max_length);
+```
+
+- **ch** The s2n_client_hello on the s2n_connection. The handle can be obtained using **s2n_connection_get_client_hello**.
+- **s2n_tls_extension_type** Enum [s2n_tls_extension_type](#s2n\_config\_set\_extension\_data) lists all supported extension types.
+- **out** Pointer to a buffer into which the extension bytes should be copied.
+- **max_length** Max number of bytes to copy into the **out** buffer.
+
+**s2n_client_hello_get_extension_length** returns the number of bytes the given extension type takes on the ClientHello message received by the server; it can be used to allocate the **out** buffer.
+**s2n_client_hello_get_extension_by_id** copies into the **out** buffer **max_length** bytes of a given extension type on the ClienthHello and returns the number of bytes that were copied.
 
 ### s2n\_connection\_is\_client\_authenticated
 

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1007,7 +1007,7 @@ uint32_t s2n_client_hello_get_cipher_suites(struct s2n_client_hello *ch, uint8_t
 ### s2n\_client\_hello\_get\_extensions
 
 ```c
-uint32_t  _length(struct s2n_client_hello *ch);
+uint32_t  s2n_client_hello_get_extensions_length(struct s2n_client_hello *ch);
 uint32_t s2n_client_hello_get_extensions(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);
 ```
 
@@ -1021,8 +1021,8 @@ uint32_t s2n_client_hello_get_extensions(struct s2n_client_hello *ch, uint8_t *o
 ### s2n\_client\_hello\_get\_extension
 
 ```c
-int _length(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type);
-int _by_id(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type, uint8_t *out, uint32_t max_length);
+int s2n_client_hello_get_extension_length(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type);
+int s2n_client_hello_get_extension_by_id(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type, uint8_t *out, uint32_t max_length);
 ```
 
 - **ch** The s2n_client_hello on the s2n_connection. The handle can be obtained using **s2n_connection_get_client_hello**.

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1007,7 +1007,7 @@ uint32_t s2n_client_hello_get_cipher_suites(struct s2n_client_hello *ch, uint8_t
 ### s2n\_client\_hello\_get\_extensions
 
 ```c
-uint32_t  s2n_client_hello_get_extensions_length(struct s2n_client_hello *ch);
+uint32_t s2n_client_hello_get_extensions_length(struct s2n_client_hello *ch);
 uint32_t s2n_client_hello_get_extensions(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);
 ```
 

--- a/tests/unit/s2n_array_test.c
+++ b/tests/unit/s2n_array_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -41,6 +41,13 @@ int main(int argc, char **argv)
         elements[i].first = i;
         elements[i].second = 'a' + i;
     }
+
+    /* Verify add and get elements with null array */
+    EXPECT_NULL(s2n_array_add(NULL));
+    EXPECT_NULL(s2n_array_get(NULL, 0));
+
+    /* Verify freeing null array */
+    EXPECT_FAILURE(s2n_array_free(NULL));
 
     EXPECT_NOT_NULL(array = s2n_array_new(element_size));
 

--- a/tests/unit/s2n_array_test.c
+++ b/tests/unit/s2n_array_test.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#include "s2n_test.h"
+#include "utils/s2n_blob.h"
+#include "utils/s2n_mem.h"
+#include "utils/s2n_safety.h"
+#include "utils/s2n_array.h"
+
+int main(int argc, char **argv)
+{
+    struct array_element {
+        int first;
+        char second;
+    };
+
+    struct s2n_array *array;
+    int num_of_elements = 17;
+    int element_size = sizeof(struct array_element);
+
+    BEGIN_TEST();
+
+    struct s2n_blob mem;
+    GUARD(s2n_alloc(&mem, sizeof(struct array_element) * num_of_elements));
+    GUARD(s2n_blob_zero(&mem));
+
+    struct array_element *elements = (struct  array_element *) (void *) mem.data;
+
+    for (int i = 0; i < num_of_elements; i++) {
+        elements[i].first = i;
+        elements[i].second = 'a' + i;
+    }
+
+    EXPECT_NOT_NULL(array = s2n_array_new(element_size));
+
+    /* Validate array parameters */
+    EXPECT_EQUAL(array->capacity, 16);
+    EXPECT_EQUAL(array->num_of_elements, 0);
+    EXPECT_EQUAL(array->element_size, element_size);
+
+    /* Add an element */
+    struct array_element *element = s2n_array_add(array);
+    element->first = elements[0].first;
+    element->second = elements[0].second;
+
+    /* Validate array parameters */
+    EXPECT_EQUAL(array->capacity, 16);
+    EXPECT_EQUAL(array->num_of_elements, 1);
+
+    /* Get first element */
+    struct array_element *first_element = s2n_array_get(array, 0);
+    EXPECT_EQUAL(first_element->first, elements[0].first);
+    EXPECT_EQUAL(first_element->second, elements[0].second);
+
+    /* Get second element */
+    struct array_element *second_element = s2n_array_get(array, 1);
+    EXPECT_NULL(second_element);
+
+    /* Add more than 16 elements */
+    for (int i = 1; i < num_of_elements; i++) {
+        struct array_element *elem = s2n_array_add(array);
+        elem->first = elements[i].first;
+        elem->second = elements[i].second;
+    }
+
+    /* Validate array parameters again */
+    EXPECT_EQUAL(array->capacity, 32);
+    EXPECT_EQUAL(array->num_of_elements, 17);
+    EXPECT_EQUAL(array->element_size, element_size);
+    EXPECT_SUCCESS(memcmp(array->elements, mem.data, num_of_elements * element_size));
+
+    /* Done with the array, make sure it can be freed */
+    EXPECT_SUCCESS(s2n_array_free(array));
+
+    END_TEST();
+}

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -72,6 +72,19 @@ int main(int argc, char **argv)
             /* First server name, matches sent_server_name */
             's', 'v', 'r',
         };
+
+        uint8_t server_name_extension[] = {
+            /* Server names len */
+            0x00, 0x06,
+            /* First server name type - host name */
+            0x00,
+            /* First server name len */
+            0x00, 0x03,
+            /* First server name, matches sent_server_name */
+            's', 'v', 'r',
+        };
+        int server_name_extension_len = sizeof(server_name_extension);
+
         int client_extensions_len = sizeof(client_extensions);
         uint8_t client_hello_prefix[] = {
             /* Protocol version TLS 1.2 */
@@ -138,6 +151,14 @@ int main(int argc, char **argv)
 
         /* Verify s2n_connection_get_client_hello returns null if client hello not yet processed */
         EXPECT_NULL(s2n_connection_get_client_hello(server_conn));
+
+        uint8_t *ext_data;
+        EXPECT_NOT_NULL(ext_data = malloc(server_name_extension_len));
+        /* Verify we don't get extension and it's when client hello is not yet processes */
+        EXPECT_FAILURE(s2n_client_hello_get_extension_length(s2n_connection_get_client_hello(server_conn), S2N_EXTENSION_SERVER_NAME));
+        EXPECT_FAILURE(s2n_client_hello_get_extension_by_id(s2n_connection_get_client_hello(server_conn), S2N_EXTENSION_SERVER_NAME, ext_data, server_name_extension_len));
+        free(ext_data);
+        ext_data = NULL;
 
         /* Send the client hello message */
         EXPECT_EQUAL(write(client_to_server[1], record_header, sizeof(record_header)), sizeof(record_header));
@@ -254,6 +275,28 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(memcmp(extensions_out, client_hello->extensions.data, max_len));
         free(extensions_out);
         extensions_out = NULL;
+
+        /* Verify server name extension and it's length are returned correctly */
+        EXPECT_EQUAL(s2n_client_hello_get_extension_length(client_hello, S2N_EXTENSION_SERVER_NAME), server_name_extension_len);
+        EXPECT_NOT_NULL(ext_data = malloc(server_name_extension_len));
+        EXPECT_EQUAL(s2n_client_hello_get_extension_by_id(client_hello, S2N_EXTENSION_SERVER_NAME, ext_data, server_name_extension_len), server_name_extension_len);
+        EXPECT_SUCCESS(memcmp(ext_data, server_name_extension, server_name_extension_len));
+        free(ext_data);
+        ext_data = NULL;
+
+        /* Verify server name extension is truncated if extension_size > max_len */
+        EXPECT_NOT_NULL(ext_data = malloc(server_name_extension_len - 1));
+        EXPECT_EQUAL(s2n_client_hello_get_extension_by_id(client_hello, S2N_EXTENSION_SERVER_NAME, ext_data, server_name_extension_len - 1), server_name_extension_len - 1);
+        EXPECT_SUCCESS(memcmp(ext_data, server_name_extension, server_name_extension_len - 1));
+        free(ext_data);
+        ext_data = NULL;
+
+        /* Verify get extension and its length calls for a non-existing extension type */
+        EXPECT_EQUAL(s2n_client_hello_get_extension_length(client_hello, S2N_EXTENSION_CERTIFICATE_TRANSPARENCY), 0);
+        EXPECT_NOT_NULL(ext_data = malloc(server_name_extension_len));
+        EXPECT_EQUAL(s2n_client_hello_get_extension_by_id(client_hello, S2N_EXTENSION_CERTIFICATE_TRANSPARENCY, ext_data, server_name_extension_len), 0);
+        free(ext_data);
+        ext_data = NULL;
 
         /* Not a real tls client but make sure we block on its close_notify */
         int shutdown_rc = s2n_shutdown(server_conn, &server_blocked);

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -154,7 +154,7 @@ int main(int argc, char **argv)
 
         uint8_t *ext_data;
         EXPECT_NOT_NULL(ext_data = malloc(server_name_extension_len));
-        /* Verify we don't get extension and it's when client hello is not yet processes */
+        /* Verify we don't get extension and it's length when client hello is not yet processed */
         EXPECT_FAILURE(s2n_client_hello_get_extension_length(s2n_connection_get_client_hello(server_conn), S2N_EXTENSION_SERVER_NAME));
         EXPECT_FAILURE(s2n_client_hello_get_extension_by_id(s2n_connection_get_client_hello(server_conn), S2N_EXTENSION_SERVER_NAME, ext_data, server_name_extension_len));
         free(ext_data);
@@ -291,7 +291,7 @@ int main(int argc, char **argv)
         free(ext_data);
         ext_data = NULL;
 
-        /* Verify get extension and its length calls for a non-existing extension type */
+        /* Verify get extension and it's length calls for a non-existing extension type */
         EXPECT_EQUAL(s2n_client_hello_get_extension_length(client_hello, S2N_EXTENSION_CERTIFICATE_TRANSPARENCY), 0);
         EXPECT_NOT_NULL(ext_data = malloc(server_name_extension_len));
         EXPECT_EQUAL(s2n_client_hello_get_extension_by_id(client_hello, S2N_EXTENSION_CERTIFICATE_TRANSPARENCY, ext_data, server_name_extension_len), 0);

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -321,6 +321,8 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(client_hello->extensions.size, 0);
         EXPECT_NULL(client_hello->extensions.data);
 
+        /* Verify parsed extesions array in client hello is cleared */
+        EXPECT_NULL(client_hello->parsed_extensions);
 
         /* Verify the connection is successfully reused after connection_wipe */
 

--- a/tests/unit/s2n_self_talk_client_hello_cb_test.c
+++ b/tests/unit/s2n_self_talk_client_hello_cb_test.c
@@ -41,7 +41,6 @@ int mock_client(int writefd, int readfd, int expect_failure)
     int rc = 0;
     const char *protocols[] = { "http/2", "http/1.1" };
 
-
     /* Give the server a chance to listen */
     sleep(1);
 

--- a/tests/unit/s2n_self_talk_client_hello_cb_test.c
+++ b/tests/unit/s2n_self_talk_client_hello_cb_test.c
@@ -39,12 +39,15 @@ int mock_client(int writefd, int readfd, int expect_failure)
     s2n_blocked_status blocked;
     int result = 0;
     int rc = 0;
+    const char *protocols[] = { "http/2", "http/1.1" };
+
 
     /* Give the server a chance to listen */
     sleep(1);
 
     conn = s2n_connection_new(S2N_CLIENT);
     config = s2n_config_new();
+    s2n_config_set_protocol_preferences(config, protocols, 2);
     s2n_config_disable_x509_verification(config);
     s2n_connection_set_config(conn, config);
     conn->server_protocol_version = S2N_TLS12;
@@ -111,7 +114,6 @@ int mock_nanoseconds_since_epoch(void *data, uint64_t *nanoseconds)
 int client_hello_swap_config(struct s2n_connection *conn, void *ctx)
 {
     struct client_hello_context *client_hello_ctx;
-    const char *server_name;
 
     if (ctx == NULL) {
         return -1;
@@ -121,9 +123,29 @@ int client_hello_swap_config(struct s2n_connection *conn, void *ctx)
     /* Incremet counter to ensure that callback was invoked */
     client_hello_ctx->invoked++;
 
-    /* Validate that we have server name */
-    server_name = s2n_get_server_name(conn);
-    if (server_name == NULL || strcmp(server_name, "example.com") != 0) {
+    /* Validate SNI extension */
+    uint8_t expected_server_name[] = {
+            /* Server names len */
+            0x00, 0x0E,
+            /* Server name type - host name */
+            0x00,
+            /* First server name len */
+            0x00, 0x0B,
+            /* First server name, matches sent_server_name */
+            'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm'};
+
+    /* Get SNI extension from client hello */
+    uint32_t len = s2n_client_hello_get_extension_length(&conn->client_hello, S2N_EXTENSION_SERVER_NAME);
+    if (len != 16) {
+        return -1;
+    }
+
+    uint8_t ser_name[16] = {0};
+    if (s2n_client_hello_get_extension_by_id(&conn->client_hello, S2N_EXTENSION_SERVER_NAME, ser_name, len) <= 0) {
+        return -1;
+    }
+
+    if (memcmp(ser_name, expected_server_name, len) != 0) {
         return -1;
     }
 
@@ -180,6 +202,10 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key(swap_config, cert_chain_pem, private_key_pem));
 
+    /* Add application protocols to swapped config */
+    const char *protocols[] = { "http/2" };
+    EXPECT_SUCCESS(s2n_config_set_protocol_preferences(swap_config, protocols, 1));
+
     /* Prepare context */
     client_hello_ctx.invoked = 0;
     client_hello_ctx.config = swap_config;
@@ -222,8 +248,8 @@ int main(int argc, char **argv)
     /* Ensure that callback was invoked */
     EXPECT_EQUAL(client_hello_ctx.invoked, 1);
 
-    /* Expect NULL negotiated protocol */
-    EXPECT_EQUAL(s2n_get_application_protocol(conn), NULL);
+    /* Expect most preferred negotiated protocol */
+    EXPECT_STRING_EQUAL(s2n_get_application_protocol(conn), protocols[0]);
 
     for (int i = 1; i < 0xffff; i += 100) {
         char * ptr = buffer;

--- a/tls/s2n_client_extensions.h
+++ b/tls/s2n_client_extensions.h
@@ -22,6 +22,11 @@
 #include "stuffer/s2n_stuffer.h"
 #include "tls/s2n_connection.h"
 
+struct s2n_client_hello_parsed_extension {
+	uint16_t extension_type;
+	struct s2n_blob extension;
+};
+
 extern int s2n_choose_preferred_signature_hash_pair(struct s2n_stuffer *in, int num_pairs, s2n_hash_algorithm *hash_alg, s2n_signature_algorithm *signature_alg);
 extern int s2n_recv_client_signature_algorithms(struct s2n_connection *conn, struct s2n_stuffer *in, s2n_hash_algorithm *out, s2n_signature_algorithm *signature_alg);
 extern int s2n_send_client_signature_algorithms(struct s2n_stuffer *out);

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -16,6 +16,7 @@
 #include <sys/param.h>
 #include <time.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 #include "crypto/s2n_fips.h"
 
@@ -29,6 +30,7 @@
 #include "tls/s2n_client_hello.h"
 #include "tls/s2n_alerts.h"
 #include "tls/s2n_tls.h"
+#include "tls/s2n_client_extensions.h"
 
 #include "stuffer/s2n_stuffer.h"
 
@@ -114,6 +116,9 @@ int s2n_client_hello_free(struct s2n_client_hello *client_hello) {
        so we don't need to free them */
     client_hello->cipher_suites.data = NULL;
     client_hello->extensions.data = NULL;
+    if (client_hello->parsed_extensions != NULL) {
+        s2n_array_free(client_hello->parsed_extensions);
+    }
 
     return 0;
 }
@@ -209,12 +214,9 @@ static int s2n_process_client_hello(struct s2n_connection *conn)
 {
     struct s2n_client_hello *client_hello = &conn->client_hello;
 
-    if (client_hello->extensions.size > 0) {
-        GUARD(s2n_client_extensions_recv(conn, &client_hello->extensions));
+    if (client_hello->parsed_extensions != NULL && client_hello->parsed_extensions->num_of_elements > 0) {
+        GUARD(s2n_client_extensions_recv(conn, client_hello->parsed_extensions));
     }
-
-    /* Mark the collected client hello as available */
-    client_hello->parsed = 1;
 
     if (conn->client_protocol_version < conn->config->cipher_preferences->minimum_protocol_version) {
         GUARD(s2n_queue_reader_unsupported_protocol_version_alert(conn));
@@ -234,10 +236,58 @@ static int s2n_process_client_hello(struct s2n_connection *conn)
     return 0;
 }
 
+static int s2n_parsed_extensions_compare(const void *p, const void *q)
+{
+
+    const struct s2n_client_hello_parsed_extension *left = (const struct s2n_client_hello_parsed_extension *) p;
+    const struct s2n_client_hello_parsed_extension *right = (const struct s2n_client_hello_parsed_extension *) q;
+
+    return left->extension_type - right->extension_type;
+}
+
+static int s2n_populate_client_hello_extensions(struct s2n_client_hello *ch)
+{
+    if (ch->parsed_extensions == NULL) {
+        notnull_check(ch->parsed_extensions = s2n_array_new(sizeof(struct s2n_client_hello_parsed_extension)));
+    }
+
+    struct s2n_stuffer in;
+
+    GUARD(s2n_stuffer_init(&in, &ch->extensions));
+    GUARD(s2n_stuffer_write(&in, &ch->extensions));
+
+    while (s2n_stuffer_data_available(&in)) {
+        uint16_t ext_size, ext_type;
+
+        GUARD(s2n_stuffer_read_uint16(&in, &ext_type));
+        GUARD(s2n_stuffer_read_uint16(&in, &ext_size));
+
+        struct s2n_client_hello_parsed_extension *parsed_extension = s2n_array_add(ch->parsed_extensions);
+        notnull_check(parsed_extension);
+
+        parsed_extension->extension_type = ext_type;
+        parsed_extension->extension.size = ext_size;
+
+        lte_check(ext_size, s2n_stuffer_data_available(&in));
+        parsed_extension->extension.data = s2n_stuffer_raw_read(&in, ext_size);
+        notnull_check(parsed_extension->extension.data);
+    }
+
+    /* Sort extensions by extension type */
+    qsort(ch->parsed_extensions->elements, ch->parsed_extensions->num_of_elements, ch->parsed_extensions->element_size, s2n_parsed_extensions_compare);
+
+    return 0;
+}
+
 int s2n_client_hello_recv(struct s2n_connection *conn)
 {
     /* Parse client hello */
     GUARD(s2n_parse_client_hello(conn));
+
+    GUARD(s2n_populate_client_hello_extensions(&conn->client_hello));
+
+    /* Mark the collected client hello as available when parsing is done and before the client hello callback */
+    conn->client_hello.parsed = 1;
 
     /* Call client_hello_cb if exists, letting application to modify s2n_connection or swap s2n_config */
     if (conn->config->client_hello_cb) {
@@ -373,6 +423,46 @@ int s2n_sslv2_client_hello_recv(struct s2n_connection *conn)
 
     conn->server->server_cert_chain = conn->config->cert_and_key_pairs;
     GUARD(s2n_conn_set_handshake_type(conn));
+
+    return 0;
+}
+
+static void *s2n_client_hello_get_parsed_extension(struct s2n_array *parsed_extensions, s2n_tls_extension_type extension_type)
+{
+    struct s2n_client_hello_parsed_extension search;
+    search.extension_type = extension_type;
+
+    return bsearch(&search, parsed_extensions->elements, parsed_extensions->num_of_elements,
+            parsed_extensions->element_size, s2n_parsed_extensions_compare);
+}
+
+int s2n_client_hello_get_extension_length(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type)
+{
+    notnull_check(ch);
+    notnull_check(ch->parsed_extensions);
+
+    struct s2n_client_hello_parsed_extension *parsed_extension = s2n_client_hello_get_parsed_extension(ch->parsed_extensions, extension_type);
+
+    if (parsed_extension != NULL) {
+        return parsed_extension->extension.size;
+    }
+
+    return 0;
+}
+
+int s2n_client_hello_get_extension_by_id(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type, uint8_t *out, uint32_t max_length)
+{
+    notnull_check(ch);
+    notnull_check(out);
+    notnull_check(ch->parsed_extensions);
+
+    struct s2n_client_hello_parsed_extension *parsed_extension = s2n_client_hello_get_parsed_extension(ch->parsed_extensions, extension_type);
+
+    if (parsed_extension != NULL) {
+        uint32_t len = parsed_extension->extension.size < max_length ? parsed_extension->extension.size : max_length;
+        memcpy_check(out, parsed_extension->extension.data, len);
+        return len;
+    }
 
     return 0;
 }

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -126,9 +126,9 @@ int s2n_client_hello_free_parsed_extensions(struct s2n_client_hello *client_hell
 {
     notnull_check(client_hello);
     if (client_hello->parsed_extensions != NULL) {
-        s2n_array_free(client_hello->parsed_extensions);
+        GUARD(s2n_array_free(client_hello->parsed_extensions));
+        client_hello->parsed_extensions = NULL;
     }
-    client_hello->parsed_extensions = NULL;
     return 0;
 }
 

--- a/tls/s2n_client_hello.h
+++ b/tls/s2n_client_hello.h
@@ -20,6 +20,8 @@
 
 #include "stuffer/s2n_stuffer.h"
 
+#include "utils/s2n_array.h"
+
 struct s2n_client_hello {
     struct s2n_stuffer raw_message;
 
@@ -29,6 +31,7 @@ struct s2n_client_hello {
      */
     struct s2n_blob cipher_suites;
     struct s2n_blob extensions;
+    struct s2n_array *parsed_extensions;
 
     unsigned int parsed:1;
 };

--- a/tls/s2n_client_hello.h
+++ b/tls/s2n_client_hello.h
@@ -37,6 +37,7 @@ struct s2n_client_hello {
 };
 
 int s2n_client_hello_free(struct s2n_client_hello *client_hello);
+int s2n_client_hello_free_parsed_extensions(struct s2n_client_hello *client_hello);
 
 extern struct s2n_client_hello *s2n_connection_get_client_hello(struct s2n_connection *conn);
 

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -560,6 +560,8 @@ int s2n_connection_wipe(struct s2n_connection *conn)
 #pragma GCC diagnostic pop
 #endif
 
+    /* Remove parsed extensions array from client_hello beforing zeroing connection */
+    GUARD(s2n_client_hello_free_parsed_extensions(&conn->client_hello));
     GUARD(s2n_connection_zero(conn, mode, config));
 
     memcpy_check(&conn->alert_in, &alert_in, sizeof(struct s2n_stuffer));

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -519,6 +519,9 @@ int s2n_connection_wipe(struct s2n_connection *conn)
 
     GUARD(s2n_free(&conn->status_response));
 
+    /* Remove parsed extensions array from client_hello */
+    GUARD(s2n_client_hello_free_parsed_extensions(&conn->client_hello));
+
     /* Allocate or resize to their original sizes */
     GUARD(s2n_stuffer_resize(&conn->in, S2N_LARGE_FRAGMENT_LENGTH));
 
@@ -560,8 +563,6 @@ int s2n_connection_wipe(struct s2n_connection *conn)
 #pragma GCC diagnostic pop
 #endif
 
-    /* Remove parsed extensions array from client_hello beforing zeroing connection */
-    GUARD(s2n_client_hello_free_parsed_extensions(&conn->client_hello));
     GUARD(s2n_connection_zero(conn, mode, config));
 
     memcpy_check(&conn->alert_in, &alert_in, sizeof(struct s2n_stuffer));

--- a/tls/s2n_tls.h
+++ b/tls/s2n_tls.h
@@ -58,7 +58,7 @@ extern int s2n_handshake_parse_header(struct s2n_connection *conn, uint8_t * mes
 extern int s2n_read_full_record(struct s2n_connection *conn, uint8_t * record_type, int *isSSLv2);
 extern int s2n_recv_close_notify(struct s2n_connection *conn, s2n_blocked_status * blocked);
 extern int s2n_client_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *out);
-extern int s2n_client_extensions_recv(struct s2n_connection *conn, struct s2n_blob *extensions);
+extern int s2n_client_extensions_recv(struct s2n_connection *conn, struct s2n_array *parsed_extensions);
 extern int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *out);
 extern int s2n_server_extensions_recv(struct s2n_connection *conn, struct s2n_blob *extensions);
 

--- a/utils/s2n_array.c
+++ b/utils/s2n_array.c
@@ -24,7 +24,7 @@ static int s2n_array_enlarge(struct s2n_array *array, uint32_t capacity)
     notnull_check(array);
     size_t array_elements_size = array->element_size * array->num_of_elements;
 
-    struct s2n_blob mem = {.data = array->elements, .size = array_elements_size, .allocated = 0 };
+    struct s2n_blob mem = {.data = array->elements, .size = array_elements_size, .allocated = array_elements_size};
 
     GUARD(s2n_realloc(&mem, array->element_size * capacity));
 

--- a/utils/s2n_array.c
+++ b/utils/s2n_array.c
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#include "utils/s2n_array.h"
+#include "utils/s2n_blob.h"
+#include "utils/s2n_mem.h"
+#include "utils/s2n_safety.h"
+
+#define S2N_INITIAL_ARRAY_SIZE 16
+
+static int s2n_array_embiggen(struct s2n_array *array, uint32_t capacity)
+{
+    struct s2n_blob mem;
+    void *tmp = array->elements;
+
+    GUARD(s2n_alloc(&mem, array->element_size * capacity));
+    GUARD(s2n_blob_zero(&mem));
+
+    size_t size = array->element_size * array->num_of_elements;
+
+    array->capacity = capacity;
+    array->elements = (void *) mem.data;
+
+    /* Copy and free exisiting elements for non-empty array */
+    if (size != 0) {
+        memcpy_check(mem.data, (uint8_t *) tmp, size);
+        mem.data = (void *) tmp;
+        mem.size = size;
+        GUARD(s2n_free(&mem));
+    }
+
+    return 0;
+}
+
+struct s2n_array *s2n_array_new(size_t element_size)
+{
+    struct s2n_blob mem;
+    struct s2n_array *array;
+
+    GUARD_PTR(s2n_alloc(&mem, sizeof(struct s2n_array)));
+
+    array = (void *) mem.data;
+    array->capacity = 0;
+    array->num_of_elements = 0;
+    array->element_size = element_size;
+    array->elements = NULL;
+
+    GUARD_PTR(s2n_array_embiggen(array, S2N_INITIAL_ARRAY_SIZE));
+
+    return array;
+}
+
+void *s2n_array_add(struct s2n_array *array)
+{
+    void *element;
+
+    if (array->num_of_elements >= array->capacity) {
+        /* Embiggen the array */
+        GUARD_PTR(s2n_array_embiggen(array, array->capacity * 2));
+    }
+
+    element = (uint8_t *) array->elements + array->element_size * array->num_of_elements;
+    array->num_of_elements++;
+
+    return element;
+}
+
+void *s2n_array_get(struct s2n_array *array, uint32_t index)
+{
+    void *element = NULL;
+
+    if (index < array->num_of_elements) {
+        element = (uint8_t *) array->elements + array->element_size * index;
+    }
+
+    return element;
+}
+
+int s2n_array_free(struct s2n_array *array)
+{
+    struct s2n_blob mem;
+
+    /* Free the elements */
+    mem.data = (void *) array->elements;
+    mem.size = array->capacity * array->element_size;
+    GUARD(s2n_free(&mem));
+
+    /* And finally the array */
+    mem.data = (void *) array;
+    mem.size = sizeof(struct s2n_array);
+    GUARD(s2n_free(&mem));
+
+    return 0;
+}

--- a/utils/s2n_array.h
+++ b/utils/s2n_array.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/utils/s2n_array.h
+++ b/utils/s2n_array.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#pragma once
+
+#include <s2n.h>
+
+struct s2n_array {
+    /* Pointer to elements in array */
+    void *elements;
+
+    /* The total number of elements currently in the array. */
+    uint32_t num_of_elements;
+
+    /* The total capacity of the array, in number of elements. */
+    uint32_t capacity;
+
+    /* The size of each element in the array */
+    size_t element_size;
+};
+
+extern struct s2n_array *s2n_array_new(size_t element_size);
+extern void *s2n_array_add(struct s2n_array *array);
+extern void *s2n_array_get(struct s2n_array *array, uint32_t index);
+extern int s2n_array_free(struct s2n_array *array);


### PR DESCRIPTION
**https://github.com/awslabs/s2n/issues/697** 

Currently we parse APLN extension and decide application protocol before client-hello callback (wherein there is a possibility of changing s2n_config based on ServerName or for some other reason, which contains server protocols), this might lead to choosing wrong protocol.  This change fixes the issue by not taking any decisions until after the client hello callback has been run so that we make use of latest s2n_config. 

Also added two new functions which can be used by callback to get information about extension:
s2n_client_hello_get_extension_length
s2n_client_hello_get_extension_by_id

Currently adding only S2N_EXTENSION_SERVER_NAME to s2n_tls_extension_type.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
