### PR TITLE
Use SSLv3-specific ciphers in S2N_CLIENT mode

### DIFF
--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -820,6 +820,12 @@ int s2n_set_cipher_as_client(struct s2n_connection *conn, uint8_t wire[S2N_TLS_C
     conn->secure.cipher_suite = s2n_cipher_suite_from_wire(wire);
     S2N_ERROR_IF(conn->secure.cipher_suite == NULL, S2N_ERR_CIPHER_NOT_SUPPORTED);
 
+    /* For SSLv3 use SSLv3-specific ciphers */
+    if (conn->actual_protocol_version == S2N_SSLv3) {
+        conn->secure.cipher_suite = conn->secure.cipher_suite->sslv3_cipher_suite;
+        notnull_check(conn->secure.cipher_suite);
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
**Issue # (if available):** 

**Description of changes:** 

Composite ciphers fix #846 introduced SSLv3-specific ciphers, but only used them when we're in S2N_SERVER mode, and missed the change for S2N_CLIENT mode.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
