### PR TITLE
Use the correct output size with rdrand. The size of the returned val…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ set(INSTALL_LIB_DIR lib CACHE PATH "Installaction directory for libraries")
 set(INSTALL_INCLUDE_DIR include CACHE PATH "installaction directory for header files")
 set(INSTALL_CMAKE_DIR lib/cmake CACHE PATH "Installation directory for cmake files")
 
+option(BUILD_TESTING "Build tests" ON)
+
 ##header files
 file(GLOB API_HEADERS
      "api/*.h"
@@ -127,39 +129,41 @@ target_include_directories(s2n PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_D
 target_include_directories(s2n PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api> $<INSTALL_INTERFACE:include>)
 target_include_directories(s2n PUBLIC $<TARGET_PROPERTY:LibCrypto::Crypto,INTERFACE_INCLUDE_DIRECTORIES>)
 
-file(GLOB TESTLIB_SRC "tests/testlib/*.c")
-file(GLOB TESTLIB_HEADERS "tests/testlib/*.h")
+if(BUILD_TESTING)
+	file(GLOB TESTLIB_SRC "tests/testlib/*.c")
+	file(GLOB TESTLIB_HEADERS "tests/testlib/*.h")
 
-add_library(testss2n ${TESTLIB_HEADERS} ${TESTLIB_SRC})
-target_include_directories(testss2n PRIVATE tests)
-target_compile_options(testss2n PRIVATE -std=c99)
-target_link_libraries(testss2n PUBLIC s2n)
+	add_library(testss2n ${TESTLIB_HEADERS} ${TESTLIB_SRC})
+	target_include_directories(testss2n PRIVATE tests)
+	target_compile_options(testss2n PRIVATE -std=c99)
+	target_link_libraries(testss2n PUBLIC s2n)
 
-#run unit tests
-file (GLOB TEST_LD_PRELOAD "tests/LD_PRELOAD/*.c")
-add_library(allocator_overrides SHARED ${TEST_LD_PRELOAD})
+	#run unit tests
+	file (GLOB TEST_LD_PRELOAD "tests/LD_PRELOAD/*.c")
+	add_library(allocator_overrides SHARED ${TEST_LD_PRELOAD})
 
-include(CTest)
-enable_testing()
+	include(CTest)
+	enable_testing()
 
-file(GLOB UNITTESTS_SRC "tests/unit/*.c")
-    foreach(test_case ${UNITTESTS_SRC})
-    string(REGEX REPLACE ".+\\/(.+)\\.c" "\\1" test_case_name ${test_case})
-    add_executable(${test_case_name} ${test_case})
-    target_link_libraries(${test_case_name} PRIVATE testss2n PRIVATE m pthread)
-    target_include_directories(${test_case_name} PRIVATE api)
-    target_include_directories(${test_case_name} PRIVATE ./)
-    target_include_directories(${test_case_name} PRIVATE tests)
-    target_compile_options(${test_case_name} PRIVATE -Wno-implicit-function-declaration -std=c99)
-    add_test(NAME ${test_case_name} COMMAND $<TARGET_FILE:${test_case_name}> WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit)
+	file(GLOB UNITTESTS_SRC "tests/unit/*.c")
+	foreach(test_case ${UNITTESTS_SRC})
+		string(REGEX REPLACE ".+\\/(.+)\\.c" "\\1" test_case_name ${test_case})
+		add_executable(${test_case_name} ${test_case})
+		target_link_libraries(${test_case_name} PRIVATE testss2n PRIVATE m pthread)
+		target_include_directories(${test_case_name} PRIVATE api)
+		target_include_directories(${test_case_name} PRIVATE ./)
+		target_include_directories(${test_case_name} PRIVATE tests)
+		target_compile_options(${test_case_name} PRIVATE -Wno-implicit-function-declaration -std=c99)
+		add_test(NAME ${test_case_name} COMMAND $<TARGET_FILE:${test_case_name}> WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit)
 
-    set_property(
-    TEST
-        ${test_case_name}
-    PROPERTY
-        ENVIRONMENT LD_PRELOAD=$<TARGET_FILE:allocator_overrides>)
+		set_property(
+			TEST
+			${test_case_name}
+			PROPERTY
+			ENVIRONMENT LD_PRELOAD=$<TARGET_FILE:allocator_overrides>)
 
-endforeach(test_case)
+	endforeach(test_case)
+endif()
 
 add_executable(s2nc "bin/s2nc.c" "bin/echo.c")
 target_link_libraries(s2nc s2n)

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -324,8 +324,13 @@ int s2n_get_rdrand_data(struct s2n_blob *out)
     int space_remaining = 0;
     struct s2n_stuffer stuffer = {{0}};
     union {
-        uint64_t u64;
+#if defined(__x86_64__)
+        uint64_t value;
         uint8_t u8[8];
+#else
+        uint32_t value;
+        uint8_t u8[4];
+#endif
     } output;
 
     GUARD(s2n_stuffer_init(&stuffer, out));
@@ -334,7 +339,7 @@ int s2n_get_rdrand_data(struct s2n_blob *out)
         int success = 0;
 
         for (int tries = 0; tries < 10; tries++) {
-            __asm__ __volatile__(".byte 0x48;\n" ".byte 0x0f;\n" ".byte 0xc7;\n" ".byte 0xf0;\n" "adcl $0x00, %%ebx;\n":"=b"(success), "=a"(output.u64)
+            __asm__ __volatile__(".byte 0x48;\n" ".byte 0x0f;\n" ".byte 0xc7;\n" ".byte 0xf0;\n" "adcl $0x00, %%ebx;\n":"=b"(success), "=a"(output.value)
                                  :"b"(0)
                                  :"cc");
 


### PR DESCRIPTION
…ue is determined by the size of the register given.

This fixes the build on i386 (utils/s2n_random.c:337:141: error: invalid output size for constraint '=a')

**Issue # (if available):** 
utils/s2n_random.c:337:141: error: invalid output size for constraint '=a'

**Description of changes:** 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
