### PR TITLE
Add s2n_config_add_pem_to_trust_store() API

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -88,7 +88,8 @@ typedef enum {
 } s2n_max_frag_len;
 
 extern int s2n_config_add_cert_chain_and_key(struct s2n_config *config, const char *cert_chain_pem, const char *private_key_pem);
-extern int s2n_config_set_verification_ca_location(struct s2n_config *config, const char *ca_file_pem, const char *ca_dir);
+extern int s2n_config_set_verification_ca_location(struct s2n_config *config, const char *ca_pem_filename, const char *ca_dir);
+extern int s2n_config_add_pem_to_trust_store(struct s2n_config *config, const char *pem);
 
 typedef uint8_t (*s2n_verify_host_fn) (const char *host_name, size_t host_name_len, void *data);
 /* will be inherited by s2n_connection. If s2n_connection specifies a callback, that callback will be used for that connection. */

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -639,13 +639,20 @@ will be used if this callback is not manually set.
 
 ### s2n\_config\_set\_verification\_ca\_location
 ```c
-int s2n_config_set_verification_ca_location(struct s2n_config *config, const char *ca_file_pem, const char *ca_dir);
+int s2n_config_set_verification_ca_location(struct s2n_config *config, const char *ca_pem_filename, const char *ca_dir);
 ```
 
 **s2n_config_set_verification_ca_location**  initializes the trust store from a CA file or directory 
 containing trusted certificates.  By default, the trust store will be initialized to the common locations 
 for the host operating system. Call this function to override that behavior.
 Returns 0 on success and -1 on failure.
