### PR TITLE
Session resumption fix

### DIFF
--- a/tests/unit/s2n_self_talk_session_resumption_test.c
+++ b/tests/unit/s2n_self_talk_session_resumption_test.c
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "testlib/s2n_testlib.h"
+
+#include <sys/wait.h>
+#include <unistd.h>
+#include <stdint.h>
+
+#include <s2n.h>
+
+#include "tls/s2n_connection.h"
+#include "tls/s2n_handshake.h"
+
+static const char SESSION_ID[] = "0123456789abcdef0123456789abcdef";
+static const char MSG[] = "Test";
+
+void mock_client(int writefd, int readfd)
+{
+    struct s2n_connection *conn;
+    struct s2n_config *config;
+    s2n_blocked_status blocked;
+    int result = 0;
+
+    /* Give the server a chance to listen */
+    sleep(1);
+
+    conn = s2n_connection_new(S2N_CLIENT);
+    config = s2n_config_new();
+    s2n_config_disable_x509_verification(config);
+    s2n_connection_set_config(conn, config);
+    conn->server_protocol_version = S2N_TLS12;
+    conn->client_protocol_version = S2N_TLS12;
+    conn->actual_protocol_version = S2N_TLS12;
+
+    s2n_connection_set_read_fd(conn, readfd);
+    s2n_connection_set_write_fd(conn, writefd);
+
+    /* Set non-empty session id to indicate that we want to try to resume session */
+    memcpy(conn->session_id, SESSION_ID, S2N_TLS_SESSION_ID_MAX_LEN);
+    conn->session_id_len = S2N_TLS_SESSION_ID_MAX_LEN;
+
+    if (s2n_negotiate(conn, &blocked) != 0) {
+        result = 1;
+    }
+
+    /* Now ensure that we got a new session id since server forced full handshake */
+    if (memcmp(conn->session_id, SESSION_ID, S2N_TLS_SESSION_ID_MAX_LEN) == 0) {
+        result = 2;
+    }
+
+    if (s2n_send(conn, MSG, sizeof(MSG), &blocked) != sizeof(MSG)) {
+        result = 3;
+    }
+
+    int shutdown_rc = -1;
+    while(shutdown_rc != 0) {
+        shutdown_rc = s2n_shutdown(conn, &blocked);
+    }
+
+    s2n_connection_free(conn);
+    s2n_config_free(config);
+
+    /* Give the server a chance to a void a sigpipe */
+    sleep(1);
+
+    _exit(result);
+}
+
+int main(int argc, char **argv)
+{
+    struct s2n_connection *conn;
+    struct s2n_config *config;
+    s2n_blocked_status blocked;
+    int status;
+    pid_t pid;
+    int server_to_client[2];
+    int client_to_server[2];
+    char *cert_chain_pem;
+    char *private_key_pem;
+
+    BEGIN_TEST();
+    EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+
+    EXPECT_SUCCESS(setenv("S2N_ENABLE_CLIENT_MODE", "1", 0));
+
+    /* Create a pipe */
+    EXPECT_SUCCESS(pipe(server_to_client));
+    EXPECT_SUCCESS(pipe(client_to_server));
+
+    /* Create a child process */
+    pid = fork();
+    if (pid == 0) {
+        /* This is the child process, close the read end of the pipe */
+        EXPECT_SUCCESS(close(client_to_server[0]));
+        EXPECT_SUCCESS(close(server_to_client[1]));
+
+        /* Write the fragmented hello message */
+        mock_client(client_to_server[1], server_to_client[0]);
+    }
+
+    /* This is the parent */
+    EXPECT_SUCCESS(close(client_to_server[1]));
+    EXPECT_SUCCESS(close(server_to_client[0]));
+
+    EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+    conn->server_protocol_version = S2N_TLS12;
+    conn->client_protocol_version = S2N_TLS12;
+    conn->actual_protocol_version = S2N_TLS12;
+
+    EXPECT_NOT_NULL(config = s2n_config_new());
+
+    EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key(config, cert_chain_pem, private_key_pem));
+
+    EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+    /* Set up the connection to read from the fd */
+    EXPECT_SUCCESS(s2n_connection_set_read_fd(conn, client_to_server[0]));
+    EXPECT_SUCCESS(s2n_connection_set_write_fd(conn, server_to_client[1]));
+
+    /* Negotiate the handshake. */
+    EXPECT_SUCCESS(s2n_negotiate(conn, &blocked));
+
+    /* Ensure the message was deivered */
+    char buffer[256];
+    int bytes_read;
+    EXPECT_SUCCESS(bytes_read = s2n_recv(conn, buffer, sizeof(buffer), &blocked));
+    EXPECT_EQUAL(bytes_read, sizeof(MSG));
+    EXPECT_EQUAL(memcmp(buffer, MSG, sizeof(MSG)), 0);
+
+    /* Shutdown handshake */
+    int shutdown_rc = -1;
+    do {
+        shutdown_rc = s2n_shutdown(conn, &blocked);
+        EXPECT_TRUE(shutdown_rc == 0 || (errno == EAGAIN && blocked));
+    } while(shutdown_rc != 0);
+
+    EXPECT_SUCCESS(s2n_connection_free(conn));
+
+    EXPECT_SUCCESS(s2n_config_free(config));
+
+    /* Clean up */
+    EXPECT_EQUAL(waitpid(-1, &status, 0), pid);
+    EXPECT_EQUAL(status, 0);
+
+    free(cert_chain_pem);
+    free(private_key_pem);
+
+    END_TEST();
+    return 0;
+}

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -305,20 +305,14 @@ int s2n_conn_set_handshake_type(struct s2n_connection *conn)
     /* A handshake type has been negotiated */
     conn->handshake.handshake_type = NEGOTIATED;
 
