### PR TITLE
Implement TLS1.3 hkdf_label_expand function

### DIFF
--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -16,10 +16,28 @@
 #include "error/s2n_errno.h"
 
 #include "crypto/s2n_hash.h"
+#include "crypto/s2n_hmac.h"
 #include "crypto/s2n_openssl.h"
 #include "crypto/s2n_fips.h"
 
 #include "utils/s2n_safety.h"
+
+int s2n_hash_hmac_alg(s2n_hash_algorithm hash_alg, s2n_hmac_algorithm *out)
+{
+    switch(hash_alg) {
+    case S2N_HASH_NONE:       *out = S2N_HMAC_NONE;   break;
+    case S2N_HASH_MD5:        *out = S2N_HMAC_MD5;    break;
+    case S2N_HASH_SHA1:       *out = S2N_HMAC_SHA1;   break;
+    case S2N_HASH_SHA224:     *out = S2N_HMAC_SHA224; break;
+    case S2N_HASH_SHA256:     *out = S2N_HMAC_SHA256; break;
+    case S2N_HASH_SHA384:     *out = S2N_HMAC_SHA384; break;
+    case S2N_HASH_SHA512:     *out = S2N_HMAC_SHA512; break;
+    case S2N_HASH_MD5_SHA1:   /* Fall through ... */
+    default:
+        S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
+    }
+    return 0;
+}
 
 int s2n_hash_digest_size(s2n_hash_algorithm alg, uint8_t *out)
 {

--- a/crypto/s2n_hkdf.c
+++ b/crypto/s2n_hkdf.c
@@ -93,6 +93,11 @@ int s2n_hkdf_expand_label(struct s2n_hmac_state *hmac, s2n_hmac_algorithm alg, c
     struct s2n_blob hkdf_label_blob = {0};
     struct s2n_stuffer hkdf_label = {{0}};
 
+    /* RFC8446 specifies that labels must be 12 characters or less, to avoid
+    ** incurring two hash rounds.
+    */
+    lte_check(label->size, 12);
+
     GUARD(s2n_blob_init(&hkdf_label_blob, hkdf_label_buf, sizeof(hkdf_label_buf)));
     GUARD(s2n_stuffer_init(&hkdf_label, &hkdf_label_blob));
     GUARD(s2n_stuffer_write_uint16(&hkdf_label, output->size));

--- a/crypto/s2n_hkdf.c
+++ b/crypto/s2n_hkdf.c
@@ -17,6 +17,8 @@
 
 #include "error/s2n_errno.h"
 
+#include "stuffer/s2n_stuffer.h"
+
 #include "crypto/s2n_hmac.h"
 
 #include "utils/s2n_blob.h"
@@ -79,6 +81,29 @@ static int s2n_hkdf_expand(struct s2n_hmac_state *hmac, s2n_hmac_algorithm alg, 
     
         GUARD(s2n_hmac_reset(hmac));
     }
+
+    return 0;
+}
+
+int s2n_hkdf_expand_label(struct s2n_hmac_state *hmac, s2n_hmac_algorithm alg, const struct s2n_blob *secret, const struct s2n_blob *label,
+                          const struct s2n_blob *context, struct s2n_blob *output)
+{
+    /* Per RFC8446: 7.1, a HKDF label is a 2 byte length field, and two 1...255 byte arrays with a one byte length field each. */
+    uint8_t hkdf_label_buf[2 + 256 + 256];
+    struct s2n_blob hkdf_label_blob = {0};
+    struct s2n_stuffer hkdf_label = {{0}};
+
+    GUARD(s2n_blob_init(&hkdf_label_blob, hkdf_label_buf, sizeof(hkdf_label_buf)));
+    GUARD(s2n_stuffer_init(&hkdf_label, &hkdf_label_blob));
+    GUARD(s2n_stuffer_write_uint16(&hkdf_label, output->size));
+    GUARD(s2n_stuffer_write_uint8(&hkdf_label, label->size + sizeof("tls13 ") - 1));
+    GUARD(s2n_stuffer_write_str(&hkdf_label, "tls13 "));
+    GUARD(s2n_stuffer_write(&hkdf_label, label));
+    GUARD(s2n_stuffer_write_uint8(&hkdf_label, context->size));
+    GUARD(s2n_stuffer_write(&hkdf_label, context));
+
+    hkdf_label_blob.size = s2n_stuffer_data_available(&hkdf_label);
+    GUARD(s2n_hkdf_expand(hmac, alg, secret, &hkdf_label_blob, output));
 
     return 0;
 }

--- a/crypto/s2n_hkdf.h
+++ b/crypto/s2n_hkdf.h
@@ -23,3 +23,9 @@
 
 extern int s2n_hkdf(struct s2n_hmac_state *hmac, s2n_hmac_algorithm alg, const struct s2n_blob *salt,
                     const struct s2n_blob *key, const struct s2n_blob *info, struct s2n_blob *output);
+
+extern int s2n_hkdf_extract(struct s2n_hmac_state *hmac, s2n_hmac_algorithm alg, const struct s2n_blob *salt,
+                            const struct s2n_blob *key, struct s2n_blob *pseudo_rand_key);
+
+extern int s2n_hkdf_expand_label(struct s2n_hmac_state *hmac, s2n_hmac_algorithm alg, const struct s2n_blob *secret, const struct s2n_blob *label,
+                                 const struct s2n_blob *context, struct s2n_blob *output);

--- a/crypto/s2n_hmac.h
+++ b/crypto/s2n_hmac.h
@@ -62,6 +62,7 @@ struct s2n_hmac_evp_backup {
 extern int s2n_hmac_digest_size(s2n_hmac_algorithm alg, uint8_t *out);
 extern int s2n_hmac_is_available(s2n_hmac_algorithm alg);
 extern int s2n_hmac_hash_alg(s2n_hmac_algorithm hmac_alg, s2n_hash_algorithm *out);
+extern int s2n_hash_hmac_alg(s2n_hash_algorithm hash_alg, s2n_hmac_algorithm *out);
 
 extern int s2n_hmac_new(struct s2n_hmac_state *state);
 extern int s2n_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm alg, const void *key, uint32_t klen);

--- a/tests/unit/s2n_tls13_prf_test.c
+++ b/tests/unit/s2n_tls13_prf_test.c
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include <string.h>
+#include <stdio.h>
+
+#include <s2n.h>
+
+#include "testlib/s2n_testlib.h"
+#include "stuffer/s2n_stuffer.h"
+#include "crypto/s2n_hkdf.h"
+
+/*
+ * Test vectors from https://datatracker.ietf.org/doc/draft-ietf-tls-tls13-vectors/?include_text=1
+ */
+int main(int argc, char **argv)
+{
+    char client_handshake_message_hex_in[] = "010000c003032724c0ba613abd59"
+                                             "4894f19ff6d59cde8364549555119b96ec1158fb9ac"
+                                             "ba397000006130113031302010000910000000b0009"
+                                             "000006736572766572ff01000100000a00140012001"
+                                             "d001700180019010001010102010301040023000000"
+                                             "3300260024001d00207e74fe9d31f2bb96f4f553465"
+                                             "b92ea8210971e71e258d6cf622c3b086db26104002b"
+                                             "0003027f1c000d0020001e040305030603020308040"
+                                             "805080604010501060102010402050206020202002d"
+                                             "00020101001c00024001";
+
+    char server_handshake_message_hex_in[] = "020000560303b9206e3d30c43c8a"
+                                             "cb1c234f9d004c6a2fecb84c6811ca285c1bbce322"
+                                             "bed16000130100002e00330024001d0020bba1ffe6"
+                                             "d10f92d4a8444aa51913fea27c3d2bfdf24489da40"
+                                             "92dfbfbfd67c53002b00027f1c";
+
+    char expected_secret_hex_in[] ="33ad0a1c607ec03b09e6cd9893680ce210adf300aa1f2660e1b22e10f170f92a";
+    char expected_expanded_hex_in[] ="6f2615a108c702c5678f54fc9dbab69716c076189c48250cebeac3576c3611ba";
+
+    struct s2n_stuffer client_handshake_message_in;
+    struct s2n_stuffer server_handshake_message_in;
+    struct s2n_stuffer expected_secret_in;
+    struct s2n_stuffer expected_expanded_in;
+    
+    char client_handshake_message[ sizeof(client_handshake_message_hex_in) / 2 ] = { 0 };
+    char server_handshake_message[ sizeof(server_handshake_message_hex_in) / 2 ] = { 0 };
+    char expected_secret[ sizeof(expected_secret_hex_in) / 2 ] = { 0 };
+    char expected_expanded[ sizeof(expected_expanded_hex_in) / 2 ] = { 0 };
+       
+    uint8_t digest_buf[SHA256_DIGEST_LENGTH];
+    uint8_t secret_buf[SHA256_DIGEST_LENGTH];
+    struct s2n_blob digest;
+    struct s2n_blob secret;
+
+    struct s2n_hash_state transcript_hash, transcript_hash_snapshot;
+
+    BEGIN_TEST();
+
+    EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_string(&client_handshake_message_in, client_handshake_message_hex_in));
+    EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_string(&server_handshake_message_in, server_handshake_message_hex_in));
+    EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_string(&expected_secret_in, expected_secret_hex_in));
+    EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_string(&expected_expanded_in, expected_expanded_hex_in));
+
+    /* Parse the hex */
+    for (int i = 0; i < sizeof(client_handshake_message); i++) {
+        uint8_t c;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint8_hex(&client_handshake_message_in, &c));
+        client_handshake_message[i] = c;
+    }
+
+    for (int i = 0; i < sizeof(server_handshake_message); i++) {
+        uint8_t c;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint8_hex(&server_handshake_message_in, &c));
+        server_handshake_message[i] = c;
+    }
+
+    for (int i = 0; i < sizeof(expected_secret); i++) {
+        uint8_t c;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint8_hex(&expected_secret_in, &c));
+        expected_secret[i] = c;
+    }
+
+    for (int i = 0; i < sizeof(expected_expanded); i++) {
+        uint8_t c;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint8_hex(&expected_expanded_in, &c));
+        expected_expanded[i] = c;
+    }
+
+    EXPECT_SUCCESS(s2n_hash_new(&transcript_hash));
+    EXPECT_SUCCESS(s2n_hash_init(&transcript_hash, S2N_HASH_SHA256));
+    EXPECT_SUCCESS(s2n_hash_copy(&transcript_hash_snapshot, &transcript_hash));
+    EXPECT_SUCCESS(s2n_hash_digest(&transcript_hash_snapshot, digest_buf, SHA256_DIGEST_LENGTH));
+
+    uint8_t salt_buf[32] = { 0 };
+    struct s2n_blob salt = { 0 };
+
+    uint8_t ikm_buf[32] = { 0 };
+    struct s2n_blob ikm = { 0 };
+
+    uint8_t output_buf[SHA256_DIGEST_LENGTH] = { 0 };
+    struct s2n_blob output = { 0 };
+
+    EXPECT_SUCCESS(s2n_blob_init(&salt, salt_buf, sizeof(salt_buf)));
+    EXPECT_SUCCESS(s2n_blob_init(&ikm, ikm_buf, sizeof(ikm_buf)));
+    EXPECT_SUCCESS(s2n_blob_init(&digest, digest_buf, sizeof(digest_buf)));
+    EXPECT_SUCCESS(s2n_blob_init(&secret, secret_buf, sizeof(secret_buf)));
+    EXPECT_SUCCESS(s2n_blob_init(&output, output_buf, sizeof(output_buf)));
+
+    struct s2n_hmac_state throwaway;
+
+    /* Validate the early secret */
+    EXPECT_SUCCESS(s2n_hkdf_extract(&throwaway, S2N_HMAC_SHA256, &salt, &ikm, &secret));
+    EXPECT_EQUAL(memcmp(secret_buf, expected_secret, sizeof(secret_buf)), 0);
+
+    /* Validate the derived secret */
+    uint8_t label_buf[] = "derived";
+    struct s2n_blob label = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&label, label_buf, sizeof(label_buf) - 1));
+    
+    struct s2n_hmac_state hmac = {0};
+    
+    EXPECT_SUCCESS(s2n_hmac_new(&hmac));
+    EXPECT_SUCCESS(s2n_hkdf_expand_label(&hmac, S2N_HMAC_SHA256, &secret, &label, &digest, &output));
+
+    EXPECT_EQUAL(memcmp(output_buf, expected_expanded, sizeof(output_buf)), 0);
+
+    EXPECT_SUCCESS(s2n_hmac_free(&hmac));
+    EXPECT_SUCCESS(s2n_hash_free(&transcript_hash));
+    EXPECT_SUCCESS(s2n_hash_free(&transcript_hash_snapshot));
+
+    END_TEST();
+}


### PR DESCRIPTION
This commit implements the TLS1.3 HKDF-Label-Expand function that forms the
basis of the TLS1.3 PRF and Key schedule.

The function is documented in section 7.1 of RFC8446:

    https://tools.ietf.org/html/rfc8446

and included in this commit are tests that use the test vectors from:

    https://datatracker.ietf.org/doc/draft-ietf-tls-tls13-vectors/?include_text=1

Subsequent commits will implement the PRF in full, and the corresponding
unit tests will grow to resemble the existing ones for the previous PRFs. For
now, this change gets the basis function implemented and shows that our
implementation matches the reference test vectors.

**Issue # (if available):** 

**Description of changes:** 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
