### PR TITLE
Don't close connection on ALPN mismatch

### DIFF
--- a/tls/s2n_client_extensions.c
+++ b/tls/s2n_client_extensions.c
@@ -270,6 +270,7 @@ static int s2n_recv_client_alpn(struct s2n_connection *conn, struct s2n_stuffer 
     struct s2n_stuffer client_protos;
     struct s2n_stuffer server_protos;
 
+
     if (!conn->config->application_protocols.size) {
         /* No protocols configured, nothing to do */
         return 0;
@@ -295,9 +296,9 @@ static int s2n_recv_client_alpn(struct s2n_connection *conn, struct s2n_stuffer 
 
     while (s2n_stuffer_data_available(&server_protos)) {
         uint8_t length;
-        uint8_t protocol[255];
+        uint8_t server_protocol[255];
         GUARD(s2n_stuffer_read_uint8(&server_protos, &length));
-        GUARD(s2n_stuffer_read_bytes(&server_protos, protocol, length));
+        GUARD(s2n_stuffer_read_bytes(&server_protos, server_protocol, length));
 
         while (s2n_stuffer_data_available(&client_protos)) {
             uint8_t client_length;
@@ -308,7 +309,7 @@ static int s2n_recv_client_alpn(struct s2n_connection *conn, struct s2n_stuffer 
             } else {
                 uint8_t client_protocol[255];
                 GUARD(s2n_stuffer_read_bytes(&client_protos, client_protocol, client_length));
-                if (memcmp(client_protocol, protocol, client_length) == 0) {
+                if (memcmp(client_protocol, server_protocol, client_length) == 0) {
                     memcpy_check(conn->application_protocol, client_protocol, client_length);
                     conn->application_protocol[client_length] = '\0';
                     return 0;
@@ -318,8 +319,7 @@ static int s2n_recv_client_alpn(struct s2n_connection *conn, struct s2n_stuffer 
 
         GUARD(s2n_stuffer_reread(&client_protos));
     }
-
-    S2N_ERROR(S2N_ERR_NO_APPLICATION_PROTOCOL);
+    return 0;
 }
 
 static int s2n_recv_client_status_request(struct s2n_connection *conn, struct s2n_stuffer *extension)


### PR DESCRIPTION
**Issue # (if available):** https://github.com/awslabs/s2n/issues/796

**Description of changes:** 
Changes s2n to not close the TLS connection on an ALPN mismatch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
