### PR TITLE
Fix memory leaks and enable valgrind on travis builds

### DIFF
--- a/.travis/install_ubuntu_dependencies.sh
+++ b/.travis/install_ubuntu_dependencies.sh
@@ -18,7 +18,7 @@ set -ex
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 sudo apt-get update
 
-DEPENDENCIES="unzip make indent kwstyle libssl-dev tcpdump"
+DEPENDENCIES="unzip make indent kwstyle libssl-dev tcpdump valgrind"
 
 sudo apt-get install -y ${DEPENDENCIES}
 

--- a/.travis/s2n_travis_build.sh
+++ b/.travis/s2n_travis_build.sh
@@ -37,7 +37,18 @@ if [[ "$GCC6_REQUIRED" == "true" ]]; then
     alias gcc=$(which gcc-6);
 fi
 
-if [[ "$TRAVIS_OS_NAME" == "linux" && "$TESTS" == "integration" ]]; then make -j 8   ; fi
+if [[ "$TRAVIS_OS_NAME" == "linux" && "$TESTS" == "integration" ]]; then
+    # For linux make a build with debug symbols and run valgrind
+    # We have to output something every 9 minutes, as some test may run longer than 10 minutes
+    # and will not produce any output
+    while sleep 9m; do echo "=====[ $SECONDS seconds still running ]====="; done &
+    S2N_DEBUG=true make -j 8 valgrind
+    kill %1
+
+    # Clean build with debug symbols and rebuild
+    make clean
+    make -j 8
+fi
 
 # Build and run unit tests with scan-build for osx. scan-build bundle isn't available for linux
 if [[ "$TRAVIS_OS_NAME" == "osx" && "$TESTS" == "integration" ]]; then  

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,9 @@ bin: libs
 integration: bin
 	$(MAKE) -C tests integration
 
+.PHONY : valgrind
+valgrind: bin
+	$(MAKE) -C tests valgrind
 
 .PHONY : fuzz
 ifeq ($(shell uname),Linux)

--- a/crypto/s2n_openssl_evp.h
+++ b/crypto/s2n_openssl_evp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -15,13 +15,8 @@
 
 #pragma once
 
-#include "utils/s2n_blob.h"
+#include <openssl/evp.h>
 
-#include <stdint.h>
+#include "utils/s2n_safety.h"
 
-int s2n_mem_init(void);
-int s2n_mem_cleanup(void);
-int s2n_alloc(struct s2n_blob *b, uint32_t size);
-int s2n_realloc(struct s2n_blob *b, uint32_t size);
-int s2n_free(struct s2n_blob *b);
-int s2n_dup(struct s2n_blob *from, struct s2n_blob *to);
+DEFINE_POINTER_CLEANUP_FUNC(EVP_PKEY*, EVP_PKEY_free);

--- a/crypto/s2n_openssl_x509.h
+++ b/crypto/s2n_openssl_x509.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -15,13 +15,9 @@
 
 #pragma once
 
-#include "utils/s2n_blob.h"
+#include <openssl/x509.h>
 
-#include <stdint.h>
+#include "utils/s2n_safety.h"
 
-int s2n_mem_init(void);
-int s2n_mem_cleanup(void);
-int s2n_alloc(struct s2n_blob *b, uint32_t size);
-int s2n_realloc(struct s2n_blob *b, uint32_t size);
-int s2n_free(struct s2n_blob *b);
-int s2n_dup(struct s2n_blob *from, struct s2n_blob *to);
+DEFINE_POINTER_CLEANUP_FUNC(X509*, X509_free);
+DEFINE_POINTER_CLEANUP_FUNC(X509_STORE_CTX*, X509_STORE_CTX_free);

--- a/crypto/s2n_pkey.c
+++ b/crypto/s2n_pkey.c
@@ -21,6 +21,12 @@
 #include "crypto/s2n_pkey.h"
 
 #include "utils/s2n_safety.h"
