### PR TITLE
Zero Initialize all Structs before use

### DIFF
--- a/.travis/zero_init_struct_helper.sh
+++ b/.travis/zero_init_struct_helper.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
 
-#set -ex
 
 usage() {
     echo "init_structs.sh struct_name init_value"

--- a/.travis/zero_init_struct_helper.sh
+++ b/.travis/zero_init_struct_helper.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+#set -ex
+
+usage() {
+    echo "init_structs.sh struct_name init_value"
+    echo "Example: ./init_structs.sh s2n_blob {0}"
+    exit 1
+}
+
+if [ "$#" -ne "2" ]; then
+    usage
+fi
+
+STRUCT_NAME=$1
+INIT_VALUE=$2
+
+LINES_WITH_UNINITIALIZED_STRUCTS=`grep -En "struct ${STRUCT_NAME} [a-z0-9_]+;" ./**/s2n*.c | cut -d: -f1-2`;
+LINE_COUNT=`echo "$LINES_WITH_UNINITIALIZED_STRUCTS" | wc -l`
+WORD_COUNT=`echo "$LINES_WITH_UNINITIALIZED_STRUCTS" | wc -w`
+
+if [ $WORD_COUNT -eq 0 ]; then
+    echo "Found zero uninitialized ${STRUCT_NAME} structs."
+    exit
+fi
+
+echo "Found $LINE_COUNT uninitialized ${STRUCT_NAME} structs..."
+
+for line in $LINES_WITH_UNINITIALIZED_STRUCTS
+do
+  # Line Format: "${file_name}:${line_num}"
+  FILENAME=`echo "${line}" | cut -d: -f 1`
+  LINE_NUM=`echo "${line}" | cut -d: -f 2`
+  
+  # Use sed to replace ";" with " = {0};"
+  SED_ARGS="-i '' '${LINE_NUM}s/;/ = ${INIT_VALUE};/' ${FILENAME}"
+  echo "Initializing ${STRUCT_NAME} at ${FILENAME}:${LINE_NUM} with: ${INIT_VALUE}."
+  echo "${SED_ARGS}"| xargs sed;
+done

--- a/.travis/zero_init_structs.sh
+++ b/.travis/zero_init_structs.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+./.travis/zero_init_struct_helper.sh s2n_blob {0}
+./.travis/zero_init_struct_helper.sh s2n_stuffer {{0}}
+./.travis/zero_init_struct_helper.sh s2n_config {0}
+./.travis/zero_init_struct_helper.sh s2n_pkey {{{0}}}
+./.travis/zero_init_struct_helper.sh s2n_session_key {0}
+./.travis/zero_init_struct_helper.sh s2n_connection_prf_handles {{{{0}}}}
+./.travis/zero_init_struct_helper.sh s2n_connection_hash_handles {{{0}}}
+./.travis/zero_init_struct_helper.sh s2n_connection_hmac_handles {{{{0}}}}
+./.travis/zero_init_struct_helper.sh s2n_client_hello_parsed_extension {0}
+./.travis/zero_init_struct_helper.sh s2n_hash_state {0}
+./.travis/zero_init_struct_helper.sh s2n_dh_params {0}
+./.travis/zero_init_struct_helper.sh s2n_map {0}
+./.travis/zero_init_struct_helper.sh timespec {0}
+./.travis/zero_init_struct_helper.sh tm {0}
+./.travis/zero_init_struct_helper.sh stat {0}

--- a/.travis/zero_init_structs.sh
+++ b/.travis/zero_init_structs.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
 
 ./.travis/zero_init_struct_helper.sh s2n_blob {0}
 ./.travis/zero_init_struct_helper.sh s2n_stuffer {{0}}

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -663,7 +663,7 @@ int main(int argc, char *const *argv)
             exit(1);
         }
 
