### PR TITLE
 Fix memleak in s2n_verify_host_information

### DIFF
--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -166,7 +166,7 @@ static uint8_t s2n_verify_host_information(struct s2n_x509_validator *validator,
     STACK_OF(GENERAL_NAME) *names_list = X509_get_ext_d2i(public_cert, NID_subject_alt_name, NULL, NULL);
     int n = sk_GENERAL_NAME_num(names_list);
     for (int i = 0; i < n && !verified; i++) {
-        GENERAL_NAME *current_name = sk_GENERAL_NAME_value(names_list, i);;
+        GENERAL_NAME *current_name = sk_GENERAL_NAME_value(names_list, i);
         if (current_name->type == GEN_DNS) {
             san_found = 1;
 

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -164,8 +164,9 @@ static uint8_t s2n_verify_host_information(struct s2n_x509_validator *validator,
 
     /* Check SubjectAltNames before CommonName as per RFC 6125 6.4.4 */
     STACK_OF(GENERAL_NAME) *names_list = X509_get_ext_d2i(public_cert, NID_subject_alt_name, NULL, NULL);
-    GENERAL_NAME *current_name = NULL;
-    while (!verified && names_list && (current_name = sk_GENERAL_NAME_pop(names_list))) {
+    int n = sk_GENERAL_NAME_num(names_list);
+    for (int i = 0; i < n && !verified; i++) {
+        GENERAL_NAME *current_name = sk_GENERAL_NAME_value(names_list, i);;
         if (current_name->type == GEN_DNS) {
             san_found = 1;
 

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -158,7 +158,7 @@ int s2n_x509_validator_set_max_chain_depth(struct s2n_x509_validator *validator,
  * For each name in the cert. Iterate them. Call the callback. If one returns true, then consider it validated,
  * if none of them return true, the cert is considered invalid.
  */
-static uint8_t verify_host_information(struct s2n_x509_validator *validator, struct s2n_connection *conn, X509 *public_cert) {
+static uint8_t s2n_verify_host_information(struct s2n_x509_validator *validator, struct s2n_connection *conn, X509 *public_cert) {
     uint8_t verified = 0;
     uint8_t san_found = 0;
 
@@ -299,7 +299,7 @@ s2n_cert_validation_code s2n_x509_validator_validate_cert_chain(struct s2n_x509_
             goto clean_up;
         }
 
-        if (conn->verify_host_fn && !verify_host_information(validator, conn, leaf)) {
+        if (conn->verify_host_fn && !s2n_verify_host_information(validator, conn, leaf)) {
             err_code = S2N_CERT_ERR_UNTRUSTED;
             goto clean_up;
         }


### PR DESCRIPTION
Previously we were poping GENERAL_NAME from the stack and not freeing them. To avoid that switched from _pop to iterating using _value, to keep GENERAL_NAMES in stack and free them after we done with lookup.

Also while in here, added s2n_ prefix to verify_host_information,

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
