### PR TITLE
Sidewinder proof for s2n_record_read

### DIFF
--- a/.travis/run_sidewinder.sh
+++ b/.travis/run_sidewinder.sh
@@ -62,8 +62,8 @@ which llvm2bpl || echo "can't find llvm2bpl"
 which clang
 clang --version
 
-runSingleTest("s2n-cbc")
-runSingleTest("s2n-record-read-aead")
-runSingleTest("s2n-record-read-cbc")
-runSingleTest("s2n-record-read-composite")
-runSingleTest("s2n-record-read-stream")
+runSingleTest "s2n-cbc"
+runSingleTest "s2n-record-read-aead"
+runSingleTest "s2n-record-read-cbc"
+runSingleTest "s2n-record-read-composite"
+runSingleTest "s2n-record-read-stream"

--- a/.travis/run_sidewinder.sh
+++ b/.travis/run_sidewinder.sh
@@ -21,6 +21,26 @@ usage() {
     exit 1
 }
 
+runSingleTest() {
+    cd "${BASE_S2N_DIR}/tests/sidewinder/working/${1}"
+    ./copy_as_needed.sh
+    make clean
+
+    #run the test.  We expect both to pass, and none to fail
+    FAILED=0
+    EXPECTED_PASS=1
+    EXPECTED_FAIL=0
+    make 2>&1 | ../../count_success.pl $EXPECTED_PASS $EXPECTED_FAIL || FAILED=1
+
+    if [ $FAILED == 1 ];
+    then
+	printf "\\033[31;1mFAILED ctverif\\033[0m\\n"
+	exit -1
+    else
+	printf "\\033[32;1mPASSED ctverif\\033[0m\\n"
+    fi
+}
+
 if [ "$#" -ne "1" ]; then
     usage
 fi
@@ -42,20 +62,8 @@ which llvm2bpl || echo "can't find llvm2bpl"
 which clang
 clang --version
 
-cd "${BASE_S2N_DIR}/tests/sidewinder/working/s2n-cbc"
-./copy_as_needed.sh
-make clean
-
-#run the test.  We expect both to pass, and none to fail
-FAILED=0
-EXPECTED_PASS=1
-EXPECTED_FAIL=0
-make 2>&1 | ../../count_success.pl $EXPECTED_PASS $EXPECTED_FAIL || FAILED=1
-
-if [ $FAILED == 1 ];
-then
-	printf "\\033[31;1mFAILED ctverif\\033[0m\\n"
-	exit -1
-else
-	printf "\\033[32;1mPASSED ctverif\\033[0m\\n"
-fi
+runSingleTest("s2n-cbc")
+runSingleTest("s2n-record-read-aead")
+runSingleTest("s2n-record-read-cbc")
+runSingleTest("s2n-record-read-composite")
+runSingleTest("s2n-record-read-stream")

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -14,9 +14,6 @@
  */
 
 #include <sys/param.h>
-#include <string.h>
-#include <unistd.h>
-#include <errno.h>
 
 #include "error/s2n_errno.h"
 

--- a/tests/sidewinder/count_success.pl
+++ b/tests/sidewinder/count_success.pl
@@ -29,7 +29,9 @@ if (@ARGV != 2) {
 my $expected_success = shift;
 my $expected_failure = shift;
 my @undefined_functions = ();
-my %allowed_undefined = ("__CONTRACT_invariant" => 1);
+my %allowed_undefined = ("__CONTRACT_invariant" => 1,
+			 "malloc" => 1,
+			 "nondet" => 1);
 
 my $verified = 0;
 my $errors = 0;

--- a/tests/sidewinder/working/patches/cbc.patch
+++ b/tests/sidewinder/working/patches/cbc.patch
@@ -1,0 +1,86 @@
+diff --git a/tests/sidewinder/working/s2n-cbc/tls/s2n_cbc.c b/tests/sidewinder/working/s2n-cbc/tls/s2n_cbc.c
+index b37efb0..077d214 100644
+--- a/tests/sidewinder/working/s2n-cbc/tls/s2n_cbc.c
++++ b/tests/sidewinder/working/s2n-cbc/tls/s2n_cbc.c
+@@ -25,6 +25,28 @@
+ 
+ #include "tls/s2n_record.h"
+ 
++#include <smack.h>
++#include <smack-contracts.h>
++#include "ct-verif.h"
++#include "sidewinder.h"
++
++/* Because of a bug in SMACK, when we try to specify the invarients for this loop in the main function, 
++ * SMACK crashes. Moving the code (unmodified) to this function sidesteps the bug. Michael Emmi has promissed
++ * a fix soon
++ */
++int double_loop(int old_mismatches, struct s2n_blob *decrypted, int check, int cutoff, int padding_length) {
++  __VERIFIER_assert(decrypted->size >= 0);
++  __VERIFIER_assert(decrypted->size <= MAX_SIZE);
++  int mismatches = old_mismatches;
++  for (int i = 0, j = decrypted->size - 1 - check; i < check && j < decrypted->size; i++, j++) {
++    invariant(i <= check);
++    invariant(j == i + decrypted->size - check - 1);
++    uint8_t mask = ~(0xff << ((i >= cutoff) * 8));
++    mismatches |= (decrypted->data[j] ^ padding_length) & mask;
++  }
++  return mismatches;
++}
++
+ /* A TLS CBC record looks like ..
+  *
+  * [ Payload data ] [ HMAC ] [ Padding ] [ Padding length byte ]
+@@ -53,17 +75,20 @@ int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, str
+        copy = &conn->server->record_mac_copy_workspace;
+     }
+     
+-    uint8_t mac_digest_size;
+-    GUARD(s2n_hmac_digest_size(hmac->alg, &mac_digest_size));
++    uint8_t mac_digest_size = DIGEST_SIZE;;
++    //GUARD(s2n_hmac_digest_size(hmac->alg, &mac_digest_size));
+ 
+     /* The record has to be at least big enough to contain the MAC,
+      * plus the padding length byte */
+     gt_check(decrypted->size, mac_digest_size);
+ 
+     int payload_and_padding_size = decrypted->size - mac_digest_size;
++    __VERIFIER_assert(payload_and_padding_size <= MAX_SIZE - 20);
+ 
+     /* Determine what the padding length is */
+     uint8_t padding_length = decrypted->data[decrypted->size - 1];
++    __VERIFIER_assume(padding_length >= 0);
++    __VERIFIER_assume(padding_length <  256);
+ 
+     int payload_length = MAX(payload_and_padding_size - padding_length - 1, 0);
+ 
+@@ -82,20 +107,21 @@ int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, str
+     GUARD(s2n_hmac_update(copy, decrypted->data + payload_length + mac_digest_size, decrypted->size - payload_length - mac_digest_size - 1));
+ 
+     /* SSLv3 doesn't specify what the padding should actually be */
+-    if (conn->actual_protocol_version == S2N_SSLv3) {
+-        return 0 - mismatches;
+-    }
++    /* if (conn->actual_protocol_version == S2N_SSLv3) { */
++    /*     return 0 - mismatches; */
++    /* } */
+ 
+     /* Check the maximum amount that could theoretically be padding */
+     int check = MIN(255, (payload_and_padding_size - 1));
+ 
+     int cutoff = check - padding_length;
+-    for (int i = 0, j = decrypted->size - 1 - check; i < check && j < decrypted->size; i++, j++) {
+-        uint8_t mask = ~(0xff << ((i >= cutoff) * 8));
+-        mismatches |= (decrypted->data[j] ^ padding_length) & mask;
+-    }
++    mismatches = double_loop(mismatches, decrypted, check, cutoff, padding_length);
++    /* for (int i = 0, j = decrypted->size - 1 - check; i < check && j < decrypted->size; i++, j++) { */
++    /*     uint8_t mask = ~(0xff << ((i >= cutoff) * 8)); */
++    /*     mismatches |= (decrypted->data[j] ^ padding_length) & mask; */
++    /* } */
+ 
+-    GUARD(s2n_hmac_reset(copy));
++    /* GUARD(s2n_hmac_reset(copy)); */
+ 
+     if (mismatches) {
+         S2N_ERROR(S2N_ERR_CBC_VERIFY);

--- a/tests/sidewinder/working/patches/hmac.patch
+++ b/tests/sidewinder/working/patches/hmac.patch
@@ -1,0 +1,109 @@
+diff --git a/tests/sidewinder/working/s2n-cbc/crypto/s2n_hmac.c b/tests/sidewinder/working/s2n-cbc/crypto/s2n_hmac.c
+index 3405781..3beeacf 100644
+--- a/tests/sidewinder/working/s2n-cbc/crypto/s2n_hmac.c
++++ b/tests/sidewinder/working/s2n-cbc/crypto/s2n_hmac.c
+@@ -26,6 +26,9 @@
+ #include "utils/s2n_blob.h"
+ #include "utils/s2n_mem.h"
+ 
++#include "smack.h"
++#include "sidewinder.h"
++
+ int s2n_hmac_hash_alg(s2n_hmac_algorithm hmac_alg, s2n_hash_algorithm *out)
+ {
+     switch(hmac_alg) {
+@@ -235,7 +238,7 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
+      * input. On some platforms, including Intel, the operation can take a
+      * smaller number of cycles if the input is "small".
+      */
+-    state->currently_in_hash_block += (4294949760 + size) % state->hash_block_size;
++    state->currently_in_hash_block += (size) % state->hash_block_size;
+     state->currently_in_hash_block %= state->hash_block_size;
+ 
+     return s2n_hash_update(&state->inner, in, size);
+@@ -311,30 +314,30 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
+     GUARD(s2n_hash_copy(&to->outer_just_key, &from->outer_just_key));
+ 
+ 
+-    memcpy_check(to->xor_pad, from->xor_pad, sizeof(to->xor_pad));
+-    memcpy_check(to->digest_pad, from->digest_pad, sizeof(to->digest_pad));
++    //memcpy_check(to->xor_pad, from->xor_pad, sizeof(to->xor_pad));
++    //memcpy_check(to->digest_pad, from->digest_pad, sizeof(to->digest_pad));
+ 
+     return 0;
+ }
+ 
+ 
+-/* Preserve the handlers for hmac state pointers to avoid re-allocation 
+- * Only valid if the HMAC is in EVP mode
+- */
+-int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac)
+-{
+-    backup->inner = hmac->inner.digest.high_level;
+-    backup->inner_just_key = hmac->inner_just_key.digest.high_level;
+-    backup->outer = hmac->outer.digest.high_level;
+-    backup->outer_just_key = hmac->outer_just_key.digest.high_level;
+-    return 0;
+-}
+-
+-int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac)
+-{
+-    hmac->inner.digest.high_level = backup->inner;
+-    hmac->inner_just_key.digest.high_level = backup->inner_just_key;
+-    hmac->outer.digest.high_level = backup->outer;
+-    hmac->outer_just_key.digest.high_level = backup->outer_just_key;
+-    return 0;
+-}
++/* /\* Preserve the handlers for hmac state pointers to avoid re-allocation  */
++/*  * Only valid if the HMAC is in EVP mode */
++/*  *\/ */
++/* int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac) */
++/* { */
++/*     backup->inner = hmac->inner.digest.high_level; */
++/*     backup->inner_just_key = hmac->inner_just_key.digest.high_level; */
++/*     backup->outer = hmac->outer.digest.high_level; */
++/*     backup->outer_just_key = hmac->outer_just_key.digest.high_level; */
++/*     return 0; */
++/* } */
++
++/* int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac) */
++/* { */
++/*     hmac->inner.digest.high_level = backup->inner; */
++/*     hmac->inner_just_key.digest.high_level = backup->inner_just_key; */
++/*     hmac->outer.digest.high_level = backup->outer; */
++/*     hmac->outer_just_key.digest.high_level = backup->outer_just_key; */
++/*     return 0; */
++/* } */
+diff --git a/tests/sidewinder/working/s2n-cbc/crypto/s2n_hmac.h b/tests/sidewinder/working/s2n-cbc/crypto/s2n_hmac.h
+index 7af7e61..e6382ce 100644
+--- a/tests/sidewinder/working/s2n-cbc/crypto/s2n_hmac.h
++++ b/tests/sidewinder/working/s2n-cbc/crypto/s2n_hmac.h
+@@ -52,12 +52,12 @@ struct s2n_hmac_state {
+     uint8_t digest_pad[SHA512_DIGEST_LENGTH];
+ };
+ 
+-struct s2n_hmac_evp_backup {
+-    struct s2n_hash_evp_digest inner;
+-    struct s2n_hash_evp_digest inner_just_key;
+-    struct s2n_hash_evp_digest outer;
+-    struct s2n_hash_evp_digest outer_just_key;
+-};
++/* struct s2n_hmac_evp_backup { */
++/*     struct s2n_hash_evp_digest inner; */
++/*     struct s2n_hash_evp_digest inner_just_key; */
++/*     struct s2n_hash_evp_digest outer; */
++/*     struct s2n_hash_evp_digest outer_just_key; */
++/* }; */
+ 
+ extern int s2n_hmac_digest_size(s2n_hmac_algorithm alg, uint8_t *out);
+ extern int s2n_hmac_is_available(s2n_hmac_algorithm alg);
+@@ -72,7 +72,7 @@ extern int s2n_hmac_digest_verify(const void *a, const void *b, uint32_t len);
+ extern int s2n_hmac_free(struct s2n_hmac_state *state);
+ extern int s2n_hmac_reset(struct s2n_hmac_state *state);
+ extern int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from);
+-extern int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac);
+-extern int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac);
++//extern int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac);
++//extern int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac);
+ 
+ 

