### PR TITLE
Select the strongest cipher when using higher version ciphers

### DIFF
--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -891,7 +891,9 @@ static int s2n_set_cipher_as_server(struct s2n_connection *conn, uint8_t * wire,
 
             /* Don't immediately choose a cipher the client shouldn't be able to support */
             if (conn->client_protocol_version < match->minimum_required_tls_version) {
-                higher_vers_match = match;
+                if (!higher_vers_match) {
+                    higher_vers_match = match;
+                }
                 continue;
             }
 
@@ -901,7 +903,7 @@ static int s2n_set_cipher_as_server(struct s2n_connection *conn, uint8_t * wire,
     }
 
     /* Settle for a cipher with a higher required proto version, if it was set */
-    if (higher_vers_match != NULL) {
+    if (higher_vers_match) {
         conn->secure.cipher_suite = higher_vers_match;
         return 0;
     }


### PR DESCRIPTION
**Description of changes:** 

If we're falling back to higher version ciphers, it seems to make more sense to select the strongest.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
