### PR TITLE
Use the new S2N_ERROR_IF Macros when possible

### DIFF
--- a/crypto/s2n_aead_cipher_chacha20_poly1305.c
+++ b/crypto/s2n_aead_cipher_chacha20_poly1305.c
@@ -48,9 +48,7 @@ static int s2n_aead_chacha20_poly1305_encrypt(struct s2n_session_key *key, struc
     eq_check(iv->size, S2N_TLS_CHACHA20_POLY1305_IV_LEN);
 
     /* Initialize the IV */
-    if (EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) != 1) {
-        S2N_ERROR(S2N_ERR_KEY_INIT);
-    }
+    S2N_ERROR_IF(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) != 1, S2N_ERR_KEY_INIT);
 
     /* Adjust our buffer pointers to account for the explicit IV and TAG lengths */
     int in_len = in->size - S2N_TLS_CHACHA20_POLY1305_TAG_LEN;
@@ -58,24 +56,16 @@ static int s2n_aead_chacha20_poly1305_encrypt(struct s2n_session_key *key, struc
 
     int out_len;
     /* Specify the AAD */
-    if (EVP_EncryptUpdate(key->evp_cipher_ctx, NULL, &out_len, aad->data, aad->size) != 1) {
-        S2N_ERROR(S2N_ERR_ENCRYPT);
-    }
+    S2N_ERROR_IF(EVP_EncryptUpdate(key->evp_cipher_ctx, NULL, &out_len, aad->data, aad->size) != 1, S2N_ERR_ENCRYPT);
 
     /* Encrypt the data */
-    if (EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &out_len, in->data, in_len) != 1) {
-        S2N_ERROR(S2N_ERR_ENCRYPT);
-    }
+    S2N_ERROR_IF(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &out_len, in->data, in_len) != 1, S2N_ERR_ENCRYPT);
 
     /* Finalize */
-    if (EVP_EncryptFinal_ex(key->evp_cipher_ctx, out->data, &out_len) != 1) {
-        S2N_ERROR(S2N_ERR_ENCRYPT);
-    }
+    S2N_ERROR_IF(EVP_EncryptFinal_ex(key->evp_cipher_ctx, out->data, &out_len) != 1, S2N_ERR_ENCRYPT);
 
     /* write the tag */
-    if (EVP_CIPHER_CTX_ctrl(key->evp_cipher_ctx, EVP_CTRL_AEAD_GET_TAG, S2N_TLS_CHACHA20_POLY1305_TAG_LEN, tag_data) != 1) {
-        S2N_ERROR(S2N_ERR_ENCRYPT);
-    }
+    S2N_ERROR_IF(EVP_CIPHER_CTX_ctrl(key->evp_cipher_ctx, EVP_CTRL_AEAD_GET_TAG, S2N_TLS_CHACHA20_POLY1305_TAG_LEN, tag_data) != 1, S2N_ERR_ENCRYPT);
 
     return 0;
 #else
@@ -91,24 +81,18 @@ static int s2n_aead_chacha20_poly1305_decrypt(struct s2n_session_key *key, struc
     eq_check(iv->size, S2N_TLS_CHACHA20_POLY1305_IV_LEN);
 
     /* Initialize the IV */
-    if (EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) != 1) {
-        S2N_ERROR(S2N_ERR_KEY_INIT);
-    }
+    S2N_ERROR_IF(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) != 1, S2N_ERR_KEY_INIT);
 
     /* Adjust our buffer pointers to account for the explicit IV and TAG lengths */
     int in_len = in->size - S2N_TLS_CHACHA20_POLY1305_TAG_LEN;
     uint8_t *tag_data = in->data + in->size - S2N_TLS_CHACHA20_POLY1305_TAG_LEN;
 
     /* Set the TAG */
-    if (EVP_CIPHER_CTX_ctrl(key->evp_cipher_ctx, EVP_CTRL_GCM_SET_TAG, S2N_TLS_CHACHA20_POLY1305_TAG_LEN, tag_data) == 0) {
-        S2N_ERROR(S2N_ERR_DECRYPT);
-    }
+    S2N_ERROR_IF(EVP_CIPHER_CTX_ctrl(key->evp_cipher_ctx, EVP_CTRL_GCM_SET_TAG, S2N_TLS_CHACHA20_POLY1305_TAG_LEN, tag_data) == 0, S2N_ERR_DECRYPT);
 
     int out_len;
     /* Specify the AAD */
-    if (EVP_DecryptUpdate(key->evp_cipher_ctx, NULL, &out_len, aad->data, aad->size) != 1) {
-        S2N_ERROR(S2N_ERR_DECRYPT);
-    }
+    S2N_ERROR_IF(EVP_DecryptUpdate(key->evp_cipher_ctx, NULL, &out_len, aad->data, aad->size) != 1, S2N_ERR_DECRYPT);
 
     int evp_decrypt_rc = 1;
     /* Decrypt the data, but don't short circuit tag verification. EVP_Decrypt* return 0 on failure, 1 for success. */
@@ -117,9 +101,7 @@ static int s2n_aead_chacha20_poly1305_decrypt(struct s2n_session_key *key, struc
     /* Verify the tag */
     evp_decrypt_rc &= EVP_DecryptFinal_ex(key->evp_cipher_ctx, out->data, &out_len);
 
-    if (evp_decrypt_rc != 1) {
-        S2N_ERROR(S2N_ERR_DECRYPT);
-    }
+    S2N_ERROR_IF(evp_decrypt_rc != 1, S2N_ERR_DECRYPT);
 
     return 0;
 #else
@@ -132,15 +114,11 @@ static int s2n_aead_chacha20_poly1305_set_encryption_key(struct s2n_session_key 
 #ifdef S2N_CHACHA20_POLY1305_AVAILABLE
     eq_check(in->size, S2N_TLS_CHACHA20_POLY1305_KEY_LEN);
 
-    if (EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_chacha20_poly1305(), NULL, NULL, NULL) != 1) {
-        S2N_ERROR(S2N_ERR_KEY_INIT);
-    }
+    S2N_ERROR_IF(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_chacha20_poly1305(), NULL, NULL, NULL) != 1, S2N_ERR_KEY_INIT);
 
     EVP_CIPHER_CTX_ctrl(key->evp_cipher_ctx, EVP_CTRL_AEAD_SET_IVLEN, S2N_TLS_CHACHA20_POLY1305_IV_LEN, NULL);
 
-    if (EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, in->data, NULL) != 1) {
-        S2N_ERROR(S2N_ERR_KEY_INIT);
-    }
+    S2N_ERROR_IF(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, in->data, NULL) != 1, S2N_ERR_KEY_INIT);
 
     return 0;
 #else
@@ -153,15 +131,11 @@ static int s2n_aead_chacha20_poly1305_set_decryption_key(struct s2n_session_key 
 #ifdef S2N_CHACHA20_POLY1305_AVAILABLE
     eq_check(in->size, S2N_TLS_CHACHA20_POLY1305_KEY_LEN);
 
-    if (EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_chacha20_poly1305(), NULL, NULL, NULL) != 1) {
-        S2N_ERROR(S2N_ERR_KEY_INIT);
-    }
+    S2N_ERROR_IF(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_chacha20_poly1305(), NULL, NULL, NULL) != 1, S2N_ERR_KEY_INIT);
 
     EVP_CIPHER_CTX_ctrl(key->evp_cipher_ctx, EVP_CTRL_AEAD_SET_IVLEN, S2N_TLS_CHACHA20_POLY1305_IV_LEN, NULL);
 
-    if (EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, in->data, NULL) != 1) {
-        S2N_ERROR(S2N_ERR_KEY_INIT);
-    }
+    S2N_ERROR_IF(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, in->data, NULL) != 1, S2N_ERR_KEY_INIT);
 
     return 0;
 #else

--- a/crypto/s2n_cbc_cipher_3des.c
+++ b/crypto/s2n_cbc_cipher_3des.c
@@ -31,18 +31,12 @@ static int s2n_cbc_cipher_3des_encrypt(struct s2n_session_key *key, struct s2n_b
 {
     gte_check(out->size, in->size);
 
-    if (EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0) {
-        S2N_ERROR(S2N_ERR_KEY_INIT);
-    }
+    S2N_ERROR_IF(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0, S2N_ERR_KEY_INIT);
 
     int len = out->size;
-    if (EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0) {
-        S2N_ERROR(S2N_ERR_ENCRYPT);
-    }
+    S2N_ERROR_IF(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0, S2N_ERR_ENCRYPT);
 
-    if (len != in->size) {
-        S2N_ERROR(S2N_ERR_ENCRYPT);
-    }
+    S2N_ERROR_IF(len != in->size, S2N_ERR_ENCRYPT);
 
     return 0;
 }
@@ -51,14 +45,10 @@ static int s2n_cbc_cipher_3des_decrypt(struct s2n_session_key *key, struct s2n_b
 {
     gte_check(out->size, in->size);
 
-    if (EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0) {
-        S2N_ERROR(S2N_ERR_KEY_INIT);
-    }
+    S2N_ERROR_IF(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0, S2N_ERR_KEY_INIT);
 
     int len = out->size;
-    if (EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0) {
-        S2N_ERROR(S2N_ERR_DECRYPT);
-    }
+    S2N_ERROR_IF(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0, S2N_ERR_DECRYPT);
 
     return 0;
 }
@@ -68,9 +58,7 @@ static int s2n_cbc_cipher_3des_set_decryption_key(struct s2n_session_key *key, s
     eq_check(in->size, 192 / 8);
 
     EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
-    if (EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_des_ede3_cbc(), NULL, in->data, NULL) != 1) {
-        S2N_ERROR(S2N_ERR_KEY_INIT);
-    }
+    S2N_ERROR_IF(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_des_ede3_cbc(), NULL, in->data, NULL) != 1, S2N_ERR_KEY_INIT);
 
     return 0;
 }
@@ -80,9 +68,7 @@ static int s2n_cbc_cipher_3des_set_encryption_key(struct s2n_session_key *key, s
     eq_check(in->size, 192 / 8);
 
     EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
-    if (EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_des_ede3_cbc(), NULL, in->data, NULL) != 1) {
-        S2N_ERROR(S2N_ERR_KEY_INIT);
-    }
+    S2N_ERROR_IF(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_des_ede3_cbc(), NULL, in->data, NULL) != 1, S2N_ERR_KEY_INIT);
 
     return 0;
 }

