### PR TITLE
Added s2n_connection_is_ocsp_stapled call

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -196,6 +196,7 @@ extern int s2n_connection_get_session_ticket_lifetime_hint(struct s2n_connection
 extern ssize_t s2n_connection_get_session_length(struct s2n_connection *conn);
 extern ssize_t s2n_connection_get_session_id_length(struct s2n_connection *conn);
 extern int s2n_connection_is_session_resumed(struct s2n_connection *conn);
+extern int s2n_connection_is_ocsp_stapled(struct s2n_connection *conn);
 
 /* RFC's that define below values:
  *  - https://tools.ietf.org/html/rfc5246#section-7.4.4

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1118,7 +1118,7 @@ during the handshake.  If no status response is received, NULL is returned.
 int s2n_connection_is_ocsp_stapled(struct s2n_connection *conn);
 ```
 
-**s2n_connection_is_ocsp_stapled** returns 1 if OCSP response was send (if connection is in S2N_SERVER mode) or received (if connection is in S2N_CLIENT mode) during handshake, otherwise it returns 0.
+**s2n_connection_is_ocsp_stapled** returns 1 if OCSP response was sent (if connection is in S2N_SERVER mode) or received (if connection is in S2N_CLIENT mode) during handshake, otherwise it returns 0.
 
 ### s2n\_connection\_get\_alert
 

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1112,6 +1112,14 @@ const uint8_t *s2n_connection_get_ocsp_response(struct s2n_connection *conn, uin
 **s2n_connection_get_ocsp_response** returns the OCSP response sent by a server
 during the handshake.  If no status response is received, NULL is returned.
 
+### s2n\_connection\_is\_ocsp\_stapled
+
+```c
+int s2n_connection_is_ocsp_stapled(struct s2n_connection *conn);
+```
+
+**s2n_connection_is_ocsp_stapled** returns 1 if OCSP response was send (if connection is in S2N_SERVER mode) or received (if connection is in S2N_CLIENT mode) during handshake, otherwise it returns 0.
+
 ### s2n\_connection\_get\_alert
 
 ```c
@@ -1169,7 +1177,7 @@ int s2n_connection_is_session_resumed(struct s2n_connection *conn);
 
 **s2n_connection_get_session_id_length** returns session id length from the connection.
 
-**s2n_connection_is_session_resumed** checks if the handshake is abbreviated or not.
+**s2n_connection_is_session_resumed** returns 1 if the handshake was abbreviated, otherwise returns 0.
 
 ### Session Ticket Specific calls
 

--- a/tests/unit/s2n_client_extensions_test.c
+++ b/tests/unit/s2n_client_extensions_test.c
@@ -688,7 +688,11 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
+        /* Verify that the server didn't send an OCSP response. */
+        EXPECT_EQUAL(s2n_connection_is_ocsp_stapled(server_conn), 0);
+
         /* Verify that the client didn't receive an OCSP response. */
+        EXPECT_EQUAL(s2n_connection_is_ocsp_stapled(client_conn), 0);
         EXPECT_NULL(s2n_connection_get_ocsp_response(client_conn, &length));
         EXPECT_EQUAL(length, 0);
 
@@ -753,7 +757,11 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
+        /* Verify that the server didn't send an OCSP response. */
+        EXPECT_EQUAL(s2n_connection_is_ocsp_stapled(server_conn), 0);
+
         /* Verify that the client didn't receive an OCSP response. */
+        EXPECT_EQUAL(s2n_connection_is_ocsp_stapled(client_conn), 0);
         EXPECT_NULL(s2n_connection_get_ocsp_response(client_conn, &length));
         EXPECT_EQUAL(length, 0);
 
@@ -820,7 +828,11 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
+        /* Verify that the server sent an OCSP response. */
+        EXPECT_EQUAL(s2n_connection_is_ocsp_stapled(server_conn), 1);
+
         /* Verify that the client received an OCSP response. */
+        EXPECT_EQUAL(s2n_connection_is_ocsp_stapled(client_conn), 1);
         EXPECT_NOT_NULL(server_ocsp_reply = s2n_connection_get_ocsp_response(client_conn, &length));
         EXPECT_EQUAL(length, sizeof(server_ocsp_status));
 

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1015,9 +1015,7 @@ int s2n_connection_kill(struct s2n_connection *conn)
 
 const uint8_t *s2n_connection_get_ocsp_response(struct s2n_connection *conn, uint32_t * length)
 {
-    if (!length) {
-        return NULL;
-    }
+    notnull_check_ptr(length);
 
     *length = conn->status_response.size;
     return conn->status_response.data;

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -97,6 +97,7 @@ struct s2n_handshake {
 
 /* Handshake needs OCSP status message */
 #define OCSP_STATUS                 0x08
+#define IS_OCSP_STAPLED( type ) ( (type) & OCSP_STATUS )
 
 /* Handshake should request a Client Certificate */
 #define CLIENT_AUTH                 0x10

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -341,7 +341,14 @@ ssize_t s2n_connection_get_session_length(struct s2n_connection *conn)
 
 int s2n_connection_is_session_resumed(struct s2n_connection *conn)
 {
-    return IS_RESUMPTION_HANDSHAKE(conn->handshake.handshake_type);
+    notnull_check(conn);
+    return IS_RESUMPTION_HANDSHAKE(conn->handshake.handshake_type) ? 1 : 0;
+}
+
+int s2n_connection_is_ocsp_stapled(struct s2n_connection *conn)
+{
+    notnull_check(conn);
+    return IS_OCSP_STAPLED(conn->handshake.handshake_type) ? 1 : 0;
 }
 
 /* This function is used in s2n_get_ticket_encrypt_decrypt_key to compute the weight


### PR DESCRIPTION
**Issue # (if available):** 

**Description of changes:** 
s2n_connection_is_ocsp_stapled call allows server to know if OCSP response was sent during 
 handshake, which is useful for logging or metering purposes.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
