### PR TITLE
Allow Client Auth in FIPS Mode

### DIFF
--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -374,7 +374,10 @@ int handle_connection(int fd, struct s2n_config *config, struct conn_settings se
     }
 
     if (settings.mutual_auth) {
-        s2n_config_set_client_auth_type(config, S2N_CERT_AUTH_REQUIRED);
+        if (s2n_config_set_client_auth_type(config, S2N_CERT_AUTH_REQUIRED) < 0) {
+            print_s2n_error("Error setting client auth type");
+            exit(1);
+        }
 
         if (settings.ca_dir || settings.ca_file) {
             if (s2n_config_set_verification_ca_location(config, settings.ca_file, settings.ca_dir) < 0) {
@@ -554,11 +557,6 @@ int main(int argc, char *const *argv)
 
     if (conn_settings.prefer_throughput && conn_settings.prefer_low_latency) {
         fprintf(stderr, "prefer-throughput and prefer-low-latency options are mutually exclusive\n");
-        exit(1);
-    }
-
-    if (fips_mode && conn_settings.mutual_auth) {
-        fprintf(stderr, "Mutual Auth cannot be enabled when s2n is in FIPS mode\n");
         exit(1);
     }
 

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -277,6 +277,7 @@ static int s2n_evp_hash_allow_md5_for_fips(struct s2n_hash_state *state)
      * outside of the TLS 1.0 and 1.1 PRF when in FIPS mode. When needed, this must
      * be called prior to s2n_hash_init().
      */
+    GUARD(s2n_digest_allow_md5_for_fips(&state->digest.high_level.evp_md5_secondary));
     return s2n_digest_allow_md5_for_fips(&state->digest.high_level.evp);
 }
 
@@ -426,7 +427,7 @@ static int s2n_evp_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *f
 static int s2n_evp_hash_reset(struct s2n_hash_state *state)
 {
     int reset_md5_for_fips = 0;
-    if ((state->alg == S2N_HASH_MD5) && s2n_digest_is_md5_allowed_for_fips(&state->digest.high_level.evp)) {
+    if ((state->alg == S2N_HASH_MD5 || state->alg == S2N_HASH_MD5_SHA1) && s2n_digest_is_md5_allowed_for_fips(&state->digest.high_level.evp)) {
         reset_md5_for_fips = 1;
     }
 
@@ -439,7 +440,6 @@ static int s2n_evp_hash_reset(struct s2n_hash_state *state)
     if (reset_md5_for_fips) {
         GUARD(s2n_hash_allow_md5_for_fips(state));
     }
-
     /* hash_init resets the ready_for_input and currently_in_hash fields */
     return s2n_evp_hash_init(state, state->alg);
 }
@@ -515,7 +515,7 @@ int s2n_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm alg)
     GUARD(s2n_hash_set_impl(state));
 
     if (s2n_hash_is_available(alg) ||
-       ((alg == S2N_HASH_MD5) && s2n_digest_is_md5_allowed_for_fips(&state->digest.high_level.evp))) {
+       ((alg == S2N_HASH_MD5 || alg == S2N_HASH_MD5_SHA1) && s2n_digest_is_md5_allowed_for_fips(&state->digest.high_level.evp))) {
         /* s2n will continue to initialize an "unavailable" hash when s2n is in FIPS mode and
          * FIPS is forcing the hash to be made available.
          */

--- a/tests/integration/s2n_handshake_test_s_client.py
+++ b/tests/integration/s2n_handshake_test_s_client.py
@@ -265,10 +265,6 @@ def client_auth_test(host, port, test_ciphers, fips_mode):
 
     print("\n\tRunning client auth tests:")
 
-    if fips_mode:
-        print("\t\033[33;1mSKIPPED\033[0m - Client Auth not supported in FIPS mode")
-        return 0
-
     for filename in os.listdir(TEST_CERT_DIRECTORY):
         if "client_cert" in filename and "rsa" in filename:
             client_cert_path = TEST_CERT_DIRECTORY + filename
@@ -332,11 +328,6 @@ def sigalg_test(host, port, fips_mode, use_client_auth=None, no_ticket=False):
     failed = 0
 
     print("\n\tRunning signature algorithm tests:")
-
-    if fips_mode and use_client_auth:
-        print("\t\033[33;1mSKIPPED\033[0m - Client Auth not supported in FIPS mode")
-        return 0
-
     print("\tExpected supported:   " + str(supported_sigs))
     print("\tExpected unsupported: " + str(unsupported_sigs))
 

--- a/tests/unit/s2n_mutual_auth_test.c
+++ b/tests/unit/s2n_mutual_auth_test.c
@@ -102,22 +102,6 @@ int main(int argc, char **argv)
 
     BEGIN_TEST();
 
-    /* s2n support for Mutual Auth when in FIPS mode is not yet implemented. */
-    if (s2n_is_in_fips_mode()) {
-        /* Test Mutual Auth fails using s2n_config_set_client_auth_type */
-        EXPECT_NOT_NULL(config = s2n_config_new());
-        EXPECT_FAILURE(s2n_config_set_client_auth_type(config, S2N_CERT_AUTH_REQUIRED));
-        EXPECT_SUCCESS(s2n_config_free(config));
-
-        /* Test Mutual Auth fails using s2n_connection_set_client_auth_type */
-        struct s2n_connection *conn;
-        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_FAILURE(s2n_connection_set_client_auth_type(conn, S2N_CERT_AUTH_REQUIRED));
-        EXPECT_SUCCESS(s2n_connection_free(conn));
-
-        END_TEST();
-    }
-
     EXPECT_SUCCESS(setenv("S2N_ENABLE_CLIENT_MODE", "1", 0));
     EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
     EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));

--- a/tests/unit/s2n_optional_client_auth_test.c
+++ b/tests/unit/s2n_optional_client_auth_test.c
@@ -62,22 +62,6 @@ int main(int argc, char **argv)
 
     BEGIN_TEST();
 
-    /* s2n support for mutual auth when in FIPS mode is not yet implemented. */
-    if (s2n_is_in_fips_mode()) {
-        /* Test optional client auth fails using s2n_config_set_client_auth_type. */
-        EXPECT_NOT_NULL(server_config = s2n_config_new());
-        EXPECT_FAILURE(s2n_config_set_client_auth_type(server_config, S2N_CERT_AUTH_OPTIONAL));
-        EXPECT_SUCCESS(s2n_config_free(server_config));
-
-        /* Test optional client auth fails using s2n_connection_set_client_auth_type. */
-        struct s2n_connection *conn;
-        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_FAILURE(s2n_connection_set_client_auth_type(conn, S2N_CERT_AUTH_OPTIONAL));
-        EXPECT_SUCCESS(s2n_connection_free(conn));
-
-        END_TEST();
-    }
-
     EXPECT_SUCCESS(setenv("S2N_ENABLE_CLIENT_MODE", "1", 0));
     EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
     EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));

