### PR TITLE
Ignore unknown or unsupported signature-hash algorithm pairs

### DIFF
--- a/tls/s2n_signature_algorithms.c
+++ b/tls/s2n_signature_algorithms.c
@@ -22,10 +22,8 @@
 
 static int s2n_sig_hash_algs_pairs_set(struct s2n_sig_hash_alg_pairs *sig_hash_algs, uint8_t sig_alg, uint8_t hash_alg)
 {
-    /* The RFC requires these values to be between 0 and 255 */
-    S2N_ERROR_IF(hash_alg > 255, S2N_ERR_HASH_INVALID_ALGORITHM);
-    S2N_ERROR_IF(sig_alg > 255, S2N_ERR_INVALID_SIGNATURE_ALGORITHM);
-
+    /* Skip unknown or unsupported values. If we receive any of these in the signature_algorithms extension 
+     * or CertificateRequest, we can ignore them and fall back to using the default signature-hash algorithm combination */
     if (hash_alg < TLS_HASH_ALGORITHM_COUNT && sig_alg < TLS_SIGNATURE_ALGORITHM_COUNT) {
         sig_hash_algs->matrix[sig_alg][hash_alg] = 1;
     }


### PR DESCRIPTION
Ignore signature-hash algorithm pairs that are within the range of valid values but are unknown or unsupported. Send an alert for all other (invalid) values. 

**Issue # (if available):** N/A

**Description of changes:** 

We currently ignore unknown, unsupported, and invalid values. If we receive any of these in the signature_algorithms extension or CertificateRequest, we just ignore them and fall back to using the default signature-hash algorithm combination. This is partially because we set s2n_errno but do not check it. The concern was that someone could add a GUARD around the call to `s2n_sig_hash_algs_pairs_set` which would change this behavior and start failing the handshake.  

This change only sets s2n_errno for invalid values, and skips unknown or unsupported valid values. It also ensures that we fail the handshake if s2n_errno is set.

@raycoll has a unit test that he will submit to verify this behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
