### PR TITLE
Allow Clients with Optional Client Auth to not negotiate Client Auth

### DIFF
--- a/tests/saw/README.md
+++ b/tests/saw/README.md
@@ -1,11 +1,11 @@
-#SAW tests for s2n
+# SAW tests for s2n
 
 This repository contains specifications of the various parts of the HMAC
 algorithm used in TLS along with SAW scripts to prove the s2n implementation of
 this algorithm equivalent to the spec.
 
 
-##The tests
+## The tests
 
 Currently this directory houses a test that compares the s2n
 implementation of HMAC with a cryptol spec of the same. There are 3
@@ -37,7 +37,7 @@ instructions for how automated solvers can be used to prove this
 equivalence. When run with the command `saw HMAC.saw`, this file loads
 in the other two and proves the HMAC files equivalent.
 
-##The build
+## The build
 
 Running the saw tests will require a SAW executable, which must be
 able to find the Z3 prover on the path. Future examples might require

--- a/tests/saw/s2n_handshake_io.saw
+++ b/tests/saw/s2n_handshake_io.saw
@@ -111,7 +111,8 @@ let setup_connection = do {
    ocsp_flag <- crucible_fresh_var "ocsp_flag" (llvm_int 32);
    crucible_points_to (conn_status_type pconn) (crucible_term ocsp_flag);
 
- 
+   let client_cert_auth_type = {{ if cca_ov != 0 then cca else config_cca }};
+
    return (pconn, {{ {corked_io = corked_io
                      ,mode      = mode
                      ,handshake = {message_number = message_number
@@ -123,8 +124,9 @@ let setup_connection = do {
                             ((ocsp_flag == 1) && (status_size > 0)) ||
                             ((mode == 1) && (ocsp_flag == 1))
                      ,resume_from_cache = False
-                     ,client_auth_flag = (if cca_ov != 0 then cca != 0 else config_cca != 0)
-                     }
+                     ,client_auth_flag = if mode == S2N_CLIENT then client_cert_auth_type == 1 else 
+                                            if mode == S2N_SERVER then client_cert_auth_type != 0 else False
+                     }                  
                   }}); 
 };
 

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -242,6 +242,8 @@ static message_type_t handshakes[128][16] = {
 #define ACTIVE_STATE( conn ) state_machine[ ACTIVE_MESSAGE( (conn) ) ]
 #define PREVIOUS_STATE( conn ) state_machine[ PREVIOUS_MESSAGE( (conn) ) ]
 
+#define EXPECTED_MESSAGE_TYPE( conn ) ACTIVE_STATE( conn ).message_type
+
 /* Used in our test cases */
 message_type_t s2n_conn_get_current_message_type(struct s2n_connection *conn)
 {
@@ -323,7 +325,12 @@ int s2n_conn_set_handshake_type(struct s2n_connection *conn)
 
     s2n_cert_auth_type client_cert_auth_type;
     GUARD(s2n_connection_get_client_auth_type(conn, &client_cert_auth_type));
-    if(client_cert_auth_type != S2N_CERT_AUTH_NONE) {
+
+    if (conn->mode == S2N_CLIENT && client_cert_auth_type == S2N_CERT_AUTH_REQUIRED) {
+        /* If we're a client, and Client Auth is REQUIRED, then the Client must expect the CLIENT_CERT_REQ Message */
+        conn->handshake.handshake_type |= CLIENT_AUTH;
+    } else if (conn->mode == S2N_SERVER && client_cert_auth_type != S2N_CERT_AUTH_NONE) {
+        /* If we're a server, and Client Auth is REQUIRED or OPTIONAL, then the server must send the CLIENT_CERT_REQ Message*/
         conn->handshake.handshake_type |= CLIENT_AUTH;
     }
 
@@ -592,8 +599,8 @@ static int handshake_read_io(struct s2n_connection *conn)
     /* Record is a handshake message */
     while (s2n_stuffer_data_available(&conn->in)) {
         int r;
-        uint8_t handshake_message_type;
-        GUARD((r = read_full_handshake_message(conn, &handshake_message_type)));
+        uint8_t actual_handshake_message_type;
+        GUARD((r = read_full_handshake_message(conn, &actual_handshake_message_type)));
 
         /* Do we need more data? */
         if (r == 1) {
@@ -606,7 +613,19 @@ static int handshake_read_io(struct s2n_connection *conn)
             return 0;
         }
 
-        S2N_ERROR_IF(handshake_message_type != ACTIVE_STATE(conn).message_type, S2N_ERR_BAD_MESSAGE);
+        s2n_cert_auth_type client_cert_auth_type;
+        GUARD(s2n_connection_get_client_auth_type(conn, &client_cert_auth_type));
+
+        /* If we're a Client, and received a ClientCertRequest message instead of a ServerHelloDone, and ClientAuth
+         * is set to optional, then switch the State Machine that we're using to expect the ClientCertRequest. */
+        if(conn->mode == S2N_CLIENT
+                && client_cert_auth_type == S2N_CERT_AUTH_OPTIONAL
+                && actual_handshake_message_type == TLS_CLIENT_CERT_REQ
+                && EXPECTED_MESSAGE_TYPE(conn) == TLS_SERVER_HELLO_DONE) {
+            conn->handshake.handshake_type |= CLIENT_AUTH;
+        }
+
+        S2N_ERROR_IF(actual_handshake_message_type != EXPECTED_MESSAGE_TYPE(conn), S2N_ERR_BAD_MESSAGE);
 
         /* Call the relevant handler */
         r = ACTIVE_STATE(conn).handler[conn->mode] (conn);


### PR DESCRIPTION
**Issue # (if available):** https://github.com/awslabs/s2n/issues/815

**Description of changes:** 
Fix Client side bug in handling Optional Client Auth.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