-        struct stat st;
+        struct stat st = {0};
         if (fstat(fd, &st) < 0) {
             fprintf(stderr, "Error fstat-ing OCSP response file: '%s'\n", strerror(errno));
             exit(1);

--- a/crypto/s2n_composite_cipher_aes_sha.c
+++ b/crypto/s2n_composite_cipher_aes_sha.c
@@ -114,7 +114,7 @@ static int s2n_composite_cipher_aes_sha_initial_hmac(struct s2n_session_key *key
 {
     uint8_t ctrl_buf[S2N_TLS12_AAD_LEN];
     struct s2n_blob ctrl_blob = { .data = ctrl_buf, .size = S2N_TLS12_AAD_LEN };
-    struct s2n_stuffer ctrl_stuffer;
+    struct s2n_stuffer ctrl_stuffer = {{0}};
     GUARD(s2n_stuffer_init(&ctrl_stuffer, &ctrl_blob));
 
     GUARD(s2n_stuffer_write_bytes(&ctrl_stuffer, sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));

--- a/crypto/s2n_dhe.c
+++ b/crypto/s2n_dhe.c
@@ -206,7 +206,7 @@ int s2n_dh_params_to_p_g_Ys(struct s2n_dh_params *server_dh_params, struct s2n_s
 
 int s2n_dh_compute_shared_secret_as_client(struct s2n_dh_params *server_dh_params, struct s2n_stuffer *Yc_out, struct s2n_blob *shared_key)
 {
-    struct s2n_dh_params client_params;
+    struct s2n_dh_params client_params = {0};
     uint8_t *client_pub_key;
     uint16_t client_pub_key_size;
     int shared_key_size;

--- a/crypto/s2n_ecc.c
+++ b/crypto/s2n_ecc.c
@@ -50,7 +50,7 @@ int s2n_ecc_generate_ephemeral_key(struct s2n_ecc_params *server_ecc_params)
 int s2n_ecc_write_ecc_params(struct s2n_ecc_params *server_ecc_params, struct s2n_stuffer *out, struct s2n_blob *written)
 {
     uint8_t point_len;
-    struct s2n_blob point;
+    struct s2n_blob point = {0};
 
     /* Remember when the written data starts */
     written->data = s2n_stuffer_raw_write(out, 0);
@@ -123,7 +123,7 @@ int s2n_ecc_read_ecc_params(struct s2n_ecc_params *server_ecc_params, struct s2n
 int s2n_ecc_compute_shared_secret_as_server(struct s2n_ecc_params *server_ecc_params, struct s2n_stuffer *Yc_in, struct s2n_blob *shared_key)
 {
     uint8_t client_public_len;
-    struct s2n_blob client_public_blob;
+    struct s2n_blob client_public_blob = {0};
     EC_POINT *client_public;
     int rc;
 
@@ -222,7 +222,7 @@ static int s2n_ecc_write_point_data_snug(const EC_POINT * point, const EC_GROUP 
 static int s2n_ecc_write_point_with_length(const EC_POINT * point, const EC_GROUP * group, struct s2n_stuffer *out)
 {
     uint8_t point_len;
-    struct s2n_blob point_blob;
+    struct s2n_blob point_blob = {0};
 
     GUARD(s2n_ecc_calculate_point_length(point, group, &point_len));
 
@@ -258,7 +258,7 @@ static int s2n_ecc_compute_shared_secret(EC_KEY * own_key, const EC_POINT * peer
 
 int s2n_ecc_find_supported_curve(struct s2n_blob *iana_ids, const struct s2n_ecc_named_curve **found)
 {
-    struct s2n_stuffer iana_ids_in;
+    struct s2n_stuffer iana_ids_in = {{0}};
 
     GUARD(s2n_stuffer_init(&iana_ids_in, iana_ids));
     GUARD(s2n_stuffer_write(&iana_ids_in, iana_ids));

--- a/crypto/s2n_ecdsa.c
+++ b/crypto/s2n_ecdsa.c
@@ -83,7 +83,7 @@ static int s2n_ecdsa_verify(const struct s2n_pkey *pub, struct s2n_hash_state *d
 static int s2n_ecdsa_keys_match(const struct s2n_pkey *pub, const struct s2n_pkey *priv) 
 {
     uint8_t input[16];
-    struct s2n_blob random_input;
+    struct s2n_blob random_input = {0};
     struct s2n_blob signature = { 0 };
     struct s2n_hash_state state_in = { 0 }, state_out = { 0 };
 

--- a/stuffer/s2n_stuffer_file.c
+++ b/stuffer/s2n_stuffer_file.c
@@ -77,7 +77,7 @@ int s2n_stuffer_send_to_fd(struct s2n_stuffer *stuffer, int wfd, uint32_t len)
 
 int s2n_stuffer_alloc_ro_from_fd(struct s2n_stuffer *stuffer, int rfd)
 {
-    struct stat st;
+    struct stat st = {0};
 
     S2N_ERROR_IF(fstat(rfd, &st) < 0, S2N_ERR_FSTAT);
 

--- a/stuffer/s2n_stuffer_pem.c
+++ b/stuffer/s2n_stuffer_pem.c
@@ -76,7 +76,7 @@ static int s2n_stuffer_pem_read_contents(struct s2n_stuffer *pem, struct s2n_stu
 {
     uint8_t base64_buf[64] = { 0 };
     struct s2n_blob base64__blob = { .data = base64_buf, .size = sizeof(base64_buf) };
-    struct s2n_stuffer base64_stuffer;
+    struct s2n_stuffer base64_stuffer = {{0}};
     GUARD(s2n_stuffer_init(&base64_stuffer, &base64__blob));
 
     while (1) {

--- a/tls/s2n_client_cert.c
+++ b/tls/s2n_client_cert.c
@@ -31,7 +31,7 @@
 int s2n_client_cert_recv(struct s2n_connection *conn)
 {
     struct s2n_stuffer *in = &conn->handshake.io;
-    struct s2n_blob client_cert_chain;
+    struct s2n_blob client_cert_chain = {0};
 
     GUARD(s2n_stuffer_read_uint24(in, &client_cert_chain.size));
 

--- a/tls/s2n_client_cert_verify.c
+++ b/tls/s2n_client_cert_verify.c
@@ -39,12 +39,12 @@ int s2n_client_cert_verify_recv(struct s2n_connection *conn)
         GUARD(s2n_get_signature_hash_pair_if_supported(in, &chosen_hash_alg, &chosen_signature_alg));
     }
     uint16_t signature_size;
-    struct s2n_blob signature;
+    struct s2n_blob signature = {0};
     GUARD(s2n_stuffer_read_uint16(in, &signature_size));
     signature.size = signature_size;
     signature.data = s2n_stuffer_raw_read(in, signature.size);
     notnull_check(signature.data);
-    struct s2n_hash_state hash_state;
+    struct s2n_hash_state hash_state = {0};
     GUARD(s2n_handshake_get_hash_state(conn, chosen_hash_alg, &hash_state));
 
     switch (chosen_signature_alg) {
@@ -78,10 +78,10 @@ int s2n_client_cert_verify_send(struct s2n_connection *conn)
         GUARD(s2n_stuffer_write_uint8(out, (uint8_t) chosen_signature_alg));
     }
 
-    struct s2n_hash_state hash_state;
+    struct s2n_hash_state hash_state = {0};
     GUARD(s2n_handshake_get_hash_state(conn, chosen_hash_alg, &hash_state));
 
-    struct s2n_blob signature;
+    struct s2n_blob signature = {0};
 
     switch (chosen_signature_alg) {
     /* s2n currently only supports RSA Signatures */

--- a/tls/s2n_client_extensions.c
+++ b/tls/s2n_client_extensions.c
@@ -110,7 +110,7 @@ int s2n_client_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *
         /* Name type - host name, RFC3546 */
         GUARD(s2n_stuffer_write_uint8(out, 0));
 
-        struct s2n_blob server_name;
+        struct s2n_blob server_name = {0};
         server_name.data = (uint8_t *) conn->server_name;
         server_name.size = server_name_len;
         GUARD(s2n_stuffer_write_uint16(out, server_name_len));
@@ -179,7 +179,7 @@ int s2n_client_extensions_recv(struct s2n_connection *conn, struct s2n_array *pa
         struct s2n_client_hello_parsed_extension *parsed_extension = s2n_array_get(parsed_extensions, i);
         notnull_check(parsed_extension);
 
-        struct s2n_stuffer extension;
+        struct s2n_stuffer extension = {{0}};
         GUARD(s2n_stuffer_init(&extension, &parsed_extension->extension));
         GUARD(s2n_stuffer_write(&extension, &parsed_extension->extension));
 
@@ -267,8 +267,8 @@ static int s2n_recv_client_signature_algorithms(struct s2n_connection *conn, str
 static int s2n_recv_client_alpn(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
     uint16_t size_of_all;
-    struct s2n_stuffer client_protos;
-    struct s2n_stuffer server_protos;
+    struct s2n_stuffer client_protos = {{0}};
+    struct s2n_stuffer server_protos = {{0}};
 
     if (!conn->config->application_protocols.size) {
         /* No protocols configured, nothing to do */
@@ -341,7 +341,7 @@ static int s2n_recv_client_status_request(struct s2n_connection *conn, struct s2
 static int s2n_recv_client_elliptic_curves(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
     uint16_t size_of_all;
-    struct s2n_blob proposed_curves;
+    struct s2n_blob proposed_curves = {0};
 
     GUARD(s2n_stuffer_read_uint16(extension, &size_of_all));
     if (size_of_all > s2n_stuffer_data_available(extension) || size_of_all % 2) {

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -256,7 +256,7 @@ static int s2n_populate_client_hello_extensions(struct s2n_client_hello *ch)
         notnull_check(ch->parsed_extensions = s2n_array_new(sizeof(struct s2n_client_hello_parsed_extension)));
     }
 
-    struct s2n_stuffer in;
+    struct s2n_stuffer in = {{0}};
 
     GUARD(s2n_stuffer_init(&in, &ch->extensions));
     GUARD(s2n_stuffer_write(&in, &ch->extensions));
@@ -320,7 +320,7 @@ int s2n_client_hello_recv(struct s2n_connection *conn)
 int s2n_client_hello_send(struct s2n_connection *conn)
 {
     struct s2n_stuffer *out = &conn->handshake.io;
-    struct s2n_stuffer client_random;
+    struct s2n_stuffer client_random = {{0}};
     struct s2n_blob b, r;
     uint8_t client_protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN];
 
@@ -422,7 +422,7 @@ int s2n_sslv2_client_hello_recv(struct s2n_connection *conn)
         GUARD(s2n_stuffer_skip_read(in, session_id_length));
     }
 
-    struct s2n_blob b;
+    struct s2n_blob b = {0};
     b.data = conn->secure.client_random;
     b.size = S2N_TLS_RANDOM_DATA_LEN;
 
@@ -442,7 +442,7 @@ int s2n_client_hello_get_parsed_extension(struct s2n_array *parsed_extensions, s
 {
     notnull_check(parsed_extensions);
 
-    struct s2n_client_hello_parsed_extension search;
+    struct s2n_client_hello_parsed_extension search = {0};
     search.extension_type = extension_type;
 
     struct s2n_client_hello_parsed_extension *result_extension = bsearch(&search, parsed_extensions->elements, parsed_extensions->num_of_elements,
@@ -460,7 +460,7 @@ ssize_t s2n_client_hello_get_extension_length(struct s2n_client_hello *ch, s2n_t
     notnull_check(ch);
     notnull_check(ch->parsed_extensions);
 
-    struct s2n_client_hello_parsed_extension parsed_extension;
+    struct s2n_client_hello_parsed_extension parsed_extension = {0};
 
     if (s2n_client_hello_get_parsed_extension(ch->parsed_extensions, extension_type, &parsed_extension)) {
         return 0;
@@ -475,7 +475,7 @@ ssize_t s2n_client_hello_get_extension_by_id(struct s2n_client_hello *ch, s2n_tl
     notnull_check(out);
     notnull_check(ch->parsed_extensions);
 
-    struct s2n_client_hello_parsed_extension parsed_extension;
+    struct s2n_client_hello_parsed_extension parsed_extension = {0};
 
     if (s2n_client_hello_get_parsed_extension(ch->parsed_extensions, extension_type, &parsed_extension)) {
         return 0;

--- a/tls/s2n_client_key_exchange.c
+++ b/tls/s2n_client_key_exchange.c
@@ -89,7 +89,7 @@ static int s2n_rsa_client_key_recv(struct s2n_connection *conn)
 static int s2n_dhe_client_key_recv(struct s2n_connection *conn)
 {
     struct s2n_stuffer *in = &conn->handshake.io;
-    struct s2n_blob shared_key;
+    struct s2n_blob shared_key = {0};
 
     /* Get the shared key */
     if (conn->secure.cipher_suite->key_exchange_alg->flags & S2N_KEY_EXCHANGE_ECC) {
@@ -135,7 +135,7 @@ int s2n_client_key_recv(struct s2n_connection *conn)
 static int s2n_dhe_client_key_send(struct s2n_connection *conn)
 {
     struct s2n_stuffer *out = &conn->handshake.io;
-    struct s2n_blob shared_key;
+    struct s2n_blob shared_key = {0};
 
     if (conn->secure.cipher_suite->key_exchange_alg->flags & S2N_KEY_EXCHANGE_ECC) {
         GUARD(s2n_ecc_compute_shared_secret_as_client(&conn->secure.server_ecc_params, out, &shared_key));
@@ -174,7 +174,7 @@ static int s2n_rsa_client_key_send(struct s2n_connection *conn)
     client_protocol_version[0] = conn->client_protocol_version / 10;
     client_protocol_version[1] = conn->client_protocol_version % 10;
 
-    struct s2n_blob pms;
+    struct s2n_blob pms = {0};
     pms.data = conn->secure.rsa_premaster_secret;
     pms.size = S2N_TLS_SECRET_LEN;
 
@@ -190,7 +190,7 @@ static int s2n_rsa_client_key_send(struct s2n_connection *conn)
         GUARD(s2n_stuffer_write_uint16(&conn->handshake.io, encrypted_size));
     }
 
-    struct s2n_blob encrypted;
+    struct s2n_blob encrypted = {0};
     encrypted.data = s2n_stuffer_raw_write(&conn->handshake.io, encrypted_size);
     encrypted.size = encrypted_size;
     notnull_check(encrypted.data);

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -33,7 +33,7 @@
 
 static int monotonic_clock(void *data, uint64_t *nanoseconds)
 {
-    struct timespec current_time;
+    struct timespec current_time = {0};
 
     GUARD(clock_gettime(S2N_CLOCK_HW, &current_time));
 
@@ -45,7 +45,7 @@ static int monotonic_clock(void *data, uint64_t *nanoseconds)
 
 static int wall_clock(void *data, uint64_t *nanoseconds)
 {
-    struct timespec current_time;
+    struct timespec current_time = {0};
 
     GUARD(clock_gettime(S2N_CLOCK_SYS, &current_time));
 
@@ -62,16 +62,16 @@ static uint8_t default_client_config_init = 0;
 static uint8_t default_fips_config_init = 0;
 
 
-static struct s2n_config s2n_default_config;
+static struct s2n_config s2n_default_config = {0};
 
 /* This config should only used by the s2n_client for unit/integration testing purposes. */
-static struct s2n_config s2n_unsafe_client_testing_config;
+static struct s2n_config s2n_unsafe_client_testing_config = {0};
 
-static struct s2n_config s2n_unsafe_client_ecdsa_testing_config;
+static struct s2n_config s2n_unsafe_client_ecdsa_testing_config = {0};
 
-static struct s2n_config default_client_config;
+static struct s2n_config default_client_config = {0};
 
-static struct s2n_config s2n_default_fips_config;
+static struct s2n_config s2n_default_fips_config = {0};
 
 static int s2n_config_init(struct s2n_config *config)
 {
@@ -224,7 +224,7 @@ void s2n_wipe_static_configs(void) {
 
 struct s2n_config *s2n_config_new(void)
 {
-    struct s2n_blob allocator;
+    struct s2n_blob allocator = {0};
     struct s2n_config *new_config;
 
     GUARD_PTR(s2n_alloc(&allocator, sizeof(struct s2n_config)));
@@ -294,7 +294,7 @@ int s2n_config_free(struct s2n_config *config)
 
 int s2n_config_set_protocol_preferences(struct s2n_config *config, const char *const *protocols, int protocol_count)
 {
-    struct s2n_stuffer protocol_stuffer;
+    struct s2n_stuffer protocol_stuffer = {{0}};
 
     GUARD(s2n_free(&config->application_protocols));
 
@@ -424,7 +424,7 @@ int s2n_config_set_verification_ca_location(struct s2n_config *config, const cha
 
 int s2n_config_add_cert_chain_from_stuffer(struct s2n_config *config, struct s2n_stuffer *chain_in_stuffer)
 {
-    struct s2n_stuffer cert_out_stuffer;
+    struct s2n_stuffer cert_out_stuffer = {{0}};
     GUARD(s2n_stuffer_growable_alloc(&cert_out_stuffer, 2048));
 
     struct s2n_cert **insert = &config->cert_and_key_pairs->cert_chain.head;
@@ -439,7 +439,7 @@ int s2n_config_add_cert_chain_from_stuffer(struct s2n_config *config, struct s2n
             }
             break;
         }
-        struct s2n_blob mem;
+        struct s2n_blob mem = {0};
         GUARD(s2n_alloc(&mem, sizeof(struct s2n_cert)));
         new_node = (struct s2n_cert *)(void *)mem.data;
 
@@ -467,7 +467,7 @@ int s2n_config_add_cert_chain_from_stuffer(struct s2n_config *config, struct s2n
 
 int s2n_config_add_cert_chain(struct s2n_config *config, const char *cert_chain_pem)
 {
-    struct s2n_stuffer chain_in_stuffer;
+    struct s2n_stuffer chain_in_stuffer = {{0}};
 
     /* Turn the chain into a stuffer */
     GUARD(s2n_stuffer_alloc_ro_from_string(&chain_in_stuffer, cert_chain_pem));
@@ -481,7 +481,7 @@ int s2n_config_add_cert_chain(struct s2n_config *config, const char *cert_chain_
 int s2n_config_add_private_key(struct s2n_config *config, const char *private_key_pem)
 {
     struct s2n_stuffer key_in_stuffer, key_out_stuffer;
-    struct s2n_blob key_blob;
+    struct s2n_blob key_blob = {0};
 
     GUARD(s2n_pkey_zero_init(&config->cert_and_key_pairs->private_key));
 
@@ -505,7 +505,7 @@ int s2n_config_add_private_key(struct s2n_config *config, const char *private_ke
 
 int s2n_config_add_cert_chain_and_key(struct s2n_config *config, const char *cert_chain_pem, const char *private_key_pem)
 {
-    struct s2n_blob mem;
+    struct s2n_blob mem = {0};
 
     /* Allocate the memory for the chain and key struct */
     GUARD(s2n_alloc(&mem, sizeof(struct s2n_cert_chain_and_key)));
@@ -520,7 +520,7 @@ int s2n_config_add_cert_chain_and_key(struct s2n_config *config, const char *cer
     GUARD(s2n_config_add_private_key(config, private_key_pem));
 
     /* Parse the leaf cert for the public key and certificate type */
-    struct s2n_pkey public_key;
+    struct s2n_pkey public_key = {{{0}}};
     s2n_cert_type cert_type;
     GUARD(s2n_asn1der_to_public_key_and_type(&public_key, &cert_type, &config->cert_and_key_pairs->cert_chain.head->raw));
     GUARD(s2n_cert_set_cert_type(config->cert_and_key_pairs->cert_chain.head, cert_type));
@@ -540,7 +540,7 @@ int s2n_config_add_dhparams(struct s2n_config *config, const char *dhparams_pem)
 {
     struct s2n_stuffer dhparams_in_stuffer, dhparams_out_stuffer;
     struct s2n_blob dhparams_blob = {0};
-    struct s2n_blob mem;
+    struct s2n_blob mem = {0};
 
     /* Allocate the memory for the chain and key struct */
     GUARD(s2n_alloc(&mem, sizeof(struct s2n_dh_params)));

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -137,7 +137,7 @@ static int s2n_connection_init_hmacs(struct s2n_connection *conn)
 
 struct s2n_connection *s2n_connection_new(s2n_mode mode)
 {
-    struct s2n_blob blob;
+    struct s2n_blob blob = {0};
     struct s2n_connection *conn;
 
     GUARD_PTR(s2n_alloc(&blob, sizeof(struct s2n_connection)));
@@ -531,23 +531,23 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     /* First make a copy of everything we'd like to save, which isn't very much. */
     int mode = conn->mode;
     struct s2n_config *config = conn->config;
-    struct s2n_stuffer alert_in;
-    struct s2n_stuffer reader_alert_out;
-    struct s2n_stuffer writer_alert_out;
-    struct s2n_stuffer handshake_io;
-    struct s2n_stuffer client_hello_raw_message;
-    struct s2n_stuffer header_in;
-    struct s2n_stuffer in;
-    struct s2n_stuffer out;
+    struct s2n_stuffer alert_in = {{0}};
+    struct s2n_stuffer reader_alert_out = {{0}};
+    struct s2n_stuffer writer_alert_out = {{0}};
+    struct s2n_stuffer handshake_io = {{0}};
+    struct s2n_stuffer client_hello_raw_message = {{0}};
+    struct s2n_stuffer header_in = {{0}};
+    struct s2n_stuffer in = {{0}};
+    struct s2n_stuffer out = {{0}};
     /* Session keys will be wiped. Preserve structs to avoid reallocation */
-    struct s2n_session_key initial_client_key;
-    struct s2n_session_key initial_server_key;
-    struct s2n_session_key secure_client_key;
-    struct s2n_session_key secure_server_key;
+    struct s2n_session_key initial_client_key = {0};
+    struct s2n_session_key initial_server_key = {0};
+    struct s2n_session_key secure_client_key = {0};
+    struct s2n_session_key secure_server_key = {0};
     /* Parts of the PRF working space, hash states, and hmac states  will be wiped. Preserve structs to avoid reallocation */
-    struct s2n_connection_prf_handles prf_handles;
-    struct s2n_connection_hash_handles hash_handles;
-    struct s2n_connection_hmac_handles hmac_handles;
+    struct s2n_connection_prf_handles prf_handles = {{{{0}}}};
+    struct s2n_connection_hash_handles hash_handles = {{{0}}};
+    struct s2n_connection_hmac_handles hmac_handles = {{{{0}}}};
 
     /* Wipe all of the sensitive stuff */
     GUARD(s2n_connection_wipe_keys(conn));
@@ -735,7 +735,7 @@ int s2n_connection_set_client_auth_type(struct s2n_connection *conn, s2n_cert_au
 
 int s2n_connection_set_read_fd(struct s2n_connection *conn, int rfd)
 {
-    struct s2n_blob ctx_mem;
+    struct s2n_blob ctx_mem = {0};
     struct s2n_socket_read_io_context *peer_socket_ctx;
 
     GUARD(s2n_alloc(&ctx_mem, sizeof(struct s2n_socket_read_io_context)));
@@ -757,7 +757,7 @@ int s2n_connection_set_read_fd(struct s2n_connection *conn, int rfd)
 
 int s2n_connection_set_write_fd(struct s2n_connection *conn, int wfd)
 {
-    struct s2n_blob ctx_mem;
+    struct s2n_blob ctx_mem = {0};
     struct s2n_socket_write_io_context *peer_socket_ctx;
 
     GUARD(s2n_alloc(&ctx_mem, sizeof(struct s2n_socket_write_io_context)));
@@ -882,11 +882,11 @@ const char *s2n_get_server_name(struct s2n_connection *conn)
     }
 
     /* server name is not yet obtained from client hello, get it now */
-    struct s2n_client_hello_parsed_extension parsed_extension;
+    struct s2n_client_hello_parsed_extension parsed_extension = {0};
 
     GUARD_PTR(s2n_client_hello_get_parsed_extension(conn->client_hello.parsed_extensions, S2N_EXTENSION_SERVER_NAME, &parsed_extension));
 
-    struct s2n_stuffer extension;
+    struct s2n_stuffer extension = {{0}};
     GUARD_PTR(s2n_stuffer_init(&extension, &parsed_extension.extension));
     GUARD_PTR(s2n_stuffer_write(&extension, &parsed_extension.extension));
 

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -415,7 +415,7 @@ static int handshake_write_io(struct s2n_connection *conn)
     }
 
     /* Write the handshake data to records in fragment sized chunks */
-    struct s2n_blob out;
+    struct s2n_blob out = {0};
     while (s2n_stuffer_data_available(&conn->handshake.io) > 0) {
         int max_payload_size;
         GUARD((max_payload_size = s2n_record_max_write_payload_size(conn)));
@@ -498,7 +498,7 @@ static int s2n_handshake_conn_update_hashes(struct s2n_connection *conn)
     GUARD(s2n_stuffer_reread(&conn->handshake.io));
     GUARD(s2n_handshake_parse_header(conn, &message_type, &handshake_message_length));
 
-    struct s2n_blob handshake_record;
+    struct s2n_blob handshake_record = {0};
     handshake_record.data = conn->handshake.io.blob.data;
     handshake_record.size = TLS_HANDSHAKE_HEADER_LENGTH + handshake_message_length;
     notnull_check(handshake_record.data);

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -360,7 +360,7 @@ static int s2n_prf(struct s2n_connection *conn, struct s2n_blob *secret, struct 
 int s2n_prf_master_secret(struct s2n_connection *conn, struct s2n_blob *premaster_secret)
 {
     struct s2n_blob client_random, server_random, master_secret;
-    struct s2n_blob label;
+    struct s2n_blob label = {0};
     uint8_t master_secret_label[] = "master secret";
 
     client_random.data = conn->secure.client_random;
@@ -441,8 +441,8 @@ int s2n_prf_client_finished(struct s2n_connection *conn)
     uint8_t md5_digest[MD5_DIGEST_LENGTH];
     uint8_t sha_digest[SHA384_DIGEST_LENGTH];
     uint8_t client_finished_label[] = "client finished";
-    struct s2n_blob client_finished;
-    struct s2n_blob label;
+    struct s2n_blob client_finished = {0};
+    struct s2n_blob label = {0};
 
     if (conn->actual_protocol_version == S2N_SSLv3) {
         return s2n_sslv3_client_finished(conn);
@@ -494,8 +494,8 @@ int s2n_prf_server_finished(struct s2n_connection *conn)
     uint8_t md5_digest[MD5_DIGEST_LENGTH];
     uint8_t sha_digest[SHA384_DIGEST_LENGTH];
     uint8_t server_finished_label[] = "server finished";
-    struct s2n_blob server_finished;
-    struct s2n_blob label;
+    struct s2n_blob server_finished = {0};
+    struct s2n_blob label = {0};
 
     if (conn->actual_protocol_version == S2N_SSLv3) {
         return s2n_sslv3_server_finished(conn);
@@ -543,7 +543,7 @@ int s2n_prf_server_finished(struct s2n_connection *conn)
 
 static int s2n_prf_make_client_key(struct s2n_connection *conn, struct s2n_stuffer *key_material)
 {
-    struct s2n_blob client_key;
+    struct s2n_blob client_key = {0};
     client_key.size = conn->secure.cipher_suite->record_alg->cipher->key_material_size;
     client_key.data = s2n_stuffer_raw_read(key_material, client_key.size);
     notnull_check(client_key.data);
@@ -559,7 +559,7 @@ static int s2n_prf_make_client_key(struct s2n_connection *conn, struct s2n_stuff
 
 static int s2n_prf_make_server_key(struct s2n_connection *conn, struct s2n_stuffer *key_material)
 {
-    struct s2n_blob server_key;
+    struct s2n_blob server_key = {0};
     server_key.size = conn->secure.cipher_suite->record_alg->cipher->key_material_size;
     server_key.data = s2n_stuffer_raw_read(key_material, server_key.size);
 
@@ -587,7 +587,7 @@ int s2n_prf_key_expansion(struct s2n_connection *conn)
     out.data = key_block;
     out.size = sizeof(key_block);
 
-    struct s2n_stuffer key_material;
+    struct s2n_stuffer key_material = {{0}};
     GUARD(s2n_prf(conn, &master_secret, &label, &server_random, &client_random, &out));
     GUARD(s2n_stuffer_init(&key_material, &out));
     GUARD(s2n_stuffer_write(&key_material, &out));

--- a/tls/s2n_record_read_aead.c
+++ b/tls/s2n_record_read_aead.c
@@ -51,7 +51,7 @@ int s2n_record_parse_aead(
 
     uint8_t aad_iv[S2N_TLS_MAX_IV_LEN] = { 0 };
     struct s2n_blob iv = {.data = aad_iv,.size = sizeof(aad_iv) };
-    struct s2n_stuffer iv_stuffer;
+    struct s2n_stuffer iv_stuffer = {{0}};
     GUARD(s2n_stuffer_init(&iv_stuffer, &iv));
 
     if (cipher_suite->record_alg->flags & S2N_TLS12_AES_GCM_AEAD_NONCE) {
@@ -80,7 +80,7 @@ int s2n_record_parse_aead(
     payload_length -= cipher_suite->record_alg->cipher->io.aead.record_iv_size;
     payload_length -= cipher_suite->record_alg->cipher->io.aead.tag_size;
 
-    struct s2n_stuffer ad_stuffer;
+    struct s2n_stuffer ad_stuffer = {{0}};
     GUARD(s2n_stuffer_init(&ad_stuffer, &aad));
     GUARD(s2n_aead_aad_init(conn, sequence_number, content_type, payload_length, &ad_stuffer));
 

--- a/tls/s2n_record_write.c
+++ b/tls/s2n_record_write.c
@@ -174,7 +174,7 @@ int s2n_record_write(struct s2n_connection *conn, uint8_t content_type, struct s
 
     /* If we're AEAD, write the sequence number as an IV, and generate the AAD */
     if (cipher_suite->record_alg->cipher->type == S2N_AEAD) {
-        struct s2n_stuffer iv_stuffer;
+        struct s2n_stuffer iv_stuffer = {{0}};
         iv.data = aad_iv;
         iv.size = sizeof(aad_iv);
         GUARD(s2n_stuffer_init(&iv_stuffer, &iv));
@@ -202,7 +202,7 @@ int s2n_record_write(struct s2n_connection *conn, uint8_t content_type, struct s
         aad.data = aad_gen;
         aad.size = sizeof(aad_gen);
 
-        struct s2n_stuffer ad_stuffer;
+        struct s2n_stuffer ad_stuffer = {{0}};
         GUARD(s2n_stuffer_init(&ad_stuffer, &aad));
         GUARD(s2n_aead_aad_init(conn, sequence_number, content_type, data_bytes_to_take, &ad_stuffer));
     } else if (cipher_suite->record_alg->cipher->type == S2N_CBC || cipher_suite->record_alg->cipher->type == S2N_COMPOSITE) {
@@ -273,7 +273,7 @@ int s2n_record_write(struct s2n_connection *conn, uint8_t content_type, struct s
     }
 
     /* Do the encryption */
-    struct s2n_blob en;
+    struct s2n_blob en = {0};
     en.size = encrypted_length;
     en.data = s2n_stuffer_raw_write(&conn->out, en.size);
     notnull_check(en.data);

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -176,7 +176,7 @@ int s2n_resume_from_cache(struct s2n_connection *conn)
 {
     uint8_t data[S2N_STATE_SIZE_IN_BYTES] = { 0 };
     struct s2n_blob entry = {.data = data,.size = S2N_STATE_SIZE_IN_BYTES };
-    struct s2n_stuffer from;
+    struct s2n_stuffer from = {{0}};
     uint64_t size;
 
     if (conn->session_id_len == 0 || conn->session_id_len > S2N_TLS_SESSION_ID_MAX_LEN) {
@@ -205,7 +205,7 @@ int s2n_store_to_cache(struct s2n_connection *conn)
 {
     uint8_t data[S2N_STATE_SIZE_IN_BYTES] = { 0 };
     struct s2n_blob entry = {.data = data,.size = S2N_STATE_SIZE_IN_BYTES };
-    struct s2n_stuffer to;
+    struct s2n_stuffer to = {{0}};
 
     if (!s2n_allowed_to_cache_connection(conn)) {
         return -1;
@@ -233,11 +233,11 @@ int s2n_connection_set_session(struct s2n_connection *conn, const uint8_t *sessi
     notnull_check(session);
     int ret_val = 0;
 
-    struct s2n_blob session_data;
+    struct s2n_blob session_data = {0};
     GUARD(s2n_alloc(&session_data, length));
     memcpy(session_data.data, session, length);
 
-    struct s2n_stuffer from;
+    struct s2n_stuffer from = {{0}};
     GUARD_GOTO(s2n_stuffer_init(&from, &session_data), failed);
     GUARD_GOTO(s2n_stuffer_write(&from, &session_data), failed);
     GUARD_GOTO(s2n_client_deserialize_resumption_state(conn, &from), failed);
@@ -263,12 +263,12 @@ int s2n_connection_get_session(struct s2n_connection *conn, uint8_t *session, si
 
     S2N_ERROR_IF(len > max_length, S2N_ERR_SERIALIZED_SESSION_STATE_TOO_LONG);
 
-    struct s2n_blob serailized_data;
+    struct s2n_blob serailized_data = {0};
     serailized_data.data = session;
     serailized_data.size = len;
     GUARD(s2n_blob_zero(&serailized_data));
 
-    struct s2n_stuffer to;
+    struct s2n_stuffer to = {{0}};
     GUARD(s2n_stuffer_init(&to, &serailized_data));
     GUARD(s2n_client_serialize_resumption_state(conn, &to));
 

--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -61,7 +61,7 @@ int s2n_flush(struct s2n_connection *conn, s2n_blocked_status * blocked)
 
     /* If there's an alert pending out, send that */
     if (s2n_stuffer_data_available(&conn->reader_alert_out) == 2) {
-        struct s2n_blob alert;
+        struct s2n_blob alert = {0};
         alert.data = conn->reader_alert_out.blob.data;
         alert.size = 2;
         GUARD(s2n_record_write(conn, TLS_ALERT, &alert));
@@ -74,7 +74,7 @@ int s2n_flush(struct s2n_connection *conn, s2n_blocked_status * blocked)
 
     /* Do the same for writer driven alerts */
     if (s2n_stuffer_data_available(&conn->writer_alert_out) == 2) {
-        struct s2n_blob alert;
+        struct s2n_blob alert = {0};
         alert.data = conn->writer_alert_out.blob.data;
         alert.size = 2;
         GUARD(s2n_record_write(conn, TLS_ALERT, &alert));

--- a/tls/s2n_server_cert.c
+++ b/tls/s2n_server_cert.c
@@ -34,7 +34,7 @@ int s2n_server_cert_recv(struct s2n_connection *conn)
     GUARD(s2n_pkey_zero_init(&public_key));
 
     s2n_cert_type cert_type;
-    struct s2n_blob cert_chain;
+    struct s2n_blob cert_chain = {0};
     cert_chain.data = s2n_stuffer_raw_read(&conn->handshake.io, size_of_all_certificates);
     cert_chain.size = size_of_all_certificates;
 

--- a/tls/s2n_server_extensions.c
+++ b/tls/s2n_server_extensions.c
@@ -124,15 +124,15 @@ int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *
 
 int s2n_server_extensions_recv(struct s2n_connection *conn, struct s2n_blob *extensions)
 {
-    struct s2n_stuffer in;
+    struct s2n_stuffer in = {{0}};
 
     GUARD(s2n_stuffer_init(&in, extensions));
     GUARD(s2n_stuffer_write(&in, extensions));
 
     while (s2n_stuffer_data_available(&in)) {
-        struct s2n_blob ext;
+        struct s2n_blob ext = {0};
         uint16_t extension_type, extension_size;
-        struct s2n_stuffer extension;
+        struct s2n_stuffer extension = {{0}};
 
         GUARD(s2n_stuffer_read_uint16(&in, &extension_type));
         GUARD(s2n_stuffer_read_uint16(&in, &extension_size));

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -96,7 +96,7 @@ int s2n_server_hello_recv(struct s2n_connection *conn)
 
         S2N_ERROR_IF(extensions_size > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);
 
-        struct s2n_blob extensions;
+        struct s2n_blob extensions = {0};
         extensions.size = extensions_size;
         extensions.data = s2n_stuffer_raw_read(in, extensions.size);
         notnull_check(extensions.data);
@@ -127,7 +127,7 @@ int s2n_server_hello_recv(struct s2n_connection *conn)
 int s2n_server_hello_send(struct s2n_connection *conn)
 {
     struct s2n_stuffer *out = &conn->handshake.io;
-    struct s2n_stuffer server_random;
+    struct s2n_stuffer server_random = {{0}};
     struct s2n_blob b, r;
     uint8_t protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN];
 

--- a/tls/s2n_server_key_exchange.c
+++ b/tls/s2n_server_key_exchange.c
@@ -48,8 +48,8 @@ int s2n_server_key_recv(struct s2n_connection *conn)
 static int s2n_ecdhe_server_key_recv(struct s2n_connection *conn)
 {
     struct s2n_stuffer *in = &conn->handshake.io;
-    struct s2n_blob ecdhparams;
-    struct s2n_blob signature;
+    struct s2n_blob ecdhparams = {0};
+    struct s2n_blob signature = {0};
     uint16_t signature_length;
 
     /* Read server ECDH params and calculate their hash */
@@ -160,7 +160,7 @@ int s2n_server_key_send(struct s2n_connection *conn)
 static int s2n_ecdhe_server_key_send(struct s2n_connection *conn)
 {
     struct s2n_stuffer *out = &conn->handshake.io;
-    struct s2n_blob ecdhparams;
+    struct s2n_blob ecdhparams = {0};
 
     /* Generate an ephemeral key and  */
     GUARD(s2n_ecc_generate_ephemeral_key(&conn->secure.server_ecc_params));
@@ -215,7 +215,7 @@ static int s2n_dhe_server_key_send(struct s2n_connection *conn)
 
 static int s2n_write_signature_blob(struct s2n_stuffer *out, const struct s2n_pkey *priv_key, struct s2n_hash_state *digest)
 {
-    struct s2n_blob signature;
+    struct s2n_blob signature = {0};
     
     /* Leave signature length blank for now until we're done signing */
     uint16_t sig_len = 0;

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -87,9 +87,9 @@ int s2n_x509_trust_store_add_pem(struct s2n_x509_trust_store *store, const char 
 
     s2n_error err = S2N_ERR_DECODE_CERTIFICATE;
 
-    struct s2n_stuffer pem_in_stuffer;
-    struct s2n_stuffer der_out_stuffer;
-    struct s2n_blob next_cert = { 0 };
+    struct s2n_stuffer pem_in_stuffer = {{0}};
+    struct s2n_stuffer der_out_stuffer = {{0}};
+    struct s2n_blob next_cert = {0};
 
     GUARD_GOTO(s2n_stuffer_alloc_ro_from_string(&pem_in_stuffer, pem), clean_up);
     GUARD_GOTO(s2n_stuffer_growable_alloc(&der_out_stuffer, 2048), clean_up);
@@ -282,7 +282,7 @@ s2n_cert_validation_code s2n_x509_validator_validate_cert_chain(struct s2n_x509_
     X509_STORE_CTX *ctx = NULL;
 
     struct s2n_blob cert_chain_blob = {.data = cert_chain_in, .size = cert_chain_len};
-    struct s2n_stuffer cert_chain_in_stuffer;
+    struct s2n_stuffer cert_chain_in_stuffer = {{0}};
     if (s2n_stuffer_init(&cert_chain_in_stuffer, &cert_chain_blob) < 0) {
         return S2N_CERT_ERR_INVALID;
     }
@@ -295,7 +295,7 @@ s2n_cert_validation_code s2n_x509_validator_validate_cert_chain(struct s2n_x509_
     s2n_cert_validation_code err_code = S2N_CERT_ERR_INVALID;
     X509 *server_cert = NULL;
  
-    struct s2n_pkey public_key;
+    struct s2n_pkey public_key = {{{0}}};
     s2n_pkey_zero_init(&public_key);
 
     while (s2n_stuffer_data_available(&cert_chain_in_stuffer) && certificate_count < validator->max_chain_depth) {
@@ -309,7 +309,7 @@ s2n_cert_validation_code s2n_x509_validator_validate_cert_chain(struct s2n_x509_
             goto clean_up;
         }
 
-        struct s2n_blob asn1cert;
+        struct s2n_blob asn1cert = {0};
         asn1cert.data = s2n_stuffer_raw_read(&cert_chain_in_stuffer, certificate_size);
         asn1cert.size = certificate_size;
         if (asn1cert.data == NULL) {

--- a/utils/s2n_array.c
+++ b/utils/s2n_array.c
@@ -40,7 +40,7 @@ static int s2n_array_enlarge(struct s2n_array *array, uint32_t capacity)
 
 struct s2n_array *s2n_array_new(size_t element_size)
 {
-    struct s2n_blob mem;
+    struct s2n_blob mem = {0};
     struct s2n_array *array;
 
     GUARD_PTR(s2n_alloc(&mem, sizeof(struct s2n_array)));
@@ -91,7 +91,7 @@ void *s2n_array_get(struct s2n_array *array, uint32_t index)
 int s2n_array_free(struct s2n_array *array)
 {
     notnull_check(array);
-    struct s2n_blob mem;
+    struct s2n_blob mem = {0};
 
     /* Free the elements */
     mem.data = (void *) array->elements;

--- a/utils/s2n_asn1_time.c
+++ b/utils/s2n_asn1_time.c
@@ -61,15 +61,6 @@ static inline void get_current_timesettings(long *gmt_offset, int *is_dst) {
     *is_dst = time_ptr.tm_isdst;
 }
 
-struct parser_args {
-    uint8_t offset_negative;
-    uint8_t local_time_assumed;
-    uint8_t current_digit;
-    long offset_hours;
-    long offset_minutes;
-    struct tm time;
-};
-
 /* this is just a standard state machine for ASN1 date format... nothing special.
  * just do a character at a time and change the state per character encountered.
  * when finished the above time structure should be filled in along with some

--- a/utils/s2n_asn1_time.c
+++ b/utils/s2n_asn1_time.c
@@ -53,7 +53,7 @@ static inline long get_gmt_offset(struct tm *t) {
 }
 
 static inline void get_current_timesettings(long *gmt_offset, int *is_dst) {
-    struct tm time_ptr;
+    struct tm time_ptr = {0};
     time_t raw_time;
     time(&raw_time);
     localtime_r(&raw_time, &time_ptr);

--- a/utils/s2n_asn1_time.h
+++ b/utils/s2n_asn1_time.h
@@ -16,6 +16,16 @@
 #pragma once
 
 #include <stdint.h>
+#include <time.h>
+
+struct parser_args {
+    uint8_t offset_negative;
+    uint8_t local_time_assumed;
+    uint8_t current_digit;
+    long offset_hours;
+    long offset_minutes;
+    struct tm time;
+};
 
 /**
  * Converts an asn1 formatted time string to ticks since epoch in nanoseconds.

--- a/utils/s2n_map.c
+++ b/utils/s2n_map.c
@@ -24,31 +24,11 @@
 #include "utils/s2n_blob.h"
 #include "utils/s2n_mem.h"
 #include "utils/s2n_map.h"
+#include "utils/s2n_map_internal.h"
 
 #include <s2n.h>
 
 #define S2N_INITIAL_TABLE_SIZE 1024
-
-struct s2n_map_entry {
-    struct s2n_blob key;
-    struct s2n_blob value;
-};
-
-struct s2n_map {
-    /* The total capacity of the table, in number of elements. */
-    uint32_t capacity;
-
-    /* The total number of elements currently in the table. Used for measuring the load factor */
-    uint32_t size;
-
-    /* Once a map has been looked up, it is considered immutable */
-    int      immutable;
-
-    /* Pointer to the hash-table, should be capacity * sizeof(struct s2n_map_entry) */
-    struct s2n_map_entry *table;
-
-    struct s2n_hash_state sha256;
-};
 
 static int s2n_map_slot(struct s2n_map *map, struct s2n_blob *key, uint32_t *slot)
 {

--- a/utils/s2n_map.c
+++ b/utils/s2n_map.c
@@ -48,8 +48,8 @@ static int s2n_map_slot(struct s2n_map *map, struct s2n_blob *key, uint32_t *slo
 
 static int s2n_map_embiggen(struct s2n_map *map, uint32_t capacity)
 {
-    struct s2n_blob mem;
-    struct s2n_map tmp;
+    struct s2n_blob mem = {0};
+    struct s2n_map tmp = {0};
 
     S2N_ERROR_IF(map->immutable, S2N_ERR_MAP_IMMUTABLE);
 
@@ -87,7 +87,7 @@ static int s2n_map_embiggen(struct s2n_map *map, uint32_t capacity)
 
 struct s2n_map *s2n_map_new()
 {
-    struct s2n_blob mem;
+    struct s2n_blob mem = {0};
     struct s2n_map *map;
 
     GUARD_PTR(s2n_alloc(&mem, sizeof(struct s2n_map)));
@@ -209,7 +209,7 @@ int s2n_map_lookup(struct s2n_map *map, struct s2n_blob *key, struct s2n_blob *v
 
 int s2n_map_free(struct s2n_map *map)
 {
-    struct s2n_blob mem;
+    struct s2n_blob mem = {0};
 
     /* Free the keys and values */
     for (int i = 0; i < map->capacity; i++) {

--- a/utils/s2n_map_internal.h
+++ b/utils/s2n_map_internal.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#pragma once
+
+#include "utils/s2n_map.h"
+
+struct s2n_map_entry {
+    struct s2n_blob key;
+    struct s2n_blob value;
+};
+
+struct s2n_map {
+    /* The total capacity of the table, in number of elements. */
+    uint32_t capacity;
+
+    /* The total number of elements currently in the table. Used for measuring the load factor */
+    uint32_t size;
+
+    /* Once a map has been looked up, it is considered immutable */
+    int immutable;
+
+    /* Pointer to the hash-table, should be capacity * sizeof(struct s2n_map_entry) */
+    struct s2n_map_entry *table;
+
+    struct s2n_hash_state sha256;
+};

--- a/utils/s2n_map_internal.h
+++ b/utils/s2n_map_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -322,7 +322,7 @@ int s2n_get_rdrand_data(struct s2n_blob *out)
 
 #if defined(__x86_64__) || defined(__i386__)
     int space_remaining = 0;
-    struct s2n_stuffer stuffer;
+    struct s2n_stuffer stuffer = {{0}};
     union {
         uint64_t u64;
         uint8_t u8[8];


### PR DESCRIPTION
**Issue # (if available):** 
Partial fix for https://github.com/awslabs/s2n/issues/790
We still don't fail the build for uninitialized structs, but we now initialize every struct before use.

**Description of changes:** 
This change has 3 commits:
 1. Move struct definitions to header files
 2. Add Zero Init Struct Scripts
 3. Run that Zero Init Script to ensure all struct are zero initialized.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
