### PR TITLE
Key exchange code refactor

### DIFF
--- a/crypto/s2n_ecc.h
+++ b/crypto/s2n_ecc.h
@@ -41,8 +41,8 @@ struct s2n_ecc_params {
 
 int s2n_ecc_generate_ephemeral_key(struct s2n_ecc_params *server_ecc_params);
 int s2n_ecc_write_ecc_params(struct s2n_ecc_params *server_ecc_params, struct s2n_stuffer *out, struct s2n_blob *written);
-int s2n_ecc_read_ecc_params(struct s2n_stuffer *in, struct s2n_blob *data_to_verify, struct s2n_ecdhe_server_data *data);
-int s2n_ecc_parse_ecc_params(struct s2n_ecc_params *server_ecc_params, struct s2n_ecdhe_server_data *data);
+int s2n_ecc_read_ecc_params(struct s2n_stuffer *in, struct s2n_blob *data_to_verify, struct s2n_ecdhe_raw_server_params *data);
+int s2n_ecc_parse_ecc_params(struct s2n_ecc_params *server_ecc_params, struct s2n_ecdhe_raw_server_params *data);
 int s2n_ecc_compute_shared_secret_as_server(struct s2n_ecc_params *server_ecc_params, struct s2n_stuffer *Yc_in, struct s2n_blob *shared_key);
 int s2n_ecc_compute_shared_secret_as_client(struct s2n_ecc_params *server_ecc_params, struct s2n_stuffer *Yc_out, struct s2n_blob *shared_key);
 int s2n_ecc_find_supported_curve(struct s2n_blob *iana_ids, const struct s2n_ecc_named_curve **found);

--- a/crypto/s2n_ecc.h
+++ b/crypto/s2n_ecc.h
@@ -17,6 +17,7 @@
 
 #include <openssl/ec.h>
 
+#include "tls/s2n_kex_data.h"
 #include "stuffer/s2n_stuffer.h"
 #include "crypto/s2n_hash.h"
 
@@ -40,7 +41,8 @@ struct s2n_ecc_params {
 
 int s2n_ecc_generate_ephemeral_key(struct s2n_ecc_params *server_ecc_params);
 int s2n_ecc_write_ecc_params(struct s2n_ecc_params *server_ecc_params, struct s2n_stuffer *out, struct s2n_blob *written);
-int s2n_ecc_read_ecc_params(struct s2n_ecc_params *server_ecc_params, struct s2n_stuffer *in, struct s2n_blob *read);
+int s2n_ecc_read_ecc_params(struct s2n_stuffer *in, struct s2n_blob *data_to_verify, struct s2n_ecdhe_server_data *data);
+int s2n_ecc_parse_ecc_params(struct s2n_ecc_params *server_ecc_params, struct s2n_ecdhe_server_data *data);
 int s2n_ecc_compute_shared_secret_as_server(struct s2n_ecc_params *server_ecc_params, struct s2n_stuffer *Yc_in, struct s2n_blob *shared_key);
 int s2n_ecc_compute_shared_secret_as_client(struct s2n_ecc_params *server_ecc_params, struct s2n_stuffer *Yc_out, struct s2n_blob *shared_key);
 int s2n_ecc_find_supported_curve(struct s2n_blob *iana_ids, const struct s2n_ecc_named_curve **found);

--- a/tests/fuzz/LD_PRELOAD/s2n_server_fuzz_test_overrides.c
+++ b/tests/fuzz/LD_PRELOAD/s2n_server_fuzz_test_overrides.c
@@ -47,13 +47,13 @@ int s2n_constant_time_equals(const uint8_t *a, const uint8_t *b, uint32_t len)
     return 1;
 }
 
-int s2n_rsa_client_key_recv(struct s2n_connection *conn)
+int s2n_rsa_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared_key)
 {
     /* Perform the original function */
-    typedef int (*orig_s2n_rsa_client_key_recv_func_type)(struct s2n_connection *conn);
+    typedef int (*orig_s2n_rsa_client_key_recv_func_type)(struct s2n_connection *conn, struct s2n_blob *shared_key);
     orig_s2n_rsa_client_key_recv_func_type orig_s2n_rsa_client_key_recv;
     orig_s2n_rsa_client_key_recv = (orig_s2n_rsa_client_key_recv_func_type) dlsym(RTLD_NEXT, "s2n_rsa_client_key_recv");
-    int original_return_code = orig_s2n_rsa_client_key_recv(conn);
+    int original_return_code = orig_s2n_rsa_client_key_recv(conn, shared_key);
 
     /* Then, overwrite the RSA Failed flag to false before returning, this will help fuzzing code coverage. */
     conn->handshake.rsa_failed = 0;

--- a/tests/saw/s2n_handshake_io.saw
+++ b/tests/saw/s2n_handshake_io.saw
@@ -20,8 +20,8 @@ let conn_secure_cipher_suite pconn =
 //let key_exchange_algorithm csuite = crucible_elem csuite 3;
 let key_exchange_algorithm csuite = crucible_field csuite "key_exchange_alg";
 
-//let kea_flags kea = crucible_elem kea 0;
-let kea_flags kea = crucible_field kea "flags";
+let kea_is_ephemeral kea = crucible_elem kea 0;
+//let kea_is_ephemeral kea = crucible_field kea "is_ephemeral";
 
 //conn->status_type
 let conn_status_type pconn = crucible_field pconn "status_type";
@@ -95,11 +95,11 @@ let setup_connection = do {
    cipher_suite <- crucible_alloc (llvm_struct "struct.s2n_cipher_suite");
    crucible_points_to (conn_secure_cipher_suite pconn)  cipher_suite;
 
-   kea <- crucible_alloc (llvm_struct "struct.s2n_key_exchange_algorithm");
+   kea <- crucible_alloc (llvm_struct "struct.s2n_kex");
    crucible_points_to (key_exchange_algorithm cipher_suite) kea;
 
-   eph_flag <- crucible_fresh_var "eph_flag" (llvm_int 16);
-   crucible_points_to (kea_flags kea) (crucible_term eph_flag);
+   eph_flag <- crucible_fresh_var "eph_flag" (llvm_int 8);
+   crucible_points_to (kea_is_ephemeral kea) (crucible_term eph_flag);
 
    config <- crucible_alloc (llvm_struct "struct.s2n_config");
    crucible_points_to (conn_config pconn) config;
@@ -132,7 +132,7 @@ let setup_connection = do {
 		                  ,handshake_type = handshake_type}
          	     ,corked    = cork_val
                      ,is_caching_enabled = False
-                     ,key_exchange_eph =(eph_flag && 2) != zero 
+                     ,key_exchange_eph = eph_flag != zero
                      ,server_can_send_ocsp =
                             ((ocsp_flag == 1) && (status_size > 0)) ||
                             ((mode == 1) && (ocsp_flag == 1))

--- a/tests/unit/s2n_cipher_suite_match_test.c
+++ b/tests/unit/s2n_cipher_suite_match_test.c
@@ -14,6 +14,7 @@
  */
 
 #include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
 
 #include <string.h>
 
@@ -32,6 +33,14 @@ int main(int argc, char **argv)
         int count;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
+        char *cert_chain;
+        char *private_key;
+        EXPECT_NOT_NULL(cert_chain = malloc(S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_NOT_NULL(private_key = malloc(S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key(conn->config, cert_chain, private_key));
+
         count = 0;
         for (int i = 0; i < 0xffff; i++) {
             wire[0] = (i >> 8);
@@ -46,6 +55,9 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(count, 32);
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
+        free(private_key);
+        free(cert_chain);
+
     }
 
     /* Test server cipher selection and scsv detection */

--- a/tests/unit/s2n_ecc_test.c
+++ b/tests/unit/s2n_ecc_test.c
@@ -38,7 +38,10 @@ int main(int argc, char **argv)
         /* Server sends the public */
         EXPECT_SUCCESS(s2n_ecc_write_ecc_params(&server_params, &wire, &ecdh_params_sent));
         /* Client reads the public */
-        EXPECT_SUCCESS(s2n_ecc_read_ecc_params(&client_params, &wire, &ecdh_params_received));
+        struct s2n_ecdhe_server_data ecdhe_data = {{0}};
+        EXPECT_SUCCESS(s2n_ecc_read_ecc_params(&wire, &ecdh_params_received, &ecdhe_data));
+        EXPECT_SUCCESS(s2n_ecc_parse_ecc_params(&client_params, &ecdhe_data));
+
         /* The client got the curve */
         EXPECT_EQUAL(client_params.negotiated_curve, server_params.negotiated_curve);
 
@@ -59,6 +62,4 @@ int main(int argc, char **argv)
     }
 
     END_TEST();
-    return 0;
 }
-

--- a/tests/unit/s2n_ecc_test.c
+++ b/tests/unit/s2n_ecc_test.c
@@ -38,7 +38,7 @@ int main(int argc, char **argv)
         /* Server sends the public */
         EXPECT_SUCCESS(s2n_ecc_write_ecc_params(&server_params, &wire, &ecdh_params_sent));
         /* Client reads the public */
-        struct s2n_ecdhe_server_data ecdhe_data = {{0}};
+        struct s2n_ecdhe_raw_server_params ecdhe_data = {{0}};
         EXPECT_SUCCESS(s2n_ecc_read_ecc_params(&wire, &ecdh_params_received, &ecdhe_data));
         EXPECT_SUCCESS(s2n_ecc_parse_ecc_params(&client_params, &ecdhe_data));
 

--- a/tests/unit/s2n_record_test.c
+++ b/tests/unit/s2n_record_test.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 
 #include <s2n.h>
+#include "tls/s2n_kex.h"
 
 #include "testlib/s2n_testlib.h"
 

--- a/tls/Makefile
+++ b/tls/Makefile
@@ -18,7 +18,7 @@ OBJS=$(SRCS:.c=.o)
 
 BITCODE_DIR?=../tests/saw/bitcode/
 
-BCS_1=s2n_handshake_io.bc s2n_connection.bc
+BCS_1=s2n_handshake_io.bc s2n_connection.bc s2n_kex.bc
 BCS=$(addprefix $(BITCODE_DIR), $(BCS_1))
 
 .PHONY : all

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -23,7 +23,6 @@
 #include "tls/s2n_cipher_preferences.h"
 #include "tls/s2n_cipher_suites.h"
 #include "tls/s2n_client_key_exchange.h"
-#include "tls/s2n_connection.h"
 #include "tls/s2n_server_key_exchange.h"
 #include "tls/s2n_tls.h"
 
@@ -31,24 +30,24 @@
 
 const struct s2n_key_exchange_algorithm s2n_rsa = {
     .flags = 0,
-    .server_key_recv = &s2n_rsa_server_key_recv,
-    .server_key_send = &s2n_rsa_server_key_send,
+    .server_key_recv = &s2n_rsa_server_recv_key,
+    .server_key_send = &s2n_rsa_server_send_key,
     .client_key_recv = &s2n_rsa_client_key_recv,
     .client_key_send = &s2n_rsa_client_key_send,
 };
 
 const struct s2n_key_exchange_algorithm s2n_dhe = {
     .flags = S2N_KEY_EXCHANGE_DH | S2N_KEY_EXCHANGE_EPH,
-    .server_key_recv = &s2n_dhe_server_key_recv,
-    .server_key_send = &s2n_dhe_server_key_send,
+    .server_key_recv = &s2n_dhe_server_recv_params,
+    .server_key_send = &s2n_dhe_server_send_params,
     .client_key_recv = &s2n_dhe_client_key_recv,
     .client_key_send = &s2n_dhe_client_key_send,
 };
 
 const struct s2n_key_exchange_algorithm s2n_ecdhe = {
     .flags = S2N_KEY_EXCHANGE_DH | S2N_KEY_EXCHANGE_EPH | S2N_KEY_EXCHANGE_ECC,
-    .server_key_recv = &s2n_ecdhe_server_key_recv,
-    .server_key_send = &s2n_ecdhe_server_key_send,
+    .server_key_recv = &s2n_ecdhe_server_recv_params,
+    .server_key_send = &s2n_ecdhe_server_send_params,
     .client_key_recv = &s2n_ecdhe_client_key_recv,
     .client_key_send = &s2n_ecdhe_client_key_send,
 };

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -22,20 +22,35 @@
 
 #include "tls/s2n_cipher_preferences.h"
 #include "tls/s2n_cipher_suites.h"
+#include "tls/s2n_client_key_exchange.h"
 #include "tls/s2n_connection.h"
+#include "tls/s2n_server_key_exchange.h"
 #include "tls/s2n_tls.h"
+
 #include "utils/s2n_safety.h"
 
 const struct s2n_key_exchange_algorithm s2n_rsa = {
     .flags = 0,
+    .server_key_recv = &s2n_rsa_server_key_recv,
+    .server_key_send = &s2n_rsa_server_key_send,
+    .client_key_recv = &s2n_rsa_client_key_recv,
+    .client_key_send = &s2n_rsa_client_key_send,
 };
 
 const struct s2n_key_exchange_algorithm s2n_dhe = {
     .flags = S2N_KEY_EXCHANGE_DH | S2N_KEY_EXCHANGE_EPH,
+    .server_key_recv = &s2n_dhe_server_key_recv,
+    .server_key_send = &s2n_dhe_server_key_send,
+    .client_key_recv = &s2n_dhe_client_key_recv,
+    .client_key_send = &s2n_dhe_client_key_send,
 };
 
 const struct s2n_key_exchange_algorithm s2n_ecdhe = {
     .flags = S2N_KEY_EXCHANGE_DH | S2N_KEY_EXCHANGE_EPH | S2N_KEY_EXCHANGE_ECC,
+    .server_key_recv = &s2n_ecdhe_server_key_recv,
+    .server_key_send = &s2n_ecdhe_server_key_send,
+    .client_key_recv = &s2n_ecdhe_client_key_recv,
+    .client_key_send = &s2n_ecdhe_client_key_send,
 };
 
 const struct s2n_record_algorithm s2n_record_alg_null = {

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -21,9 +21,6 @@
 #include "crypto/s2n_openssl.h"
 
 #include "tls/s2n_cipher_preferences.h"
-#include "tls/s2n_cipher_suites.h"
-#include "tls/s2n_client_key_exchange.h"
-#include "tls/s2n_server_key_exchange.h"
 #include "tls/s2n_tls.h"
 #include "tls/s2n_kex.h"
 #include "utils/s2n_safety.h"

--- a/tls/s2n_cipher_suites.h
+++ b/tls/s2n_cipher_suites.h
@@ -32,7 +32,7 @@ struct s2n_key_exchange_algorithm {
     /* OR'ed S2N_KEY_EXCHANGE_* flags */
     uint16_t flags;
 
-    int (*server_key_recv)(struct s2n_connection *conn, struct s2n_blob *data_to_sign);
+    int (*server_key_recv)(struct s2n_connection *conn, struct s2n_blob *data_to_verify);
     int (*server_key_send)(struct s2n_connection *conn, struct s2n_blob *data_to_sign);
     int (*client_key_recv)(struct s2n_connection *conn, struct s2n_blob *shared_key);
     int (*client_key_send)(struct s2n_connection *conn, struct s2n_blob *shared_key);

--- a/tls/s2n_cipher_suites.h
+++ b/tls/s2n_cipher_suites.h
@@ -31,6 +31,11 @@
 struct s2n_key_exchange_algorithm {
     /* OR'ed S2N_KEY_EXCHANGE_* flags */
     uint16_t flags;
+
+    int (*server_key_recv)(struct s2n_connection *conn, struct s2n_blob *data_to_sign);
+    int (*server_key_send)(struct s2n_connection *conn, struct s2n_blob *data_to_sign);
+    int (*client_key_recv)(struct s2n_connection *conn, struct s2n_blob *shared_key);
+    int (*client_key_send)(struct s2n_connection *conn, struct s2n_blob *shared_key);
 };
 
 extern const struct s2n_key_exchange_algorithm s2n_rsa;

--- a/tls/s2n_cipher_suites.h
+++ b/tls/s2n_cipher_suites.h
@@ -28,20 +28,6 @@
 #define S2N_KEY_EXCHANGE_EPH      0x02  /* Ephemeral key exchange */
 #define S2N_KEY_EXCHANGE_ECC      0x04  /* Elliptic curve cryptography */
 
-struct s2n_key_exchange_algorithm {
-    /* OR'ed S2N_KEY_EXCHANGE_* flags */
-    uint16_t flags;
-
-    int (*server_key_recv)(struct s2n_connection *conn, struct s2n_blob *data_to_verify);
-    int (*server_key_send)(struct s2n_connection *conn, struct s2n_blob *data_to_sign);
-    int (*client_key_recv)(struct s2n_connection *conn, struct s2n_blob *shared_key);
-    int (*client_key_send)(struct s2n_connection *conn, struct s2n_blob *shared_key);
-};
-
-extern const struct s2n_key_exchange_algorithm s2n_rsa;
-extern const struct s2n_key_exchange_algorithm s2n_dhe;
-extern const struct s2n_key_exchange_algorithm s2n_ecdhe;
-
 typedef enum {
     S2N_AUTHENTICATION_RSA = 0,
     S2N_AUTHENTICATION_ECDSA
@@ -85,7 +71,7 @@ struct s2n_cipher_suite {
     const char *name;
     const uint8_t iana_value[S2N_TLS_CIPHER_SUITE_LEN];
 
-    const struct s2n_key_exchange_algorithm *key_exchange_alg;
+    const struct s2n_kex *key_exchange_alg;
 
     const s2n_authentication_method auth_method;
 

--- a/tls/s2n_client_key_exchange.c
+++ b/tls/s2n_client_key_exchange.c
@@ -113,11 +113,11 @@ int s2n_ecdhe_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shar
 
 int s2n_client_key_recv(struct s2n_connection *conn)
 {
-    const struct s2n_key_exchange_algorithm *kem_core = conn->secure.cipher_suite->key_exchange_alg;
+    const struct s2n_key_exchange_algorithm *key_exchange = conn->secure.cipher_suite->key_exchange_alg;
     struct s2n_blob shared_key = {0};
 
-    notnull_check(kem_core->client_key_recv);
-    GUARD(kem_core->client_key_recv(conn, &shared_key));
+    notnull_check(key_exchange->client_key_recv);
+    GUARD(key_exchange->client_key_recv(conn, &shared_key));
     GUARD(calculate_keys(conn, &shared_key));
     return 0;
 }
@@ -178,11 +178,11 @@ int s2n_rsa_client_key_send(struct s2n_connection *conn, struct s2n_blob *shared
 
 int s2n_client_key_send(struct s2n_connection *conn)
 {
-    const struct s2n_key_exchange_algorithm *kem_core = conn->secure.cipher_suite->key_exchange_alg;
+    const struct s2n_key_exchange_algorithm *key_exchange = conn->secure.cipher_suite->key_exchange_alg;
     struct s2n_blob shared_key = {0};
 
-    notnull_check(kem_core->client_key_send);
-    GUARD(kem_core->client_key_send(conn, &shared_key));
+    notnull_check(key_exchange->client_key_send);
+    GUARD(key_exchange->client_key_send(conn, &shared_key));
     GUARD(calculate_keys(conn, &shared_key));
     return 0;
 }

--- a/tls/s2n_client_key_exchange.c
+++ b/tls/s2n_client_key_exchange.c
@@ -70,8 +70,7 @@ int s2n_rsa_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared
     shared_key->data = conn->secure.rsa_premaster_secret;
     shared_key->size = S2N_TLS_SECRET_LEN;
 
-    uint32_t encrypted_size = s2n_stuffer_data_available(in);
-    struct s2n_blob encrypted = {.size = encrypted_size, .data = s2n_stuffer_raw_read(in, length)};
+    struct s2n_blob encrypted = {.size = length, .data = s2n_stuffer_raw_read(in, length)};
 
     notnull_check(encrypted.data);
     gt_check(encrypted.size, 0);

--- a/tls/s2n_client_key_exchange.c
+++ b/tls/s2n_client_key_exchange.c
@@ -67,12 +67,12 @@ int s2n_rsa_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared
     client_protocol_version[1] = conn->client_protocol_version % 10;
 
     /* Decrypt the pre-master secret */
-    struct s2n_blob encrypted;
     shared_key->data = conn->secure.rsa_premaster_secret;
     shared_key->size = S2N_TLS_SECRET_LEN;
 
-    encrypted.size = s2n_stuffer_data_available(in);
-    encrypted.data = s2n_stuffer_raw_read(in, length);
+    uint32_t encrypted_size = s2n_stuffer_data_available(in);
+    struct s2n_blob encrypted = {.size = encrypted_size, .data = s2n_stuffer_raw_read(in, length)};
+
     notnull_check(encrypted.data);
     gt_check(encrypted.size, 0);
 

--- a/tls/s2n_client_key_exchange.h
+++ b/tls/s2n_client_key_exchange.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include "tls/s2n_connection.h"
+#include "utils/s2n_blob.h"
+
+int s2n_dhe_client_key_send(struct s2n_connection *conn, struct s2n_blob *shared_key);
+int s2n_dhe_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared_key);
+
+int s2n_ecdhe_client_key_send(struct s2n_connection *conn, struct s2n_blob *shared_key);
+int s2n_ecdhe_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared_key);
+
+int s2n_rsa_client_key_send(struct s2n_connection *conn, struct s2n_blob *shared_key);
+int s2n_rsa_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared_key);

--- a/tls/s2n_client_key_exchange.h
+++ b/tls/s2n_client_key_exchange.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -18,11 +18,27 @@
 #include "tls/s2n_connection.h"
 #include "utils/s2n_blob.h"
 
+/*
+ * The below methods are used to perform the specific key exchange algorithm including reading data from the connection.
+ * They are to be used by the client to handle sending the client's portion of the key exchange data. They are not
+ * responsible for verifying the response or reading the signature from the connection.
+ *
+ * conn: in parameter which is the current connection
+ * data_to_verify: out parameter that is the data required to be added to the signature hash to be used for verifying
+ * the data
+ */
 int s2n_dhe_client_key_send(struct s2n_connection *conn, struct s2n_blob *shared_key);
-int s2n_dhe_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared_key);
-
 int s2n_ecdhe_client_key_send(struct s2n_connection *conn, struct s2n_blob *shared_key);
-int s2n_ecdhe_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared_key);
-
 int s2n_rsa_client_key_send(struct s2n_connection *conn, struct s2n_blob *shared_key);
+
+/*
+ * The below methods are used to perform the specific key exchange algorithm including writing data to the connection.
+ * They are to be used by the server to handle receiving the client's portion of the key exchange data. They are not
+ * responsible for signing the response or writing the signature to the connection.
+ *
+ * conn: in parameter which is the current connection
+ * data_to_sign: out parameter that is the data required to be added to the signature hash to be used for signing
+ */
+int s2n_dhe_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared_key);
+int s2n_ecdhe_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared_key);
 int s2n_rsa_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared_key);

