### PR TITLE
Remove the *_key_check function calls

### DIFF
--- a/crypto/s2n_ecdsa.c
+++ b/crypto/s2n_ecdsa.c
@@ -145,11 +145,6 @@ int s2n_evp_pkey_to_ecdsa_private_key(s2n_ecdsa_private_key *ecdsa_key, EVP_PKEY
     EC_KEY *ec_key = EVP_PKEY_get1_EC_KEY(evp_private_key);
     S2N_ERROR_IF(ec_key == NULL, S2N_ERR_DECODE_PRIVATE_KEY);
     
-    if (!EC_KEY_check_key(ec_key)) {
-        EC_KEY_free(ec_key);
-        S2N_ERROR(S2N_ERR_KEY_CHECK);
-    }
-
     ecdsa_key->ec_key = ec_key;
     return 0;
 }
@@ -158,11 +153,6 @@ int s2n_evp_pkey_to_ecdsa_public_key(s2n_ecdsa_public_key *ecdsa_key, EVP_PKEY *
 {
     EC_KEY *ec_key = EVP_PKEY_get1_EC_KEY(evp_public_key);
     S2N_ERROR_IF(ec_key == NULL, S2N_ERR_DECODE_CERTIFICATE);
-    
-    if (!EC_KEY_check_key(ec_key)) {
-        EC_KEY_free(ec_key);
-        S2N_ERROR(S2N_ERR_KEY_CHECK);
-    }
     
     ecdsa_key->ec_key = ec_key;
     return 0;

--- a/crypto/s2n_rsa.c
+++ b/crypto/s2n_rsa.c
@@ -200,11 +200,6 @@ int s2n_evp_pkey_to_rsa_private_key(s2n_rsa_private_key *rsa_key, EVP_PKEY *evp_
     RSA *rsa = EVP_PKEY_get1_RSA(evp_private_key);
     S2N_ERROR_IF(rsa == NULL, S2N_ERR_DECODE_PRIVATE_KEY);
     
-    if (!RSA_check_key(rsa)) {
-        RSA_free(rsa);
-        S2N_ERROR(S2N_ERR_KEY_CHECK);
-    }
-
     rsa_key->rsa = rsa;
     return 0;
 }


### PR DESCRIPTION
**Issue # (if available):** N/A

**Description of changes:** 

This change would make it the responsibility of the calling application to ensure keys are correctly formed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
