### PR TITLE
Unit tests memleaks fixes

### DIFF
--- a/crypto/s2n_ecdsa.c
+++ b/crypto/s2n_ecdsa.c
@@ -84,31 +84,39 @@ static int s2n_ecdsa_keys_match(const struct s2n_pkey *pub, const struct s2n_pke
 {
     uint8_t input[16];
     struct s2n_blob random_input;
-    struct s2n_blob signature;
-    struct s2n_hash_state state_in, state_out;
+    struct s2n_blob signature = { 0 };
+    struct s2n_hash_state state_in = { 0 }, state_out = { 0 };
 
     random_input.data = input;
     random_input.size = sizeof(input);
-    GUARD(s2n_get_public_random_data(&random_input));
+    GUARD_GOTO(s2n_get_public_random_data(&random_input), failed);
 
     /* s2n_hash_new only allocates memory when using high-level EVP hashes, currently restricted to FIPS mode. */
-    GUARD(s2n_hash_new(&state_in));
-    GUARD(s2n_hash_new(&state_out));
+    GUARD_GOTO(s2n_hash_new(&state_in), failed);
+    GUARD_GOTO(s2n_hash_new(&state_out), failed);
 
-    GUARD(s2n_hash_init(&state_in, S2N_HASH_SHA1));
-    GUARD(s2n_hash_init(&state_out, S2N_HASH_SHA1));
-    GUARD(s2n_hash_update(&state_in, input, sizeof(input)));
-    GUARD(s2n_hash_update(&state_out, input, sizeof(input)));
+    GUARD_GOTO(s2n_hash_init(&state_in, S2N_HASH_SHA1), failed);
+    GUARD_GOTO(s2n_hash_init(&state_out, S2N_HASH_SHA1), failed);
+    GUARD_GOTO(s2n_hash_update(&state_in, input, sizeof(input)), failed);
+    GUARD_GOTO(s2n_hash_update(&state_out, input, sizeof(input)), failed);
 
-    GUARD(s2n_alloc(&signature, s2n_ecdsa_der_signature_size(priv)));
-    
-    GUARD(s2n_ecdsa_sign(priv, &state_in, &signature));
-    GUARD(s2n_ecdsa_verify(pub, &state_out, &signature));
+    GUARD_GOTO(s2n_alloc(&signature, s2n_ecdsa_der_signature_size(priv)), failed);
 
-    GUARD(s2n_hash_free(&state_in));
-    GUARD(s2n_hash_free(&state_out));
+    GUARD_GOTO(s2n_ecdsa_sign(priv, &state_in, &signature), failed);
+    GUARD_GOTO(s2n_ecdsa_verify(pub, &state_out, &signature), failed);
 
-    return 0;
+    int rc = 0;
+    goto cleanup;
+
+failed:
+    rc = -1;
+
+cleanup:
+    s2n_hash_free(&state_in);
+    s2n_hash_free(&state_out);
+    s2n_free(&signature);
+
+    return rc;
 }
 
 static int s2n_ecdsa_key_free(struct s2n_pkey *pkey)

--- a/crypto/s2n_ecdsa.c
+++ b/crypto/s2n_ecdsa.c
@@ -108,6 +108,7 @@ static int s2n_ecdsa_keys_match(const struct s2n_pkey *pub, const struct s2n_pke
     int rc = 0;
     goto cleanup;
 
+    //cppcheck-suppress unusedLabel
 failed:
     rc = -1;
 

--- a/tests/unit/s2n_aead_aes_test.c
+++ b/tests/unit/s2n_aead_aes_test.c
@@ -31,6 +31,13 @@
 #include "tls/s2n_record.h"
 #include "tls/s2n_prf.h"
 
+static int destroy_server_keys(struct s2n_connection *server_conn)
+{
+    GUARD(server_conn->initial.cipher_suite->record_alg->cipher->destroy_key(&server_conn->initial.server_key));
+    GUARD(server_conn->initial.cipher_suite->record_alg->cipher->destroy_key(&server_conn->initial.client_key));
+    return 0;
+}
+
 static int setup_server_keys(struct s2n_connection *server_conn, struct s2n_blob *key)
 {
     GUARD(server_conn->initial.cipher_suite->record_alg->cipher->init(&server_conn->initial.server_key));
@@ -77,6 +84,7 @@ int main(int argc, char **argv)
         conn->server = &conn->initial;
         conn->client = &conn->initial;
         conn->initial.cipher_suite->record_alg = &s2n_record_alg_aes128_gcm;
+        EXPECT_SUCCESS(destroy_server_keys(conn));
         EXPECT_SUCCESS(setup_server_keys(conn, &aes128));
         EXPECT_SUCCESS(bytes_written = s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
@@ -126,6 +134,7 @@ int main(int argc, char **argv)
         conn->client_protocol_version = S2N_TLS12;
         conn->actual_protocol_version = S2N_TLS12;
         conn->initial.cipher_suite->record_alg = &s2n_record_alg_aes128_gcm;
+        EXPECT_SUCCESS(destroy_server_keys(conn));
         EXPECT_SUCCESS(setup_server_keys(conn, &aes128));
         EXPECT_SUCCESS(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
@@ -152,6 +161,7 @@ int main(int argc, char **argv)
             conn->client_protocol_version = S2N_TLS12;
             conn->actual_protocol_version = S2N_TLS12;
             conn->initial.cipher_suite->record_alg = &s2n_record_alg_aes128_gcm;
+            EXPECT_SUCCESS(destroy_server_keys(conn));
             EXPECT_SUCCESS(setup_server_keys(conn, &aes128));
             EXPECT_SUCCESS(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
@@ -176,6 +186,7 @@ int main(int argc, char **argv)
             conn->client_protocol_version = S2N_TLS12;
             conn->actual_protocol_version = S2N_TLS12;
             conn->initial.cipher_suite->record_alg = &s2n_record_alg_aes128_gcm;
+            EXPECT_SUCCESS(destroy_server_keys(conn));
             EXPECT_SUCCESS(setup_server_keys(conn, &aes128));
             EXPECT_SUCCESS(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
@@ -200,6 +211,7 @@ int main(int argc, char **argv)
             conn->client_protocol_version = S2N_TLS12;
             conn->actual_protocol_version = S2N_TLS12;
             conn->initial.cipher_suite->record_alg = &s2n_record_alg_aes128_gcm;
+            EXPECT_SUCCESS(destroy_server_keys(conn));
             EXPECT_SUCCESS(setup_server_keys(conn, &aes128));
             EXPECT_SUCCESS(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
@@ -217,8 +229,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
         }
     }
-    EXPECT_SUCCESS(conn->initial.cipher_suite->record_alg->cipher->destroy_key(&conn->initial.server_key));
-    EXPECT_SUCCESS(conn->initial.cipher_suite->record_alg->cipher->destroy_key(&conn->initial.client_key));
+    EXPECT_SUCCESS(destroy_server_keys(conn));
     EXPECT_SUCCESS(s2n_connection_free(conn));
 
     /* test the AES256 cipher */
@@ -238,6 +249,7 @@ int main(int argc, char **argv)
         conn->client_protocol_version = S2N_TLS12;
         conn->actual_protocol_version = S2N_TLS12;
         conn->initial.cipher_suite->record_alg = &s2n_record_alg_aes256_gcm;
+        EXPECT_SUCCESS(destroy_server_keys(conn));
         EXPECT_SUCCESS(setup_server_keys(conn, &aes256));
         conn->actual_protocol_version = S2N_TLS12;
         EXPECT_SUCCESS(bytes_written = s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
@@ -287,6 +299,7 @@ int main(int argc, char **argv)
         conn->client_protocol_version = S2N_TLS12;
         conn->actual_protocol_version = S2N_TLS12;
         conn->initial.cipher_suite->record_alg = &s2n_record_alg_aes256_gcm;
+        EXPECT_SUCCESS(destroy_server_keys(conn));
         EXPECT_SUCCESS(setup_server_keys(conn, &aes256));
         conn->actual_protocol_version = S2N_TLS12;
         EXPECT_SUCCESS(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
@@ -314,6 +327,7 @@ int main(int argc, char **argv)
             conn->client_protocol_version = S2N_TLS12;
             conn->actual_protocol_version = S2N_TLS12;
             conn->initial.cipher_suite->record_alg = &s2n_record_alg_aes256_gcm;
+            EXPECT_SUCCESS(destroy_server_keys(conn));
             EXPECT_SUCCESS(setup_server_keys(conn, &aes256));
             conn->actual_protocol_version = S2N_TLS12;
             EXPECT_SUCCESS(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
@@ -339,6 +353,7 @@ int main(int argc, char **argv)
             conn->client_protocol_version = S2N_TLS12;
             conn->actual_protocol_version = S2N_TLS12;
             conn->initial.cipher_suite->record_alg = &s2n_record_alg_aes256_gcm;
+            EXPECT_SUCCESS(destroy_server_keys(conn));
             EXPECT_SUCCESS(setup_server_keys(conn, &aes256));
             conn->actual_protocol_version = S2N_TLS12;
             EXPECT_SUCCESS(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
@@ -364,6 +379,7 @@ int main(int argc, char **argv)
             conn->client_protocol_version = S2N_TLS12;
             conn->actual_protocol_version = S2N_TLS12;
             conn->initial.cipher_suite->record_alg = &s2n_record_alg_aes256_gcm;
+            EXPECT_SUCCESS(destroy_server_keys(conn));
             EXPECT_SUCCESS(setup_server_keys(conn, &aes256));
             conn->actual_protocol_version = S2N_TLS12;
             EXPECT_SUCCESS(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
@@ -382,8 +398,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
         }
     }
-    EXPECT_SUCCESS(conn->initial.cipher_suite->record_alg->cipher->destroy_key(&conn->initial.server_key));
-    EXPECT_SUCCESS(conn->initial.cipher_suite->record_alg->cipher->destroy_key(&conn->initial.client_key));
+    EXPECT_SUCCESS(destroy_server_keys(conn));
     EXPECT_SUCCESS(s2n_connection_free(conn));
 
     END_TEST();

--- a/tests/unit/s2n_aead_chacha20_poly1305_test.c
+++ b/tests/unit/s2n_aead_chacha20_poly1305_test.c
@@ -32,6 +32,13 @@
 #include "tls/s2n_record.h"
 #include "tls/s2n_prf.h"
 
+static int destroy_server_keys(struct s2n_connection *server_conn)
+{
+    GUARD(server_conn->initial.cipher_suite->record_alg->cipher->destroy_key(&server_conn->initial.server_key));
+    GUARD(server_conn->initial.cipher_suite->record_alg->cipher->destroy_key(&server_conn->initial.client_key));
+    return 0;
+}
+
 static int setup_server_keys(struct s2n_connection *server_conn, struct s2n_blob *key)
 {
     GUARD(server_conn->initial.cipher_suite->record_alg->cipher->init(&server_conn->initial.server_key));
@@ -78,6 +85,7 @@ int main(int argc, char **argv)
         conn->server_protocol_version = S2N_TLS12;
         conn->client_protocol_version = S2N_TLS12;
         conn->actual_protocol_version = S2N_TLS12;
+        EXPECT_SUCCESS(destroy_server_keys(conn));
         EXPECT_SUCCESS(setup_server_keys(conn, &chacha20_poly1305_key));
         EXPECT_SUCCESS(bytes_written = s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
@@ -126,6 +134,7 @@ int main(int argc, char **argv)
         conn->server_protocol_version = S2N_TLS12;
         conn->client_protocol_version = S2N_TLS12;
         conn->actual_protocol_version = S2N_TLS12;
+        EXPECT_SUCCESS(destroy_server_keys(conn));
         EXPECT_SUCCESS(setup_server_keys(conn, &chacha20_poly1305_key));
         EXPECT_SUCCESS(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
@@ -153,6 +162,7 @@ int main(int argc, char **argv)
             conn->server_protocol_version = S2N_TLS12;
             conn->client_protocol_version = S2N_TLS12;
             conn->actual_protocol_version = S2N_TLS12;
+            EXPECT_SUCCESS(destroy_server_keys(conn));
             EXPECT_SUCCESS(setup_server_keys(conn, &chacha20_poly1305_key));
             EXPECT_SUCCESS(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
@@ -178,6 +188,7 @@ int main(int argc, char **argv)
             conn->server_protocol_version = S2N_TLS12;
             conn->client_protocol_version = S2N_TLS12;
             conn->actual_protocol_version = S2N_TLS12;
+            EXPECT_SUCCESS(destroy_server_keys(conn));
             EXPECT_SUCCESS(setup_server_keys(conn, &chacha20_poly1305_key));
             EXPECT_SUCCESS(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
@@ -198,6 +209,7 @@ int main(int argc, char **argv)
         }
     }
 
+    EXPECT_SUCCESS(destroy_server_keys(conn));
     EXPECT_SUCCESS(s2n_connection_free(conn));
     END_TEST();
 }

--- a/tests/unit/s2n_aes_sha_composite_test.c
+++ b/tests/unit/s2n_aes_sha_composite_test.c
@@ -329,5 +329,7 @@ int main(int argc, char **argv)
         }
     }
 
+    EXPECT_SUCCESS(s2n_connection_free(conn));
+
     END_TEST();
 }

--- a/tests/unit/s2n_array_test.c
+++ b/tests/unit/s2n_array_test.c
@@ -90,5 +90,7 @@ int main(int argc, char **argv)
     /* Done with the array, make sure it can be freed */
     EXPECT_SUCCESS(s2n_array_free(array));
 
+    EXPECT_SUCCESS(s2n_free(&mem));
+
     END_TEST();
 }

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -305,7 +305,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(server_conn->close_notify_queued, 1);
 
          /* Wipe connection */
-        s2n_connection_wipe(server_conn);
+        EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
 
         /* Verify connection_wipe resized the s2n_client_hello.raw_message stuffer */
         EXPECT_NOT_NULL(client_hello->raw_message.blob.data);
@@ -333,6 +333,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_read_fd(server_conn, client_to_server[0]));
         EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
 
+        /* Recreate config */
+        EXPECT_SUCCESS(s2n_config_free(server_config));
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key, S2N_MAX_TEST_PEM_SIZE));

--- a/tests/unit/s2n_drbg_test.c
+++ b/tests/unit/s2n_drbg_test.c
@@ -253,5 +253,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_stuffer_free(&nist_reference_returned_bits));
     EXPECT_SUCCESS(s2n_stuffer_free(&nist_reference_values));
 
+    EXPECT_SUCCESS(s2n_config_free(config));
+
     END_TEST();
 }

--- a/tests/unit/s2n_fragmentation_coalescing_test.c
+++ b/tests/unit/s2n_fragmentation_coalescing_test.c
@@ -433,6 +433,7 @@ int main(int argc, char **argv)
 
         /* Write the fragmented hello message */
         fragmented_message(p[1]);
+        EXPECT_SUCCESS(s2n_config_free(config));
         EXPECT_SUCCESS(s2n_connection_free(conn));
         _exit(0);
     }
@@ -479,6 +480,7 @@ int main(int argc, char **argv)
         /* Write the fragmented hello message */
         coalesced_message(p[1]);
         EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
         _exit(0);
     }
 