--- a/tls/s2n_client_key_exchange.h
+++ b/tls/s2n_client_key_exchange.h
@@ -18,27 +18,10 @@
 #include "tls/s2n_connection.h"
 #include "utils/s2n_blob.h"
 
-/*
- * The below methods are used to perform the specific key exchange algorithm including reading data from the connection.
- * They are to be used by the client to handle sending the client's portion of the key exchange data. They are not
- * responsible for verifying the response or reading the signature from the connection.
- *
- * conn: in parameter which is the current connection
- * data_to_verify: out parameter that is the data required to be added to the signature hash to be used for verifying
- * the data
- */
 int s2n_dhe_client_key_send(struct s2n_connection *conn, struct s2n_blob *shared_key);
 int s2n_ecdhe_client_key_send(struct s2n_connection *conn, struct s2n_blob *shared_key);
 int s2n_rsa_client_key_send(struct s2n_connection *conn, struct s2n_blob *shared_key);
 
-/*
- * The below methods are used to perform the specific key exchange algorithm including writing data to the connection.
- * They are to be used by the server to handle receiving the client's portion of the key exchange data. They are not
- * responsible for signing the response or writing the signature to the connection.
- *
- * conn: in parameter which is the current connection
- * data_to_sign: out parameter that is the data required to be added to the signature hash to be used for signing
- */
 int s2n_dhe_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared_key);
 int s2n_ecdhe_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared_key);
 int s2n_rsa_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared_key);

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -15,16 +15,18 @@
 
 #pragma once
 
