### PR TITLE
Fix a crash in s2n_x509_trust_store_add_pem()

### DIFF
--- a/tests/unit/s2n_x509_validator_test.c
+++ b/tests/unit/s2n_x509_validator_test.c
@@ -1112,5 +1112,14 @@ int main(int argc, char **argv) {
         s2n_x509_trust_store_wipe(&trust_store);
     }
 
+    /* Test trust store in a configuration can handle invalid PEM without crashing */
+    {
+        struct s2n_config *cfg = s2n_config_new();
+        s2n_config_add_pem_to_trust_store(cfg, "");
+        s2n_config_free(cfg);
+        /* Expect no crash. */
+    }
+
+
     END_TEST();
 }

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -89,7 +89,7 @@ int s2n_x509_trust_store_add_pem(struct s2n_x509_trust_store *store, const char 
 
     struct s2n_stuffer pem_in_stuffer;
     struct s2n_stuffer der_out_stuffer;
-    struct s2n_blob next_cert;
+    struct s2n_blob next_cert = { 0 };
 
     GUARD_GOTO(s2n_stuffer_alloc_ro_from_string(&pem_in_stuffer, pem), clean_up);
     GUARD_GOTO(s2n_stuffer_growable_alloc(&der_out_stuffer, 2048), clean_up);


### PR DESCRIPTION
**Issue:** 

Without this patch, the following test crashes S2N:

    #include <s2n.h>

    int main() {
        struct s2n_config *cfg = s2n_config_new();
        s2n_config_add_pem_to_trust_store(cfg, "");
        s2n_config_free(cfg);
    }

This is because of a call to s2n_free() on an unitialized variable.

**Description of changes:** 

Fix the uninitialized use by initializing the `s2n_blob` to hold a `NULL` reference instead.
The commit also adds a regression test for this bug.

I verified that all unit tests that passed before on master still pass locally with the patch in place. Tested with LibreSSL and OpenSSL as libcrypto providers. Without the patch, the new unit test fails.