### PR TITLE
Remove s2n_cleanup_atexit() handler

### DIFF
--- a/utils/s2n_init.c
+++ b/utils/s2n_init.c
@@ -58,7 +58,6 @@ int s2n_cleanup(void)
 static void s2n_cleanup_atexit(void)
 {
     s2n_rand_cleanup_thread();
-    s2n_cipher_suites_cleanup();
     s2n_rand_cleanup();
     s2n_mem_cleanup();
     s2n_wipe_static_configs();


### PR DESCRIPTION
**Issue # (if available):** 
None

**Description of changes:** 
Removes the call to `s2n_cipher_suites_cleanup()` in the `atexit()` handler code that cleans up memory on process exit. 

This change is being made because locally running `kill <s2n_pid>` on a process with active connections may result in a Segfault and coredump of the process memory. This happens because the `s2n_cipher_suites_cleanup()`  NULL's out the global cipher algorithm function pointers, causing a race condition to occur with other active threads that may attempt to dereference these null pointers. 

We want to avoid creating coredumps since they contain private information that we don't want written to disk.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
