### PR TITLE
Add Better Error Message about prlimit for mlock errors

### DIFF
--- a/error/s2n_errno.c
+++ b/error/s2n_errno.c
@@ -40,7 +40,7 @@ struct s2n_error_translation EN[] = {
     {S2N_ERR_DECRYPT, "error decrypting data"},
     {S2N_ERR_MADVISE, "error calling madvise"},
     {S2N_ERR_ALLOC, "error allocating memory"},
-    {S2N_ERR_MLOCK, "error calling mlock"},
+    {S2N_ERR_MLOCK, "error calling mlock (Did you run prlimit?)"},
     {S2N_ERR_MUNLOCK, "error calling munlock"},
     {S2N_ERR_FSTAT, "error calling fstat"},
     {S2N_ERR_OPEN, "error calling open"},


### PR DESCRIPTION
**Issue # (if available):** https://github.com/awslabs/s2n/issues/677

**Description of changes:** Adds a Suggestion to the mlock error message. Helpful for new developers getting started that may not know about running prlimit on Ubuntu.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