--- a/crypto/s2n_cbc_cipher_aes.c
+++ b/crypto/s2n_cbc_cipher_aes.c
@@ -36,18 +36,12 @@ static int s2n_cbc_cipher_aes_encrypt(struct s2n_session_key *key, struct s2n_bl
 {
     gte_check(out->size, in->size);
 
-    if (EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0) {
-        S2N_ERROR(S2N_ERR_KEY_INIT);
-    }
+    S2N_ERROR_IF(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0, S2N_ERR_KEY_INIT);
 
     int len = out->size;
-    if (EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0) {
-        S2N_ERROR(S2N_ERR_ENCRYPT);
-    }
+    S2N_ERROR_IF(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0, S2N_ERR_ENCRYPT);
 
-    if (len != in->size) {
-        S2N_ERROR(S2N_ERR_ENCRYPT);
-    }
+    S2N_ERROR_IF(len != in->size, S2N_ERR_ENCRYPT);
 
     return 0;
 }
@@ -56,14 +50,10 @@ int s2n_cbc_cipher_aes_decrypt(struct s2n_session_key *key, struct s2n_blob *iv,
 {
     gte_check(out->size, in->size);
 
-    if (EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0) {
-        S2N_ERROR(S2N_ERR_KEY_INIT);
-    }
+    S2N_ERROR_IF(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0, S2N_ERR_KEY_INIT);
 
     int len = out->size;
-    if (EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0) {
-        S2N_ERROR(S2N_ERR_DECRYPT);
-    }
+    S2N_ERROR_IF(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0, S2N_ERR_DECRYPT);
 
     return 0;
 }
@@ -74,9 +64,7 @@ int s2n_cbc_cipher_aes128_set_decryption_key(struct s2n_session_key *key, struct
 
     /* Always returns 1 */
     EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
-    if (EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_aes_128_cbc(), NULL, in->data, NULL) != 1) {
-        S2N_ERROR(S2N_ERR_KEY_INIT);
-    }
+    S2N_ERROR_IF(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_aes_128_cbc(), NULL, in->data, NULL) != 1, S2N_ERR_KEY_INIT);
 
     return 0;
 }
@@ -86,9 +74,7 @@ static int s2n_cbc_cipher_aes128_set_encryption_key(struct s2n_session_key *key,
     eq_check(in->size, 128 / 8);
 
     EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
-    if (EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_aes_128_cbc(), NULL, in->data, NULL) != 1) {
-        S2N_ERROR(S2N_ERR_KEY_INIT);
-    }
+    S2N_ERROR_IF(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_aes_128_cbc(), NULL, in->data, NULL) != 1, S2N_ERR_KEY_INIT);
 
     return 0;
 }
@@ -98,9 +84,7 @@ static int s2n_cbc_cipher_aes256_set_decryption_key(struct s2n_session_key *key,
     eq_check(in->size, 256 / 8);
 
     EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
-    if (EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_aes_256_cbc(), NULL, in->data, NULL) != 1) {
-        S2N_ERROR(S2N_ERR_KEY_INIT);
-    }
+    S2N_ERROR_IF(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_aes_256_cbc(), NULL, in->data, NULL) != 1, S2N_ERR_KEY_INIT);
 
     return 0;
 }
@@ -110,9 +94,7 @@ int s2n_cbc_cipher_aes256_set_encryption_key(struct s2n_session_key *key, struct
     eq_check(in->size, 256 / 8);
 
     EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
-    if (EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_aes_256_cbc(), NULL, in->data, NULL) != 1) {
-        S2N_ERROR(S2N_ERR_KEY_INIT);
-    }
+    S2N_ERROR_IF(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_aes_256_cbc(), NULL, in->data, NULL) != 1, S2N_ERR_KEY_INIT);
 
     return 0;
 }