@@ -524,6 +526,7 @@ int main(int argc, char **argv)
         /* Write the fragmented hello message */
         interleaved_message(p[1]);
         EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
         _exit(0);
     }
 
@@ -569,6 +572,7 @@ int main(int argc, char **argv)
         /* Write the fragmented hello message */
         interleaved_fragmented_warning_alert(p[1]);
         EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
         _exit(0);
     }
 
@@ -614,6 +618,7 @@ int main(int argc, char **argv)
         /* Write the fragmented hello message */
         interleaved_fragmented_fatal_alert(p[1]);
         EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
         _exit(0);
     }
 

--- a/tests/unit/s2n_malformed_handshake_test.c
+++ b/tests/unit/s2n_malformed_handshake_test.c
@@ -270,6 +270,7 @@ int main(int argc, char **argv)
         send_messages(p[1], server_hello_message, sizeof(server_hello_message), good_certificate_list, sizeof(good_certificate_list));
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
         _exit(0);
     }
 
@@ -318,6 +319,7 @@ int main(int argc, char **argv)
         send_messages(p[1], server_hello_message, sizeof(server_hello_message), empty_certificate_list, sizeof(empty_certificate_list));
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
         _exit(0);
     }
 
@@ -366,6 +368,7 @@ int main(int argc, char **argv)
         send_messages(p[1], server_hello_message, sizeof(server_hello_message), empty_certificate, sizeof(empty_certificate));
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
         _exit(0);
     }
 
