### PR TITLE
Update s2n_public_random with better variable name to be clear the pa…

### DIFF
--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -166,11 +166,14 @@ int s2n_get_urandom_data(struct s2n_blob *blob)
     return 0;
 }
 
-int64_t s2n_public_random(int64_t max)
+/*
+ * Return a random number in the range [0, bound)
+ */
+int64_t s2n_public_random(int64_t bound)
 {
     uint64_t r;
 
-    gt_check(max, 0);
+    gt_check(bound, 0);
 
     while (1) {
         struct s2n_blob blob = {.data = (void *)&r, sizeof(r) };
@@ -184,13 +187,13 @@ int64_t s2n_public_random(int64_t max)
          * r == 257 is out of range.
          *
          * To de-bias the dice, we discard values of r that are higher
-         * that the highest multiple of 'max' an int can support. If
-         * max is a uint, then in the worst case we discard 50% - 1 r's.
-         * But since 'max' is an int and INT_MAX is <= UINT_MAX / 2,
+         * that the highest multiple of 'bound' an int can support. If
+         * bound is a uint, then in the worst case we discard 50% - 1 r's.
+         * But since 'bound' is an int and INT_MAX is <= UINT_MAX / 2,
          * in the worst case we discard 25% - 1 r's.
          */
-        if (r < (UINT64_MAX - (UINT64_MAX % max))) {
-            return r % max;
+        if (r < (UINT64_MAX - (UINT64_MAX % bound))) {
+            return r % bound;
         }
     }
 }


### PR DESCRIPTION
…ramter is exclusive

**Issue # (if available):** 
https://github.com/awslabs/s2n/issues/805

**Description of changes:** 
s2n_public_random is used in 3 places currently:
* s2n_record_test: picks a random byte to corrupt. This correctly uses length of the fragment as the parameter which should be exclusive
* s2n_connection: pick a random amount of time to sleep between 10 and 30 seconds in nanoseconds.  In theory can never sleep for 30 seconds exactly and could be updated , it still has 19,999,999,999 other valid delays
* s2n_resume: pick a random weight for a ticket, correctly picks a number between [0,1)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
