### PR TITLE
Update install_cppcheck.sh to use known working commit

### DIFF
--- a/.travis/install_cppcheck.sh
+++ b/.travis/install_cppcheck.sh
@@ -29,4 +29,8 @@ INSTALL_DIR=$1
 cd "$INSTALL_DIR"
 git clone https://github.com/danmar/cppcheck.git
 cd cppcheck
+
+# Last known working commit
+git checkout 3b8a3aa4b
+
 make


### PR DESCRIPTION
**Issue # (if available):** https://github.com/awslabs/s2n/issues/787

**Description of changes:** 
Updates `install_cppcheck.sh` script to use a known working commit until we update our `run_cppcheck.sh` script. 

Note that this fix will not work until the Travis build caches are cleared since the previous cppcheck builds are cached.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