+
 #include <stdint.h>
 #include <s2n.h>
 
-#include "tls/s2n_crypto.h"
 #include "tls/s2n_signature_algorithms.h"
 #include "tls/s2n_tls_parameters.h"
 
 #include "stuffer/s2n_stuffer.h"
 
 #include "crypto/s2n_hash.h"
+
+#include "tls/s2n_crypto.h"
 
 /* This is the list of message types that we support */
 typedef enum {

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -15,18 +15,16 @@
 
 #pragma once
 
-
 #include <stdint.h>
 #include <s2n.h>
 
+#include "tls/s2n_crypto.h"
 #include "tls/s2n_signature_algorithms.h"
 #include "tls/s2n_tls_parameters.h"
 
 #include "stuffer/s2n_stuffer.h"
 
 #include "crypto/s2n_hash.h"
-
-#include "tls/s2n_crypto.h"
 
 /* This is the list of message types that we support */
 typedef enum {

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -28,6 +28,7 @@
 #include "tls/s2n_resume.h"
 #include "tls/s2n_alerts.h"
 #include "tls/s2n_tls.h"
+#include "tls/s2n_kex.h"
 
 #include "stuffer/s2n_stuffer.h"
 
@@ -355,7 +356,7 @@ skip_cache_lookup:
         conn->handshake.handshake_type |= CLIENT_AUTH;
     }
 
-    if (conn->secure.cipher_suite->key_exchange_alg->flags & S2N_KEY_EXCHANGE_EPH) {
+    if (s2n_kex_is_ephemeral(conn->secure.cipher_suite->key_exchange_alg)) {
         conn->handshake.handshake_type |= PERFECT_FORWARD_SECRECY;
     }
 

--- a/tls/s2n_kex.c
+++ b/tls/s2n_kex.c
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "tls/s2n_server_key_exchange.h"
+#include "tls/s2n_client_key_exchange.h"
+#include "tls/s2n_kex.h"
+#include "tls/s2n_cipher_suites.h"
+#include "utils/s2n_safety.h"
+#include "s2n_tls.h"
+
+static int get_ecc_extension_size(const struct s2n_connection *conn)
+{
+    if (s2n_server_can_send_ec_point_formats(conn)){
+        return 6;
+    } else {
+        return 0;
+    }
+}
+
+static int get_no_extension_size(const struct s2n_connection *conn)
+{
+    return 0;
+}
+
+/* Write the Supported Points Format extension.
+ * RFC 4492 section 5.2 states that the absence of this extension in the Server Hello
+ * is equivalent to allowing only the uncompressed point format. Let's send the
+ * extension in case clients(Openssl 1.0.0) don't honor the implied behavior.
+ */
+static int write_ecc_extension(const struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    if (s2n_server_can_send_ec_point_formats(conn)) {
+        GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_EC_POINT_FORMATS));
+        /* Total extension length */
+        GUARD(s2n_stuffer_write_uint16(out, 2));
+        /* Format list length */
+        GUARD(s2n_stuffer_write_uint8(out, 1));
+        /* Only uncompressed format is supported. Interoperability shouldn't be an issue:
+         * RFC 4492 Section 5.1.2: Implementations must support it for all of their curves.
+         */
+        GUARD(s2n_stuffer_write_uint8(out, TLS_EC_FORMAT_UNCOMPRESSED));
+    }
+    return 0;
+}
+
+static int no_extension(const struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    return 0;
+}
+
+static int check_dh(const struct s2n_connection *conn)
+{
+    return conn->config->dhparams != NULL;
+}
+
+static int check_ecc(const struct s2n_connection *conn)
+{
+    return conn->secure.server_ecc_params.negotiated_curve != NULL;
+}
+
+const struct s2n_kex s2n_rsa = {
+        .is_ephemeral = 0,
+        .get_extension_size = &get_no_extension_size,
+        .write_server_extensions = &no_extension,
+        .server_key_recv = &s2n_rsa_server_recv_key,
+        .server_key_send = &s2n_rsa_server_send_key,
+        .client_key_recv = &s2n_rsa_client_key_recv,
+        .client_key_send = &s2n_rsa_client_key_send,
+};
+
+const struct s2n_kex s2n_dhe = {
+        .is_ephemeral = 1,
+        .get_extension_size = &get_no_extension_size,
+        .write_server_extensions = &no_extension,
+        .connection_supported = &check_dh,
+        .server_key_recv = &s2n_dhe_server_recv_params,
+        .server_key_send = &s2n_dhe_server_send_params,
+        .client_key_recv = &s2n_dhe_client_key_recv,
+        .client_key_send = &s2n_dhe_client_key_send,
+};
+
+const struct s2n_kex s2n_ecdhe = {
+        .is_ephemeral = 1,
+        .get_extension_size = &get_ecc_extension_size,
+        .write_server_extensions = &write_ecc_extension,
+        .connection_supported = &check_ecc,
+        .server_key_recv = &s2n_ecdhe_server_recv_params,
+        .server_key_send = &s2n_ecdhe_server_send_params,
+        .client_key_recv = &s2n_ecdhe_client_key_recv,
+        .client_key_send = &s2n_ecdhe_client_key_send,
+};
+
+int s2n_kex_server_extension_size(const struct s2n_kex *kex, struct s2n_connection *conn)
+{
+    notnull_check(kex->get_extension_size);
+    return kex->get_extension_size(conn);
+}
+
+int s2n_kex_write_server_extension(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    notnull_check(kex->write_server_extensions);
+    return kex->write_server_extensions(conn, out);
+}
+
+int s2n_kex_supported(const struct s2n_kex *kex, struct s2n_connection *conn)
+{
+    notnull_check(kex->connection_supported);
+    return kex->connection_supported(conn);
+}
+
+int s2n_kex_is_ephemeral(const struct s2n_kex *kex)
+{
+    return kex->is_ephemeral;
+}
+
+int s2n_kex_server_key_recv(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *data_to_verify)
+{
+    notnull_check(kex->server_key_recv);
+    return kex->server_key_recv(conn, data_to_verify);
+}
+
+int s2n_kex_server_key_send(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *data_to_sign)
+{
+    notnull_check(kex->server_key_send);
+    return kex->server_key_send(conn, data_to_sign);
+}
+
+int s2n_kex_client_key_recv(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *shared_key)
+{
+    notnull_check(kex->client_key_recv);
+    return kex->client_key_recv(conn, shared_key);
+}
+
+int s2n_kex_client_key_send(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *shared_key)
+{
+    notnull_check(kex->client_key_send);
+    return kex->client_key_send(conn, shared_key);
+}

