### PR TITLE
Fix `apt-get update' failures in build scripts

### DIFF
--- a/.travis/install_ctverif_dependencies.sh
+++ b/.travis/install_ctverif_dependencies.sh
@@ -35,7 +35,7 @@ sudo add-apt-repository "deb http://download.mono-project.com/repo/debian wheezy
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 
 #    echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
-sudo apt-get update
+sudo apt-get update -o Acquire::CompressionTypes::Order::=gz
 sudo apt-get install -y ${DEPENDENCIES}
 sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.7 20
 sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.7 20
@@ -47,4 +47,3 @@ pip install pyyaml
 which python
 python --version
 pip install psutil
-

--- a/.travis/install_sidetrail_dependencies.sh
+++ b/.travis/install_sidetrail_dependencies.sh
@@ -39,7 +39,7 @@ DEPENDENCIES+=" clang-3.9 llvm-3.9 llvm-3.9-dev"
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb http://download.mono-project.com/repo/ubuntu trusty main" | sudo tee /etc/apt/sources.list.d/mono-official.list
 
-sudo apt-get update
+sudo apt-get update -o Acquire::CompressionTypes::Order::=gz
 sudo apt-get install -y ${DEPENDENCIES}
 pip install pyyaml
 

--- a/.travis/install_ubuntu_dependencies.sh
+++ b/.travis/install_ubuntu_dependencies.sh
@@ -16,7 +16,7 @@
 set -ex
 
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-sudo apt-get update
+sudo apt-get update -o Acquire::CompressionTypes::Order::=gz
 
 DEPENDENCIES="unzip make indent kwstyle libssl-dev tcpdump valgrind"
 
@@ -28,7 +28,7 @@ fi
 
 # Download and Install prlimit for memlock
 if [[ ! -d "$PRLIMIT_INSTALL_DIR" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-    mkdir -p "$PRLIMIT_INSTALL_DIR" && sudo .travis/install_prlimit.sh "$(mktemp -d)" "$PRLIMIT_INSTALL_DIR"; 
+    mkdir -p "$PRLIMIT_INSTALL_DIR" && sudo .travis/install_prlimit.sh "$(mktemp -d)" "$PRLIMIT_INSTALL_DIR";
 fi
 
 if [[ "$TESTS" == "ctverif" || "$TESTS" == "ALL" ]] ; then


### PR DESCRIPTION
**Issue # (if available):**  https://github.com/awslabs/s2n/issues/689.

**Description of changes:** 
Adds `Acquire::CompressionTypes::Order::=gz` config option to `apt-get update` as a workaround.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
