### PR TITLE
fixed invalid C function prototype

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -50,7 +50,7 @@ extern int s2n_error_get_type(int error);
 struct s2n_config;
 struct s2n_connection;
 
-extern unsigned long s2n_get_openssl_version();
+extern unsigned long s2n_get_openssl_version(void);
 extern int s2n_init(void);
 extern int s2n_cleanup(void);
 extern struct s2n_config *s2n_config_new(void);

--- a/utils/s2n_init.c
+++ b/utils/s2n_init.c
@@ -24,7 +24,7 @@
 
 static void s2n_cleanup_atexit(void);
 
-unsigned long s2n_get_openssl_version()
+unsigned long s2n_get_openssl_version(void)
 {
     return OPENSSL_VERSION_NUMBER;
 }


### PR DESCRIPTION
Invalid C prototype s2n_get_openssl_version (-Werror=strict-prototypes) was added in commit: https://github.com/awslabs/s2n/commit/f01ea6ec2ff7d80600e5a1a080707f122bd4511b

**Description of changes:** 
Added void to to signify no parameters

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