+
+### s2n\_config\_add\_pem\_to\_trust\_store
+```c
+int s2n_config_add_pem_to_trust_store(struct s2n_config *config, const char *pem);
+```
+
+**s2n_config_add_pem_to_trust_store**  Initialize trust store from a PEM. This will allocate memory, and load PEM into the Trust Store
 
 ### s2n\_verify\_host\_fn
 ```c

--- a/tests/unit/s2n_x509_validator_test.c
+++ b/tests/unit/s2n_x509_validator_test.c
@@ -123,6 +123,20 @@ int main(int argc, char **argv) {
         s2n_x509_trust_store_wipe(&trust_store);
     }
 
+    /* test trust store from PEM */
+    {
+        struct s2n_x509_trust_store trust_store;
+        s2n_x509_trust_store_init_empty(&trust_store);
+        char *cert_chain = NULL;
+        EXPECT_NOT_NULL(cert_chain = malloc(S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
+        int err_code = s2n_x509_trust_store_add_pem(&trust_store, cert_chain);
+        free(cert_chain);
+        EXPECT_EQUAL(0, err_code);
+        EXPECT_TRUE(s2n_x509_trust_store_has_certs(&trust_store));
+        s2n_x509_trust_store_wipe(&trust_store);
+    }
+
     /* test trust store from non-existent PEM file */
     {
         struct s2n_x509_trust_store trust_store;
@@ -278,6 +292,47 @@ int main(int argc, char **argv) {
         s2n_x509_trust_store_wipe(&trust_store);
     }
 
+    /* test validator in safe mode, with properly configured trust store, using s2n PEM Parser. */
+    {
+        struct s2n_x509_trust_store trust_store;
+        s2n_x509_trust_store_init_empty(&trust_store);
+
+        char *cert_chain = NULL;
+        EXPECT_NOT_NULL(cert_chain = malloc(S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
+        int err_code = s2n_x509_trust_store_add_pem(&trust_store, cert_chain);
+        free(cert_chain);
+        EXPECT_EQUAL(0, err_code);
+
+        struct s2n_x509_validator validator;
+        s2n_x509_validator_init(&validator, &trust_store, 1);
+
+        struct s2n_connection *connection = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(connection);
+
+        struct host_verify_data verify_data = { .callback_invoked = 0, .found_name = 0, .name = NULL };
+        EXPECT_SUCCESS(s2n_connection_set_verify_host_callback(connection, verify_host_accept_everything, &verify_data));
+
+        uint8_t cert_chain_pem[S2N_MAX_TEST_PEM_SIZE];
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, (char *) cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
+        struct s2n_stuffer chain_stuffer;
+        uint32_t chain_len = write_pem_file_to_stuffer_as_chain(&chain_stuffer, (const char *) cert_chain_pem);
+        EXPECT_TRUE(chain_len > 0);
+        uint8_t *chain_data = s2n_stuffer_raw_read(&chain_stuffer, (uint32_t) chain_len);
+
+        struct s2n_pkey public_key_out;
+        s2n_cert_type cert_type;
+        EXPECT_EQUAL(S2N_CERT_OK,
+                     s2n_x509_validator_validate_cert_chain(&validator, connection, chain_data, chain_len, &cert_type, &public_key_out));
+        s2n_stuffer_free(&chain_stuffer);
+        EXPECT_EQUAL(1, verify_data.callback_invoked);
+        EXPECT_EQUAL(S2N_CERT_TYPE_RSA_SIGN, cert_type);
+        s2n_connection_free(connection);
+
+        s2n_x509_validator_wipe(&validator);
+        s2n_x509_trust_store_wipe(&trust_store);
+    }
+
     /* test validator in safe mode, with properly configured trust store, but max chain depth is exceeded*/
     {
         struct s2n_x509_trust_store trust_store;
@@ -425,6 +480,45 @@ int main(int argc, char **argv) {
         s2n_x509_trust_store_wipe(&trust_store);
     }
 
+    /* test validator in safe mode, with properly configured trust store, but host isn't trusted, using s2n PEM Parser */
+    {
+        struct s2n_x509_trust_store trust_store;
+        s2n_x509_trust_store_init_empty(&trust_store);
+
+        char *cert_chain = NULL;
+        EXPECT_NOT_NULL(cert_chain = malloc(S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
+        int err_code = s2n_x509_trust_store_add_pem(&trust_store, cert_chain);
+        free(cert_chain);
+        EXPECT_EQUAL(0, err_code);
+
+        struct host_verify_data verify_data = {.name = "127.0.0.1", .found_name = 0, .callback_invoked = 0,};
+
+        struct s2n_x509_validator validator;
+        s2n_x509_validator_init(&validator, &trust_store, 1);
+
+        struct s2n_connection *connection = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(connection);
+        EXPECT_SUCCESS(s2n_connection_set_verify_host_callback(connection, verify_host_reject_everything, &verify_data));
+
+        uint8_t cert_chain_pem[S2N_MAX_TEST_PEM_SIZE];
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, (char *) cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
+        struct s2n_stuffer chain_stuffer;
+        uint32_t chain_len = write_pem_file_to_stuffer_as_chain(&chain_stuffer, (const char *) cert_chain_pem);
+        EXPECT_TRUE(chain_len > 0);
+        uint8_t *chain_data = s2n_stuffer_raw_read(&chain_stuffer, (uint32_t) chain_len);
+
+        struct s2n_pkey public_key_out;
+        s2n_cert_type cert_type;
+        int ret_val = s2n_x509_validator_validate_cert_chain(&validator, connection, chain_data, chain_len, &cert_type, &public_key_out);
+        EXPECT_EQUAL(S2N_CERT_ERR_UNTRUSTED, ret_val);
+        s2n_stuffer_free(&chain_stuffer);
+        EXPECT_EQUAL(1, verify_data.callback_invoked);
+        s2n_connection_free(connection);
+        s2n_x509_validator_wipe(&validator);
+        s2n_x509_trust_store_wipe(&trust_store);
+    }
+
     /* test validator in safe mode, with properly configured trust store. host name validation succeeds */
     {
         struct s2n_x509_trust_store trust_store;
@@ -457,6 +551,47 @@ int main(int argc, char **argv) {
 
         s2n_connection_free(connection);
         s2n_pkey_free(&public_key_out);
+        s2n_x509_validator_wipe(&validator);
+        s2n_x509_trust_store_wipe(&trust_store);
+    }
+
+    /* test validator in safe mode, with properly configured trust store. host name validation succeeds, using s2n PEM Parser */
+    {
+        struct s2n_x509_trust_store trust_store;
+        s2n_x509_trust_store_init_empty(&trust_store);
+
+        char *cert_chain = NULL;
+        EXPECT_NOT_NULL(cert_chain = malloc(S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
+        int err_code = s2n_x509_trust_store_add_pem(&trust_store, cert_chain);
+        free(cert_chain);
+        EXPECT_EQUAL(0, err_code);
+
+        struct host_verify_data verify_data = {.name = "127.0.0.1", .found_name = 0, .callback_invoked = 0,};
+
+        struct s2n_x509_validator validator;
+        s2n_x509_validator_init(&validator, &trust_store, 1);
+
+        struct s2n_connection *connection = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(connection);
+        EXPECT_SUCCESS(s2n_connection_set_verify_host_callback(connection, verify_host_accept_everything, &verify_data));
+
+        uint8_t cert_chain_pem[S2N_MAX_TEST_PEM_SIZE];
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, (char *) cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
+        struct s2n_stuffer chain_stuffer;
+        uint32_t chain_len = write_pem_file_to_stuffer_as_chain(&chain_stuffer, (const char *) cert_chain_pem);
+        EXPECT_TRUE(chain_len > 0);
+        uint8_t *chain_data = s2n_stuffer_raw_read(&chain_stuffer, (uint32_t) chain_len);
+
+        struct s2n_pkey public_key_out;
+        s2n_cert_type cert_type;
+        EXPECT_EQUAL(S2N_CERT_OK,
+                     s2n_x509_validator_validate_cert_chain(&validator, connection, chain_data, chain_len, &cert_type, &public_key_out));
+        s2n_stuffer_free(&chain_stuffer);
+        EXPECT_EQUAL(1, verify_data.callback_invoked);
+        EXPECT_EQUAL(S2N_CERT_TYPE_RSA_SIGN, cert_type);
+
+        s2n_connection_free(connection);
         s2n_x509_validator_wipe(&validator);
         s2n_x509_trust_store_wipe(&trust_store);
     }
@@ -622,6 +757,54 @@ int main(int argc, char **argv) {
         s2n_stuffer_free(&ocsp_data_stuffer);
         s2n_connection_free(connection);
         s2n_pkey_free(&public_key_out);
+        s2n_x509_validator_wipe(&validator);
+        s2n_x509_trust_store_wipe(&trust_store);
+    }
+
+    /* Test valid OCSP date range, but with s2n PEM Parser */
+    {
+        struct s2n_x509_trust_store trust_store;
+        s2n_x509_trust_store_init_empty(&trust_store);
+
+         char *cert_chain = NULL;
+        EXPECT_NOT_NULL(cert_chain = malloc(S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_OCSP_CA_CERT, cert_chain, S2N_MAX_TEST_PEM_SIZE));
+        int err_code = s2n_x509_trust_store_add_pem(&trust_store, cert_chain);
+        free(cert_chain);
+        EXPECT_EQUAL(0, err_code);
+
+        struct s2n_x509_validator validator;
+        s2n_x509_validator_init(&validator, &trust_store, 1);
+
+        struct s2n_connection *connection = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(connection);
+
+        struct host_verify_data verify_data = { .callback_invoked = 0, .found_name = 0, .name = NULL };
+        EXPECT_SUCCESS(s2n_connection_set_verify_host_callback(connection, verify_host_accept_everything, &verify_data));
+
+        uint8_t cert_chain_pem[S2N_MAX_TEST_PEM_SIZE];
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_OCSP_SERVER_CERT, (char *) cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
+        struct s2n_stuffer chain_stuffer;
+        uint32_t chain_len = write_pem_file_to_stuffer_as_chain(&chain_stuffer, (const char *) cert_chain_pem);
+        EXPECT_TRUE(chain_len > 0);
+        uint8_t *chain_data = s2n_stuffer_raw_read(&chain_stuffer, (uint32_t) chain_len);
+
+        struct s2n_pkey public_key_out;
+        s2n_cert_type cert_type;
+        EXPECT_EQUAL(S2N_CERT_OK,
+                     s2n_x509_validator_validate_cert_chain(&validator, connection, chain_data, chain_len, &cert_type, &public_key_out));
+        s2n_stuffer_free(&chain_stuffer);
+
+        EXPECT_EQUAL(1, verify_data.callback_invoked);
+        struct s2n_stuffer ocsp_data_stuffer;
+        EXPECT_SUCCESS(read_file(&ocsp_data_stuffer, S2N_OCSP_RESPONSE_DER, S2N_MAX_TEST_PEM_SIZE));
+        uint32_t ocsp_data_len = s2n_stuffer_data_available(&ocsp_data_stuffer);
+        EXPECT_TRUE(ocsp_data_len > 0);
+        EXPECT_EQUAL(S2N_CERT_OK, s2n_x509_validator_validate_cert_stapled_ocsp_response(&validator, connection,
+                                                                                          s2n_stuffer_raw_read(&ocsp_data_stuffer, ocsp_data_len),
+                                                                                          ocsp_data_len));
+        s2n_stuffer_free(&ocsp_data_stuffer);
+        s2n_connection_free(connection);
         s2n_x509_validator_wipe(&validator);
         s2n_x509_trust_store_wipe(&trust_store);
     }

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -401,7 +401,17 @@ int s2n_config_set_status_request_type(struct s2n_config *config, s2n_status_req
     return 0;
 }
 
-int s2n_config_set_verification_ca_location(struct s2n_config *config, const char *ca_file_pem, const char *ca_dir)
+int s2n_config_add_pem_to_trust_store(struct s2n_config *config, const char *pem){
+    notnull_check(config);
+    notnull_check(pem);
+
+    GUARD(s2n_x509_trust_store_add_pem(&config->trust_store, pem));
+
+    return 0;
+
+}
+
+int s2n_config_set_verification_ca_location(struct s2n_config *config, const char *ca_pem_filename, const char *ca_dir)
 {
     notnull_check(config);
     int err_code = s2n_x509_trust_store_from_ca_file(&config->trust_store, ca_file_pem, ca_dir);

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -408,7 +408,6 @@ int s2n_config_add_pem_to_trust_store(struct s2n_config *config, const char *pem
     GUARD(s2n_x509_trust_store_add_pem(&config->trust_store, pem));
 
     return 0;
-
 }
 
 int s2n_config_set_verification_ca_location(struct s2n_config *config, const char *ca_pem_filename, const char *ca_dir)

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -413,7 +413,7 @@ int s2n_config_add_pem_to_trust_store(struct s2n_config *config, const char *pem
 int s2n_config_set_verification_ca_location(struct s2n_config *config, const char *ca_pem_filename, const char *ca_dir)
 {
     notnull_check(config);
-    int err_code = s2n_x509_trust_store_from_ca_file(&config->trust_store, ca_file_pem, ca_dir);
+    int err_code = s2n_x509_trust_store_from_ca_file(&config->trust_store, ca_pem_filename, ca_dir);
 
     if (!err_code) {
         config->status_request_type = s2n_x509_ocsp_stapling_supported() ? S2N_STATUS_REQUEST_OCSP : S2N_STATUS_REQUEST_NONE;

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -85,45 +85,42 @@ int s2n_x509_trust_store_add_pem(struct s2n_x509_trust_store *store, const char 
         store->trust_store = X509_STORE_new();
     }
 
-    s2n_error err = S2N_ERR_OK;
+    s2n_error err = S2N_ERR_DECODE_CERTIFICATE;
 
     struct s2n_stuffer pem_in_stuffer;
-    GUARD(s2n_stuffer_alloc_ro_from_string(&pem_in_stuffer, pem));
     struct s2n_stuffer der_out_stuffer;
-    GUARD(s2n_stuffer_growable_alloc(&der_out_stuffer, 2048));
+    struct s2n_blob next_cert;
 
-    uint32_t chain_size = 0;
+    GUARD_GOTO(s2n_stuffer_alloc_ro_from_string(&pem_in_stuffer, pem), clean_up);
+    GUARD_GOTO(s2n_stuffer_growable_alloc(&der_out_stuffer, 2048), clean_up);
+
     do {
-
-        if (s2n_stuffer_certificate_from_pem(&pem_in_stuffer, &der_out_stuffer) < 0) {
-            if (chain_size == 0) {
-                err = S2N_ERR_NO_CERTIFICATE_IN_PEM;
-                goto clean_up;
-            }
-            break;
-        }
-
-        struct s2n_blob next_cert;
-        GUARD(s2n_alloc(&next_cert, s2n_stuffer_data_available(&der_out_stuffer)));
-        GUARD(s2n_stuffer_read(&der_out_stuffer, &next_cert));
+        GUARD_GOTO(s2n_stuffer_certificate_from_pem(&pem_in_stuffer, &der_out_stuffer), clean_up);
+        GUARD_GOTO(s2n_alloc(&next_cert, s2n_stuffer_data_available(&der_out_stuffer)), clean_up);
+        GUARD_GOTO(s2n_stuffer_read(&der_out_stuffer, &next_cert), clean_up);
 
         const uint8_t *data = next_cert.data;
-        uint32_t len = next_cert.size;
-        X509 *ca_cert = d2i_X509(NULL, &data, len);
-        GUARD(s2n_free(&next_cert));
-
+        X509 *ca_cert = d2i_X509(NULL, &data, next_cert.size);
         if (ca_cert == NULL) {
-            err = S2N_ERR_DECODE_CERTIFICATE;
             goto clean_up;
         }
 
-        X509_STORE_add_cert(store->trust_store, ca_cert);
+        int rc = X509_STORE_add_cert(store->trust_store, ca_cert);
         X509_free(ca_cert);
+
+        if (rc != 1) {
+            goto clean_up;
+        }
+
+        GUARD_GOTO(s2n_free(&next_cert), clean_up);
     } while (s2n_stuffer_data_available(&pem_in_stuffer));
+
+    err = S2N_ERR_OK;
 
     clean_up:
         GUARD(s2n_stuffer_free(&pem_in_stuffer));
         GUARD(s2n_stuffer_free(&der_out_stuffer));
+        GUARD(s2n_free(&next_cert));
 
     if (err != S2N_ERR_OK){
         S2N_ERROR(err);

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -129,14 +129,14 @@ int s2n_x509_trust_store_add_pem(struct s2n_x509_trust_store *store, const char 
     return 0;
 }
 
-int s2n_x509_trust_store_from_ca_file(struct s2n_x509_trust_store *store, const char *ca_file, const char *path) {
+int s2n_x509_trust_store_from_ca_file(struct s2n_x509_trust_store *store, const char *ca_pem_filename, const char *ca_dir) {
 
     if (!store->trust_store) {
         store->trust_store = X509_STORE_new();
         notnull_check(store->trust_store);
     }
 
-    int err_code = X509_STORE_load_locations(store->trust_store, ca_file, path);
+    int err_code = X509_STORE_load_locations(store->trust_store, ca_pem_filename, ca_dir);
     if (!err_code) {
         s2n_x509_trust_store_wipe(store);
         return -1;

--- a/tls/s2n_x509_validator.h
+++ b/tls/s2n_x509_validator.h
@@ -65,9 +65,12 @@ uint8_t s2n_x509_trust_store_has_certs(struct s2n_x509_trust_store *store);
 /** Initializes the trust store to default system paths **/
 int s2n_x509_trust_store_from_system_defaults(struct s2n_x509_trust_store *store);
 
+/** Initialize trust store from a PEM. This will allocate memory, and load PEM into the Trust Store **/
+int s2n_x509_trust_store_add_pem(struct s2n_x509_trust_store *store, const char *pem);
+
 /** Initialize trust store from a CA file. This will allocate memory, and load each cert in the file into the trust store
  *  Returns 0 on success, or S2N error codes on failure. */
-int s2n_x509_trust_store_from_ca_file(struct s2n_x509_trust_store *store, const char *ca_file, const char *path);
+int s2n_x509_trust_store_from_ca_file(struct s2n_x509_trust_store *store, const char *pem_filename, const char *dir_path);
 
 /** Cleans up, and frees any underlying memory in the trust store. */
 void s2n_x509_trust_store_wipe(struct s2n_x509_trust_store *store);

--- a/tls/s2n_x509_validator.h
+++ b/tls/s2n_x509_validator.h
@@ -70,7 +70,7 @@ int s2n_x509_trust_store_add_pem(struct s2n_x509_trust_store *store, const char 
 
 /** Initialize trust store from a CA file. This will allocate memory, and load each cert in the file into the trust store
  *  Returns 0 on success, or S2N error codes on failure. */
-int s2n_x509_trust_store_from_ca_file(struct s2n_x509_trust_store *store, const char *pem_filename, const char *dir_path);
+int s2n_x509_trust_store_from_ca_file(struct s2n_x509_trust_store *store, const char *ca_pem_filename, const char *ca_dir);
 
 /** Cleans up, and frees any underlying memory in the trust store. */
 void s2n_x509_trust_store_wipe(struct s2n_x509_trust_store *store);


### PR DESCRIPTION
**Issue # (if available):** https://github.com/awslabs/s2n/issues/725

**Description of changes:** 
Right now the only API for adding Certs to the X509 Trust Store is `s2n_config_set_verification_ca_location()` which takes a file path and a directory path. This change adds an API that takes a PEM file directly and adds it to the Trust Store, similar to the `s2n_config_add_cert_chain_and_key()` API.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.