### PR TITLE
Created new APIs to include custom cipher suites, issue_724

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -201,6 +201,56 @@ typedef enum {
     S2N_CERT_TYPE_ECDSA_FIXED_ECDH = 66,
 } s2n_cert_type;
 
+typedef enum {
+    S2N_TLS_VERSION_SSLv2 = 20,
+    S2N_TLS_VERSION_SSLv3 = 30,
+    S2N_TLS_VERSION_TLS10 = 31,
+    S2N_TLS_VERSION_TLS11 = 32,
+    S2N_TLS_VERSION_TLS12 = 33,
+} s2n_tls_version_type;
+
+typedef enum {
+    S2N_RSA_WITH_RC4_128_MD5 = 0,
+    S2N_RSA_WITH_RC4_128_SHA,
+    S2N_RSA_WITH_3DES_EDE_CBC_SHA,
+    S2N_DHE_RSA_WITH_3DES_EDE_CBC_SHA,
+    S2N_RSA_WITH_AES_128_CBC_SHA,
+    S2N_DHE_RSA_WITH_AES_128_CBC_SHA,
+    S2N_RSA_WITH_AES_256_CBC_SHA,
+    S2N_DHE_RSA_WITH_AES_256_CBC_SHA,
+    S2N_RSA_WITH_AES_128_CBC_SHA256,
+    S2N_RSA_WITH_AES_256_CBC_SHA256,
+    S2N_DHE_RSA_WITH_AES_128_CBC_SHA256,
+    S2N_DHE_RSA_WITH_AES_256_CBC_SHA256,
+    S2N_RSA_WITH_AES_128_GCM_SHA256,
+    S2N_RSA_WITH_AES_256_GCM_SHA384,
+    S2N_DHE_RSA_WITH_AES_128_GCM_SHA256,
+    S2N_DHE_RSA_WITH_AES_256_GCM_SHA384,
+    S2N_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+    S2N_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+    S2N_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+    S2N_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+    S2N_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+    S2N_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+    S2N_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,
+    S2N_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+    S2N_ECDHE_RSA_WITH_AES_256_CBC_SHA384,
+    S2N_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+    S2N_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+    S2N_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+    S2N_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+    S2N_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+    S2N_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+} s2n_cipher_suite_type;
+
+struct s2n_cipher_preferences;
+
+extern int s2n_config_set_custom_cipher_preferences(struct s2n_config *config, struct s2n_cipher_preferences *cipher_preferences);
+extern int s2n_cipher_preferences_set_cipher_suites(struct s2n_cipher_preferences *cipher_preferences, const s2n_cipher_suite_type *ciphers, size_t ciphers_count);
+extern int s2n_cipher_preferences_set_min_tls_version(struct s2n_cipher_preferences *cipher_preferences, s2n_tls_version_type min_tls_version);
+extern struct s2n_cipher_preferences *s2n_cipher_preferences_new();
+extern int s2n_cipher_preferences_free(struct s2n_cipher_preferences *cipher_preferences);
+
 struct s2n_pkey;
 typedef struct s2n_pkey s2n_cert_public_key;
 typedef struct s2n_pkey s2n_cert_private_key;

