### PR TITLE
Fix for memory leaks seen during session resumption

### DIFF
--- a/tls/s2n_server_ccs.c
+++ b/tls/s2n_server_ccs.c
@@ -47,20 +47,12 @@ int s2n_server_ccs_recv(struct s2n_connection *conn)
     /* Flush any partial alert messages that were pending */
     GUARD(s2n_stuffer_wipe(&conn->alert_in));
 
-    if (IS_RESUMPTION_HANDSHAKE(conn->handshake.handshake_type)) {
-        GUARD(s2n_prf_key_expansion(conn));
-    }
-
     return 0;
 }
 
 int s2n_server_ccs_send(struct s2n_connection *conn)
 {
     GUARD(s2n_stuffer_write_uint8(&conn->handshake.io, CHANGE_CIPHER_SPEC_TYPE));
-
-    if (IS_RESUMPTION_HANDSHAKE(conn->handshake.handshake_type)) {
-        GUARD(s2n_prf_key_expansion(conn));
-    }
 
     return 0;
 }


### PR DESCRIPTION
s2n_prf_key_expansion is being called multiple times in-case of session resumption and resulted in memory leaks, removing the key expansion call from cipher change spec functions.

Without the fix  UNIT_TESTS=s2n_self_talk_session_resumption_test make valgrind shows below leaks in logs and with the fix I don't see them:
==6379== 680 bytes in 1 blocks are definitely lost in loss record 595 of 600
==6379==    at 0x4C2DBB6: malloc (vg_replace_malloc.c:299)
==6379==    by 0x5ADDE77: CRYPTO_malloc (in /lib/x86_64-linux-gnu/libcrypto.so.1.0.0)
==6379==    by 0x5B9B000: EVP_CipherInit_ex (in /lib/x86_64-linux-gnu/libcrypto.so.1.0.0)
==6379==    by 0x506AF28: s2n_aead_cipher_aes128_gcm_set_encryption_key (in /home/ubuntu/Desktop/s2n/lib/libs2n.so)
==6379==    by 0x5057D72: s2n_prf_key_expansion (in /home/ubuntu/Desktop/s2n/lib/libs2n.so)
==6379==    by 0x505F258: s2n_server_hello_recv (in /home/ubuntu/Desktop/s2n/lib/libs2n.so)
==6379==    by 0x5064966: handshake_read_io (in /home/ubuntu/Desktop/s2n/lib/libs2n.so)
==6379==    by 0x5064E9A: s2n_negotiate (in /home/ubuntu/Desktop/s2n/lib/libs2n.so)
==6379==    by 0x404FB7: mock_client (in /home/ubuntu/Desktop/s2n/tests/unit/s2n_self_talk_session_resumption_test)
==6379==    by 0x401500: main (in /home/ubuntu/Desktop/s2n/tests/unit/s2n_self_talk_session_resumption_test)
==6379==

==6378== 680 bytes in 1 blocks are definitely lost in loss record 47 of 51
==6378==    at 0x4C2DBB6: malloc (vg_replace_malloc.c:299)
==6378==    by 0x5ADDE77: CRYPTO_malloc (in /lib/x86_64-linux-gnu/libcrypto.so.1.0.0)
==6378==    by 0x5B9B000: EVP_CipherInit_ex (in /lib/x86_64-linux-gnu/libcrypto.so.1.0.0)
==6378==    by 0x506B078: s2n_aead_cipher_aes128_gcm_set_decryption_key (in /home/ubuntu/Desktop/s2n/lib/libs2n.so)
==6378==    by 0x5057B74: s2n_prf_key_expansion (in /home/ubuntu/Desktop/s2n/lib/libs2n.so)
==6378==    by 0x50683BF: s2n_server_ccs_send (in /home/ubuntu/Desktop/s2n/lib/libs2n.so)
==6378==    by 0x5064F4D: s2n_negotiate (in /home/ubuntu/Desktop/s2n/lib/libs2n.so)
==6378==    by 0x40172F: main (in /home/ubuntu/Desktop/s2n/tests/unit/s2n_self_talk_session_resumption_test)
==6378==

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
