### PR TITLE
Compare IANA values in s2n_connection_is_valid_for_cipher_preferences

### DIFF
--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -623,8 +623,9 @@ int s2n_connection_is_valid_for_cipher_preferences(struct s2n_connection *conn, 
         return 0;
     }
 
+    struct s2n_cipher_suite *cipher = conn->secure.cipher_suite;
     for (int i = 0; i < preferences->count; ++i) {
-        if (0 == strcmp(preferences->suites[i]->name, conn->secure.cipher_suite->name)) {
+        if (0 == memcmp(preferences->suites[i]->iana_value, cipher->iana_value, S2N_TLS_CIPHER_SUITE_LEN)) {
             return 1;
         }
     }

--- a/tls/s2n_cipher_suites.h
+++ b/tls/s2n_cipher_suites.h
@@ -78,7 +78,7 @@ struct s2n_cipher_suite {
 
     /* Cipher name in Openssl format */
     const char *name;
-    const uint8_t iana_value[2];
+    const uint8_t iana_value[S2N_TLS_CIPHER_SUITE_LEN];
 
     const struct s2n_key_exchange_algorithm *key_exchange_alg;
 


### PR DESCRIPTION
**Issue # (if available):** 

**Description of changes:** 

IANA values are uniq and take just 2 bytes, while cipher name are longer and may take more time to compare.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