-    if (s2n_allowed_to_cache_connection(conn)) {
-        /* If a TLS session is resumed, the Server should respond in its ServerHello with the same SessionId the
-         * Client sent in the ClientHello, otherwise the Server should respond with a new SessionId. */
-        if (!s2n_resume_from_cache(conn)) {
-            return 0;
-        } else {
-            GUARD(s2n_generate_new_client_session_id(conn));
-        }
-    } else {
-        /* Per RFC5246 7.4.1.3: The server may return an empty session_id to indicate that the session will not be
-         * cached and therefore cannot be resumed. However some clients don't handle empty session ids in
-         * ServerHello well, so instead of removing generate a new id. */
-        GUARD(s2n_generate_new_client_session_id(conn));
+    /* If a TLS session is resumed, the Server should respond in its ServerHello with the same SessionId the
+     * Client sent in the ClientHello. */
+    if (s2n_allowed_to_cache_connection(conn) && !s2n_resume_from_cache(conn)) {
+        return 0;
     }
+
+    /* If we're doing full handshake, generate a new session id. */
+    GUARD(s2n_generate_new_client_session_id(conn));
 
     /* If we get this far, it's a full handshake */
     conn->handshake.handshake_type |= FULL_HANDSHAKE;

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -38,7 +38,6 @@ int s2n_server_hello_recv(struct s2n_connection *conn)
 {
     struct s2n_stuffer *in = &conn->handshake.io;
     uint8_t compression_method;
-    uint8_t session_id[S2N_TLS_SESSION_ID_MAX_LEN];
     uint8_t session_id_len;
     uint16_t extensions_size;
     uint8_t protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN];
@@ -63,7 +62,7 @@ int s2n_server_hello_recv(struct s2n_connection *conn)
     S2N_ERROR_IF(session_id_len > S2N_TLS_SESSION_ID_MAX_LEN, S2N_ERR_BAD_MESSAGE);
 
     conn->session_id_len = session_id_len;
-    GUARD(s2n_stuffer_read_bytes(in, session_id, session_id_len));
+    GUARD(s2n_stuffer_read_bytes(in, conn->session_id, session_id_len));
     uint8_t *cipher_suite_wire = s2n_stuffer_raw_read(in, S2N_TLS_CIPHER_SUITE_LEN);
     notnull_check(cipher_suite_wire);
     GUARD(s2n_set_cipher_as_client(conn, cipher_suite_wire));


### PR DESCRIPTION
**Issue # (if available):** #746

**Description of changes:** 

2 changes:
1. Read session_id from ServerHello into conn->session_id: Mainly for testing, but can be reused in future for client session resumption
2. Generate new session id if session caching is disabled: Previously s2n would send session id which it received from ClientHello, making client think that we're doing abbreviated handshake. As result the handshake was failing. Fixes #746

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
