### PR TITLE
 add s2n_connection_is_valid_for_cipher_preferences API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,7 @@ matrix:
     - env: S2N_LIBCRYPTO=openssl-1.1.x-master BUILD_S2N=true TESTS=integration GCC6_REQUIRED=true
     # Optional until we resolve broken remote dependency: https://github.com/awslabs/s2n/pull/615
     - env: TESTS=ctverif
+    - env: S2N_LIBCRYPTO=openssl-1.0.2-fips BUILD_S2N=true TESTS=integration GCC6_REQUIRED=true
 
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,6 @@ matrix:
     - env: S2N_LIBCRYPTO=openssl-1.1.x-master BUILD_S2N=true TESTS=integration GCC6_REQUIRED=true
     # Optional until we resolve broken remote dependency: https://github.com/awslabs/s2n/pull/615
     - env: TESTS=ctverif
-    - env: S2N_LIBCRYPTO=openssl-1.0.2-fips BUILD_S2N=true TESTS=integration GCC6_REQUIRED=true
 
   fast_finish: true
 

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -229,6 +229,7 @@ extern int s2n_connection_get_actual_protocol_version(struct s2n_connection *con
 extern int s2n_connection_get_client_hello_version(struct s2n_connection *conn);
 extern int s2n_connection_client_cert_used(struct s2n_connection *conn);
 extern const char *s2n_connection_get_cipher(struct s2n_connection *conn);
+extern int s2n_connection_is_valid_for_cipher_preferences(struct s2n_connection *conn, const char *version);
 extern const char *s2n_connection_get_curve(struct s2n_connection *conn);
 extern int s2n_connection_get_alert(struct s2n_connection *conn);
 

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -903,9 +903,9 @@ int s2n_connection_is_valid_for_cipher_preferences(struct s2n_connection *conn, 
 
 **s2n_connection_is_valid_for_cipher_preferences** checks if the cipher used by current connection
 is supported by a given cipher preferences. It returns 
-1   if the connection satisfies the cipher suite 
-0   if it does not
--1  on any other errors
+-  1 if the connection satisfies the cipher suite 
+-  0 if it does not
+- -1 on any other errors
 
 
 ## s2n\_connection\_set\_cipher\_preferences

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -895,6 +895,16 @@ file-descriptor should be active and connected. s2n also supports setting the
 read and write file-descriptors to different values (for pipes or other unusual
 types of I/O).
 
+## s2n\_connection\_is\_valid\_for\_cipher\_preferences
+
+```c
+int s2n_connection_is_valid_for_cipher_preferences(struct s2n_connection *conn, const char *version);
+```
+
+**s2n_connection_is_valid_for_cipher_preferences** checks if the cipher used by current connection
+is supported by a given cipher preferences.
+
+
 ## s2n\_connection\_set\_cipher\_preferences
 
 ```c

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -902,7 +902,10 @@ int s2n_connection_is_valid_for_cipher_preferences(struct s2n_connection *conn, 
 ```
 
 **s2n_connection_is_valid_for_cipher_preferences** checks if the cipher used by current connection
-is supported by a given cipher preferences.
+is supported by a given cipher preferences. It returns 
+1   if the connection satisfies the cipher suite 
+0   if it does not
+-1  on any other errors
 
 
 ## s2n\_connection\_set\_cipher\_preferences

--- a/tests/unit/s2n_cipher_suite_match_test.c
+++ b/tests/unit/s2n_cipher_suite_match_test.c
@@ -136,11 +136,15 @@ int main(int argc, char **argv)
         const uint8_t cipher_count = sizeof(wire_ciphers) / S2N_TLS_CIPHER_SUITE_LEN;
         EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers, cipher_count));
         EXPECT_EQUAL(conn->secure_renegotiation, 0);
