### PR TITLE
Don't wipe the connection when peer closed it

### DIFF
--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -130,7 +130,6 @@ ssize_t s2n_recv(struct s2n_connection * conn, void *buf, ssize_t size, s2n_bloc
     struct s2n_blob out = {.data = (uint8_t *) buf };
 
     if (conn->closed) {
-        GUARD(s2n_connection_wipe(conn));
         return 0;
     }
 
@@ -144,7 +143,6 @@ ssize_t s2n_recv(struct s2n_connection * conn, void *buf, ssize_t size, s2n_bloc
             if (s2n_errno == S2N_ERR_CLOSED) {
                 *blocked = S2N_NOT_BLOCKED;
                 if (!bytes_read) {
-                    GUARD(s2n_connection_wipe(conn));
                     return 0;
                 } else {
                     return bytes_read;

--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -52,10 +52,6 @@ int s2n_flush(struct s2n_connection *conn, s2n_blocked_status * blocked)
 
     if (conn->closing) {
         conn->closed = 1;
-        /* Delay wiping for close_notify. s2n_shutdown() needs to wait for peer's close_notify */
-        if (!conn->close_notify_queued) {
-            GUARD(s2n_connection_wipe(conn));
-        }
     }
     GUARD(s2n_stuffer_rewrite(&conn->out));
 


### PR DESCRIPTION
**Issue # (if available):** 

**Description of changes:** 

Sometimes software uses the connection object at the end of processing for logging purpouses. Wiping the connection after peer closed it, takes away an opportunity to do any useful logging.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
