### PR TITLE
add two elb TLSPolicies 2018-06

### DIFF
--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -334,7 +334,7 @@ const struct s2n_cipher_preferences elb_security_policy_tls_1_2_2017_01 = {
 struct s2n_cipher_suite *cipher_suites_elb_security_policy_tls_1_1_2017_01[] = {
     /* &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256, */
     &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
-    /* &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256 */
+    /* &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256, */
     &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
     /* &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha, */
     &s2n_ecdhe_rsa_with_aes_128_cbc_sha,
@@ -356,6 +356,54 @@ const struct s2n_cipher_preferences elb_security_policy_tls_1_1_2017_01 = {
     .count = sizeof(cipher_suites_elb_security_policy_tls_1_1_2017_01) / sizeof(cipher_suites_elb_security_policy_tls_1_1_2017_01[0]),
     .suites = cipher_suites_elb_security_policy_tls_1_1_2017_01,
     .minimum_protocol_version = S2N_TLS11
+};
+
+struct s2n_cipher_suite *cipher_suites_elb_security_policy_tls_1_2_ext_2018_06[] = {
+    /* &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256, */
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    /* &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256, */
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
+    /* &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha, */
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha,
+    /* &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384, */
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    /* &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384, */
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha,
+    /* &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha, */
+    &s2n_rsa_with_aes_128_gcm_sha256,
+    &s2n_rsa_with_aes_128_cbc_sha256,
+    &s2n_rsa_with_aes_128_cbc_sha,
+    &s2n_rsa_with_aes_256_gcm_sha384,
+    &s2n_rsa_with_aes_256_cbc_sha256,
+    &s2n_rsa_with_aes_256_cbc_sha,
+};
+
+const struct s2n_cipher_preferences elb_security_policy_tls_1_2_ext_2018_06 = {
+    .count = sizeof(cipher_suites_elb_security_policy_tls_1_2_ext_2018_06) / sizeof(cipher_suites_elb_security_policy_tls_1_2_ext_2018_06[0]),
+    .suites = cipher_suites_elb_security_policy_tls_1_2_ext_2018_06,
+    .minimum_protocol_version = S2N_TLS12
+};
+
+struct s2n_cipher_suite *cipher_suites_elb_security_policy_fs_2018_06[] = {
+    /* &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256, */
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    /* &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256, */
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
+    /* &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha, */
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha,
+    /* &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384, */
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    /* &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384, */
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha,
+    /* &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha, */
+};
+
+const struct s2n_cipher_preferences elb_security_policy_fs_2018_06 = {
+    .count = sizeof(cipher_suites_elb_security_policy_fs_2018_06) / sizeof(cipher_suites_elb_security_policy_fs_2018_06[0]),
+    .suites = cipher_suites_elb_security_policy_fs_2018_06,
+    .minimum_protocol_version = S2N_TLS10
 };
 
 struct s2n_cipher_suite *cipher_suites_cloudfront_upstream[] = {
@@ -497,6 +545,8 @@ struct {
     { "ELBSecurityPolicy-2016-08", &elb_security_policy_2016_08},
     { "ELBSecurityPolicy-TLS-1-1-2017-01", &elb_security_policy_tls_1_1_2017_01},
     { "ELBSecurityPolicy-TLS-1-2-2017-01", &elb_security_policy_tls_1_2_2017_01},
+    { "ELBSecurityPolicy-TLS-1-2-Ext-2018-06", &elb_security_policy_tls_1_2_ext_2018_06},
+    { "ELBSecurityPolicy-FS-2018-06", &elb_security_policy_fs_2018_06},
     { "CloudFront-Upstream", &cipher_preferences_cloudfront_upstream },
     { "CloudFront-SSL-v-3", &cipher_preferences_cloudfront_ssl_v_3 },
     { "CloudFront-TLS-1-0-2014", &cipher_preferences_cloudfront_tls_1_0_2014 },

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -256,18 +256,18 @@ const struct s2n_cipher_preferences cipher_preferences_20170718 = {
 };
 
 struct s2n_cipher_suite *cipher_suites_elb_security_policy_2015_04[] = {
-    /* &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256, */
+    &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
     &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
-    /* &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256, */
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
     &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
-    /* &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha, */
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha,
     &s2n_ecdhe_rsa_with_aes_128_cbc_sha,
-    /* &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384, */
+    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
     &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
-    /* &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384, */
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384,
     &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
     &s2n_ecdhe_rsa_with_aes_256_cbc_sha,
-    /* &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha, */
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha,
     &s2n_rsa_with_aes_128_gcm_sha256,
     &s2n_rsa_with_aes_128_cbc_sha256,
     &s2n_rsa_with_aes_128_cbc_sha,
@@ -284,18 +284,18 @@ const struct s2n_cipher_preferences elb_security_policy_2015_04 = {
 };
 
 struct s2n_cipher_suite *cipher_suites_elb_security_policy_2016_08[] = {
-    /* &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256, */
+    &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
     &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
-    /* &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256, */
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
     &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
-    /* &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha, */
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha,
     &s2n_ecdhe_rsa_with_aes_128_cbc_sha,
-    /* &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384, */
+    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
     &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
-    /* &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384, */
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384,
     &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
     &s2n_ecdhe_rsa_with_aes_256_cbc_sha,
-    /* &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha, */
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha,
     &s2n_rsa_with_aes_128_gcm_sha256,
     &s2n_rsa_with_aes_128_cbc_sha256,
     &s2n_rsa_with_aes_128_cbc_sha,
@@ -311,13 +311,13 @@ const struct s2n_cipher_preferences elb_security_policy_2016_08 = {
 };
 
 struct s2n_cipher_suite *cipher_suites_elb_security_policy_tls_1_2_2017_01[] = {
-    /* &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256, */
+    &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
     &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
-    /* &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256, */
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
     &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
-    /* &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384, */
+    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
     &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
-    /* &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384, */
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384,
     &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
     &s2n_rsa_with_aes_128_gcm_sha256,
     &s2n_rsa_with_aes_128_cbc_sha256,
@@ -332,18 +332,18 @@ const struct s2n_cipher_preferences elb_security_policy_tls_1_2_2017_01 = {
 };
 
 struct s2n_cipher_suite *cipher_suites_elb_security_policy_tls_1_1_2017_01[] = {
-    /* &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256, */
+    &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
     &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
-    /* &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256, */
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
     &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
-    /* &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha, */
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha,
     &s2n_ecdhe_rsa_with_aes_128_cbc_sha,
-    /* &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384, */
+    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
     &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
-    /* &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384, */
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384,
     &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
     &s2n_ecdhe_rsa_with_aes_256_cbc_sha,
-    /* &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha, */
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha,
     &s2n_rsa_with_aes_128_gcm_sha256,
     &s2n_rsa_with_aes_128_cbc_sha256,
     &s2n_rsa_with_aes_128_cbc_sha,
@@ -359,18 +359,18 @@ const struct s2n_cipher_preferences elb_security_policy_tls_1_1_2017_01 = {
 };
 
 struct s2n_cipher_suite *cipher_suites_elb_security_policy_tls_1_2_ext_2018_06[] = {
-    /* &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256, */
+    &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
     &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
-    /* &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256, */
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
     &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
-    /* &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha, */
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha,
     &s2n_ecdhe_rsa_with_aes_128_cbc_sha,
-    /* &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384, */
+    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
     &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
-    /* &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384, */
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384,
     &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
     &s2n_ecdhe_rsa_with_aes_256_cbc_sha,
-    /* &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha, */
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha,
     &s2n_rsa_with_aes_128_gcm_sha256,
     &s2n_rsa_with_aes_128_cbc_sha256,
     &s2n_rsa_with_aes_128_cbc_sha,
@@ -386,18 +386,18 @@ const struct s2n_cipher_preferences elb_security_policy_tls_1_2_ext_2018_06 = {
 };
 
 struct s2n_cipher_suite *cipher_suites_elb_security_policy_fs_2018_06[] = {
-    /* &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256, */
+    &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
     &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
-    /* &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256, */
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
     &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
-    /* &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha, */
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha,
     &s2n_ecdhe_rsa_with_aes_128_cbc_sha,
-    /* &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384, */
+    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
     &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
-    /* &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384, */
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384,
     &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
     &s2n_ecdhe_rsa_with_aes_256_cbc_sha,
-    /* &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha, */
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha,
 };
 
 const struct s2n_cipher_preferences elb_security_policy_fs_2018_06 = {

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -46,6 +46,8 @@ extern const struct s2n_cipher_preferences elb_security_policy_2015_04;
 extern const struct s2n_cipher_preferences elb_security_policy_2016_08;
 extern const struct s2n_cipher_preferences elb_security_policy_tls_1_2_2017_01;
 extern const struct s2n_cipher_preferences elb_security_policy_tls_1_1_2017_01;
+extern const struct s2n_cipher_preferences elb_security_policy_tls_1_2_ext_2018_06;
+extern const struct s2n_cipher_preferences elb_security_policy_fs_2018_06;
 
 extern int s2n_find_cipher_pref_from_version(const char *version, const struct s2n_cipher_preferences **cipher_preferences);
 extern int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *version);


### PR DESCRIPTION
**Issue # (if available):** 

**Description of changes:** 
Add two TLS policies: ELBSecurityPolicy-TLS-1-2-Ext-2018-06, ELBSecurityPolicy-FS-2018-06

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
