### PR TITLE
Fix s2n client accepting unpreferred sigalgs in ske

### DIFF
--- a/tls/s2n_server_key_exchange.c
+++ b/tls/s2n_server_key_exchange.c
@@ -58,9 +58,7 @@ static int s2n_ecdhe_server_key_recv(struct s2n_connection *conn)
     if (conn->actual_protocol_version == S2N_TLS12) {
         s2n_hash_algorithm hash_algorithm;
         s2n_signature_algorithm signature_algorithm;
-        int matched = s2n_get_signature_hash_pair_if_supported(in, &hash_algorithm, &signature_algorithm);
-
-        S2N_ERROR_IF(!matched, S2N_ERR_BAD_MESSAGE);
+        GUARD(s2n_get_signature_hash_pair_if_supported(in, &hash_algorithm, &signature_algorithm));
 
         GUARD(s2n_hash_init(&conn->secure.signature_hash, hash_algorithm));
     } else {
@@ -119,9 +117,7 @@ static int s2n_dhe_server_key_recv(struct s2n_connection *conn)
     if (conn->actual_protocol_version == S2N_TLS12) {
         s2n_hash_algorithm hash_algorithm;
         s2n_signature_algorithm signature_algorithm;
-        int matched = s2n_get_signature_hash_pair_if_supported(in, &hash_algorithm, &signature_algorithm);
-
-        S2N_ERROR_IF(!matched, S2N_ERR_BAD_MESSAGE);
+        GUARD(s2n_get_signature_hash_pair_if_supported(in, &hash_algorithm, &signature_algorithm));
 
         GUARD(s2n_hash_init(&conn->secure.signature_hash, hash_algorithm));
     } else {

--- a/tls/s2n_signature_algorithms.c
+++ b/tls/s2n_signature_algorithms.c
@@ -113,7 +113,7 @@ int s2n_get_signature_hash_pair_if_supported(struct s2n_stuffer *in, s2n_hash_al
         S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
     }
 
-    return hash_matched;
+    return 0;
 }
 
 int s2n_send_supported_signature_algorithms(struct s2n_stuffer *out)


### PR DESCRIPTION
Previously when calling ```s2n_get_signature_hash_pair_if_supported``` in server key exchange we accepted sigalg if result was non-zero and rejected sigalg if result was 0. However the only 2 values that function returns are -1 if match wasn't found and 1 if it was found. As result we always accepted any sigalg in ske.

This change adds GUARDs around ```s2n_get_signature_hash_pair_if_supported``` call and makes function return 0 in case of success.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