@@ -414,6 +417,7 @@ int main(int argc, char **argv)
         send_messages(p[1], server_hello_message, sizeof(server_hello_message), certificate_list_too_large, sizeof(certificate_list_too_large));
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
         _exit(0);
     }
 
@@ -462,6 +466,7 @@ int main(int argc, char **argv)
         send_messages(p[1], server_hello_message, sizeof(server_hello_message), certificate_too_large, sizeof(certificate_too_large));
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
         _exit(0);
     }
 
@@ -510,6 +515,7 @@ int main(int argc, char **argv)
         send_messages(p[1], server_hello_message, sizeof(server_hello_message), certificate_list_too_large, sizeof(certificate_list_too_large));
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
         _exit(0);
     }
 
@@ -531,6 +537,7 @@ int main(int argc, char **argv)
     EXPECT_EQUAL(waitpid(pid, &status, 0), pid);
     EXPECT_EQUAL(status, 0);
     EXPECT_SUCCESS(close(p[0]));
+    EXPECT_SUCCESS(s2n_connection_free(conn));
     EXPECT_SUCCESS(s2n_config_free(config));
 
     END_TEST();

--- a/tests/unit/s2n_mutual_auth_test.c
+++ b/tests/unit/s2n_mutual_auth_test.c
@@ -212,6 +212,8 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_stuffer_free(&server_to_client));
+        EXPECT_SUCCESS(s2n_stuffer_free(&client_to_server));
     }
 
 
