### PR TITLE
Dynamic record size implementation and integration test

### DIFF
--- a/.travis/install_ubuntu_dependencies.sh
+++ b/.travis/install_ubuntu_dependencies.sh
@@ -18,7 +18,7 @@ set -ex
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 sudo apt-get update
 
-DEPENDENCIES="indent kwstyle"
+DEPENDENCIES="indent kwstyle tcpdump"
 
 sudo apt-get install -y ${DEPENDENCIES}
 

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -146,6 +146,7 @@ extern int s2n_connection_set_send_cb(struct s2n_connection *conn, s2n_send_fn s
 
 extern int s2n_connection_prefer_throughput(struct s2n_connection *conn);
 extern int s2n_connection_prefer_low_latency(struct s2n_connection *conn);
+extern int s2n_connection_set_dynamic_record_threshold(struct s2n_connection *conn, uint32_t resize_threshold, uint16_t timeout_threshold);
 
 /* If you don't want to use the configuration wide callback, you can set this per connection and it will be honored. */
 extern int s2n_connection_set_verify_host_callback(struct s2n_connection *config, s2n_verify_host_fn host_fn, void *data);

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -16,6 +16,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>
+#include <sys/param.h>
 #include <poll.h>
 #include <netdb.h>
 
@@ -63,6 +64,10 @@ void usage()
     fprintf(stderr, "    Turns off certification validation altogether.\n");
     fprintf(stderr, "  -r,--reconnect\n");
     fprintf(stderr, "    Drop and re-make the connection with the same Session-ID\n");
+    fprintf(stderr, "  -D,--dynamic\n");
+    fprintf(stderr, "    Set dynamic record resize threshold\n");
+    fprintf(stderr, "  -t,--timeout\n");
+    fprintf(stderr, "    Set dynamic record timeout threshold\n");
     fprintf(stderr, "\n");
     exit(1);
 }
@@ -219,6 +224,8 @@ int main(int argc, char *const *argv)
     uint8_t insecure = 0;
     int reconnect = 0;
     s2n_status_request_type type = S2N_STATUS_REQUEST_NONE;
+    uint32_t dyn_rec_threshold = 0;
+    uint8_t dyn_rec_timeout = 0;
     /* required args */
     const char *cipher_prefs = "default";
     const char *host = NULL;
@@ -237,11 +244,13 @@ int main(int argc, char *const *argv)
         {"ca-file", required_argument, 0, 'f'},
         {"ca-dir", required_argument, 0, 'd'},
         {"insecure", no_argument, 0, 'i'},
-        {"reconnect", no_argument, 0, 'r'}
+        {"reconnect", no_argument, 0, 'r'},
+        {"Dynamic", required_argument, 0, 'D'},
+        {"timeout", required_argument, 0, 't'},
     };
     while (1) {
         int option_index = 0;
-        int c = getopt_long(argc, argv, "a:c:ehn:sf:d:ir", long_options, &option_index);
+        int c = getopt_long(argc, argv, "a:c:ehn:sf:d:D:t:ir", long_options, &option_index);
         if (c == -1) {
             break;
         }
@@ -278,6 +287,15 @@ int main(int argc, char *const *argv)
             break;
         case 'r':
             reconnect = 5;
+            break;
+        case 't':
+            dyn_rec_timeout = (uint8_t) MIN(255, atoi(optarg));
+            break;
+        case 'D':
+            dyn_rec_threshold = strtoul(optarg, 0, 10);
+            if (errno == ERANGE) {
+              dyn_rec_threshold = 0;      
+            }
             break;
         case '?':
         default:
@@ -406,6 +424,10 @@ int main(int argc, char *const *argv)
                 print_s2n_error("Error getting serialized session state");
                 exit(1);
             }
+        }
+
+        if (dyn_rec_threshold > 0 && dyn_rec_timeout > 0) {
+            s2n_connection_set_dynamic_record_threshold(conn, dyn_rec_threshold, dyn_rec_timeout);
         }
 
         if (echo_input == 1) {

--- a/tests/integration/Makefile
+++ b/tests/integration/Makefile
@@ -30,6 +30,12 @@ all:
 	LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
 	python3 s2n_client_endpoint_handshake_test.py $(S2ND_HOST) $(S2ND_PORT); \
 	)
