### PR TITLE
cmake: enable _FORTIFY_SOURCE only for release builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,8 +103,12 @@ set_target_properties(s2n PROPERTIES LINKER_LANGUAGE C)
 set(CMAKE_C_FLAGS_DEBUGOPT "")
 
 target_compile_options(s2n PRIVATE -pedantic -std=c99 -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-subscripts -Wuninitialized -Wshadow -Wcast-qual -Wcast-align -Wwrite-strings -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security)
-target_compile_definitions(s2n PRIVATE -D_POSIX_C_SOURCE=200809L -D_FORTIFY_SOURCE=2)
 target_compile_options(s2n PUBLIC -fPIC)
+
+target_compile_definitions(s2n PRIVATE -D_POSIX_C_SOURCE=200809L)
+if(CMAKE_BUILD_TYPE MATCHES Release)
+    target_compile_definitions(s2n PRIVATE -D_FORTIFY_SOURCE=2)
+endif()
 
 if(NO_STACK_PROTECTOR)
     target_compile_options(s2n PRIVATE -Wstack-protector -fstack-protector-all)


### PR DESCRIPTION
**Issue # (if available):** N/A

**Description of changes:** The `cmake` build currently doesn't compile out of the box. Users are presented with an error:

`/usr/include/features.h:330:4: error: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Werror=cpp]`

This is because `cmake` builds debug builds without any optimization by default. This change updates the `CmakeLists.txt` file to check the build type and enable `_FORTIFY_SOURCE` only if we are on a release build (with optimizations). The build works properly now out of the box.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
