### PR TITLE
Make PKCS#1 v1.5 unpadding constant time

### DIFF
--- a/crypto/s2n_rsa.c
+++ b/crypto/s2n_rsa.c
@@ -130,14 +130,19 @@ static int s2n_rsa_encrypt(const struct s2n_pkey *pub, struct s2n_blob *in, stru
 static int s2n_rsa_decrypt(const struct s2n_pkey *priv, struct s2n_blob *in, struct s2n_blob *out)
 {
     unsigned char intermediate[4096];
+    size_t expected_size = s2n_rsa_encrypted_size(priv);
 
-    S2N_ERROR_IF(s2n_rsa_encrypted_size(priv) > sizeof(intermediate), S2N_ERR_NOMEM);
+    S2N_ERROR_IF(expected_size > sizeof(intermediate), S2N_ERR_NOMEM);
     S2N_ERROR_IF(out->size > sizeof(intermediate), S2N_ERR_NOMEM);
 
+    GUARD(s2n_get_urandom_data(out));
+
     const s2n_rsa_private_key *key = &priv->key.rsa_key;
-    int r = RSA_private_decrypt(in->size, (unsigned char *)in->data, intermediate, key->rsa, RSA_PKCS1_PADDING);
-    GUARD(s2n_constant_time_copy_or_dont(out->data, intermediate, out->size, r != out->size));
-    S2N_ERROR_IF(r != out->size, S2N_ERR_SIZE_MISMATCH);
+    int r = RSA_private_decrypt(in->size, (unsigned char *)in->data, intermediate, key->rsa, RSA_NO_PADDING);
+    GUARD(r);
+    S2N_ERROR_IF(r != expected_size, S2N_ERR_SIZE_MISMATCH);
+
+    s2n_constant_time_pkcs1_unpad_or_dont(out->data, intermediate, r, out->size);
 
     return 0;
 }

--- a/crypto/s2n_rsa.c
+++ b/crypto/s2n_rsa.c
@@ -130,8 +130,9 @@ static int s2n_rsa_encrypt(const struct s2n_pkey *pub, struct s2n_blob *in, stru
 static int s2n_rsa_decrypt(const struct s2n_pkey *priv, struct s2n_blob *in, struct s2n_blob *out)
 {
     unsigned char intermediate[4096];
-    size_t expected_size = s2n_rsa_encrypted_size(priv);
+    const size_t expected_size = s2n_rsa_encrypted_size(priv);
 
+    GUARD(expected_size);
     S2N_ERROR_IF(expected_size > sizeof(intermediate), S2N_ERR_NOMEM);
     S2N_ERROR_IF(out->size > sizeof(intermediate), S2N_ERR_NOMEM);
 
@@ -139,7 +140,6 @@ static int s2n_rsa_decrypt(const struct s2n_pkey *priv, struct s2n_blob *in, str
 
     const s2n_rsa_private_key *key = &priv->key.rsa_key;
     int r = RSA_private_decrypt(in->size, (unsigned char *)in->data, intermediate, key->rsa, RSA_NO_PADDING);
-    GUARD(r);
     S2N_ERROR_IF(r != expected_size, S2N_ERR_SIZE_MISMATCH);
 
     s2n_constant_time_pkcs1_unpad_or_dont(out->data, intermediate, r, out->size);

--- a/utils/s2n_safety.c
+++ b/utils/s2n_safety.c
@@ -99,3 +99,52 @@ int s2n_constant_time_copy_or_dont(uint8_t * dest, const uint8_t * src, uint32_t
 
     return 0;
 }
+
+/* If src contains valid PKCS#1 v1.5 padding of exactly expectlen bytes, decode
+ * it into dst, otherwise leave dst alone. Execution time is independent of the
+ * content of src, but may depend on srclen/expectlen.
+ *
+ * Normally, one would fill dst with random bytes before calling this function.
+ */
+int s2n_constant_time_pkcs1_unpad_or_dont(uint8_t * dst, const uint8_t * src, uint32_t srclen, uint32_t expectlen)
+{
+    S2N_PUBLIC_INPUT(dst);
+    S2N_PUBLIC_INPUT(src);
+    S2N_PUBLIC_INPUT(srclen);
+    S2N_PUBLIC_INPUT(expectlen);
+
+    /* Before doing anything else, some basic sanity checks on input lengths */
+    if (srclen < expectlen + 3) {
+        /* Not enough room for PKCS#1v1.5 padding, so treat it as bad padding */
+        return 0;
+    }
+
+    /* First, determine (in constant time) whether the padding is valid.
+     * If the padding is valid we expect that:
+     * Bytes 0 and 1 will equal 0x00 and 0x02
+     * Bytes (srclen-expectlen-1) will be zero
+     * Bytes 2 through (srclen-expectlen-1) will be nonzero
+     */
+    uint8_t dont_copy = 0;
+    const uint8_t *start_of_data = src + srclen - expectlen;
+
+    dont_copy |= src[0] ^ 0x00;
+    dont_copy |= src[1] ^ 0x02;
+    dont_copy |= start_of_data[-1] ^ 0x00;
+
+    for (uint32_t i = 2; i < srclen - expectlen - 1; i++) {
+        /* Note! We avoid using logical NOT (!) here; while in practice
+         * many compilers will use constant-time sequences for this operator,
+         * at least on x86 (e.g. cmp -> setcc, or vectorized pcmpeq), this is
+         * not guaranteed to hold, and some architectures might not have a
+         * convenient mechanism for generating a branchless logical not. */
+        uint8_t mask = ((uint_fast16_t)((uint_fast16_t)(src[i]) - 1)) >> 8;
+        /* src[i] = 0 : mask = 0xff */
+        /* src[i] > 0 : mask = 0x00 */
+        dont_copy |= mask;
+    }
+
+    s2n_constant_time_copy_or_dont(dst, start_of_data, expectlen, dont_copy);
+
+    return 0;
+}

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -114,6 +114,11 @@ extern int s2n_constant_time_equals(const uint8_t * a, const uint8_t * b, uint32
 /* Copy src to dst, or don't copy it, in constant time */
 extern int s2n_constant_time_copy_or_dont(const uint8_t * dst, const uint8_t * src, uint32_t len, uint8_t dont);
 
+/* If src contains valid PKCS#1 v1.5 padding of exactly expectlen bytes, decode
+ * it into dst, otherwise leave dst alone, in constant time.
+ * Always returns zero. */
+extern int s2n_constant_time_pkcs1_unpad_or_dont(uint8_t * dst, const uint8_t * src, uint32_t srclen, uint32_t expectlen);
+
 /* Runs _thecleanup function on _thealloc once _thealloc went out of scope */
 #define DEFER_CLEANUP(_thealloc, _thecleanup) \
    __attribute__((cleanup(_thecleanup))) _thealloc


### PR DESCRIPTION
This resolves the "9 Lives of Bleichenbacher's CAT" timing issue, as described at
http://cat.eyalro.net/. Thanks to Eyal Ronen, Robert Gillham, Daniel Genkin,
Adi Shamir, David Wong and Yuval Yarom for the report.

**Issue # (if available):** 

**Description of changes:** 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
