### PR TITLE
Fix `valstr` length error in s2n_map_test.c

### DIFF
--- a/tests/unit/s2n_map_test.c
+++ b/tests/unit/s2n_map_test.c
@@ -23,7 +23,7 @@
 int main(int argc, char **argv)
 {
     char keystr[sizeof("ffff")];
-    char valstr[sizeof("8192")];
+    char valstr[sizeof("16384")];
     struct s2n_map *empty, *map;
     struct s2n_blob key;
     struct s2n_blob val;
@@ -114,7 +114,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(snprintf(valstr, sizeof(valstr), "%05d", i));
         }
         else {
-            // The first 10 entries were overwritten with i+1
+            /* The first 10 entries were overwritten with i+1 */
             EXPECT_SUCCESS(snprintf(keystr, sizeof(keystr), "%04x", i));
             EXPECT_SUCCESS(snprintf(valstr, sizeof(valstr), "%05d", i+1));
         }


### PR DESCRIPTION
Fixes #844

**Issue # (if available): #844** 

**Description of changes:** 

Initialize `valstr` with a 5 character string so we don't truncate the output when using `%05d` format specifiers.  I could have gone the other way and made the format specifiers `%04d` but went this way instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
