### PR TITLE
Fix memleak in s2n_x509_validator_validate_cert_chain

### DIFF
--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -339,7 +339,7 @@ s2n_cert_validation_code s2n_x509_validator_validate_cert_chain(struct s2n_x509_
 
 clean_up:
     if (ctx) {
-        X509_STORE_CTX_cleanup(ctx);
+        X509_STORE_CTX_free(ctx);
     }
 
     if (err_code != S2N_CERT_OK) {


### PR DESCRIPTION
Previously was using X509_STORE_CTX_cleanup, which cleans up structure, but doesn't free memory for it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
