### PR TITLE
Support for additional ANSI String types for client-side certificate validation

### DIFF
--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -249,7 +249,14 @@ static uint8_t s2n_verify_host_information(struct s2n_x509_validator *validator,
                     char peer_cn[255];
                     static size_t peer_cn_size = sizeof(peer_cn);
                     memset_check(&peer_cn, 0, peer_cn_size);
-                    if (ASN1_STRING_type(common_name) == V_ASN1_UTF8STRING) {
+                    
+                    // X520CommonName allows the following ANSI string types per RFC 5280 Appendix A.1
+                    if (ASN1_STRING_type(common_name) == V_ASN1_TELETEXSTRING || 
+                        ASN1_STRING_type(common_name) == V_ASN1_PRINTABLESTRING ||
+                        ASN1_STRING_type(common_name) == V_ASN1_UNIVERSALSTRING ||
+                        ASN1_STRING_type(common_name) == V_ASN1_UTF8STRING ||
+                        ASN1_STRING_type(common_name) == V_ASN1_BMPSTRING ) {
+
                         size_t len = (size_t) ASN1_STRING_length(common_name);
 
                         lte_check(len, sizeof(peer_cn) - 1);


### PR DESCRIPTION
**Issue # (if available):** 
UTF8String is the recommended type, but not the only type that is used. Adding support for the other common types.

**Description of changes:** 
Add other types that are supported, the test for checking several top level domains would have caught this and is probably a good test to add.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
