### PR TITLE
Fix signature digest algorithm selection

### DIFF
--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -374,12 +374,6 @@ int s2n_client_hello_send(struct s2n_connection *conn)
     /* Write the extensions */
     GUARD(s2n_client_extensions_send(conn, out));
 
-    /* Default our signature digest algorithm to SHA1. Will be used when verifying a client certificate. */
-    conn->secure.conn_hash_alg = S2N_HASH_MD5_SHA1;
-    if (conn->actual_protocol_version == S2N_TLS12 || s2n_is_in_fips_mode()) {
-        conn->secure.conn_hash_alg = S2N_HASH_SHA1;
-    }
-
     return 0;
 }
 


### PR DESCRIPTION
1. Select signature digest algorithm in s2n_server_hello_recv when we know the actual_protocol_version. Previously we were failing handshakes for TLS prior to 1.2 version.
2. Use MD5 SHA1 only if auth_method is RSA.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
