### PR TITLE
Make fips tests optional until #821 is resolved

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,8 @@ matrix:
     - env: S2N_LIBCRYPTO=openssl-1.1.x-master BUILD_S2N=true TESTS=integration GCC6_REQUIRED=true
     # Optional until we resolve broken remote dependency: https://github.com/awslabs/s2n/pull/615
     - env: TESTS=ctverif
+    # Optional until https://github.com/awslabs/s2n/issues/821 is fixed
+    - env: S2N_LIBCRYPTO=openssl-1.0.2-fips BUILD_S2N=true TESTS=integration GCC6_REQUIRED=true
 
   fast_finish: true
 


### PR DESCRIPTION
**Issue # (if available):** #821

**Description of changes:** 

This bug introduced in OpenSSL 1.0.2p is causing ECDSA tests to fail with fips build. Until the bug is fixed, moved fips build to allow failures.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
