### PR TITLE
time_t is a screwy type and is not 64 bit on 32bit builds, this broke…

### DIFF
--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -38,7 +38,7 @@ static int monotonic_clock(void *data, uint64_t *nanoseconds)
 
     GUARD(clock_gettime(S2N_CLOCK_HW, &current_time));
 
-    *nanoseconds = current_time.tv_sec * 1000000000;
+    *nanoseconds = (uint64_t)current_time.tv_sec * 1000000000ull;
     *nanoseconds += current_time.tv_nsec;
 
     return 0;
@@ -50,7 +50,7 @@ static int wall_clock(void *data, uint64_t *nanoseconds)
 
     GUARD(clock_gettime(S2N_CLOCK_SYS, &current_time));
 
-    *nanoseconds = current_time.tv_sec * 1000000000;
+    *nanoseconds = (uint64_t)current_time.tv_sec * 1000000000ull;
     *nanoseconds += current_time.tv_nsec;
 
     return 0;

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -360,7 +360,8 @@ s2n_cert_validation_code s2n_x509_validator_validate_cert_chain(struct s2n_x509_
         conn->config->wall_clock(conn->config->sys_clock_ctx, &current_sys_time);
 
         /* this wants seconds not nanoseconds */
-        X509_STORE_CTX_set_time(ctx, 0, current_sys_time / 1000000000);
+        time_t current_time = (time_t)(current_sys_time / 1000000000);
+        X509_STORE_CTX_set_time(ctx, 0, current_time);
 
         op_code = X509_verify_cert(ctx);
 


### PR DESCRIPTION
… x509 expiration validation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
