### PR TITLE
Add s2n_conn_set_cipher_preferences() API

### DIFF
--- a/.travis/install_sidewinder_dependencies.sh
+++ b/.travis/install_sidewinder_dependencies.sh
@@ -51,7 +51,20 @@ sudo update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llv
 sudo update-alternatives --install /usr/bin/llvm-link llvm-link /usr/bin/llvm-link-${LLVM_SHORT_VERSION} 30
 sudo update-alternatives --install /usr/bin/llvm-dis llvm-dis /usr/bin/llvm-dis-${LLVM_SHORT_VERSION} 30
 
+which clang
+clang --version
+clang-3.9 --version
 
+mkdir -p ~/override_clang
+ln -s /usr/bin/clang          ~/override_clang/clang
+ln -s /usr/bin/clang++        ~/override_clang/clang++
+ln -s /usr/bin/llvm-config   ~/override_clang/llvm-config
+ln -s /usr/bin/llvm-link      ~/override_clang/llvm-link
+ln -s /usr/bin/llvm-dis       ~/override_clang/llvm-dis
+sudo chmod +x ~/override_clang/*
+
+export PATH="$HOME/override_clang/:${PATH}"
+which clang
 clang --version
 clang-3.9 --version
 

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -153,7 +153,7 @@ typedef enum { S2N_BUILT_IN_BLINDING, S2N_SELF_SERVICE_BLINDING } s2n_blinding;
 extern int s2n_connection_set_blinding(struct s2n_connection *conn, s2n_blinding blinding);
 extern uint64_t s2n_connection_get_delay(struct s2n_connection *conn);
 
-extern int s2n_conn_set_cipher_preferences(struct s2n_connection *conn, const char *version);
+extern int s2n_connection_set_cipher_preferences(struct s2n_connection *conn, const char *version);
 extern int s2n_set_server_name(struct s2n_connection *conn, const char *server_name);
 extern const char *s2n_get_server_name(struct s2n_connection *conn);
 extern const char *s2n_get_application_protocol(struct s2n_connection *conn);

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -153,6 +153,7 @@ typedef enum { S2N_BUILT_IN_BLINDING, S2N_SELF_SERVICE_BLINDING } s2n_blinding;
 extern int s2n_connection_set_blinding(struct s2n_connection *conn, s2n_blinding blinding);
 extern uint64_t s2n_connection_get_delay(struct s2n_connection *conn);
 
+extern int s2n_conn_set_cipher_preferences(struct s2n_connection *conn, const char *version);
 extern int s2n_set_server_name(struct s2n_connection *conn, const char *server_name);
 extern const char *s2n_get_server_name(struct s2n_connection *conn);
 extern const char *s2n_get_application_protocol(struct s2n_connection *conn);

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -878,6 +878,16 @@ file-descriptor should be active and connected. s2n also supports setting the
 read and write file-descriptors to different values (for pipes or other unusual
 types of I/O).
 
+## s2n\_conn\_set\_cipher\_preferences
+
+```c
+int s2n_conn_set_cipher_preferences(struct s2n_connection *conn, const char *version);
+```
+
+**s2n_conn_set_cipher_preferences** sets the cipher preference override for the
+s2n_connection. Calling this function is not necessary unless you want to set the
+cipher preferences on the connection to something different than what is in the s2n_config.
+
 ### s2n\_set\_server\_name
 
 ```c

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -878,13 +878,13 @@ file-descriptor should be active and connected. s2n also supports setting the
 read and write file-descriptors to different values (for pipes or other unusual
 types of I/O).
 
-## s2n\_conn\_set\_cipher\_preferences
+## s2n\_connection\_set\_cipher\_preferences
 
 ```c
-int s2n_conn_set_cipher_preferences(struct s2n_connection *conn, const char *version);
+int s2n_connection_set_cipher_preferences(struct s2n_connection *conn, const char *version);
 ```
 
-**s2n_conn_set_cipher_preferences** sets the cipher preference override for the
+**s2n_connection_set_cipher_preferences** sets the cipher preference override for the
 s2n_connection. Calling this function is not necessary unless you want to set the
 cipher preferences on the connection to something different than what is in the s2n_config.
 

--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -101,13 +101,15 @@ int test_cipher_preferences(struct s2n_config *server_config, struct s2n_config 
         struct s2n_cipher_preferences server_cipher_preferences;
         struct s2n_connection *client_conn;
         struct s2n_connection *server_conn;
+        server_conn = s2n_connection_new(S2N_SERVER);
+        notnull_check(server_conn);
         int server_to_client[2];
         int client_to_server[2];
-        struct s2n_cipher_suite *cur_cipher = cipher_preferences->suites[cipher_idx];
+        struct s2n_cipher_suite *expected_cipher = cipher_preferences->suites[cipher_idx];
         uint8_t expect_failure = 0;
 
         /* Expect failure if the libcrypto we're building with can't support the cipher */
