### PR TITLE
Use S2N_CLOCK_HW instead of CLOCK_MONOTONIC_RAW

### DIFF
--- a/tests/unit/s2n_session_ticket_test.c
+++ b/tests/unit/s2n_session_ticket_test.c
@@ -38,7 +38,7 @@ int mock_nanoseconds_since_epoch(void *data, uint64_t *nanoseconds)
 {
     struct timespec current_time;
 
-    clock_gettime(CLOCK_MONOTONIC_RAW, &current_time);
+    clock_gettime(S2N_CLOCK_HW, &current_time);
 
     *nanoseconds = current_time.tv_sec * 1000000000;
     *nanoseconds += current_time.tv_nsec;


### PR DESCRIPTION
**Description of changes:** 

CLOCK_MONOTONIC_RAW fails on some compilers.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
