### PR TITLE
Remove both remaining uses of GUARD_GOTO

### DIFF
--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -266,27 +266,16 @@ int s2n_connection_set_session(struct s2n_connection *conn, const uint8_t *sessi
 {
     notnull_check(conn);
     notnull_check(session);
-    int ret_val = 0;
 
-    struct s2n_blob session_data = {0};
+    DEFER_CLEANUP(struct s2n_blob session_data = {0}, s2n_free);
     GUARD(s2n_alloc(&session_data, length));
     memcpy(session_data.data, session, length);
 
     struct s2n_stuffer from = {{0}};
-    GUARD_GOTO(s2n_stuffer_init(&from, &session_data), failed);
-    GUARD_GOTO(s2n_stuffer_write(&from, &session_data), failed);
-    GUARD_GOTO(s2n_client_deserialize_resumption_state(conn, &from), failed);
-
-    ret_val = 0;
-    goto clean_up;
-
-    // cppcheck-suppress unusedLabel
-failed:
-    ret_val = -1;
-
-clean_up:
-    GUARD(s2n_free(&session_data));
-    return ret_val;
+    GUARD(s2n_stuffer_init(&from, &session_data));
+    GUARD(s2n_stuffer_write(&from, &session_data));
+    GUARD(s2n_client_deserialize_resumption_state(conn, &from));
+    return 0;
 }
 
 int s2n_connection_get_session(struct s2n_connection *conn, uint8_t *session, size_t max_length)


### PR DESCRIPTION
**Issue # (if available):** 

**Description of changes:** 
By using the new DEFER_CLEANUP macros, no longer need to use GUARD_GOTO. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
