### PR TITLE
Added reconnect option to s2n client and an integration test

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -181,6 +181,8 @@ extern int s2n_connection_get_client_cert_chain(struct s2n_connection *conn, uin
 extern int s2n_connection_set_session(struct s2n_connection *conn, const uint8_t *session, size_t length);
 extern int s2n_connection_get_session(struct s2n_connection *conn, uint8_t *session, size_t max_length);
 extern ssize_t s2n_connection_get_session_length(struct s2n_connection *conn);
+extern const uint8_t *s2n_connection_get_session_id(struct s2n_connection *conn);
+extern int s2n_connection_is_session_resumed(struct s2n_connection *conn);
 
 /* RFC's that define below values:
  *  - https://tools.ietf.org/html/rfc5246#section-7.4.4

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -181,7 +181,7 @@ extern int s2n_connection_get_client_cert_chain(struct s2n_connection *conn, uin
 extern int s2n_connection_set_session(struct s2n_connection *conn, const uint8_t *session, size_t length);
 extern int s2n_connection_get_session(struct s2n_connection *conn, uint8_t *session, size_t max_length);
 extern ssize_t s2n_connection_get_session_length(struct s2n_connection *conn);
-extern const uint8_t *s2n_connection_get_session_id(struct s2n_connection *conn);
+extern ssize_t s2n_connection_get_session_id_length(struct s2n_connection *conn);
 extern int s2n_connection_is_session_resumed(struct s2n_connection *conn);
 
 /* RFC's that define below values:

--- a/bin/echo.c
+++ b/bin/echo.c
@@ -92,6 +92,9 @@ int negotiate(struct s2n_connection *conn)
     }
 
     printf("Cipher negotiated: %s\n", s2n_connection_get_cipher(conn));
+    if (s2n_connection_is_session_resumed(conn)) {
+        printf("Resumed session\n");
+    }
 
     return 0;
 }

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -194,7 +194,6 @@ int cache_retrieve(void *ctx, const void *key, uint64_t key_size, void *value, u
     *value_size = cache[index].value_len;
     memcpy(value, cache[index].value, cache[index].value_len);
 
-    printf("Resumed session ");
     for (int i = 0; i < key_size; i++) {
         printf("%02x", ((const uint8_t *)key)[i]);
     }

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1118,6 +1118,8 @@ const char * s2n_connection_get_curve(struct s2n_connection *conn);
 int s2n_connection_set_session(struct s2n_connection *conn, const uint8_t *session, size_t length);
 int s2n_connection_get_session(struct s2n_connection *conn, uint8_t *session, size_t max_length);
 ssize_t s2n_connection_get_session_length(struct s2n_connection *conn);
+const uint8_t *s2n_connection_get_session_id(struct s2n_connection *conn);
+int s2n_connection_is_session_resumed(struct s2n_connection *conn);
 ```
 
 - **session** session will contain serialized session related information needed to resume handshake.
@@ -1129,6 +1131,10 @@ ssize_t s2n_connection_get_session_length(struct s2n_connection *conn);
 **s2n_connection_get_session** serializes the session state from connection and copies into the **session** buffer and returns the number of bytes that were copied.
 
 **s2n_connection_get_session_length** returns number of bytes needed to store serailized session state; it can be used to allocate the **session** buffer.
+
+**s2n_connection_get_session_id** returns session id from the connection if exists else returns null.
+
+**s2n_connection_is_session_resumed** checks if the handshake is abbreviated or not.
 
 ### s2n\_connection\_wipe
 

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1118,7 +1118,7 @@ const char * s2n_connection_get_curve(struct s2n_connection *conn);
 int s2n_connection_set_session(struct s2n_connection *conn, const uint8_t *session, size_t length);
 int s2n_connection_get_session(struct s2n_connection *conn, uint8_t *session, size_t max_length);
 ssize_t s2n_connection_get_session_length(struct s2n_connection *conn);
-const uint8_t *s2n_connection_get_session_id(struct s2n_connection *conn);
+ssize_t s2n_connection_get_session_id_length(struct s2n_connection *conn);
 int s2n_connection_is_session_resumed(struct s2n_connection *conn);
 ```
 
@@ -1132,7 +1132,7 @@ int s2n_connection_is_session_resumed(struct s2n_connection *conn);
 
 **s2n_connection_get_session_length** returns number of bytes needed to store serailized session state; it can be used to allocate the **session** buffer.
 
-**s2n_connection_get_session_id** returns session id from the connection if exists else returns null.
+**s2n_connection_get_session_id_length** returns session id length from the connection.
 
 **s2n_connection_is_session_resumed** checks if the handshake is abbreviated or not.
 

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -908,13 +908,10 @@ const char *s2n_get_application_protocol(struct s2n_connection *conn)
     return conn->application_protocol;
 }
 
-const uint8_t *s2n_connection_get_session_id(struct s2n_connection *conn)
+ssize_t s2n_connection_get_session_id_length(struct s2n_connection *conn)
 {
-    if (conn->session_id_len == 0) {
-        return NULL;
-    }
-
-    return conn->session_id;
+    notnull_check(conn);
+    return conn->session_id_len;
 }
 
 int s2n_connection_set_blinding(struct s2n_connection *conn, s2n_blinding blinding)

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -908,6 +908,15 @@ const char *s2n_get_application_protocol(struct s2n_connection *conn)
     return conn->application_protocol;
 }
 
+const uint8_t *s2n_connection_get_session_id(struct s2n_connection *conn)
+{
+    if (conn->session_id_len == 0) {
+        return NULL;
+    }
+
+    return conn->session_id;
+}
+
 int s2n_connection_set_blinding(struct s2n_connection *conn, s2n_blinding blinding)
 {
     conn->blinding = blinding;

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -282,3 +282,9 @@ ssize_t s2n_connection_get_session_length(struct s2n_connection *conn)
      */
     return 1 + 1 + conn->session_id_len + S2N_STATE_SIZE_IN_BYTES;
 }
+
+int s2n_connection_is_session_resumed(struct s2n_connection *conn)
+{
+    return IS_RESUMPTION_HANDSHAKE(conn->handshake.handshake_type);
+}
+


### PR DESCRIPTION
This includes following changes:

* Similar to openssl s_client added reconnect option to s2n client, when enabled client will try to connect to given end-point 6 (1 + 5 (resumed)) times each time dropping the connection and starting fresh, it will also use session resumption with session ids if available.
* Added integration test, now s2n client will connect to openssl server to check if we can resume sessions correctly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
