### PR TITLE
Fix Flaky AES and ChaCha AEAD Unit Tests

### DIFF
--- a/tests/unit/s2n_aead_aes_test.c
+++ b/tests/unit/s2n_aead_aes_test.c
@@ -78,6 +78,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_wipe(conn));
         EXPECT_SUCCESS(s2n_connection_prefer_low_latency(conn));
+        conn->actual_protocol_version_established = 1;
         conn->server_protocol_version = S2N_TLS12;
         conn->client_protocol_version = S2N_TLS12;
         conn->actual_protocol_version = S2N_TLS12;
@@ -130,6 +131,7 @@ int main(int argc, char **argv)
 
         /* Start over */
         EXPECT_SUCCESS(s2n_connection_wipe(conn));
+        conn->actual_protocol_version_established = 1;
         conn->server_protocol_version = S2N_TLS12;
         conn->client_protocol_version = S2N_TLS12;
         conn->actual_protocol_version = S2N_TLS12;
@@ -146,10 +148,22 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
         /* Tamper the protocol version in the header, and ensure decryption fails, as we use this in the AAD */
-        conn->in.blob.data[2] = 2;
+        EXPECT_EQUAL(conn->header_in.blob.data[0], TLS_APPLICATION_DATA);
+        conn->header_in.blob.data[0] ^= 1; // Flip a bit in the content_type of the TLS Record Header
+
         EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
+        EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA ^ 1);
+
+        /**
+         * We are trying to test the case when the Additional Authenticated Data in AEAD ciphers is tampered with.
+         *
+         * AEAD Ciphers authenticate several fields, including the TLS Record content_type, so this should fail since
+         * we flipped a bit. See s2n_aead_aad_init() for which fields are added to the additional authenticated data.
+         *
+         * We can't flip the TLS Protocol Version bits here because s2n_record_header_parse() will error before we
+         * attempt decryption with AES-GCM because the Protocol version doesn't match "conn->actual_protocol_version".
+         */
         EXPECT_FAILURE(s2n_record_parse(conn));
-        EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
@@ -157,6 +171,7 @@ int main(int argc, char **argv)
         /* Tamper with the explicit IV and ensure decryption fails */
         for (int j = 0; j < S2N_TLS_GCM_EXPLICIT_IV_LEN; j++) {
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
+            conn->actual_protocol_version_established = 1;
             conn->server_protocol_version = S2N_TLS12;
             conn->client_protocol_version = S2N_TLS12;
             conn->actual_protocol_version = S2N_TLS12;
@@ -182,6 +197,7 @@ int main(int argc, char **argv)
         /* Tamper with the TAG and ensure decryption fails */
         for (int j = 0; j < S2N_TLS_GCM_TAG_LEN; j++) {
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
+            conn->actual_protocol_version_established = 1;
             conn->server_protocol_version = S2N_TLS12;
             conn->client_protocol_version = S2N_TLS12;
             conn->actual_protocol_version = S2N_TLS12;
@@ -207,6 +223,7 @@ int main(int argc, char **argv)
         /* Tamper with the ciphertext and ensure decryption fails */
         for (int j = 0; j < i - S2N_TLS_GCM_TAG_LEN; j++) {
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
+            conn->actual_protocol_version_established = 1;
             conn->server_protocol_version = S2N_TLS12;
             conn->client_protocol_version = S2N_TLS12;
             conn->actual_protocol_version = S2N_TLS12;
@@ -245,6 +262,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_wipe(conn));
         /* Set prefer low latency for S2N_SMALL_FRAGMENT_LENGTH for */
         EXPECT_SUCCESS(s2n_connection_prefer_low_latency(conn));
+        conn->actual_protocol_version_established = 1;
         conn->server_protocol_version = S2N_TLS12;
         conn->client_protocol_version = S2N_TLS12;
         conn->actual_protocol_version = S2N_TLS12;
@@ -323,6 +341,7 @@ int main(int argc, char **argv)
         /* Tamper with the IV and ensure decryption fails */
         for (int j = 0; j < S2N_TLS_GCM_IV_LEN; j++) {
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
+            conn->actual_protocol_version_established = 1;
             conn->server_protocol_version = S2N_TLS12;
             conn->client_protocol_version = S2N_TLS12;
             conn->actual_protocol_version = S2N_TLS12;
@@ -349,6 +368,7 @@ int main(int argc, char **argv)
         /* Tamper with the TAG and ensure decryption fails */
         for (int j = 0; j < S2N_TLS_GCM_TAG_LEN; j++) {
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
+            conn->actual_protocol_version_established = 1;
             conn->server_protocol_version = S2N_TLS12;
             conn->client_protocol_version = S2N_TLS12;
             conn->actual_protocol_version = S2N_TLS12;
@@ -375,6 +395,7 @@ int main(int argc, char **argv)
         /* Tamper with the ciphertext and ensure decryption fails */
         for (int j = S2N_TLS_GCM_IV_LEN; j < i - S2N_TLS_GCM_TAG_LEN; j++) {
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
+            conn->actual_protocol_version_established = 1;
             conn->server_protocol_version = S2N_TLS12;
             conn->client_protocol_version = S2N_TLS12;
             conn->actual_protocol_version = S2N_TLS12;


### PR DESCRIPTION
**Issue # (if available):** https://github.com/awslabs/s2n/issues/675

**Description of changes:** 
Fixes the Flakiness of the ChaCha AEAD unit test. 

The problem was that `conn->in.blob.data[2] = 2;` is setting the 2nd byte of encrypted data to `2` when it 's possible for that byte to already be `2`, causing the `EXPECT_FAILURE(s2n_record_parse(conn));` to pass when it should fail. 

The original intention of this line was to change `conn->header_in.blob.data[2]` (the 2nd byte of the TLS Record Header) not the 2nd byte of the encrypted data. These Header bytes are included in the "Additional Authenticated Data" for all AEAD ciphers, so flipping those bytes should cause the Authentication to fail for any AEAD cipher. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
