### PR TITLE
Fix ECDSA and TLS13 PRF tests in FIPS build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,8 +75,6 @@ matrix:
     - env: S2N_LIBCRYPTO=openssl-1.1.x-master BUILD_S2N=true TESTS=integration GCC6_REQUIRED=true
     # Optional until we resolve broken remote dependency: https://github.com/awslabs/s2n/pull/615
     - env: TESTS=ctverif
-    # Optional until https://github.com/awslabs/s2n/issues/821 is fixed
-    - env: S2N_LIBCRYPTO=openssl-1.0.2-fips BUILD_S2N=true TESTS=integration GCC6_REQUIRED=true
 
   fast_finish: true
 

--- a/.travis/install_openssl_1_0_2_fips.sh
+++ b/.travis/install_openssl_1_0_2_fips.sh
@@ -61,9 +61,10 @@ make
 sudo make install
 
 cd "$BUILD_DIR"
-curl --retry 3 -L https://github.com/openssl/openssl/archive/OpenSSL_1_0_2-stable.zip --output openssl-OpenSSL_1_0_2-stable.zip
+# Pull from a specific commit since an ECDSA PEM parsing bug was introduced into the branch
+curl --retry 3 -L https://github.com/openssl/openssl/archive/6a815969776e3329fdffcc12c77e047e3a15be78.zip --output openssl-OpenSSL_1_0_2-stable.zip
 unzip openssl-OpenSSL_1_0_2-stable.zip
-cd openssl-OpenSSL_1_0_2-stable
+cd openssl-6a815969776e3329fdffcc12c77e047e3a15be78
 
 FIPS_OPTIONS="fips --with-fipsdir=$FIPSDIR shared"
 

--- a/tests/unit/s2n_tls13_prf_test.c
+++ b/tests/unit/s2n_tls13_prf_test.c
@@ -99,6 +99,7 @@ int main(int argc, char **argv)
     }
 
     EXPECT_SUCCESS(s2n_hash_new(&transcript_hash));
+    EXPECT_SUCCESS(s2n_hash_new(&transcript_hash_snapshot));
     EXPECT_SUCCESS(s2n_hash_init(&transcript_hash, S2N_HASH_SHA256));
     EXPECT_SUCCESS(s2n_hash_copy(&transcript_hash_snapshot, &transcript_hash));
     EXPECT_SUCCESS(s2n_hash_digest(&transcript_hash_snapshot, digest_buf, SHA256_DIGEST_LENGTH));
@@ -119,6 +120,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_blob_init(&output, output_buf, sizeof(output_buf)));
 
     struct s2n_hmac_state throwaway;
+    EXPECT_SUCCESS(s2n_hmac_new(&throwaway));
 
     /* Validate the early secret */
     EXPECT_SUCCESS(s2n_hkdf_extract(&throwaway, S2N_HMAC_SHA256, &salt, &ikm, &secret));

--- a/tests/unit/s2n_tls13_prf_test.c
+++ b/tests/unit/s2n_tls13_prf_test.c
@@ -138,6 +138,7 @@ int main(int argc, char **argv)
 
     EXPECT_EQUAL(memcmp(output_buf, expected_expanded, sizeof(output_buf)), 0);
 
+    EXPECT_SUCCESS(s2n_hmac_free(&throwaway));
     EXPECT_SUCCESS(s2n_hmac_free(&hmac));
     EXPECT_SUCCESS(s2n_hash_free(&transcript_hash));
     EXPECT_SUCCESS(s2n_hash_free(&transcript_hash_snapshot));


### PR DESCRIPTION
**Issue # (if available):** 
Related to (but not a complete fix for): #821 

**Description of changes:** 
A bug was introduced into the Openssl 1.0.2 branch that seems to affect ECDSA PEM parsing in FIPS mode. This change pulls a specific revision that does not include the bug. 

We have been skipping the failing build and haven't been checking the tests for recent commits. To fully re-enable the FIPS build, we also needed to fix a bug in the TLS13 PRF test that manifests only in FIPS mode.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