+        EXPECT_SUCCESS(s2n_connection_is_valid_for_cipher_preferences(conn, "test_all")); 
+        EXPECT_FAILURE(s2n_connection_is_valid_for_cipher_preferences(conn, "null"));
         EXPECT_SUCCESS(s2n_connection_wipe(conn));
 
         const uint8_t cipher_count_renegotiation = sizeof(wire_ciphers_renegotiation) / S2N_TLS_CIPHER_SUITE_LEN;
         EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_renegotiation, cipher_count_renegotiation));
         EXPECT_EQUAL(conn->secure_renegotiation, 1);
+        EXPECT_SUCCESS(s2n_connection_is_valid_for_cipher_preferences(conn, "test_all")); 
+        EXPECT_FAILURE(s2n_connection_is_valid_for_cipher_preferences(conn, "not_exist"));
         EXPECT_SUCCESS(s2n_connection_wipe(conn));
 
         const uint8_t cipher_count_fallback = sizeof(wire_ciphers_fallback) / S2N_TLS_CIPHER_SUITE_LEN;
@@ -148,6 +152,8 @@ int main(int argc, char **argv)
         conn->client_protocol_version = S2N_TLS11;
         EXPECT_FAILURE(s2n_set_cipher_as_tls_server(conn, wire_ciphers_fallback, cipher_count_fallback));
         EXPECT_EQUAL(conn->secure_renegotiation, 0);
+        EXPECT_SUCCESS(s2n_connection_is_valid_for_cipher_preferences(conn, "null"));
+        EXPECT_FAILURE(s2n_connection_is_valid_for_cipher_preferences(conn, "CloudFront-TLS-1-2-2018"));
         EXPECT_SUCCESS(s2n_connection_wipe(conn));
 
         EXPECT_SUCCESS(s2n_connection_free(conn));

--- a/tests/unit/s2n_cipher_suite_match_test.c
+++ b/tests/unit/s2n_cipher_suite_match_test.c
@@ -136,6 +136,7 @@ int main(int argc, char **argv)
         const uint8_t cipher_count = sizeof(wire_ciphers) / S2N_TLS_CIPHER_SUITE_LEN;
         EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers, cipher_count));
         EXPECT_EQUAL(conn->secure_renegotiation, 0);
+        conn->actual_protocol_version = S2N_TLS10;
         EXPECT_EQUAL(1, s2n_connection_is_valid_for_cipher_preferences(conn, "test_all")); 
         EXPECT_EQUAL(0, s2n_connection_is_valid_for_cipher_preferences(conn, "null"));
         EXPECT_SUCCESS(s2n_connection_wipe(conn));
@@ -143,6 +144,7 @@ int main(int argc, char **argv)
         const uint8_t cipher_count_renegotiation = sizeof(wire_ciphers_renegotiation) / S2N_TLS_CIPHER_SUITE_LEN;
         EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_renegotiation, cipher_count_renegotiation));
         EXPECT_EQUAL(conn->secure_renegotiation, 1);
+        conn->actual_protocol_version = S2N_TLS12;
         EXPECT_EQUAL(1, s2n_connection_is_valid_for_cipher_preferences(conn, "test_all")); 
         EXPECT_EQUAL(-1, s2n_connection_is_valid_for_cipher_preferences(conn, "not_exist"));
         EXPECT_SUCCESS(s2n_connection_wipe(conn));
@@ -152,6 +154,7 @@ int main(int argc, char **argv)
         conn->client_protocol_version = S2N_TLS11;
         EXPECT_FAILURE(s2n_set_cipher_as_tls_server(conn, wire_ciphers_fallback, cipher_count_fallback));
         EXPECT_EQUAL(conn->secure_renegotiation, 0);
+        conn->actual_protocol_version = S2N_TLS11;
         EXPECT_EQUAL(1, s2n_connection_is_valid_for_cipher_preferences(conn, "null"));
         EXPECT_EQUAL(0, s2n_connection_is_valid_for_cipher_preferences(conn, "CloudFront-TLS-1-2-2018"));
         EXPECT_SUCCESS(s2n_connection_wipe(conn));

