### PR TITLE
Use gcc cleanup

### DIFF
--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -87,10 +87,9 @@ int s2n_x509_trust_store_add_pem(struct s2n_x509_trust_store *store, const char 
         store->trust_store = X509_STORE_new();
     }
 
-
     _cleanup_(s2n_stuffer_free) struct s2n_stuffer pem_in_stuffer = {{0}};
     _cleanup_(s2n_stuffer_free)struct s2n_stuffer der_out_stuffer = {{0}};
-    _cleanup_(s2n_free) struct s2n_blob next_cert = { 0 };
+    _cleanup_(s2n_free) struct s2n_blob next_cert = {0};
 
     GUARD(s2n_stuffer_alloc_ro_from_string(&pem_in_stuffer, pem));
     GUARD(s2n_stuffer_growable_alloc(&der_out_stuffer, 2048));

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -100,8 +100,8 @@ int s2n_x509_trust_store_add_pem(struct s2n_x509_trust_store *store, const char 
         GUARD(s2n_stuffer_read(&der_out_stuffer, &next_cert));
 
         const uint8_t *data = next_cert.data;
-	DEFER_CLEANUP(X509 *ca_cert = d2i_X509(NULL, &data, next_cert.size), X509_freep);
-	S2N_ERROR_IF(ca_cert == NULL, S2N_ERR_DECODE_CERTIFICATE);
+        DEFER_CLEANUP(X509 *ca_cert = d2i_X509(NULL, &data, next_cert.size), X509_freep);
+        S2N_ERROR_IF(ca_cert == NULL, S2N_ERR_DECODE_CERTIFICATE);
 
         GUARD_OSSL(X509_STORE_add_cert(store->trust_store, ca_cert), S2N_ERR_DECODE_CERTIFICATE);
     } while (s2n_stuffer_data_available(&pem_in_stuffer));

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -47,6 +47,8 @@
 
 #define DEFAULT_MAX_CHAIN_DEPTH 7
 
+DEFINE_TRIVIAL_CLEANUP_FUNC(X509*, X509_free);
+
 uint8_t s2n_x509_ocsp_stapling_supported(void) {
     return S2N_OCSP_STAPLING_SUPPORTED;
 }
@@ -85,46 +87,25 @@ int s2n_x509_trust_store_add_pem(struct s2n_x509_trust_store *store, const char 
         store->trust_store = X509_STORE_new();
     }
 
-    s2n_error err = S2N_ERR_DECODE_CERTIFICATE;
 
-    struct s2n_stuffer pem_in_stuffer = {{0}};
-    struct s2n_stuffer der_out_stuffer = {{0}};
-    struct s2n_blob next_cert = {0};
+    _cleanup_(s2n_stuffer_free) struct s2n_stuffer pem_in_stuffer = {{0}};
+    _cleanup_(s2n_stuffer_free)struct s2n_stuffer der_out_stuffer = {{0}};
+    _cleanup_(s2n_free) struct s2n_blob next_cert = { 0 };
 
-    GUARD_GOTO(s2n_stuffer_alloc_ro_from_string(&pem_in_stuffer, pem), clean_up);
-    GUARD_GOTO(s2n_stuffer_growable_alloc(&der_out_stuffer, 2048), clean_up);
+    GUARD(s2n_stuffer_alloc_ro_from_string(&pem_in_stuffer, pem));
+    GUARD(s2n_stuffer_growable_alloc(&der_out_stuffer, 2048));
 
     do {
-        GUARD_GOTO(s2n_stuffer_certificate_from_pem(&pem_in_stuffer, &der_out_stuffer), clean_up);
-        GUARD_GOTO(s2n_alloc(&next_cert, s2n_stuffer_data_available(&der_out_stuffer)), clean_up);
-        GUARD_GOTO(s2n_stuffer_read(&der_out_stuffer, &next_cert), clean_up);
+        GUARD(s2n_stuffer_certificate_from_pem(&pem_in_stuffer, &der_out_stuffer));
+        GUARD(s2n_alloc(&next_cert, s2n_stuffer_data_available(&der_out_stuffer)));
+        GUARD(s2n_stuffer_read(&der_out_stuffer, &next_cert));
 
         const uint8_t *data = next_cert.data;
-        X509 *ca_cert = d2i_X509(NULL, &data, next_cert.size);
-        if (ca_cert == NULL) {
-            goto clean_up;
-        }
+        _cleanup_(X509_freep) X509 *ca_cert = d2i_X509(NULL, &data, next_cert.size);
+	S2N_ERROR_IF(ca_cert == NULL, S2N_ERR_DECODE_CERTIFICATE);
 
-        int rc = X509_STORE_add_cert(store->trust_store, ca_cert);
-        X509_free(ca_cert);
-
-        if (rc != 1) {
-            goto clean_up;
-        }
-
-        GUARD_GOTO(s2n_free(&next_cert), clean_up);
+        GUARD_OSSL(X509_STORE_add_cert(store->trust_store, ca_cert), S2N_ERR_DECODE_CERTIFICATE);
     } while (s2n_stuffer_data_available(&pem_in_stuffer));
-
-    err = S2N_ERR_OK;
-
-    clean_up:
-        GUARD(s2n_stuffer_free(&pem_in_stuffer));
-        GUARD(s2n_stuffer_free(&der_out_stuffer));
-        GUARD(s2n_free(&next_cert));
-
-    if (err != S2N_ERR_OK){
-        S2N_ERROR(err);
-    }
 
     return 0;
 }

--- a/utils/s2n_mem.h
+++ b/utils/s2n_mem.h
@@ -34,4 +34,6 @@ int s2n_dup(struct s2n_blob *from, struct s2n_blob *to);
   }							    \
   struct __useless_struct_to_allow_trailing_semicolon__
 
-#define _cleanup_(x) __attribute__((cleanup(x)))
+#define DEFER_CLEANUP(_thealloc, _thecleanup) \
+   __attribute__((cleanup(_thecleanup))) _thealloc
+

--- a/utils/s2n_mem.h
+++ b/utils/s2n_mem.h
@@ -25,3 +25,13 @@ int s2n_alloc(struct s2n_blob *b, uint32_t size);
 int s2n_realloc(struct s2n_blob *b, uint32_t size);
 int s2n_free(struct s2n_blob *b);
 int s2n_dup(struct s2n_blob *from, struct s2n_blob *to);
+
+
+#define DEFINE_TRIVIAL_CLEANUP_FUNC(type, func)             \
+  static inline void func##p(type *p) {			    \
+    if (p && *p)					    \
+      func(*p);						    \
+  }							    \
+  struct __useless_struct_to_allow_trailing_semicolon__
+
+#define _cleanup_(x) __attribute__((cleanup(x)))


### PR DESCRIPTION
**Issue # (if available):** 
https://github.com/awslabs/s2n/issues/737

**Description of changes:** 
Modern C compilers have an __attribute(cleanup()) that calls a destructor when the variable goes out of scope.   This is a tracer bullet to see how it looks using it for one function - if this looks good, it could be extended to any other functions that need to do cleanup.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