-        if (!cur_cipher->available) {
+        if (!expected_cipher->available) {
             expect_failure = 1;
         }
 
@@ -116,8 +118,8 @@ int test_cipher_preferences(struct s2n_config *server_config, struct s2n_config 
            will never be NULL */
         memcpy(&server_cipher_preferences, cipher_preferences, sizeof(server_cipher_preferences));
         server_cipher_preferences.count = 1;
-        server_cipher_preferences.suites = &cur_cipher;
-        server_config->cipher_preferences = &server_cipher_preferences;
+        server_cipher_preferences.suites = &expected_cipher;
+        server_conn->cipher_pref_override = &server_cipher_preferences;
 
         /* Create nonblocking pipes */
         GUARD(pipe(server_to_client));
@@ -136,8 +138,6 @@ int test_cipher_preferences(struct s2n_config *server_config, struct s2n_config 
         client_conn->client_protocol_version = S2N_TLS12;
         client_conn->actual_protocol_version = S2N_TLS12;
 
-        server_conn = s2n_connection_new(S2N_SERVER);
-        notnull_check(server_conn);
         GUARD(s2n_connection_set_read_fd(server_conn, client_to_server[0]));
         GUARD(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
         GUARD(s2n_connection_set_config(server_conn, server_config));
@@ -147,6 +147,11 @@ int test_cipher_preferences(struct s2n_config *server_config, struct s2n_config 
 
         if (!expect_failure) {
             GUARD(try_handshake(server_conn, client_conn));
+            const char* actual_cipher = s2n_connection_get_cipher(server_conn);
+            if (strcmp(actual_cipher, expected_cipher->name) != 0){
+                return -1;
+            }
+
         } else {
             eq_check(try_handshake(server_conn, client_conn), -1);
         }

--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -151,7 +151,6 @@ int test_cipher_preferences(struct s2n_config *server_config, struct s2n_config 
             if (strcmp(actual_cipher, expected_cipher->name) != 0){
                 return -1;
             }
-
         } else {
             eq_check(try_handshake(server_conn, client_conn), -1);
         }

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -22,7 +22,6 @@
 #include "error/s2n_errno.h"
 #include "utils/s2n_safety.h"
 
-
 /* s2n's list of cipher suites, in order of preference, as of 2014-06-01 */
 struct s2n_cipher_suite *cipher_suites_20140601[] = {
     &s2n_dhe_rsa_with_aes_128_cbc_sha256,

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -20,6 +20,8 @@
 #include "tls/s2n_config.h"
 
 #include "error/s2n_errno.h"
+#include "utils/s2n_safety.h"
+
 
 /* s2n's list of cipher suites, in order of preference, as of 2014-06-01 */
 struct s2n_cipher_suite *cipher_suites_20140601[] = {
@@ -387,15 +389,30 @@ struct {
     { NULL, NULL }
 };
 
-int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *version)
+int s2n_find_cipher_pref_from_version(const char *version, const struct s2n_cipher_preferences **cipher_preferences)
 {
+    notnull_check(version);
+    notnull_check(cipher_preferences);
+
     for (int i = 0; selection[i].version != NULL; i++) {
         if (!strcasecmp(version, selection[i].version)) {
-            config->cipher_preferences = selection[i].preferences;
+            *cipher_preferences = selection[i].preferences;
             return 0;
         }
     }
 
     S2N_ERROR(S2N_ERR_INVALID_CIPHER_PREFERENCES);
+}
+
+int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *version)
+{
+    GUARD(s2n_find_cipher_pref_from_version(version, &config->cipher_preferences));
+    return 0;
+}
+
+int s2n_conn_set_cipher_preferences(struct s2n_connection *conn, const char *version)
+{
+    GUARD(s2n_find_cipher_pref_from_version(version, &conn->cipher_pref_override));
+    return 0;
 }
 

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -409,7 +409,7 @@ int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *ver
     return 0;
 }
 
-int s2n_conn_set_cipher_preferences(struct s2n_connection *conn, const char *version)
+int s2n_connection_set_cipher_preferences(struct s2n_connection *conn, const char *version)
 {
     GUARD(s2n_find_cipher_pref_from_version(version, &conn->cipher_pref_override));
     return 0;

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -47,4 +47,5 @@ extern const struct s2n_cipher_preferences elb_security_policy_2016_08;
 extern const struct s2n_cipher_preferences elb_security_policy_tls_1_2_2017_01;
 extern const struct s2n_cipher_preferences elb_security_policy_tls_1_1_2017_01;
 
+extern int s2n_find_cipher_pref_from_version(const char *version, const struct s2n_cipher_preferences **cipher_preferences);
 extern int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *version);

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -696,9 +696,12 @@ static int s2n_set_cipher_as_server(struct s2n_connection *conn, uint8_t * wire,
         conn->secure_renegotiation = 1;
     }
 
+    const struct s2n_cipher_preferences *cipher_preferences;
+    GUARD(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
+
     /* s2n supports only server order */
-    for (int i = 0; i < conn->config->cipher_preferences->count; i++) {
-        const uint8_t *ours = conn->config->cipher_preferences->suites[i]->iana_value;
+    for (int i = 0; i < cipher_preferences->count; i++) {
+        const uint8_t *ours = cipher_preferences->suites[i]->iana_value;
 
         if (s2n_wire_ciphers_contain(ours, wire, count, cipher_suite_len)) {
             /* We have a match */

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -214,7 +214,10 @@ static int s2n_process_client_hello(struct s2n_connection *conn)
         GUARD(s2n_client_extensions_recv(conn, client_hello->parsed_extensions));
     }
 
-    if (conn->client_protocol_version < conn->config->cipher_preferences->minimum_protocol_version) {
+    const struct s2n_cipher_preferences *cipher_preferences;
+    GUARD(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
+
+    if (conn->client_protocol_version < cipher_preferences->minimum_protocol_version) {
         GUARD(s2n_queue_reader_unsupported_protocol_version_alert(conn));
         S2N_ERROR(S2N_ERR_BAD_MESSAGE);
     }
@@ -328,12 +331,15 @@ int s2n_client_hello_send(struct s2n_connection *conn)
     GUARD(s2n_stuffer_copy(&client_random, out, S2N_TLS_RANDOM_DATA_LEN));
     GUARD(s2n_stuffer_write_uint8(out, session_id_len));
 
+    const struct s2n_cipher_preferences *cipher_preferences;
+    GUARD(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
+
     /* Find the number of available suites in the preference list. Some ciphers may be unavailable if s2n is built
      * with an older libcrypto
      */
     uint16_t num_available_suites = 0;
-    for (int i = 0; i < conn->config->cipher_preferences->count; i++) {
-        if (conn->config->cipher_preferences->suites[i]->available) {
+    for (int i = 0; i < cipher_preferences->count; i++) {
+        if (cipher_preferences->suites[i]->available) {
             num_available_suites++;
         }
     }
@@ -342,9 +348,9 @@ int s2n_client_hello_send(struct s2n_connection *conn)
     GUARD(s2n_stuffer_write_uint16(out, num_available_suites * S2N_TLS_CIPHER_SUITE_LEN));
 
     /* Now, write the IANA values every available cipher suite in our list */
-    for (int i = 0; i < conn->config->cipher_preferences->count; i++ ) {
-        if (conn->config->cipher_preferences->suites[i]->available) {
-            GUARD(s2n_stuffer_write_bytes(out, conn->config->cipher_preferences->suites[i]->iana_value, S2N_TLS_CIPHER_SUITE_LEN));
+    for (int i = 0; i < cipher_preferences->count; i++ ) {
+        if (cipher_preferences->suites[i]->available) {
+            GUARD(s2n_stuffer_write_bytes(out, cipher_preferences->suites[i]->iana_value, S2N_TLS_CIPHER_SUITE_LEN));
         }
     }
 
@@ -373,7 +379,10 @@ int s2n_sslv2_client_hello_recv(struct s2n_connection *conn)
     uint16_t challenge_length;
     uint8_t *cipher_suites;
 
-    if (conn->client_protocol_version < conn->config->cipher_preferences->minimum_protocol_version || conn->client_protocol_version > conn->server_protocol_version) {
+    const struct s2n_cipher_preferences *cipher_preferences;
+    GUARD(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
+
+    if (conn->client_protocol_version < cipher_preferences->minimum_protocol_version || conn->client_protocol_version > conn->server_protocol_version) {
         GUARD(s2n_queue_reader_unsupported_protocol_version_alert(conn));
         S2N_ERROR(S2N_ERR_BAD_MESSAGE);
     }

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -177,6 +177,7 @@ struct s2n_connection *s2n_connection_new(s2n_mode mode)
     conn->managed_io = 0;
     conn->corked_io = 0;
     conn->context = NULL;
+    conn->cipher_pref_override = NULL;
 
     /* Allocate the fixed-size stuffers */
     blob.data = conn->alert_in_data;
@@ -683,6 +684,20 @@ int s2n_connection_get_client_cert_chain(struct s2n_connection *conn, uint8_t **
 
     *der_cert_chain_out = conn->secure.client_cert_chain.data;
     *cert_chain_len = conn->secure.client_cert_chain.size;
+
+    return 0;
+}
+
+int s2n_connection_get_cipher_preferences(struct s2n_connection *conn, const struct s2n_cipher_preferences **cipher_preferences)
+{
+    notnull_check(conn);
+    notnull_check(cipher_preferences);
+
+    if(conn->cipher_pref_override != NULL) {
+        *cipher_preferences = conn->cipher_pref_override;
+    } else {
+        *cipher_preferences = conn->config->cipher_preferences;
+    }
 
     return 0;
 }

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -44,6 +44,9 @@ struct s2n_connection {
     /* The configuration (cert, key .. etc ) */
     struct s2n_config *config;
 
+    /* Overrides Cipher Preferences in config if non-null */
+    const struct s2n_cipher_preferences *cipher_pref_override;
+
     /* The user defined context associated with connection */
     void *context;
 
@@ -239,6 +242,7 @@ int s2n_connection_kill(struct s2n_connection *conn);
 int s2n_connection_send_stuffer(struct s2n_stuffer *stuffer, struct s2n_connection *conn, uint32_t len);
 int s2n_connection_recv_stuffer(struct s2n_stuffer *stuffer, struct s2n_connection *conn, uint32_t len);
 
+extern int s2n_connection_get_cipher_preferences(struct s2n_connection *conn, const struct s2n_cipher_preferences **cipher_preferences);
 extern int s2n_connection_set_client_auth_type(struct s2n_connection *conn, s2n_cert_auth_type cert_auth_type);
 extern int s2n_connection_get_client_auth_type(struct s2n_connection *conn, s2n_cert_auth_type *client_cert_auth_type);
 extern int s2n_connection_get_client_cert_chain(struct s2n_connection *conn, uint8_t **der_cert_chain_out, uint32_t *cert_chain_len);

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -47,7 +47,10 @@ int s2n_server_hello_recv(struct s2n_connection *conn)
 
     conn->server_protocol_version = (uint8_t)(protocol_version[0] * 10) + protocol_version[1];
 
-    if (conn->server_protocol_version < conn->config->cipher_preferences->minimum_protocol_version || conn->server_protocol_version > conn->client_protocol_version) {
+    const struct s2n_cipher_preferences *cipher_preferences;
+    GUARD(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
+
+    if (conn->server_protocol_version < cipher_preferences->minimum_protocol_version || conn->server_protocol_version > conn->client_protocol_version) {
         GUARD(s2n_queue_reader_unsupported_protocol_version_alert(conn));
         S2N_ERROR(S2N_ERR_BAD_MESSAGE);
     }


### PR DESCRIPTION
**Issue # (if available):** https://github.com/awslabs/s2n/issues/717

**Description of changes:** 
Allow users of s2n to override the Cipher Preferences on a single connection so that multiple `s2n_configs` aren't needed for different cipher preferences.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