@@ -288,6 +290,8 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_stuffer_free(&server_to_client));
+        EXPECT_SUCCESS(s2n_stuffer_free(&client_to_server));
     }
 
 
@@ -367,6 +371,8 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_stuffer_free(&server_to_client));
+        EXPECT_SUCCESS(s2n_stuffer_free(&client_to_server));
     }
 
     /*
@@ -447,6 +453,8 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_stuffer_free(&server_to_client));
+        EXPECT_SUCCESS(s2n_stuffer_free(&client_to_server));
     }
 
     EXPECT_SUCCESS(s2n_config_free(config));

--- a/tests/unit/s2n_self_talk_alpn_test.c
+++ b/tests/unit/s2n_self_talk_alpn_test.c
@@ -100,6 +100,8 @@ int mock_client(int writefd, int readfd, const char **protocols, int count, cons
     /* Give the server a chance to a void a sigpipe */
     sleep(1);
 
+    s2n_cleanup();
+
     _exit(result);
 }
 

--- a/tests/unit/s2n_self_talk_client_hello_cb_test.c
+++ b/tests/unit/s2n_self_talk_client_hello_cb_test.c
@@ -87,6 +87,8 @@ int mock_client(int writefd, int readfd, int expect_failure)
     /* Give the server a chance to a void a sigpipe */
     sleep(1);
 
