### PR TITLE
cmake: Add include directory of LibCrypto to public s2n interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,7 @@ target_link_libraries(s2n PRIVATE LibCrypto::Crypto PRIVATE ${OS_LIBS})
 
 target_include_directories(s2n PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 target_include_directories(s2n PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api> $<INSTALL_INTERFACE:include>)
+target_include_directories(s2n PUBLIC $<TARGET_PROPERTY:LibCrypto::Crypto,INTERFACE_INCLUDE_DIRECTORIES>)
 
 file(GLOB TESTLIB_SRC "tests/testlib/*.c")
 file(GLOB TESTLIB_HEADERS "tests/testlib/*.h")


### PR DESCRIPTION
# Commit message

cmake: Add include directory of LibCrypto to public s2n interface

s2n.h includes SSL include files. If the prefix to the SSL includes
isn't included in s2n's public interface include directories, then
external projects depending on s2n must link against LibCrypto
explicitly.

# Example

Either remove LibCrypto from your system, or install a C compiler that ships its own include-directories and does not usr /usr/include. The s2n build will fail:

```
[ 41%] Linking C static library lib/libs2n.a
[ 41%] Built target s2n
Scanning dependencies of target s2nd
[ 42%] Building C object CMakeFiles/s2nd.dir/bin/s2nd.c.o
/tmp/s2n/bin/s2nd.c:36:28: fatal error: openssl/crypto.h: No such file or directory
compilation terminated.
```

This is because `s2nd` only depends on s2n, but not on LibCrypto::Crypto explicitly.

Building external projects fails in the same fashion:

```
$ cat > CMakeLists.txt <<EOF
cmake_minimum_required(VERSION 3.0)
project(s2n_test)
find_package(s2n REQUIRED)
add_executable(s2n_test test.c)
target_link_libraries(s2n_test s2n)
EOF
$ cat > test.c <<EOF
#include <s2n.h>

int main() {
	s2n_init();
}
EOF
$ cmake
$ make
[...]
[ 50%] Building C object CMakeFiles/s2n_test.dir/test.c.o
In file included from /tmp/test.c:1:0:
/tmp/s2n/include/s2n.h:24:30: fatal error: openssl/ossl_typ.h: No such file or directory
```
..with this patch, both cases compile fine. (I've checked that if LibCrypto is found in the system directories, no additional `-isystem` is added to the command line.)