### PR TITLE
Move valgrind into its own target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,14 @@ env:
   - S2N_LIBCRYPTO=openssl-1.1.x-master BUILD_S2N=true TESTS=integration GCC6_REQUIRED=true
   - S2N_LIBCRYPTO=openssl-1.1.0 LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=120
   - S2N_LIBCRYPTO=openssl-1.0.2-fips LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=120
+  - S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=valgrind GCC6_REQUIRED=true
 
 matrix:
   exclude:
   - os: osx
     env: TESTS=ctverif
+  - os: osx
+    env: S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=valgrind GCC6_REQUIRED=true
   - os: osx
     env: S2N_LIBCRYPTO=openssl-1.1.x-master BUILD_S2N=true TESTS=integration GCC6_REQUIRED=true
   - os: osx

--- a/.travis/s2n_travis_build.sh
+++ b/.travis/s2n_travis_build.sh
@@ -37,16 +37,16 @@ if [[ "$GCC6_REQUIRED" == "true" ]]; then
     alias gcc=$(which gcc-6);
 fi
 
-if [[ "$TRAVIS_OS_NAME" == "linux" && "$TESTS" == "integration" ]]; then
+if [[ "$TRAVIS_OS_NAME" == "linux" && "$TESTS" == "valgrind" ]]; then
     # For linux make a build with debug symbols and run valgrind
     # We have to output something every 9 minutes, as some test may run longer than 10 minutes
     # and will not produce any output
     while sleep 9m; do echo "=====[ $SECONDS seconds still running ]====="; done &
     S2N_DEBUG=true make -j 8 valgrind
     kill %1
+fi
 
-    # Clean build with debug symbols and rebuild
-    make clean
+if [[ "$TRAVIS_OS_NAME" == "linux" && "$TESTS" == "integration" ]]; then
     make -j 8
 fi
 


### PR DESCRIPTION
Running valgrind is slow and we don't want to slow down other tests. For now only 1.0.2 build, as others are flaky. Will sent a different PR once I figure out why.

**Issue # (if available):** 

**Description of changes:** 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