--- a/tls/s2n_client_cert_verify.c
+++ b/tls/s2n_client_cert_verify.c
@@ -46,11 +46,12 @@ int s2n_client_cert_verify_recv(struct s2n_connection *conn)
     notnull_check(signature.data);
     struct s2n_hash_state hash_state = {0};
     GUARD(s2n_handshake_get_hash_state(conn, chosen_hash_alg, &hash_state));
-
+    GUARD(s2n_hash_copy(&conn->handshake.ccv_hash_copy, &hash_state));
+    
     switch (chosen_signature_alg) {
     case S2N_SIGNATURE_RSA:
     case S2N_SIGNATURE_ECDSA:
-        GUARD(s2n_pkey_verify(&conn->secure.client_public_key, &hash_state, &signature));
+        GUARD(s2n_pkey_verify(&conn->secure.client_public_key, &conn->handshake.ccv_hash_copy, &signature));
         break;
     default:
         S2N_ERROR(S2N_ERR_INVALID_SIGNATURE_ALGORITHM);

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -338,18 +338,10 @@ int s2n_config_get_client_auth_type(struct s2n_config *config, s2n_cert_auth_typ
 
 int s2n_config_set_client_auth_type(struct s2n_config *config, s2n_cert_auth_type client_auth_type)
 {
-    if ((client_auth_type != S2N_CERT_AUTH_NONE) && s2n_is_in_fips_mode()) {
-        /* s2n support for Client Auth when in FIPS mode is not yet implemented.
-         * When implemented, FIPS only permits Client Auth for TLS 1.2
-         */
-        S2N_ERROR(S2N_ERR_CLIENT_AUTH_NOT_SUPPORTED_IN_FIPS_MODE);
-    }
-
     if ((client_auth_type != S2N_CERT_AUTH_NONE) && config->use_tickets) {
         /* s2n does not support handshakes with CLIENT_AUTH when in session resumption mode */
         S2N_ERROR(S2N_ERR_CLIENT_AUTH_NOT_SUPPORTED_IN_SESSION_RESUMPTION_MODE);
     }
-
     notnull_check(config);
     config->client_cert_auth_type = client_auth_type;
     return 0;

--- a/tls/s2n_connection_evp_digests.c
+++ b/tls/s2n_connection_evp_digests.c
@@ -44,6 +44,7 @@ int s2n_connection_save_hash_state(struct s2n_connection_hash_handles *hash_hand
     hash_handles->sha384 = conn->handshake.sha384.digest.high_level;
     hash_handles->sha512 = conn->handshake.sha512.digest.high_level;
     hash_handles->md5_sha1 = conn->handshake.md5_sha1.digest.high_level;
+    hash_handles->ccv_hash_copy = conn->handshake.ccv_hash_copy.digest.high_level;
     hash_handles->prf_md5_hash_copy = conn->handshake.prf_md5_hash_copy.digest.high_level;
     hash_handles->prf_sha1_hash_copy = conn->handshake.prf_sha1_hash_copy.digest.high_level;
     hash_handles->prf_tls12_hash_copy = conn->handshake.prf_tls12_hash_copy.digest.high_level;
@@ -103,6 +104,7 @@ int s2n_connection_restore_hash_state(struct s2n_connection *conn, struct s2n_co
     conn->handshake.sha384.digest.high_level = hash_handles->sha384;
     conn->handshake.sha512.digest.high_level = hash_handles->sha512;
     conn->handshake.md5_sha1.digest.high_level = hash_handles->md5_sha1;
+    conn->handshake.ccv_hash_copy.digest.high_level = hash_handles->ccv_hash_copy;
     conn->handshake.prf_md5_hash_copy.digest.high_level = hash_handles->prf_md5_hash_copy;
     conn->handshake.prf_sha1_hash_copy.digest.high_level = hash_handles->prf_sha1_hash_copy;
     conn->handshake.prf_tls12_hash_copy.digest.high_level = hash_handles->prf_tls12_hash_copy;

--- a/tls/s2n_connection_evp_digests.h
+++ b/tls/s2n_connection_evp_digests.h
@@ -37,6 +37,7 @@ struct s2n_connection_hash_handles {
     struct s2n_hash_evp_digest sha384;
     struct s2n_hash_evp_digest sha512;
     struct s2n_hash_evp_digest md5_sha1;
+    struct s2n_hash_evp_digest ccv_hash_copy;
     struct s2n_hash_evp_digest prf_md5_hash_copy;
     struct s2n_hash_evp_digest prf_sha1_hash_copy;
     struct s2n_hash_evp_digest prf_tls12_hash_copy;

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -65,6 +65,9 @@ struct s2n_handshake {
     struct s2n_hash_state sha512;
     struct s2n_hash_state md5_sha1;
 
+    /* A copy of the handshake messages hash used to validate the CertificateVerify message */
+    struct s2n_hash_state ccv_hash_copy;
+
     /* Used for SSLv3, TLS 1.0, and TLS 1.1 PRFs */
     struct s2n_hash_state prf_md5_hash_copy;
     struct s2n_hash_state prf_sha1_hash_copy;

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -392,8 +392,12 @@ static int s2n_conn_update_handshake_hashes(struct s2n_connection *conn, struct 
     const uint8_t md5_sha1_required = (s2n_handshake_is_hash_required(&conn->handshake, S2N_HASH_MD5) &&
                                        s2n_handshake_is_hash_required(&conn->handshake, S2N_HASH_SHA1));
 
-    if (md5_sha1_required && s2n_hash_is_available(S2N_HASH_MD5_SHA1)) {
-        /* The MD5_SHA1 hash cannot be initialized when FIPS mode is set. */
+    if (md5_sha1_required) {
+        /* The MD5_SHA1 hash can still be used for TLS 1.0 and 1.1 in FIPS mode for 
+         * the handshake hashes. This will only be used for the signature check in the
+         * CertificateVerify message and the PRF. NIST SP 800-52r1 approves use
+         * of MD5_SHA1 for these use cases (see footnotes 15 and 20, and section
+         * 3.3.2) */
         GUARD(s2n_hash_update(&conn->handshake.md5_sha1, data->data, data->size));
     }
 


### PR DESCRIPTION
**Issue # (if available):** 
#633 

**Description of changes:** 
Client Auth was previously disabled because it was thought to be disallowed in FIPS mode for TLS versions 1.0 and 1.1. This was because of the use of algorithms that are typically disallowed in FIPS mode in the signature of the CertificateVerify message. According to https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r1.pdf, the MD5/SHA-1 signature is allowed for this use case.

An additional `s2n_hash_state` was added specifically for use when verifying the client's CertificateVerify message. In TLS 1.0/1.1, we could continue to use the md5_sha1 handshake hash without a problem. In TLS 1.2 however, the algorithm-specific handshake hashes are also used in the algorithm-specific PRF. This resulted in two calls to the mutating`EVP_DigestFinal_ex()` function if the negotiated signature/hash algorithm was the same as the PRF (for example, if you used `openssl s_client -tls1_2 -connect 127.0.0.1:8903 -cipher ECDHE-RSA-AES128-GCM-SHA256 -key client_key.pem -cert client_cert.pem -sigalgs RSA+SHA256`).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
