### PR TITLE
Replace pipe read operations with communicate() in s2n_handshake_test_s_client.py

### DIFF
--- a/tests/integration/s2n_handshake_test_s_client.py
+++ b/tests/integration/s2n_handshake_test_s_client.py
@@ -38,11 +38,6 @@ PROTO_VERS_TO_S_CLIENT_ARG = {
 
 S_CLIENT_SUCCESSFUL_OCSP="OCSP Response Status: successful"
 
-def communicate_process(p, input):
-    t = threading.Timer(0.1, p.kill)
-    t.start()
-    return p.communicate(input.encode("utf-8"))[0].decode("utf-8").split('\n')
-
 def communicate_processes(*processes):
     outs = []
     for p in processes:
@@ -157,13 +152,11 @@ def try_handshake(endpoint, port, cipher, ssl_version, server_cert=None, server_
     sleep(0.1)
     outs = communicate_processes(s_client, s2nd)
     s_out = outs[1]
-    # print (s_out)
     if '' == s_out:
         print ("No output from client PIPE, skip")
         return 0
 
     c_out = outs[0]
-    # print (c_out)
     if '' == c_out:
         print ("No output from client PIPE, skip")
         return 0

--- a/tests/integration/s2n_handshake_test_s_client.py
+++ b/tests/integration/s2n_handshake_test_s_client.py
@@ -147,13 +147,14 @@ def try_handshake(endpoint, port, cipher, ssl_version, server_cert=None, server_
     s_client.stdin.write(msg)
     s_client.stdin.flush()
 
+    # Wait for pipe ready for write
+    sleep(0.1)
     # Write the cipher name from s2n server to client
     s2nd.stdin.write(msg)
     s2nd.stdin.flush()
 
-    # Wait for pipe ready
+    # Wait for pipe ready for read
     sleep(0.1)
-
     outs = communicate_processes(s_client, s2nd)
     s_out = outs[1]
     # print (s_out)


### PR DESCRIPTION
**Issue # (if available):** 
https://github.com/awslabs/s2n/issues/880 
A developer constantly encounters deadlocks in s2n_handshake_test_s_client.py on his local setup, which blocks his PR.

**Description of changes:** 
Replace pipe read operations with communicate() in s2n_handshake_test_s_client.py

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
