### PR TITLE
Added S2N_DEBUG env var which enables DEBUG_CFLAGS

### DIFF
--- a/s2n.mk
+++ b/s2n.mk
@@ -56,6 +56,10 @@ CFLAGS += ${DEFAULT_CFLAGS}
 
 DEBUG_CFLAGS = -g3 -ggdb -fno-omit-frame-pointer -fno-optimize-sibling-calls
 
+ifdef S2N_DEBUG
+	CFLAGS += ${DEBUG_CFLAGS}
+endif
+
 FUZZ_CFLAGS = -fsanitize-coverage=trace-pc-guard -fsanitize=address,undefined,leak
 
 ifeq ($(S2N_UNSAFE_FUZZING_MODE),1)


### PR DESCRIPTION
**Issue # (if available):** 

**Description of changes:** `S2N_DEBUG=1 make` to build with debug symbols

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