+    s2n_cleanup();
+
     _exit(result);
 }
 

--- a/tests/unit/s2n_timer_test.c
+++ b/tests/unit/s2n_timer_test.c
@@ -59,5 +59,7 @@ int main(int argc, char **argv)
     EXPECT_EQUAL(nanoseconds, 10);
     EXPECT_EQUAL(mock_time, 40); /* Work-around for cppcheck complaining that mock_time is never read after being set */
 
+    EXPECT_SUCCESS(s2n_config_free(config));
+
     END_TEST();
 }

--- a/tests/unit/s2n_x509_validator_test.c
+++ b/tests/unit/s2n_x509_validator_test.c
@@ -165,6 +165,7 @@ int main(int argc, char **argv) {
         s2n_stuffer_free(&chain_stuffer);
         EXPECT_EQUAL(S2N_CERT_TYPE_RSA_SIGN, cert_type);
         s2n_connection_free(connection);
+        s2n_pkey_free(&public_key_out);
         s2n_x509_validator_wipe(&validator);
     }
 
@@ -189,6 +190,7 @@ int main(int argc, char **argv) {
         s2n_stuffer_free(&chain_stuffer);
         EXPECT_EQUAL(S2N_CERT_TYPE_RSA_SIGN, cert_type);
         s2n_connection_free(connection);
+        s2n_pkey_free(&public_key_out);
         s2n_x509_validator_wipe(&validator);
     }
 
@@ -235,6 +237,7 @@ int main(int argc, char **argv) {
 
         EXPECT_EQUAL(S2N_CERT_ERR_UNTRUSTED, err_code);
         s2n_connection_free(connection);
+        s2n_pkey_free(&public_key_out);
         s2n_x509_validator_wipe(&validator);
         s2n_x509_trust_store_wipe(&trust_store);
     }