--- a/tls/s2n_kex.c
+++ b/tls/s2n_kex.c
@@ -80,9 +80,9 @@ const struct s2n_kex s2n_rsa = {
         .get_server_extension_size = &get_no_extension_size,
         .write_server_extensions = &write_no_extension,
         .connection_supported = &check_rsa_key,
-        .server_key_recv_read_data = &s2n_rsa_server_key_recv_read_data,
-        .server_key_recv_parse_data = &s2n_rsa_server_key_recv_parse_data,
-        .server_key_send = &s2n_rsa_server_key_send,
+        .server_key_recv_read_data = NULL,
+        .server_key_recv_parse_data = NULL,
+        .server_key_send = NULL,
         .client_key_recv = &s2n_rsa_client_key_recv,
         .client_key_send = &s2n_rsa_client_key_send,
 };
@@ -134,16 +134,16 @@ int s2n_kex_is_ephemeral(const struct s2n_kex *kex)
     return kex->is_ephemeral;
 }
 
-int s2n_kex_server_key_recv_parse_data(const struct s2n_kex *kex, struct s2n_connection *conn, union s2n_kex_server_data *kex_data)
+int s2n_kex_server_key_recv_parse_data(const struct s2n_kex *kex, struct s2n_connection *conn, union s2n_kex_raw_server_data *raw_server_data)
 {
     notnull_check(kex->server_key_recv_parse_data);
-    return kex->server_key_recv_parse_data(conn, kex_data);
+    return kex->server_key_recv_parse_data(conn, raw_server_data);
 }
 
-int s2n_kex_server_key_recv_read_data(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *data_to_verify, union s2n_kex_server_data *kex_data)
+int s2n_kex_server_key_recv_read_data(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *data_to_verify, union s2n_kex_raw_server_data *raw_server_data)
 {
     notnull_check(kex->server_key_recv_read_data);
-    return kex->server_key_recv_read_data(conn, data_to_verify, kex_data);
+    return kex->server_key_recv_read_data(conn, data_to_verify, raw_server_data);
 }
 
 int s2n_kex_server_key_send(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *data_to_sign)

