### PR TITLE
Use the first matching sigalg

### DIFF
--- a/tls/s2n_client_cert_verify.c
+++ b/tls/s2n_client_cert_verify.c
@@ -44,10 +44,12 @@ int s2n_client_cert_verify_recv(struct s2n_connection *conn)
     signature.size = signature_size;
     signature.data = s2n_stuffer_raw_read(in, signature.size);
     notnull_check(signature.data);
+
+    /* Use a copy of the hash state since the verify digest computation may modify the running hash state we need later. */
     struct s2n_hash_state hash_state = {0};
     GUARD(s2n_handshake_get_hash_state(conn, chosen_hash_alg, &hash_state));
     GUARD(s2n_hash_copy(&conn->handshake.ccv_hash_copy, &hash_state));
-    
+
     switch (chosen_signature_alg) {
     case S2N_SIGNATURE_RSA:
     case S2N_SIGNATURE_ECDSA:
@@ -79,8 +81,10 @@ int s2n_client_cert_verify_send(struct s2n_connection *conn)
         GUARD(s2n_stuffer_write_uint8(out, (uint8_t) chosen_signature_alg));
     }
 
+    /* Use a copy of the hash state since the verify digest computation may modify the running hash state we need later. */
     struct s2n_hash_state hash_state = {0};
     GUARD(s2n_handshake_get_hash_state(conn, chosen_hash_alg, &hash_state));
+    GUARD(s2n_hash_copy(&conn->handshake.ccv_hash_copy, &hash_state));
 
     struct s2n_blob signature = {0};
 
@@ -92,7 +96,7 @@ int s2n_client_cert_verify_send(struct s2n_connection *conn)
 
         signature.data = s2n_stuffer_raw_write(out, signature.size);
         notnull_check(signature.data);
-        GUARD(s2n_pkey_sign(&conn->config->cert_and_key_pairs->private_key, &hash_state, &signature));
+        GUARD(s2n_pkey_sign(&conn->config->cert_and_key_pairs->private_key, &conn->handshake.ccv_hash_copy, &signature));
         break;
     default:
         S2N_ERROR(S2N_ERR_INVALID_SIGNATURE_ALGORITHM);

--- a/tls/s2n_signature_algorithms.c
+++ b/tls/s2n_signature_algorithms.c
@@ -27,7 +27,7 @@ static int s2n_sig_hash_algs_pairs_set(struct s2n_sig_hash_alg_pairs *sig_hash_a
     if (hash_alg < TLS_HASH_ALGORITHM_COUNT && sig_alg < TLS_SIGNATURE_ALGORITHM_COUNT) {
         sig_hash_algs->matrix[sig_alg][hash_alg] = 1;
     }
-    
+
     return 0;
 }
 
@@ -68,12 +68,13 @@ int s2n_set_signature_hash_pair_from_preference_list(struct s2n_connection *conn
         if (s2n_sig_hash_alg_pairs_get(sig_hash_algs, sig_alg_chosen, s2n_preferred_hashes[i]) == 1) {
             /* Just set hash_alg_chosen because sig_alg_chosen was set above based on cert type */
             hash_alg_chosen = s2n_hash_tls_to_alg[s2n_preferred_hashes[i]];
+            break;
         }
     }
 
     *hash = hash_alg_chosen;
     *sig = sig_alg_chosen;
-    
+
     return 0;
 }
 


### PR DESCRIPTION
Previously we iterated thru the entire list. Short circuit and choose
the first match from the preference list.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
