### PR TITLE
Brute-force comparison test for s2n_constant_time_equals

### DIFF
--- a/tests/unit/s2n_safety_test.c
+++ b/tests/unit/s2n_safety_test.c
@@ -213,5 +213,23 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(s2n_constant_time_equals(b, e, sizeof(a)), 1);
     }
 
+    uint8_t x[1];
+    uint8_t y[1];
+
+    for (int i = 0; i < 256; i++) {
+        for (int j = 0; j < 256; j++) {
+           x[0] = i;
+           y[0] = j;
+
+           int expected = 0;
+
+           if (i == j) {
+                expected = 1;
+           }
+
+           EXPECT_EQUAL(s2n_constant_time_equals(x, y, sizeof(x)), expected);
+        }
+    }
+
     END_TEST();
 }


### PR DESCRIPTION
OpenSSL recently found an interesting security issue: crypto_memcmp
was comparing only the least significant bit on HPUX due to an
incorrect assembly implementation.

Our existing positive and negative test cases would not find an issue
like this (especially in the MSB).

This commit adds a test that a full brute-force comparison between
all possible 256 * 256 byte values.

**Issue # (if available):** 

**Description of changes:** 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
