### PR TITLE
Be lenient with record version for ClientHello

### DIFF
--- a/tests/unit/s2n_client_extensions_test.c
+++ b/tests/unit/s2n_client_extensions_test.c
@@ -265,8 +265,8 @@ int main(int argc, char **argv)
         uint8_t record_header[] = {
             /* Record type HANDSHAKE */
             0x16,
-            /* Protocol version TLS 1.2 */
-            0x03, 0x03,
+            /* Protocol version garbage value. s2n should still accept this. */
+            0x01, 0x01,
             /* Message len */
             (message_len >> 8) & 0xff, (message_len & 0xff),
         };


### PR DESCRIPTION
The RFC has suggestions about what a client should use for this field.
Client implementations may not obey this suggestion and use a garbage
value instead({0,0}).

**Issue # (if available):** 

**Description of changes:** 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
