### PR TITLE
Downgrade sslyze to 1.4.0

### DIFF
--- a/.travis/install_sslyze.sh
+++ b/.travis/install_sslyze.sh
@@ -15,7 +15,7 @@
 set -e
 
 pip install --user --upgrade pip setuptools
-pip install --user --upgrade nassl sslyze
+pip install --user --upgrade nassl sslyze==1.4.0
 
 which sslyze
 sslyze --version


### PR DESCRIPTION
1.4.1 is broken for python2

Fixes #754

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