--- a/tests/unit/s2n_self_talk_cipher_preferences_test.c
+++ b/tests/unit/s2n_self_talk_cipher_preferences_test.c
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "testlib/s2n_testlib.h"
+
+#include <sys/wait.h>
+#include <unistd.h>
+#include <stdint.h>
+
+#include <s2n.h>
+#include <errno.h>
+
+#include "tls/s2n_connection.h"
+#include "tls/s2n_handshake.h"
+
+void mock_client(int writefd, int readfd)
+{
+    struct s2n_connection *conn;
+    struct s2n_config *config;
+    struct s2n_cipher_preferences *ciphers;
+    s2n_blocked_status blocked;
+    int ciphers_count = 1;
+    int result = 0;
+
+    /* Give the server a chance to listen */
+    sleep(1);
+
+    /* Both server and client only support one common cipher suite, handshake should complete */
+    conn = s2n_connection_new(S2N_CLIENT);
+    config = s2n_config_new();
+
+    ciphers = s2n_cipher_preferences_new();
+    s2n_cipher_suite_type cipher_suites[] = { S2N_ECDHE_RSA_WITH_AES_128_GCM_SHA256 };
+    s2n_cipher_preferences_set_cipher_suites(ciphers, cipher_suites, ciphers_count);
+    s2n_cipher_preferences_set_min_tls_version(ciphers, S2N_TLS_VERSION_TLS12);
+    s2n_config_set_custom_cipher_preferences(config, ciphers);
+
+    s2n_config_disable_x509_verification(config);
+    s2n_connection_set_config(conn, config);
+
+    s2n_connection_set_read_fd(conn, readfd);
+    s2n_connection_set_write_fd(conn, writefd);
+
+    if (s2n_negotiate(conn, &blocked) != 0) {
+        result = 1;
+    }
+
+    /* Shutdown handshake */
+    int shutdown_rc = -1;
+    do {
+        shutdown_rc = s2n_shutdown(conn, &blocked);
+    } while(shutdown_rc != 0);
+
+    s2n_connection_free(conn);
+
+    /* Give the server a chance to avoid sigpipe */
+    sleep(1);
+
+    /* Both server and client only support one but different cipher suite, handshake should fail */
+    conn = s2n_connection_new(S2N_CLIENT);
+
+    cipher_suites[0] = S2N_RSA_WITH_RC4_128_SHA;
+    s2n_cipher_preferences_set_cipher_suites(ciphers, cipher_suites, ciphers_count);
+
+    s2n_connection_set_config(conn, config);
+
+    s2n_connection_set_read_fd(conn, readfd);
+    s2n_connection_set_write_fd(conn, writefd);
+
+    if (s2n_negotiate(conn, &blocked) == 0) {
+        result = 2;
+    }
+
+    s2n_connection_free(conn);
+    s2n_cipher_preferences_free(ciphers);
+    s2n_config_free(config);
+
+    /* Give the server a chance to avoid sigpipe */
+    sleep(1);
+
+    _exit(result);
+}
+
+int main(int argc, char **argv)
+{
+    struct s2n_connection *conn;
+    struct s2n_config *config;
+    s2n_blocked_status blocked;
+    int status;
+    pid_t pid;
+    int server_to_client[2];
+    int client_to_server[2];
+    char *cert_chain_pem;
+    char *private_key_pem;
+    struct s2n_cipher_preferences *ciphers;
+    int ciphers_count = 1;
+    int shutdown_rc = -1;
+
+    BEGIN_TEST();
+    EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+
+    EXPECT_SUCCESS(setenv("S2N_ENABLE_CLIENT_MODE", "1", 0));
+
+    /* Create a pipe */
+    EXPECT_SUCCESS(pipe(server_to_client));
+    EXPECT_SUCCESS(pipe(client_to_server));
+
+    /* Create a child process */
+    pid = fork();
+    if (pid == 0) {
+        /* This is the child process, close the read end of the pipe */
+        EXPECT_SUCCESS(close(client_to_server[0]));
+        EXPECT_SUCCESS(close(server_to_client[1]));
+
+        /* Write the fragmented hello message */
+        mock_client(client_to_server[1], server_to_client[0]);
+    }
+
+    /* This is the parent */
+    EXPECT_SUCCESS(close(client_to_server[1]));
+    EXPECT_SUCCESS(close(server_to_client[0]));
+
+    EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
+    
+    EXPECT_NOT_NULL(config = s2n_config_new());
+    EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key(config, cert_chain_pem, private_key_pem));
+    
+    EXPECT_NOT_NULL(ciphers = s2n_cipher_preferences_new());
+    s2n_cipher_suite_type cipher_suites[] = { S2N_ECDHE_RSA_WITH_AES_128_GCM_SHA256 };
+    EXPECT_SUCCESS(s2n_cipher_preferences_set_cipher_suites(ciphers, cipher_suites, ciphers_count));
+    EXPECT_SUCCESS(s2n_cipher_preferences_set_min_tls_version(ciphers, S2N_TLS_VERSION_TLS12))
+    EXPECT_SUCCESS(s2n_config_set_custom_cipher_preferences(config, ciphers));
+
+    /* Both server and client only support one common cipher suite, handshake should complete */
+    {
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        /* Set up the connection to read from the fd */
+        EXPECT_SUCCESS(s2n_connection_set_read_fd(conn, client_to_server[0]));
+        EXPECT_SUCCESS(s2n_connection_set_write_fd(conn, server_to_client[1]));
+
+        /* Negotiate the handshake. */
+        EXPECT_SUCCESS(s2n_negotiate(conn, &blocked));
+
+        /* Shutdown handshake */
+        do {
+            shutdown_rc = s2n_shutdown(conn, &blocked);
+            EXPECT_TRUE(shutdown_rc == 0 || (errno == EAGAIN && blocked));
+        } while(shutdown_rc != 0);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Both server and client only support one but different cipher suite, handshake should fail */
+    {
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+
+        /* Set up the connection to read from the fd */
+        EXPECT_SUCCESS(s2n_connection_set_read_fd(conn, client_to_server[0]));
+        EXPECT_SUCCESS(s2n_connection_set_write_fd(conn, server_to_client[1]));
+
+        /* Negotiate the handshake. */
+        EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Close the pipes */
+    EXPECT_SUCCESS(close(client_to_server[0]));
+    EXPECT_SUCCESS(close(server_to_client[1]));
+
+    /* Clean up */
+    EXPECT_SUCCESS(s2n_config_free(config));
+    EXPECT_SUCCESS(s2n_cipher_preferences_free(ciphers));
+
+    EXPECT_EQUAL(waitpid(-1, &status, 0), pid);
+    EXPECT_EQUAL(status, 0);
+
+    free(cert_chain_pem);
+    free(private_key_pem);
+
+    END_TEST();
+    return 0;
+}

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -548,9 +548,11 @@ struct s2n_cipher_suite s2n_dhe_rsa_with_chacha20_poly1305_sha256 = /* 0xCC,0xAA
 };
 
 /* All of the cipher suites that s2n negotiates, in order of IANA value.
- * Exposed for the "test_all" cipher preference list.
+ * Make sure this order is consistent with the s2n_cipher_suite_type enums defined in s2n.h,
+ * as it used to set up cipher suites from enums. This is also exposed for
+ * the "test_all" cipher preference list.
  */
-static struct s2n_cipher_suite *s2n_all_cipher_suites[] = {
+struct s2n_cipher_suite *s2n_all_cipher_suites[] = {
     &s2n_rsa_with_rc4_128_md5,                     /* 0x00,0x04 */
     &s2n_rsa_with_rc4_128_sha,                     /* 0x00,0x05 */
     &s2n_rsa_with_3des_ede_cbc_sha,                /* 0x00,0x0A */

--- a/tls/s2n_cipher_suites.h
+++ b/tls/s2n_cipher_suites.h
@@ -134,6 +134,8 @@ extern struct s2n_cipher_suite s2n_ecdhe_rsa_with_aes_256_gcm_sha384;
 extern struct s2n_cipher_suite s2n_ecdhe_rsa_with_chacha20_poly1305_sha256;
 extern struct s2n_cipher_suite s2n_dhe_rsa_with_chacha20_poly1305_sha256;
 
+extern struct s2n_cipher_suite *s2n_all_cipher_suites[];
+
 extern int s2n_cipher_suites_init(void);
 extern int s2n_cipher_suites_cleanup(void);
 extern struct s2n_cipher_suite *s2n_cipher_suite_from_wire(const uint8_t cipher_suite[S2N_TLS_CIPHER_SUITE_LEN]);

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -686,3 +686,11 @@ int s2n_config_get_cert_type(struct s2n_config *config, s2n_cert_type *cert_type
     
     return 0;
 }
+
+int s2n_config_set_custom_cipher_preferences(struct s2n_config *config, struct s2n_cipher_preferences *cipher_preferences)
+{
+    notnull_check(config);
+    notnull_check(cipher_preferences);
+    config->cipher_preferences = cipher_preferences;
+    return 0;
+}


### PR DESCRIPTION
Issue #724 

Added support to include custom ciphers suited for doing handshakes. 
I want to do later - add validations for compatible cipher suites and min_tls_version.




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