+	# Run dynamic record size tests
+	( \
+	DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" \
+	LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
+	python3 s2n_dynamic_record_size_test.py --libcrypto $(S2N_LIBCRYPTO) $(S2ND_HOST) $(S2ND_PORT); \
+	)
 	# Run s_client handshake tests
 	( \
 	DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" \

--- a/tests/integration/data/test_buf
+++ b/tests/integration/data/test_buf
@@ -1,0 +1,961 @@
+#
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+"""
+Handshake tests using Openssl s_client against s2nd
+Openssl 1.1.0 removed SSLv3, 3DES, an RC4, so we won't have coverage there.
+"""
+
+import argparse
+import os
+import sys
+import subprocess
+import itertools
+import multiprocessing
+from os import environ
+from multiprocessing.pool import ThreadPool
+from s2n_test_constants import *
+
+PROTO_VERS_TO_S_CLIENT_ARG = {
+    S2N_TLS10 : "-tls1",
+    S2N_TLS11 : "-tls1_1",
+    S2N_TLS12 : "-tls1_2",
+}
+
+S_CLIENT_SUCCESSFUL_OCSP="OCSP Response Status: successful"
+
+def cleanup_processes(*processes):
+    for p in processes:
+        p.kill()
+        p.wait()
+
+def try_handshake(endpoint, port, cipher, ssl_version, server_cert=None, server_key=None, ocsp=None, sig_algs=None, curves=None, resume=False,
+        prefer_low_latency=False, enter_fips_mode=False, client_auth=None, client_cert=DEFAULT_CLIENT_CERT_PATH, client_key=DEFAULT_CLIENT_KEY_PATH):
+    """
+    Attempt to handshake against s2nd listening on `endpoint` and `port` using Openssl s_client
+
+    :param int endpoint: endpoint for s2nd to listen on
+    :param int port: port for s2nd to listen on
+    :param str cipher: ciphers for Openssl s_client to offer. See https://www.openssl.org/docs/man1.0.2/apps/ciphers.html
+    :param int ssl_version: SSL version for s_client to use
+    :param str server_cert: path to certificate for s2nd to use
+    :param str server_key: path to private key for s2nd to use
+    :param str ocsp: path to OCSP response file for stapling
+    :param str sig_algs: Signature algorithms for s_client to offer
+    :param str curves: Elliptic curves for s_client to offer
+    :param bool resume: True if s_client should try to reconnect to s2nd and reuse the same TLS session. False for normal negotiation.
+    :param bool prefer_low_latency: True if s2nd should use 1500 for max outgoing record size. False for default max.
+    :param bool enter_fips_mode: True if s2nd should enter libcrypto's FIPS mode. Libcrypto must be built with a FIPS module to enter FIPS mode.
+    :param bool client_auth: True if the test should try and use client authentication
+    :param str client_cert: Path to the client's cert file
+    :param str client_key: Path to the client's private key file
+    :return: 0 on successfully negotiation(s), -1 on failure
+    """
+
+    # Override certificate for ECDSA if unspecified. We can remove this when we
+    # support multiple certificates
+    if server_cert is None and "ECDSA" in cipher:
+        server_cert = TEST_ECDSA_CERT
+        server_key = TEST_ECDSA_KEY
+   
+    # Fire up s2nd
+    s2nd_cmd = ["../../bin/s2nd"]
+
+    if server_cert is not None:
+        s2nd_cmd.extend(["--cert", server_cert])
+    if server_key is not None:
+        s2nd_cmd.extend(["--key", server_key])
+    if ocsp is not None:
+        s2nd_cmd.extend(["--ocsp", ocsp])
+    if prefer_low_latency == True:
+        s2nd_cmd.append("--prefer-low-latency")
+    if client_auth is not None:
+        s2nd_cmd.append("-m")
+        s2nd_cmd.extend(["-t", client_cert])
+
+    s2nd_cmd.extend([str(endpoint), str(port)])
+    
+    s2nd_ciphers = "test_all"
+    if enter_fips_mode == True:
+        s2nd_ciphers = "test_all_fips"
+        s2nd_cmd.append("--enter-fips-mode")
+    if "ECDSA" in cipher:
+        s2nd_ciphers = "test_all_ecdsa"
+    s2nd_cmd.append("-c")
+    s2nd_cmd.append(s2nd_ciphers)
+    
+    s2nd = subprocess.Popen(s2nd_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+
+    # Make sure it's running
+    s2nd.stdout.readline()
+
+    s_client_cmd = ["openssl", "s_client", PROTO_VERS_TO_S_CLIENT_ARG[ssl_version],
+            "-connect", str(endpoint) + ":" + str(port)]
+    if cipher is not None:
+        s_client_cmd.extend(["-cipher", cipher])
+    if sig_algs is not None:
+        s_client_cmd.extend(["-sigalgs", sig_algs])
+    if curves is not None:
+        s_client_cmd.extend(["-curves", curves])
+    if resume == True:
+        s_client_cmd.append("-reconnect")
+    if client_auth is not None:
+        s_client_cmd.extend(["-key", client_key])
+        s_client_cmd.extend(["-cert", client_cert])
+    if ocsp is not None:
+        s_client_cmd.append("-status")
+
+    # Fire up s_client
+    s_client = subprocess.Popen(s_client_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+
+    # Validate that s_client resumes successfully against s2nd
+    if resume is True:
+        seperators = 0
+        for line in s2nd.stdout:
+            line = line.decode("utf-8").strip()
+            if line.startswith("Resumed session"):
+                seperators += 1
+
+            if seperators == 5:
+                break
+
+        if seperators != 5:
+            cleanup_processes(s2nd, s_client)
+            return -1
+
+    # Validate that s_client accepted s2nd's stapled OCSP response
+    if ocsp is not None:
+        ocsp_success = False
+        for line in s_client.stdout:
+            line = line.decode("utf-8").strip()
+            if S_CLIENT_SUCCESSFUL_OCSP in line:
+                ocsp_success = True
+                break
+        if not ocsp_success:
+            cleanup_processes(s2nd, s_client)
+            return -1
+
+    # Write the cipher name towards s2n
+    s_client.stdin.write((cipher + "\n").encode("utf-8"))
+    s_client.stdin.flush()
+
+    # Read it
+    found = 0
+    for line in range(0, 10):
+        output = s2nd.stdout.readline().decode("utf-8")
+        if output.strip() == cipher:
+            found = 1
+            break
+
+    if found == 0:
+        cleanup_processes(s2nd, s_client)
+        return -1
+
+    # Write the cipher name from s2n
+    s2nd.stdin.write((cipher + "\n").encode("utf-8"))
+    s2nd.stdin.flush()
+    found = 0
+    for line in range(0, 512):
+        output = s_client.stdout.readline().decode("utf-8")
+        if output.strip() == cipher:
+            found = 1
+            break
+
+    if found == 0:
+        cleanup_processes(s2nd, s_client)
+        return -1
+
+    cleanup_processes(s2nd, s_client)
+
+    return 0
+
+def cert_path_to_str(cert_path):
+    # Converts a path to a cert into a string usable for printing to test output
+    # Example: "./test_certs/rsa_2048_sha256_client_cert.pem" => "RSA-2048-SHA256"
+    return '-'.join(cert_path[cert_path.rfind('/')+1:].split('_')[:3]).upper()
+
+def print_result(result_prefix, return_code):
+    suffix = ""
+    if return_code == 0:
+        if sys.stdout.isatty():
+            suffix = "\033[32;1mPASSED\033[0m"
+        else:
+            suffix = "PASSED"
+    else:
+        if sys.stdout.isatty():
+            suffix = "\033[31;1mFAILED\033[0m"
+        else:
+            suffix ="FAILED"
+            
+    print(result_prefix + suffix)
+
+def create_thread_pool():
+    threadpool_size = multiprocessing.cpu_count() * 2  #Multiply by 2 since performance improves slightly if CPU has hyperthreading
+    print("\tCreating ThreadPool of size: " + str(threadpool_size))
+    threadpool = ThreadPool(processes=threadpool_size)
+    return threadpool
+
+def run_handshake_test(host, port, ssl_version, cipher, fips_mode, use_client_auth, client_cert_path, client_key_path):
+    cipher_name = cipher.openssl_name
+    cipher_vers = cipher.min_tls_vers
+
+    # Skip the cipher if openssl can't test it. 3DES/RC4 are disabled by default in 1.1.0
+    if not cipher.openssl_1_1_0_compatible:
+        return 0
+
+    if ssl_version < cipher_vers:
+        return 0
+    
+    client_cert_str=str(use_client_auth)
+    
+    if (use_client_auth is not None) and (client_cert_path is not None):
+        client_cert_str = cert_path_to_str(client_cert_path)
+
+    ret = try_handshake(host, port, cipher_name, ssl_version, enter_fips_mode=fips_mode, client_auth=use_client_auth, client_cert=client_cert_path, client_key=client_key_path)
+    
+    result_prefix = "Cipher: %-28s ClientCert: %-16s Vers: %-8s ... " % (cipher_name, client_cert_str, S2N_PROTO_VERS_TO_STR[ssl_version])
+    print_result(result_prefix, ret)
+    
+    return ret
+
+def handshake_test(host, port, test_ciphers, fips_mode, use_client_auth=None, use_client_cert=None, use_client_key=None):
+    """
+    Basic handshake tests using all valid combinations of supported cipher suites and TLS versions.
+    """
+    print("\n\tRunning handshake tests:")
+    
+    failed = 0
+    for ssl_version in [S2N_TLS10, S2N_TLS11, S2N_TLS12]:
+        print("\n\tTesting ciphers using client version: " + S2N_PROTO_VERS_TO_STR[ssl_version])
+        threadpool = create_thread_pool()
+        port_offset = 0
+        results = []
+        
+        for cipher in test_ciphers:
+            async_result = threadpool.apply_async(run_handshake_test, (host, port + port_offset, ssl_version, cipher, fips_mode, use_client_auth, use_client_cert, use_client_key))
+            port_offset += 1
+            results.append(async_result)
+
+        threadpool.close()
+        threadpool.join()
+        for async_result in results:
+            if async_result.get() != 0:
+                failed = 1
+
+    return failed
+    
+
+def client_auth_test(host, port, test_ciphers, fips_mode):
+    failed = 0
+
+    print("\n\tRunning client auth tests:")
+
+    if fips_mode:
+        print("\t\033[33;1mSKIPPED\033[0m - Client Auth not supported in FIPS mode")
+        return 0
+
+    for filename in os.listdir(TEST_CERT_DIRECTORY):
+        if "client_cert" in filename and "rsa" in filename:
+            client_cert_path = TEST_CERT_DIRECTORY + filename
+            client_key_path = TEST_CERT_DIRECTORY + filename.replace("client_cert", "client_key")
+            ret = handshake_test(host, port, test_ciphers, fips_mode, use_client_auth=True, use_client_cert=client_cert_path, use_client_key=client_key_path)
+            if ret is not 0:
+                failed += 1
+                
+    return failed
+
+def resume_test(host, port, test_ciphers, fips_mode):
+    """
+    Tests s2n's session resumption capability using all valid combinations of cipher suite and TLS version.
+    """
+    print("\n\tRunning resumption tests:")
+    failed = 0
+    for ssl_version in [S2N_TLS10, S2N_TLS11, S2N_TLS12]:
+        print("\n\tTesting ciphers using client version: " + S2N_PROTO_VERS_TO_STR[ssl_version])
+        for cipher in test_ciphers:
+            cipher_name = cipher.openssl_name
+            cipher_vers = cipher.min_tls_vers
+
+            # Skip the cipher if openssl can't test it. 3DES/RC4 are disabled by default in 1.1.0
+            if not cipher.openssl_1_1_0_compatible:
+                continue
+
+            if ssl_version < cipher_vers:
+                continue
+
+            ret = try_handshake(host, port, cipher_name, ssl_version, resume=True, enter_fips_mode=fips_mode)
+            result_prefix = "Cipher: %-30s Vers: %-10s ... " % (cipher_name, S2N_PROTO_VERS_TO_STR[ssl_version])
+            print_result(result_prefix, ret)
+            if ret != 0:
+                failed = 1
+
+    return failed
+
+supported_sigs = ["RSA+SHA1", "RSA+SHA224", "RSA+SHA256", "RSA+SHA384", "RSA+SHA512"]
+unsupported_sigs = ["ECDSA+SHA256", "ECDSA+SHA512"]
+
+def run_sigalg_test(host, port, cipher, ssl_version, permutation, fips_mode, use_client_auth):
+    # Put some unsupported algs in front to make sure we gracefully skip them
+    mixed_sigs = unsupported_sigs + list(permutation)
+    mixed_sigs_str = ':'.join(mixed_sigs)
+    ret = try_handshake(host, port, cipher.openssl_name, ssl_version, sig_algs=mixed_sigs_str, enter_fips_mode=fips_mode, client_auth=use_client_auth)
+        
+    # Trim the RSA part off for brevity. User should know we are only supported RSA at the moment.
+    prefix = "Digests: %-35s ClientAuth: %-6s Vers: %-8s... " % (':'.join([x[4:] for x in permutation]), str(use_client_auth), S2N_PROTO_VERS_TO_STR[S2N_TLS12])
+    print_result(prefix, ret)
+    return ret
+
+def sigalg_test(host, port, fips_mode, use_client_auth=None):
+    """
+    Acceptance test for supported signature algorithms. Tests all possible supported sigalgs with unsupported ones mixed in
+    for noise.
+    """
+    failed = 0
+
+    print("\n\tRunning signature algorithm tests:")
+
+    if fips_mode and use_client_auth:
+        print("\t\033[33;1mSKIPPED\033[0m - Client Auth not supported in FIPS mode")
+        return 0
+
+    print("\tExpected supported:   " + str(supported_sigs))
+    print("\tExpected unsupported: " + str(unsupported_sigs))
+
+    for size in range(1, len(supported_sigs) + 1):
+        print("\n\t\tTesting ciphers using signature preferences of size: " + str(size))
+        threadpool = create_thread_pool()
+        portOffset = 0
+        results = []
+        # Produce permutations of every accepted signature algorithm in every possible order
+        for permutation in itertools.permutations(supported_sigs, size):
+            for cipher in ALL_TEST_CIPHERS:
+                # Try an ECDHE cipher suite and a DHE one
+                if(cipher.openssl_name == "ECDHE-RSA-AES128-GCM-SHA256" or cipher.openssl_name == "DHE-RSA-AES128-GCM-SHA256"):
+                    async_result = threadpool.apply_async(run_sigalg_test, (host, port + portOffset, cipher, S2N_TLS12, permutation, fips_mode, use_client_auth))
+                    portOffset = portOffset + 1
+                    results.append(async_result)
+
+        threadpool.close()
+        threadpool.join()
+        for async_result in results:
+            if async_result.get() != 0:
+                failed = 1
+
+    return failed
+
+def elliptic_curve_test(host, port, fips_mode):
+    """
+    Acceptance test for supported elliptic curves. Tests all possible supported curves with unsupported curves mixed in
+    for noise.
+    """
+    supported_curves = ["P-256", "P-384"]
+    unsupported_curves = ["B-163", "K-409"]
+    print("\n\tRunning elliptic curve tests:")
+    print("\tExpected supported:   " + str(supported_curves))
+    print("\tExpected unsupported: " + str(unsupported_curves))
+
+    failed = 0
+    for size in range(1, len(supported_curves) + 1):
+        print("\n\t\tTesting ciphers using curve list of size: " + str(size))
+
+        # Produce permutations of every accepted curve in every possible order
+        for permutation in itertools.permutations(supported_curves, size):
+            # Put some unsupported curves in front to make sure we gracefully skip them
+            mixed_curves = unsupported_curves + list(permutation)
+            mixed_curves_str = ':'.join(mixed_curves)
+            for cipher in filter(lambda x: x.openssl_name == "ECDHE-RSA-AES128-GCM-SHA256" or x.openssl_name == "ECDHE-RSA-AES128-SHA", ALL_TEST_CIPHERS):
+                if fips_mode and cipher.openssl_fips_compatible == False:
+                    continue
+                ret = try_handshake(host, port, cipher.openssl_name, S2N_TLS12, curves=mixed_curves_str, enter_fips_mode=fips_mode)
+                prefix = "Curves: %-40s Vers: %10s ... " % (':'.join(list(permutation)), S2N_PROTO_VERS_TO_STR[S2N_TLS12])
+                print_result(prefix, ret)
+                if ret != 0:
+                    failed = 1
+    return failed
+
+def elliptic_curve_fallback_test(host, port, fips_mode):
+    """
+    Tests graceful fallback when s2n doesn't support any curves offered by the client. A non-ecc suite should be
+    negotiated.
+    """
+    failed = 0
+    # Make sure s2n can still negotiate a non-EC kx(AES256-GCM-SHA384) suite if we don't match anything on the client
+    unsupported_curves = ["B-163", "K-409"]
+    ret = try_handshake(host, port, "ECDHE-RSA-AES128-SHA256:AES256-GCM-SHA384", S2N_TLS12, curves=":".join(unsupported_curves), enter_fips_mode=fips_mode)
+    print_result("%-65s ... " % "Testing curve mismatch fallback", ret)
+    if ret != 0:
+        failed = 1
+
+    return failed
+
+def handshake_fragmentation_test(host, port, fips_mode):
+    """
+    Tests successful negotation with s_client despite message fragmentation. Max record size is clamped to force s2n
+    to fragment the ServerCertifcate message.
+    """
+    print("\n\tRunning handshake fragmentation tests:")
+    failed = 0
+    for ssl_version in [S2N_TLS10, S2N_TLS11, S2N_TLS12]:
+        print("\n\tTesting ciphers using client version: " + S2N_PROTO_VERS_TO_STR[ssl_version])
+        # Cipher isn't relevant for this test, pick one available in all OpenSSL versions and all TLS versions
+        cipher_name = "AES256-SHA"
+
+        # Low latency option indirectly forces fragmentation.
+        ret = try_handshake(host, port, cipher_name, ssl_version, prefer_low_latency=True, enter_fips_mode=fips_mode)
+        result_prefix = "Cipher: %-30s Vers: %-10s ... " % (cipher_name, S2N_PROTO_VERS_TO_STR[ssl_version])
+        print_result(result_prefix, ret)
+        if ret != 0:
+            failed = 1
+
+    failed = 0
+    return failed
+
+def ocsp_stapling_test(host, port, fips_mode):
+    """
+    Test s2n's server OCSP stapling capability
+    """
+    print("\n\tRunning OCSP stapling tests:")
+    failed = 0
+    for ssl_version in [S2N_TLS10, S2N_TLS11, S2N_TLS12]:
+        print("\n\tTesting ciphers using client version: " + S2N_PROTO_VERS_TO_STR[ssl_version])
+        # Cipher isn't relevant for this test, pick one available in all TLS versions
+        cipher_name = "AES256-SHA"
+
+        ret = try_handshake(host, port, cipher_name, ssl_version, enter_fips_mode=fips_mode, server_cert=TEST_OCSP_CERT, server_key=TEST_OCSP_KEY,
+                ocsp=TEST_OCSP_RESPONSE_FILE)
+        result_prefix = "Cipher: %-30s Vers: %-10s ... " % (cipher_name, S2N_PROTO_VERS_TO_STR[ssl_version])
+        print_result(result_prefix, ret)
+        if ret != 0:
+            failed = 1
+
+    return failed
+
+def main():
+    parser = argparse.ArgumentParser(description='Runs TLS server integration tests against s2nd using Openssl s_client')
+    parser.add_argument('host', help='The host for s2nd to bind to')
+    parser.add_argument('port', type=int, help='The port for s2nd to bind to')
+    parser.add_argument('--libcrypto', default='openssl-1.1.0', choices=['openssl-1.0.2', 'openssl-1.0.2-fips', 'openssl-1.1.0', 'openssl-1.1.x-master', 'libressl'],
+            help="""The Libcrypto that s2n was built with. s2n supports different cipher suites depending on
+                    libcrypto version. Defaults to openssl-1.1.0.""")
+    args = parser.parse_args()
+
+    # Retrieve the test ciphers to use based on the libcrypto version s2n was built with
+    test_ciphers = S2N_LIBCRYPTO_TO_TEST_CIPHERS[args.libcrypto]
+    host = args.host
+    port = args.port
+
+    fips_mode = False
+    if environ.get("S2N_TEST_IN_FIPS_MODE") is not None:
+        fips_mode = True
+        print("\nRunning s2nd in FIPS mode.")
+
+    print("\nRunning tests with: " + os.popen('openssl version').read())
+
+    failed = 0
+    failed += resume_test(host, port, test_ciphers, fips_mode)
+    failed += handshake_test(host, port, test_ciphers, fips_mode)
+    failed += client_auth_test(host, port, test_ciphers, fips_mode)
+    failed += sigalg_test(host, port, fips_mode)
+    failed += sigalg_test(host, port, fips_mode, use_client_auth=True)
+    failed += elliptic_curve_test(host, port, fips_mode)
+    failed += elliptic_curve_fallback_test(host, port, fips_mode)
+    failed += handshake_fragmentation_test(host, port, fips_mode)
+    failed += ocsp_stapling_test(host, port, fips_mode)
+    return failed
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+
+#
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+"""
+Handshake tests using Openssl s_client against s2nd
+Openssl 1.1.0 removed SSLv3, 3DES, an RC4, so we won't have coverage there.
+"""
+
+import argparse
+import os
+import sys
+import subprocess
+import itertools
+import multiprocessing
+from os import environ
+from multiprocessing.pool import ThreadPool
+from s2n_test_constants import *
+
+PROTO_VERS_TO_S_CLIENT_ARG = {
+    S2N_TLS10 : "-tls1",
+    S2N_TLS11 : "-tls1_1",
+    S2N_TLS12 : "-tls1_2",
+}
+
+S_CLIENT_SUCCESSFUL_OCSP="OCSP Response Status: successful"
+
+def cleanup_processes(*processes):
+    for p in processes:
+        p.kill()
+        p.wait()
+
+def try_handshake(endpoint, port, cipher, ssl_version, server_cert=None, server_key=None, ocsp=None, sig_algs=None, curves=None, resume=False,
+        prefer_low_latency=False, enter_fips_mode=False, client_auth=None, client_cert=DEFAULT_CLIENT_CERT_PATH, client_key=DEFAULT_CLIENT_KEY_PATH):
+    """
+    Attempt to handshake against s2nd listening on `endpoint` and `port` using Openssl s_client
+
+    :param int endpoint: endpoint for s2nd to listen on
+    :param int port: port for s2nd to listen on
+    :param str cipher: ciphers for Openssl s_client to offer. See https://www.openssl.org/docs/man1.0.2/apps/ciphers.html
+    :param int ssl_version: SSL version for s_client to use
+    :param str server_cert: path to certificate for s2nd to use
+    :param str server_key: path to private key for s2nd to use
+    :param str ocsp: path to OCSP response file for stapling
+    :param str sig_algs: Signature algorithms for s_client to offer
+    :param str curves: Elliptic curves for s_client to offer
+    :param bool resume: True if s_client should try to reconnect to s2nd and reuse the same TLS session. False for normal negotiation.
+    :param bool prefer_low_latency: True if s2nd should use 1500 for max outgoing record size. False for default max.
+    :param bool enter_fips_mode: True if s2nd should enter libcrypto's FIPS mode. Libcrypto must be built with a FIPS module to enter FIPS mode.
+    :param bool client_auth: True if the test should try and use client authentication
+    :param str client_cert: Path to the client's cert file
+    :param str client_key: Path to the client's private key file
+    :return: 0 on successfully negotiation(s), -1 on failure
+    """
+
+    # Override certificate for ECDSA if unspecified. We can remove this when we
+    # support multiple certificates
+    if server_cert is None and "ECDSA" in cipher:
+        server_cert = TEST_ECDSA_CERT
+        server_key = TEST_ECDSA_KEY
+   
+    # Fire up s2nd
+    s2nd_cmd = ["../../bin/s2nd"]
+
+    if server_cert is not None:
+        s2nd_cmd.extend(["--cert", server_cert])
+    if server_key is not None:
+        s2nd_cmd.extend(["--key", server_key])
+    if ocsp is not None:
+        s2nd_cmd.extend(["--ocsp", ocsp])
+    if prefer_low_latency == True:
+        s2nd_cmd.append("--prefer-low-latency")
+    if client_auth is not None:
+        s2nd_cmd.append("-m")
+        s2nd_cmd.extend(["-t", client_cert])
+
+    s2nd_cmd.extend([str(endpoint), str(port)])
+    
+    s2nd_ciphers = "test_all"
+    if enter_fips_mode == True:
+        s2nd_ciphers = "test_all_fips"
+        s2nd_cmd.append("--enter-fips-mode")
+    if "ECDSA" in cipher:
+        s2nd_ciphers = "test_all_ecdsa"
+    s2nd_cmd.append("-c")
+    s2nd_cmd.append(s2nd_ciphers)
+    
+    s2nd = subprocess.Popen(s2nd_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+
+    # Make sure it's running
+    s2nd.stdout.readline()
+
+    s_client_cmd = ["openssl", "s_client", PROTO_VERS_TO_S_CLIENT_ARG[ssl_version],
+            "-connect", str(endpoint) + ":" + str(port)]
+    if cipher is not None:
+        s_client_cmd.extend(["-cipher", cipher])
+    if sig_algs is not None:
+        s_client_cmd.extend(["-sigalgs", sig_algs])
+    if curves is not None:
+        s_client_cmd.extend(["-curves", curves])
+    if resume == True:
+        s_client_cmd.append("-reconnect")
+    if client_auth is not None:
+        s_client_cmd.extend(["-key", client_key])
+        s_client_cmd.extend(["-cert", client_cert])
+    if ocsp is not None:
+        s_client_cmd.append("-status")
+
+    # Fire up s_client
+    s_client = subprocess.Popen(s_client_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+
+    # Validate that s_client resumes successfully against s2nd
+    if resume is True:
+        seperators = 0
+        for line in s2nd.stdout:
+            line = line.decode("utf-8").strip()
+            if line.startswith("Resumed session"):
+                seperators += 1
+
+            if seperators == 5:
+                break
+
+        if seperators != 5:
+            cleanup_processes(s2nd, s_client)
+            return -1
+
+    # Validate that s_client accepted s2nd's stapled OCSP response
+    if ocsp is not None:
+        ocsp_success = False
+        for line in s_client.stdout:
+            line = line.decode("utf-8").strip()
+            if S_CLIENT_SUCCESSFUL_OCSP in line:
+                ocsp_success = True
+                break
+        if not ocsp_success:
+            cleanup_processes(s2nd, s_client)
+            return -1
+
+    # Write the cipher name towards s2n
+    s_client.stdin.write((cipher + "\n").encode("utf-8"))
+    s_client.stdin.flush()
+
+    # Read it
+    found = 0
+    for line in range(0, 10):
+        output = s2nd.stdout.readline().decode("utf-8")
+        if output.strip() == cipher:
+            found = 1
+            break
+
+    if found == 0:
+        cleanup_processes(s2nd, s_client)
+        return -1
+
+    # Write the cipher name from s2n
+    s2nd.stdin.write((cipher + "\n").encode("utf-8"))
+    s2nd.stdin.flush()
+    found = 0
+    for line in range(0, 512):
+        output = s_client.stdout.readline().decode("utf-8")
+        if output.strip() == cipher:
+            found = 1
+            break
+
+    if found == 0:
+        cleanup_processes(s2nd, s_client)
+        return -1
+
+    cleanup_processes(s2nd, s_client)
+
+    return 0
+
+def cert_path_to_str(cert_path):
+    # Converts a path to a cert into a string usable for printing to test output
+    # Example: "./test_certs/rsa_2048_sha256_client_cert.pem" => "RSA-2048-SHA256"
+    return '-'.join(cert_path[cert_path.rfind('/')+1:].split('_')[:3]).upper()
+
+def print_result(result_prefix, return_code):
+    suffix = ""
+    if return_code == 0:
+        if sys.stdout.isatty():
+            suffix = "\033[32;1mPASSED\033[0m"
+        else:
+            suffix = "PASSED"
+    else:
+        if sys.stdout.isatty():
+            suffix = "\033[31;1mFAILED\033[0m"
+        else:
+            suffix ="FAILED"
+            
+    print(result_prefix + suffix)
+
+def create_thread_pool():
+    threadpool_size = multiprocessing.cpu_count() * 2  #Multiply by 2 since performance improves slightly if CPU has hyperthreading
+    print("\tCreating ThreadPool of size: " + str(threadpool_size))
+    threadpool = ThreadPool(processes=threadpool_size)
+    return threadpool
+
+def run_handshake_test(host, port, ssl_version, cipher, fips_mode, use_client_auth, client_cert_path, client_key_path):
+    cipher_name = cipher.openssl_name
+    cipher_vers = cipher.min_tls_vers
+
+    # Skip the cipher if openssl can't test it. 3DES/RC4 are disabled by default in 1.1.0
+    if not cipher.openssl_1_1_0_compatible:
+        return 0
+
+    if ssl_version < cipher_vers:
+        return 0
+    
+    client_cert_str=str(use_client_auth)
+    
+    if (use_client_auth is not None) and (client_cert_path is not None):
+        client_cert_str = cert_path_to_str(client_cert_path)
+
+    ret = try_handshake(host, port, cipher_name, ssl_version, enter_fips_mode=fips_mode, client_auth=use_client_auth, client_cert=client_cert_path, client_key=client_key_path)
+    
+    result_prefix = "Cipher: %-28s ClientCert: %-16s Vers: %-8s ... " % (cipher_name, client_cert_str, S2N_PROTO_VERS_TO_STR[ssl_version])
+    print_result(result_prefix, ret)
+    
+    return ret
+
+def handshake_test(host, port, test_ciphers, fips_mode, use_client_auth=None, use_client_cert=None, use_client_key=None):
+    """
+    Basic handshake tests using all valid combinations of supported cipher suites and TLS versions.
+    """
+    print("\n\tRunning handshake tests:")
+    
+    failed = 0
+    for ssl_version in [S2N_TLS10, S2N_TLS11, S2N_TLS12]:
+        print("\n\tTesting ciphers using client version: " + S2N_PROTO_VERS_TO_STR[ssl_version])
+        threadpool = create_thread_pool()
+        port_offset = 0
+        results = []
+        
+        for cipher in test_ciphers:
+            async_result = threadpool.apply_async(run_handshake_test, (host, port + port_offset, ssl_version, cipher, fips_mode, use_client_auth, use_client_cert, use_client_key))
+            port_offset += 1
+            results.append(async_result)
+
+        threadpool.close()
+        threadpool.join()
+        for async_result in results:
+            if async_result.get() != 0:
+                failed = 1
+
+    return failed
+    
+
+def client_auth_test(host, port, test_ciphers, fips_mode):
+    failed = 0
+
+    print("\n\tRunning client auth tests:")
+
+    if fips_mode:
+        print("\t\033[33;1mSKIPPED\033[0m - Client Auth not supported in FIPS mode")
+        return 0
+
+    for filename in os.listdir(TEST_CERT_DIRECTORY):
+        if "client_cert" in filename and "rsa" in filename:
+            client_cert_path = TEST_CERT_DIRECTORY + filename
+            client_key_path = TEST_CERT_DIRECTORY + filename.replace("client_cert", "client_key")
+            ret = handshake_test(host, port, test_ciphers, fips_mode, use_client_auth=True, use_client_cert=client_cert_path, use_client_key=client_key_path)
+            if ret is not 0:
+                failed += 1
+                
+    return failed
+
+def resume_test(host, port, test_ciphers, fips_mode):
+    """
+    Tests s2n's session resumption capability using all valid combinations of cipher suite and TLS version.
+    """
+    print("\n\tRunning resumption tests:")
+    failed = 0
+    for ssl_version in [S2N_TLS10, S2N_TLS11, S2N_TLS12]:
+        print("\n\tTesting ciphers using client version: " + S2N_PROTO_VERS_TO_STR[ssl_version])
+        for cipher in test_ciphers:
+            cipher_name = cipher.openssl_name
+            cipher_vers = cipher.min_tls_vers
+
+            # Skip the cipher if openssl can't test it. 3DES/RC4 are disabled by default in 1.1.0
+            if not cipher.openssl_1_1_0_compatible:
+                continue
+
+            if ssl_version < cipher_vers:
+                continue
+
+            ret = try_handshake(host, port, cipher_name, ssl_version, resume=True, enter_fips_mode=fips_mode)
+            result_prefix = "Cipher: %-30s Vers: %-10s ... " % (cipher_name, S2N_PROTO_VERS_TO_STR[ssl_version])
+            print_result(result_prefix, ret)
+            if ret != 0:
+                failed = 1
+
+    return failed
+
+supported_sigs = ["RSA+SHA1", "RSA+SHA224", "RSA+SHA256", "RSA+SHA384", "RSA+SHA512"]
+unsupported_sigs = ["ECDSA+SHA256", "ECDSA+SHA512"]
+
+def run_sigalg_test(host, port, cipher, ssl_version, permutation, fips_mode, use_client_auth):
+    # Put some unsupported algs in front to make sure we gracefully skip them
+    mixed_sigs = unsupported_sigs + list(permutation)
+    mixed_sigs_str = ':'.join(mixed_sigs)
+    ret = try_handshake(host, port, cipher.openssl_name, ssl_version, sig_algs=mixed_sigs_str, enter_fips_mode=fips_mode, client_auth=use_client_auth)
+        
+    # Trim the RSA part off for brevity. User should know we are only supported RSA at the moment.
+    prefix = "Digests: %-35s ClientAuth: %-6s Vers: %-8s... " % (':'.join([x[4:] for x in permutation]), str(use_client_auth), S2N_PROTO_VERS_TO_STR[S2N_TLS12])
+    print_result(prefix, ret)
+    return ret
+
+def sigalg_test(host, port, fips_mode, use_client_auth=None):
+    """
+    Acceptance test for supported signature algorithms. Tests all possible supported sigalgs with unsupported ones mixed in
+    for noise.
+    """
+    failed = 0
+
+    print("\n\tRunning signature algorithm tests:")
+
+    if fips_mode and use_client_auth:
+        print("\t\033[33;1mSKIPPED\033[0m - Client Auth not supported in FIPS mode")
+        return 0
+
+    print("\tExpected supported:   " + str(supported_sigs))
+    print("\tExpected unsupported: " + str(unsupported_sigs))
+
+    for size in range(1, len(supported_sigs) + 1):
+        print("\n\t\tTesting ciphers using signature preferences of size: " + str(size))
+        threadpool = create_thread_pool()
+        portOffset = 0
+        results = []
+        # Produce permutations of every accepted signature algorithm in every possible order
+        for permutation in itertools.permutations(supported_sigs, size):
+            for cipher in ALL_TEST_CIPHERS:
+                # Try an ECDHE cipher suite and a DHE one
+                if(cipher.openssl_name == "ECDHE-RSA-AES128-GCM-SHA256" or cipher.openssl_name == "DHE-RSA-AES128-GCM-SHA256"):
+                    async_result = threadpool.apply_async(run_sigalg_test, (host, port + portOffset, cipher, S2N_TLS12, permutation, fips_mode, use_client_auth))
+                    portOffset = portOffset + 1
+                    results.append(async_result)
+
+        threadpool.close()
+        threadpool.join()
+        for async_result in results:
+            if async_result.get() != 0:
+                failed = 1
+
+    return failed
+
+def elliptic_curve_test(host, port, fips_mode):
+    """
+    Acceptance test for supported elliptic curves. Tests all possible supported curves with unsupported curves mixed in
+    for noise.
+    """
+    supported_curves = ["P-256", "P-384"]
+    unsupported_curves = ["B-163", "K-409"]
+    print("\n\tRunning elliptic curve tests:")
+    print("\tExpected supported:   " + str(supported_curves))
+    print("\tExpected unsupported: " + str(unsupported_curves))
+
+    failed = 0
+    for size in range(1, len(supported_curves) + 1):
+        print("\n\t\tTesting ciphers using curve list of size: " + str(size))
+
+        # Produce permutations of every accepted curve in every possible order
+        for permutation in itertools.permutations(supported_curves, size):
+            # Put some unsupported curves in front to make sure we gracefully skip them
+            mixed_curves = unsupported_curves + list(permutation)
+            mixed_curves_str = ':'.join(mixed_curves)
+            for cipher in filter(lambda x: x.openssl_name == "ECDHE-RSA-AES128-GCM-SHA256" or x.openssl_name == "ECDHE-RSA-AES128-SHA", ALL_TEST_CIPHERS):
+                if fips_mode and cipher.openssl_fips_compatible == False:
+                    continue
+                ret = try_handshake(host, port, cipher.openssl_name, S2N_TLS12, curves=mixed_curves_str, enter_fips_mode=fips_mode)
+                prefix = "Curves: %-40s Vers: %10s ... " % (':'.join(list(permutation)), S2N_PROTO_VERS_TO_STR[S2N_TLS12])
+                print_result(prefix, ret)
+                if ret != 0:
+                    failed = 1
+    return failed
+
+def elliptic_curve_fallback_test(host, port, fips_mode):
+    """
+    Tests graceful fallback when s2n doesn't support any curves offered by the client. A non-ecc suite should be
+    negotiated.
+    """
+    failed = 0
+    # Make sure s2n can still negotiate a non-EC kx(AES256-GCM-SHA384) suite if we don't match anything on the client
+    unsupported_curves = ["B-163", "K-409"]
+    ret = try_handshake(host, port, "ECDHE-RSA-AES128-SHA256:AES256-GCM-SHA384", S2N_TLS12, curves=":".join(unsupported_curves), enter_fips_mode=fips_mode)
+    print_result("%-65s ... " % "Testing curve mismatch fallback", ret)
+    if ret != 0:
+        failed = 1
+
+    return failed
+
+def handshake_fragmentation_test(host, port, fips_mode):
+    """
+    Tests successful negotation with s_client despite message fragmentation. Max record size is clamped to force s2n
+    to fragment the ServerCertifcate message.
+    """
+    print("\n\tRunning handshake fragmentation tests:")
+    failed = 0
+    for ssl_version in [S2N_TLS10, S2N_TLS11, S2N_TLS12]:
+        print("\n\tTesting ciphers using client version: " + S2N_PROTO_VERS_TO_STR[ssl_version])
+        # Cipher isn't relevant for this test, pick one available in all OpenSSL versions and all TLS versions
+        cipher_name = "AES256-SHA"
+
+        # Low latency option indirectly forces fragmentation.
+        ret = try_handshake(host, port, cipher_name, ssl_version, prefer_low_latency=True, enter_fips_mode=fips_mode)
+        result_prefix = "Cipher: %-30s Vers: %-10s ... " % (cipher_name, S2N_PROTO_VERS_TO_STR[ssl_version])
+        print_result(result_prefix, ret)
+        if ret != 0:
+            failed = 1
+
+    failed = 0
+    return failed
+
+def ocsp_stapling_test(host, port, fips_mode):
+    """
+    Test s2n's server OCSP stapling capability
+    """
+    print("\n\tRunning OCSP stapling tests:")
+    failed = 0
+    for ssl_version in [S2N_TLS10, S2N_TLS11, S2N_TLS12]:
+        print("\n\tTesting ciphers using client version: " + S2N_PROTO_VERS_TO_STR[ssl_version])
+        # Cipher isn't relevant for this test, pick one available in all TLS versions
+        cipher_name = "AES256-SHA"
+
+        ret = try_handshake(host, port, cipher_name, ssl_version, enter_fips_mode=fips_mode, server_cert=TEST_OCSP_CERT, server_key=TEST_OCSP_KEY,
+                ocsp=TEST_OCSP_RESPONSE_FILE)
+        result_prefix = "Cipher: %-30s Vers: %-10s ... " % (cipher_name, S2N_PROTO_VERS_TO_STR[ssl_version])
+        print_result(result_prefix, ret)
+        if ret != 0:
+            failed = 1
+
+    return failed
+
+def main():
+    parser = argparse.ArgumentParser(description='Runs TLS server integration tests against s2nd using Openssl s_client')
+    parser.add_argument('host', help='The host for s2nd to bind to')
+    parser.add_argument('port', type=int, help='The port for s2nd to bind to')
+    parser.add_argument('--libcrypto', default='openssl-1.1.0', choices=['openssl-1.0.2', 'openssl-1.0.2-fips', 'openssl-1.1.0', 'openssl-1.1.x-master', 'libressl'],
+            help="""The Libcrypto that s2n was built with. s2n supports different cipher suites depending on
+                    libcrypto version. Defaults to openssl-1.1.0.""")
+    args = parser.parse_args()
+
+    # Retrieve the test ciphers to use based on the libcrypto version s2n was built with
+    test_ciphers = S2N_LIBCRYPTO_TO_TEST_CIPHERS[args.libcrypto]
+    host = args.host
+    port = args.port
+
+    fips_mode = False
+    if environ.get("S2N_TEST_IN_FIPS_MODE") is not None:
+        fips_mode = True
+        print("\nRunning s2nd in FIPS mode.")
+
+    print("\nRunning tests with: " + os.popen('openssl version').read())
+
+    failed = 0
+    failed += resume_test(host, port, test_ciphers, fips_mode)
+    failed += handshake_test(host, port, test_ciphers, fips_mode)
+    failed += client_auth_test(host, port, test_ciphers, fips_mode)
+    failed += sigalg_test(host, port, fips_mode)
+    failed += sigalg_test(host, port, fips_mode, use_client_auth=True)
+    failed += elliptic_curve_test(host, port, fips_mode)
+    failed += elliptic_curve_fallback_test(host, port, fips_mode)
+    failed += handshake_fragmentation_test(host, port, fips_mode)
+    failed += ocsp_stapling_test(host, port, fips_mode)
+    return failed
+
+if __name__ == "__main__":
+    sys.exit(main())
+

--- a/tests/integration/s2n_dynamic_record_size_test.py
+++ b/tests/integration/s2n_dynamic_record_size_test.py
@@ -1,0 +1,288 @@
+#
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+"""
+Dynamic record size tests using s2nc against Openssl s_server
+"""
+
+import argparse
+import os
+import sys
+import subprocess
+import itertools
+import multiprocessing
+from multiprocessing.pool import ThreadPool
+from s2n_test_constants import *
+from time import sleep
+
+PROTO_VERS_TO_S_SERVER_ARG = {
+    S2N_TLS10: "-tls1",
+    S2N_TLS11: "-tls1_1",
+    S2N_TLS12: "-tls1_2",
+}
+
+test_file = './data/test_buf'
+file_size = os.path.getsize(test_file)
+
+def cleanup_processes(*processes):
+    for p in processes:
+        p.kill()
+        p.wait()
+
+
+def try_dynamic_record(endpoint, port, cipher, ssl_version, threshold, server_cert=None, server_key=None, sig_algs=None, curves=None, dh_params=None):
+    """
+    Attempt to handshake against Openssl s_server listening on `endpoint` and `port` using s2nc
+
+    :param int endpoint: endpoint for Openssl s_server to listen on
+    :param int port: port for Openssl s_server to listen on
+    :param str cipher: ciphers for Openssl s_server to use. See https://www.openssl.org/docs/man1.0.2/apps/ciphers.html
+    :param int ssl_version: SSL version for Openssl s_server to use
+    :param str server_cert: path to certificate for Openssl s_server to use
+    :param str server_key: path to private key for Openssl s_server to use
+    :param str sig_algs: Signature algorithms for Openssl s_server to accept
+    :param str curves: Elliptic curves for Openssl s_server to accept
+    :param str dh_params: path to DH params for Openssl s_server to use
+    :return: 0 on successfully negotiation(s), -1 on failure
+    """
+
+    # Override certificate for ECDSA if unspecified. We can remove this when we
+    # support multiple certificates
+    if server_cert is None and cipher is not None and "ECDSA" in cipher:
+        server_cert = TEST_ECDSA_CERT
+        server_key = TEST_ECDSA_KEY
+
+    if server_cert is None:
+        server_cert = TEST_RSA_CERT
+        server_key = TEST_RSA_KEY
+
+    if dh_params is None:
+        dh_params = TEST_DH_PARAMS
+
+    # Start Openssl s_server
+    s_server_cmd = ["openssl", "s_server", PROTO_VERS_TO_S_SERVER_ARG[ssl_version],
+            "-accept", str(port)]
+    if server_cert is not None:
+        s_server_cmd.extend(["-cert", server_cert])
+    if server_key is not None:
+        s_server_cmd.extend(["-key", server_key])
+    if cipher is not None:
+        s_server_cmd.extend(["-cipher", cipher])
+    if sig_algs is not None:
+        s_server_cmd.extend(["-sigalgs", sig_algs])
+    if curves is not None:
+        s_server_cmd.extend(["-curves", curves])
+    if dh_params is not None:
+        s_server_cmd.extend(["-dhparam", dh_params])
+
+    # Fire up s_server
+    s_server = subprocess.Popen(s_server_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    # Make sure it's accepting
+    found = 0
+    for line in range(0, 10):
+        output = s_server.stdout.readline().decode("utf-8")
+        if output.strip() == "ACCEPT":
+            # Openssl first prints ACCEPT and only then actually binds the socket, so wait for a bit...
+            sleep(0.1)
+            found = 1
+            break
+
+    if not found:
+        server_error = s_server.stderr.read().decode("utf-8")
+        if "no cipher match" in server_error:
+            print ("Skipped unsupported cipher: {}".format(cipher))
+            return -2
+
+        sys.stderr.write("Failed to start s_server: {}\nSTDERR: {}\n".format(" ".join(s_server_cmd), server_error))
+        cleanup_processes(s_server)
+        return -1
+
+    # Fire up s2nc
+    print("\n\tRunning s2n dynamic record size tests with threshold:", threshold)
+    s2nc_cmd = ["../../bin/s2nc", "-e", "-D", str(threshold), "-t", "1", "-c", "test_all", "-i"]
+    s2nc_cmd.extend([str(endpoint), str(port)])
+
+    envVars = os.environ.copy()
+    envVars["S2N_ENABLE_CLIENT_MODE"] = "1"
+
+    file_input = open(test_file)
+    s2nc = subprocess.Popen(s2nc_cmd, stdin=file_input, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=envVars)
+
+    # Read from s2nc until we get successful connection message
+    found = 0
+    seperators = 0
+    for line in range(0, 10):
+        output = s2nc.stdout.readline().decode("utf-8")
+        if output.strip() == "Connected to {}:{}".format(endpoint, port):
+            found = 1
+
+    # Wait file send complete        
+    s2nc.wait()
+    cleanup_processes(s_server)
+
+    if not found:
+        sys.stderr.write("= TEST FAILED =\ns_server cmd: {}\n s_server STDERR: {}\n\ns2nc cmd: {}\nSTDERR {}\n".format(" ".join(s_server_cmd), s_server.stderr.read().decode("utf-8"), " ".join(s2nc_cmd), s2nc.stderr.read().decode("utf-8")))
+        return -1   
+
+    return 0
+
+def print_result(result_prefix, return_code):
+    suffix = ""
+    if return_code == 0:
+        if sys.stdout.isatty():
+            suffix = "\033[32;1mPASSED\033[0m"
+        else:
+            suffix = "PASSED"
+    else:
+        if sys.stdout.isatty():
+            suffix = "\033[31;1mFAILED\033[0m"
+        else:
+            suffix ="FAILED"
+
+    print(result_prefix + suffix)
+
+def run_test(host, port, ssl_version, cipher, threshold):
+    cipher_name = cipher.openssl_name
+
+    failed = 0
+    tcpdump_filter = "dst port " + str(port)
+    tcpdump_cmd = ["sudo", "tcpdump", "-i", "lo", "-n", tcpdump_filter] 
+    tcpdump = subprocess.Popen(tcpdump_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    ret = try_dynamic_record(host, port, cipher_name, ssl_version, threshold)
+    # Skip no cipher match error
+    if ret != -2: 
+        failed += ret
+        print("\nAnalyzing tcpdump results for cipher {}".format(cipher_name))
+        # Case 1: first half of application data is optimized for latency
+        failed += analyze_latency_dump(tcpdump.stdout)
+        # Case 2: second half of application data is optimize for throughput
+        failed += analyze_throughput_dump(tcpdump.stdout)
+
+    subprocess.call(["sudo", "killall", "-9", "tcpdump"])
+    tcpdump.wait()
+
+    return failed
+
+
+def test(host, port, test_ciphers, threshold):
+    failed = 0
+    ssl_version = S2N_TLS12
+    # Get the first testable cipher
+    for cipher in test_ciphers:
+        cipher_vers = cipher.min_tls_vers
+        if not cipher.openssl_1_1_0_compatible:
+            continue
+        if ssl_version < cipher_vers:
+            continue
+        result = run_test(host, port, ssl_version, cipher, threshold)
+        if result != 0:
+            failed += 1
+            break
+
+    return failed
+
+def analyze_latency_dump(stream):
+    failed = 0
+    first_line = stream.readline().decode("utf-8")
+    if ("mss" not in first_line):
+        return 1
+
+    mss_pos = first_line.find("mss")
+    mss_str = first_line[mss_pos : mss_pos + 10]
+    mss = mss_str[4 : mss_str.find(',')]
+    print("mss={}".format(mss))
+    
+    for line in range(0, 18):
+        output = stream.readline().decode("utf-8").strip()
+        # print(output)
+        pos = output.find("length")
+        if pos < 0:
+            continue
+        length = output[pos + 6 : len(output)]
+        # Tcp package size should always <= mss
+        if length > mss:
+            failed = 1
+            break
+
+    return failed
+
+def analyze_throughput_dump(stream):
+    failed = 1
+
+    for line in range(0, 18):
+        output = stream.readline().decode("utf-8").strip()
+        # print(output)
+        pos = output.find("length")
+        if pos < 0:
+            continue
+        length = output[pos + 6 : len(output)]
+        # Tcp package size can exceed MTU, which results in segementation
+        if int(length) > 1500:
+            failed = 0
+            break
+
+    return failed
+
+def get_local_mtu():
+    cmd = ["ifconfig", "lo"]
+    p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    mtu = 65536
+    for line in range(0, 5):
+        output = p.stdout.readline().decode("utf-8")
+        if ("MTU:" in output):
+            word_list = output.split()
+            mtu_list = word_list[3].split(':')
+            mtu = mtu_list[1]
+            break
+
+    p.wait()
+    return mtu
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Runs TLS server integration tests against Openssl s_server using s2nc')
+    parser.add_argument('host', help='The host for s2nc to connect to')
+    parser.add_argument('port', type=int, help='The port for s_server to bind to')
+    parser.add_argument('--libcrypto', default='openssl-1.1.0', choices=['openssl-1.0.2', 'openssl-1.0.2-fips', 'openssl-1.1.0', 'openssl-1.1.x-master', 'libressl'],
+            help="""The Libcrypto that s2n was built with. s2n supports different cipher suites depending on
+                    libcrypto version. Defaults to openssl-1.1.0.""")
+    args = parser.parse_args()
+
+    # Retrieve the test ciphers to use based on the libcrypto version s2n was built with
+    test_ciphers = S2N_LIBCRYPTO_TO_TEST_CIPHERS[args.libcrypto]    
+    host = args.host
+    port = args.port
+
+    local_mtu = get_local_mtu()
+    # Simulate common MTU 1500
+    subprocess.call(["sudo", "ifconfig", "lo", "mtu", "1500"])    
+    
+    failed = 0
+    
+    failed += test(host, port, test_ciphers, int(file_size / 2))
+
+    # Recover localhost MTU
+    subprocess.call(["sudo", "ifconfig", "lo", "mtu", local_mtu])
+
+    print_result("TLS dynamic record size test " , failed)
+
+    return failed
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -774,6 +774,11 @@ int s2n_connection_set_write_fd(struct s2n_connection *conn, int wfd)
      */
     GUARD(s2n_socket_write_snapshot(conn));
 
+    uint8_t ipv6;
+    if (0 == s2n_socket_is_ipv6(wfd, &ipv6)) {
+        conn->ipv6 = (ipv6 ? 1 : 0);
+    }
+
     return 0;
 }
 
@@ -990,6 +995,15 @@ int s2n_connection_prefer_low_latency(struct s2n_connection *conn)
         conn->max_outgoing_fragment_length = S2N_SMALL_FRAGMENT_LENGTH;
     }
 
+    return 0;
+}
+
+int s2n_connection_set_dynamic_record_threshold(struct s2n_connection *conn, uint32_t resize_threshold, uint16_t timeout_threshold)
+{
+    notnull_check(conn);
+
+    conn->dynamic_record_resize_threshold = resize_threshold;
+    conn->dynamic_record_timeout_threshold = timeout_threshold;
     return 0;
 }
 

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -81,6 +81,9 @@ struct s2n_connection {
      */
     unsigned secure_renegotiation:1;
 
+     /* whether the connection address is ipv6 or not */
+    unsigned ipv6:1;
+
     /* Is this connection a client or a server connection */
     s2n_mode mode;
 
@@ -89,6 +92,9 @@ struct s2n_connection {
 
     /* A timer to measure the time between record writes */
     struct s2n_timer write_timer;
+
+    /* last written time */
+    uint64_t last_write_elapsed;
 
     /* When fatal errors occurs, s2n imposes a pause before
      * the connection is closed. If non-zero, this value tracks
@@ -182,6 +188,17 @@ struct s2n_connection {
      * Default value: S2N_DEFAULT_FRAGMENT_LENGTH
      */
     uint16_t max_outgoing_fragment_length;
+
+    /* The number of bytes to send before changing the record size. 
+     * If this value > 0 then dynamic TLS record size is enabled. Otherwise, the feature is disabled (default). 
+     */
+    uint32_t dynamic_record_resize_threshold;
+
+    /* Reset record size back to a single segment after threshold seconds of inactivity */
+    uint16_t dynamic_record_timeout_threshold;
+
+    /* number of bytes consumed during application activity */
+    uint64_t active_application_bytes_consumed;
 
     /* Negotiated TLS extension Maximum Fragment Length code */
     uint8_t mfl_code;

--- a/tls/s2n_record.h
+++ b/tls/s2n_record.h
@@ -20,6 +20,7 @@
 #include "s2n_connection.h"
 
 extern int s2n_record_max_write_payload_size(struct s2n_connection *conn);
+extern int s2n_record_min_write_payload_size(struct s2n_connection *conn);
 extern int s2n_record_write(struct s2n_connection *conn, uint8_t content_type, struct s2n_blob *in);
 extern int s2n_record_parse(struct s2n_connection *conn);
 extern int s2n_record_header_parse(struct s2n_connection *conn, uint8_t * content_type, uint16_t * fragment_length);

--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -121,10 +121,28 @@ ssize_t s2n_send(struct s2n_connection * conn, const void *buf, ssize_t size, s2
     /* Defensive check against an invalid retry */
     S2N_ERROR_IF(conn->current_user_data_consumed > size, S2N_ERR_SEND_SIZE);
 
+    uint64_t elapsed;
+    GUARD(s2n_timer_elapsed(conn->config, &conn->write_timer, &elapsed));
+    /* Reset record size back to a single segment after threshold seconds of inactivity */
+    if (conn->dynamic_record_timeout_threshold > 0 && 
+        elapsed - conn->last_write_elapsed > (uint64_t) conn->dynamic_record_timeout_threshold * 1000000000) {
+        conn->active_application_bytes_consumed = 0;
+    }
+    conn->last_write_elapsed = elapsed;
+
     /* Now write the data we were asked to send this round */
     while (size - conn->current_user_data_consumed) {
         struct s2n_blob in = {.data = ((uint8_t *)(uintptr_t) buf) + conn->current_user_data_consumed };
         in.size = MIN(size - conn->current_user_data_consumed, max_payload_size);
+        /* If dynamic record size is enabled,
+         * use small TLS records that fit into a single TCP segment for the threshold bytes of data     
+         */
+        if (conn->active_application_bytes_consumed < (uint64_t) conn->dynamic_record_resize_threshold) {
+            int min_payload_size = s2n_record_min_write_payload_size(conn);
+            if (min_payload_size < in.size) {
+                in.size = min_payload_size; 
+            }
+        }
 
         /* Don't split messages in server mode for interoperability with naive clients.
          * Some clients may have expectations based on the amount of content in the first record.
@@ -140,6 +158,7 @@ ssize_t s2n_send(struct s2n_connection * conn, const void *buf, ssize_t size, s2
         GUARD(s2n_stuffer_rewrite(&conn->out));
         GUARD(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
         conn->current_user_data_consumed += in.size;
+        conn->active_application_bytes_consumed += in.size;
 
         /* Send it */
         if (s2n_flush(conn, blocked) < 0) {

--- a/tls/s2n_tls_parameters.h
+++ b/tls/s2n_tls_parameters.h
@@ -106,6 +106,18 @@
 #define TLS_EC_CURVE_SECP_256_R1           23
 #define TLS_EC_CURVE_SECP_384_R1           24
 
+/* Ethernet maximum transmission unit (MTU)
+ * MTU is usually associated with the Ethernet protocol,
+ * where a 1500-byte packet is the largest allowed in it
+ */
+#define ETH_MTU 1500
+
+#define IP_V4_HEADER_LENGTH 20
+#define IP_V6_HEADER_LENGTH 40
+
+#define TCP_HEADER_LENGTH 20
+#define TCP_OPTIONS_LENGTH 40
+
 /* The maximum size of a TLS record is 16389 bytes. This is;  1 byte for content
  * type, 2 bytes for the protocol version, 2 bytes for the length field,
  * and then up to 2^14 for the encrypted+compressed payload data.

--- a/utils/s2n_socket.c
+++ b/utils/s2n_socket.c
@@ -184,3 +184,20 @@ int s2n_socket_write(void *io_context, const uint8_t *buf, uint32_t len)
     errno = 0;
     return write(wfd, buf, len);
 }
+
+int s2n_socket_is_ipv6(int fd, uint8_t *ipv6) 
+{
+    notnull_check(ipv6);
+
+    socklen_t len;
+    struct sockaddr_storage addr;
+    len = sizeof (addr);
+    GUARD(getpeername(fd, (struct sockaddr*)&addr, &len));
+    
+    *ipv6 = 0;
+    if (AF_INET6 == addr.ss_family) {
+       *ipv6 = 1;
+    }
+            
+    return 0;
+}

--- a/utils/s2n_socket.h
+++ b/utils/s2n_socket.h
@@ -47,3 +47,4 @@ extern int s2n_socket_write_uncork(struct s2n_connection *conn);
 extern int s2n_socket_set_read_size(struct s2n_connection *conn, int size);
 extern int s2n_socket_read(void *io_context, uint8_t *buf, uint32_t len);
 extern int s2n_socket_write(void *io_context, const uint8_t *buf, uint32_t len);
+extern int s2n_socket_is_ipv6(int fd, uint8_t *ipv6);


### PR DESCRIPTION
combine commits from https://github.com/fatrat1117/s2n/commits/dyn-rec-pr which is reviewed by team internally.

**Issue # (if available):** 
https://github.com/awslabs/s2n/issues/2

**Description of changes:** 
s2n_connection_set_dynamic_record_threshold sets the number of bytes to send before changing the record size. If this value > 0 then dynamic TLS record size is enabled. Otherwise, the feature is disabled (default).
If dynamic record size is enabled, s2n_send
1. Uses small TLS records that fit into a single TCP segment for the threshold bytes of data.
2. Resets record size back to a single segment after timeout_threshold seconds of inactivity.
