### PR TITLE
Remove dead code in s2n_cipher_suites.c

### DIFF
--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 #include "error/s2n_errno.h"
 
 #include "crypto/s2n_cipher.h"
+#include "crypto/s2n_openssl.h"
 
 #include "tls/s2n_cipher_preferences.h"
 #include "tls/s2n_cipher_suites.h"
@@ -702,18 +703,6 @@ const struct s2n_cipher_preferences cipher_preferences_test_all_ecdsa = {
     .suites = s2n_all_ecdsa_cipher_suites,
     .minimum_protocol_version = S2N_TLS10
 };
-
-/**
- * openssl with OPENSSL_VERSION_NUMBER < 0x10100003L made data type details unavailable
- * libressl use openssl with data type details available, but mandatorily set
- * OPENSSL_VERSION_NUMBER = 0x20000000L, insane!
- * https://github.com/aws/aws-sdk-cpp/pull/507/commits/2c99f1fe0c4b4683280caeb161538d4724d6a179
- */
-#if defined(LIBRESSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER == 0x20000000L)
-#undef OPENSSL_VERSION_NUMBER
-#define OPENSSL_VERSION_NUMBER 0x1000107fL
-#endif
-#define OPENSSL_VERSION_LESS_1_1 (OPENSSL_VERSION_NUMBER < 0x10100003L)
 
 /* Determines cipher suite availability and selects record algorithms */
 int s2n_cipher_suites_init(void)


### PR DESCRIPTION
Looks like leftover from a merge. These macros are now defined in
https://github.com/awslabs/s2n/blob/master/crypto/s2n_openssl.h#L18-L27

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
