### PR TITLE
Use a GUARD_OSSL Macro

### DIFF
--- a/crypto/s2n_cbc_cipher_3des.c
+++ b/crypto/s2n_cbc_cipher_3des.c
@@ -31,11 +31,10 @@ static int s2n_cbc_cipher_3des_encrypt(struct s2n_session_key *key, struct s2n_b
 {
     gte_check(out->size, in->size);
 
-    S2N_ERROR_IF(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0, S2N_ERR_KEY_INIT);
+    GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
 
     int len = out->size;
-    S2N_ERROR_IF(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0, S2N_ERR_ENCRYPT);
-
+    GUARD_OSSL(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_ENCRYPT);
     S2N_ERROR_IF(len != in->size, S2N_ERR_ENCRYPT);
 
     return 0;
@@ -45,10 +44,10 @@ static int s2n_cbc_cipher_3des_decrypt(struct s2n_session_key *key, struct s2n_b
 {
     gte_check(out->size, in->size);
 
-    S2N_ERROR_IF(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0, S2N_ERR_KEY_INIT);
+    GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
 
     int len = out->size;
-    S2N_ERROR_IF(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0, S2N_ERR_DECRYPT);
+    GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_DECRYPT);
 
     return 0;
 }
@@ -58,7 +57,7 @@ static int s2n_cbc_cipher_3des_set_decryption_key(struct s2n_session_key *key, s
     eq_check(in->size, 192 / 8);
 
     EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
-    S2N_ERROR_IF(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_des_ede3_cbc(), NULL, in->data, NULL) != 1, S2N_ERR_KEY_INIT);
+    GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_des_ede3_cbc(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
     return 0;
 }
@@ -68,7 +67,7 @@ static int s2n_cbc_cipher_3des_set_encryption_key(struct s2n_session_key *key, s
     eq_check(in->size, 192 / 8);
 
     EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
-    S2N_ERROR_IF(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_des_ede3_cbc(), NULL, in->data, NULL) != 1, S2N_ERR_KEY_INIT);
+    GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_des_ede3_cbc(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
     return 0;
 }

--- a/crypto/s2n_cbc_cipher_aes.c
+++ b/crypto/s2n_cbc_cipher_aes.c
@@ -36,11 +36,10 @@ static int s2n_cbc_cipher_aes_encrypt(struct s2n_session_key *key, struct s2n_bl
 {
     gte_check(out->size, in->size);
 
-    S2N_ERROR_IF(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0, S2N_ERR_KEY_INIT);
+    GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
 
     int len = out->size;
-    S2N_ERROR_IF(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0, S2N_ERR_ENCRYPT);
-
+    GUARD_OSSL(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_ENCRYPT);
     S2N_ERROR_IF(len != in->size, S2N_ERR_ENCRYPT);
 
     return 0;
@@ -50,10 +49,9 @@ int s2n_cbc_cipher_aes_decrypt(struct s2n_session_key *key, struct s2n_blob *iv,
 {
     gte_check(out->size, in->size);
 
-    S2N_ERROR_IF(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0, S2N_ERR_KEY_INIT);
-
+    GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
     int len = out->size;
-    S2N_ERROR_IF(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0, S2N_ERR_DECRYPT);
+    GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_DECRYPT);
 
     return 0;
 }
@@ -64,7 +62,7 @@ int s2n_cbc_cipher_aes128_set_decryption_key(struct s2n_session_key *key, struct
 
     /* Always returns 1 */
     EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
-    S2N_ERROR_IF(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_aes_128_cbc(), NULL, in->data, NULL) != 1, S2N_ERR_KEY_INIT);
+    GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_aes_128_cbc(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
     return 0;
 }
@@ -74,7 +72,7 @@ static int s2n_cbc_cipher_aes128_set_encryption_key(struct s2n_session_key *key,
     eq_check(in->size, 128 / 8);
 
     EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
-    S2N_ERROR_IF(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_aes_128_cbc(), NULL, in->data, NULL) != 1, S2N_ERR_KEY_INIT);
+    GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_aes_128_cbc(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
     return 0;
 }
@@ -84,7 +82,7 @@ static int s2n_cbc_cipher_aes256_set_decryption_key(struct s2n_session_key *key,
     eq_check(in->size, 256 / 8);
 
     EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
-    S2N_ERROR_IF(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_aes_256_cbc(), NULL, in->data, NULL) != 1, S2N_ERR_KEY_INIT);
+    GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_aes_256_cbc(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
     return 0;
 }
@@ -94,7 +92,7 @@ int s2n_cbc_cipher_aes256_set_encryption_key(struct s2n_session_key *key, struct
     eq_check(in->size, 256 / 8);
 
     EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
-    S2N_ERROR_IF(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_aes_256_cbc(), NULL, in->data, NULL) != 1, S2N_ERR_KEY_INIT);
+    GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_aes_256_cbc(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
     return 0;
 }

--- a/crypto/s2n_composite_cipher_aes_sha.c
+++ b/crypto/s2n_composite_cipher_aes_sha.c
@@ -140,9 +140,8 @@ static int s2n_composite_cipher_aes_sha_encrypt(struct s2n_session_key *key, str
 {
     eq_check(out->size, in->size);
 
-    S2N_ERROR_IF(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0, S2N_ERR_KEY_INIT);
-
-    S2N_ERROR_IF(EVP_Cipher(key->evp_cipher_ctx, out->data, in->data, in->size) == 0, S2N_ERR_ENCRYPT);
+    GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
+    GUARD_OSSL(EVP_Cipher(key->evp_cipher_ctx, out->data, in->data, in->size), S2N_ERR_ENCRYPT);
 
     return 0;
 }
@@ -151,9 +150,8 @@ static int s2n_composite_cipher_aes_sha_decrypt(struct s2n_session_key *key, str
 {
     eq_check(out->size, in->size);
 
-    S2N_ERROR_IF(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data) == 0, S2N_ERR_KEY_INIT);
-
-    S2N_ERROR_IF(EVP_Cipher(key->evp_cipher_ctx, out->data, in->data, in->size) == 0, S2N_ERR_DECRYPT);
+    GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
+    GUARD_OSSL(EVP_Cipher(key->evp_cipher_ctx, out->data, in->data, in->size), S2N_ERR_DECRYPT);
 
     return 0;
 }

--- a/crypto/s2n_dhe.c
+++ b/crypto/s2n_dhe.c
@@ -108,17 +108,13 @@ static int s2n_set_p_g_Ys_dh_params(struct s2n_dh_params *dh_params, struct s2n_
     BIGNUM *bn_Ys = BN_bin2bn((const unsigned char *)Ys->data, Ys->size, NULL);
 
     #if S2N_OPENSSL_VERSION_AT_LEAST(1,1,0) && !defined(LIBRESSL_VERSION_NUMBER)
-        if (DH_set0_pqg(dh_params->dh, bn_p, NULL, bn_g) == 0) {
-            /* Per https://www.openssl.org/docs/man1.1.0/crypto/DH_get0_pqg.html:
-             * values that have been passed in should not be freed directly after this function has been called
-             */
-            S2N_ERROR(S2N_ERR_DH_PARAMS_CREATE);
-        }
-
-        if (DH_set0_key(dh_params->dh, bn_Ys, NULL) == 0) {
-            /* Same as DH_set0_pqg */
-            S2N_ERROR(S2N_ERR_DH_PARAMS_CREATE);
-        }
+       /* Per https://www.openssl.org/docs/man1.1.0/crypto/DH_get0_pqg.html:
+	* values that have been passed in should not be freed directly after this function has been called
+	*/
+        GUARD_OSSL(DH_set0_pqg(dh_params->dh, bn_p, NULL, bn_g), S2N_ERR_DH_PARAMS_CREATE);
+        
+	/* Same as DH_set0_pqg */
+        GUARD_OSSL(DH_set0_key(dh_params->dh, bn_Ys, NULL), S2N_ERR_DH_PARAMS_CREATE);
     #else
         dh_params->dh->p = bn_p;
         dh_params->dh->g = bn_g;

--- a/crypto/s2n_dhe.c
+++ b/crypto/s2n_dhe.c
@@ -84,9 +84,7 @@ static int s2n_check_p_g_dh_params(struct s2n_dh_params *dh_params)
     notnull_check(p);
 
     S2N_ERROR_IF(DH_size(dh_params->dh) < S2N_MIN_DH_PRIME_SIZE_BYTES, S2N_ERR_DH_PARAMS_CREATE);
-
     S2N_ERROR_IF(BN_is_zero(g), S2N_ERR_DH_PARAMS_CREATE);
-
     S2N_ERROR_IF(BN_is_zero(p), S2N_ERR_DH_PARAMS_CREATE);
 
     return 0;
@@ -289,8 +287,7 @@ int s2n_dh_params_check(struct s2n_dh_params *params)
 {
     int codes = 0;
 
-    S2N_ERROR_IF(DH_check(params->dh, &codes) == 0, S2N_ERR_DH_PARAMETER_CHECK);
-
+    GUARD_OSSL(DH_check(params->dh, &codes), S2N_ERR_DH_PARAMETER_CHECK);
     S2N_ERROR_IF(codes != 0, S2N_ERR_DH_PARAMETER_CHECK);
 
     return 0;
@@ -310,7 +307,7 @@ int s2n_dh_generate_ephemeral_key(struct s2n_dh_params *dh_params)
 {
     GUARD(s2n_check_p_g_dh_params(dh_params));
 
-    S2N_ERROR_IF(DH_generate_key(dh_params->dh) == 0, S2N_ERR_DH_GENERATING_PARAMETERS);
+    GUARD_OSSL(DH_generate_key(dh_params->dh), S2N_ERR_DH_GENERATING_PARAMETERS);
 
     return 0;
 }

--- a/crypto/s2n_drbg.c
+++ b/crypto/s2n_drbg.c
@@ -27,7 +27,7 @@
 static int s2n_drbg_block_encrypt(EVP_CIPHER_CTX * ctx, uint8_t in[S2N_DRBG_BLOCK_SIZE], uint8_t out[S2N_DRBG_BLOCK_SIZE])
 {
     int len = S2N_DRBG_BLOCK_SIZE;
-    S2N_ERROR_IF(EVP_EncryptUpdate(ctx, out, &len, in, S2N_DRBG_BLOCK_SIZE) != 1, S2N_ERR_DRBG);
+    GUARD_OSSL(EVP_EncryptUpdate(ctx, out, &len, in, S2N_DRBG_BLOCK_SIZE), S2N_ERR_DRBG);
     eq_check(len, S2N_DRBG_BLOCK_SIZE);
 
     return 0;
@@ -74,7 +74,7 @@ static int s2n_drbg_update(struct s2n_drbg *drbg, struct s2n_blob *provided_data
     }
 
     /* Update the key and value */
-    S2N_ERROR_IF(EVP_EncryptInit_ex(drbg->ctx, EVP_aes_128_ecb(), NULL, temp, NULL) != 1, S2N_ERR_DRBG);
+    GUARD_OSSL(EVP_EncryptInit_ex(drbg->ctx, EVP_aes_128_ecb(), NULL, temp, NULL), S2N_ERR_DRBG);
 
     memcpy_check(drbg->v, temp + S2N_DRBG_BLOCK_SIZE, S2N_DRBG_BLOCK_SIZE);
 
@@ -119,7 +119,7 @@ int s2n_drbg_instantiate(struct s2n_drbg *drbg, struct s2n_blob *personalization
     (void)EVP_CIPHER_CTX_init(drbg->ctx);
 
     /* Start off with zeroed key, per 10.2.1.3.1 item 5 */
-    S2N_ERROR_IF(EVP_EncryptInit_ex(drbg->ctx, EVP_aes_128_ecb(), NULL, drbg->v, NULL) != 1, S2N_ERR_DRBG);
+    GUARD_OSSL(EVP_EncryptInit_ex(drbg->ctx, EVP_aes_128_ecb(), NULL, drbg->v, NULL), S2N_ERR_DRBG);
 
     /* Copy the personalization string */
     GUARD(s2n_blob_zero(&ps));
@@ -160,7 +160,7 @@ int s2n_drbg_wipe(struct s2n_drbg *drbg)
     struct s2n_blob state = {.data = (void *)drbg,.size = sizeof(struct s2n_drbg) };
 
     if (drbg->ctx) {
-        S2N_ERROR_IF(EVP_CIPHER_CTX_cleanup(drbg->ctx) != 1, S2N_ERR_DRBG);
+        GUARD_OSSL(EVP_CIPHER_CTX_cleanup(drbg->ctx), S2N_ERR_DRBG);
 
         EVP_CIPHER_CTX_free(drbg->ctx);
         drbg->ctx = NULL;

--- a/crypto/s2n_ecdsa.c
+++ b/crypto/s2n_ecdsa.c
@@ -43,7 +43,7 @@ static int s2n_ecdsa_sign(const struct s2n_pkey *priv, struct s2n_hash_state *di
     GUARD(s2n_hash_digest(digest, digest_out, digest_length));
 
     unsigned int signature_size = signature->size;
-    S2N_ERROR_IF(ECDSA_sign(0, digest_out, digest_length, signature->data, &signature_size, key->ec_key) == 0, S2N_ERR_SIGN);
+    GUARD_OSSL(ECDSA_sign(0, digest_out, digest_length, signature->data, &signature_size, key->ec_key), S2N_ERR_SIGN);
     S2N_ERROR_IF(signature_size > signature->size, S2N_ERR_SIZE_MISMATCH);
     signature->size = signature_size;
 
@@ -65,7 +65,7 @@ static int s2n_ecdsa_verify(const struct s2n_pkey *pub, struct s2n_hash_state *d
     GUARD(s2n_hash_digest(digest, digest_out, digest_length));
     
     /* ECDSA_verify ignores the first parameter */
-    S2N_ERROR_IF(ECDSA_verify(0, digest_out, digest_length, signature->data, signature->size, key->ec_key) == 0, S2N_ERR_VERIFY_SIGNATURE);
+    GUARD_OSSL(ECDSA_verify(0, digest_out, digest_length, signature->data, signature->size, key->ec_key), S2N_ERR_VERIFY_SIGNATURE);
 
     GUARD(s2n_hash_reset(digest));
     

--- a/crypto/s2n_evp.c
+++ b/crypto/s2n_evp.c
@@ -24,9 +24,7 @@ int s2n_digest_allow_md5_for_fips(struct s2n_evp_digest *evp_digest)
      * to comply with the TLS 1.0 and 1.1 RFC's for the PRF. MD5 cannot be used
      * outside of the TLS 1.0 and 1.1 PRF when in FIPS mode.
      */
-    if(!s2n_is_in_fips_mode() || (evp_digest->ctx == NULL)){
-        S2N_ERROR(S2N_ERR_ALLOW_MD5_FOR_FIPS_FAILED);
-    }
+    S2N_ERROR_IF(!s2n_is_in_fips_mode() || (evp_digest->ctx == NULL), S2N_ERR_ALLOW_MD5_FOR_FIPS_FAILED);
 
     EVP_MD_CTX_set_flags(evp_digest->ctx, EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
 

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -146,7 +146,7 @@ static int s2n_low_level_hash_update(struct s2n_hash_state *state, const void *d
     case S2N_HASH_NONE:
         break;
     case S2N_HASH_MD5:
-      GUARD_OSSL(MD5_Update(&state->digest.low_level.md5, data, size), S2N_ERR_HASH_UPDATE_FAILED);
+        GUARD_OSSL(MD5_Update(&state->digest.low_level.md5, data, size), S2N_ERR_HASH_UPDATE_FAILED);
         break;
     case S2N_HASH_SHA1:
         GUARD_OSSL(SHA1_Update(&state->digest.low_level.sha1, data, size), S2N_ERR_HASH_UPDATE_FAILED);
@@ -384,7 +384,7 @@ static int s2n_evp_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *f
     case S2N_HASH_SHA256:
     case S2N_HASH_SHA384:
     case S2N_HASH_SHA512:
-      GUARD_OSSL(EVP_MD_CTX_copy_ex(to->digest.high_level.evp.ctx, from->digest.high_level.evp.ctx), S2N_ERR_HASH_COPY_FAILED);
+        GUARD_OSSL(EVP_MD_CTX_copy_ex(to->digest.high_level.evp.ctx, from->digest.high_level.evp.ctx), S2N_ERR_HASH_COPY_FAILED);
         break;
     case S2N_HASH_MD5_SHA1:
         if (s2n_digest_is_md5_allowed_for_fips(&from->digest.high_level.evp)) {
@@ -415,7 +415,7 @@ static int s2n_evp_hash_reset(struct s2n_hash_state *state)
     GUARD_OSSL(S2N_EVP_MD_CTX_RESET(state->digest.high_level.evp.ctx), S2N_ERR_HASH_WIPE_FAILED);
     
     if (state->alg == S2N_HASH_MD5_SHA1) {
-      GUARD_OSSL(S2N_EVP_MD_CTX_RESET(state->digest.high_level.evp_md5_secondary.ctx), S2N_ERR_HASH_WIPE_FAILED);
+        GUARD_OSSL(S2N_EVP_MD_CTX_RESET(state->digest.high_level.evp_md5_secondary.ctx), S2N_ERR_HASH_WIPE_FAILED);
     }
 
     if (reset_md5_for_fips) {

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -101,39 +101,35 @@ static int s2n_low_level_hash_new(struct s2n_hash_state *state)
 
 static int s2n_low_level_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm alg)
 {
-    int r;
     switch (alg) {
     case S2N_HASH_NONE:
-        r = 1;
         break;
     case S2N_HASH_MD5:
-        r = MD5_Init(&state->digest.low_level.md5);
+        GUARD_OSSL(MD5_Init(&state->digest.low_level.md5), S2N_ERR_HASH_INIT_FAILED);
         break;
     case S2N_HASH_SHA1:
-        r = SHA1_Init(&state->digest.low_level.sha1);
+        GUARD_OSSL(SHA1_Init(&state->digest.low_level.sha1), S2N_ERR_HASH_INIT_FAILED);
         break;
     case S2N_HASH_SHA224:
-        r = SHA224_Init(&state->digest.low_level.sha224);
+        GUARD_OSSL(SHA224_Init(&state->digest.low_level.sha224), S2N_ERR_HASH_INIT_FAILED);
         break;
     case S2N_HASH_SHA256:
-        r = SHA256_Init(&state->digest.low_level.sha256);
+        GUARD_OSSL(SHA256_Init(&state->digest.low_level.sha256), S2N_ERR_HASH_INIT_FAILED);
         break;
     case S2N_HASH_SHA384:
-        r = SHA384_Init(&state->digest.low_level.sha384);
+        GUARD_OSSL(SHA384_Init(&state->digest.low_level.sha384), S2N_ERR_HASH_INIT_FAILED);
         break;
     case S2N_HASH_SHA512:
-        r = SHA512_Init(&state->digest.low_level.sha512);
+        GUARD_OSSL(SHA512_Init(&state->digest.low_level.sha512), S2N_ERR_HASH_INIT_FAILED);
         break;
     case S2N_HASH_MD5_SHA1:
-        r = SHA1_Init(&state->digest.low_level.md5_sha1.sha1);
-        r &= MD5_Init(&state->digest.low_level.md5_sha1.md5);
+        GUARD_OSSL(SHA1_Init(&state->digest.low_level.md5_sha1.sha1), S2N_ERR_HASH_INIT_FAILED);;
+        GUARD_OSSL(MD5_Init(&state->digest.low_level.md5_sha1.md5), S2N_ERR_HASH_INIT_FAILED);;
         break;
 
     default:
         S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
     }
-
-    S2N_ERROR_IF(r == 0, S2N_ERR_HASH_INIT_FAILED);
 
     state->alg = alg;
     state->is_ready_for_input = 1;
@@ -146,38 +142,34 @@ static int s2n_low_level_hash_update(struct s2n_hash_state *state, const void *d
 {
     S2N_ERROR_IF(!state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
 
-    int r;
     switch (state->alg) {
     case S2N_HASH_NONE:
-        r = 1;
         break;
     case S2N_HASH_MD5:
-        r = MD5_Update(&state->digest.low_level.md5, data, size);
+      GUARD_OSSL(MD5_Update(&state->digest.low_level.md5, data, size), S2N_ERR_HASH_UPDATE_FAILED);
         break;
     case S2N_HASH_SHA1:
-        r = SHA1_Update(&state->digest.low_level.sha1, data, size);
+        GUARD_OSSL(SHA1_Update(&state->digest.low_level.sha1, data, size), S2N_ERR_HASH_UPDATE_FAILED);
         break;
     case S2N_HASH_SHA224:
-        r = SHA224_Update(&state->digest.low_level.sha224, data, size);
+        GUARD_OSSL(SHA224_Update(&state->digest.low_level.sha224, data, size), S2N_ERR_HASH_UPDATE_FAILED);
         break;
     case S2N_HASH_SHA256:
-        r = SHA256_Update(&state->digest.low_level.sha256, data, size);
+        GUARD_OSSL(SHA256_Update(&state->digest.low_level.sha256, data, size), S2N_ERR_HASH_UPDATE_FAILED);
         break;
     case S2N_HASH_SHA384:
-        r = SHA384_Update(&state->digest.low_level.sha384, data, size);
+        GUARD_OSSL(SHA384_Update(&state->digest.low_level.sha384, data, size), S2N_ERR_HASH_UPDATE_FAILED);
         break;
     case S2N_HASH_SHA512:
-        r = SHA512_Update(&state->digest.low_level.sha512, data, size);
+        GUARD_OSSL(SHA512_Update(&state->digest.low_level.sha512, data, size), S2N_ERR_HASH_UPDATE_FAILED);
         break;
     case S2N_HASH_MD5_SHA1:
-        r = SHA1_Update(&state->digest.low_level.md5_sha1.sha1, data, size);
-        r &= MD5_Update(&state->digest.low_level.md5_sha1.md5, data, size);
+        GUARD_OSSL(SHA1_Update(&state->digest.low_level.md5_sha1.sha1, data, size), S2N_ERR_HASH_UPDATE_FAILED);
+        GUARD_OSSL(MD5_Update(&state->digest.low_level.md5_sha1.md5, data, size), S2N_ERR_HASH_UPDATE_FAILED);
         break;
     default:
         S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
     }
-
-    S2N_ERROR_IF(r == 0, S2N_ERR_HASH_UPDATE_FAILED);
 
     state->currently_in_hash += size;
 
@@ -188,45 +180,41 @@ static int s2n_low_level_hash_digest(struct s2n_hash_state *state, void *out, ui
 {
     S2N_ERROR_IF(!state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
 
-    int r;
     switch (state->alg) {
     case S2N_HASH_NONE:
-        r = 1;
         break;
     case S2N_HASH_MD5:
         eq_check(size, MD5_DIGEST_LENGTH);
-        r = MD5_Final(out, &state->digest.low_level.md5);
+	GUARD_OSSL(MD5_Final(out, &state->digest.low_level.md5), S2N_ERR_HASH_DIGEST_FAILED);
         break;
     case S2N_HASH_SHA1:
         eq_check(size, SHA_DIGEST_LENGTH);
-        r = SHA1_Final(out, &state->digest.low_level.sha1);
+        GUARD_OSSL(SHA1_Final(out, &state->digest.low_level.sha1), S2N_ERR_HASH_DIGEST_FAILED);
         break;
     case S2N_HASH_SHA224:
         eq_check(size, SHA224_DIGEST_LENGTH);
-        r = SHA224_Final(out, &state->digest.low_level.sha224);
+        GUARD_OSSL(SHA224_Final(out, &state->digest.low_level.sha224), S2N_ERR_HASH_DIGEST_FAILED);
         break;
     case S2N_HASH_SHA256:
         eq_check(size, SHA256_DIGEST_LENGTH);
-        r = SHA256_Final(out, &state->digest.low_level.sha256);
+        GUARD_OSSL(SHA256_Final(out, &state->digest.low_level.sha256), S2N_ERR_HASH_DIGEST_FAILED);
         break;
     case S2N_HASH_SHA384:
         eq_check(size, SHA384_DIGEST_LENGTH);
-        r = SHA384_Final(out, &state->digest.low_level.sha384);
+        GUARD_OSSL(SHA384_Final(out, &state->digest.low_level.sha384), S2N_ERR_HASH_DIGEST_FAILED);
         break;
     case S2N_HASH_SHA512:
         eq_check(size, SHA512_DIGEST_LENGTH);
-        r = SHA512_Final(out, &state->digest.low_level.sha512);
+        GUARD_OSSL(SHA512_Final(out, &state->digest.low_level.sha512), S2N_ERR_HASH_DIGEST_FAILED);
         break;
     case S2N_HASH_MD5_SHA1:
         eq_check(size, MD5_DIGEST_LENGTH + SHA_DIGEST_LENGTH);
-        r = SHA1_Final(((uint8_t *) out) + MD5_DIGEST_LENGTH, &state->digest.low_level.md5_sha1.sha1);
-        r &= MD5_Final(out, &state->digest.low_level.md5_sha1.md5);
+        GUARD_OSSL(SHA1_Final(((uint8_t *) out) + MD5_DIGEST_LENGTH, &state->digest.low_level.md5_sha1.sha1), S2N_ERR_HASH_DIGEST_FAILED);
+        GUARD_OSSL(MD5_Final(out, &state->digest.low_level.md5_sha1.md5), S2N_ERR_HASH_DIGEST_FAILED);
         break;
     default:
         S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
     }
-
-    S2N_ERROR_IF(r == 0, S2N_ERR_HASH_DIGEST_FAILED);
 
     state->currently_in_hash = 0;
     state->is_ready_for_input = 0;
@@ -276,38 +264,34 @@ static int s2n_evp_hash_allow_md5_for_fips(struct s2n_hash_state *state)
 
 static int s2n_evp_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm alg)
 {
-    int r;
     switch (alg) {
     case S2N_HASH_NONE:
-        r = 1;
         break;
     case S2N_HASH_MD5:
-        r = EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_md5(), NULL);
+        GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_md5(), NULL), S2N_ERR_HASH_INIT_FAILED);
         break;
     case S2N_HASH_SHA1:
-        r = EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha1(), NULL);
+      GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha1(), NULL), S2N_ERR_HASH_INIT_FAILED);
         break;
     case S2N_HASH_SHA224:
-        r = EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha224(), NULL);
+        GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha224(), NULL), S2N_ERR_HASH_INIT_FAILED);
         break;
     case S2N_HASH_SHA256:
-        r = EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha256(), NULL);
+        GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha256(), NULL), S2N_ERR_HASH_INIT_FAILED);
         break;
     case S2N_HASH_SHA384:
-        r = EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha384(), NULL);
+        GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha384(), NULL), S2N_ERR_HASH_INIT_FAILED);
         break;
     case S2N_HASH_SHA512:
-        r = EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha512(), NULL);
+        GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha512(), NULL), S2N_ERR_HASH_INIT_FAILED);
         break;
     case S2N_HASH_MD5_SHA1:
-        r = EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha1(), NULL);
-        r &= EVP_DigestInit_ex(state->digest.high_level.evp_md5_secondary.ctx, EVP_md5(), NULL);
+        GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha1(), NULL), S2N_ERR_HASH_INIT_FAILED);
+        GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp_md5_secondary.ctx, EVP_md5(), NULL), S2N_ERR_HASH_INIT_FAILED);
         break;
     default:
         S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
     }
