### PR TITLE
Add ELB Security Policies

### DIFF
--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -254,12 +254,121 @@ const struct s2n_cipher_preferences cipher_preferences_20170718 = {
     .minimum_protocol_version = S2N_TLS10
 };
 
+struct s2n_cipher_suite *cipher_suites_elb_security_policy_2015_04[] = {
+    /* &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256, */
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    /* &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256, */
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
+    /* &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha, */
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha,
+    /* &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384, */
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    /* &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384, */
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha,
+    /* &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha, */
+    &s2n_rsa_with_aes_128_gcm_sha256,
+    &s2n_rsa_with_aes_128_cbc_sha256,
+    &s2n_rsa_with_aes_128_cbc_sha,
+    &s2n_rsa_with_aes_256_gcm_sha384,
+    &s2n_rsa_with_aes_256_cbc_sha256,
+    &s2n_rsa_with_aes_256_cbc_sha,
+    &s2n_rsa_with_3des_ede_cbc_sha,
+};
+
+const struct s2n_cipher_preferences elb_security_policy_2015_04 = {
+    .count = sizeof(cipher_suites_elb_security_policy_2015_04) / sizeof(cipher_suites_elb_security_policy_2015_04[0]),
+    .suites = cipher_suites_elb_security_policy_2015_04,
+    .minimum_protocol_version = S2N_TLS10
+};
+
+struct s2n_cipher_suite *cipher_suites_elb_security_policy_2016_08[] = {
+    /* &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256, */
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    /* &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256, */
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
+    /* &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha, */
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha,
+    /* &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384, */
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    /* &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384, */
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha,
+    /* &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha, */
+    &s2n_rsa_with_aes_128_gcm_sha256,
+    &s2n_rsa_with_aes_128_cbc_sha256,
+    &s2n_rsa_with_aes_128_cbc_sha,
+    &s2n_rsa_with_aes_256_gcm_sha384,
+    &s2n_rsa_with_aes_256_cbc_sha256,
+    &s2n_rsa_with_aes_256_cbc_sha,
+};
+
+const struct s2n_cipher_preferences elb_security_policy_2016_08 = {
+    .count = sizeof(cipher_suites_elb_security_policy_2016_08) / sizeof(cipher_suites_elb_security_policy_2016_08[0]),
+    .suites = cipher_suites_elb_security_policy_2016_08,
+    .minimum_protocol_version = S2N_TLS10
+};
+
+struct s2n_cipher_suite *cipher_suites_elb_security_policy_tls_1_2_2017_01[] = {
+    /* &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256, */
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    /* &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256, */
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
+    /* &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384, */
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    /* &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384, */
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+    &s2n_rsa_with_aes_128_gcm_sha256,
+    &s2n_rsa_with_aes_128_cbc_sha256,
+    &s2n_rsa_with_aes_256_gcm_sha384,
+    &s2n_rsa_with_aes_256_cbc_sha256,
+};
+
+const struct s2n_cipher_preferences elb_security_policy_tls_1_2_2017_01 = {
+    .count = sizeof(cipher_suites_elb_security_policy_tls_1_2_2017_01) / sizeof(cipher_suites_elb_security_policy_tls_1_2_2017_01[0]),
+    .suites = cipher_suites_elb_security_policy_tls_1_2_2017_01,
+    .minimum_protocol_version = S2N_TLS12
+};
+
+struct s2n_cipher_suite *cipher_suites_elb_security_policy_tls_1_1_2017_01[] = {
+    /* &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256, */
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    /* &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256 */
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
+    /* &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha, */
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha,
+    /* &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384, */
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    /* &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384, */
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha,
+    /* &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha, */
+    &s2n_rsa_with_aes_128_gcm_sha256,
+    &s2n_rsa_with_aes_128_cbc_sha256,
+    &s2n_rsa_with_aes_128_cbc_sha,
+    &s2n_rsa_with_aes_256_gcm_sha384,
+    &s2n_rsa_with_aes_256_cbc_sha256,
+    &s2n_rsa_with_aes_256_cbc_sha,
+};
+
+const struct s2n_cipher_preferences elb_security_policy_tls_1_1_2017_01 = {
+    .count = sizeof(cipher_suites_elb_security_policy_tls_1_1_2017_01) / sizeof(cipher_suites_elb_security_policy_tls_1_1_2017_01[0]),
+    .suites = cipher_suites_elb_security_policy_tls_1_1_2017_01,
+    .minimum_protocol_version = S2N_TLS11
+};
+
 struct {
     const char *version;
     const struct s2n_cipher_preferences *preferences;
 } selection[] = {
     { "default", &cipher_preferences_20170210 },
     { "default_fips", &cipher_preferences_20170405},
+    { "ELBSecurityPolicy-TLS-1-0-2015-04", &elb_security_policy_2015_04},
+    /* Not a mistake. TLS-1-0-2015-05 and 2016-08 are equivalent */
+    { "ELBSecurityPolicy-TLS-1-0-2015-05", &elb_security_policy_2016_08},
+    { "ELBSecurityPolicy-2016-08", &elb_security_policy_2016_08},
+    { "ELBSecurityPolicy-TLS-1-1-2017-01", &elb_security_policy_tls_1_1_2017_01},
+    { "ELBSecurityPolicy-TLS-1-2-2017-01", &elb_security_policy_tls_1_2_2017_01},
     { "20140601", &cipher_preferences_20140601 },
     { "20141001", &cipher_preferences_20141001 },
     { "20150202", &cipher_preferences_20150202 },

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -39,5 +39,11 @@ extern const struct s2n_cipher_preferences cipher_preferences_20170405;
 extern const struct s2n_cipher_preferences cipher_preferences_20170718;
 extern const struct s2n_cipher_preferences cipher_preferences_test_all;
 extern const struct s2n_cipher_preferences cipher_preferences_test_all_fips;
+
+/* See https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html */
+extern const struct s2n_cipher_preferences elb_security_policy_2015_04;
+extern const struct s2n_cipher_preferences elb_security_policy_2016_08;
+extern const struct s2n_cipher_preferences elb_security_policy_tls_1_2_2017_01;
+extern const struct s2n_cipher_preferences elb_security_policy_tls_1_1_2017_01;
 
 extern int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *version);


### PR DESCRIPTION
Information for each policy was pulled from
https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html
I verified the preferences here by running a cipher scan[1] against
a real ELB instance for each policy.

ELB policies support ECDSA cipher suites. I decided to add a *commented*
out entry for each ECDSA suite in the proper positions. We can uncomment
these once we add ECDSA cipher support.

[1] https://github.com/rbsec/sslscan

**Issue # (if available):** 

**Description of changes:** 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
