### PR TITLE
Fix goto guards

### DIFF
--- a/tests/sidewinder/working/patches/safety1.patch
+++ b/tests/sidewinder/working/patches/safety1.patch
@@ -80,7 +80,7 @@
    } while (0)
  
 -#define GUARD( x )              if ( (x) < 0 ) return -1
--#define GUARD_GOTO( x , label ) if ( (x) < 0 ) goto label;
+-#define GUARD_GOTO( x , label ) if ( (x) < 0 ) goto label
 -#define GUARD_PTR( x )          if ( (x) < 0 ) return NULL
 +#define GUARD( x )              __VERIFIER_assume( (x) >= 0 )
 +#define GUARD_GOTO( x , label ) __VERIFIER_assume( (x) >= 0 )

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -79,7 +79,7 @@ static inline void* trace_memcpy_check(void *restrict to, const void *restrict f
   } while (0)
 
 #define GUARD( x )              if ( (x) < 0 ) return -1
-#define GUARD_GOTO( x , label ) if ( (x) < 0 ) goto label;
+#define GUARD_GOTO( x , label ) if ( (x) < 0 ) goto label
 #define GUARD_PTR( x )          if ( (x) < 0 ) return NULL
 
 /* TODO: use the OSSL error code in error reporting https://github.com/awslabs/s2n/issues/705 */


### PR DESCRIPTION
**Issue # (if available):** 

**Description of changes:** 
There is an extra ";" at the end of GUARD_GOTO. This could cause confusion when the macro is used.  Removed the ";", and fix the sidewinder patch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
