### PR TITLE
Remove Unit Test that compares DRBG and urandom performance

### DIFF
--- a/tests/unit/s2n_drbg_test.c
+++ b/tests/unit/s2n_drbg_test.c
@@ -233,11 +233,6 @@ int main(int argc, char **argv)
     }
     EXPECT_SUCCESS(s2n_timer_reset(config, &timer, &urandom_nanoseconds));
 
-    /* Confirm that the DRBG is faster than urandom when rdrand is enabled */
-    if (s2n_cpu_supports_rdrand()) {
-        EXPECT_TRUE(drbg_nanoseconds < urandom_nanoseconds);
-    }
-
     /* NOTE: s2n_random_test also includes monobit tests for this DRBG */
 
     /* the DRBG state is 128 bytes, test that we can get more than that */


### PR DESCRIPTION
**Issue # (if available):** https://github.com/awslabs/s2n/issues/666

**Description of changes:** 
Removes the Unit Test that verifies that S2N's DRBG is faster than `/dev/urandom`. In Linux Kernel Versions 4.8 and later `/dev/urandom` is now ChaCha20 based, which causes s2n to fail to build on these newer Kernel versions.

**Relevant Links about the `/dev/urandom` Upgrade:**
 1. https://kernelnewbies.org/Linux_4.8#Core_.28various.29
 2. https://lwn.net/Articles/686033/
 3. https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=e192be9d9a30555aae2ca1dc3aad37cba484cd4a
 4. http://www.chronox.de/lrng.html
 5. http://www.chronox.de/lrng/doc/lrng.pdf

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
