### PR TITLE
Retry installing test dependencies to mitigate network timeout impacts during builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,7 @@ matrix:
   fast_finish: true
 
 before_install:
+  - apt-key list
   - source .travis/s2n_setup_env.sh
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ before_install:
   - source .travis/s2n_setup_env.sh
 
 install:
-  - .travis/s2n_install_test_dependencies.sh
+  - travis_retry .travis/s2n_install_test_dependencies.sh
   
 script:
   - .travis/s2n_travis_build.sh


### PR DESCRIPTION
**Issue # (if available):** 
N/A

**Description of changes:** 
I noticed a lot of build failures during dependency installation like https://travis-ci.org/awslabs/s2n/jobs/487108904 and https://docs.travis-ci.com/user/common-build-problems/#timeouts-installing-dependencies recommends using this built in travis function. I can't find a case where it logged that did retry something but it doesn't seem to hurt either.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
