### PR TITLE
[Recreated] Add check for cert type when choosing cipher

### DIFF
--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -629,6 +629,7 @@ struct {
     { "test_all", &cipher_preferences_test_all },
     { "test_all_fips", &cipher_preferences_test_all_fips },
     { "test_all_ecdsa", &cipher_preferences_test_all_ecdsa },
+    { "test_ecdsa_priority", &cipher_preferences_test_ecdsa_priority },
     { "null", &cipher_preferences_null },
     { NULL, NULL }
 };

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -40,6 +40,7 @@ extern const struct s2n_cipher_preferences cipher_preferences_20170718;
 extern const struct s2n_cipher_preferences cipher_preferences_test_all;
 extern const struct s2n_cipher_preferences cipher_preferences_test_all_fips;
 extern const struct s2n_cipher_preferences cipher_preferences_test_all_ecdsa;
+extern const struct s2n_cipher_preferences cipher_preferences_test_ecdsa_priority;
 
 /* See https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html */
 extern const struct s2n_cipher_preferences elb_security_policy_2015_04;


### PR DESCRIPTION
**Issue # (if available):** 

**Description of changes:** 
    - In order to support ECDSA, we need to be able to choose ECDSA
    cipher instead of RSA when there is an ECDSA certificate configured
    - Added testing for both RSA cert/cipher and ECDSA cert/cipher
    matching (Unit test and Integration test).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
