### PR TITLE
Prefer shared lib over static lib for finding libcrypto

### DIFF
--- a/cmake/modules/FindLibCrypto.cmake
+++ b/cmake/modules/FindLibCrypto.cmake
@@ -18,7 +18,7 @@ find_path(LibCrypto_INCLUDE_DIR
         )
 
 find_library(LibCrypto_LIBRARY
-        NAMES libcrypto.a libcrypto.so
+        NAMES libcrypto.so libcrypto.a
         HINTS ${CMAKE_INSTALL_PREFIX}/build/crypto
         ${CMAKE_INSTALL_PREFIX}/build
         ${CMAKE_INSTALL_PREFIX}


### PR DESCRIPTION
Otherwise, most of the time when you try to link libcrypto, you get lots of -fPIC warnings, because the static lib is not compiled with -fPIC.

This unblocks all of the aws-crt-* repos

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