-
-    S2N_ERROR_IF(r == 0, S2N_ERR_HASH_INIT_FAILED);
 
     state->alg = alg;
     state->is_ready_for_input = 1;
@@ -320,10 +304,8 @@ static int s2n_evp_hash_update(struct s2n_hash_state *state, const void *data, u
 {
     S2N_ERROR_IF(!state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
 
-    int r;
     switch (state->alg) {
     case S2N_HASH_NONE:
-        r = 1;
         break;
     case S2N_HASH_MD5:
     case S2N_HASH_SHA1:
@@ -331,17 +313,15 @@ static int s2n_evp_hash_update(struct s2n_hash_state *state, const void *data, u
     case S2N_HASH_SHA256:
     case S2N_HASH_SHA384:
     case S2N_HASH_SHA512:
-        r = EVP_DigestUpdate(state->digest.high_level.evp.ctx, data, size);
+        GUARD_OSSL(EVP_DigestUpdate(state->digest.high_level.evp.ctx, data, size), S2N_ERR_HASH_UPDATE_FAILED);
         break;
     case S2N_HASH_MD5_SHA1:
-        r = EVP_DigestUpdate(state->digest.high_level.evp.ctx, data, size);
-        r &= EVP_DigestUpdate(state->digest.high_level.evp_md5_secondary.ctx, data, size);
+        GUARD_OSSL(EVP_DigestUpdate(state->digest.high_level.evp.ctx, data, size), S2N_ERR_HASH_UPDATE_FAILED);
+        GUARD_OSSL(EVP_DigestUpdate(state->digest.high_level.evp_md5_secondary.ctx, data, size), S2N_ERR_HASH_UPDATE_FAILED);
         break;
     default:
         S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
     }
-
-    S2N_ERROR_IF(r == 0, S2N_ERR_HASH_UPDATE_FAILED);
 
     state->currently_in_hash += size;
 
@@ -352,7 +332,6 @@ static int s2n_evp_hash_digest(struct s2n_hash_state *state, void *out, uint32_t
 {
     S2N_ERROR_IF(!state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
 
-    int r;
     unsigned int digest_size = size;
     uint8_t expected_digest_size;
     GUARD(s2n_hash_digest_size(state->alg, &expected_digest_size));
@@ -365,7 +344,6 @@ static int s2n_evp_hash_digest(struct s2n_hash_state *state, void *out, uint32_t
 
     switch (state->alg) {
     case S2N_HASH_NONE:
-        r = 1;
         break;
     case S2N_HASH_MD5:
     case S2N_HASH_SHA1:
@@ -373,21 +351,19 @@ static int s2n_evp_hash_digest(struct s2n_hash_state *state, void *out, uint32_t
     case S2N_HASH_SHA256:
     case S2N_HASH_SHA384:
     case S2N_HASH_SHA512:
-        r = EVP_DigestFinal_ex(state->digest.high_level.evp.ctx, out, &digest_size);
+      GUARD_OSSL(EVP_DigestFinal_ex(state->digest.high_level.evp.ctx, out, &digest_size), S2N_ERR_HASH_DIGEST_FAILED);
         break;
     case S2N_HASH_MD5_SHA1:
         GUARD(s2n_hash_digest_size(S2N_HASH_SHA1, &sha1_digest_size));
         sha1_primary_digest_size = sha1_digest_size;
         md5_secondary_digest_size = digest_size - sha1_primary_digest_size;
 
-        r = EVP_DigestFinal_ex(state->digest.high_level.evp.ctx, ((uint8_t *) out) + MD5_DIGEST_LENGTH, &sha1_primary_digest_size);
-        r &= EVP_DigestFinal_ex(state->digest.high_level.evp_md5_secondary.ctx, out, &md5_secondary_digest_size);
+        GUARD_OSSL(EVP_DigestFinal_ex(state->digest.high_level.evp.ctx, ((uint8_t *) out) + MD5_DIGEST_LENGTH, &sha1_primary_digest_size), S2N_ERR_HASH_DIGEST_FAILED);
+        GUARD_OSSL(EVP_DigestFinal_ex(state->digest.high_level.evp_md5_secondary.ctx, out, &md5_secondary_digest_size), S2N_ERR_HASH_DIGEST_FAILED);
         break;
     default:
         S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
     }
-
-    S2N_ERROR_IF(r == 0, S2N_ERR_HASH_DIGEST_FAILED);
 
     state->currently_in_hash = 0;
     state->is_ready_for_input = 0;
@@ -396,10 +372,8 @@ static int s2n_evp_hash_digest(struct s2n_hash_state *state, void *out, uint32_t
 
 static int s2n_evp_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *from)
 {
-    int r;
     switch (from->alg) {
     case S2N_HASH_NONE:
-        r = 1;
         break;
     case S2N_HASH_MD5:
         if (s2n_digest_is_md5_allowed_for_fips(&from->digest.high_level.evp)) {
@@ -410,20 +384,19 @@ static int s2n_evp_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *f
     case S2N_HASH_SHA256:
     case S2N_HASH_SHA384:
     case S2N_HASH_SHA512:
-        r = EVP_MD_CTX_copy_ex(to->digest.high_level.evp.ctx, from->digest.high_level.evp.ctx);
+      GUARD_OSSL(EVP_MD_CTX_copy_ex(to->digest.high_level.evp.ctx, from->digest.high_level.evp.ctx), S2N_ERR_HASH_COPY_FAILED);
         break;
     case S2N_HASH_MD5_SHA1:
         if (s2n_digest_is_md5_allowed_for_fips(&from->digest.high_level.evp)) {
             GUARD(s2n_hash_allow_md5_for_fips(to));
         }
-        r = EVP_MD_CTX_copy_ex(to->digest.high_level.evp.ctx, from->digest.high_level.evp.ctx);
-        r &= EVP_MD_CTX_copy_ex(to->digest.high_level.evp_md5_secondary.ctx, from->digest.high_level.evp_md5_secondary.ctx);
+	GUARD_OSSL(EVP_MD_CTX_copy_ex(to->digest.high_level.evp.ctx, from->digest.high_level.evp.ctx), S2N_ERR_HASH_COPY_FAILED);
+	GUARD_OSSL(EVP_MD_CTX_copy_ex(to->digest.high_level.evp_md5_secondary.ctx, from->digest.high_level.evp_md5_secondary.ctx), S2N_ERR_HASH_COPY_FAILED);
         break;
     default:
         S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
     }
 
-    S2N_ERROR_IF(r == 0, S2N_ERR_HASH_COPY_FAILED);
     to->hash_impl = from->hash_impl;
     to->alg = from->alg;
     to->is_ready_for_input = from->is_ready_for_input;
@@ -439,14 +412,11 @@ static int s2n_evp_hash_reset(struct s2n_hash_state *state)
         reset_md5_for_fips = 1;
     }
 
-    int r;
-    r = S2N_EVP_MD_CTX_RESET(state->digest.high_level.evp.ctx);
+    GUARD_OSSL(S2N_EVP_MD_CTX_RESET(state->digest.high_level.evp.ctx), S2N_ERR_HASH_WIPE_FAILED);
     
     if (state->alg == S2N_HASH_MD5_SHA1) {
-        r &= S2N_EVP_MD_CTX_RESET(state->digest.high_level.evp_md5_secondary.ctx);
+      GUARD_OSSL(S2N_EVP_MD_CTX_RESET(state->digest.high_level.evp_md5_secondary.ctx), S2N_ERR_HASH_WIPE_FAILED);
     }
-
-    S2N_ERROR_IF(r == 0, S2N_ERR_HASH_WIPE_FAILED);
 
     if (reset_md5_for_fips) {
         GUARD(s2n_hash_allow_md5_for_fips(state));

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -351,7 +351,7 @@ static int s2n_evp_hash_digest(struct s2n_hash_state *state, void *out, uint32_t
     case S2N_HASH_SHA256:
     case S2N_HASH_SHA384:
     case S2N_HASH_SHA512:
-      GUARD_OSSL(EVP_DigestFinal_ex(state->digest.high_level.evp.ctx, out, &digest_size), S2N_ERR_HASH_DIGEST_FAILED);
+        GUARD_OSSL(EVP_DigestFinal_ex(state->digest.high_level.evp.ctx, out, &digest_size), S2N_ERR_HASH_DIGEST_FAILED);
         break;
     case S2N_HASH_MD5_SHA1:
         GUARD(s2n_hash_digest_size(S2N_HASH_SHA1, &sha1_digest_size));

--- a/crypto/s2n_rsa.c
+++ b/crypto/s2n_rsa.c
@@ -101,7 +101,7 @@ static int s2n_rsa_sign(const struct s2n_pkey *priv, struct s2n_hash_state *dige
     GUARD(s2n_hash_digest(digest, digest_out, digest_length));
 
     unsigned int signature_size = signature->size;
-    S2N_ERROR_IF(RSA_sign(NID_type, digest_out, digest_length, signature->data, &signature_size, key->rsa) == 0, S2N_ERR_SIGN);
+    GUARD_OSSL(RSA_sign(NID_type, digest_out, digest_length, signature->data, &signature_size, key->rsa), S2N_ERR_SIGN);
     S2N_ERROR_IF(signature_size > signature->size, S2N_ERR_SIZE_MISMATCH);
     signature->size = signature_size;
 
@@ -121,7 +121,7 @@ static int s2n_rsa_verify(const struct s2n_pkey *pub, struct s2n_hash_state *dig
     uint8_t digest_out[S2N_MAX_DIGEST_LEN];
     GUARD(s2n_hash_digest(digest, digest_out, digest_length));
 
-    S2N_ERROR_IF(RSA_verify(NID_type, digest_out, digest_length, signature->data, signature->size, key->rsa) == 0, S2N_ERR_VERIFY_SIGNATURE);
+    GUARD_OSSL(RSA_verify(NID_type, digest_out, digest_length, signature->data, signature->size, key->rsa), S2N_ERR_VERIFY_SIGNATURE);
 
     return 0;
 }
@@ -144,7 +144,6 @@ static int s2n_rsa_decrypt(const struct s2n_pkey *priv, struct s2n_blob *in, str
     const s2n_rsa_private_key *key = &priv->key.rsa_key;
 
     S2N_ERROR_IF(s2n_rsa_private_encrypted_size(key) > sizeof(intermediate), S2N_ERR_NOMEM);
-
     S2N_ERROR_IF(out->size > sizeof(intermediate), S2N_ERR_NOMEM);
 
     int r = RSA_private_decrypt(in->size, (unsigned char *)in->data, intermediate, key->rsa, RSA_PKCS1_PADDING);

--- a/crypto/s2n_stream_cipher_rc4.c
+++ b/crypto/s2n_stream_cipher_rc4.c
@@ -30,7 +30,7 @@ static int s2n_stream_cipher_rc4_encrypt(struct s2n_session_key *key, struct s2n
     gte_check(out->size, in->size);
 
     int len = out->size;
-    S2N_ERROR_IF(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0, S2N_ERR_ENCRYPT);
+    GUARD_OSSL(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_ENCRYPT);
 
     S2N_ERROR_IF(len != in->size, S2N_ERR_ENCRYPT);
 
@@ -42,7 +42,7 @@ static int s2n_stream_cipher_rc4_decrypt(struct s2n_session_key *key, struct s2n
     gte_check(out->size, in->size);
 
     int len = out->size;
-    S2N_ERROR_IF(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size) == 0, S2N_ERR_ENCRYPT);
+    GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_ENCRYPT);
 
     S2N_ERROR_IF(len != in->size, S2N_ERR_ENCRYPT);
 
@@ -52,7 +52,7 @@ static int s2n_stream_cipher_rc4_decrypt(struct s2n_session_key *key, struct s2n
 static int s2n_stream_cipher_rc4_set_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
     eq_check(in->size, 16);
-    S2N_ERROR_IF(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_rc4(), NULL, in->data, NULL) != 1, S2N_ERR_KEY_INIT);
+    GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_rc4(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
     return 0;
 }
@@ -60,7 +60,7 @@ static int s2n_stream_cipher_rc4_set_encryption_key(struct s2n_session_key *key,
 static int s2n_stream_cipher_rc4_set_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
     eq_check(in->size, 16);
-    S2N_ERROR_IF(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_rc4(), NULL, in->data, NULL) != 1, S2N_ERR_KEY_INIT);
+    GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_rc4(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
     return 0;
 }

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -101,8 +101,8 @@ static int s2n_evp_hmac_p_hash_digest_init(struct s2n_prf_working_space *ws)
         GUARD(s2n_digest_allow_md5_for_fips(&ws->tls.p_hash.evp_hmac.evp_digest));
     }
 
-    S2N_ERROR_IF(EVP_DigestSignInit(ws->tls.p_hash.evp_hmac.evp_digest.ctx, NULL, ws->tls.p_hash.evp_hmac.evp_digest.md, NULL, ws->tls.p_hash.evp_hmac.mac_key) == 0,
-		 S2N_ERR_P_HASH_INIT_FAILED);
+    GUARD_OSSL(EVP_DigestSignInit(ws->tls.p_hash.evp_hmac.evp_digest.ctx, NULL, ws->tls.p_hash.evp_hmac.evp_digest.md, NULL, ws->tls.p_hash.evp_hmac.mac_key),
+	       S2N_ERR_P_HASH_INIT_FAILED);
 
     return 0;
 }
@@ -144,7 +144,7 @@ static int s2n_evp_hmac_p_hash_init(struct s2n_prf_working_space *ws, s2n_hmac_a
 
 static int s2n_evp_hmac_p_hash_update(struct s2n_prf_working_space *ws, const void *data, uint32_t size)
 {
-    S2N_ERROR_IF(EVP_DigestSignUpdate(ws->tls.p_hash.evp_hmac.evp_digest.ctx, data, (size_t)size) == 0, S2N_ERR_P_HASH_UPDATE_FAILED);
+    GUARD_OSSL(EVP_DigestSignUpdate(ws->tls.p_hash.evp_hmac.evp_digest.ctx, data, (size_t)size), S2N_ERR_P_HASH_UPDATE_FAILED);
 
     return 0;
 }
@@ -154,14 +154,14 @@ static int s2n_evp_hmac_p_hash_digest(struct s2n_prf_working_space *ws, void *di
     /* EVP_DigestSign API's require size_t data structures */
     size_t digest_size = size;
 
-    S2N_ERROR_IF(EVP_DigestSignFinal(ws->tls.p_hash.evp_hmac.evp_digest.ctx, (unsigned char *)digest, &digest_size) == 0, S2N_ERR_P_HASH_FINAL_FAILED);
+    GUARD_OSSL(EVP_DigestSignFinal(ws->tls.p_hash.evp_hmac.evp_digest.ctx, (unsigned char *)digest, &digest_size), S2N_ERR_P_HASH_FINAL_FAILED);
 
     return 0;
 }
 
 static int s2n_evp_hmac_p_hash_wipe(struct s2n_prf_working_space *ws)
 {
-    S2N_ERROR_IF(S2N_EVP_MD_CTX_RESET(ws->tls.p_hash.evp_hmac.evp_digest.ctx) == 0, S2N_ERR_P_HASH_WIPE_FAILED);
+  GUARD_OSSL(S2N_EVP_MD_CTX_RESET(ws->tls.p_hash.evp_hmac.evp_digest.ctx), S2N_ERR_P_HASH_WIPE_FAILED);
 
     return 0;
 }

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -84,7 +84,7 @@ static inline void* trace_memcpy_check(void *restrict to, const void *restrict f
 /* TODO: use the OSSL error code in error reporting https://github.com/awslabs/s2n/issues/705 */
 #define GUARD_OSSL( x , errcode )			\
   do {							\
-  if (( x ) == 0) {					\
+  if (( x ) != 1) {					\
     S2N_ERROR( errcode );				\
   }							\
   } while (0)

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -81,6 +81,14 @@ static inline void* trace_memcpy_check(void *restrict to, const void *restrict f
 #define GUARD( x )      if ( (x) < 0 ) return -1
 #define GUARD_PTR( x )  if ( (x) < 0 ) return NULL
 
+/* TODO: use the OSSL error code in error reporting https://github.com/awslabs/s2n/issues/705 */
+#define GUARD_OSSL( x , errcode )			\
+  do {							\
+  if (( x ) == 0) {					\
+    S2N_ERROR( errcode );				\
+  }							\
+  } while (0)
+
 /**
  * Get the process id
  *


### PR DESCRIPTION
**Issue # (if available):** 
https://github.com/awslabs/s2n/issues/705

**Description of changes:** 
I updated all places I could find where libcrypto functions were being called with results checked against 0, to use  a GUARD_OSSL Macro as discussed in https://github.com/awslabs/s2n/issues/705.  Capturing the error code from OSSL is future work, but this should mean it only has to be done in one place.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