--- a/tests/unit/s2n_cipher_suite_match_test.c
+++ b/tests/unit/s2n_cipher_suite_match_test.c
@@ -136,15 +136,15 @@ int main(int argc, char **argv)
         const uint8_t cipher_count = sizeof(wire_ciphers) / S2N_TLS_CIPHER_SUITE_LEN;
         EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers, cipher_count));
         EXPECT_EQUAL(conn->secure_renegotiation, 0);
-        EXPECT_SUCCESS(s2n_connection_is_valid_for_cipher_preferences(conn, "test_all")); 
-        EXPECT_FAILURE(s2n_connection_is_valid_for_cipher_preferences(conn, "null"));
+        EXPECT_EQUAL(1, s2n_connection_is_valid_for_cipher_preferences(conn, "test_all")); 
+        EXPECT_EQUAL(0, s2n_connection_is_valid_for_cipher_preferences(conn, "null"));
         EXPECT_SUCCESS(s2n_connection_wipe(conn));
 
         const uint8_t cipher_count_renegotiation = sizeof(wire_ciphers_renegotiation) / S2N_TLS_CIPHER_SUITE_LEN;
         EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_renegotiation, cipher_count_renegotiation));
         EXPECT_EQUAL(conn->secure_renegotiation, 1);
-        EXPECT_SUCCESS(s2n_connection_is_valid_for_cipher_preferences(conn, "test_all")); 
-        EXPECT_FAILURE(s2n_connection_is_valid_for_cipher_preferences(conn, "not_exist"));
+        EXPECT_EQUAL(1, s2n_connection_is_valid_for_cipher_preferences(conn, "test_all")); 
+        EXPECT_EQUAL(-1, s2n_connection_is_valid_for_cipher_preferences(conn, "not_exist"));
         EXPECT_SUCCESS(s2n_connection_wipe(conn));
 
         const uint8_t cipher_count_fallback = sizeof(wire_ciphers_fallback) / S2N_TLS_CIPHER_SUITE_LEN;
@@ -152,8 +152,8 @@ int main(int argc, char **argv)
         conn->client_protocol_version = S2N_TLS11;
         EXPECT_FAILURE(s2n_set_cipher_as_tls_server(conn, wire_ciphers_fallback, cipher_count_fallback));
         EXPECT_EQUAL(conn->secure_renegotiation, 0);
-        EXPECT_SUCCESS(s2n_connection_is_valid_for_cipher_preferences(conn, "null"));
-        EXPECT_FAILURE(s2n_connection_is_valid_for_cipher_preferences(conn, "CloudFront-TLS-1-2-2018"));
+        EXPECT_EQUAL(1, s2n_connection_is_valid_for_cipher_preferences(conn, "null"));
+        EXPECT_EQUAL(0, s2n_connection_is_valid_for_cipher_preferences(conn, "CloudFront-TLS-1-2-2018"));
         EXPECT_SUCCESS(s2n_connection_wipe(conn));
 
         EXPECT_SUCCESS(s2n_connection_free(conn));

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -622,9 +622,9 @@ int s2n_connection_is_valid_for_cipher_preferences(struct s2n_connection *conn, 
         if (0 == strcmp(preferences->suites[i]->name, conn->secure.cipher_suite->name) &&
             /* make sure we dont use a tls version lower than that configured by the version */
             s2n_connection_get_actual_protocol_version(conn) >= preferences->suites[i]->minimum_required_tls_version) {
-            return 0;
+            return 1;
         }
     }
 
-    S2N_ERROR(S2N_ERR_INVALID_CIPHER_PREFERENCES);
+    return 0;
 }

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -15,7 +15,7 @@
 
 #include <strings.h>
 #include <stdint.h>
-
+#include <s2n.h>
 #include "tls/s2n_cipher_preferences.h"
 #include "tls/s2n_config.h"
 
