### PR TITLE
Add API to get the Version of Openssl that s2n was compiled with

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -50,6 +50,7 @@ extern int s2n_error_get_type(int error);
 struct s2n_config;
 struct s2n_connection;
 
+extern unsigned long s2n_get_openssl_version();
 extern int s2n_init(void);
 extern int s2n_cleanup(void);
 extern struct s2n_config *s2n_config_new(void);

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -442,6 +442,16 @@ if (s2n_recv(conn, &blocked) < 0) {
 
 ## Initialization and teardown
 
+### s2n\_get\_openssl\_version
+
+```c
+unsigned long s2n_get_openssl_version();
+```
+
+**s2n_get_openssl_version** returns the version number of OpenSSL that s2n was compiled with. It can be used by 
+applications to validate at runtime that the versions of s2n and Openssl that they have loaded are correct.
+
+
 ### s2n\_init
 
 ```c

--- a/utils/s2n_init.c
+++ b/utils/s2n_init.c
@@ -20,7 +20,14 @@
 #include "utils/s2n_random.h"
 #include "utils/s2n_safety.h"
 
+#include "openssl/opensslv.h"
+
 static void s2n_cleanup_atexit(void);
+
+unsigned long s2n_get_openssl_version()
+{
+    return OPENSSL_VERSION_NUMBER;
+}
 
 int s2n_init(void)
 {


### PR DESCRIPTION
**Issue # (if available):** N/A

**Description of changes:** 
Adds new API to get the OpenSSL Version that s2n was compiled with.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