--- a/tls/s2n_kex.c
+++ b/tls/s2n_kex.c
@@ -80,7 +80,8 @@ const struct s2n_kex s2n_rsa = {
         .get_server_extension_size = &get_no_extension_size,
         .write_server_extensions = &write_no_extension,
         .connection_supported = &check_rsa_key,
-        .server_key_recv = &s2n_rsa_server_key_recv,
+        .server_key_recv_read_data = &s2n_rsa_server_key_recv_read_data,
+        .server_key_recv_parse_data = &s2n_rsa_server_key_recv_parse_data,
         .server_key_send = &s2n_rsa_server_key_send,
         .client_key_recv = &s2n_rsa_client_key_recv,
         .client_key_send = &s2n_rsa_client_key_send,
@@ -91,7 +92,8 @@ const struct s2n_kex s2n_dhe = {
         .get_server_extension_size = &get_no_extension_size,
         .write_server_extensions = &write_no_extension,
         .connection_supported = &check_dhe,
-        .server_key_recv = &s2n_dhe_server_key_recv,
+        .server_key_recv_read_data = &s2n_dhe_server_key_recv_read_data,
+        .server_key_recv_parse_data = &s2n_dhe_server_key_recv_parse_data,
         .server_key_send = &s2n_dhe_server_key_send,
         .client_key_recv = &s2n_dhe_client_key_recv,
         .client_key_send = &s2n_dhe_client_key_send,
@@ -102,7 +104,8 @@ const struct s2n_kex s2n_ecdhe = {
         .get_server_extension_size = &get_server_ecc_extension_size,
         .write_server_extensions = &write_server_ecc_extension,
         .connection_supported = &check_ecdhe,
-        .server_key_recv = &s2n_ecdhe_server_key_recv,
+        .server_key_recv_read_data = &s2n_ecdhe_server_key_recv_read_data,
+        .server_key_recv_parse_data = &s2n_ecdhe_server_key_recv_parse_data,
         .server_key_send = &s2n_ecdhe_server_key_send,
         .client_key_recv = &s2n_ecdhe_client_key_recv,
         .client_key_send = &s2n_ecdhe_client_key_send,
@@ -131,10 +134,16 @@ int s2n_kex_is_ephemeral(const struct s2n_kex *kex)
     return kex->is_ephemeral;
 }
 
-int s2n_kex_server_key_recv(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *data_to_verify)
+int s2n_kex_server_key_recv_parse_data(const struct s2n_kex *kex, struct s2n_connection *conn, union s2n_kex_server_data *kex_data)
 {
-    notnull_check(kex->server_key_recv);
-    return kex->server_key_recv(conn, data_to_verify);
+    notnull_check(kex->server_key_recv_parse_data);
+    return kex->server_key_recv_parse_data(conn, kex_data);
+}
+
+int s2n_kex_server_key_recv_read_data(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *data_to_verify, union s2n_kex_server_data *kex_data)
+{
+    notnull_check(kex->server_key_recv_read_data);
+    return kex->server_key_recv_read_data(conn, data_to_verify, kex_data);
 }
 
 int s2n_kex_server_key_send(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *data_to_sign)

--- a/tls/s2n_kex.h
+++ b/tls/s2n_kex.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "tls/s2n_connection.h"
+
+struct s2n_kex {
+    uint8_t is_ephemeral;
+
+    int (*get_extension_size)(const struct s2n_connection *conn);
+    int (*write_server_extensions)(const struct s2n_connection *conn, struct s2n_stuffer *out);
+    int (*connection_supported)(const struct s2n_connection *conn);
+    int (*server_key_recv)(struct s2n_connection *conn, struct s2n_blob *data_to_verify);
+    int (*server_key_send)(struct s2n_connection *conn, struct s2n_blob *data_to_sign);
+    int (*client_key_recv)(struct s2n_connection *conn, struct s2n_blob *shared_key);
+    int (*client_key_send)(struct s2n_connection *conn, struct s2n_blob *shared_key);
+};
+
+extern const struct s2n_kex s2n_rsa;
+extern const struct s2n_kex s2n_dhe;
+extern const struct s2n_kex s2n_ecdhe;
+
+extern int s2n_kex_server_extension_size(const struct s2n_kex *kex, struct s2n_connection *conn);
+extern int s2n_kex_write_server_extension(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_stuffer *out);
+extern int s2n_kex_supported(const struct s2n_kex *kex, struct s2n_connection *conn);
+extern int s2n_kex_is_ephemeral(const struct s2n_kex *kex);
+
+extern int s2n_kex_server_key_recv(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *data_to_verify);
+extern int s2n_kex_server_key_send(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *data_to_sign);
+extern int s2n_kex_client_key_recv(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *shared_key);
+extern int s2n_kex_client_key_send(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *shared_key);

--- a/tls/s2n_kex.h
+++ b/tls/s2n_kex.h
@@ -17,6 +17,7 @@
 
 #include <stdint.h>
 #include "tls/s2n_connection.h"
+#include "tls/s2n_kex_data.h"
 
 struct s2n_kex {
     uint8_t is_ephemeral;
@@ -24,7 +25,8 @@ struct s2n_kex {
     int (*get_server_extension_size)(const struct s2n_connection *conn);
     int (*write_server_extensions)(const struct s2n_connection *conn, struct s2n_stuffer *out);
     int (*connection_supported)(const struct s2n_connection *conn);
-    int (*server_key_recv)(struct s2n_connection *conn, struct s2n_blob *data_to_verify);
+    int (*server_key_recv_read_data)(struct s2n_connection *conn, struct s2n_blob *data_to_verify, union s2n_kex_server_data *kex_data);
+    int (*server_key_recv_parse_data)(struct s2n_connection *conn, union s2n_kex_server_data *kex_data);
     int (*server_key_send)(struct s2n_connection *conn, struct s2n_blob *data_to_sign);
     int (*client_key_recv)(struct s2n_connection *conn, struct s2n_blob *shared_key);
     int (*client_key_send)(struct s2n_connection *conn, struct s2n_blob *shared_key);
@@ -39,7 +41,8 @@ extern int s2n_kex_write_server_extension(const struct s2n_kex *kex, struct s2n_
 extern int s2n_kex_supported(const struct s2n_kex *kex, struct s2n_connection *conn);
 extern int s2n_kex_is_ephemeral(const struct s2n_kex *kex);
 
-extern int s2n_kex_server_key_recv(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *data_to_verify);
+extern int s2n_kex_server_key_recv_read_data(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *data_to_verify, union s2n_kex_server_data *kex_data);
+extern int s2n_kex_server_key_recv_parse_data(const struct s2n_kex *kex, struct s2n_connection *conn, union s2n_kex_server_data *kex_data);
 extern int s2n_kex_server_key_send(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *data_to_sign);
 extern int s2n_kex_client_key_recv(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *shared_key);
 extern int s2n_kex_client_key_send(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *shared_key);

--- a/tls/s2n_kex.h
+++ b/tls/s2n_kex.h
@@ -25,8 +25,8 @@ struct s2n_kex {
     int (*get_server_extension_size)(const struct s2n_connection *conn);
     int (*write_server_extensions)(const struct s2n_connection *conn, struct s2n_stuffer *out);
     int (*connection_supported)(const struct s2n_connection *conn);
-    int (*server_key_recv_read_data)(struct s2n_connection *conn, struct s2n_blob *data_to_verify, union s2n_kex_server_data *kex_data);
-    int (*server_key_recv_parse_data)(struct s2n_connection *conn, union s2n_kex_server_data *kex_data);
+    int (*server_key_recv_read_data)(struct s2n_connection *conn, struct s2n_blob *data_to_verify, union s2n_kex_raw_server_data *kex_data);
+    int (*server_key_recv_parse_data)(struct s2n_connection *conn, union s2n_kex_raw_server_data *kex_data);
     int (*server_key_send)(struct s2n_connection *conn, struct s2n_blob *data_to_sign);
     int (*client_key_recv)(struct s2n_connection *conn, struct s2n_blob *shared_key);
     int (*client_key_send)(struct s2n_connection *conn, struct s2n_blob *shared_key);
@@ -41,8 +41,9 @@ extern int s2n_kex_write_server_extension(const struct s2n_kex *kex, struct s2n_
 extern int s2n_kex_supported(const struct s2n_kex *kex, struct s2n_connection *conn);
 extern int s2n_kex_is_ephemeral(const struct s2n_kex *kex);
 
-extern int s2n_kex_server_key_recv_read_data(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *data_to_verify, union s2n_kex_server_data *kex_data);
-extern int s2n_kex_server_key_recv_parse_data(const struct s2n_kex *kex, struct s2n_connection *conn, union s2n_kex_server_data *kex_data);
+extern int s2n_kex_server_key_recv_read_data(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *data_to_verify,
+        union s2n_kex_raw_server_data *raw_server_data);
+extern int s2n_kex_server_key_recv_parse_data(const struct s2n_kex *kex, struct s2n_connection *conn, union s2n_kex_raw_server_data *raw_server_data);
 extern int s2n_kex_server_key_send(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *data_to_sign);
 extern int s2n_kex_client_key_recv(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *shared_key);
 extern int s2n_kex_client_key_send(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *shared_key);

--- a/tls/s2n_kex.h
+++ b/tls/s2n_kex.h
@@ -21,7 +21,7 @@
 struct s2n_kex {
     uint8_t is_ephemeral;
 
-    int (*get_extension_size)(const struct s2n_connection *conn);
+    int (*get_server_extension_size)(const struct s2n_connection *conn);
     int (*write_server_extensions)(const struct s2n_connection *conn, struct s2n_stuffer *out);
     int (*connection_supported)(const struct s2n_connection *conn);
     int (*server_key_recv)(struct s2n_connection *conn, struct s2n_blob *data_to_verify);

--- a/tls/s2n_kex_data.h
+++ b/tls/s2n_kex_data.h
@@ -17,18 +17,18 @@
 
 #include "utils/s2n_blob.h"
 
-struct s2n_ecdhe_server_data {
+struct s2n_ecdhe_raw_server_params {
     struct s2n_blob point_blob;
     struct s2n_blob curve_blob;
 };
 
-struct s2n_dhe_server_data {
+struct s2n_dhe_raw_server_points {
     struct s2n_blob p;
     struct s2n_blob g;
     struct s2n_blob Ys;
 };
 
-union s2n_kex_server_data {
-    struct s2n_ecdhe_server_data ecdhe_data;
-    struct s2n_dhe_server_data dhe_data;
+union s2n_kex_raw_server_data {
+    struct s2n_ecdhe_raw_server_params ecdhe_data;
+    struct s2n_dhe_raw_server_points dhe_data;
 };

--- a/tls/s2n_kex_data.h
+++ b/tls/s2n_kex_data.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include "utils/s2n_blob.h"
+
+struct s2n_ecdhe_server_data {
+    struct s2n_blob point_blob;
+    struct s2n_blob curve_blob;
+};
+
+struct s2n_dh_server_data {
+    struct s2n_blob p;
+    struct s2n_blob g;
+    struct s2n_blob Ys;
+};
+
+union s2n_kex_server_data {
+    struct s2n_ecdhe_server_data ecdhe_data;
+    struct s2n_dh_server_data dh_data;
+};

--- a/tls/s2n_kex_data.h
+++ b/tls/s2n_kex_data.h
@@ -22,7 +22,7 @@ struct s2n_ecdhe_server_data {
     struct s2n_blob curve_blob;
 };
 
-struct s2n_dh_server_data {
+struct s2n_dhe_server_data {
     struct s2n_blob p;
     struct s2n_blob g;
     struct s2n_blob Ys;
@@ -30,5 +30,5 @@ struct s2n_dh_server_data {
 
 union s2n_kex_server_data {
     struct s2n_ecdhe_server_data ecdhe_data;
-    struct s2n_dh_server_data dh_data;
+    struct s2n_dhe_server_data dhe_data;
 };

--- a/tls/s2n_server_extensions.c
+++ b/tls/s2n_server_extensions.c
@@ -21,6 +21,7 @@
 #include "tls/s2n_tls_parameters.h"
 #include "tls/s2n_connection.h"
 #include "tls/s2n_tls.h"
+#include "tls/s2n_kex.h"
 #include "tls/s2n_cipher_suites.h"
 
 #include "stuffer/s2n_stuffer.h"
@@ -51,9 +52,7 @@ int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *
         total_size += 5;
     }
 
-    if (s2n_server_can_send_ec_point_formats(conn)) {
-        total_size += 6;
-    }
+    total_size += s2n_kex_server_extension_size(conn->secure.cipher_suite->key_exchange_alg, conn);
 
     if (s2n_server_can_send_sct_list(conn)) {
         total_size += 4 + conn->config->cert_and_key_pairs->sct_list.size;
@@ -71,22 +70,7 @@ int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *
 
     GUARD(s2n_stuffer_write_uint16(out, total_size));
 
-    /* Write the Supported Points Format extension.
-     * RFC 4492 section 5.2 states that the absence of this extension in the Server Hello
-     * is equivalent to allowing only the uncompressed point format. Let's send the
-     * extension in case clients(Openssl 1.0.0) don't honor the implied behavior.
-     */
-    if (s2n_server_can_send_ec_point_formats(conn))  {
-        GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_EC_POINT_FORMATS));
-        /* Total extension length */
-        GUARD(s2n_stuffer_write_uint16(out, 2));
-        /* Format list length */
-        GUARD(s2n_stuffer_write_uint8(out, 1));
-        /* Only uncompressed format is supported. Interoperability shouldn't be an issue:
-         * RFC 4492 Section 5.1.2: Implementations must support it for all of their curves.
-         */
-        GUARD(s2n_stuffer_write_uint8(out, TLS_EC_FORMAT_UNCOMPRESSED));
-    }
+    GUARD(s2n_kex_write_server_extension(conn->secure.cipher_suite->key_exchange_alg, conn, out));
 
     /* Write the renegotiation_info extension */
     if (conn->secure_renegotiation) {

--- a/tls/s2n_server_key_exchange.c
+++ b/tls/s2n_server_key_exchange.c
@@ -58,11 +58,9 @@ int s2n_server_key_recv(struct s2n_connection *conn)
     GUARD(s2n_hash_update(signature_hash, data_to_sign.data, data_to_sign.size));
 
     /* Verify the signature */
-    struct s2n_blob signature = {0};
     uint16_t signature_length;
     GUARD(s2n_stuffer_read_uint16(in, &signature_length));
-    signature.size = signature_length;
-    signature.data = s2n_stuffer_raw_read(in, signature.size);
+    struct s2n_blob signature = {.size = signature_length, .data = s2n_stuffer_raw_read(in, signature.size)};
     notnull_check(signature.data);
     gt_check(signature_length, 0);
 
@@ -85,7 +83,7 @@ int s2n_ecdhe_server_recv_params(struct s2n_connection *conn, struct s2n_blob *d
 int s2n_dhe_server_recv_params(struct s2n_connection *conn, struct s2n_blob *data_to_verify)
 {
     struct s2n_stuffer *in = &conn->handshake.io;
-    struct s2n_blob p, g, Ys;
+    struct s2n_blob p, g, Ys = {0};
     uint16_t p_length;
     uint16_t g_length;
     uint16_t Ys_length;

--- a/tls/s2n_server_key_exchange.c
+++ b/tls/s2n_server_key_exchange.c
@@ -39,6 +39,7 @@ int s2n_server_key_recv(struct s2n_connection *conn)
     struct s2n_blob data_to_sign = {0};
 
     /* Read and process the KEM data */
+    notnull_check(kem_core->server_key_recv);
     GUARD(kem_core->server_key_recv(conn, &data_to_sign));
 
     /* Add common signature data */
@@ -72,7 +73,7 @@ int s2n_server_key_recv(struct s2n_connection *conn)
     return 0;
 }
 
-int s2n_ecdhe_server_key_recv(struct s2n_connection *conn, struct s2n_blob *data_to_sign)
+int s2n_ecdhe_server_recv_params(struct s2n_connection *conn, struct s2n_blob *data_to_sign)
 {
     struct s2n_stuffer *in = &conn->handshake.io;
 
@@ -81,7 +82,7 @@ int s2n_ecdhe_server_key_recv(struct s2n_connection *conn, struct s2n_blob *data
     return 0;
 }
 
-int s2n_dhe_server_key_recv(struct s2n_connection *conn, struct s2n_blob *data_to_sign)
+int s2n_dhe_server_recv_params(struct s2n_connection *conn, struct s2n_blob *data_to_sign)
 {
     struct s2n_stuffer *in = &conn->handshake.io;
     struct s2n_blob p, g, Ys;
@@ -125,6 +126,7 @@ int s2n_server_key_send(struct s2n_connection *conn)
     struct s2n_blob data_to_sign = {0};
 
     /* Call the negotiated key exchange method to send it's data */
+    notnull_check(kem_core->server_key_send);
     GUARD(kem_core->server_key_send(conn, &data_to_sign));
 
     /* Add common signature data */
@@ -146,7 +148,7 @@ int s2n_server_key_send(struct s2n_connection *conn)
     return 0;
 }
 
-int s2n_ecdhe_server_key_send(struct s2n_connection *conn, struct s2n_blob *data_to_sign)
+int s2n_ecdhe_server_send_params(struct s2n_connection *conn, struct s2n_blob *data_to_sign)
 {
     struct s2n_stuffer *out = &conn->handshake.io;
 
@@ -158,7 +160,7 @@ int s2n_ecdhe_server_key_send(struct s2n_connection *conn, struct s2n_blob *data
     return 0;
 }
 
-int s2n_dhe_server_key_send(struct s2n_connection *conn, struct s2n_blob *data_to_sign)
+int s2n_dhe_server_send_params(struct s2n_connection *conn, struct s2n_blob *data_to_sign)
 {
     struct s2n_stuffer *out = &conn->handshake.io;
 
@@ -198,12 +200,12 @@ static int s2n_write_signature_blob(struct s2n_stuffer *out, const struct s2n_pk
 }
 
 // The server should never receive an RSA key during the key exchange
-int s2n_rsa_server_key_recv(struct s2n_connection *conn, struct s2n_blob *data_to_sign)
+int s2n_rsa_server_recv_key(struct s2n_connection *conn, struct s2n_blob *data_to_sign)
 {
     S2N_ERROR(S2N_ERR_HANDSHAKE_STATE);
 }
 // The server should never send an additional RSA key during the key exchange
-int s2n_rsa_server_key_send(struct s2n_connection *conn, struct s2n_blob *data_to_sign)
+int s2n_rsa_server_send_key(struct s2n_connection *conn, struct s2n_blob *data_to_sign)
 {
     S2N_ERROR(S2N_ERR_HANDSHAKE_STATE);
 }

--- a/tls/s2n_server_key_exchange.c
+++ b/tls/s2n_server_key_exchange.c
@@ -60,7 +60,8 @@ int s2n_server_key_recv(struct s2n_connection *conn)
     /* Verify the signature */
     uint16_t signature_length;
     GUARD(s2n_stuffer_read_uint16(in, &signature_length));
-    struct s2n_blob signature = {.size = signature_length, .data = s2n_stuffer_raw_read(in, signature.size)};
+
+    struct s2n_blob signature = {.size = signature_length, .data = s2n_stuffer_raw_read(in, signature_length)};
     notnull_check(signature.data);
     gt_check(signature_length, 0);
 

--- a/tls/s2n_server_key_exchange.c
+++ b/tls/s2n_server_key_exchange.c
@@ -96,7 +96,7 @@ int s2n_ecdhe_server_key_recv_parse_data(struct s2n_connection *conn, union s2n_
 int s2n_dhe_server_key_recv_read_data(struct s2n_connection *conn, struct s2n_blob *data_to_verify, union s2n_kex_server_data *kex_data)
 {
     struct s2n_stuffer *in = &conn->handshake.io;
-    struct s2n_dh_server_data *dhe_data = &kex_data->dh_data;
+    struct s2n_dhe_server_data *dhe_data = &kex_data->dhe_data;
 
     uint16_t p_length;
     uint16_t g_length;
@@ -130,7 +130,7 @@ int s2n_dhe_server_key_recv_read_data(struct s2n_connection *conn, struct s2n_bl
 
 int s2n_dhe_server_key_recv_parse_data(struct s2n_connection *conn, union s2n_kex_server_data *kex_data)
 {
-    struct s2n_dh_server_data dhe_data = kex_data->dh_data;
+    struct s2n_dhe_server_data dhe_data = kex_data->dhe_data;
 
     /* Copy the DH details */
     GUARD(s2n_dh_p_g_Ys_to_dh_params(&conn->secure.server_dh_params, &dhe_data.p, &dhe_data.g, &dhe_data.Ys));

--- a/tls/s2n_server_key_exchange.h
+++ b/tls/s2n_server_key_exchange.h
@@ -28,7 +28,7 @@
  */
 int s2n_dhe_server_recv_params(struct s2n_connection *conn, struct s2n_blob *data_to_verify);
 int s2n_ecdhe_server_recv_params(struct s2n_connection *conn, struct s2n_blob *data_to_verify);
-int s2n_rsa_server_recv_key(struct s2n_connection *conn, struct s2n_blob *data_to_recv);
+int s2n_rsa_server_recv_key(struct s2n_connection *conn, struct s2n_blob *data_to_verify);
 
 /*
  * The below methods are used to perform the specific key exchange algorithm including writing data to the connection.

--- a/tls/s2n_server_key_exchange.h
+++ b/tls/s2n_server_key_exchange.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include "tls/s2n_connection.h"
+#include "utils/s2n_blob.h"
+
+int s2n_dhe_server_key_recv(struct s2n_connection *conn, struct s2n_blob *data_to_sign);
+int s2n_dhe_server_key_send(struct s2n_connection *conn, struct s2n_blob *data_to_sign);
+
+int s2n_ecdhe_server_key_recv(struct s2n_connection *conn, struct s2n_blob *data_to_sign);
+int s2n_ecdhe_server_key_send(struct s2n_connection *conn, struct s2n_blob *data_to_sign);
+
+int s2n_rsa_server_key_recv(struct s2n_connection *conn, struct s2n_blob *data_to_sign);
+int s2n_rsa_server_key_send(struct s2n_connection *conn, struct s2n_blob *data_to_sign);

--- a/tls/s2n_server_key_exchange.h
+++ b/tls/s2n_server_key_exchange.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -17,12 +17,27 @@
 
 #include "tls/s2n_connection.h"
 #include "utils/s2n_blob.h"
+/*
+ * The below methods are used to perform the specific key exchange algorithm including reading data from the connection.
+ * They are to be used by the client to handle receiving the server's portion of the key exchange. They are not
+ * responsible for verifying the response or reading the signature from the connection.
+ *
+ * conn: in parameter which is the current connection
+ * data_to_verify: out parameter that is the data required to be added to the signature hash to be used for verifying
+ * the data
+ */
+int s2n_dhe_server_recv_params(struct s2n_connection *conn, struct s2n_blob *data_to_verify);
+int s2n_ecdhe_server_recv_params(struct s2n_connection *conn, struct s2n_blob *data_to_verify);
+int s2n_rsa_server_recv_key(struct s2n_connection *conn, struct s2n_blob *data_to_recv);
 
-int s2n_dhe_server_key_recv(struct s2n_connection *conn, struct s2n_blob *data_to_sign);
-int s2n_dhe_server_key_send(struct s2n_connection *conn, struct s2n_blob *data_to_sign);
-
-int s2n_ecdhe_server_key_recv(struct s2n_connection *conn, struct s2n_blob *data_to_sign);
-int s2n_ecdhe_server_key_send(struct s2n_connection *conn, struct s2n_blob *data_to_sign);
-
-int s2n_rsa_server_key_recv(struct s2n_connection *conn, struct s2n_blob *data_to_sign);
-int s2n_rsa_server_key_send(struct s2n_connection *conn, struct s2n_blob *data_to_sign);
+/*
+ * The below methods are used to perform the specific key exchange algorithm including writing data to the connection.
+ * They are to be used by the server to handle sending the server's portion of the key exchange. They are not
+ * responsible for signing the response or writing the signature to the connection.
+ *
+ * conn: in parameter which is the current connection
+ * data_to_sign: out parameter that is the data required to be added to the signature hash to be used for signing
+ */
+int s2n_dhe_server_send_params(struct s2n_connection *conn, struct s2n_blob *data_to_sign);
+int s2n_ecdhe_server_send_params(struct s2n_connection *conn, struct s2n_blob *data_to_sign);
+int s2n_rsa_server_send_key(struct s2n_connection *conn, struct s2n_blob *data_to_sign);

--- a/tls/s2n_server_key_exchange.h
+++ b/tls/s2n_server_key_exchange.h
@@ -24,7 +24,7 @@
  * the data and rely on the caller to verify the data.
  * conn: in parameter which is the current connection
  * data_to_verify: out parameter that is the data required to be added to the signature hash to be used for verifying the data
- * kex_data: out parameter that is the temporary, unverified key exchange data, this must be passed to the corresponding parse method
+ * kex_data: out parameter that is the temporary, unverified key exchange data, this will be passed to the corresponding parse method
  */
 int s2n_dhe_server_key_recv_read_data(struct s2n_connection *conn, struct s2n_blob *data_to_verify, union s2n_kex_server_data *kex_data);
 int s2n_ecdhe_server_key_recv_read_data(struct s2n_connection *conn, struct s2n_blob *data_to_verify, union s2n_kex_server_data *kex_data);

--- a/tls/s2n_server_key_exchange.h
+++ b/tls/s2n_server_key_exchange.h
@@ -16,20 +16,31 @@
 #pragma once
 
 #include "tls/s2n_connection.h"
+#include "tls/s2n_kex.h"
 #include "utils/s2n_blob.h"
 
 /*
- * The below methods are used to perform the specific key exchange algorithm including reading data from the connection.
- * They are to be used by the client to handle receiving the server's portion of the key exchange. They are not
+ * The below methods are used to read in the specific key exchange messages from the connection. They take no action on
+ * the data and rely on the caller to verify the data.
+ * conn: in parameter which is the current connection
+ * data_to_verify: out parameter that is the data required to be added to the signature hash to be used for verifying the data
+ * kex_data: out parameter that is the temporary, unverified key exchange data, this must be passed to the corresponding parse method
+ */
+int s2n_dhe_server_key_recv_read_data(struct s2n_connection *conn, struct s2n_blob *data_to_verify, union s2n_kex_server_data *kex_data);
+int s2n_ecdhe_server_key_recv_read_data(struct s2n_connection *conn, struct s2n_blob *data_to_verify, union s2n_kex_server_data *kex_data);
+int s2n_rsa_server_key_recv_read_data(struct s2n_connection *conn, struct s2n_blob *data_to_verify, union s2n_kex_server_data *kex_data);
+
+/*
+ * The below methods are used to parse the specific key exchange data, it does not read data from the connection.
+ * They are to be used by the client to handle parsing the server's portion of the key exchange. They are not
  * responsible for verifying the response or reading the signature from the connection.
  *
  * conn: in parameter which is the current connection
- * data_to_verify: out parameter that is the data required to be added to the signature hash to be used for verifying
- * the data
+ * kex_data: in parameter that is the verified key exchange data to be used
  */
-int s2n_dhe_server_key_recv(struct s2n_connection *conn, struct s2n_blob *data_to_verify);
-int s2n_ecdhe_server_key_recv(struct s2n_connection *conn, struct s2n_blob *data_to_verify);
-int s2n_rsa_server_key_recv(struct s2n_connection *conn, struct s2n_blob *data_to_verify);
+int s2n_dhe_server_key_recv_parse_data(struct s2n_connection *conn, union s2n_kex_server_data *kex_data);
+int s2n_ecdhe_server_key_recv_parse_data(struct s2n_connection *conn, union s2n_kex_server_data *kex_data);
+int s2n_rsa_server_key_recv_parse_data(struct s2n_connection *conn, union s2n_kex_server_data *kex_data);
 
 /*
  * The below methods are used to perform the specific key exchange algorithm including writing data to the connection.

--- a/tls/s2n_server_key_exchange.h
+++ b/tls/s2n_server_key_exchange.h
@@ -17,6 +17,7 @@
 
 #include "tls/s2n_connection.h"
 #include "utils/s2n_blob.h"
+
 /*
  * The below methods are used to perform the specific key exchange algorithm including reading data from the connection.
  * They are to be used by the client to handle receiving the server's portion of the key exchange. They are not
@@ -26,9 +27,9 @@
  * data_to_verify: out parameter that is the data required to be added to the signature hash to be used for verifying
  * the data
  */
-int s2n_dhe_server_recv_params(struct s2n_connection *conn, struct s2n_blob *data_to_verify);
-int s2n_ecdhe_server_recv_params(struct s2n_connection *conn, struct s2n_blob *data_to_verify);
-int s2n_rsa_server_recv_key(struct s2n_connection *conn, struct s2n_blob *data_to_verify);
+int s2n_dhe_server_key_recv(struct s2n_connection *conn, struct s2n_blob *data_to_verify);
+int s2n_ecdhe_server_key_recv(struct s2n_connection *conn, struct s2n_blob *data_to_verify);
+int s2n_rsa_server_key_recv(struct s2n_connection *conn, struct s2n_blob *data_to_verify);
 
 /*
  * The below methods are used to perform the specific key exchange algorithm including writing data to the connection.
@@ -38,6 +39,6 @@ int s2n_rsa_server_recv_key(struct s2n_connection *conn, struct s2n_blob *data_t
  * conn: in parameter which is the current connection
  * data_to_sign: out parameter that is the data required to be added to the signature hash to be used for signing
  */
-int s2n_dhe_server_send_params(struct s2n_connection *conn, struct s2n_blob *data_to_sign);
-int s2n_ecdhe_server_send_params(struct s2n_connection *conn, struct s2n_blob *data_to_sign);
-int s2n_rsa_server_send_key(struct s2n_connection *conn, struct s2n_blob *data_to_sign);
+int s2n_dhe_server_key_send(struct s2n_connection *conn, struct s2n_blob *data_to_sign);
+int s2n_ecdhe_server_key_send(struct s2n_connection *conn, struct s2n_blob *data_to_sign);
+int s2n_rsa_server_key_send(struct s2n_connection *conn, struct s2n_blob *data_to_sign);

--- a/tls/s2n_server_key_exchange.h
+++ b/tls/s2n_server_key_exchange.h
@@ -19,37 +19,11 @@
 #include "tls/s2n_kex.h"
 #include "utils/s2n_blob.h"
 
-/*
- * The below methods are used to read in the specific key exchange messages from the connection. They take no action on
- * the data and rely on the caller to verify the data.
- * conn: in parameter which is the current connection
- * data_to_verify: out parameter that is the data required to be added to the signature hash to be used for verifying the data
- * kex_data: out parameter that is the temporary, unverified key exchange data, this will be passed to the corresponding parse method
- */
-int s2n_dhe_server_key_recv_read_data(struct s2n_connection *conn, struct s2n_blob *data_to_verify, union s2n_kex_server_data *kex_data);
-int s2n_ecdhe_server_key_recv_read_data(struct s2n_connection *conn, struct s2n_blob *data_to_verify, union s2n_kex_server_data *kex_data);
-int s2n_rsa_server_key_recv_read_data(struct s2n_connection *conn, struct s2n_blob *data_to_verify, union s2n_kex_server_data *kex_data);
+int s2n_dhe_server_key_recv_read_data(struct s2n_connection *conn, struct s2n_blob *data_to_verify, union s2n_kex_raw_server_data *raw_server_data);
+int s2n_ecdhe_server_key_recv_read_data(struct s2n_connection *conn, struct s2n_blob *data_to_verify, union s2n_kex_raw_server_data *raw_server_data);
 
-/*
- * The below methods are used to parse the specific key exchange data, it does not read data from the connection.
- * They are to be used by the client to handle parsing the server's portion of the key exchange. They are not
- * responsible for verifying the response or reading the signature from the connection.
- *
- * conn: in parameter which is the current connection
- * kex_data: in parameter that is the verified key exchange data to be used
- */
-int s2n_dhe_server_key_recv_parse_data(struct s2n_connection *conn, union s2n_kex_server_data *kex_data);
-int s2n_ecdhe_server_key_recv_parse_data(struct s2n_connection *conn, union s2n_kex_server_data *kex_data);
-int s2n_rsa_server_key_recv_parse_data(struct s2n_connection *conn, union s2n_kex_server_data *kex_data);
+int s2n_dhe_server_key_recv_parse_data(struct s2n_connection *conn, union s2n_kex_raw_server_data *raw_server_data);
+int s2n_ecdhe_server_key_recv_parse_data(struct s2n_connection *conn, union s2n_kex_raw_server_data *raw_server_data);
 
-/*
- * The below methods are used to perform the specific key exchange algorithm including writing data to the connection.
- * They are to be used by the server to handle sending the server's portion of the key exchange. They are not
- * responsible for signing the response or writing the signature to the connection.
- *
- * conn: in parameter which is the current connection
- * data_to_sign: out parameter that is the data required to be added to the signature hash to be used for signing
- */
 int s2n_dhe_server_key_send(struct s2n_connection *conn, struct s2n_blob *data_to_sign);
 int s2n_ecdhe_server_key_send(struct s2n_connection *conn, struct s2n_blob *data_to_sign);
-int s2n_rsa_server_key_send(struct s2n_connection *conn, struct s2n_blob *data_to_sign);

--- a/tls/s2n_tls.h
+++ b/tls/s2n_tls.h
@@ -67,8 +67,7 @@ extern int s2n_server_extensions_recv(struct s2n_connection *conn, struct s2n_bl
 extern uint16_t mfl_code_to_length[5];
 
 #define s2n_server_can_send_ec_point_formats(conn) \
-        (((conn)->secure.cipher_suite->key_exchange_alg->flags & S2N_KEY_EXCHANGE_ECC) && \
-        (conn)->ec_point_formats)
+        ((conn)->ec_point_formats)
 
 #define s2n_server_can_send_ocsp(conn) ((conn)->status_type == S2N_STATUS_REQUEST_OCSP && \
         (conn)->config->cert_and_key_pairs && \


### PR DESCRIPTION
**Issue # (if available):** 
https://github.com/awslabs/s2n/issues/904

**Description of changes:** 
This pull requests refactors out the common key exchange signing/verifying/KDF code into 4 central methods. This leaves the differences between RSA, DHE, and ECDHE as function pointers to be used by the main s2n client/server send/receive methods. This will make it easier to add additional key exchange algorithms in the future.

The next part of this refactor could include refactoring the s2n_connection object to use a union of the RSA, DHE params, and ECDHE params to save on memory.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