--- a/crypto/s2n_composite_cipher_aes_sha.c
+++ b/crypto/s2n_composite_cipher_aes_sha.c
@@ -130,9 +130,7 @@ static int s2n_composite_cipher_aes_sha_initial_hmac(struct s2n_session_key *key
      */
     int ctrl_ret = EVP_CIPHER_CTX_ctrl(key->evp_cipher_ctx, EVP_CTRL_AEAD_TLS1_AAD, S2N_TLS12_AAD_LEN, ctrl_buf);
 
-    if (ctrl_ret < 0) {
-        S2N_ERROR(S2N_ERR_INITIAL_HMAC);
-    }
+    S2N_ERROR_IF(ctrl_ret < 0, S2N_ERR_INITIAL_HMAC);
 
     *extra = ctrl_ret;
     return 0;
@@ -142,13 +140,9 @@ static int s2n_composite_cipher_aes_sha_encrypt(struct s2n_session_key *key, str
 {
     eq_check(out->size, in->size);
 
-    if (EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0) {
-        S2N_ERROR(S2N_ERR_KEY_INIT);
-    }
+    S2N_ERROR_IF(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0, S2N_ERR_KEY_INIT);
 
-    if (EVP_Cipher(key->evp_cipher_ctx, out->data, in->data, in->size) == 0) {
-        S2N_ERROR(S2N_ERR_ENCRYPT);
-    }
+    S2N_ERROR_IF(EVP_Cipher(key->evp_cipher_ctx, out->data, in->data, in->size) == 0, S2N_ERR_ENCRYPT);
 
     return 0;
 }
@@ -157,13 +151,9 @@ static int s2n_composite_cipher_aes_sha_decrypt(struct s2n_session_key *key, str
 {
     eq_check(out->size, in->size);
 
-    if (EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0) {
-        S2N_ERROR(S2N_ERR_KEY_INIT);
-    }
+    S2N_ERROR_IF(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0, S2N_ERR_KEY_INIT);
 
-    if (EVP_Cipher(key->evp_cipher_ctx, out->data, in->data, in->size) == 0) {
-        S2N_ERROR(S2N_ERR_DECRYPT);
-    }
+    S2N_ERROR_IF(EVP_Cipher(key->evp_cipher_ctx, out->data, in->data, in->size) == 0, S2N_ERR_DECRYPT);
 
     return 0;
 }

--- a/crypto/s2n_dhe.c
+++ b/crypto/s2n_dhe.c
@@ -83,17 +83,11 @@ static int s2n_check_p_g_dh_params(struct s2n_dh_params *dh_params)
     notnull_check(g);
     notnull_check(p);
 
-    if (DH_size(dh_params->dh) < S2N_MIN_DH_PRIME_SIZE_BYTES) {
-        S2N_ERROR(S2N_ERR_DH_PARAMS_CREATE);
-    }
+    S2N_ERROR_IF(DH_size(dh_params->dh) < S2N_MIN_DH_PRIME_SIZE_BYTES, S2N_ERR_DH_PARAMS_CREATE);
 
-    if (BN_is_zero(g)) {
-        S2N_ERROR(S2N_ERR_DH_PARAMS_CREATE);
-    }
+    S2N_ERROR_IF(BN_is_zero(g), S2N_ERR_DH_PARAMS_CREATE);
 
-    if (BN_is_zero(p)) {
-        S2N_ERROR(S2N_ERR_DH_PARAMS_CREATE);
-    }
+    S2N_ERROR_IF(BN_is_zero(p), S2N_ERR_DH_PARAMS_CREATE);
 
     return 0;
 }
@@ -104,9 +98,7 @@ static int s2n_check_pub_key_dh_params(struct s2n_dh_params *dh_params)
 
     notnull_check(pub_key);
 
-    if (BN_is_zero(pub_key)) {
-        S2N_ERROR(S2N_ERR_DH_PARAMS_CREATE);
-    }
+    S2N_ERROR_IF(BN_is_zero(pub_key), S2N_ERR_DH_PARAMS_CREATE);
 
     return 0;
 }
@@ -172,9 +164,7 @@ int s2n_pkcs3_to_dh_params(struct s2n_dh_params *dh_params, struct s2n_blob *pkc
 int s2n_dh_p_g_Ys_to_dh_params(struct s2n_dh_params *server_dh_params, struct s2n_blob *p, struct s2n_blob *g, struct s2n_blob *Ys)
 {
     server_dh_params->dh = DH_new();
-    if (server_dh_params->dh == NULL) {
-        S2N_ERROR(S2N_ERR_DH_PARAMS_CREATE);
-    }
+    S2N_ERROR_IF(server_dh_params->dh == NULL, S2N_ERR_DH_PARAMS_CREATE);
 
     GUARD(s2n_set_p_g_Ys_dh_params(server_dh_params, p, g, Ys));
     GUARD(s2n_check_all_dh_params(server_dh_params));
@@ -203,23 +193,17 @@ int s2n_dh_params_to_p_g_Ys(struct s2n_dh_params *server_dh_params, struct s2n_s
     GUARD(s2n_stuffer_write_uint16(out, p_size));
     p = s2n_stuffer_raw_write(out, p_size);
     notnull_check(p);
-    if (BN_bn2bin(bn_p, p) != p_size) {
-        S2N_ERROR(S2N_ERR_DH_SERIALIZING);
-    }
+    S2N_ERROR_IF(BN_bn2bin(bn_p, p) != p_size, S2N_ERR_DH_SERIALIZING);
 
     GUARD(s2n_stuffer_write_uint16(out, g_size));
     g = s2n_stuffer_raw_write(out, g_size);
     notnull_check(g);
-    if (BN_bn2bin(bn_g, g) != g_size) {
-        S2N_ERROR(S2N_ERR_DH_SERIALIZING);
-    }
+    S2N_ERROR_IF(BN_bn2bin(bn_g, g) != g_size, S2N_ERR_DH_SERIALIZING);
 
     GUARD(s2n_stuffer_write_uint16(out, Ys_size));
     Ys = s2n_stuffer_raw_write(out, Ys_size);
     notnull_check(Ys);
-    if (BN_bn2bin(bn_Ys, Ys) != Ys_size) {
-        S2N_ERROR(S2N_ERR_DH_SERIALIZING);
-    }
+    S2N_ERROR_IF(BN_bn2bin(bn_Ys, Ys) != Ys_size, S2N_ERR_DH_SERIALIZING);
 
     output->size = p_size + 2 + g_size + 2 + Ys_size + 2;
 
@@ -305,13 +289,9 @@ int s2n_dh_params_check(struct s2n_dh_params *params)
 {
     int codes = 0;
 
-    if (DH_check(params->dh, &codes) == 0) {
-        S2N_ERROR(S2N_ERR_DH_PARAMETER_CHECK);
-    }
+    S2N_ERROR_IF(DH_check(params->dh, &codes) == 0, S2N_ERR_DH_PARAMETER_CHECK);
 
-    if (codes != 0) {
-        S2N_ERROR(S2N_ERR_DH_PARAMETER_CHECK);
-    }
+    S2N_ERROR_IF(codes != 0, S2N_ERR_DH_PARAMETER_CHECK);
 
     return 0;
 }
@@ -321,9 +301,7 @@ int s2n_dh_params_copy(struct s2n_dh_params *from, struct s2n_dh_params *to)
     GUARD(s2n_check_p_g_dh_params(from));
 
     to->dh = DHparams_dup(from->dh);
-    if (to->dh == NULL) {
-        S2N_ERROR(S2N_ERR_DH_COPYING_PARAMETERS);
-    }
+    S2N_ERROR_IF(to->dh == NULL, S2N_ERR_DH_COPYING_PARAMETERS);
 
     return 0;
 }
@@ -332,9 +310,7 @@ int s2n_dh_generate_ephemeral_key(struct s2n_dh_params *dh_params)
 {
     GUARD(s2n_check_p_g_dh_params(dh_params));
 
-    if (DH_generate_key(dh_params->dh) == 0) {
-        S2N_ERROR(S2N_ERR_DH_GENERATING_PARAMETERS);
-    }
+    S2N_ERROR_IF(DH_generate_key(dh_params->dh) == 0, S2N_ERR_DH_GENERATING_PARAMETERS);
 
     return 0;
 }

--- a/crypto/s2n_drbg.c
+++ b/crypto/s2n_drbg.c
@@ -27,9 +27,7 @@
 static int s2n_drbg_block_encrypt(EVP_CIPHER_CTX * ctx, uint8_t in[S2N_DRBG_BLOCK_SIZE], uint8_t out[S2N_DRBG_BLOCK_SIZE])
 {
     int len = S2N_DRBG_BLOCK_SIZE;
-    if (EVP_EncryptUpdate(ctx, out, &len, in, S2N_DRBG_BLOCK_SIZE) != 1) {
-        S2N_ERROR(S2N_ERR_DRBG);
-    }
+    S2N_ERROR_IF(EVP_EncryptUpdate(ctx, out, &len, in, S2N_DRBG_BLOCK_SIZE) != 1, S2N_ERR_DRBG);
     eq_check(len, S2N_DRBG_BLOCK_SIZE);
 
     return 0;
@@ -76,9 +74,7 @@ static int s2n_drbg_update(struct s2n_drbg *drbg, struct s2n_blob *provided_data
     }
 
     /* Update the key and value */
-    if (EVP_EncryptInit_ex(drbg->ctx, EVP_aes_128_ecb(), NULL, temp, NULL) != 1) {
-        S2N_ERROR(S2N_ERR_DRBG);
-    }
+    S2N_ERROR_IF(EVP_EncryptInit_ex(drbg->ctx, EVP_aes_128_ecb(), NULL, temp, NULL) != 1, S2N_ERR_DRBG);
 
     memcpy_check(drbg->v, temp + S2N_DRBG_BLOCK_SIZE, S2N_DRBG_BLOCK_SIZE);
 
@@ -119,15 +115,11 @@ int s2n_drbg_instantiate(struct s2n_drbg *drbg, struct s2n_blob *personalization
     GUARD(s2n_blob_zero(&value));
 
     drbg->ctx = EVP_CIPHER_CTX_new();
-    if (!drbg->ctx) {
-        S2N_ERROR(S2N_ERR_DRBG);
-    }
+    S2N_ERROR_IF(!drbg->ctx, S2N_ERR_DRBG);
     (void)EVP_CIPHER_CTX_init(drbg->ctx);
 
     /* Start off with zeroed key, per 10.2.1.3.1 item 5 */
-    if (EVP_EncryptInit_ex(drbg->ctx, EVP_aes_128_ecb(), NULL, drbg->v, NULL) != 1) {
-        S2N_ERROR(S2N_ERR_DRBG);
-    }
+    S2N_ERROR_IF(EVP_EncryptInit_ex(drbg->ctx, EVP_aes_128_ecb(), NULL, drbg->v, NULL) != 1, S2N_ERR_DRBG);
 
     /* Copy the personalization string */
     GUARD(s2n_blob_zero(&ps));
@@ -148,9 +140,7 @@ int s2n_drbg_generate(struct s2n_drbg *drbg, struct s2n_blob *blob)
 {
     uint8_t all_zeros[32] = { 0 };
     struct s2n_blob zeros = {.data = all_zeros,.size = sizeof(all_zeros) };
-    if (blob->size > S2N_DRBG_GENERATE_LIMIT) {
-        S2N_ERROR(S2N_ERR_DRBG_REQUEST_SIZE);
-    }
+    S2N_ERROR_IF(blob->size > S2N_DRBG_GENERATE_LIMIT, S2N_ERR_DRBG_REQUEST_SIZE);
 
     /* If either the entropy generator is set, for prediction resistance,
      * or if we reach the definitely-need-to-reseed limit, then reseed.
@@ -169,9 +159,7 @@ int s2n_drbg_wipe(struct s2n_drbg *drbg)
 {
     struct s2n_blob state = {.data = (void *)drbg,.size = sizeof(struct s2n_drbg) };
 
-    if (EVP_CIPHER_CTX_cleanup(drbg->ctx) != 1) {
-        S2N_ERROR(S2N_ERR_DRBG);
-    }
+    S2N_ERROR_IF(EVP_CIPHER_CTX_cleanup(drbg->ctx) != 1, S2N_ERR_DRBG);
 
     EVP_CIPHER_CTX_free(drbg->ctx);
     drbg->ctx = NULL;

--- a/crypto/s2n_ecdsa.c
+++ b/crypto/s2n_ecdsa.c
@@ -43,12 +43,8 @@ static int s2n_ecdsa_sign(const struct s2n_pkey *priv, struct s2n_hash_state *di
     GUARD(s2n_hash_digest(digest, digest_out, digest_length));
 
     unsigned int signature_size = signature->size;
-    if (ECDSA_sign(0, digest_out, digest_length, signature->data, &signature_size, key->ec_key) == 0) {
-        S2N_ERROR(S2N_ERR_SIGN);
-    }
-    if (signature_size > signature->size) {
-        S2N_ERROR(S2N_ERR_SIZE_MISMATCH);
-    }
+    S2N_ERROR_IF(ECDSA_sign(0, digest_out, digest_length, signature->data, &signature_size, key->ec_key) == 0, S2N_ERR_SIGN);
+    S2N_ERROR_IF(signature_size > signature->size, S2N_ERR_SIZE_MISMATCH);
     signature->size = signature_size;
 
     GUARD(s2n_hash_reset(digest));
@@ -69,9 +65,7 @@ static int s2n_ecdsa_verify(const struct s2n_pkey *pub, struct s2n_hash_state *d
     GUARD(s2n_hash_digest(digest, digest_out, digest_length));
     
     /* ECDSA_verify ignores the first parameter */
-    if (ECDSA_verify(0, digest_out, digest_length, signature->data, signature->size, key->ec_key) == 0) {
-        S2N_ERROR(S2N_ERR_VERIFY_SIGNATURE);
-    }
+    S2N_ERROR_IF(ECDSA_verify(0, digest_out, digest_length, signature->data, signature->size, key->ec_key) == 0, S2N_ERR_VERIFY_SIGNATURE);
 
     GUARD(s2n_hash_reset(digest));
     
@@ -133,9 +127,7 @@ int s2n_ecdsa_signature_size(const s2n_ecdsa_private_key *key)
 int s2n_evp_pkey_to_ecdsa_private_key(s2n_ecdsa_private_key *ecdsa_key, EVP_PKEY *evp_private_key)
 {
     EC_KEY *ec_key = EVP_PKEY_get1_EC_KEY(evp_private_key);
-    if (ec_key == NULL) {
-        S2N_ERROR(S2N_ERR_DECODE_PRIVATE_KEY);
-    }
+    S2N_ERROR_IF(ec_key == NULL, S2N_ERR_DECODE_PRIVATE_KEY);
     
     if (!EC_KEY_check_key(ec_key)) {
         EC_KEY_free(ec_key);
@@ -149,9 +141,7 @@ int s2n_evp_pkey_to_ecdsa_private_key(s2n_ecdsa_private_key *ecdsa_key, EVP_PKEY
 int s2n_evp_pkey_to_ecdsa_public_key(s2n_ecdsa_public_key *ecdsa_key, EVP_PKEY *evp_public_key)
 {
     EC_KEY *ec_key = EVP_PKEY_get1_EC_KEY(evp_public_key);
-    if (ec_key == NULL) {
-        S2N_ERROR(S2N_ERR_DECODE_CERTIFICATE);
-    }
+    S2N_ERROR_IF(ec_key == NULL, S2N_ERR_DECODE_CERTIFICATE);
     
     if (!EC_KEY_check_key(ec_key)) {
         EC_KEY_free(ec_key);

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -133,9 +133,7 @@ static int s2n_low_level_hash_init(struct s2n_hash_state *state, s2n_hash_algori
         S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
     }
 
-    if (r == 0) {
-        S2N_ERROR(S2N_ERR_HASH_INIT_FAILED);
-    }
+    S2N_ERROR_IF(r == 0, S2N_ERR_HASH_INIT_FAILED);
 
     state->alg = alg;
     state->is_ready_for_input = 1;
@@ -179,9 +177,7 @@ static int s2n_low_level_hash_update(struct s2n_hash_state *state, const void *d
         S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
     }
 
-    if (r == 0) {
-        S2N_ERROR(S2N_ERR_HASH_UPDATE_FAILED);
-    }
+    S2N_ERROR_IF(r == 0, S2N_ERR_HASH_UPDATE_FAILED);
 
     state->currently_in_hash += size;
 
@@ -230,9 +226,7 @@ static int s2n_low_level_hash_digest(struct s2n_hash_state *state, void *out, ui
         S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
     }
 
-    if (r == 0) {
-        S2N_ERROR(S2N_ERR_HASH_DIGEST_FAILED);
-    }
+    S2N_ERROR_IF(r == 0, S2N_ERR_HASH_DIGEST_FAILED);
 
     state->currently_in_hash = 0;
     state->is_ready_for_input = 0;
@@ -313,9 +307,7 @@ static int s2n_evp_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm al
         S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
     }
 
-    if (r == 0) {
-        S2N_ERROR(S2N_ERR_HASH_INIT_FAILED);
-    }
+    S2N_ERROR_IF(r == 0, S2N_ERR_HASH_INIT_FAILED);
 
     state->alg = alg;
     state->is_ready_for_input = 1;
@@ -349,9 +341,7 @@ static int s2n_evp_hash_update(struct s2n_hash_state *state, const void *data, u
         S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
     }
 
-    if (r == 0) {
-        S2N_ERROR(S2N_ERR_HASH_UPDATE_FAILED);
-    }
+    S2N_ERROR_IF(r == 0, S2N_ERR_HASH_UPDATE_FAILED);
 
     state->currently_in_hash += size;
 
@@ -397,9 +387,7 @@ static int s2n_evp_hash_digest(struct s2n_hash_state *state, void *out, uint32_t
         S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
     }
 
-    if (r == 0) {
-        S2N_ERROR(S2N_ERR_HASH_DIGEST_FAILED);
-    }
+    S2N_ERROR_IF(r == 0, S2N_ERR_HASH_DIGEST_FAILED);
 
     state->currently_in_hash = 0;
     state->is_ready_for_input = 0;
@@ -435,9 +423,7 @@ static int s2n_evp_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *f
         S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
     }
 
-    if (r == 0) {
-        S2N_ERROR(S2N_ERR_HASH_COPY_FAILED);
-    }
+    S2N_ERROR_IF(r == 0, S2N_ERR_HASH_COPY_FAILED);
     to->hash_impl = from->hash_impl;
     to->alg = from->alg;
     to->is_ready_for_input = from->is_ready_for_input;
@@ -460,9 +446,7 @@ static int s2n_evp_hash_reset(struct s2n_hash_state *state)
         r &= S2N_EVP_MD_CTX_RESET(state->digest.high_level.evp_md5_secondary.ctx);
     }
 
-    if (r == 0) {
-        S2N_ERROR(S2N_ERR_HASH_WIPE_FAILED);
-    }
+    S2N_ERROR_IF(r == 0, S2N_ERR_HASH_WIPE_FAILED);
 
     if (reset_md5_for_fips) {
         GUARD(s2n_hash_allow_md5_for_fips(state));

--- a/crypto/s2n_hkdf.c
+++ b/crypto/s2n_hkdf.c
@@ -56,9 +56,7 @@ static int s2n_hkdf_expand(struct s2n_hmac_state *hmac, s2n_hmac_algorithm alg, 
         total_rounds++;
     }
 
-    if (total_rounds > MAX_HKDF_ROUNDS || total_rounds == 0) {
-        S2N_ERROR(S2N_ERR_HKDF_OUTPUT_SIZE);
-    }
+    S2N_ERROR_IF(total_rounds > MAX_HKDF_ROUNDS || total_rounds == 0, S2N_ERR_HKDF_OUTPUT_SIZE);
 
     for (uint32_t curr_round = 1; curr_round <= total_rounds; curr_round++) {
         uint32_t cat_len;

--- a/crypto/s2n_pkey.c
+++ b/crypto/s2n_pkey.c
@@ -98,9 +98,7 @@ int s2n_asn1der_to_private_key(struct s2n_pkey *priv_key, struct s2n_blob *asn1d
 
     /* Detect key type */
     EVP_PKEY *evp_private_key = d2i_AutoPrivateKey(NULL, (const unsigned char **)(void *)&key_to_parse, asn1der->size);
-    if (evp_private_key == NULL) {
-        S2N_ERROR(S2N_ERR_DECODE_PRIVATE_KEY);
-    }
+    S2N_ERROR_IF(evp_private_key == NULL, S2N_ERR_DECODE_PRIVATE_KEY);
     
     /* If key parsing is successful, d2i_AutoPrivateKey increments *key_to_parse to the byte following the parsed data */
     uint32_t parsed_len = key_to_parse - asn1der->data;
@@ -143,9 +141,7 @@ int s2n_asn1der_to_public_key(struct s2n_pkey *pub_key, struct s2n_blob *asn1der
     uint8_t *cert_to_parse = asn1der->data;
     
     X509 *cert = d2i_X509(NULL, (const unsigned char **)(void *)&cert_to_parse, asn1der->size);
-    if (cert == NULL) {
-        S2N_ERROR(S2N_ERR_DECODE_CERTIFICATE);
-    }
+    S2N_ERROR_IF(cert == NULL, S2N_ERR_DECODE_CERTIFICATE);
     
     /* If cert parsing is successful, d2i_X509 increments *cert_to_parse to the byte following the parsed data */
     uint32_t parsed_len = cert_to_parse - asn1der->data;
@@ -157,9 +153,7 @@ int s2n_asn1der_to_public_key(struct s2n_pkey *pub_key, struct s2n_blob *asn1der
     EVP_PKEY *evp_public_key = X509_get_pubkey(cert);
     X509_free(cert);
 
-    if (evp_public_key == NULL) {
-        S2N_ERROR(S2N_ERR_DECODE_CERTIFICATE);
-    }
+    S2N_ERROR_IF(evp_public_key == NULL, S2N_ERR_DECODE_CERTIFICATE);
 
     /* Check for success in decoding certificate according to type */
     int type = EVP_PKEY_base_id(evp_public_key);

--- a/crypto/s2n_sequence.c
+++ b/crypto/s2n_sequence.c
@@ -31,9 +31,7 @@ int s2n_increment_sequence_number(struct s2n_blob *sequence_number)
          * renegotiate instead. We don't support renegotiation. Caller needs to create a new session.
          * This condition is very unlikely. It requires 2^64 - 1 records to be sent.
          */
-        if (i == 0) {
-            S2N_ERROR(S2N_ERR_RECORD_LIMIT);
-        }
+        S2N_ERROR_IF(i == 0, S2N_ERR_RECORD_LIMIT);
 
         /* seq[i] wrapped, so let it carry */
     }

--- a/crypto/s2n_stream_cipher_null.c
+++ b/crypto/s2n_stream_cipher_null.c
@@ -27,9 +27,7 @@ static uint8_t s2n_stream_cipher_null_available()
 
 static int s2n_stream_cipher_null_endecrypt(struct s2n_session_key *key, struct s2n_blob *in, struct s2n_blob *out)
 {
-    if (out->data < in->data) {
-        S2N_ERROR(S2N_ERR_SIZE_MISMATCH);
-    }
+    S2N_ERROR_IF(out->data < in->data, S2N_ERR_SIZE_MISMATCH);
 
     if (in->data != out->data) {
         memcpy_check(in->data, out->data, out->size);

--- a/crypto/s2n_stream_cipher_rc4.c
+++ b/crypto/s2n_stream_cipher_rc4.c
@@ -30,13 +30,9 @@ static int s2n_stream_cipher_rc4_encrypt(struct s2n_session_key *key, struct s2n
     gte_check(out->size, in->size);
 
     int len = out->size;
-    if (EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0) {
-        S2N_ERROR(S2N_ERR_ENCRYPT);
-    }
+    S2N_ERROR_IF(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0, S2N_ERR_ENCRYPT);
 
-    if (len != in->size) {
-        S2N_ERROR(S2N_ERR_ENCRYPT);
-    }
+    S2N_ERROR_IF(len != in->size, S2N_ERR_ENCRYPT);
 
     return 0;
 }
@@ -46,13 +42,9 @@ static int s2n_stream_cipher_rc4_decrypt(struct s2n_session_key *key, struct s2n
     gte_check(out->size, in->size);
 
     int len = out->size;
-    if (EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0) {
-        S2N_ERROR(S2N_ERR_ENCRYPT);
-    }
+    S2N_ERROR_IF(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0, S2N_ERR_ENCRYPT);
 
-    if (len != in->size) {
-        S2N_ERROR(S2N_ERR_ENCRYPT);
-    }
+    S2N_ERROR_IF(len != in->size, S2N_ERR_ENCRYPT);
 
     return 0;
 }
@@ -60,9 +52,7 @@ static int s2n_stream_cipher_rc4_decrypt(struct s2n_session_key *key, struct s2n
 static int s2n_stream_cipher_rc4_set_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
     eq_check(in->size, 16);
-    if (EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_rc4(), NULL, in->data, NULL) != 1) {
-        S2N_ERROR(S2N_ERR_KEY_INIT);
-    }
+    S2N_ERROR_IF(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_rc4(), NULL, in->data, NULL) != 1, S2N_ERR_KEY_INIT);
 
     return 0;
 }
@@ -70,9 +60,7 @@ static int s2n_stream_cipher_rc4_set_encryption_key(struct s2n_session_key *key,
 static int s2n_stream_cipher_rc4_set_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
     eq_check(in->size, 16);
-    if (EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_rc4(), NULL, in->data, NULL) != 1) {
-        S2N_ERROR(S2N_ERR_KEY_INIT);
-    }
+    S2N_ERROR_IF(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_rc4(), NULL, in->data, NULL) != 1, S2N_ERR_KEY_INIT);
 
     return 0;
 }

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -79,12 +79,8 @@ int s2n_stuffer_free(struct s2n_stuffer *stuffer)
 
 int s2n_stuffer_resize(struct s2n_stuffer *stuffer, const uint32_t size)
 {
-    if (stuffer->growable == 0) {
-        S2N_ERROR(S2N_ERR_RESIZE_STATIC_STUFFER);
-    }
-    if (stuffer->tainted == 1) {
-        S2N_ERROR(S2N_ERR_RESIZE_TAINTED_STUFFER);
-    }
+    S2N_ERROR_IF(stuffer->growable == 0, S2N_ERR_RESIZE_STATIC_STUFFER);
+    S2N_ERROR_IF(stuffer->tainted == 1, S2N_ERR_RESIZE_TAINTED_STUFFER);
     if (size == stuffer->blob.size) {
         return 0;
     }
@@ -147,9 +143,7 @@ int s2n_stuffer_wipe(struct s2n_stuffer *stuffer)
 
 int s2n_stuffer_skip_read(struct s2n_stuffer *stuffer, uint32_t n)
 {
-    if (s2n_stuffer_data_available(stuffer) < n) {
-        S2N_ERROR(S2N_ERR_STUFFER_OUT_OF_DATA);
-    }
+    S2N_ERROR_IF(s2n_stuffer_data_available(stuffer) < n, S2N_ERR_STUFFER_OUT_OF_DATA);
 
     stuffer->read_cursor += n;
     return 0;

--- a/stuffer/s2n_stuffer_base64.c
+++ b/stuffer/s2n_stuffer_base64.c
@@ -100,25 +100,19 @@ int s2n_stuffer_read_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *out
         /* The first two characters can never be '=' and in general
          * everything has to be a valid character. 
          */
-        if (value1 == 64 || value2 == 64 || value2 == 255 || value3 == 255 || value4 == 255) {
-            S2N_ERROR(S2N_ERR_INVALID_BASE64);
-        }
+        S2N_ERROR_IF(value1 == 64 || value2 == 64 || value2 == 255 || value3 == 255 || value4 == 255, S2N_ERR_INVALID_BASE64);
 
         if (o.data[2] == '=') {
             /* If there is only one output byte, then the second value
              * should have none of its bottom four bits set.
              */
-            if (o.data[3] != '=' || value2 & 0x0f) {
-                S2N_ERROR(S2N_ERR_INVALID_BASE64);
-            }
+            S2N_ERROR_IF(o.data[3] != '=' || value2 & 0x0f, S2N_ERR_INVALID_BASE64);
             bytes_this_round = 1;
             value3 = 0;
             value4 = 0;
         } else if (o.data[3] == '=') {
             /* The last two bits of the final value should be unset */
-            if (value3 & 0x03) {
-                S2N_ERROR(S2N_ERR_INVALID_BASE64);
-            }
+            S2N_ERROR_IF(value3 & 0x03, S2N_ERR_INVALID_BASE64);
 
             bytes_this_round = 2;
             value4 = 0;

--- a/stuffer/s2n_stuffer_file.c
+++ b/stuffer/s2n_stuffer_file.c
@@ -79,14 +79,10 @@ int s2n_stuffer_alloc_ro_from_fd(struct s2n_stuffer *stuffer, int rfd)
 {
     struct stat st;
 
-    if (fstat(rfd, &st) < 0) {
-        S2N_ERROR(S2N_ERR_FSTAT);
-    }
+    S2N_ERROR_IF(fstat(rfd, &st) < 0, S2N_ERR_FSTAT);
 
     stuffer->blob.data = mmap(0, st.st_size, PROT_READ, MAP_PRIVATE, rfd, 0);
-    if (stuffer->blob.data == MAP_FAILED) {
-        S2N_ERROR(S2N_ERR_MMAP);
-    }
+    S2N_ERROR_IF(stuffer->blob.data == MAP_FAILED, S2N_ERR_MMAP);
 
     stuffer->blob.size = st.st_size;
 

--- a/stuffer/s2n_stuffer_text.c
+++ b/stuffer/s2n_stuffer_text.c
@@ -53,9 +53,7 @@ int s2n_stuffer_read_expected_str(struct s2n_stuffer *stuffer, const char *expec
 {
     void *actual = s2n_stuffer_raw_read(stuffer, strlen(expected));
     notnull_check(actual);
-    if (memcmp(actual, expected, strlen(expected))) {
-        S2N_ERROR(S2N_ERR_STUFFER_NOT_FOUND);
-    }
+    S2N_ERROR_IF(memcmp(actual, expected, strlen(expected)), S2N_ERR_STUFFER_NOT_FOUND);
     return 0;
 }
 

--- a/tls/s2n_alerts.c
+++ b/tls/s2n_alerts.c
@@ -58,9 +58,7 @@
 
 int s2n_process_alert_fragment(struct s2n_connection *conn)
 {
-    if (s2n_stuffer_data_available(&conn->alert_in) == 2) {
-        S2N_ERROR(S2N_ERR_ALERT_PRESENT);
-    }
+    S2N_ERROR_IF(s2n_stuffer_data_available(&conn->alert_in) == 2, S2N_ERR_ALERT_PRESENT);
 
     while (s2n_stuffer_data_available(&conn->in)) {
         uint8_t bytes_required = 2;

--- a/tls/s2n_cbc.c
+++ b/tls/s2n_cbc.c
@@ -97,9 +97,7 @@ int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, str
 
     GUARD(s2n_hmac_reset(copy));
 
-    if (mismatches) {
-        S2N_ERROR(S2N_ERR_CBC_VERIFY);
-    }
+    S2N_ERROR_IF(mismatches, S2N_ERR_CBC_VERIFY);
 
     return 0;
 }

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -603,9 +603,7 @@ int s2n_set_cipher_as_client(struct s2n_connection *conn, uint8_t wire[S2N_TLS_C
 {
     /* See if the cipher is one we support */
     conn->secure.cipher_suite = s2n_cipher_suite_from_wire(wire);
-    if (conn->secure.cipher_suite == NULL) {
-        S2N_ERROR(S2N_ERR_CIPHER_NOT_SUPPORTED);
-    }
+    S2N_ERROR_IF(conn->secure.cipher_suite == NULL, S2N_ERR_CIPHER_NOT_SUPPORTED);
 
     return 0;
 }

--- a/tls/s2n_client_ccs.c
+++ b/tls/s2n_client_ccs.c
@@ -41,9 +41,7 @@ int s2n_client_ccs_recv(struct s2n_connection *conn)
     conn->client = &conn->secure;
 
     GUARD(s2n_stuffer_read_uint8(&conn->handshake.io, &type));
-    if (type != CHANGE_CIPHER_SPEC_TYPE) {
-        S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-    }
+    S2N_ERROR_IF(type != CHANGE_CIPHER_SPEC_TYPE, S2N_ERR_BAD_MESSAGE);
 
     /* Flush any partial alert messages that were pending */
     GUARD(s2n_stuffer_wipe(&conn->alert_in));

--- a/tls/s2n_client_cert.c
+++ b/tls/s2n_client_cert.c
@@ -35,9 +35,7 @@ int s2n_client_cert_recv(struct s2n_connection *conn)
 
     GUARD(s2n_stuffer_read_uint24(in, &client_cert_chain.size));
 
-    if (client_cert_chain.size > s2n_stuffer_data_available(in)) {
-        S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-    }
+    S2N_ERROR_IF(client_cert_chain.size > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);
 
     if (client_cert_chain.size == 0) {
         GUARD(s2n_conn_set_handshake_no_client_cert(conn));

--- a/tls/s2n_client_extensions.c
+++ b/tls/s2n_client_extensions.c
@@ -357,9 +357,7 @@ static int s2n_recv_client_alpn(struct s2n_connection *conn, struct s2n_stuffer 
         while (s2n_stuffer_data_available(&client_protos)) {
             uint8_t client_length;
             GUARD(s2n_stuffer_read_uint8(&client_protos, &client_length));
-            if (client_length > s2n_stuffer_data_available(&client_protos)) {
-                S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-            }
+            S2N_ERROR_IF(client_length > s2n_stuffer_data_available(&client_protos), S2N_ERR_BAD_MESSAGE);
             if (client_length != length) {
                 GUARD(s2n_stuffer_skip_read(&client_protos, client_length));
             } else {
@@ -431,9 +429,7 @@ static int s2n_recv_client_renegotiation_info(struct s2n_connection *conn, struc
     /* RFC5746 Section 3.2: The renegotiated_connection field is of zero length for the initial handshake. */
     uint8_t renegotiated_connection_len;
     GUARD(s2n_stuffer_read_uint8(extension, &renegotiated_connection_len));
-    if (s2n_stuffer_data_available(extension) || renegotiated_connection_len) {
-        S2N_ERROR(S2N_ERR_NON_EMPTY_RENEGOTIATION_INFO);
-    }
+    S2N_ERROR_IF(s2n_stuffer_data_available(extension) || renegotiated_connection_len, S2N_ERR_NON_EMPTY_RENEGOTIATION_INFO);
 
     conn->secure_renegotiation = 1;
     return 0;

--- a/tls/s2n_client_finished.c
+++ b/tls/s2n_client_finished.c
@@ -32,9 +32,7 @@ int s2n_client_finished_recv(struct s2n_connection *conn)
     uint8_t *their_version = s2n_stuffer_raw_read(&conn->handshake.io, S2N_TLS_FINISHED_LEN);
     notnull_check(their_version);
 
-    if (!s2n_constant_time_equals(our_version, their_version, S2N_TLS_FINISHED_LEN) || conn->handshake.rsa_failed) {
-        S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-    }
+    S2N_ERROR_IF(!s2n_constant_time_equals(our_version, their_version, S2N_TLS_FINISHED_LEN) || conn->handshake.rsa_failed, S2N_ERR_BAD_MESSAGE);
 
     return 0;
 }

--- a/tls/s2n_client_key_exchange.c
+++ b/tls/s2n_client_key_exchange.c
@@ -42,9 +42,7 @@ static int s2n_rsa_client_key_recv(struct s2n_connection *conn)
         GUARD(s2n_stuffer_read_uint16(in, &length));
     }
 
-    if (length > s2n_stuffer_data_available(in)) {
-        S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-    }
+    S2N_ERROR_IF(length > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);
 
     /* Keep a copy of the client protocol version in wire format */
     client_protocol_version[0] = conn->client_protocol_version / 10;
@@ -186,9 +184,7 @@ static int s2n_rsa_client_key_send(struct s2n_connection *conn)
     memcpy_check(conn->secure.rsa_premaster_secret, client_protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN);
 
     int encrypted_size = s2n_rsa_public_encrypted_size(&conn->secure.server_public_key.key.rsa_key);
-    if (encrypted_size < 0 || encrypted_size > 0xffff) {
-        S2N_ERROR(S2N_ERR_SIZE_MISMATCH);
-    }
+    S2N_ERROR_IF(encrypted_size < 0 || encrypted_size > 0xffff, S2N_ERR_SIZE_MISMATCH);
 
     if (conn->actual_protocol_version > S2N_SSLv3) {
         GUARD(s2n_stuffer_write_uint16(&conn->handshake.io, encrypted_size));

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -312,9 +312,7 @@ int s2n_config_set_protocol_preferences(struct s2n_config *config, const char *c
         size_t length = strlen(protocols[i]);
         uint8_t protocol[255];
 
-        if (length > 255 || (s2n_stuffer_data_available(&protocol_stuffer) + length + 1) > 65535) {
-            S2N_ERROR(S2N_ERR_APPLICATION_PROTOCOL_TOO_LONG);
-        }
+        S2N_ERROR_IF(length > 255 || (s2n_stuffer_data_available(&protocol_stuffer) + length + 1) > 65535, S2N_ERR_APPLICATION_PROTOCOL_TOO_LONG);
         memcpy_check(protocol, protocols[i], length);
         GUARD(s2n_stuffer_write_uint8(&protocol_stuffer, length));
         GUARD(s2n_stuffer_write_bytes(&protocol_stuffer, protocol, length));
@@ -443,9 +441,7 @@ int s2n_config_add_cert_chain_from_stuffer(struct s2n_config *config, struct s2n
      * A bug in s2n's PEM parsing OR a malformed PEM in the user's chain.
      * Be conservative and fail instead of using a partial chain.
      */
-    if (s2n_stuffer_data_available(chain_in_stuffer) > 0) {
-        S2N_ERROR(S2N_ERR_INVALID_PEM);
-    }
+    S2N_ERROR_IF(s2n_stuffer_data_available(chain_in_stuffer) > 0, S2N_ERR_INVALID_PEM);
     config->cert_and_key_pairs->cert_chain.chain_size = chain_size;
 
     return 0;
@@ -642,9 +638,7 @@ int s2n_config_send_max_fragment_length(struct s2n_config *config, s2n_max_frag_
 {
     notnull_check(config);
 
-    if (mfl_code > S2N_TLS_MAX_FRAG_LEN_4096) {
-        S2N_ERROR(S2N_ERR_INVALID_MAX_FRAG_LEN);
-    }
+    S2N_ERROR_IF(mfl_code > S2N_TLS_MAX_FRAG_LEN_4096, S2N_ERR_INVALID_MAX_FRAG_LEN);
 
     config->mfl_code = mfl_code;
 

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -787,9 +787,7 @@ int s2n_connection_client_cert_used(struct s2n_connection *conn)
 
 int s2n_connection_get_alert(struct s2n_connection *conn)
 {
-    if (s2n_stuffer_data_available(&conn->alert_in) != 2) {
-        S2N_ERROR(S2N_ERR_NO_ALERT);
-    }
+    S2N_ERROR_IF(s2n_stuffer_data_available(&conn->alert_in) != 2, S2N_ERR_NO_ALERT);
 
     uint8_t alert_code = 0;
     GUARD(s2n_stuffer_read_uint8(&conn->alert_in, &alert_code));
@@ -800,14 +798,10 @@ int s2n_connection_get_alert(struct s2n_connection *conn)
 
 int s2n_set_server_name(struct s2n_connection *conn, const char *server_name)
 {
-    if (conn->mode != S2N_CLIENT) {
-        S2N_ERROR(S2N_ERR_CLIENT_MODE);
-    }
+    S2N_ERROR_IF(conn->mode != S2N_CLIENT, S2N_ERR_CLIENT_MODE);
 
     int len = strlen(server_name);
-    if (len > 255) {
-        S2N_ERROR(S2N_ERR_SERVER_NAME_TOO_LONG);
-    }
+    S2N_ERROR_IF(len > 255, S2N_ERR_SERVER_NAME_TOO_LONG);
 
     memcpy_check(conn->server_name, server_name, len);
 

--- a/tls/s2n_handshake.c
+++ b/tls/s2n_handshake.c
@@ -27,9 +27,7 @@
 
 int s2n_handshake_write_header(struct s2n_connection *conn, uint8_t message_type)
 {
-    if (s2n_stuffer_data_available(&conn->handshake.io)) {
-        S2N_ERROR(S2N_ERR_HANDSHAKE_STATE);
-    }
+    S2N_ERROR_IF(s2n_stuffer_data_available(&conn->handshake.io), S2N_ERR_HANDSHAKE_STATE);
 
     /* Write the message header */
     GUARD(s2n_stuffer_write_uint8(&conn->handshake.io, message_type));
@@ -44,9 +42,7 @@ int s2n_handshake_write_header(struct s2n_connection *conn, uint8_t message_type
 int s2n_handshake_finish_header(struct s2n_connection *conn)
 {
     uint16_t length = s2n_stuffer_data_available(&conn->handshake.io);
-    if (length < TLS_HANDSHAKE_HEADER_LENGTH) {
-        S2N_ERROR(S2N_ERR_SIZE_MISMATCH);
-    }
+    S2N_ERROR_IF(length < TLS_HANDSHAKE_HEADER_LENGTH, S2N_ERR_SIZE_MISMATCH);
 
     uint16_t payload = length - TLS_HANDSHAKE_HEADER_LENGTH;
 
@@ -61,9 +57,7 @@ int s2n_handshake_finish_header(struct s2n_connection *conn)
 
 int s2n_handshake_parse_header(struct s2n_connection *conn, uint8_t * message_type, uint32_t * length)
 {
-    if (s2n_stuffer_data_available(&conn->handshake.io) < TLS_HANDSHAKE_HEADER_LENGTH) {
-        S2N_ERROR(S2N_ERR_SIZE_MISMATCH);
-    }
+    S2N_ERROR_IF(s2n_stuffer_data_available(&conn->handshake.io) < TLS_HANDSHAKE_HEADER_LENGTH, S2N_ERR_SIZE_MISMATCH);
 
     /* read the message header */
     GUARD(s2n_stuffer_read_uint8(&conn->handshake.io, message_type));

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -339,9 +339,7 @@ int s2n_conn_set_handshake_type(struct s2n_connection *conn)
 int s2n_conn_set_handshake_no_client_cert(struct s2n_connection *conn) {
     s2n_cert_auth_type client_cert_auth_type;
     GUARD(s2n_connection_get_client_auth_type(conn, &client_cert_auth_type));
-    if (client_cert_auth_type != S2N_CERT_AUTH_OPTIONAL) {
-        S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-    }
+    S2N_ERROR_IF(client_cert_auth_type != S2N_CERT_AUTH_OPTIONAL, S2N_ERR_BAD_MESSAGE);
 
     conn->handshake.handshake_type |= NO_CLIENT_CERT;
     return 0;
@@ -471,9 +469,7 @@ static int read_full_handshake_message(struct s2n_connection *conn, uint8_t * me
     uint32_t handshake_message_length;
     GUARD(s2n_handshake_parse_header(conn, message_type, &handshake_message_length));
 
-    if (handshake_message_length > S2N_MAXIMUM_HANDSHAKE_MESSAGE_LENGTH) {
-        S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-    }
+    S2N_ERROR_IF(handshake_message_length > S2N_MAXIMUM_HANDSHAKE_MESSAGE_LENGTH, S2N_ERR_BAD_MESSAGE);
 
     uint32_t bytes_to_take = handshake_message_length - s2n_stuffer_data_available(&conn->handshake.io);
     bytes_to_take = MIN(bytes_to_take, s2n_stuffer_data_available(&conn->in));
@@ -513,9 +509,7 @@ static int s2n_handshake_conn_update_hashes(struct s2n_connection *conn)
 
 static int s2n_handshake_handle_sslv2(struct s2n_connection *conn)
 {
-    if (ACTIVE_MESSAGE(conn) != CLIENT_HELLO) {
-        S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-    }
+    S2N_ERROR_IF(ACTIVE_MESSAGE(conn) != CLIENT_HELLO, S2N_ERR_BAD_MESSAGE);
 
     /* Add the message to our handshake hashes */
     struct s2n_blob hashed = {.data = conn->header_in.blob.data + 2,.size = 3 };
@@ -562,12 +556,8 @@ static int handshake_read_io(struct s2n_connection *conn)
     /* Now we have a record, but it could be a partial fragment of a message, or it might
      * contain several messages.
      */
-    if (record_type == TLS_APPLICATION_DATA) {
-        S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-    } else if (record_type == TLS_CHANGE_CIPHER_SPEC) {
-        if (s2n_stuffer_data_available(&conn->in) != 1) {
-            S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-        }
+    S2N_ERROR_IF(record_type == TLS_APPLICATION_DATA, S2N_ERR_BAD_MESSAGE);
+        S2N_ERROR_IF(s2n_stuffer_data_available(&conn->in) != 1, S2N_ERR_BAD_MESSAGE);
 
         GUARD(s2n_stuffer_copy(&conn->in, &conn->handshake.io, s2n_stuffer_data_available(&conn->in)));
         GUARD(ACTIVE_STATE(conn).handler[conn->mode] (conn));
@@ -613,9 +603,7 @@ static int handshake_read_io(struct s2n_connection *conn)
             return 0;
         }
 
-        if (handshake_message_type != ACTIVE_STATE(conn).message_type) {
-            S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-        }
+        S2N_ERROR_IF(handshake_message_type != ACTIVE_STATE(conn).message_type, S2N_ERR_BAD_MESSAGE);
 
         /* Call the relevant handler */
         r = ACTIVE_STATE(conn).handler[conn->mode] (conn);

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -557,6 +557,7 @@ static int handshake_read_io(struct s2n_connection *conn)
      * contain several messages.
      */
     S2N_ERROR_IF(record_type == TLS_APPLICATION_DATA, S2N_ERR_BAD_MESSAGE);
+    if(record_type == TLS_CHANGE_CIPHER_SPEC) {
         S2N_ERROR_IF(s2n_stuffer_data_available(&conn->in) != 1, S2N_ERR_BAD_MESSAGE);
 
         GUARD(s2n_stuffer_copy(&conn->in, &conn->handshake.io, s2n_stuffer_data_available(&conn->in)));

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -101,7 +101,8 @@ static int s2n_evp_hmac_p_hash_digest_init(struct s2n_prf_working_space *ws)
         GUARD(s2n_digest_allow_md5_for_fips(&ws->tls.p_hash.evp_hmac.evp_digest));
     }
 
-    S2N_ERROR_IF(EVP_DigestSignInit(ws->tls.p_hash.evp_hmac.evp_digest.ctx, NULL, ws->tls.p_hash.evp_hmac.evp_digest.md, NULL, ws->tls.p_hash.evp_hmac.mac_key) == 0, S2N_ERR_P_HASH_INIT_FAILED);
+    S2N_ERROR_IF(EVP_DigestSignInit(ws->tls.p_hash.evp_hmac.evp_digest.ctx, NULL, ws->tls.p_hash.evp_hmac.evp_digest.md, NULL, ws->tls.p_hash.evp_hmac.mac_key) == 0,
+		 S2N_ERR_P_HASH_INIT_FAILED);
 
     return 0;
 }

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -101,9 +101,7 @@ static int s2n_evp_hmac_p_hash_digest_init(struct s2n_prf_working_space *ws)
         GUARD(s2n_digest_allow_md5_for_fips(&ws->tls.p_hash.evp_hmac.evp_digest));
     }
 
-    if (EVP_DigestSignInit(ws->tls.p_hash.evp_hmac.evp_digest.ctx, NULL, ws->tls.p_hash.evp_hmac.evp_digest.md, NULL, ws->tls.p_hash.evp_hmac.mac_key) == 0) {
-        S2N_ERROR(S2N_ERR_P_HASH_INIT_FAILED);
-    }
+    S2N_ERROR_IF(EVP_DigestSignInit(ws->tls.p_hash.evp_hmac.evp_digest.ctx, NULL, ws->tls.p_hash.evp_hmac.evp_digest.md, NULL, ws->tls.p_hash.evp_hmac.mac_key) == 0, S2N_ERR_P_HASH_INIT_FAILED);
 
     return 0;
 }
@@ -145,9 +143,7 @@ static int s2n_evp_hmac_p_hash_init(struct s2n_prf_working_space *ws, s2n_hmac_a
 
 static int s2n_evp_hmac_p_hash_update(struct s2n_prf_working_space *ws, const void *data, uint32_t size)
 {
-    if (EVP_DigestSignUpdate(ws->tls.p_hash.evp_hmac.evp_digest.ctx, data, (size_t)size) == 0) {
-        S2N_ERROR(S2N_ERR_P_HASH_UPDATE_FAILED);
-    }
+    S2N_ERROR_IF(EVP_DigestSignUpdate(ws->tls.p_hash.evp_hmac.evp_digest.ctx, data, (size_t)size) == 0, S2N_ERR_P_HASH_UPDATE_FAILED);
 
     return 0;
 }
@@ -157,18 +153,14 @@ static int s2n_evp_hmac_p_hash_digest(struct s2n_prf_working_space *ws, void *di
     /* EVP_DigestSign API's require size_t data structures */
     size_t digest_size = size;
 
-    if (EVP_DigestSignFinal(ws->tls.p_hash.evp_hmac.evp_digest.ctx, (unsigned char *)digest, &digest_size) == 0) {
-        S2N_ERROR(S2N_ERR_P_HASH_FINAL_FAILED);
-    }
+    S2N_ERROR_IF(EVP_DigestSignFinal(ws->tls.p_hash.evp_hmac.evp_digest.ctx, (unsigned char *)digest, &digest_size) == 0, S2N_ERR_P_HASH_FINAL_FAILED);
 
     return 0;
 }
 
 static int s2n_evp_hmac_p_hash_wipe(struct s2n_prf_working_space *ws)
 {
-    if (S2N_EVP_MD_CTX_RESET(ws->tls.p_hash.evp_hmac.evp_digest.ctx) == 0) {
-        S2N_ERROR(S2N_ERR_P_HASH_WIPE_FAILED);
-    }
+    S2N_ERROR_IF(S2N_EVP_MD_CTX_RESET(ws->tls.p_hash.evp_hmac.evp_digest.ctx) == 0, S2N_ERR_P_HASH_WIPE_FAILED);
 
     return 0;
 }

--- a/tls/s2n_record_read.c
+++ b/tls/s2n_record_read.c
@@ -38,9 +38,7 @@ int s2n_sslv2_record_header_parse(struct s2n_connection *conn, uint8_t * record_
 {
     struct s2n_stuffer *in = &conn->header_in;
 
-    if (s2n_stuffer_data_available(in) < S2N_TLS_RECORD_HEADER_LENGTH) {
-        S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-    }
+    S2N_ERROR_IF(s2n_stuffer_data_available(in) < S2N_TLS_RECORD_HEADER_LENGTH, S2N_ERR_BAD_MESSAGE);
 
     GUARD(s2n_stuffer_read_uint16(in, fragment_length));
 
@@ -61,9 +59,7 @@ int s2n_record_header_parse(struct s2n_connection *conn, uint8_t * content_type,
 {
     struct s2n_stuffer *in = &conn->header_in;
 
-    if (s2n_stuffer_data_available(in) < S2N_TLS_RECORD_HEADER_LENGTH) {
-        S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-    }
+    S2N_ERROR_IF(s2n_stuffer_data_available(in) < S2N_TLS_RECORD_HEADER_LENGTH, S2N_ERR_BAD_MESSAGE);
 
     GUARD(s2n_stuffer_read_uint8(in, content_type));
 
@@ -82,9 +78,7 @@ int s2n_record_header_parse(struct s2n_connection *conn, uint8_t * content_type,
         S2N_ERROR(S2N_ERR_BAD_MESSAGE);
     }
 
-    if (conn->actual_protocol_version_established && conn->actual_protocol_version != version) {
-        S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-    }
+    S2N_ERROR_IF(conn->actual_protocol_version_established && conn->actual_protocol_version != version, S2N_ERR_BAD_MESSAGE);
 
     GUARD(s2n_stuffer_read_uint16(in, fragment_length));
 

--- a/tls/s2n_record_write.c
+++ b/tls/s2n_record_write.c
@@ -108,9 +108,7 @@ int s2n_record_write(struct s2n_connection *conn, uint8_t content_type, struct s
         implicit_iv = conn->client->client_implicit_iv;
     }
 
-    if (s2n_stuffer_data_available(&conn->out)) {
-        S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-    }
+    S2N_ERROR_IF(s2n_stuffer_data_available(&conn->out), S2N_ERR_BAD_MESSAGE);
 
     uint8_t mac_digest_size;
     GUARD(s2n_hmac_digest_size(mac->alg, &mac_digest_size));

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -165,9 +165,7 @@ ssize_t s2n_recv(struct s2n_connection * conn, void *buf, ssize_t size, s2n_bloc
             return -1;
         }
 
-        if (isSSLv2) {
-            S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-        }
+        S2N_ERROR_IF(isSSLv2, S2N_ERR_BAD_MESSAGE);
 
         if (record_type != TLS_APPLICATION_DATA) {
             if (record_type == TLS_ALERT) {
@@ -217,13 +215,9 @@ int s2n_recv_close_notify(struct s2n_connection *conn, s2n_blocked_status * bloc
 
     GUARD(s2n_read_full_record(conn, &record_type, &isSSLv2));
 
-    if (isSSLv2) {
-        S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-    }
+    S2N_ERROR_IF(isSSLv2, S2N_ERR_BAD_MESSAGE);
 
-    if (record_type != TLS_ALERT) {
-        S2N_ERROR(S2N_ERR_SHUTDOWN_RECORD_TYPE);
-    }
+    S2N_ERROR_IF(record_type != TLS_ALERT, S2N_ERR_SHUTDOWN_RECORD_TYPE);
 
     /* Only succeeds for an incoming close_notify alert */
     GUARD(s2n_process_alert_fragment(conn));

--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -95,9 +95,7 @@ ssize_t s2n_send(struct s2n_connection * conn, const void *buf, ssize_t size, s2
     ssize_t user_data_sent;
     int max_payload_size;
 
-    if (conn->closed) {
-        S2N_ERROR(S2N_ERR_CLOSED);
-    }
+    S2N_ERROR_IF(conn->closed, S2N_ERR_CLOSED);
 
     /* Flush any pending I/O */
     GUARD(s2n_flush(conn, blocked));
@@ -121,9 +119,7 @@ ssize_t s2n_send(struct s2n_connection * conn, const void *buf, ssize_t size, s2
     }
 
     /* Defensive check against an invalid retry */
-    if (conn->current_user_data_consumed > size) {
-        S2N_ERROR(S2N_ERR_SEND_SIZE);
-    }
+    S2N_ERROR_IF(conn->current_user_data_consumed > size, S2N_ERR_SEND_SIZE);
 
     /* Now write the data we were asked to send this round */
     while (size - conn->current_user_data_consumed) {

--- a/tls/s2n_server_ccs.c
+++ b/tls/s2n_server_ccs.c
@@ -32,9 +32,7 @@ int s2n_server_ccs_recv(struct s2n_connection *conn)
     uint8_t type;
 
     GUARD(s2n_stuffer_read_uint8(&conn->handshake.io, &type));
-    if (type != CHANGE_CIPHER_SPEC_TYPE) {
-        S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-    }
+    S2N_ERROR_IF(type != CHANGE_CIPHER_SPEC_TYPE, S2N_ERR_BAD_MESSAGE);
 
     /* Zero the sequence number */
     struct s2n_blob seq = {.data = conn->secure.server_sequence_number,.size = S2N_TLS_SEQUENCE_NUM_LEN };

--- a/tls/s2n_server_cert.c
+++ b/tls/s2n_server_cert.c
@@ -29,9 +29,7 @@ int s2n_server_cert_recv(struct s2n_connection *conn)
 
     GUARD(s2n_stuffer_read_uint24(&conn->handshake.io, &size_of_all_certificates));
 
-    if (size_of_all_certificates > s2n_stuffer_data_available(&conn->handshake.io) || size_of_all_certificates < 3) {
-        S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-    }
+    S2N_ERROR_IF(size_of_all_certificates > s2n_stuffer_data_available(&conn->handshake.io) || size_of_all_certificates < 3, S2N_ERR_BAD_MESSAGE);
 
     s2n_cert_public_key public_key;
     s2n_cert_type cert_type;
@@ -42,9 +40,7 @@ int s2n_server_cert_recv(struct s2n_connection *conn)
     S2N_ERROR_IF(s2n_x509_validator_validate_cert_chain(&conn->x509_validator, conn, cert_chain.data,
                                                         cert_chain.size, &cert_type, &public_key) != S2N_CERT_OK, S2N_ERR_CERT_UNTRUSTED);
 
-    if (cert_type != S2N_CERT_TYPE_RSA_SIGN) {
-        S2N_ERROR(S2N_ERR_INVALID_SIGNATURE_ALGORITHM);
-    }
+    S2N_ERROR_IF(cert_type != S2N_CERT_TYPE_RSA_SIGN, S2N_ERR_INVALID_SIGNATURE_ALGORITHM);
 
     /* We know it's an RSA Key, verify it isn't null. */
     GUARD(s2n_rsa_check_key_exists(&public_key));

--- a/tls/s2n_server_done.c
+++ b/tls/s2n_server_done.c
@@ -24,9 +24,7 @@
 
 int s2n_server_done_recv(struct s2n_connection *conn)
 {
-    if (s2n_stuffer_data_available(&conn->handshake.io)) {
-        S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-    }
+    S2N_ERROR_IF(s2n_stuffer_data_available(&conn->handshake.io), S2N_ERR_BAD_MESSAGE);
 
     return 0;
 }

--- a/tls/s2n_server_extensions.c
+++ b/tls/s2n_server_extensions.c
@@ -209,9 +209,7 @@ int s2n_recv_server_max_frag_len(struct s2n_connection *conn, struct s2n_stuffer
 {
     uint8_t mfl_code;
     GUARD(s2n_stuffer_read_uint8(extension, &mfl_code));
-    if (mfl_code != conn->config->mfl_code) {
-        S2N_ERROR(S2N_ERR_MAX_FRAG_LEN_MISMATCH);
-    }
+    S2N_ERROR_IF(mfl_code != conn->config->mfl_code, S2N_ERR_MAX_FRAG_LEN_MISMATCH);
 
     return 0;
 }

--- a/tls/s2n_server_finished.c
+++ b/tls/s2n_server_finished.c
@@ -38,9 +38,7 @@ int s2n_server_finished_recv(struct s2n_connection *conn)
     uint8_t *their_version = s2n_stuffer_raw_read(&conn->handshake.io, length);
     notnull_check(their_version);
 
-    if (!s2n_constant_time_equals(our_version, their_version, length)) {
-        S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-    }
+    S2N_ERROR_IF(!s2n_constant_time_equals(our_version, their_version, length), S2N_ERR_BAD_MESSAGE);
 
     return 0;
 }

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -57,9 +57,7 @@ int s2n_server_hello_recv(struct s2n_connection *conn)
     GUARD(s2n_stuffer_read_bytes(in, conn->secure.server_random, S2N_TLS_RANDOM_DATA_LEN));
     GUARD(s2n_stuffer_read_uint8(in, &session_id_len));
 
-    if (session_id_len > S2N_TLS_SESSION_ID_MAX_LEN) {
-        S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-    }
+    S2N_ERROR_IF(session_id_len > S2N_TLS_SESSION_ID_MAX_LEN, S2N_ERR_BAD_MESSAGE);
 
     conn->session_id_len = session_id_len;
     GUARD(s2n_stuffer_read_bytes(in, session_id, session_id_len));
@@ -68,16 +66,12 @@ int s2n_server_hello_recv(struct s2n_connection *conn)
     GUARD(s2n_set_cipher_as_client(conn, cipher_suite_wire));
     GUARD(s2n_stuffer_read_uint8(in, &compression_method));
 
-    if (compression_method != S2N_TLS_COMPRESSION_METHOD_NULL) {
-        S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-    }
+    S2N_ERROR_IF(compression_method != S2N_TLS_COMPRESSION_METHOD_NULL, S2N_ERR_BAD_MESSAGE);
 
     if (s2n_stuffer_data_available(in) >= 2) {
         GUARD(s2n_stuffer_read_uint16(in, &extensions_size));
 
-        if (extensions_size > s2n_stuffer_data_available(in)) {
-            S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-        }
+        S2N_ERROR_IF(extensions_size > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);
 
         struct s2n_blob extensions;
         extensions.size = extensions_size;

--- a/tls/s2n_server_key_exchange.c
+++ b/tls/s2n_server_key_exchange.c
@@ -61,9 +61,7 @@ static int s2n_ecdhe_server_key_recv(struct s2n_connection *conn)
         GUARD(s2n_stuffer_read_uint8(in, &hash_algorithm));
         GUARD(s2n_stuffer_read_uint8(in, &signature_algorithm));
 
-        if (signature_algorithm != TLS_SIGNATURE_ALGORITHM_RSA) {
-            S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-        }
+        S2N_ERROR_IF(signature_algorithm != TLS_SIGNATURE_ALGORITHM_RSA, S2N_ERR_BAD_MESSAGE);
 
         int matched = 0;
         for (int i = 0; i < sizeof(s2n_preferred_hashes); i++) {
@@ -73,9 +71,7 @@ static int s2n_ecdhe_server_key_recv(struct s2n_connection *conn)
             }
         }
 
-        if (!matched) {
-            S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-        }
+        S2N_ERROR_IF(!matched, S2N_ERR_BAD_MESSAGE);
 
         GUARD(s2n_hash_init(&conn->secure.signature_hash, s2n_hash_tls_to_alg[hash_algorithm]));
     } else {
@@ -94,9 +90,7 @@ static int s2n_ecdhe_server_key_recv(struct s2n_connection *conn)
 
     gt_check(signature_length, 0);
 
-    if (s2n_pkey_verify(&conn->secure.server_public_key, &conn->secure.signature_hash, &signature) < 0) {
-        S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-    }
+    S2N_ERROR_IF(s2n_pkey_verify(&conn->secure.server_public_key, &conn->secure.signature_hash, &signature) < 0, S2N_ERR_BAD_MESSAGE);
 
     /* We don't need the key any more, so free it */
     GUARD(s2n_pkey_free(&conn->secure.server_public_key));
@@ -143,9 +137,7 @@ static int s2n_dhe_server_key_recv(struct s2n_connection *conn)
         GUARD(s2n_stuffer_read_uint8(in, &hash_algorithm));
         GUARD(s2n_stuffer_read_uint8(in, &signature_algorithm));
 
-        if (signature_algorithm != TLS_SIGNATURE_ALGORITHM_RSA) {
-            S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-        }
+        S2N_ERROR_IF(signature_algorithm != TLS_SIGNATURE_ALGORITHM_RSA, S2N_ERR_BAD_MESSAGE);
 
         int matched = 0;
         for (int i = 0; i < sizeof(s2n_preferred_hashes); i++) {
@@ -155,9 +147,7 @@ static int s2n_dhe_server_key_recv(struct s2n_connection *conn)
             }
         }
 
-        if (!matched) {
-            S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-        }
+        S2N_ERROR_IF(!matched, S2N_ERR_BAD_MESSAGE);
 
         GUARD(s2n_hash_init(&conn->secure.signature_hash, s2n_hash_tls_to_alg[hash_algorithm]));
     } else {
@@ -175,9 +165,7 @@ static int s2n_dhe_server_key_recv(struct s2n_connection *conn)
 
     gt_check(signature_length, 0);
 
-    if (s2n_pkey_verify(&conn->secure.server_public_key, &conn->secure.signature_hash, &signature) < 0) {
-        S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-    }
+    S2N_ERROR_IF(s2n_pkey_verify(&conn->secure.server_public_key, &conn->secure.signature_hash, &signature) < 0, S2N_ERR_BAD_MESSAGE);
 
     /* We don't need the key any more, so free it */
     GUARD(s2n_pkey_free(&conn->secure.server_public_key));
@@ -228,9 +216,7 @@ static int s2n_ecdhe_server_key_send(struct s2n_connection *conn)
     signature.data = s2n_stuffer_raw_write(out, signature.size);
     notnull_check(signature.data);
 
-    if (s2n_pkey_sign(&conn->config->cert_and_key_pairs->private_key, &conn->secure.signature_hash, &signature) < 0) {
-        S2N_ERROR(S2N_ERR_DH_FAILED_SIGNING);
-    }
+    S2N_ERROR_IF(s2n_pkey_sign(&conn->config->cert_and_key_pairs->private_key, &conn->secure.signature_hash, &signature) < 0, S2N_ERR_DH_FAILED_SIGNING);
 
     return 0;
 }
@@ -265,9 +251,7 @@ static int s2n_dhe_server_key_send(struct s2n_connection *conn)
     signature.data = s2n_stuffer_raw_write(out, signature.size);
     notnull_check(signature.data);
 
-    if (s2n_pkey_sign(&conn->config->cert_and_key_pairs->private_key, &conn->secure.signature_hash, &signature) < 0) {
-        S2N_ERROR(S2N_ERR_DH_FAILED_SIGNING);
-    }
+    S2N_ERROR_IF(s2n_pkey_sign(&conn->config->cert_and_key_pairs->private_key, &conn->secure.signature_hash, &signature) < 0, S2N_ERR_DH_FAILED_SIGNING);
 
     return 0;
 }

--- a/tls/s2n_shutdown.c
+++ b/tls/s2n_shutdown.c
@@ -33,9 +33,7 @@ int s2n_shutdown(struct s2n_connection *conn, s2n_blocked_status * more)
 
     uint64_t elapsed;
     GUARD(s2n_timer_elapsed(conn->config, &conn->write_timer, &elapsed));
-    if (elapsed < conn->delay) {
-        S2N_ERROR(S2N_ERR_SHUTDOWN_PAUSED);
-    }
+    S2N_ERROR_IF(elapsed < conn->delay, S2N_ERR_SHUTDOWN_PAUSED);
 
     /* Queue our close notify, once. Use warning level so clients don't give up */
     GUARD(s2n_queue_writer_close_alert_warning(conn));

--- a/utils/s2n_map.c
+++ b/utils/s2n_map.c
@@ -70,9 +70,7 @@ static int s2n_map_embiggen(struct s2n_map *map, uint32_t capacity)
     struct s2n_blob mem;
     struct s2n_map tmp;
 
-    if (map->immutable) {
-        S2N_ERROR(S2N_ERR_MAP_IMMUTABLE);
-    }
+    S2N_ERROR_IF(map->immutable, S2N_ERR_MAP_IMMUTABLE);
 
     GUARD(s2n_alloc(&mem, (capacity * sizeof(struct s2n_map_entry))));
     GUARD(s2n_blob_zero(&mem));
@@ -129,9 +127,7 @@ struct s2n_map *s2n_map_new()
 
 int s2n_map_add(struct s2n_map *map, struct s2n_blob *key, struct s2n_blob *value)
 {
-    if (map->immutable) {
-        S2N_ERROR(S2N_ERR_MAP_IMMUTABLE);
-    }
+    S2N_ERROR_IF(map->immutable, S2N_ERR_MAP_IMMUTABLE);
 
     if (map->capacity < (map->size * 2)) {
         /* Embiggen the map */
@@ -169,9 +165,7 @@ int s2n_map_complete(struct s2n_map *map)
 
 int s2n_map_lookup(struct s2n_map *map, struct s2n_blob *key, struct s2n_blob *value)
 {
-    if (!map->immutable) {
-        S2N_ERROR(S2N_ERR_MAP_MUTABLE);
-    }
+    S2N_ERROR_IF(!map->immutable, S2N_ERR_MAP_MUTABLE);
 
     uint32_t slot = s2n_map_slot(map, key);
 

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -69,9 +69,7 @@ int s2n_realloc(struct s2n_blob *b, uint32_t size)
     void *data;
     if (!use_mlock) {
         data = realloc(b->data, size);
-        if (!data) {
-            S2N_ERROR(S2N_ERR_ALLOC);
-        }
+        S2N_ERROR_IF(!data, S2N_ERR_ALLOC);
 
         b->data = data;
         b->size = size;
@@ -81,9 +79,7 @@ int s2n_realloc(struct s2n_blob *b, uint32_t size)
 
     /* Page aligned allocation required for mlock */
     uint32_t allocate = page_size * (((size - 1) / page_size) + 1);
-    if (posix_memalign(&data, page_size, allocate)) {
-        S2N_ERROR(S2N_ERR_ALLOC);
-    }
+    S2N_ERROR_IF(posix_memalign(&data, page_size, allocate), S2N_ERR_ALLOC);
 
     if (b->size) {
         memcpy_check(data, b->data, b->size);
@@ -122,9 +118,7 @@ int s2n_free(struct s2n_blob *b)
     b->size = 0;
     b->allocated = 0;
 
-    if (munlock_rc < 0) {
-        S2N_ERROR(S2N_ERR_MUNLOCK);
-    }
+    S2N_ERROR_IF(munlock_rc < 0, S2N_ERR_MUNLOCK);
     b->mlocked = 0;
 
     return 0;

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -236,18 +236,12 @@ int s2n_rand_init(void)
     }
 #if defined(MAP_INHERIT_ZERO)
     zero_if_forked_ptr = mmap(NULL, sizeof(int), PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
-    if (zero_if_forked_ptr == MAP_FAILED) {
-        S2N_ERROR(S2N_ERR_OPEN_RANDOM);
-    }
+    S2N_ERROR_IF(zero_if_forked_ptr == MAP_FAILED, S2N_ERR_OPEN_RANDOM);
 
-    if (minherit(zero_if_forked_ptr, sizeof(int), MAP_INHERIT_ZERO) == -1) {
-        S2N_ERROR(S2N_ERR_OPEN_RANDOM);
-    }
+    S2N_ERROR_IF(minherit(zero_if_forked_ptr, sizeof(int), MAP_INHERIT_ZERO) == -1, S2N_ERR_OPEN_RANDOM);
 #else
 
-    if (pthread_atfork(NULL, NULL, s2n_on_fork) != 0) {
-        S2N_ERROR(S2N_ERR_OPEN_RANDOM);
-    }
+    S2N_ERROR_IF(pthread_atfork(NULL, NULL, s2n_on_fork) != 0, S2N_ERR_OPEN_RANDOM);
 #endif
 
     GUARD(s2n_defend_if_forked());
@@ -265,9 +259,7 @@ int s2n_rand_init(void)
 
     /* Use that engine for rand() */
     e = ENGINE_by_id("s2n_rand");
-    if (e == NULL || ENGINE_init(e) != 1 || ENGINE_set_default(e, ENGINE_METHOD_RAND) != 1 || ENGINE_free(e) != 1) {
-        S2N_ERROR(S2N_ERR_OPEN_RANDOM);
-    }
+    S2N_ERROR_IF(e == NULL || ENGINE_init(e) != 1 || ENGINE_set_default(e, ENGINE_METHOD_RAND) != 1 || ENGINE_free(e) != 1, S2N_ERR_OPEN_RANDOM);
 #endif
 
     return 0;
@@ -275,9 +267,7 @@ int s2n_rand_init(void)
 
 int s2n_rand_cleanup(void)
 {
-    if (entropy_fd == -1) {
-        S2N_ERROR(S2N_ERR_NOT_INITIALIZED);
-    }
+    S2N_ERROR_IF(entropy_fd == -1, S2N_ERR_NOT_INITIALIZED);
 
     GUARD(s2n_drbg_wipe(&per_thread_private_drbg));
     GUARD(s2n_drbg_wipe(&per_thread_public_drbg));


### PR DESCRIPTION
**Issue # (if available):** 
https://github.com/awslabs/s2n/issues/692
**Description of changes:** 
I had a bit of free time, so I wrote a python script to convert the old format to the new, cleaner macro, as per https://github.com/awslabs/s2n/issues/692

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
