### PR TITLE
Bug fix while populating extensions from client hello and api updates

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -122,14 +122,14 @@ extern int s2n_config_set_client_hello_cb(struct s2n_config *config, s2n_client_
 
 struct s2n_client_hello;
 extern struct s2n_client_hello *s2n_connection_get_client_hello(struct s2n_connection *conn);
-extern uint32_t s2n_client_hello_get_raw_message_length(struct s2n_client_hello *ch);
-extern uint32_t s2n_client_hello_get_raw_message(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);
-extern uint32_t s2n_client_hello_get_cipher_suites_length(struct s2n_client_hello *ch);
-extern uint32_t s2n_client_hello_get_cipher_suites(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);
-extern uint32_t s2n_client_hello_get_extensions_length(struct s2n_client_hello *ch);
-extern uint32_t s2n_client_hello_get_extensions(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);
-extern int s2n_client_hello_get_extension_length(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type);
-extern int s2n_client_hello_get_extension_by_id(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type, uint8_t *out, uint32_t max_length);
+extern ssize_t s2n_client_hello_get_raw_message_length(struct s2n_client_hello *ch);
+extern ssize_t s2n_client_hello_get_raw_message(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);
+extern ssize_t s2n_client_hello_get_cipher_suites_length(struct s2n_client_hello *ch);
+extern ssize_t s2n_client_hello_get_cipher_suites(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);
+extern ssize_t s2n_client_hello_get_extensions_length(struct s2n_client_hello *ch);
+extern ssize_t s2n_client_hello_get_extensions(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);
+extern ssize_t s2n_client_hello_get_extension_length(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type);
+extern ssize_t s2n_client_hello_get_extension_by_id(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type, uint8_t *out, uint32_t max_length);
 
 extern int s2n_connection_set_fd(struct s2n_connection *conn, int fd);
 extern int s2n_connection_set_read_fd(struct s2n_connection *conn, int readfd);

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -986,8 +986,8 @@ Earliest point during the handshake when this structure is available for use is 
 ### s2n\_client\_hello\_get\_raw\_message
 
 ```c
-uint32_t s2n_client_hello_get_raw_message_length(struct s2n_client_hello *ch);
-uint32_t s2n_client_hello_get_raw_message(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);
+ssize_t s2n_client_hello_get_raw_message_length(struct s2n_client_hello *ch);
+ssize_t s2n_client_hello_get_raw_message(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);
 ```
 
 - **ch** The s2n_client_hello on the s2n_connection. The handle can be obtained using **s2n_connection_get_client_hello**.
@@ -1001,8 +1001,8 @@ The ClientHello instrumented using this function will have the Random bytes zero
 ### s2n\_client\_hello\_get\_cipher\_suites
 
 ```c
-uint32_t s2n_client_hello_get_cipher_suites_length(struct s2n_client_hello *ch);
-uint32_t s2n_client_hello_get_cipher_suites(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);
+ssize_t s2n_client_hello_get_cipher_suites_length(struct s2n_client_hello *ch);
+ssize_t s2n_client_hello_get_cipher_suites(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);
 ```
 
 - **ch** The s2n_client_hello on the s2n_connection. The handle can be obtained using **s2n_connection_get_client_hello**.
@@ -1015,8 +1015,8 @@ uint32_t s2n_client_hello_get_cipher_suites(struct s2n_client_hello *ch, uint8_t
 ### s2n\_client\_hello\_get\_extensions
 
 ```c
-uint32_t s2n_client_hello_get_extensions_length(struct s2n_client_hello *ch);
-uint32_t s2n_client_hello_get_extensions(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);
+ssize_t s2n_client_hello_get_extensions_length(struct s2n_client_hello *ch);
+ssize_t s2n_client_hello_get_extensions(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);
 ```
 
 - **ch** The s2n_client_hello on the s2n_connection. The handle can be obtained using **s2n_connection_get_client_hello**.
@@ -1029,8 +1029,8 @@ uint32_t s2n_client_hello_get_extensions(struct s2n_client_hello *ch, uint8_t *o
 ### s2n\_client\_hello\_get\_extension
 
 ```c
-int s2n_client_hello_get_extension_length(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type);
-int s2n_client_hello_get_extension_by_id(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type, uint8_t *out, uint32_t max_length);
+ssize_t s2n_client_hello_get_extension_length(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type);
+ssize_t s2n_client_hello_get_extension_by_id(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type, uint8_t *out, uint32_t max_length);
 ```
 
 - **ch** The s2n_client_hello on the s2n_connection. The handle can be obtained using **s2n_connection_get_client_hello**.

--- a/tests/integration/s2n_handshake_test_gnutls.py
+++ b/tests/integration/s2n_handshake_test_gnutls.py
@@ -169,6 +169,10 @@ def main():
             if ssl_version < cipher_vers:
                 continue
 
+            # gnutls-cli always adds tls extensions to client hello, add NO_EXTENSIONS flag for SSLv3 to avoid that
+            if ssl_version == S2N_SSLv3:
+                cipher_priority_str = cipher_priority_str + ":%NO_EXTENSIONS"
+
             # Add the SSL version to make the cipher priority string fully qualified
             complete_priority_str = cipher_priority_str + ":+" + S2N_PROTO_VERS_TO_GNUTLS[ssl_version] + ":+SIGN-ALL"
 

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -374,6 +374,24 @@ int main(int argc, char **argv)
         free(sent_client_hello);
     }
 
+    /* Client hello api with NULL inputs */
+    {
+        uint32_t len = 128;
+        uint8_t *out;
+        EXPECT_NOT_NULL(out = malloc(len));
+
+        EXPECT_FAILURE(s2n_client_hello_get_raw_message_length(NULL));
+        EXPECT_FAILURE(s2n_client_hello_get_raw_message(NULL, out, len));
+        EXPECT_FAILURE(s2n_client_hello_get_cipher_suites_length(NULL));
+        EXPECT_FAILURE(s2n_client_hello_get_cipher_suites(NULL, out, len));
+        EXPECT_FAILURE(s2n_client_hello_get_extensions_length(NULL));
+        EXPECT_FAILURE(s2n_client_hello_get_extensions(NULL, out, len));
+        EXPECT_FAILURE(s2n_client_hello_get_extension_length(NULL, S2N_EXTENSION_SERVER_NAME));
+        EXPECT_FAILURE(s2n_client_hello_get_extension_by_id(NULL, S2N_EXTENSION_SERVER_NAME, out, len));
+        free(out);
+        out = NULL;
+    }
+
     free(cert_chain);
     free(private_key);
     END_TEST();

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -51,13 +51,13 @@ static uint32_t min_size(struct s2n_blob *blob, uint32_t max_length) {
     return blob->size < max_length ? blob->size : max_length;
 }
 
-uint32_t s2n_client_hello_get_raw_message_length(struct s2n_client_hello *ch) {
+ssize_t s2n_client_hello_get_raw_message_length(struct s2n_client_hello *ch) {
     notnull_check(ch);
 
     return ch->raw_message.blob.size;
 }
 
-uint32_t s2n_client_hello_get_raw_message(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length)
+ssize_t s2n_client_hello_get_raw_message(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length)
 {
     notnull_check(ch);
     notnull_check(out);
@@ -71,13 +71,13 @@ uint32_t s2n_client_hello_get_raw_message(struct s2n_client_hello *ch, uint8_t *
     return len;
 }
 
-uint32_t s2n_client_hello_get_cipher_suites_length(struct s2n_client_hello *ch) {
+ssize_t s2n_client_hello_get_cipher_suites_length(struct s2n_client_hello *ch) {
     notnull_check(ch);
 
     return ch->cipher_suites.size;
 }
 
-uint32_t s2n_client_hello_get_cipher_suites(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length)
+ssize_t s2n_client_hello_get_cipher_suites(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length)
 {
     notnull_check(ch);
     notnull_check(out);
@@ -90,13 +90,13 @@ uint32_t s2n_client_hello_get_cipher_suites(struct s2n_client_hello *ch, uint8_t
     return len;
 }
 
-uint32_t s2n_client_hello_get_extensions_length(struct s2n_client_hello *ch) {
+ssize_t s2n_client_hello_get_extensions_length(struct s2n_client_hello *ch) {
     notnull_check(ch);
 
     return ch->extensions.size;
 }
 
-uint32_t s2n_client_hello_get_extensions(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length)
+ssize_t s2n_client_hello_get_extensions(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length)
 {
     notnull_check(ch);
     notnull_check(out);
@@ -244,6 +244,11 @@ static int s2n_parsed_extensions_compare(const void *p, const void *q)
 
 static int s2n_populate_client_hello_extensions(struct s2n_client_hello *ch)
 {
+    if (ch->extensions.size == 0) {
+        /* Client hello with no extensions, might be SSLv3, exit early */
+        return 0;
+    }
+
     if (ch->parsed_extensions == NULL) {
         notnull_check(ch->parsed_extensions = s2n_array_new(sizeof(struct s2n_client_hello_parsed_extension)));
     }
@@ -435,7 +440,7 @@ static void *s2n_client_hello_get_parsed_extension(struct s2n_array *parsed_exte
             parsed_extensions->element_size, s2n_parsed_extensions_compare);
 }
 
-int s2n_client_hello_get_extension_length(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type)
+ssize_t s2n_client_hello_get_extension_length(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type)
 {
     notnull_check(ch);
     notnull_check(ch->parsed_extensions);
@@ -449,7 +454,7 @@ int s2n_client_hello_get_extension_length(struct s2n_client_hello *ch, s2n_tls_e
     return 0;
 }
 
-int s2n_client_hello_get_extension_by_id(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type, uint8_t *out, uint32_t max_length)
+ssize_t s2n_client_hello_get_extension_by_id(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type, uint8_t *out, uint32_t max_length)
 {
     notnull_check(ch);
     notnull_check(out);

--- a/tls/s2n_client_hello.h
+++ b/tls/s2n_client_hello.h
@@ -41,11 +41,11 @@ int s2n_client_hello_free_parsed_extensions(struct s2n_client_hello *client_hell
 
 extern struct s2n_client_hello *s2n_connection_get_client_hello(struct s2n_connection *conn);
 
-extern uint32_t s2n_client_hello_get_raw_message_length(struct s2n_client_hello *ch);
-extern uint32_t s2n_client_hello_get_raw_message(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);
+extern ssize_t s2n_client_hello_get_raw_message_length(struct s2n_client_hello *ch);
+extern ssize_t s2n_client_hello_get_raw_message(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);
 
-extern uint32_t s2n_client_hello_get_cipher_suites_length(struct s2n_client_hello *ch);
-extern uint32_t s2n_client_hello_get_cipher_suites(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);
+extern ssize_t s2n_client_hello_get_cipher_suites_length(struct s2n_client_hello *ch);
+extern ssize_t s2n_client_hello_get_cipher_suites(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);
 
-extern uint32_t s2n_client_hello_get_extensions_length(struct s2n_client_hello *ch);
-extern uint32_t s2n_client_hello_get_extensions(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);
+extern ssize_t s2n_client_hello_get_extensions_length(struct s2n_client_hello *ch);
+extern ssize_t s2n_client_hello_get_extensions(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);


### PR DESCRIPTION
This PR includes:
1/ Bug fix while populating extensions from a client hello with empty extensions.
2/ Update the return type for some APIs in client hello where we have a possibility of returning -1

Updated s2n_handshake_test_gnutls.py first and integration tests get stuck while running SSLv3 cipher tests, fixed extensions population bug and integration tests succeed. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
