### PR TITLE
added s2n_peek function

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -165,6 +165,7 @@ typedef enum { S2N_NOT_BLOCKED = 0, S2N_BLOCKED_ON_READ, S2N_BLOCKED_ON_WRITE } 
 extern int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status *blocked);
 extern ssize_t s2n_send(struct s2n_connection *conn, const void *buf, ssize_t size, s2n_blocked_status *blocked);
 extern ssize_t s2n_recv(struct s2n_connection *conn,  void *buf, ssize_t size, s2n_blocked_status *blocked);
+extern uint32_t s2n_peek(struct s2n_connection *conn);
 
 extern int s2n_connection_wipe(struct s2n_connection *conn);
 extern int s2n_connection_free(struct s2n_connection *conn);

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -207,6 +207,10 @@ ssize_t s2n_recv(struct s2n_connection * conn, void *buf, ssize_t size, s2n_bloc
     return bytes_read;
 }
 
+uint32_t s2n_peek(struct s2n_connection *conn) {
+    return s2n_stuffer_data_available(&conn->in);
+}
+
 int s2n_recv_close_notify(struct s2n_connection *conn, s2n_blocked_status * blocked)
 {
     uint8_t record_type;


### PR DESCRIPTION
**Issue # (if available):** 

**Description of changes:** 
Add a s2n_peek function to the api.  This function is a external wrapper around the s2n_stuffer_data_available macro. This allows users of S2N to peek inside the data buffer of an S2N connection to see if there more data to be read without actually reading it.
 
This is useful when using select() on the underlying S2N file descriptor with a message based application layer protocol.
 
As a single call to s2n_recv may read all data off the underlying file descriptor, select() will be unable to tell you there if there is more application data ready for processing already loaded into the S2N buffer.
s2n_peek can then be used to determine if s2n_recv needs to be called before more data comes in on the raw fd.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