@@ -269,6 +272,7 @@ int main(int argc, char **argv) {
         EXPECT_EQUAL(1, verify_data.callback_invoked);
         EXPECT_EQUAL(S2N_CERT_TYPE_RSA_SIGN, cert_type);
         s2n_connection_free(connection);
+        s2n_pkey_free(&public_key_out);
 
         s2n_x509_validator_wipe(&validator);
         s2n_x509_trust_store_wipe(&trust_store);
@@ -305,6 +309,7 @@ int main(int argc, char **argv) {
         EXPECT_EQUAL(0, verify_data.callback_invoked);
         EXPECT_EQUAL(S2N_CERT_TYPE_RSA_SIGN, cert_type);
         s2n_connection_free(connection);
+        s2n_pkey_free(&public_key_out);
 
         s2n_x509_validator_wipe(&validator);
         s2n_x509_trust_store_wipe(&trust_store);
@@ -344,6 +349,7 @@ int main(int argc, char **argv) {
         EXPECT_EQUAL(1, verify_data.callback_invoked);
         s2n_config_set_wall_clock(connection->config, old_clock, NULL);
         s2n_connection_free(connection);
+        s2n_pkey_free(&public_key_out);
 
         s2n_x509_validator_wipe(&validator);
         s2n_x509_trust_store_wipe(&trust_store);
@@ -380,6 +386,7 @@ int main(int argc, char **argv) {
 
         EXPECT_EQUAL(1, verify_data.callback_invoked);
         s2n_connection_free(connection);
+        s2n_pkey_free(&public_key_out);
         s2n_x509_validator_wipe(&validator);
         s2n_x509_trust_store_wipe(&trust_store);
     }
@@ -413,6 +420,7 @@ int main(int argc, char **argv) {
         s2n_stuffer_free(&chain_stuffer);
         EXPECT_EQUAL(1, verify_data.callback_invoked);
         s2n_connection_free(connection);
+        s2n_pkey_free(&public_key_out);
         s2n_x509_validator_wipe(&validator);
         s2n_x509_trust_store_wipe(&trust_store);
     }
@@ -448,6 +456,7 @@ int main(int argc, char **argv) {
         EXPECT_EQUAL(S2N_CERT_TYPE_RSA_SIGN, cert_type);
 
         s2n_connection_free(connection);
+        s2n_pkey_free(&public_key_out);
         s2n_x509_validator_wipe(&validator);
         s2n_x509_trust_store_wipe(&trust_store);
     }
@@ -487,6 +496,7 @@ int main(int argc, char **argv) {
         EXPECT_EQUAL(S2N_CERT_TYPE_RSA_SIGN, cert_type);
 
         s2n_connection_free(connection);
+        s2n_pkey_free(&public_key_out);
         s2n_x509_validator_wipe(&validator);
         s2n_x509_trust_store_wipe(&trust_store);
     }
@@ -527,6 +537,7 @@ int main(int argc, char **argv) {
         EXPECT_EQUAL(S2N_CERT_TYPE_RSA_SIGN, cert_type);
 
         s2n_connection_free(connection);
+        s2n_pkey_free(&public_key_out);
         s2n_x509_validator_wipe(&validator);
         s2n_x509_trust_store_wipe(&trust_store);
     }
@@ -567,6 +578,7 @@ int main(int argc, char **argv) {
         EXPECT_EQUAL(S2N_CERT_TYPE_RSA_SIGN, cert_type);
 
         s2n_connection_free(connection);
+        s2n_pkey_free(&public_key_out);
         s2n_x509_validator_wipe(&validator);
         s2n_x509_trust_store_wipe(&trust_store);
     }
@@ -609,6 +621,7 @@ int main(int argc, char **argv) {
                                                                                           ocsp_data_len));
         s2n_stuffer_free(&ocsp_data_stuffer);
         s2n_connection_free(connection);
+        s2n_pkey_free(&public_key_out);
         s2n_x509_validator_wipe(&validator);
         s2n_x509_trust_store_wipe(&trust_store);
     }
@@ -641,6 +654,7 @@ int main(int argc, char **argv) {
         s2n_stuffer_free(&chain_stuffer);
         EXPECT_EQUAL(S2N_CERT_TYPE_RSA_SIGN, cert_type);
         s2n_connection_free(connection);
+        s2n_pkey_free(&public_key_out);
 
         s2n_x509_validator_wipe(&validator);
         s2n_x509_trust_store_wipe(&trust_store);
@@ -674,6 +688,7 @@ int main(int argc, char **argv) {
         s2n_stuffer_free(&chain_stuffer);
         EXPECT_EQUAL(S2N_CERT_TYPE_RSA_SIGN, cert_type);
         s2n_connection_free(connection);
+        s2n_pkey_free(&public_key_out);
 
         s2n_x509_validator_wipe(&validator);
         s2n_x509_trust_store_wipe(&trust_store);
@@ -707,6 +722,7 @@ int main(int argc, char **argv) {
         s2n_stuffer_free(&chain_stuffer);
         EXPECT_EQUAL(S2N_CERT_TYPE_RSA_SIGN, cert_type);
         s2n_connection_free(connection);
+        s2n_pkey_free(&public_key_out);
 
         s2n_x509_validator_wipe(&validator);
         s2n_x509_trust_store_wipe(&trust_store);
@@ -738,6 +754,7 @@ int main(int argc, char **argv) {
         s2n_stuffer_free(&chain_stuffer);
         EXPECT_EQUAL(S2N_CERT_TYPE_RSA_SIGN, cert_type);
         s2n_connection_free(connection);
+        s2n_pkey_free(&public_key_out);
 
         s2n_x509_validator_wipe(&validator);
         s2n_x509_trust_store_wipe(&trust_store);
@@ -785,6 +802,7 @@ int main(int argc, char **argv) {
         s2n_config_set_wall_clock(connection->config, old_clock, NULL);
         s2n_stuffer_free(&ocsp_data_stuffer);
         s2n_connection_free(connection);
+        s2n_pkey_free(&public_key_out);
         s2n_x509_validator_wipe(&validator);
         s2n_x509_trust_store_wipe(&trust_store);
     }
@@ -833,6 +851,7 @@ int main(int argc, char **argv) {
 
         s2n_stuffer_free(&ocsp_data_stuffer);
         s2n_connection_free(connection);
+        s2n_pkey_free(&public_key_out);
         s2n_x509_validator_wipe(&validator);
         s2n_x509_trust_store_wipe(&trust_store);
     }
@@ -881,6 +900,7 @@ int main(int argc, char **argv) {
 
         s2n_stuffer_free(&ocsp_data_stuffer);
         s2n_connection_free(connection);
+        s2n_pkey_free(&public_key_out);
         s2n_x509_validator_wipe(&validator);
         s2n_x509_trust_store_wipe(&trust_store);
     }

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -78,8 +78,9 @@ static inline void* trace_memcpy_check(void *restrict to, const void *restrict f
     lt_check(__tmp_n, high);                    \
   } while (0)
 
-#define GUARD( x )      if ( (x) < 0 ) return -1
-#define GUARD_PTR( x )  if ( (x) < 0 ) return NULL
+#define GUARD( x )              if ( (x) < 0 ) return -1
+#define GUARD_GOTO( x , label ) if ( (x) < 0 ) goto label;
+#define GUARD_PTR( x )          if ( (x) < 0 ) return NULL
 
 /* TODO: use the OSSL error code in error reporting https://github.com/awslabs/s2n/issues/705 */
 #define GUARD_OSSL( x , errcode )			\


### PR DESCRIPTION
Mainly fixes for memleaks which happen due to bugs in unit tests + 1 memleak fix in s2n_ecdsa_keys_match. I've added macros GUARD_GOTO to simplify releasing resources a bit, but better proposals are welcome. I've tried adding macros to generate cleanup sections like this:

```c
#define CLEANUP(x) \
    goto cleanup;
    failed: \
    x \
    return -1; \
    cleanup: \
    x

int s2n_some_function() {
    ...
    GUARD_CLEANUP(s2n_some_other_function());
    ...
    CLEANUP(
        s2n_release_resources_here();
    );
    return 0;
}
```

But wasn't super happy with it, as macros becomes a bit non-obvious when reading the code.

There are still some memory leaks similar to s2n_ecdsa_keys_match, but I didn't want to fix those before we settle on a pattern to handle such scenarios.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
