### PR TITLE
Use latest OpenSSL stable release for FIPS travis builds

### DIFF
--- a/.travis/install_openssl_1_0_2_fips.sh
+++ b/.travis/install_openssl_1_0_2_fips.sh
@@ -61,10 +61,9 @@ make
 sudo make install
 
 cd "$BUILD_DIR"
-# Pull from a specific commit since an ECDSA PEM parsing bug was introduced into the branch
-curl --retry 3 -L https://github.com/openssl/openssl/archive/6a815969776e3329fdffcc12c77e047e3a15be78.zip --output openssl-OpenSSL_1_0_2-stable.zip
+curl --retry 3 -L https://github.com/openssl/openssl/archive/OpenSSL_1_0_2-stable.zip --output openssl-OpenSSL_1_0_2-stable.zip
 unzip openssl-OpenSSL_1_0_2-stable.zip
-cd openssl-6a815969776e3329fdffcc12c77e047e3a15be78
+cd openssl-OpenSSL_1_0_2-stable
 
 FIPS_OPTIONS="fips --with-fipsdir=$FIPSDIR shared"
 


### PR DESCRIPTION
**Issue # (if available):** #821 

**Description of changes:** With the fix in OpenSSL 1.0.2q for CVE-2018-5407 (openssl/openssl#7135), Issue #821 is fixed. FIPS builds can now use the latest OpenSSL 1.0.2-stable commit.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