+#include "utils/s2n_mem.h"
+
+
+DEFINE_TRIVIAL_CLEANUP_FUNC(X509*, X509_free);
+DEFINE_TRIVIAL_CLEANUP_FUNC(EVP_PKEY*, EVP_PKEY_free);
+
 
 int s2n_pkey_zero_init(struct s2n_pkey *pkey) 
 {
@@ -155,25 +161,21 @@ int s2n_asn1der_to_private_key(struct s2n_pkey *priv_key, struct s2n_blob *asn1d
 int s2n_asn1der_to_public_key_and_type(struct s2n_pkey *pub_key, s2n_cert_type *cert_type_out, struct s2n_blob *asn1der)
 {
     uint8_t *cert_to_parse = asn1der->data;
-    
-    X509 *cert = d2i_X509(NULL, (const unsigned char **)(void *)&cert_to_parse, asn1der->size);
+    DEFER_CLEANUP(X509 *cert = NULL, X509_freep);
+
+    cert = d2i_X509(NULL, (const unsigned char **)(void *)&cert_to_parse, asn1der->size);
     S2N_ERROR_IF(cert == NULL, S2N_ERR_DECODE_CERTIFICATE);
-    
+
     /* If cert parsing is successful, d2i_X509 increments *cert_to_parse to the byte following the parsed data */
     uint32_t parsed_len = cert_to_parse - asn1der->data;
-    if (parsed_len != asn1der->size) {
-        X509_free(cert);
-        S2N_ERROR(S2N_ERR_DECODE_CERTIFICATE);
-    }
+    S2N_ERROR_IF(parsed_len != asn1der->size, S2N_ERR_DECODE_CERTIFICATE);
 
-    EVP_PKEY *evp_public_key = X509_get_pubkey(cert);
-    X509_free(cert);
-
+    DEFER_CLEANUP(EVP_PKEY *evp_public_key = X509_get_pubkey(cert), EVP_PKEY_freep);
     S2N_ERROR_IF(evp_public_key == NULL, S2N_ERR_DECODE_CERTIFICATE);
 
     /* Check for success in decoding certificate according to type */
     int type = EVP_PKEY_base_id(evp_public_key);
-    
+
     int ret;
     switch (type) {
     case EVP_PKEY_RSA:
@@ -182,7 +184,7 @@ int s2n_asn1der_to_public_key_and_type(struct s2n_pkey *pub_key, s2n_cert_type *
             break;
         }
         ret = s2n_evp_pkey_to_rsa_public_key(&pub_key->key.rsa_key, evp_public_key);
-        *cert_type_out = S2N_CERT_TYPE_RSA_SIGN; 
+        *cert_type_out = S2N_CERT_TYPE_RSA_SIGN;
         break;
     case EVP_PKEY_EC:
         ret = s2n_ecdsa_pkey_init(pub_key);
@@ -190,15 +192,12 @@ int s2n_asn1der_to_public_key_and_type(struct s2n_pkey *pub_key, s2n_cert_type *
             break;
         }
         ret = s2n_evp_pkey_to_ecdsa_public_key(&pub_key->key.ecdsa_key, evp_public_key);
-        *cert_type_out = S2N_CERT_TYPE_ECDSA_SIGN; 
+        *cert_type_out = S2N_CERT_TYPE_ECDSA_SIGN;
         break;
     default:
-        EVP_PKEY_free(evp_public_key);
         S2N_ERROR(S2N_ERR_DECODE_CERTIFICATE);
     }
-    
-    EVP_PKEY_free(evp_public_key);
-    
+
     return ret;
 }
 

--- a/crypto/s2n_pkey.c
+++ b/crypto/s2n_pkey.c
@@ -13,19 +13,14 @@
  * permissions and limitations under the License.
  */
 
-#include <openssl/evp.h>
-#include <openssl/x509.h>
+#include <crypto/s2n_openssl_evp.h>
+#include <crypto/s2n_openssl_x509.h>
 
 #include "error/s2n_errno.h"
 
 #include "crypto/s2n_pkey.h"
 
 #include "utils/s2n_safety.h"
-#include "utils/s2n_mem.h"
-
-
-DEFINE_TRIVIAL_CLEANUP_FUNC(X509*, X509_free);
-DEFINE_TRIVIAL_CLEANUP_FUNC(EVP_PKEY*, EVP_PKEY_free);
 
 
 int s2n_pkey_zero_init(struct s2n_pkey *pkey) 
@@ -161,7 +156,7 @@ int s2n_asn1der_to_private_key(struct s2n_pkey *priv_key, struct s2n_blob *asn1d
 int s2n_asn1der_to_public_key_and_type(struct s2n_pkey *pub_key, s2n_cert_type *cert_type_out, struct s2n_blob *asn1der)
 {
     uint8_t *cert_to_parse = asn1der->data;
-    DEFER_CLEANUP(X509 *cert = NULL, X509_freep);
+    DEFER_CLEANUP(X509 *cert = NULL, X509_free_pointer);
 
     cert = d2i_X509(NULL, (const unsigned char **)(void *)&cert_to_parse, asn1der->size);
     S2N_ERROR_IF(cert == NULL, S2N_ERR_DECODE_CERTIFICATE);
@@ -170,7 +165,7 @@ int s2n_asn1der_to_public_key_and_type(struct s2n_pkey *pub_key, s2n_cert_type *
     uint32_t parsed_len = cert_to_parse - asn1der->data;
     S2N_ERROR_IF(parsed_len != asn1der->size, S2N_ERR_DECODE_CERTIFICATE);
 
-    DEFER_CLEANUP(EVP_PKEY *evp_public_key = X509_get_pubkey(cert), EVP_PKEY_freep);
+    DEFER_CLEANUP(EVP_PKEY *evp_public_key = X509_get_pubkey(cert), EVP_PKEY_free_pointer);
     S2N_ERROR_IF(evp_public_key == NULL, S2N_ERR_DECODE_CERTIFICATE);
 
     /* Check for success in decoding certificate according to type */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -21,11 +21,18 @@ else
 endif
 
 .PHONY : all
-all:
-	${MAKE} -C testlib
-	${MAKE} -C LD_PRELOAD
+all: libs
 	${MAKE} -C unit
 	@echo "\033[1m ${COMPILE_INFO} \033[0;39m"
+
+.PHONY : valgrind
+valgrind: libs
+	${MAKE} -C unit valgrind
+
+.PHONY : libs
+libs:
+	${MAKE} -C testlib
+	${MAKE} -C LD_PRELOAD
 
 .PHONY : integration
 integration:

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -16,7 +16,7 @@
 SRCS=$(wildcard *.c)
 OBJS=$(SRCS:.c=.o)
 TESTS=$(SRCS:.c=)
-VALGRIND_TESTS=$(SRCS:.c=_valgrind)
+VALGRIND_TESTS=$(SRCS:.c=.valgrind)
 CRYPTO_LDFLAGS = -L$(LIBCRYPTO_ROOT)/lib
 
 # Users can specify a subset of tests to be run, otherwise run all tests.
@@ -46,6 +46,13 @@ $(UNIT_TESTS)::
 	LD_PRELOAD="../LD_PRELOAD/allocator_overrides.so" \
 	./$@
 
+$(VALGRIND_TESTS)::
+	@${CC} ${CFLAGS} -o $(@:.valgrind=) $(@:.valgrind=.c) ${LDFLAGS} 2>&1
+	@DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" \
+	LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
+	S2N_VALGRIND=1 \
+	valgrind --leak-check=full --run-libc-freeres=no -q --error-exitcode=9 --gen-suppressions=all --log-fd=2 --num-callers=40 --leak-resolution=high --undef-value-errors=no --trace-children=yes --suppressions=valgrind.suppressions \
+	./$(@:.valgrind=)
+
 .PHONY : valgrind
-valgrind: $(TESTS)
-	(for test in *_test ; do DYLD_LIBRARY_PATH="../../lib/:../testlib/:$$DYLD_LIBRARY_PATH" LD_LIBRARY_PATH="../../lib/:../testlib/:$$LD_LIBRARY_PATH" valgrind --leak-check=full --run-libc-freeres=no -q --error-exitcode=0 --gen-suppressions=all --log-fd=2 --num-callers=40 --leak-resolution=high --log-file=$$test-valgrind.log --undef-value-errors=no --trace-children=yes ./$$test; done )
+valgrind: $(VALGRIND_TESTS)

--- a/tests/unit/s2n_cbc_verify_test.c
+++ b/tests/unit/s2n_cbc_verify_test.c
@@ -265,7 +265,7 @@ int main(int argc, char **argv)
         hi = mac_median + (mac_stddev / 2);
 
         if ((int64_t) pad_median < lo || (int64_t) pad_median > hi) {
-            printf("\n\nRecord size: %dMAC Median: %" PRIu64 " (Avg: %" PRIu64 " Stddev: %" PRIu64 ")\n"
+            printf("\n\nRecord size: %d\nMAC Median: %" PRIu64 " (Avg: %" PRIu64 " Stddev: %" PRIu64 ")\n"
                    "PAD Median: %" PRIu64 " (Avg: %" PRIu64 " Stddev: %" PRIu64 ")\n\n", 
                     i, mac_median, mac_avg, mac_stddev, pad_median, pad_avg, pad_stddev);
             FAIL();

--- a/tests/unit/s2n_cbc_verify_test.c
+++ b/tests/unit/s2n_cbc_verify_test.c
@@ -124,6 +124,11 @@ int main(int argc, char **argv)
 
     BEGIN_TEST();
 
+    /* Valgrind affects execution timing, making this test unreliable */
+    if (getenv("S2N_VALGRIND") != NULL) {
+        END_TEST();
+    }
+
     EXPECT_SUCCESS(s2n_hmac_new(&check_mac));
     EXPECT_SUCCESS(s2n_hmac_new(&record_mac));
 

--- a/tests/unit/s2n_cleanup_test.c
+++ b/tests/unit/s2n_cleanup_test.c
@@ -20,6 +20,7 @@
 #include <stdbool.h>
 
 #include "utils/s2n_mem.h"
+#include "utils/s2n_safety.h"
 
 #define S2N_UNUSED(x) do { (void) x; } while (0)
 
@@ -35,7 +36,7 @@ void foo_free(struct foo* p){
   foo_cleanup_calls++;
 }
 
-DEFINE_TRIVIAL_CLEANUP_FUNC(struct foo*, foo_free);
+DEFINE_POINTER_CLEANUP_FUNC(struct foo*, foo_free);
 
 int check_cleanup_obj_on_fn_exit()
 {
@@ -47,7 +48,7 @@ int check_cleanup_obj_on_fn_exit()
 int check_cleanup_pointer_on_fn_exit()
 {
   struct foo thefoo= {0};
-  DEFER_CLEANUP(struct foo* foop = &thefoo, foo_freep);
+  DEFER_CLEANUP(struct foo* foop = &thefoo, foo_free_pointer);
   S2N_UNUSED(thefoo);
   S2N_UNUSED(foop);
   return 0;
@@ -56,7 +57,7 @@ int check_cleanup_pointer_on_fn_exit()
 //check that our macros don't cleanup null objects
 int check_dont_cleanup_null_on_fn_exit()
 {
-  DEFER_CLEANUP(struct foo* foop = NULL, foo_freep);
+  DEFER_CLEANUP(struct foo* foop = NULL, foo_free_pointer);
   S2N_UNUSED(foop);
   return 0;
 }

--- a/tests/unit/s2n_random_test.c
+++ b/tests/unit/s2n_random_test.c
@@ -54,7 +54,6 @@ int main(int argc, char **argv)
 {
     uint8_t bits[8] = { 0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01 };
     uint8_t bit_set_run[8];
-    intptr_t slot;
     int p[2], status;
     pid_t pid;
     uint8_t data[5120];
@@ -70,10 +69,8 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_get_public_random_data(&blob));
 
     /* Create two threads and have them each grab 100 bytes */
-    slot = 0;
-    EXPECT_SUCCESS(pthread_create(&threads[0], NULL, thread_safety_tester, (void *)slot));
-    slot = 1;
-    EXPECT_SUCCESS(pthread_create(&threads[1], NULL, thread_safety_tester, (void *)slot));
+    EXPECT_SUCCESS(pthread_create(&threads[0], NULL, thread_safety_tester, (void *)0));
+    EXPECT_SUCCESS(pthread_create(&threads[1], NULL, thread_safety_tester, (void *)1));
 
     /* Wait for those threads to finish */
     EXPECT_SUCCESS(pthread_join(threads[0], NULL));

--- a/tests/unit/s2n_self_talk_nonblocking_test.c
+++ b/tests/unit/s2n_self_talk_nonblocking_test.c
@@ -25,6 +25,7 @@
 #include <s2n.h>
 
 #include "utils/s2n_random.h"
+#include "utils/s2n_safety.h"
 
 #include "tls/s2n_connection.h"
 #include "tls/s2n_handshake.h"

--- a/tests/unit/s2n_self_talk_nonblocking_test.c
+++ b/tests/unit/s2n_self_talk_nonblocking_test.c
@@ -78,9 +78,12 @@ int mock_client(int writefd, int readfd, uint8_t *expected_data, uint32_t size)
 
     free(buffer);
     s2n_connection_free(client_conn);
+    s2n_config_free(client_config);
 
     /* Give the server a chance to a void a sigpipe */
     sleep(1);
+
+    s2n_cleanup();
 
     return 0;
 }
@@ -113,15 +116,12 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_config_add_dhparams(config, dhparams_pem));
 
     const uint32_t data_size = 10000000;
-    uint8_t *data = malloc(data_size);
-    EXPECT_NOT_NULL(data);
-
     /* Get some random data to send/receive */
-    struct s2n_blob blob;
-    blob.data = data;
-    blob.size = data_size;
+    DEFER_CLEANUP(struct s2n_blob blob = {0}, s2n_free);
+    s2n_alloc(&blob, data_size);
+
     EXPECT_SUCCESS(s2n_get_urandom_data(&blob));
-    
+
     /* Create a pipe */
     EXPECT_SUCCESS(pipe(server_to_client));
     EXPECT_SUCCESS(pipe(client_to_server));
@@ -134,9 +134,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(close(server_to_client[1]));
 
         /* Run the client */
-        const int client_rc = mock_client(client_to_server[1], server_to_client[0], data, data_size);
+        const int client_rc = mock_client(client_to_server[1], server_to_client[0], blob.data, data_size);
 
-        free(data);
         _exit(client_rc);
     }
 
@@ -166,7 +165,7 @@ int main(int argc, char **argv)
     /* Try to all 10MB of data, should be enough to fill PIPEBUF, so
        we'll get blocked at some point */
     uint32_t remaining = data_size;
-    uint8_t *ptr = data;
+    uint8_t *ptr = blob.data;
     while (remaining) {
         int r = s2n_send(conn, ptr, remaining, &blocked);
         if (r < 0) {
@@ -214,8 +213,6 @@ int main(int argc, char **argv)
     free(private_key_pem);
     free(dhparams_pem);
     END_TEST();
-
-    free(data);
 
     return 0;
 }

--- a/tests/unit/s2n_session_ticket_test.c
+++ b/tests/unit/s2n_session_ticket_test.c
@@ -51,7 +51,6 @@ int main(int argc, char **argv)
 {
     char *cert_chain;
     char *private_key;
-    char *dummy_ptr;
     struct s2n_connection *client_conn;
     struct s2n_connection *server_conn;
     struct s2n_config *client_config;
@@ -108,7 +107,6 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
     EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key, S2N_MAX_TEST_PEM_SIZE));
 
-    EXPECT_NOT_NULL(dummy_ptr = malloc(sizeof(char)));
     EXPECT_SUCCESS(setenv("S2N_ENABLE_CLIENT_MODE", "1", 0));
     EXPECT_SUCCESS(setenv("S2N_DONT_MLOCK", "1", 0));
 

--- a/tests/unit/s2n_tls13_prf_test.c
+++ b/tests/unit/s2n_tls13_prf_test.c
@@ -49,16 +49,16 @@ int main(int argc, char **argv)
     char expected_secret_hex_in[] ="33ad0a1c607ec03b09e6cd9893680ce210adf300aa1f2660e1b22e10f170f92a";
     char expected_expanded_hex_in[] ="6f2615a108c702c5678f54fc9dbab69716c076189c48250cebeac3576c3611ba";
 
-    struct s2n_stuffer client_handshake_message_in;
-    struct s2n_stuffer server_handshake_message_in;
-    struct s2n_stuffer expected_secret_in;
-    struct s2n_stuffer expected_expanded_in;
-    
+    DEFER_CLEANUP(struct s2n_stuffer client_handshake_message_in = {{0}}, s2n_stuffer_free);
+    DEFER_CLEANUP(struct s2n_stuffer server_handshake_message_in = {{0}}, s2n_stuffer_free);
+    DEFER_CLEANUP(struct s2n_stuffer expected_secret_in = {{0}}, s2n_stuffer_free);
+    DEFER_CLEANUP(struct s2n_stuffer expected_expanded_in = {{0}}, s2n_stuffer_free);
+
     char client_handshake_message[ sizeof(client_handshake_message_hex_in) / 2 ] = { 0 };
     char server_handshake_message[ sizeof(server_handshake_message_hex_in) / 2 ] = { 0 };
     char expected_secret[ sizeof(expected_secret_hex_in) / 2 ] = { 0 };
     char expected_expanded[ sizeof(expected_expanded_hex_in) / 2 ] = { 0 };
-       
+
     uint8_t digest_buf[SHA256_DIGEST_LENGTH];
     uint8_t secret_buf[SHA256_DIGEST_LENGTH];
     struct s2n_blob digest;
@@ -130,9 +130,9 @@ int main(int argc, char **argv)
     uint8_t label_buf[] = "derived";
     struct s2n_blob label = { 0 };
     EXPECT_SUCCESS(s2n_blob_init(&label, label_buf, sizeof(label_buf) - 1));
-    
+
     struct s2n_hmac_state hmac = {0};
-    
+
     EXPECT_SUCCESS(s2n_hmac_new(&hmac));
     EXPECT_SUCCESS(s2n_hkdf_expand_label(&hmac, S2N_HMAC_SHA256, &secret, &label, &digest, &output));
 

--- a/tests/unit/s2n_tls13_prf_test.c
+++ b/tests/unit/s2n_tls13_prf_test.c
@@ -23,6 +23,7 @@
 #include "testlib/s2n_testlib.h"
 #include "stuffer/s2n_stuffer.h"
 #include "crypto/s2n_hkdf.h"
+#include "utils/s2n_safety.h"
 
 /*
  * Test vectors from https://datatracker.ietf.org/doc/draft-ietf-tls-tls13-vectors/?include_text=1

--- a/tests/unit/s2n_x509_validator_test.c
+++ b/tests/unit/s2n_x509_validator_test.c
@@ -333,6 +333,7 @@ int main(int argc, char **argv) {
         EXPECT_EQUAL(1, verify_data.callback_invoked);
         EXPECT_EQUAL(S2N_CERT_TYPE_RSA_SIGN, cert_type);
         s2n_connection_free(connection);
+        s2n_pkey_free(&public_key_out);
 
         s2n_x509_validator_wipe(&validator);
         s2n_x509_trust_store_wipe(&trust_store);
@@ -602,6 +603,7 @@ int main(int argc, char **argv) {
         s2n_stuffer_free(&chain_stuffer);
         EXPECT_EQUAL(1, verify_data.callback_invoked);
         EXPECT_EQUAL(S2N_CERT_TYPE_RSA_SIGN, cert_type);
+        s2n_pkey_free(&public_key_out);
 
         s2n_connection_free(connection);
         s2n_x509_validator_wipe(&validator);
@@ -811,6 +813,7 @@ int main(int argc, char **argv) {
         EXPECT_EQUAL(S2N_CERT_OK,
                      s2n_x509_validator_validate_cert_chain(&validator, connection, chain_data, chain_len, &cert_type, &public_key_out));
         s2n_stuffer_free(&chain_stuffer);
+        s2n_pkey_free(&public_key_out);
 
         EXPECT_EQUAL(1, verify_data.callback_invoked);
         struct s2n_stuffer ocsp_data_stuffer;

--- a/tests/unit/valgrind.suppressions
+++ b/tests/unit/valgrind.suppressions
@@ -1,0 +1,12 @@
+# It looks like valgrind may generate false positives on pthreads: https://stackoverflow.com/a/13132968
+{
+   pthred_false_positive
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   fun:allocate_dtv
+   fun:_dl_allocate_tls
+   fun:allocate_stack
+   fun:pthread_create@@GLIBC_2.2.5
+   fun:main
+}

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -439,7 +439,7 @@ int s2n_config_set_verification_ca_location(struct s2n_config *config, const cha
 
 int s2n_config_add_cert_chain_from_stuffer(struct s2n_config *config, struct s2n_stuffer *chain_in_stuffer)
 {
-    struct s2n_stuffer cert_out_stuffer = {{0}};
+    DEFER_CLEANUP(struct s2n_stuffer cert_out_stuffer = {{0}}, s2n_stuffer_free);
     GUARD(s2n_stuffer_growable_alloc(&cert_out_stuffer, 2048));
 
     struct s2n_cert **insert = &config->cert_and_key_pairs->cert_chain.head;
@@ -449,7 +449,6 @@ int s2n_config_add_cert_chain_from_stuffer(struct s2n_config *config, struct s2n
 
         if (s2n_stuffer_certificate_from_pem(chain_in_stuffer, &cert_out_stuffer) < 0) {
             if (chain_size == 0) {
-                GUARD(s2n_stuffer_free(&cert_out_stuffer));
                 S2N_ERROR(S2N_ERR_NO_CERTIFICATE_IN_PEM);
             }
             break;
@@ -467,8 +466,6 @@ int s2n_config_add_cert_chain_from_stuffer(struct s2n_config *config, struct s2n
         *insert = new_node;
         insert = &new_node->next;
     } while (s2n_stuffer_data_available(chain_in_stuffer));
-
-    GUARD(s2n_stuffer_free(&cert_out_stuffer));
 
     /* Leftover data at this point means one of two things:
      * A bug in s2n's PEM parsing OR a malformed PEM in the user's chain.
@@ -495,7 +492,8 @@ int s2n_config_add_cert_chain(struct s2n_config *config, const char *cert_chain_
 
 int s2n_config_add_private_key(struct s2n_config *config, const char *private_key_pem)
 {
-    struct s2n_stuffer key_in_stuffer, key_out_stuffer;
+    DEFER_CLEANUP(struct s2n_stuffer key_in_stuffer = {{0}}, s2n_stuffer_free);
+    DEFER_CLEANUP(struct s2n_stuffer key_out_stuffer = {{0}}, s2n_stuffer_free);
     struct s2n_blob key_blob = {0};
 
     GUARD(s2n_pkey_zero_init(&config->cert_and_key_pairs->private_key));
@@ -506,14 +504,12 @@ int s2n_config_add_private_key(struct s2n_config *config, const char *private_ke
 
     /* Convert pem to asn1 and asn1 to the private key. Handles both PKCS#1 and PKCS#8 formats */
     GUARD(s2n_stuffer_private_key_from_pem(&key_in_stuffer, &key_out_stuffer));
-    GUARD(s2n_stuffer_free(&key_in_stuffer));
     key_blob.size = s2n_stuffer_data_available(&key_out_stuffer);
     key_blob.data = s2n_stuffer_raw_read(&key_out_stuffer, key_blob.size);
     notnull_check(key_blob.data);
 
     /* Get key type and create appropriate key context */
     GUARD(s2n_asn1der_to_private_key(&config->cert_and_key_pairs->private_key, &key_blob));
-    GUARD(s2n_stuffer_free(&key_out_stuffer));
 
     return 0;
 }
@@ -535,25 +531,21 @@ int s2n_config_add_cert_chain_and_key(struct s2n_config *config, const char *cer
     GUARD(s2n_config_add_private_key(config, private_key_pem));
 
     /* Parse the leaf cert for the public key and certificate type */
-    struct s2n_pkey public_key = {{{0}}};
+    DEFER_CLEANUP(struct s2n_pkey public_key = {{{0}}}, s2n_pkey_free);
     s2n_cert_type cert_type;
     GUARD(s2n_asn1der_to_public_key_and_type(&public_key, &cert_type, &config->cert_and_key_pairs->cert_chain.head->raw));
     GUARD(s2n_cert_set_cert_type(config->cert_and_key_pairs->cert_chain.head, cert_type));
 
     /* Validate the leaf cert's public key matches the provided private key */
-    int key_match_ret = s2n_pkey_match(&public_key, &config->cert_and_key_pairs->private_key);
-    GUARD(s2n_pkey_free(&public_key));
-    if (key_match_ret < 0) {
-        /* s2n_errno already set */
-        return -1;
-    }
+    GUARD(s2n_pkey_match(&public_key, &config->cert_and_key_pairs->private_key));
 
     return 0;
 }
 
 int s2n_config_add_dhparams(struct s2n_config *config, const char *dhparams_pem)
 {
-    struct s2n_stuffer dhparams_in_stuffer, dhparams_out_stuffer;
+    DEFER_CLEANUP(struct s2n_stuffer dhparams_in_stuffer = {{0}}, s2n_stuffer_free);
+    DEFER_CLEANUP(struct s2n_stuffer dhparams_out_stuffer = {{0}}, s2n_stuffer_free);
     struct s2n_blob dhparams_blob = {0};
     struct s2n_blob mem = {0};
 
@@ -567,15 +559,11 @@ int s2n_config_add_dhparams(struct s2n_config *config, const char *dhparams_pem)
     /* Convert pem to asn1 and asn1 to the private key */
     GUARD(s2n_stuffer_dhparams_from_pem(&dhparams_in_stuffer, &dhparams_out_stuffer));
 
-    GUARD(s2n_stuffer_free(&dhparams_in_stuffer));
-
     dhparams_blob.size = s2n_stuffer_data_available(&dhparams_out_stuffer);
     dhparams_blob.data = s2n_stuffer_raw_read(&dhparams_out_stuffer, dhparams_blob.size);
     notnull_check(dhparams_blob.data);
 
     GUARD(s2n_pkcs3_to_dh_params(config->dhparams, &dhparams_blob));
-
-    GUARD(s2n_free(&dhparams_blob));
 
     return 0;
 }
@@ -782,13 +770,12 @@ int s2n_config_add_ticket_crypto_key(struct s2n_config *config,
     GUARD(s2n_alloc(&allocator, sizeof(struct s2n_ticket_key)));
     session_ticket_key = (struct s2n_ticket_key *) (void *) allocator.data;
 
-    struct s2n_hmac_state hmac;
+    DEFER_CLEANUP(struct s2n_hmac_state hmac = {0}, s2n_hmac_free);
 
     GUARD(s2n_hmac_new(&hmac));
     GUARD(s2n_hkdf(&hmac, S2N_HMAC_SHA256, &salt, &in_key, &info, &out_key));
-    GUARD(s2n_hmac_free(&hmac));
 
-    struct s2n_hash_state hash = { 0 };
+    DEFER_CLEANUP(struct s2n_hash_state hash = {0}, s2n_hash_free);
     uint8_t hash_output[SHA_DIGEST_LENGTH];
 
     GUARD(s2n_hash_new(&hash));

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -178,7 +178,7 @@ static int s2n_client_deserialize_with_session_ticket(struct s2n_connection *con
         S2N_ERROR(S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
     }
 
-    GUARD(s2n_alloc(&conn->client_ticket, session_ticket_len));
+    GUARD(s2n_realloc(&conn->client_ticket, session_ticket_len));
     GUARD(s2n_stuffer_read(from, &conn->client_ticket));
 
     GUARD(s2n_client_deserialize_session_state(conn, from));

--- a/tls/s2n_server_new_session_ticket.c
+++ b/tls/s2n_server_new_session_ticket.c
@@ -37,7 +37,7 @@ int s2n_server_nst_recv(struct s2n_connection *conn) {
     GUARD(s2n_stuffer_read_uint16(&conn->handshake.io, &session_ticket_len));
 
     if (session_ticket_len > 0) {
-        GUARD(s2n_alloc(&conn->client_ticket, session_ticket_len));
+        GUARD(s2n_realloc(&conn->client_ticket, session_ticket_len));
 
         GUARD(s2n_stuffer_read(&conn->handshake.io, &conn->client_ticket));
     }

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -48,6 +48,7 @@
 #define DEFAULT_MAX_CHAIN_DEPTH 7
 
 DEFINE_TRIVIAL_CLEANUP_FUNC(X509*, X509_free);
+DEFINE_TRIVIAL_CLEANUP_FUNC(X509_STORE_CTX*, X509_STORE_CTX_free);
 
 uint8_t s2n_x509_ocsp_stapling_supported(void) {
     return S2N_OCSP_STAPLING_SUPPORTED;
@@ -89,12 +90,13 @@ int s2n_x509_trust_store_add_pem(struct s2n_x509_trust_store *store, const char 
 
     DEFER_CLEANUP(struct s2n_stuffer pem_in_stuffer = {{0}}, s2n_stuffer_free);
     DEFER_CLEANUP(struct s2n_stuffer der_out_stuffer = {{0}}, s2n_stuffer_free);
-    DEFER_CLEANUP(struct s2n_blob next_cert = {0}, s2n_free);
 
     GUARD(s2n_stuffer_alloc_ro_from_string(&pem_in_stuffer, pem));
     GUARD(s2n_stuffer_growable_alloc(&der_out_stuffer, 2048));
 
     do {
+        DEFER_CLEANUP(struct s2n_blob next_cert = {0}, s2n_free);
+
         GUARD(s2n_stuffer_certificate_from_pem(&pem_in_stuffer, &der_out_stuffer));
         GUARD(s2n_alloc(&next_cert, s2n_stuffer_data_available(&der_out_stuffer)));
         GUARD(s2n_stuffer_read(&der_out_stuffer, &next_cert));
@@ -259,10 +261,10 @@ s2n_cert_validation_code s2n_x509_validator_validate_cert_chain(struct s2n_x509_
         return S2N_CERT_ERR_UNTRUSTED;
     }
 
-    X509_STORE_CTX *ctx = NULL;
+    DEFER_CLEANUP(X509_STORE_CTX *ctx = NULL, X509_STORE_CTX_freep);
 
     struct s2n_blob cert_chain_blob = {.data = cert_chain_in, .size = cert_chain_len};
-    struct s2n_stuffer cert_chain_in_stuffer = {{0}};
+    DEFER_CLEANUP(struct s2n_stuffer cert_chain_in_stuffer = {{0}}, s2n_stuffer_free);
     if (s2n_stuffer_init(&cert_chain_in_stuffer, &cert_chain_blob) < 0) {
         return S2N_CERT_ERR_INVALID;
     }
@@ -272,28 +274,27 @@ s2n_cert_validation_code s2n_x509_validator_validate_cert_chain(struct s2n_x509_
 
     uint32_t certificate_count = 0;
 
-    s2n_cert_validation_code err_code = S2N_CERT_ERR_INVALID;
     X509 *server_cert = NULL;
- 
-    struct s2n_pkey public_key = {{{0}}};
+
+    DEFER_CLEANUP(struct s2n_pkey public_key = {{{0}}}, s2n_pkey_free);
     s2n_pkey_zero_init(&public_key);
 
     while (s2n_stuffer_data_available(&cert_chain_in_stuffer) && certificate_count < validator->max_chain_depth) {
         uint32_t certificate_size = 0;
 
         if (s2n_stuffer_read_uint24(&cert_chain_in_stuffer, &certificate_size) < 0) {
-            goto clean_up;
+            return S2N_CERT_ERR_INVALID;
         }
 
         if (certificate_size == 0 || certificate_size > s2n_stuffer_data_available(&cert_chain_in_stuffer)) {
-            goto clean_up;
+            return S2N_CERT_ERR_INVALID;
         }
 
         struct s2n_blob asn1cert = {0};
         asn1cert.data = s2n_stuffer_raw_read(&cert_chain_in_stuffer, certificate_size);
         asn1cert.size = certificate_size;
         if (asn1cert.data == NULL) {
-            goto clean_up;
+            return S2N_CERT_ERR_INVALID;
         }
 
         const uint8_t *data = asn1cert.data;
@@ -302,20 +303,20 @@ s2n_cert_validation_code s2n_x509_validator_validate_cert_chain(struct s2n_x509_
             /* the cert is der encoded, just convert it. */
             server_cert = d2i_X509(NULL, &data, asn1cert.size);
             if (!server_cert) {
-                goto clean_up;
+                return S2N_CERT_ERR_INVALID;
             }
 
             /* add the cert to the chain. */
             if (!sk_X509_push(validator->cert_chain, server_cert)) {
                 X509_free(server_cert);
-                goto clean_up;
+                return S2N_CERT_ERR_INVALID;
             }
          }
 
         /* Pull the public key from the first certificate */
         if (certificate_count == 0) {
             if (s2n_asn1der_to_public_key_and_type(&public_key, cert_type, &asn1cert) < 0) {
-                goto clean_up;
+                return S2N_CERT_ERR_INVALID;
             }
         }
 
@@ -324,25 +325,22 @@ s2n_cert_validation_code s2n_x509_validator_validate_cert_chain(struct s2n_x509_
 
     /* if this occurred we exceeded validator->max_chain_depth */
     if (!validator->skip_cert_validation && s2n_stuffer_data_available(&cert_chain_in_stuffer)) {
-        err_code = S2N_CERT_ERR_MAX_CHAIN_DEPTH_EXCEEDED;
-        goto clean_up;
+        return S2N_CERT_ERR_MAX_CHAIN_DEPTH_EXCEEDED;
     }
 
     if (certificate_count < 1) {
-        goto clean_up;
+        return S2N_CERT_ERR_INVALID;
     }
 
 
     if (!validator->skip_cert_validation) {
         X509 *leaf = sk_X509_value(validator->cert_chain, 0);
         if (!leaf) {
-            err_code = S2N_CERT_ERR_INVALID;
-            goto clean_up;
+            return S2N_CERT_ERR_INVALID;
         }
 
         if (conn->verify_host_fn && !s2n_verify_host_information(validator, conn, leaf)) {
-            err_code = S2N_CERT_ERR_UNTRUSTED;
-            goto clean_up;
+            return S2N_CERT_ERR_UNTRUSTED;
         }
 
         /* now that we have a chain, get the store and check against it. */
@@ -352,7 +350,7 @@ s2n_cert_validation_code s2n_x509_validator_validate_cert_chain(struct s2n_x509_
                                           validator->cert_chain);
 
         if (op_code <= 0) {
-            goto clean_up;
+            return S2N_CERT_ERR_INVALID;
         }
 
         X509_VERIFY_PARAM *param = X509_STORE_CTX_get0_param(ctx);
@@ -368,27 +366,17 @@ s2n_cert_validation_code s2n_x509_validator_validate_cert_chain(struct s2n_x509_
         op_code = X509_verify_cert(ctx);
 
         if (op_code <= 0) {
-            op_code = X509_STORE_CTX_get_error(ctx);
-            err_code = S2N_CERT_ERR_UNTRUSTED;
-            goto clean_up;
+            return S2N_CERT_ERR_UNTRUSTED;
         }
     }
 
 
     *public_key_out = public_key;
-    err_code = S2N_CERT_OK;
 
-clean_up:
-    if (ctx) {
-        X509_STORE_CTX_free(ctx);
-    }
+    /* Reset the old struct, so we don't clean up public_key_out */
+    s2n_pkey_zero_init(&public_key);
 
-    if (err_code != S2N_CERT_OK) {
-        s2n_pkey_free(&public_key);
-    }
-
-    s2n_stuffer_free(&cert_chain_in_stuffer);
-    return err_code;
+    return S2N_CERT_OK;
 }
 
 s2n_cert_validation_code s2n_x509_validator_validate_cert_stapled_ocsp_response(struct s2n_x509_validator *validator,

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -82,6 +82,9 @@ static inline int s2n_defend_if_forked(void)
     struct s2n_blob private = {.data = s2n_private_drbg,.size = sizeof(s2n_private_drbg) };
 
     if (zero_if_forked == 0) {
+        /* Clean up the old drbg first */
+        GUARD(s2n_rand_cleanup_thread());
+        /* Instantiate the new ones */
         GUARD(s2n_drbg_instantiate(&per_thread_public_drbg, &public));
         GUARD(s2n_drbg_instantiate(&per_thread_private_drbg, &private));
         zero_if_forked = 1;

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -93,11 +93,11 @@ static inline void* trace_memcpy_check(void *restrict to, const void *restrict f
 #define GUARD_PTR( x )          if ( (x) < 0 ) return NULL
 
 /* TODO: use the OSSL error code in error reporting https://github.com/awslabs/s2n/issues/705 */
-#define GUARD_OSSL( x , errcode )			\
-  do {							\
-  if (( x ) != 1) {					\
-    S2N_ERROR( errcode );				\
-  }							\
+#define GUARD_OSSL( x , errcode )               \
+  do {                                          \
+  if (( x ) != 1) {                             \
+    S2N_ERROR( errcode );                       \
+  }                                             \
   } while (0)
 
 /**
@@ -113,3 +113,18 @@ extern int s2n_constant_time_equals(const uint8_t * a, const uint8_t * b, uint32
 
 /* Copy src to dst, or don't copy it, in constant time */
 extern int s2n_constant_time_copy_or_dont(const uint8_t * dst, const uint8_t * src, uint32_t len, uint8_t dont);
+
+/* Runs _thecleanup function on _thealloc once _thealloc went out of scope */
+#define DEFER_CLEANUP(_thealloc, _thecleanup) \
+   __attribute__((cleanup(_thecleanup))) _thealloc
+
+/* Creates cleanup function for pointers from function func which accepts a pointer.
+ * This is useful for DEFER_CLEANUP as it passes &_thealloc into _thecleanup function,
+ * so if _thealloc is a pointer _thecleanup will receive a pointer to a pointer.*/
+#define DEFINE_POINTER_CLEANUP_FUNC(type, func)             \
+  static inline void func##_pointer(type *p) {              \
+    if (p && *p)                                            \
+      func(*p);                                             \
+  }                                                         \
+  struct __useless_struct_to_allow_trailing_semicolon__
+


### PR DESCRIPTION
**Issue # (if available):** #622 

This change fixes memory leaks which existed in s2n UTs and runs valgrind as a part of travis workflow.

Notes:
1. To make valgrind output more useful valgrind build runs with `S2N_DEBUG` enabled
2. s2n_cbc_verify_test is skipped under valgrind as timings are unreliable with valgrind.
3. Moved `DEFER_CLEANUP` macroses into s2n_safety.h as they can be used for any clean ups not only for objects in s2n_mem.h. Also renamed `DEFINE_TRIVIAL_CLEANUP_FUNC` to `DEFINE_POINTER_CLEANUP_FUNC` as it seems to be more descriptive.


**Description of changes:** 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
