### PR TITLE
Check if Shellcheck is already installed

### DIFF
--- a/.travis/install_shellcheck.sh
+++ b/.travis/install_shellcheck.sh
@@ -28,7 +28,7 @@ fi
 TRAVIS_PLATFORM=$1
 
 if [ "$TRAVIS_PLATFORM" == "linux" ]; then
-    sudo apt-get -qq install shellcheck -y
+    which shellcheck || sudo apt-get -qq install shellcheck -y
 elif [ "$TRAVIS_PLATFORM" == "osx" ]; then
     # Installing an existing package is a "failure" in brew
     brew install shellcheck || true ;

--- a/.travis/s2n_install_test_dependencies.sh
+++ b/.travis/s2n_install_test_dependencies.sh
@@ -29,8 +29,9 @@ if [[ ! -d test-deps ]]; then
 fi
 
 #Install & Run shell check before installing dependencies
-echo "Running ShellCheck..."
+echo "Installing ShellCheck..."
 .travis/install_shellcheck.sh "$TRAVIS_OS_NAME"
+echo "Running ShellCheck..."
 .travis/run_shellcheck.sh
 echo "Shell Check is success."
 


### PR DESCRIPTION
**Issue # (if available):** N/A

**Description of changes:** 
Looks like Shellcheck is already installed by default on Travis instances, but is not present in (possibly removed from?) the Ubuntu Repositories for 14.04.

Added logic to skip the `apt-get` if shellcheck is already installed.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