--- a/tests/sidewinder/working/patches/safety1.patch
+++ b/tests/sidewinder/working/patches/safety1.patch
@@ -1,0 +1,84 @@
+--- /Users/dsn/github/s2n/utils/s2n_safety.h	2018-02-09 10:26:05.000000000 -0500
++++ s2n_safety.h	2018-02-09 10:28:30.000000000 -0500
+@@ -15,23 +15,23 @@
+ 
+ #pragma once
+ 
+-#include <string.h>
++//#include <string.h>
+ #include <sys/types.h>
+ #include <stdint.h>
+ 
+ #include "error/s2n_errno.h"
++#include "s2n_annotations.h"
++#include "sidewinder.h"
++
++void __VERIFIER_assume(int);
+ 
+ /* NULL check a pointer */
+ #define notnull_check( ptr )           do { if ( (ptr) == NULL ) { S2N_ERROR(S2N_ERR_NULL); } } while(0)
++#define MEMCOPY_COST 2
+ 
+ static inline void* trace_memcpy_check(void *restrict to, const void *restrict from, size_t size, const char *debug_str)
+ {
+-    if (to == NULL || from == NULL) {
+-        s2n_errno = S2N_ERR_NULL;
+-        s2n_debug_str = debug_str;
+-        return NULL;
+-    }
+-
++    __VERIFIER_ASSUME_LEAKAGE(size * MEMCOPY_COST);
+     return memcpy(to, from, size);
+ }
+ 
+@@ -39,32 +39,26 @@
+  */
+ #define memcpy_check( d, s, n )                                             \
+   do {                                                                      \
+-    __typeof( n ) __tmp_n = ( n );                                          \
+-    if ( __tmp_n ) {                                                        \
+-      void *r = trace_memcpy_check( (d), (s) , (__tmp_n), _S2N_DEBUG_LINE); \
+-      if (r == NULL) { return -1; }                                         \
+-    }                                                                       \
++    memcpy(d,s,n);							\
+   } while(0)
+ 
+-#define memset_check( d, c, n )                                             \
++#define memset_check( d, c, n )						\
+   do {                                                                      \
+     __typeof( n ) __tmp_n = ( n );                                          \
+     if ( __tmp_n ) {                                                        \
+       __typeof( d ) __tmp_d = ( d );                                        \
+       notnull_check( __tmp_d );                                             \
+-      memset( __tmp_d, (c), __tmp_n);                                       \
++      my_memset( __tmp_d, (c), __tmp_n);                                    \
+     }                                                                       \
+   } while(0)
+ 
+-#define char_to_digit(c, d)  do { if(!isdigit(c)) { S2N_ERROR(S2N_ERR_SAFETY); } d = c - '0'; } while(0)
+-
+ /* Range check a number */
+-#define gte_check(n, min)  do { if ( (n) < min ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)
+-#define lte_check(n, max)  do { if ( (n) > max ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)
+-#define gt_check(n, min)  do { if ( (n) <= min ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)
+-#define lt_check(n, max)  do { if ( (n) >= max ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)
+-#define eq_check(a, b)  do { if ( (a) != (b) ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)
+-#define ne_check(a, b)  do { if ( (a) == (b) ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)
++#define gte_check(n, min)  __VERIFIER_assume( (n) >= (min) )
++#define lte_check(n, max)  __VERIFIER_assume( (n) <= (max) )
++#define gt_check(n, min)   __VERIFIER_assume( (n) >  (min) )
++#define lt_check(n, max)   __VERIFIER_assume( (n) <  (max) )
++#define eq_check(a, b)     __VERIFIER_assume( (a) ==  (b) )
++#define ne_check(a, b)     __VERIFIER_assume( (a) !=  (b) )
+ #define inclusive_range_check( low, n, high )   \
+   do  {                                         \
+     __typeof( n ) __tmp_n = ( n );              \
+@@ -78,7 +72,7 @@
+     lt_check(__tmp_n, high);                    \
+   } while (0)
+ 
+-#define GUARD( x )      if ( (x) < 0 ) return -1
++#define GUARD( x ) __VERIFIER_assume( (x) >= 0 )
+ #define GUARD_PTR( x )  if ( (x) < 0 ) return NULL
+ 
+ /**

--- a/tests/sidewinder/working/patches/safety2.patch
+++ b/tests/sidewinder/working/patches/safety2.patch
@@ -1,0 +1,36 @@
+--- /Users/dsn/github/s2n/utils/s2n_safety.c	2018-02-01 17:51:30.000000000 -0500
++++ utils/s2n_safety.c	2018-02-09 10:28:30.000000000 -0500
+@@ -39,6 +39,16 @@
+ #endif
+ }
+ 
++void * my_memset ( void * ptr, int value, size_t num ){
++  uint8_t* p = (uint8_t*)(ptr);
++  __VERIFIER_assert(num >= 0);
++  for(int i =0; i < num; ++i) {
++    S2N_INVARIENT(i <= num);
++    p[i] = value;
++  }
++}
++
++
+ /**
+  * Given arrays "a" and "b" of length "len", determine whether they
+  * hold equal contents.
+@@ -55,14 +65,12 @@
+  */
+ int s2n_constant_time_equals(const uint8_t * a, const uint8_t * b, uint32_t len)
+ {
+-    S2N_PUBLIC_INPUT(a);
+-    S2N_PUBLIC_INPUT(b);
++  //S2N_PUBLIC_INPUT(a);
++  //S2N_PUBLIC_INPUT(b);
+     S2N_PUBLIC_INPUT(len);
+     
+     uint8_t xor = 0;
+     for (int i = 0; i < len; i++) {
+-        /* Invariants must hold for each execution of the loop
+-	 * and at loop exit, hence the <= */ 
+         S2N_INVARIENT(i <= len);
+         xor |= a[i] ^ b[i];
+     }

--- a/tests/sidewinder/working/s2n-record-read-aead/Makefile
+++ b/tests/sidewinder/working/s2n-record-read-aead/Makefile
@@ -1,0 +1,18 @@
+include ../../lib/ct-verif.mk
+
+cflags +=-D__TIMING_CONTRACTS__
+#the overriden .h
+cflags += -I$(CURDIR)
+#original .h
+cflags += -I$(CURDIR)/../../../../
+#/api .h that haven't fixed that
+cflags += -I$(CURDIR)/../../../../api/
+cflags += -fPIC -std=c99 -fgnu89-inline
+extras +=  crypto/s2n_hash.c crypto/s2n_hmac.c   stuffer/s2n_stuffer.c tls/s2n_cbc.c  tls/s2n_aead.c tls/s2n_record_read_aead.c  utils/s2n_safety.c utils/s2n_mem.c 
+goals  += s2n_record_parse_wrapper@s2n_record_read_wrapper.c
+#goals += test_leakage@s2n_record_read_wrapper.c
+full_self_comp += true
+smtlog += p.smt2
+shadowingArgs += "self_comp_mode=full,branchcond_assertion=assert_never,memory_assertion=assert_never"
+timing += true
+printModel += true

--- a/tests/sidewinder/working/s2n-record-read-aead/clean.sh
+++ b/tests/sidewinder/working/s2n-record-read-aead/clean.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+make clean
+rm -r crypto
+rm -r tls
+rm -r stuffer
+rm -r utils

--- a/tests/sidewinder/working/s2n-record-read-aead/copy_as_needed.sh
+++ b/tests/sidewinder/working/s2n-record-read-aead/copy_as_needed.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+set -x 
+BASEDIR=$(pwd)
+echo $BASEDIR
+S2N_BASE="$BASEDIR/../../../.."
+echo $S2N_BASE
+
+cd $BASEDIR
+mkdir -p crypto
+#The hmac should be based off the old hmac, so just apply the patches to add the invarients
+cp $S2N_BASE/crypto/s2n_hmac.c crypto/
+cp $S2N_BASE/crypto/s2n_hmac.h crypto/
+patch -p5 < ../patches/hmac.patch
+
+#the hash uses my stubs for now, so replace the file
+cp ../stubs/s2n_hash.c crypto/
+cp ../stubs/s2n_hash.h crypto/
+
+mkdir -p stuffer
+cp $S2N_BASE/stuffer/s2n_stuffer.c stuffer/
+
+mkdir -p tls
+#add invariants etc needed for the proof to the s2n_cbc code
+cp $S2N_BASE/tls/s2n_aead.c tls/
+cp $S2N_BASE/tls/s2n_cbc.c tls/
+cp $S2N_BASE/tls/s2n_record_read_aead.c tls/
+patch -p5 < ../patches/cbc.patch
+
+mkdir -p utils
+cp s2n_annotations.h utils/
+cp $S2N_BASE/utils/s2n_safety.c utils/
+cp $S2N_BASE/utils/s2n_safety.h utils/
+cp ../stubs/s2n_mem.c utils/
+patch -p5 < ../patches/safety1.patch
+patch -p5 < ../patches/safety2.patch
+
+cp ../stubs/s2n_annotations.h utils/
+

--- a/tests/sidewinder/working/s2n-record-read-aead/run.sh
+++ b/tests/sidewinder/working/s2n-record-read-aead/run.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+
+./copy_as_needed.sh
+make clean
+time make

--- a/tests/sidewinder/working/s2n-record-read-aead/s2n_annotations.h
+++ b/tests/sidewinder/working/s2n-record-read-aead/s2n_annotations.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include <smack-contracts.h>
+#include "ct-verif.h"
+
+#define S2N_PUBLIC_INPUT( __a )  public_in(__SMACK_value( __a ))
+#define S2N_INVARIENT( __a ) invariant ( __a )

--- a/tests/sidewinder/working/s2n-record-read-aead/s2n_record_read_wrapper.c
+++ b/tests/sidewinder/working/s2n-record-read-aead/s2n_record_read_wrapper.c
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <sys/param.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "crypto/s2n_hmac.h"
+
+#include "tls/s2n_record.h"
+#include "tls/s2n_prf.h"
+#include "tls/s2n_connection.h"
+
+#include <smack.h>
+#include <smack-contracts.h>
+#include "ct-verif.h"
+#include "sidewinder.h"
+#include "utils/s2n_safety.h"
+#include "tls/s2n_cipher_suites.h"
+#include "utils/s2n_blob.h"
+#include "crypto/s2n_cipher.h"
+
+int s2n_record_parse_aead(
+    const struct s2n_cipher_suite *cipher_suite,
+    struct s2n_connection *conn,
+    uint8_t content_type,
+    uint16_t encrypted_length,
+    uint8_t * implicit_iv,
+    struct s2n_hmac_state *mac,
+    uint8_t * sequence_number,
+    struct s2n_session_key *session_key);
+
+
+#define DECRYPT_COST 10
+#define IV_SIZE 16
+#define MAX_SIZE 1024
+#define TAG_SIZE 16
+
+int decrypt_cbc(struct s2n_session_key *session_key,
+		struct s2n_blob* iv,
+		struct s2n_blob* in,
+		struct s2n_blob* out)
+
+{
+  int size = in->size;
+  __VERIFIER_ASSUME_LEAKAGE(size * DECRYPT_COST);
+  out->data = malloc(size);
+  return 0;
+}
+
+int decrypt_stream(struct s2n_session_key *session_key,
+		   struct s2n_blob* in,
+		   struct s2n_blob* out)
+
+{
+  int size = in->size;
+  __VERIFIER_ASSUME_LEAKAGE(size * DECRYPT_COST);
+  out->data = malloc(size);
+  return 0;
+}
+
+int decrypt_aead(struct s2n_session_key *session_key,
+		struct s2n_blob* iv,
+		struct s2n_blob* aad,
+		struct s2n_blob* in,
+		struct s2n_blob* out)
+
+{
+  int size = in->size;
+  __VERIFIER_ASSUME_LEAKAGE(size * DECRYPT_COST);
+  out->data = malloc(size);
+  return 0;
+}
+
+
+int s2n_increment_sequence_number(uint8_t * sequence_number){
+  __VERIFIER_ASSUME_LEAKAGE(0);
+  return 0;
+}
+
+int g_padding_length;
+
+int s2n_record_parse_wrapper(int payload_length,
+			     int *xor_pad,
+			     int * digest_pad,
+			     int packet_size,
+			     int padding_length,
+			     int encrypted_length,
+			     uint8_t content_type,
+			     int flags
+)
+{
+  __VERIFIER_ASSERT_MAX_LEAKAGE(100);
+  __VERIFIER_assume(packet_size > 0);
+  __VERIFIER_assume(packet_size < MAX_SIZE);
+  __VERIFIER_assume(payload_length > 0);
+  __VERIFIER_assume(payload_length <= packet_size);
+  __VERIFIER_assume(encrypted_length > 0);
+  __VERIFIER_assume(encrypted_length <= packet_size);
+  __VERIFIER_assume(padding_length >= 0);
+  __VERIFIER_assume(padding_length < 256);
+  __VERIFIER_assume(padding_length < payload_length);
+  public_in(__SMACK_value(packet_size));
+  public_in(__SMACK_value(payload_length));
+  public_in(__SMACK_value(padding_length));
+  public_in(__SMACK_value(encrypted_length));
+  public_in(__SMACK_value(flags));
+  
+  struct s2n_hmac_state hmac = {
+    .alg = S2N_HMAC_SHA1,
+    .hash_block_size = BLOCK_SIZE,
+    .currently_in_hash_block = 0,
+    .digest_size = SHA_DIGEST_LENGTH,
+    .xor_pad_size = BLOCK_SIZE,
+    .inner.alg = S2N_HASH_SHA1,
+    .inner.currently_in_hash_block = 0,
+    .inner_just_key.alg = S2N_HASH_SHA1,
+    .inner_just_key.currently_in_hash_block = 0,
+    .outer.alg = S2N_HASH_SHA1,
+    .outer.currently_in_hash_block = 0,
+    .outer_just_key.alg = S2N_HASH_SHA1,
+    .outer_just_key.currently_in_hash_block = 0,
+     .xor_pad = *xor_pad,
+    //xor_pad is an array
+    .digest_pad = *digest_pad
+  };
+
+  
+  struct s2n_cipher aead_cipher = {
+    .type = S2N_AEAD,
+    .io.aead.decrypt = decrypt_aead,
+    .io.aead.record_iv_size = IV_SIZE,
+    .io.aead.fixed_iv_size = IV_SIZE,
+    .io.aead.tag_size = TAG_SIZE,
+  };
+  
+  struct s2n_record_algorithm record_algorithm = {
+    .cipher = &aead_cipher,
+    .flags = flags
+  };
+  
+  struct s2n_cipher_suite cipher_suite = {
+    .record_alg = &record_algorithm,
+  };
+
+  uint8_t data1[MAX_SIZE];
+  uint8_t data2[MAX_SIZE];
+  
+  struct s2n_connection conn = {
+    .actual_protocol_version = S2N_TLS10,
+    .in = {
+      .read_cursor = 0,
+      .write_cursor = MAX_SIZE,
+      .blob = {
+	.data = data1,
+	.size = MAX_SIZE,
+      },
+    },
+    .header_in = {
+      .read_cursor = 0,
+      .write_cursor = S2N_TLS_RECORD_HEADER_LENGTH,
+      .blob = {
+	.data = data2,
+	.size = MAX_SIZE,
+      },
+    },
+  };
+
+  uint8_t sequence_number[S2N_TLS_SEQUENCE_NUM_LEN];
+  struct s2n_session_key session_key;
+  uint8_t implicit_iv[S2N_TLS_MAX_IV_LEN];
+
+  g_padding_length = padding_length;
+  return s2n_record_parse_aead(&cipher_suite, &conn, content_type, encrypted_length, implicit_iv, &hmac, sequence_number, &session_key);
+}

--- a/tests/sidewinder/working/s2n-record-read-aead/s2n_record_read_wrapper.c
+++ b/tests/sidewinder/working/s2n-record-read-aead/s2n_record_read_wrapper.c
@@ -48,29 +48,6 @@ int s2n_record_parse_aead(
 #define MAX_SIZE 1024
 #define TAG_SIZE 16
 
-int decrypt_cbc(struct s2n_session_key *session_key,
-		struct s2n_blob* iv,
-		struct s2n_blob* in,
-		struct s2n_blob* out)
-
-{
-  int size = in->size;
-  __VERIFIER_ASSUME_LEAKAGE(size * DECRYPT_COST);
-  out->data = malloc(size);
-  return 0;
-}
-
-int decrypt_stream(struct s2n_session_key *session_key,
-		   struct s2n_blob* in,
-		   struct s2n_blob* out)
-
-{
-  int size = in->size;
-  __VERIFIER_ASSUME_LEAKAGE(size * DECRYPT_COST);
-  out->data = malloc(size);
-  return 0;
-}
-
 int decrypt_aead(struct s2n_session_key *session_key,
 		struct s2n_blob* iv,
 		struct s2n_blob* aad,
@@ -84,36 +61,21 @@ int decrypt_aead(struct s2n_session_key *session_key,
   return 0;
 }
 
-
 int s2n_increment_sequence_number(uint8_t * sequence_number){
   __VERIFIER_ASSUME_LEAKAGE(0);
   return 0;
 }
 
-int g_padding_length;
-
-int s2n_record_parse_wrapper(int payload_length,
-			     int *xor_pad,
-			     int * digest_pad,
-			     int packet_size,
+int s2n_record_parse_wrapper(int *xor_pad,
+			     int *digest_pad,
 			     int padding_length,
 			     int encrypted_length,
 			     uint8_t content_type,
 			     int flags
 )
 {
-  __VERIFIER_ASSERT_MAX_LEAKAGE(100);
-  __VERIFIER_assume(packet_size > 0);
-  __VERIFIER_assume(packet_size < MAX_SIZE);
-  __VERIFIER_assume(payload_length > 0);
-  __VERIFIER_assume(payload_length <= packet_size);
+  __VERIFIER_ASSERT_MAX_LEAKAGE(10);
   __VERIFIER_assume(encrypted_length > 0);
-  __VERIFIER_assume(encrypted_length <= packet_size);
-  __VERIFIER_assume(padding_length >= 0);
-  __VERIFIER_assume(padding_length < 256);
-  __VERIFIER_assume(padding_length < payload_length);
-  public_in(__SMACK_value(packet_size));
-  public_in(__SMACK_value(payload_length));
   public_in(__SMACK_value(padding_length));
   public_in(__SMACK_value(encrypted_length));
   public_in(__SMACK_value(flags));
@@ -133,7 +95,6 @@ int s2n_record_parse_wrapper(int payload_length,
     .outer_just_key.alg = S2N_HASH_SHA1,
     .outer_just_key.currently_in_hash_block = 0,
      .xor_pad = *xor_pad,
-    //xor_pad is an array
     .digest_pad = *digest_pad
   };
 
@@ -155,7 +116,9 @@ int s2n_record_parse_wrapper(int payload_length,
     .record_alg = &record_algorithm,
   };
 
+  //cppcheck-suppress unassignedVariable
   uint8_t data1[MAX_SIZE];
+  //cppcheck-suppress unassignedVariable
   uint8_t data2[MAX_SIZE];
   
   struct s2n_connection conn = {
@@ -182,6 +145,5 @@ int s2n_record_parse_wrapper(int payload_length,
   struct s2n_session_key session_key;
   uint8_t implicit_iv[S2N_TLS_MAX_IV_LEN];
 
-  g_padding_length = padding_length;
   return s2n_record_parse_aead(&cipher_suite, &conn, content_type, encrypted_length, implicit_iv, &hmac, sequence_number, &session_key);
 }

--- a/tests/sidewinder/working/s2n-record-read-aead/sidewinder.h
+++ b/tests/sidewinder/working/s2n-record-read-aead/sidewinder.h
@@ -1,0 +1,7 @@
+#pragma once
+
+void __VERIFIER_ASSERT_MAX_LEAKAGE(int max);
+void __VERIFIER_ASSUME_LEAKAGE(int assumedLeakage);
+void benign();
+#define BENIGN benign()
+//#define BENIGN

--- a/tests/sidewinder/working/s2n-record-read-cbc/Makefile
+++ b/tests/sidewinder/working/s2n-record-read-cbc/Makefile
@@ -1,0 +1,18 @@
+include ../../lib/ct-verif.mk
+
+cflags +=-D__TIMING_CONTRACTS__
+#the overriden .h
+cflags += -I$(CURDIR)
+#original .h
+cflags += -I$(CURDIR)/../../../../
+#/api .h that haven't fixed that
+cflags += -I$(CURDIR)/../../../../api/
+cflags += -fPIC -std=c99 -fgnu89-inline
+extras += crypto/s2n_hash.c crypto/s2n_hmac.c tls/s2n_cbc.c tls/s2n_record_read_cbc.c stuffer/s2n_stuffer.c utils/s2n_mem.c utils/s2n_safety.c
+goals  += s2n_record_parse_wrapper@s2n_record_read_wrapper.c
+#goals += test_leakage@s2n_record_read_wrapper.c
+full_self_comp += true
+smtlog += p.smt2
+shadowingArgs += "self_comp_mode=full,branchcond_assertion=assert_never,memory_assertion=assert_never"
+timing += true
+printModel += true

--- a/tests/sidewinder/working/s2n-record-read-cbc/clean.sh
+++ b/tests/sidewinder/working/s2n-record-read-cbc/clean.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+make clean
+rm -r crypto
+rm -r tls
+rm -r stuffer
+rm -r utils

--- a/tests/sidewinder/working/s2n-record-read-cbc/copy_as_needed.sh
+++ b/tests/sidewinder/working/s2n-record-read-cbc/copy_as_needed.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+set -x 
+BASEDIR=$(pwd)
+echo $BASEDIR
+S2N_BASE="$BASEDIR/../../../.."
+echo $S2N_BASE
+
+cd $BASEDIR
+mkdir -p crypto
+#The hmac should be based off the old hmac, so just apply the patches to add the invarients
+cp $S2N_BASE/crypto/s2n_hmac.c crypto/
+cp $S2N_BASE/crypto/s2n_hmac.h crypto/
+patch -p5 < ../patches/hmac.patch
+
+#the hash uses my stubs for now, so replace the file
+cp ../stubs/s2n_hash.c crypto/
+cp ../stubs/s2n_hash.h crypto/
+
+mkdir -p stuffer
+cp $S2N_BASE/stuffer/s2n_stuffer.c stuffer/
+
+mkdir -p tls
+#add invariants etc needed for the proof to the s2n_cbc code
+cp stubs/s2n_cbc.c tls/
+cp $S2N_BASE/tls/s2n_record_read_cbc.c tls/
+patch -p5 < record_read_cbc.patch
+
+mkdir -p utils
+cp $S2N_BASE/utils/s2n_safety.c utils/
+cp $S2N_BASE/utils/s2n_safety.h utils/
+cp ../stubs/s2n_mem.c utils/
+patch -p5 < ../patches/safety1.patch
+patch -p5 < ../patches/safety2.patch
+
+cp ../stubs/s2n_annotations.h utils/
+

--- a/tests/sidewinder/working/s2n-record-read-cbc/record_read_cbc.patch
+++ b/tests/sidewinder/working/s2n-record-read-cbc/record_read_cbc.patch
@@ -1,0 +1,28 @@
+--- /Users/dsn/github/s2n/tls/s2n_record_read_cbc.c	2018-02-09 15:50:12.000000000 -0500
++++ tls/s2n_record_read_cbc.c	2018-02-12 15:20:10.000000000 -0500
+@@ -30,6 +30,8 @@
+ #include "utils/s2n_safety.h"
+ #include "utils/s2n_blob.h"
+ 
++extern int g_padding_length;
++
+ int s2n_record_parse_cbc(
+     const struct s2n_cipher_suite *cipher_suite,
+     struct s2n_connection *conn,
+@@ -86,6 +88,8 @@
+ 
+     /* Subtract the padding length */
+     gt_check(en.size, 0);
++    //After hmac verification padding_length is declassified
++    en.data[en.size - 1] = g_padding_length;
+     payload_length -= (en.data[en.size - 1] + 1);
+ 
+     /* Update the MAC */
+@@ -106,6 +110,7 @@
+ 
+     /* Padding */
+     if (s2n_verify_cbc(conn, mac, &en) < 0) {
++        __VERIFIER_assume(0);
+         GUARD(s2n_stuffer_wipe(&conn->in));
+         S2N_ERROR(S2N_ERR_BAD_MESSAGE);
+     }

--- a/tests/sidewinder/working/s2n-record-read-cbc/run.sh
+++ b/tests/sidewinder/working/s2n-record-read-cbc/run.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+
+./copy_as_needed.sh
+make clean
+time make

--- a/tests/sidewinder/working/s2n-record-read-cbc/s2n_annotations.h
+++ b/tests/sidewinder/working/s2n-record-read-cbc/s2n_annotations.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include <smack-contracts.h>
+#include "ct-verif.h"
+
+#define S2N_PUBLIC_INPUT( __a )  public_in(__SMACK_value( __a ))
+#define S2N_INVARIENT( __a ) invariant ( __a )

--- a/tests/sidewinder/working/s2n-record-read-cbc/s2n_record_read_wrapper.c
+++ b/tests/sidewinder/working/s2n-record-read-cbc/s2n_record_read_wrapper.c
@@ -58,31 +58,6 @@ int decrypt_cbc(struct s2n_session_key *session_key,
   return 0;
 }
 
-int decrypt_stream(struct s2n_session_key *session_key,
-		   struct s2n_blob* in,
-		   struct s2n_blob* out)
-
-{
-  int size = in->size;
-  __VERIFIER_ASSUME_LEAKAGE(size * DECRYPT_COST);
-  out->data = malloc(size);
-  return 0;
-}
-
-int decrypt_aead(struct s2n_session_key *session_key,
-		struct s2n_blob* iv,
-		struct s2n_blob* aad,
-		struct s2n_blob* in,
-		struct s2n_blob* out)
-
-{
-  int size = in->size;
-  __VERIFIER_ASSUME_LEAKAGE(size * DECRYPT_COST);
-  out->data = malloc(size);
-  return 0;
-}
-
-
 int s2n_increment_sequence_number(uint8_t * sequence_number){
   __VERIFIER_ASSUME_LEAKAGE(0);
   return 0;
@@ -90,27 +65,17 @@ int s2n_increment_sequence_number(uint8_t * sequence_number){
 
 int g_padding_length;
 
-int s2n_record_parse_wrapper(int payload_length,
-			     int *xor_pad,
-			     int * digest_pad,
-			     int packet_size,
+int s2n_record_parse_wrapper(int *xor_pad,
+			     int *digest_pad,
 			     int padding_length,
 			     int encrypted_length,
 			     uint8_t content_type
 )
 {
   __VERIFIER_ASSERT_MAX_LEAKAGE(100);
-  __VERIFIER_assume(packet_size > 0);
-  __VERIFIER_assume(packet_size < MAX_SIZE);
-  __VERIFIER_assume(payload_length > 0);
-  __VERIFIER_assume(payload_length <= packet_size);
   __VERIFIER_assume(encrypted_length > 0);
-  __VERIFIER_assume(encrypted_length <= packet_size);
   __VERIFIER_assume(padding_length >= 0);
   __VERIFIER_assume(padding_length < 256);
-  __VERIFIER_assume(padding_length < payload_length);
-  public_in(__SMACK_value(packet_size));
-  public_in(__SMACK_value(payload_length));
   public_in(__SMACK_value(padding_length));
   public_in(__SMACK_value(encrypted_length));
   
@@ -129,7 +94,6 @@ int s2n_record_parse_wrapper(int payload_length,
     .outer_just_key.alg = S2N_HASH_SHA1,
     .outer_just_key.currently_in_hash_block = 0,
      .xor_pad = *xor_pad,
-    //xor_pad is an array
     .digest_pad = *digest_pad
   };
 
@@ -146,8 +110,10 @@ int s2n_record_parse_wrapper(int payload_length,
   struct s2n_cipher_suite cipher_suite = {
     .record_alg = &record_algorithm,
   };
-
+  
+  //cppcheck-suppress unassignedVariable
   uint8_t data1[MAX_SIZE];
+  //cppcheck-suppress unassignedVariable
   uint8_t data2[MAX_SIZE];
   
   struct s2n_connection conn = {

--- a/tests/sidewinder/working/s2n-record-read-cbc/s2n_record_read_wrapper.c
+++ b/tests/sidewinder/working/s2n-record-read-cbc/s2n_record_read_wrapper.c
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <sys/param.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "crypto/s2n_hmac.h"
+
+#include "tls/s2n_record.h"
+#include "tls/s2n_prf.h"
+#include "tls/s2n_connection.h"
+
+#include <smack.h>
+#include <smack-contracts.h>
+#include "ct-verif.h"
+#include "sidewinder.h"
+#include "utils/s2n_safety.h"
+#include "tls/s2n_cipher_suites.h"
+#include "utils/s2n_blob.h"
+#include "crypto/s2n_cipher.h"
+
+int s2n_record_parse_cbc(
+    const struct s2n_cipher_suite *cipher_suite,
+    struct s2n_connection *conn,
+    uint8_t content_type,
+    uint16_t encrypted_length,
+    uint8_t * implicit_iv,
+    struct s2n_hmac_state *mac,
+    uint8_t * sequence_number,
+    struct s2n_session_key *session_key);
+
+
+#define DECRYPT_COST 10
+#define IV_SIZE 16
+#define MAX_SIZE 1024
+int decrypt_cbc(struct s2n_session_key *session_key,
+		struct s2n_blob* iv,
+		struct s2n_blob* in,
+		struct s2n_blob* out)
+
+{
+  int size = in->size;
+  __VERIFIER_ASSUME_LEAKAGE(size * DECRYPT_COST);
+  out->data = malloc(size);
+  return 0;
+}
+
+int decrypt_stream(struct s2n_session_key *session_key,
+		   struct s2n_blob* in,
+		   struct s2n_blob* out)
+
+{
+  int size = in->size;
+  __VERIFIER_ASSUME_LEAKAGE(size * DECRYPT_COST);
+  out->data = malloc(size);
+  return 0;
+}
+
+int decrypt_aead(struct s2n_session_key *session_key,
+		struct s2n_blob* iv,
+		struct s2n_blob* aad,
+		struct s2n_blob* in,
+		struct s2n_blob* out)
+
+{
+  int size = in->size;
+  __VERIFIER_ASSUME_LEAKAGE(size * DECRYPT_COST);
+  out->data = malloc(size);
+  return 0;
+}
+
+
+int s2n_increment_sequence_number(uint8_t * sequence_number){
+  __VERIFIER_ASSUME_LEAKAGE(0);
+  return 0;
+}
+
+int g_padding_length;
+
+int s2n_record_parse_wrapper(int payload_length,
+			     int *xor_pad,
+			     int * digest_pad,
+			     int packet_size,
+			     int padding_length,
+			     int encrypted_length,
+			     uint8_t content_type
+)
+{
+  __VERIFIER_ASSERT_MAX_LEAKAGE(100);
+  __VERIFIER_assume(packet_size > 0);
+  __VERIFIER_assume(packet_size < MAX_SIZE);
+  __VERIFIER_assume(payload_length > 0);
+  __VERIFIER_assume(payload_length <= packet_size);
+  __VERIFIER_assume(encrypted_length > 0);
+  __VERIFIER_assume(encrypted_length <= packet_size);
+  __VERIFIER_assume(padding_length >= 0);
+  __VERIFIER_assume(padding_length < 256);
+  __VERIFIER_assume(padding_length < payload_length);
+  public_in(__SMACK_value(packet_size));
+  public_in(__SMACK_value(payload_length));
+  public_in(__SMACK_value(padding_length));
+  public_in(__SMACK_value(encrypted_length));
+  
+  struct s2n_hmac_state hmac = {
+    .alg = S2N_HMAC_SHA1,
+    .hash_block_size = BLOCK_SIZE,
+    .currently_in_hash_block = 0,
+    .digest_size = SHA_DIGEST_LENGTH,
+    .xor_pad_size = BLOCK_SIZE,
+    .inner.alg = S2N_HASH_SHA1,
+    .inner.currently_in_hash_block = 0,
+    .inner_just_key.alg = S2N_HASH_SHA1,
+    .inner_just_key.currently_in_hash_block = 0,
+    .outer.alg = S2N_HASH_SHA1,
+    .outer.currently_in_hash_block = 0,
+    .outer_just_key.alg = S2N_HASH_SHA1,
+    .outer_just_key.currently_in_hash_block = 0,
+     .xor_pad = *xor_pad,
+    //xor_pad is an array
+    .digest_pad = *digest_pad
+  };
+
+  
+  struct s2n_cipher cbc_cipher = {
+    .type = S2N_CBC,
+    .io.cbc.decrypt = decrypt_cbc,
+  };
+  
+  struct s2n_record_algorithm record_algorithm = {
+    .cipher = &cbc_cipher,
+  };
+  
+  struct s2n_cipher_suite cipher_suite = {
+    .record_alg = &record_algorithm,
+  };
+
+  uint8_t data1[MAX_SIZE];
+  uint8_t data2[MAX_SIZE];
+  
+  struct s2n_connection conn = {
+    .actual_protocol_version = S2N_TLS10,
+    .in = {
+      .read_cursor = 0,
+      .write_cursor = MAX_SIZE,
+      .blob = {
+	.data = data1,
+	.size = MAX_SIZE,
+      },
+    },
+    .header_in = {
+      .read_cursor = 0,
+      .write_cursor = S2N_TLS_RECORD_HEADER_LENGTH,
+      .blob = {
+	.data = data2,
+	.size = MAX_SIZE,
+      },
+    },
+  };
+
+  uint8_t sequence_number[S2N_TLS_SEQUENCE_NUM_LEN];
+  struct s2n_session_key session_key;
+  uint8_t implicit_iv[S2N_TLS_MAX_IV_LEN];
+
+  g_padding_length = padding_length;
+  return s2n_record_parse_cbc(&cipher_suite, &conn, content_type, encrypted_length, implicit_iv, &hmac, sequence_number, &session_key);
+}

--- a/tests/sidewinder/working/s2n-record-read-cbc/sidewinder.h
+++ b/tests/sidewinder/working/s2n-record-read-cbc/sidewinder.h
@@ -1,0 +1,7 @@
+#pragma once
+
+void __VERIFIER_ASSERT_MAX_LEAKAGE(int max);
+void __VERIFIER_ASSUME_LEAKAGE(int assumedLeakage);
+void benign();
+#define BENIGN benign()
+//#define BENIGN

--- a/tests/sidewinder/working/s2n-record-read-cbc/stubs/s2n_cbc.c
+++ b/tests/sidewinder/working/s2n-record-read-cbc/stubs/s2n_cbc.c
@@ -1,0 +1,17 @@
+#include <smack.h>
+#include "ct-verif.h"
+#include "../sidewinder.h"
+
+#define MAX_LEAKAGE_DIFFERENCE  68
+
+int nondet();
+
+int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, struct s2n_blob *decrypted)
+{
+  int leakage = nondet();
+  //We have a proof that the max leakage this step can introduce is MAX_LEAKAGE_DIFFERENCE
+  __VERIFIER_assume(leakage >= 0);
+  __VERIFIER_assume(leakage < MAX_LEAKAGE_DIFFERENCE);
+  __VERIFIER_ASSUME_LEAKAGE(leakage);
+  return 0;
+}

--- a/tests/sidewinder/working/s2n-record-read-cbc/stubs/s2n_cbc.c
+++ b/tests/sidewinder/working/s2n-record-read-cbc/stubs/s2n_cbc.c
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 #include <smack.h>
 #include "ct-verif.h"
 #include "../sidewinder.h"

--- a/tests/sidewinder/working/s2n-record-read-composite/Makefile
+++ b/tests/sidewinder/working/s2n-record-read-composite/Makefile
@@ -1,0 +1,18 @@
+include ../../lib/ct-verif.mk
+
+cflags +=-D__TIMING_CONTRACTS__
+#the overriden .h
+cflags += -I$(CURDIR)
+#original .h
+cflags += -I$(CURDIR)/../../../../
+#/api .h that haven't fixed that
+cflags += -I$(CURDIR)/../../../../api/
+cflags += -fPIC -std=c99 -fgnu89-inline
+extras += crypto/s2n_hash.c crypto/s2n_hmac.c stuffer/s2n_stuffer.c  tls/s2n_record_read_composite.c  utils/s2n_mem.c utils/s2n_safety.c
+goals  += s2n_record_parse_wrapper@s2n_record_read_wrapper.c
+#goals += test_leakage@s2n_record_read_wrapper.c
+full_self_comp += true
+smtlog += p.smt2
+shadowingArgs += "self_comp_mode=full,branchcond_assertion=assert_never,memory_assertion=assert_never"
+timing += true
+printModel += true

--- a/tests/sidewinder/working/s2n-record-read-composite/clean.sh
+++ b/tests/sidewinder/working/s2n-record-read-composite/clean.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+make clean
+rm -r crypto
+rm -r tls
+rm -r stuffer
+rm -r utils

--- a/tests/sidewinder/working/s2n-record-read-composite/copy_as_needed.sh
+++ b/tests/sidewinder/working/s2n-record-read-composite/copy_as_needed.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+set -x 
+BASEDIR=$(pwd)
+echo $BASEDIR
+S2N_BASE="$BASEDIR/../../../.."
+echo $S2N_BASE
+
+cd $BASEDIR
+mkdir -p crypto
+#The hmac should be based off the old hmac, so just apply the patches to add the invarients
+cp $S2N_BASE/crypto/s2n_hmac.c crypto/
+cp $S2N_BASE/crypto/s2n_hmac.h crypto/
+patch -p5 < ../patches/hmac.patch
+
+#the hash uses my stubs for now, so replace the file
+cp ../stubs/s2n_hash.c crypto/
+cp ../stubs/s2n_hash.h crypto/
+
+mkdir -p stuffer
+cp $S2N_BASE/stuffer/s2n_stuffer.c stuffer/
+
+mkdir -p tls
+#add invariants etc needed for the proof to the s2n_cbc code
+cp $S2N_BASE/tls/s2n_cbc.c tls/
+cp $S2N_BASE/tls/s2n_record_read_composite.c tls/
+patch -p5 < ../patches/cbc.patch
+patch -p5 < record_read.patch
+
+mkdir -p utils
+cp $S2N_BASE/utils/s2n_safety.c utils/
+cp $S2N_BASE/utils/s2n_safety.h utils/
+cp ../stubs/s2n_mem.c utils/
+patch -p5 < ../patches/safety1.patch
+patch -p5 < ../patches/safety2.patch
+
+cp ../stubs/s2n_annotations.h utils/
+

--- a/tests/sidewinder/working/s2n-record-read-composite/record_read.patch
+++ b/tests/sidewinder/working/s2n-record-read-composite/record_read.patch
@@ -1,0 +1,20 @@
+--- /Users/dsn/github/s2n/tls/s2n_record_read_composite.c	2018-02-09 10:26:56.000000000 -0500
++++ tls/s2n_record_read_composite.c	2018-02-12 15:05:26.000000000 -0500
+@@ -29,6 +29,8 @@
+ #include "utils/s2n_safety.h"
+ #include "utils/s2n_blob.h"
+ 
++extern int g_padding_length;
++
+ int s2n_record_parse_composite(
+     const struct s2n_cipher_suite *cipher_suite,
+     struct s2n_connection *conn,
+@@ -86,6 +88,8 @@
+ 
+     /* Subtract the padding length */
+     gt_check(en.size, 0);
++    //After hmac verification padding_length is declassified
++    en.data[en.size - 1] = g_padding_length;
+     payload_length -= (en.data[en.size - 1] + 1);
+ 
+     struct s2n_blob seq = {.data = sequence_number,.size = S2N_TLS_SEQUENCE_NUM_LEN };

--- a/tests/sidewinder/working/s2n-record-read-composite/run.sh
+++ b/tests/sidewinder/working/s2n-record-read-composite/run.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+
+./copy_as_needed.sh
+make clean
+time make

--- a/tests/sidewinder/working/s2n-record-read-composite/s2n_annotations.h
+++ b/tests/sidewinder/working/s2n-record-read-composite/s2n_annotations.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include <smack-contracts.h>
+#include "ct-verif.h"
+
+#define S2N_PUBLIC_INPUT( __a )  public_in(__SMACK_value( __a ))
+#define S2N_INVARIENT( __a ) invariant ( __a )

--- a/tests/sidewinder/working/s2n-record-read-composite/s2n_record_read_wrapper.c
+++ b/tests/sidewinder/working/s2n-record-read-composite/s2n_record_read_wrapper.c
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <sys/param.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "crypto/s2n_hmac.h"
+
+#include "tls/s2n_record.h"
+#include "tls/s2n_prf.h"
+#include "tls/s2n_connection.h"
+
+#include <smack.h>
+#include <smack-contracts.h>
+#include "ct-verif.h"
+#include "sidewinder.h"
+#include "utils/s2n_safety.h"
+#include "tls/s2n_cipher_suites.h"
+#include "utils/s2n_blob.h"
+#include "crypto/s2n_cipher.h"
+
+int s2n_record_parse_composite(
+    const struct s2n_cipher_suite *cipher_suite,
+    struct s2n_connection *conn,
+    uint8_t content_type,
+    uint16_t encrypted_length,
+    uint8_t * implicit_iv,
+    struct s2n_hmac_state *mac,
+    uint8_t * sequence_number,
+    struct s2n_session_key *session_key);
+
+
+#define DECRYPT_COST 10
+#define IV_SIZE 16
+#define MAX_SIZE 1024
+
+//Extra is actually mac_size
+int initial_hmac(struct s2n_session_key *key, uint8_t *sequence_number, uint8_t content_type, uint16_t protocol_version,
+		 uint16_t payload_and_eiv_len, int *extra)
+{
+  *extra = DIGEST_SIZE;
+  return 0;
+}
+
+
+int decrypt_cbc(struct s2n_session_key *session_key,
+		struct s2n_blob* iv,
+		struct s2n_blob* in,
+		struct s2n_blob* out)
+
+{
+  int size = in->size;
+  __VERIFIER_ASSUME_LEAKAGE(size * DECRYPT_COST);
+  out->data = malloc(size);
+  return 0;
+}
+
+int decrypt_stream(struct s2n_session_key *session_key,
+		   struct s2n_blob* in,
+		   struct s2n_blob* out)
+
+{
+  int size = in->size;
+  __VERIFIER_ASSUME_LEAKAGE(size * DECRYPT_COST);
+  out->data = malloc(size);
+  return 0;
+}
+
+int decrypt_aead(struct s2n_session_key *session_key,
+		struct s2n_blob* iv,
+		struct s2n_blob* aad,
+		struct s2n_blob* in,
+		struct s2n_blob* out)
+
+{
+  int size = in->size;
+  __VERIFIER_ASSUME_LEAKAGE(size * DECRYPT_COST);
+  out->data = malloc(size);
+  return 0;
+}
+
+
+int s2n_increment_sequence_number(uint8_t * sequence_number){
+  __VERIFIER_ASSUME_LEAKAGE(0);
+  return 0;
+}
+
+int g_padding_length;
+
+int s2n_record_parse_wrapper(int payload_length,
+			     int *xor_pad,
+			     int * digest_pad,
+			     int packet_size,
+			     int padding_length,
+			     int encrypted_length,
+			     uint8_t content_type
+)
+{
+  __VERIFIER_ASSERT_MAX_LEAKAGE(100);
+  __VERIFIER_assume(packet_size > 0);
+  __VERIFIER_assume(packet_size < MAX_SIZE);
+  __VERIFIER_assume(payload_length > 0);
+  __VERIFIER_assume(payload_length <= packet_size);
+  __VERIFIER_assume(encrypted_length > 0);
+  __VERIFIER_assume(encrypted_length <= packet_size);
+  __VERIFIER_assume(padding_length >= 0);
+  __VERIFIER_assume(padding_length < 256);
+  __VERIFIER_assume(padding_length < payload_length);
+  public_in(__SMACK_value(packet_size));
+  public_in(__SMACK_value(payload_length));
+  public_in(__SMACK_value(padding_length));
+  public_in(__SMACK_value(encrypted_length));
+  
+  struct s2n_hmac_state hmac = {
+    .alg = S2N_HMAC_SHA1,
+    .hash_block_size = BLOCK_SIZE,
+    .currently_in_hash_block = 0,
+    .digest_size = SHA_DIGEST_LENGTH,
+    .xor_pad_size = BLOCK_SIZE,
+    .inner.alg = S2N_HASH_SHA1,
+    .inner.currently_in_hash_block = 0,
+    .inner_just_key.alg = S2N_HASH_SHA1,
+    .inner_just_key.currently_in_hash_block = 0,
+    .outer.alg = S2N_HASH_SHA1,
+    .outer.currently_in_hash_block = 0,
+    .outer_just_key.alg = S2N_HASH_SHA1,
+    .outer_just_key.currently_in_hash_block = 0,
+     .xor_pad = *xor_pad,
+    //xor_pad is an array
+    .digest_pad = *digest_pad
+  };
+
+  
+  struct s2n_cipher comp_cipher = {
+    .type = S2N_COMPOSITE,
+    .io.comp.decrypt = decrypt_cbc,
+    .io.comp.record_iv_size = IV_SIZE,
+    .io.comp.initial_hmac = initial_hmac,
+  };
+  
+  struct s2n_record_algorithm record_algorithm = {
+    .cipher = &comp_cipher,
+  };
+  
+  struct s2n_cipher_suite cipher_suite = {
+    .record_alg = &record_algorithm,
+  };
+
+  uint8_t data1[MAX_SIZE];
+  uint8_t data2[MAX_SIZE];
+  
+  struct s2n_connection conn = {
+    .actual_protocol_version = S2N_TLS10,
+    .in = {
+      .read_cursor = 0,
+      .write_cursor = MAX_SIZE,
+      .blob = {
+	.data = data1,
+	.size = MAX_SIZE,
+      },
+    },
+    .header_in = {
+      .read_cursor = 0,
+      .write_cursor = S2N_TLS_RECORD_HEADER_LENGTH,
+      .blob = {
+	.data = data2,
+	.size = MAX_SIZE,
+      },
+    },
+  };
+
+  uint8_t sequence_number[S2N_TLS_SEQUENCE_NUM_LEN];
+  struct s2n_session_key session_key;
+  uint8_t implicit_iv[S2N_TLS_MAX_IV_LEN];
+
+  g_padding_length = padding_length;
+  return s2n_record_parse_composite(&cipher_suite, &conn, content_type, encrypted_length, implicit_iv, &hmac, sequence_number, &session_key);
+}

--- a/tests/sidewinder/working/s2n-record-read-composite/s2n_record_read_wrapper.c
+++ b/tests/sidewinder/working/s2n-record-read-composite/s2n_record_read_wrapper.c
@@ -55,8 +55,7 @@ int initial_hmac(struct s2n_session_key *key, uint8_t *sequence_number, uint8_t 
   return 0;
 }
 
-
-int decrypt_cbc(struct s2n_session_key *session_key,
+int decrypt_comp(struct s2n_session_key *session_key,
 		struct s2n_blob* iv,
 		struct s2n_blob* in,
 		struct s2n_blob* out)
@@ -67,31 +66,6 @@ int decrypt_cbc(struct s2n_session_key *session_key,
   out->data = malloc(size);
   return 0;
 }
-
-int decrypt_stream(struct s2n_session_key *session_key,
-		   struct s2n_blob* in,
-		   struct s2n_blob* out)
-
-{
-  int size = in->size;
-  __VERIFIER_ASSUME_LEAKAGE(size * DECRYPT_COST);
-  out->data = malloc(size);
-  return 0;
-}
-
-int decrypt_aead(struct s2n_session_key *session_key,
-		struct s2n_blob* iv,
-		struct s2n_blob* aad,
-		struct s2n_blob* in,
-		struct s2n_blob* out)
-
-{
-  int size = in->size;
-  __VERIFIER_ASSUME_LEAKAGE(size * DECRYPT_COST);
-  out->data = malloc(size);
-  return 0;
-}
-
 
 int s2n_increment_sequence_number(uint8_t * sequence_number){
   __VERIFIER_ASSUME_LEAKAGE(0);
@@ -100,27 +74,17 @@ int s2n_increment_sequence_number(uint8_t * sequence_number){
 
 int g_padding_length;
 
-int s2n_record_parse_wrapper(int payload_length,
-			     int *xor_pad,
-			     int * digest_pad,
-			     int packet_size,
+int s2n_record_parse_wrapper(int *xor_pad,
+			     int *digest_pad,
 			     int padding_length,
 			     int encrypted_length,
 			     uint8_t content_type
 )
 {
-  __VERIFIER_ASSERT_MAX_LEAKAGE(100);
-  __VERIFIER_assume(packet_size > 0);
-  __VERIFIER_assume(packet_size < MAX_SIZE);
-  __VERIFIER_assume(payload_length > 0);
-  __VERIFIER_assume(payload_length <= packet_size);
+  __VERIFIER_ASSERT_MAX_LEAKAGE(0);
   __VERIFIER_assume(encrypted_length > 0);
-  __VERIFIER_assume(encrypted_length <= packet_size);
   __VERIFIER_assume(padding_length >= 0);
   __VERIFIER_assume(padding_length < 256);
-  __VERIFIER_assume(padding_length < payload_length);
-  public_in(__SMACK_value(packet_size));
-  public_in(__SMACK_value(payload_length));
   public_in(__SMACK_value(padding_length));
   public_in(__SMACK_value(encrypted_length));
   
@@ -138,15 +102,13 @@ int s2n_record_parse_wrapper(int payload_length,
     .outer.currently_in_hash_block = 0,
     .outer_just_key.alg = S2N_HASH_SHA1,
     .outer_just_key.currently_in_hash_block = 0,
-     .xor_pad = *xor_pad,
-    //xor_pad is an array
+    .xor_pad = *xor_pad,
     .digest_pad = *digest_pad
   };
 
-  
   struct s2n_cipher comp_cipher = {
     .type = S2N_COMPOSITE,
-    .io.comp.decrypt = decrypt_cbc,
+    .io.comp.decrypt = decrypt_comp,
     .io.comp.record_iv_size = IV_SIZE,
     .io.comp.initial_hmac = initial_hmac,
   };
@@ -159,7 +121,9 @@ int s2n_record_parse_wrapper(int payload_length,
     .record_alg = &record_algorithm,
   };
 
+  //cppcheck-suppress unassignedVariable
   uint8_t data1[MAX_SIZE];
+  //cppcheck-suppress unassignedVariable
   uint8_t data2[MAX_SIZE];
   
   struct s2n_connection conn = {

--- a/tests/sidewinder/working/s2n-record-read-composite/sidewinder.h
+++ b/tests/sidewinder/working/s2n-record-read-composite/sidewinder.h
@@ -1,0 +1,7 @@
+#pragma once
+
+void __VERIFIER_ASSERT_MAX_LEAKAGE(int max);
+void __VERIFIER_ASSUME_LEAKAGE(int assumedLeakage);
+void benign();
+#define BENIGN benign()
+//#define BENIGN

--- a/tests/sidewinder/working/s2n-record-read-stream/Makefile
+++ b/tests/sidewinder/working/s2n-record-read-stream/Makefile
@@ -1,0 +1,17 @@
+include ../../lib/ct-verif.mk
+
+cflags +=-D__TIMING_CONTRACTS__
+#the overriden .h
+cflags += -I$(CURDIR)
+#original .h
+cflags += -I$(CURDIR)/../../../../
+#/api .h that haven't fixed that
+cflags += -I$(CURDIR)/../../../../api/
+cflags += -fPIC -std=c99 -fgnu89-inline
+extras += crypto/s2n_hmac.c  crypto/s2n_hash.c stuffer/s2n_stuffer.c tls/s2n_cbc.c  tls/s2n_record_read_stream.c  utils/s2n_mem.c utils/s2n_safety.c 
+goals  += s2n_record_parse_wrapper@s2n_record_read_wrapper.c
+full_self_comp += true
+smtlog += p.smt2
+shadowingArgs += "self_comp_mode=full,branchcond_assertion=assert_never,memory_assertion=assert_never"
+timing += true
+printModel += true

--- a/tests/sidewinder/working/s2n-record-read-stream/clean.sh
+++ b/tests/sidewinder/working/s2n-record-read-stream/clean.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+make clean
+rm -r crypto
+rm -r tls
+rm -r stuffer
+rm -r utils

--- a/tests/sidewinder/working/s2n-record-read-stream/copy_as_needed.sh
+++ b/tests/sidewinder/working/s2n-record-read-stream/copy_as_needed.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+set -x 
+BASEDIR=$(pwd)
+echo $BASEDIR
+S2N_BASE="$BASEDIR/../../../.."
+echo $S2N_BASE
+
+cd $BASEDIR
+mkdir -p crypto
+#The hmac should be based off the old hmac, so just apply the patches to add the invarients
+cp $S2N_BASE/crypto/s2n_hmac.c crypto/
+cp $S2N_BASE/crypto/s2n_hmac.h crypto/
+patch -p5 < ../patches/hmac.patch
+
+#the hash uses my stubs for now, so replace the file
+cp ../stubs/s2n_hash.c crypto/
+cp ../stubs/s2n_hash.h crypto/
+
+mkdir -p stuffer
+cp $S2N_BASE/stuffer/s2n_stuffer.c stuffer/
+
+mkdir -p tls
+#add invariants etc needed for the proof to the s2n_cbc code
+cp $S2N_BASE/tls/s2n_cbc.c tls/
+cp $S2N_BASE/tls/s2n_record_read_stream.c tls/
+patch -p5 < ../patches/cbc.patch
+
+mkdir -p utils
+cp $S2N_BASE/utils/s2n_safety.c utils/
+cp $S2N_BASE/utils/s2n_safety.h utils/
+cp ../stubs/s2n_mem.c utils/
+patch -p5 < ../patches/safety1.patch
+patch -p5 < ../patches/safety2.patch
+
+cp ../stubs/s2n_annotations.h utils/
+

--- a/tests/sidewinder/working/s2n-record-read-stream/run.sh
+++ b/tests/sidewinder/working/s2n-record-read-stream/run.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+
+./copy_as_needed.sh
+make clean
+time make

--- a/tests/sidewinder/working/s2n-record-read-stream/s2n_annotations.h
+++ b/tests/sidewinder/working/s2n-record-read-stream/s2n_annotations.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include <smack-contracts.h>
+#include "ct-verif.h"
+
+#define S2N_PUBLIC_INPUT( __a )  public_in(__SMACK_value( __a ))
+#define S2N_INVARIENT( __a ) invariant ( __a )

--- a/tests/sidewinder/working/s2n-record-read-stream/s2n_record_read_wrapper.c
+++ b/tests/sidewinder/working/s2n-record-read-stream/s2n_record_read_wrapper.c
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <sys/param.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "crypto/s2n_hmac.h"
+
+#include "tls/s2n_record.h"
+#include "tls/s2n_prf.h"
+#include "tls/s2n_connection.h"
+
+#include <smack.h>
+#include <smack-contracts.h>
+#include "ct-verif.h"
+#include "sidewinder.h"
+#include "utils/s2n_safety.h"
+#include "tls/s2n_cipher_suites.h"
+#include "utils/s2n_blob.h"
+#include "crypto/s2n_cipher.h"
+
+int s2n_record_parse_stream(
+    const struct s2n_cipher_suite *cipher_suite,
+    struct s2n_connection *conn,
+    uint8_t content_type,
+    uint16_t encrypted_length,
+    uint8_t * implicit_iv,
+    struct s2n_hmac_state *mac,
+    uint8_t * sequence_number,
+    struct s2n_session_key *session_key);
+
+
+#define DECRYPT_COST 10
+#define IV_SIZE 16
+#define MAX_SIZE 1024
+
+int decrypt_stream(struct s2n_session_key *session_key,
+		   struct s2n_blob* in,
+		   struct s2n_blob* out)
+
+{
+  int size = in->size;
+  __VERIFIER_ASSUME_LEAKAGE(size * DECRYPT_COST);
+  out->data = malloc(size);
+  return 0;
+}
+
+
+int s2n_increment_sequence_number(uint8_t * sequence_number){
+  __VERIFIER_ASSUME_LEAKAGE(0);
+  return 0;
+}
+
+int g_padding_length;
+
+int s2n_record_parse_wrapper(int payload_length,
+			     int *xor_pad,
+			     int * digest_pad,
+			     int packet_size,
+			     int padding_length,
+			     int encrypted_length,
+			     uint8_t content_type
+)
+{
+  __VERIFIER_ASSERT_MAX_LEAKAGE(100);
+  __VERIFIER_assume(packet_size > 0);
+  __VERIFIER_assume(packet_size < MAX_SIZE);
+  __VERIFIER_assume(payload_length > 0);
+  __VERIFIER_assume(payload_length <= packet_size);
+  __VERIFIER_assume(encrypted_length > 0);
+  __VERIFIER_assume(encrypted_length <= packet_size);
+  __VERIFIER_assume(padding_length >= 0);
+  __VERIFIER_assume(padding_length < 256);
+  __VERIFIER_assume(padding_length < payload_length);
+  public_in(__SMACK_value(packet_size));
+  public_in(__SMACK_value(payload_length));
+  public_in(__SMACK_value(padding_length));
+  public_in(__SMACK_value(encrypted_length));
+  
+  struct s2n_hmac_state hmac = {
+    .alg = S2N_HMAC_SHA1,
+    .hash_block_size = BLOCK_SIZE,
+    .currently_in_hash_block = 0,
+    .digest_size = SHA_DIGEST_LENGTH,
+    .xor_pad_size = BLOCK_SIZE,
+    .inner.alg = S2N_HASH_SHA1,
+    .inner.currently_in_hash_block = 0,
+    .inner_just_key.alg = S2N_HASH_SHA1,
+    .inner_just_key.currently_in_hash_block = 0,
+    .outer.alg = S2N_HASH_SHA1,
+    .outer.currently_in_hash_block = 0,
+    .outer_just_key.alg = S2N_HASH_SHA1,
+    .outer_just_key.currently_in_hash_block = 0,
+     .xor_pad = *xor_pad,
+    //xor_pad is an array
+    .digest_pad = *digest_pad
+  };
+
+  
+  struct s2n_cipher stream_cipher = {
+    .type = S2N_STREAM,
+    .io.cbc.decrypt = decrypt_stream,
+  };
+  
+  struct s2n_record_algorithm record_algorithm = {
+    .cipher = &stream_cipher,
+  };
+  
+  struct s2n_cipher_suite cipher_suite = {
+    .record_alg = &record_algorithm,
+  };
+
+  uint8_t data1[MAX_SIZE];
+  uint8_t data2[MAX_SIZE];
+  
+  struct s2n_connection conn = {
+    .actual_protocol_version = S2N_TLS10,
+    .in = {
+      .read_cursor = 0,
+      .write_cursor = MAX_SIZE,
+      .blob = {
+	.data = data1,
+	.size = MAX_SIZE,
+      },
+    },
+    .header_in = {
+      .read_cursor = 0,
+      .write_cursor = S2N_TLS_RECORD_HEADER_LENGTH,
+      .blob = {
+	.data = data2,
+	.size = MAX_SIZE,
+      },
+    },
+  };
+
+  uint8_t sequence_number[S2N_TLS_SEQUENCE_NUM_LEN];
+  struct s2n_session_key session_key;
+  uint8_t implicit_iv[S2N_TLS_MAX_IV_LEN];
+
+  g_padding_length = padding_length;
+  return s2n_record_parse_stream(&cipher_suite, &conn, content_type, encrypted_length, implicit_iv, &hmac, sequence_number, &session_key);
+}

--- a/tests/sidewinder/working/s2n-record-read-stream/s2n_record_read_wrapper.c
+++ b/tests/sidewinder/working/s2n-record-read-stream/s2n_record_read_wrapper.c
@@ -42,7 +42,6 @@ int s2n_record_parse_stream(
     uint8_t * sequence_number,
     struct s2n_session_key *session_key);
 
-
 #define DECRYPT_COST 10
 #define IV_SIZE 16
 #define MAX_SIZE 1024
@@ -58,7 +57,6 @@ int decrypt_stream(struct s2n_session_key *session_key,
   return 0;
 }
 
-
 int s2n_increment_sequence_number(uint8_t * sequence_number){
   __VERIFIER_ASSUME_LEAKAGE(0);
   return 0;
@@ -66,27 +64,17 @@ int s2n_increment_sequence_number(uint8_t * sequence_number){
 
 int g_padding_length;
 
-int s2n_record_parse_wrapper(int payload_length,
-			     int *xor_pad,
+int s2n_record_parse_wrapper(int *xor_pad,
 			     int * digest_pad,
-			     int packet_size,
 			     int padding_length,
 			     int encrypted_length,
 			     uint8_t content_type
 )
 {
-  __VERIFIER_ASSERT_MAX_LEAKAGE(100);
-  __VERIFIER_assume(packet_size > 0);
-  __VERIFIER_assume(packet_size < MAX_SIZE);
-  __VERIFIER_assume(payload_length > 0);
-  __VERIFIER_assume(payload_length <= packet_size);
+  __VERIFIER_ASSERT_MAX_LEAKAGE(0);
   __VERIFIER_assume(encrypted_length > 0);
-  __VERIFIER_assume(encrypted_length <= packet_size);
   __VERIFIER_assume(padding_length >= 0);
   __VERIFIER_assume(padding_length < 256);
-  __VERIFIER_assume(padding_length < payload_length);
-  public_in(__SMACK_value(packet_size));
-  public_in(__SMACK_value(payload_length));
   public_in(__SMACK_value(padding_length));
   public_in(__SMACK_value(encrypted_length));
   
@@ -104,8 +92,7 @@ int s2n_record_parse_wrapper(int payload_length,
     .outer.currently_in_hash_block = 0,
     .outer_just_key.alg = S2N_HASH_SHA1,
     .outer_just_key.currently_in_hash_block = 0,
-     .xor_pad = *xor_pad,
-    //xor_pad is an array
+    .xor_pad = *xor_pad,
     .digest_pad = *digest_pad
   };
 
@@ -123,7 +110,9 @@ int s2n_record_parse_wrapper(int payload_length,
     .record_alg = &record_algorithm,
   };
 
+  //cppcheck-suppress unassignedVariable
   uint8_t data1[MAX_SIZE];
+  //cppcheck-suppress unassignedVariable
   uint8_t data2[MAX_SIZE];
   
   struct s2n_connection conn = {

--- a/tests/sidewinder/working/s2n-record-read-stream/sidewinder.h
+++ b/tests/sidewinder/working/s2n-record-read-stream/sidewinder.h
@@ -1,0 +1,7 @@
+#pragma once
+
+void __VERIFIER_ASSERT_MAX_LEAKAGE(int max);
+void __VERIFIER_ASSUME_LEAKAGE(int assumedLeakage);
+void benign();
+#define BENIGN benign()
+//#define BENIGN

--- a/tests/sidewinder/working/stubs/s2n_annotations.h
+++ b/tests/sidewinder/working/stubs/s2n_annotations.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include <smack-contracts.h>
+#include "ct-verif.h"
+
+#define S2N_PUBLIC_INPUT( __a )  public_in(__SMACK_value( __a ))
+#define S2N_INVARIENT( __a ) invariant ( __a )

--- a/tests/sidewinder/working/stubs/s2n_hash.c
+++ b/tests/sidewinder/working/stubs/s2n_hash.c
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+#include "s2n_hash.h"
+#include "../error/s2n_errno.h"
+#include <smack.h>
+#include "ct-verif.h"
+#include "../sidewinder.h"
+
+int s2n_hash_digest_size(s2n_hash_algorithm alg, uint8_t *out)
+{
+    switch (alg) {
+    case S2N_HASH_NONE:     *out = 0;                    break;
+    case S2N_HASH_MD5:      *out = MD5_DIGEST_LENGTH;    break;
+    case S2N_HASH_SHA1:     *out = SHA_DIGEST_LENGTH;    break;
+    case S2N_HASH_SHA224:   *out = SHA224_DIGEST_LENGTH; break;
+    case S2N_HASH_SHA256:   *out = SHA256_DIGEST_LENGTH; break;
+    case S2N_HASH_SHA384:   *out = SHA384_DIGEST_LENGTH; break;
+    case S2N_HASH_SHA512:   *out = SHA512_DIGEST_LENGTH; break;
+    case S2N_HASH_MD5_SHA1: *out = MD5_DIGEST_LENGTH + SHA_DIGEST_LENGTH; break;
+    default:
+        S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
+    }
+    return 0;
+}
+
+int s2n_hash_new(struct s2n_hash_state *state)
+{
+  return SUCCESS;
+}
+
+int s2n_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm alg)
+{
+  __VERIFIER_ASSUME_LEAKAGE(0);
+  state->alg = alg;
+  state->currently_in_hash_block = 0;
+  return SUCCESS;
+}
+
+int num_blocks(int numBytes) {
+  /* Using div and mod directly in the stubs turned out to have significant runtime cost
+   * because the backend SMT solver does not handle these non-linear operations well.
+   * Instead, hardcode the div function.
+   * This trades off speed for generality because we have to assert that no input is larger
+   * the given bound.  Padding length cannot be more than 256, (4 SHA1 blocks). Choosing a 
+   * bound much larger than this ensures that for any padding size we can see the effect on 
+   * the packet.
+   */
+  __VERIFIER_ASSUME_LEAKAGE(0);
+  if (numBytes <  1*BLOCK_SIZE) {BENIGN;return 0;}
+  if (numBytes <  2*BLOCK_SIZE) return 1;
+  if (numBytes <  3*BLOCK_SIZE) return 2;
+  if (numBytes <  4*BLOCK_SIZE) return 3;
+  if (numBytes <  5*BLOCK_SIZE) return 4;
+  if (numBytes <  6*BLOCK_SIZE) return 5;
+  if (numBytes <  7*BLOCK_SIZE) return 6;
+  if (numBytes <  8*BLOCK_SIZE) return 7;
+  if (numBytes <  9*BLOCK_SIZE) return 8;
+  if (numBytes < 10*BLOCK_SIZE) return 9;
+  if (numBytes < 11*BLOCK_SIZE) return 10;
+  if (numBytes < 12*BLOCK_SIZE) return 11;
+  if (numBytes < 13*BLOCK_SIZE) return 12;
+  if (numBytes < 14*BLOCK_SIZE) return 13;
+  if (numBytes < 15*BLOCK_SIZE) return 14;
+  if (numBytes < 16*BLOCK_SIZE) return 15;
+  if (numBytes < 17*BLOCK_SIZE) return 16;
+  if (numBytes == 17*BLOCK_SIZE) return 17;
+  __VERIFIER_assert(0);//Unreachable
+}
+
+int s2n_hash_update(struct s2n_hash_state *state, const void *data, uint32_t size)
+{
+
+  /* The __VERIFIER_assert statements give better performance but don't add to our current spec.
+   * In particular, Boogie is bad about reestablishing invariants on values that have been put
+   * into memory, then read back out. Adding the asserts triggers Boogie to relearn the 
+   * invariant properties.
+   * The proof should hold in their absense (albeit much more slowly).
+   */
+  //cppcheck-suppress unsignedPositive
+   __VERIFIER_assert(size >= 0);
+   __VERIFIER_assert(size <= MAX_SIZE);
+   __VERIFIER_assert(state->currently_in_hash_block < BLOCK_SIZE);
+
+   /* We model a hash function as having two forms of leakage: 
+    * A per-byte-cost, which represents the cost of moving the information into the hash bufer
+    * A per-block-cost, which represents the cost of compressing one hash-block using the hash fn
+    * As discussed in the README, __VERIFIER_ASSUME_LEAKAGE allows us to annotate these 
+    * timing costs into the stub
+    */
+   __VERIFIER_ASSUME_LEAKAGE(PER_BYTE_COST * size);
+
+   state->currently_in_hash_block += size;
+   int num_filled_blocks = num_blocks(state->currently_in_hash_block);
+   __VERIFIER_ASSUME_LEAKAGE(num_filled_blocks * PER_BLOCK_COST);
+
+   state->currently_in_hash_block = state->currently_in_hash_block - num_filled_blocks*BLOCK_SIZE;
+   __VERIFIER_assert(state->currently_in_hash_block < BLOCK_SIZE);
+
+   return SUCCESS;
+}
+
+int s2n_hash_digest(struct s2n_hash_state *state, void *out, uint32_t size)
+{
+  __VERIFIER_ASSUME_LEAKAGE(0);
+  // All the leakage comes from the hash_update we do once we've updated the size fields
+
+  const int MARKER_BYTE_LENGTH = 1;
+  // append the bit '1' to the message e.g. by adding 0x80 if message length is a multiple of 8 bits.
+  uint32_t min_bytes_to_add = MARKER_BYTE_LENGTH;
+  min_bytes_to_add += LENGTH_FIELD_SIZE;
+
+  int bytes_to_add;
+  if(state->currently_in_hash_block + min_bytes_to_add <= BLOCK_SIZE){
+    BENIGN;
+    bytes_to_add = BLOCK_SIZE - state->currently_in_hash_block;
+  } else {
+    bytes_to_add = BLOCK_SIZE + (BLOCK_SIZE - state->currently_in_hash_block);
+  }
+
+  s2n_hash_update(state, NULL, bytes_to_add);
+  return SUCCESS;
+}
+
+int s2n_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *from)
+{
+  __VERIFIER_ASSUME_LEAKAGE(0);
+  to->alg = from->alg;
+  to->currently_in_hash_block = from->currently_in_hash_block;
+  return SUCCESS;
+}
+
+int s2n_hash_reset(struct s2n_hash_state *state)
+{
+  __VERIFIER_ASSUME_LEAKAGE(0);
+  state->currently_in_hash_block = 0;
+  return SUCCESS;
+}
+
+int s2n_hash_free(struct s2n_hash_state *state)
+{
+  return SUCCESS;
+}
+
+int s2n_hash_get_currently_in_hash_total(struct s2n_hash_state *state, uint64_t *out)
+{
+  *out = state->currently_in_hash_block;
+  return SUCCESS;
+}
+

--- a/tests/sidewinder/working/stubs/s2n_hash.h
+++ b/tests/sidewinder/working/stubs/s2n_hash.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <openssl/sha.h>
+#include <openssl/md5.h>
+
+#include "crypto/s2n_evp.h"
+
+#define S2N_MAX_DIGEST_LEN SHA512_DIGEST_LENGTH
+
+typedef enum {
+    S2N_HASH_NONE,
+    S2N_HASH_MD5,
+    S2N_HASH_SHA1,
+    S2N_HASH_SHA224,
+    S2N_HASH_SHA256,
+    S2N_HASH_SHA384,
+    S2N_HASH_SHA512,
+    S2N_HASH_MD5_SHA1,
+    /* Don't add any hash algorithms below S2N_HASH_SENTINEL */
+    S2N_HASH_SENTINEL
+} s2n_hash_algorithm;
+
+struct s2n_hash_state {
+  s2n_hash_algorithm alg;
+  int currently_in_hash_block;
+};
+
+/* SHA1
+ * These fields were determined from the SHA specification, augmented by
+ * analyzing SHA implementations. 
+ * PER_BLOCK_COST is the cost of a compression round.  Pessimistically assume 
+ * it is 1000 cycles/block, which is worse than real implementations (larger
+ * numbers here make lucky13 leakages look worse), and hence large is safer.
+ * PER_BYTE_COST is the cost of memcopy one byte that is already in cache,
+ * to a location already in cache.
+ */
+enum {
+  PER_BLOCK_COST = 1000,
+  PER_BYTE_COST = 1,
+  BLOCK_SIZE = 64,          
+  LENGTH_FIELD_SIZE = 8,
+  DIGEST_SIZE = 20
+};
+
+#define MAX_SIZE 1024
+
+enum {
+  SUCCESS = 0,
+  FAILURE = -1
+};
+
+extern int s2n_hash_digest_size(s2n_hash_algorithm alg, uint8_t *out);
+extern int s2n_hash_new(struct s2n_hash_state *state);
+extern int s2n_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm alg);
+extern int s2n_hash_update(struct s2n_hash_state *state, const void *data, uint32_t size);
+extern int s2n_hash_digest(struct s2n_hash_state *state, void *out, uint32_t size);
+extern int s2n_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *from);
+extern int s2n_hash_reset(struct s2n_hash_state *state);
+extern int s2n_hash_free(struct s2n_hash_state *state);
+extern int s2n_hash_get_currently_in_hash_total(struct s2n_hash_state *state, uint64_t *out);
+
+

--- a/tests/sidewinder/working/stubs/s2n_mem.c
+++ b/tests/sidewinder/working/stubs/s2n_mem.c
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <stdint.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+
+#include "error/s2n_errno.h"
+
+#include "utils/s2n_blob.h"
+#include "utils/s2n_mem.h"
+#include "utils/s2n_safety.h"
+
+static long page_size = 4096;
+static int use_mlock = 1;
+
+int s2n_mem_init(void)
+{
+    GUARD(page_size = sysconf(_SC_PAGESIZE));
+    if (getenv("S2N_DONT_MLOCK")) {
+        use_mlock = 0;
+    }
+
+    return 0;
+}
+
+int s2n_mem_cleanup(void)
+{
+    page_size = 4096;
+    use_mlock = 1;
+    return 0;
+}
+
+int s2n_alloc(struct s2n_blob *b, uint32_t size)
+{
+    b->data = NULL;
+    b->size = 0;
+    b->allocated = 0;
+    b->mlocked = 0;
+    GUARD(s2n_realloc(b, size));
+    return 0;
+}
+
+void *realloc( void *ptr, size_t new_size )
+{
+  //just leave it undet for now
+  void* ret = malloc(new_size);
+  return ret;
+}
+
+int s2n_realloc(struct s2n_blob *b, uint32_t size)
+{
+    /* if (size == 0) { */
+    /*     return s2n_free(b); */
+    /* } */
+
+    /* blob already has space for the request */
+    if (size < b->allocated) {
+        b->size = size;
+        return 0;
+    }
+
+    void *data;
+    if (!use_mlock) {
+        data = realloc(b->data, size);
+        if (!data) {
+            S2N_ERROR(S2N_ERR_ALLOC);
+        }
+
+        b->data = data;
+        b->size = size;
+        b->allocated = size;
+        return 0;
+    }
+
+/*     /\* Page aligned allocation required for mlock *\/ */
+/*     uint32_t allocate = page_size * (((size - 1) / page_size) + 1); */
+/*     if (posix_memalign(&data, page_size, allocate)) { */
+/*         S2N_ERROR(S2N_ERR_ALLOC); */
+/*     } */
+
+/*     if (b->size) { */
+/*         memcpy_check(data, b->data, b->size); */
+/*         GUARD(s2n_free(b)); */
+/*     } */
+
+/*     b->data = data; */
+/*     b->size = size; */
+/*     b->allocated = allocate; */
+
+/* #ifdef MADV_DONTDUMP */
+/*     if (madvise(b->data, size, MADV_DONTDUMP) < 0) { */
+/*         GUARD(s2n_free(b)); */
+/*         S2N_ERROR(S2N_ERR_MADVISE); */
+/*     } */
+/* #endif */
+
+/*     if (mlock(b->data, size) < 0) { */
+/*         GUARD(s2n_free(b)); */
+/*         S2N_ERROR(S2N_ERR_MLOCK); */
+/*     } */
+/*     b->mlocked = 1; */
+
+    return 0;
+}
+
+int s2n_free(struct s2n_blob *b)
+{
+    int munlock_rc = 0;
+    if (b->mlocked) {
+        munlock_rc = munlock(b->data, b->size);
+    }
+
+    free(b->data);
+    b->data = NULL;
+    b->size = 0;
+    b->allocated = 0;
+
+    if (munlock_rc < 0) {
+        S2N_ERROR(S2N_ERR_MUNLOCK);
+    }
+    b->mlocked = 0;
+
+    return 0;
+}
+
+int s2n_dup(struct s2n_blob *from, struct s2n_blob *to)
+{
+    eq_check(to->size, 0);
+    eq_check(to->data, NULL);
+
+    GUARD(s2n_alloc(to, from->size));
+    
+    memcpy_check(to->data, from->data, to->size);
+
+    return 0;
+}

--- a/tls/s2n_record_read_aead.c
+++ b/tls/s2n_record_read_aead.c
@@ -27,8 +27,9 @@
 #include "tls/s2n_record.h"
 #include "tls/s2n_record_read.h"
 
-#include "utils/s2n_safety.h"
+#include "utils/s2n_annotations.h"
 #include "utils/s2n_blob.h"
+#include "utils/s2n_safety.h"
 
 int s2n_record_parse_aead(
     const struct s2n_cipher_suite *cipher_suite,
@@ -63,6 +64,7 @@ int s2n_record_parse_aead(
         GUARD(s2n_stuffer_write_bytes(&iv_stuffer, four_zeroes, 4));
         GUARD(s2n_stuffer_write_bytes(&iv_stuffer, sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
         for (int i = 0; i < cipher_suite->record_alg->cipher->io.aead.fixed_iv_size; i++) {
+	    S2N_INVARIENT(i <= cipher_suite->record_alg->cipher->io.aead.fixed_iv_size);
             aad_iv[i] = aad_iv[i] ^ implicit_iv[i];
         }
     } else {


### PR DESCRIPTION
**Issue # (if available):** 

**Description of changes:** 
Previously, I used Sidewinder to prove that cbc_verify was timing balanced.  This PR extends the proof to include the s2n_record_read* functions that actually do decryption and verification.  This gives assurance that data-packet processing (decryption and verification of the packet) is timing-balanced.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
