### PR TITLE
cmake: Add C math library to unittests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ endif()
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 
 find_package(LibCrypto REQUIRED)
-target_link_libraries(s2n PRIVATE LibCrypto::Crypto PRIVATE ${OS_LIBS})
+target_link_libraries(s2n PRIVATE LibCrypto::Crypto PRIVATE ${OS_LIBS} m)
 
 target_include_directories(s2n PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 target_include_directories(s2n PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api> $<INSTALL_INTERFACE:include>)


### PR DESCRIPTION
Solves my problem of building on Linux.
```
lib/libs2n.a(s2n_resume.c.o): In function `s2n_compute_weight_of_encrypt_decrypt_keys':
s2n_resume.c:(.text+0x12a0): undefined reference to `pow'
s2n_resume.c:(.text+0x12cc): undefined reference to `pow'
clang-7.0: error: linker command failed with exit code 1 (use -v to see invocation)
```
The C math library is needed for building tests. In most situations this library is just a dummy, however there are still C standard libraries that separate things.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
