### PR TITLE
Move selected cert_chain to s2n_handshake_parameters

### DIFF
--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -921,11 +921,12 @@ static int s2n_cipher_is_compatible_with_cert(struct s2n_cipher_suite *cipher, s
     return 0;
 }
 
-static int s2n_set_cipher_as_server(struct s2n_connection *conn, uint8_t * wire, uint32_t count, uint32_t cipher_suite_len)
+static int s2n_set_cipher_as_server(struct s2n_connection *conn, uint8_t *wire, uint32_t count, uint32_t cipher_suite_len)
 {
-    /* Only one cert chain for now */
+    /* Only one cert chain for now. */
     notnull_check(conn->config->cert_and_key_pairs);
-    struct s2n_cert *leaf_cert = conn->config->cert_and_key_pairs->cert_chain->head;
+    conn->handshake_params.chain_and_key = conn->config->cert_and_key_pairs;
+    struct s2n_cert *leaf_cert = conn->handshake_params.chain_and_key->cert_chain->head;
 
     uint8_t renegotiation_info_scsv[S2N_TLS_CIPHER_SUITE_LEN] = { TLS_EMPTY_RENEGOTIATION_INFO_SCSV };
     struct s2n_cipher_suite *higher_vers_match = NULL;

--- a/tls/s2n_client_cert.c
+++ b/tls/s2n_client_cert.c
@@ -76,7 +76,7 @@ int s2n_client_cert_recv(struct s2n_connection *conn)
 
 int s2n_client_cert_send(struct s2n_connection *conn)
 {
-    struct s2n_cert_chain_and_key *chain_and_key = conn->config->cert_and_key_pairs;
+    struct s2n_cert_chain_and_key *chain_and_key = conn->handshake_params.chain_and_key;
     /* TODO: Check that RSA is in conn->server_preferred_cert_types and conn->secure.client_cert_sig_algorithm */
 
     if (chain_and_key == NULL) {

--- a/tls/s2n_client_cert_request.c
+++ b/tls/s2n_client_cert_request.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -26,6 +26,12 @@
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_safety.h"
 
+static int s2n_set_cert_chain_as_client(struct s2n_connection *conn)
+{
+    conn->handshake_params.chain_and_key = conn->config->cert_and_key_pairs;
+
+    return 0;
+}
 
 int s2n_client_cert_req_recv(struct s2n_connection *conn)
 {
@@ -49,6 +55,12 @@ int s2n_client_cert_req_recv(struct s2n_connection *conn)
      * Don't fail just yet as we still may succeed if we provide
      * right certificate or if ClientAuth is optional. */
     GUARD(s2n_stuffer_skip_read(in, cert_authorities_len));
+
+    /* In the future we may have more advanced logic to match a set of configured certificates against
+     * The cert authorities extension and the signature algorithms advertised.
+     * For now, this will just set the only certificate configured.
+     */
+    GUARD(s2n_set_cert_chain_as_client(conn));
 
     return 0;
 }

--- a/tls/s2n_client_cert_verify.c
+++ b/tls/s2n_client_cert_verify.c
@@ -88,15 +88,16 @@ int s2n_client_cert_verify_send(struct s2n_connection *conn)
 
     struct s2n_blob signature = {0};
 
+    struct s2n_cert_chain_and_key *cert_chain_and_key = conn->handshake_params.chain_and_key;
     switch (chosen_signature_alg) {
     /* s2n currently only supports RSA Signatures */
     case S2N_SIGNATURE_RSA:
-        signature.size = s2n_pkey_size(conn->config->cert_and_key_pairs->private_key);
+        signature.size = s2n_pkey_size(cert_chain_and_key->private_key);
         GUARD(s2n_stuffer_write_uint16(out, signature.size));
 
         signature.data = s2n_stuffer_raw_write(out, signature.size);
         notnull_check(signature.data);
-        GUARD(s2n_pkey_sign(conn->config->cert_and_key_pairs->private_key, &conn->handshake.ccv_hash_copy, &signature));
+        GUARD(s2n_pkey_sign(cert_chain_and_key->private_key, &conn->handshake.ccv_hash_copy, &signature));
         break;
     default:
         S2N_ERROR(S2N_ERR_INVALID_SIGNATURE_ALGORITHM);

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -223,8 +223,9 @@ static int s2n_process_client_hello(struct s2n_connection *conn)
     }
 
     /* Now choose the ciphers and the cert chain. */
+    /* For now, set the only cert we have configured. */
+    conn->handshake_params.chain_and_key = conn->config->cert_and_key_pairs;
     GUARD(s2n_set_cipher_as_tls_server(conn, client_hello->cipher_suites.data, client_hello->cipher_suites.size / 2));
-    conn->server->server_cert_chain = conn->config->cert_and_key_pairs;
 
     /* And set the signature and hash algorithm used for key exchange signatures */
     GUARD(s2n_set_signature_hash_pair_from_preference_list(conn, &conn->handshake_params.client_sig_hash_algs, &conn->secure.conn_hash_alg, &conn->secure.conn_sig_alg));
@@ -425,6 +426,9 @@ int s2n_sslv2_client_hello_recv(struct s2n_connection *conn)
 
     S2N_ERROR_IF(challenge_length > S2N_TLS_RANDOM_DATA_LEN, S2N_ERR_BAD_MESSAGE);
 
+    /* For now, set the only cert we have configured. */
+    conn->handshake_params.chain_and_key = conn->config->cert_and_key_pairs;
+
     cipher_suites = s2n_stuffer_raw_read(in, cipher_suites_length);
     notnull_check(cipher_suites);
     GUARD(s2n_set_cipher_as_sslv2_server(conn, cipher_suites, cipher_suites_length / S2N_SSLv2_CIPHER_SUITE_LEN));
@@ -446,7 +450,6 @@ int s2n_sslv2_client_hello_recv(struct s2n_connection *conn)
 
     GUARD(s2n_stuffer_read(in, &b));
 
-    conn->server->server_cert_chain = conn->config->cert_and_key_pairs;
     GUARD(s2n_conn_set_handshake_type(conn));
 
     return 0;

--- a/tls/s2n_client_key_exchange.c
+++ b/tls/s2n_client_key_exchange.c
@@ -81,7 +81,7 @@ int s2n_rsa_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared
     conn->secure.rsa_premaster_secret[1] = client_protocol_version[1];
 
     /* Set rsa_failed to 1 if s2n_pkey_decrypt returns anything other than zero */
-    conn->handshake.rsa_failed = !!s2n_pkey_decrypt(conn->config->cert_and_key_pairs->private_key, &encrypted, shared_key);
+    conn->handshake.rsa_failed = !!s2n_pkey_decrypt(conn->handshake_params.chain_and_key->private_key, &encrypted, shared_key);
 
     /* Set rsa_failed to 1, if it isn't already, if the protocol version isn't what we expect */
     conn->handshake.rsa_failed |= !s2n_constant_time_equals(client_protocol_version, shared_key->data, S2N_TLS_PROTOCOL_VERSION_LEN);

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/tls/s2n_crypto.h
+++ b/tls/s2n_crypto.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -59,7 +59,6 @@ struct s2n_crypto_parameters {
     struct s2n_pkey client_public_key;
     struct s2n_dh_params server_dh_params;
     struct s2n_ecc_params server_ecc_params;
-    struct s2n_cert_chain_and_key *server_cert_chain;
     s2n_hash_algorithm conn_hash_alg;
     s2n_signature_algorithm conn_sig_alg;
     struct s2n_blob client_cert_chain;

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -52,6 +52,9 @@ struct s2n_handshake_parameters {
 
     /* Signature/hash algorithm pairs offered by the server in the certificate request */
     struct s2n_sig_hash_alg_pairs server_sig_hash_algs;
+
+    /* The cert chain we will send the peer. */
+    struct s2n_cert_chain_and_key *chain_and_key;
 };
 
 struct s2n_handshake {

--- a/tls/s2n_kex.c
+++ b/tls/s2n_kex.c
@@ -62,7 +62,7 @@ static int write_no_extension(const struct s2n_connection *conn, struct s2n_stuf
 
 static int check_rsa_key(const struct s2n_connection *conn)
 {
-    return conn->config->cert_and_key_pairs != NULL;
+    return conn->handshake_params.chain_and_key != NULL;
 }
 
 static int check_dhe(const struct s2n_connection *conn)

--- a/tls/s2n_ocsp_stapling.c
+++ b/tls/s2n_ocsp_stapling.c
@@ -27,8 +27,8 @@
 int s2n_server_status_send(struct s2n_connection *conn)
 {
     GUARD(s2n_stuffer_write_uint8(&conn->handshake.io, (uint8_t) S2N_STATUS_REQUEST_OCSP));
-    GUARD(s2n_stuffer_write_uint24(&conn->handshake.io, conn->config->cert_and_key_pairs->ocsp_status.size));
-    GUARD(s2n_stuffer_write(&conn->handshake.io, &conn->config->cert_and_key_pairs->ocsp_status));
+    GUARD(s2n_stuffer_write_uint24(&conn->handshake.io, conn->handshake_params.chain_and_key->ocsp_status.size));
+    GUARD(s2n_stuffer_write(&conn->handshake.io, &conn->handshake_params.chain_and_key->ocsp_status));
 
     return 0;
 }

--- a/tls/s2n_server_cert.c
+++ b/tls/s2n_server_cert.c
@@ -64,7 +64,6 @@ int s2n_server_cert_recv(struct s2n_connection *conn)
 
 int s2n_server_cert_send(struct s2n_connection *conn)
 {
-    GUARD(s2n_send_cert_chain(&conn->handshake.io, conn->server->server_cert_chain->cert_chain));
-    
+    GUARD(s2n_send_cert_chain(&conn->handshake.io, conn->handshake_params.chain_and_key->cert_chain));
     return 0;
 }

--- a/tls/s2n_server_extensions.c
+++ b/tls/s2n_server_extensions.c
@@ -55,7 +55,7 @@ int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *
     total_size += s2n_kex_server_extension_size(conn->secure.cipher_suite->key_exchange_alg, conn);
 
     if (s2n_server_can_send_sct_list(conn)) {
-        total_size += 4 + conn->config->cert_and_key_pairs->sct_list.size;
+        total_size += 4 + conn->handshake_params.chain_and_key->sct_list.size;
     }
     if (conn->mfl_code) {
         total_size += 5;
@@ -99,9 +99,9 @@ int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *
     /* Write Signed Certificate Timestamp extension */
     if (s2n_server_can_send_sct_list(conn)) {
         GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_SCT_LIST));
-        GUARD(s2n_stuffer_write_uint16(out, conn->config->cert_and_key_pairs->sct_list.size));
-        GUARD(s2n_stuffer_write_bytes(out, conn->config->cert_and_key_pairs->sct_list.data,
-                                      conn->config->cert_and_key_pairs->sct_list.size));
+        GUARD(s2n_stuffer_write_uint16(out, conn->handshake_params.chain_and_key->sct_list.size));
+        GUARD(s2n_stuffer_write_bytes(out, conn->handshake_params.chain_and_key->sct_list.data,
+                                      conn->handshake_params.chain_and_key->sct_list.size));
     }
 
     if (conn->mfl_code) {

--- a/tls/s2n_server_key_exchange.c
+++ b/tls/s2n_server_key_exchange.c
@@ -160,7 +160,7 @@ int s2n_server_key_send(struct s2n_connection *conn)
     GUARD(s2n_hash_update(signature_hash, data_to_sign.data, data_to_sign.size));
 
     /* Sign and write the signature */
-    GUARD(s2n_write_signature_blob(out, conn->config->cert_and_key_pairs->private_key, signature_hash));
+    GUARD(s2n_write_signature_blob(out, conn->handshake_params.chain_and_key->private_key, signature_hash));
     return 0;
 }
 

--- a/tls/s2n_tls.h
+++ b/tls/s2n_tls.h
@@ -70,15 +70,15 @@ extern uint16_t mfl_code_to_length[5];
         ((conn)->ec_point_formats)
 
 #define s2n_server_can_send_ocsp(conn) ((conn)->status_type == S2N_STATUS_REQUEST_OCSP && \
-        (conn)->config->cert_and_key_pairs && \
-        (conn)->config->cert_and_key_pairs->ocsp_status.size > 0)
+        (conn)->handshake_params.chain_and_key && \
+        (conn)->handshake_params.chain_and_key->ocsp_status.size > 0)
 
 #define s2n_server_sent_ocsp(conn) ((conn)->mode == S2N_CLIENT && \
         (conn)->status_type == S2N_STATUS_REQUEST_OCSP)
 
 #define s2n_server_can_send_sct_list(conn) ((conn)->ct_level_requested == S2N_CT_SUPPORT_REQUEST && \
-        (conn)->config->cert_and_key_pairs && \
-        (conn)->config->cert_and_key_pairs->sct_list.size > 0)
+        (conn)->handshake_params.chain_and_key && \
+        (conn)->handshake_params.chain_and_key->sct_list.size > 0)
 
 #define s2n_server_sending_nst(conn) ((conn)->config->use_tickets && \
         (conn)->session_ticket_status == S2N_NEW_TICKET)


### PR DESCRIPTION
Previously this field lived in the s2n_crypto_parameters which is a very
bloated struct that should focus on holding record security state.

This change is a part of an iterative refactor where we'd like
to move negotiated handshake parameters(cipher, certificate, sigalgs)
to the s2n_handshake_parameter struct.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