@@ -174,6 +174,16 @@ struct s2n_cipher_suite *cipher_suites_20170210[] = {
     &s2n_rsa_with_aes_128_gcm_sha256,
     &s2n_rsa_with_aes_128_cbc_sha256,
     &s2n_rsa_with_aes_128_cbc_sha
+};
+
+struct s2n_cipher_suite *cipher_suites_null[] = {
+    &s2n_null_cipher_suite
+};
+
+const struct s2n_cipher_preferences cipher_preferences_null = {
+    .count = sizeof(cipher_suites_null) / sizeof(cipher_suites_null[0]),
+    .suites = cipher_suites_null,
+    .minimum_protocol_version = S2N_TLS10
 };
 
 const struct s2n_cipher_preferences cipher_preferences_20170210 = {
@@ -568,6 +578,7 @@ struct {
     { "test_all", &cipher_preferences_test_all },
     { "test_all_fips", &cipher_preferences_test_all_fips },
     { "test_all_ecdsa", &cipher_preferences_test_all_ecdsa },
+    { "null", &cipher_preferences_null },
     { NULL, NULL }
 };
 
@@ -598,3 +609,22 @@ int s2n_connection_set_cipher_preferences(struct s2n_connection *conn, const cha
     return 0;
 }
 
+int s2n_connection_is_valid_for_cipher_preferences(struct s2n_connection *conn, const char *version)
+{
+    notnull_check(conn);
+    notnull_check(version);
+    notnull_check(conn->secure.cipher_suite);
+
+    const struct s2n_cipher_preferences *preferences;
+    GUARD(s2n_find_cipher_pref_from_version(version, &preferences));
+
+    for (int i = 0; i < preferences->count; ++i) {
+        if (0 == strcmp(preferences->suites[i]->name, conn->secure.cipher_suite->name) &&
+            /* make sure we dont use a tls version lower than that configured by the version */
+            conn->secure.cipher_suite->minimum_required_tls_version >= preferences->suites[i]->minimum_required_tls_version) {
+            return 0;
+        }
+    }
+
+    S2N_ERROR(S2N_ERR_INVALID_CIPHER_PREFERENCES);
+}

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -621,7 +621,7 @@ int s2n_connection_is_valid_for_cipher_preferences(struct s2n_connection *conn, 
     for (int i = 0; i < preferences->count; ++i) {
         if (0 == strcmp(preferences->suites[i]->name, conn->secure.cipher_suite->name) &&
             /* make sure we dont use a tls version lower than that configured by the version */
-            conn->secure.cipher_suite->minimum_required_tls_version >= preferences->suites[i]->minimum_required_tls_version) {
+            s2n_connection_get_actual_protocol_version(conn) >= preferences->suites[i]->minimum_required_tls_version) {
             return 0;
         }
     }

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -618,10 +618,13 @@ int s2n_connection_is_valid_for_cipher_preferences(struct s2n_connection *conn, 
     const struct s2n_cipher_preferences *preferences;
     GUARD(s2n_find_cipher_pref_from_version(version, &preferences));
 
+    /* make sure we dont use a tls version lower than that configured by the version */
+    if (s2n_connection_get_actual_protocol_version(conn) < preferences->minimum_protocol_version) {
+        return 0;
+    }
+
     for (int i = 0; i < preferences->count; ++i) {
-        if (0 == strcmp(preferences->suites[i]->name, conn->secure.cipher_suite->name) &&
-            /* make sure we dont use a tls version lower than that configured by the version */
-            s2n_connection_get_actual_protocol_version(conn) >= preferences->suites[i]->minimum_required_tls_version) {
+        if (0 == strcmp(preferences->suites[i]->name, conn->secure.cipher_suite->name)) {
             return 1;
         }
     }


### PR DESCRIPTION
**Issue # (if available):** 
Need an API checks if the cipher used by current connection is supported by a given cipher preferences.

**Description of changes:** 
1. Add s2n_connection_is_valid_for_cipher_preferences API.
2. Temporarily move fips test to allowed failure
