### PR TITLE
Fixed a rare crash issue in tls

### DIFF
--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -827,9 +827,7 @@ int s2n_cipher_suites_cleanup(void)
 
         /* Release custom SSLv3 cipher suites */
         if (cur_suite->sslv3_cipher_suite != cur_suite) {
-            struct s2n_cipher_suite *sslv3_suite = cur_suite->sslv3_cipher_suite;
-            struct s2n_blob sslv3_suite_mem = {.data = (uint8_t *) sslv3_suite, .size = sizeof(struct s2n_cipher_suite)};
-            GUARD(s2n_free(&sslv3_suite_mem));
+            GUARD(s2n_free_object((uint8_t **)&cur_suite->sslv3_cipher_suite, sizeof(struct s2n_cipher_suite)));
         }
         cur_suite->sslv3_cipher_suite = NULL;
     }

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -128,8 +128,7 @@ int s2n_client_hello_free_parsed_extensions(struct s2n_client_hello *client_hell
 {
     notnull_check(client_hello);
     if (client_hello->parsed_extensions != NULL) {
-        GUARD(s2n_array_free(client_hello->parsed_extensions));
-        client_hello->parsed_extensions = NULL;
+        GUARD(s2n_array_free_p(&client_hello->parsed_extensions));
     }
     return 0;
 }

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -282,26 +282,19 @@ int s2n_config_free_cert_chain_and_key(struct s2n_config *config)
 
 int s2n_config_free_dhparams(struct s2n_config *config)
 {
-    struct s2n_blob b = {
-        .data = (uint8_t *) config->dhparams,
-        .size = sizeof(struct s2n_dh_params)
-    };
-
     if (config->dhparams) {
         GUARD(s2n_dh_params_free(config->dhparams));
     }
 
-    GUARD(s2n_free(&b));
+    GUARD(s2n_free_object((uint8_t **)&config->dhparams, sizeof(struct s2n_dh_params)));
     return 0;
 }
 
 int s2n_config_free(struct s2n_config *config)
 {
-    struct s2n_blob b = {.data = (uint8_t *) config,.size = sizeof(struct s2n_config) };
-
     s2n_config_cleanup(config);
 
-    GUARD(s2n_free(&b));
+    GUARD(s2n_free_object((uint8_t **)&config, sizeof(struct s2n_config)));
     return 0;
 }
 

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -257,13 +257,11 @@ int s2n_config_init_session_ticket_keys(struct s2n_config *config)
 int s2n_config_free_session_ticket_keys(struct s2n_config *config)
 {
     if (config->ticket_keys != NULL) {
-        GUARD(s2n_array_free(config->ticket_keys));
-        config->ticket_keys = NULL;
+        GUARD(s2n_array_free_p(&config->ticket_keys));
     }
 
     if (config->ticket_key_hashes != NULL) {
-        GUARD(s2n_array_free(config->ticket_key_hashes));
-        config->ticket_key_hashes = NULL;
+        GUARD(s2n_array_free_p(&config->ticket_key_hashes));
     }
 
     return 0;
@@ -650,7 +648,7 @@ int s2n_config_add_ticket_crypto_key(struct s2n_config *config,
     GUARD(s2n_hash_digest(&hash, hash_output, SHA_DIGEST_LENGTH));
 
     if (config->ticket_key_hashes->num_of_elements >= S2N_MAX_TICKET_KEY_HASHES) {
-        GUARD(s2n_array_free(config->ticket_key_hashes));
+        GUARD(s2n_array_free_p(&config->ticket_key_hashes));
         notnull_check(config->ticket_key_hashes = s2n_array_new(SHA_DIGEST_LENGTH));
     }
 

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -352,20 +352,8 @@ static int s2n_connection_free_io_contexts(struct s2n_connection *conn)
         return 0;
     }
 
-    struct s2n_blob send_io_blob = {0};
-    struct s2n_blob recv_io_blob = {0};
-
-    if (conn->send_io_context) {
-        send_io_blob.data = (uint8_t *)conn->send_io_context;
-        send_io_blob.size = sizeof(struct s2n_socket_write_io_context);
-        GUARD(s2n_free(&send_io_blob));
-    }
-
-    if (conn->recv_io_context) {
-        recv_io_blob.data = (uint8_t *)conn->recv_io_context;
-        recv_io_blob.size = sizeof(struct s2n_socket_read_io_context);
-        GUARD(s2n_free(&recv_io_blob));
-    }
+    GUARD(s2n_free_object((uint8_t **)&conn->send_io_context, sizeof(struct s2n_socket_write_io_context)));
+    GUARD(s2n_free_object((uint8_t **)&conn->recv_io_context, sizeof(struct s2n_socket_read_io_context)));
 
     return 0;
 }
@@ -459,8 +447,6 @@ static uint8_t s2n_default_verify_host(const char *host_name, size_t len, void *
 
 int s2n_connection_free(struct s2n_connection *conn)
 {
-    struct s2n_blob blob = {0};
-
     GUARD(s2n_connection_wipe_keys(conn));
     GUARD(s2n_connection_free_keys(conn));
 
@@ -482,11 +468,8 @@ int s2n_connection_free(struct s2n_connection *conn)
     s2n_x509_validator_wipe(&conn->x509_validator);
     GUARD(s2n_client_hello_free(&conn->client_hello));
     GUARD(s2n_free(&conn->application_protocols_overridden));
+    GUARD(s2n_free_object((uint8_t **)&conn, sizeof(struct s2n_connection)));
 
-    blob.data = (uint8_t *) conn;
-    blob.size = sizeof(struct s2n_connection);
-
-    GUARD(s2n_free(&blob));
     return 0;
 }
 

--- a/utils/s2n_array.c
+++ b/utils/s2n_array.c
@@ -127,22 +127,24 @@ int s2n_array_remove(struct s2n_array *array, uint32_t index)
     return 0;
 }
 
-int s2n_array_free(struct s2n_array *array)
+int s2n_array_free_p(struct s2n_array **parray)
 {
-    notnull_check(array);
-    struct s2n_blob mem = {0};
+    notnull_check(parray);
+    struct s2n_array *array = *parray;
 
+    notnull_check(array);
     /* Free the elements */
-    mem.data = (void *) array->elements;
-    mem.size = array->capacity * array->element_size;
-    GUARD(s2n_free(&mem));
+    GUARD(s2n_free_object((uint8_t **)&array->elements, array->capacity * array->element_size));
 
     /* And finally the array */
-    mem.data = (void *) array;
-    mem.size = sizeof(struct s2n_array);
-    GUARD(s2n_free(&mem));
+    GUARD(s2n_free_object((uint8_t **)parray, sizeof(struct s2n_array)));
 
     return 0;
+}
+
+int s2n_array_free(struct s2n_array *array)
+{
+    return s2n_array_free_p(&array);
 }
 
 int s2n_array_binary_search(int low, int top, struct s2n_array *array, void *element,

--- a/utils/s2n_array.h
+++ b/utils/s2n_array.h
@@ -35,5 +35,6 @@ extern void *s2n_array_add(struct s2n_array *array);
 extern void *s2n_array_get(struct s2n_array *array, uint32_t index);
 extern void *s2n_array_insert(struct s2n_array *array, uint32_t index);
 extern int s2n_array_remove(struct s2n_array *array, uint32_t index);
+extern int s2n_array_free_p(struct s2n_array **parray);
 extern int s2n_array_free(struct s2n_array *array);
 extern int s2n_array_binary_search(int low, int top, struct s2n_array *array, void *element, int (*comparator)(void*, void*));

--- a/utils/s2n_map.c
+++ b/utils/s2n_map.c
@@ -69,11 +69,7 @@ static int s2n_map_embiggen(struct s2n_map *map, uint32_t capacity)
             GUARD(s2n_free(&map->table[i].value));
         }
     }
-
-    /* Free the old memory */
-    mem.data = (void *) map->table;
-    mem.size = map->capacity * sizeof(struct s2n_map_entry);
-    GUARD(s2n_free(&mem));
+    GUARD(s2n_free_object((uint8_t **)&map->table, map->capacity * sizeof(struct s2n_map_entry)));
 
     /* Clone the temporary map */
     map->capacity = tmp.capacity;
@@ -209,8 +205,6 @@ int s2n_map_lookup(struct s2n_map *map, struct s2n_blob *key, struct s2n_blob *v
 
 int s2n_map_free(struct s2n_map *map)
 {
-    struct s2n_blob mem = {0};
-
     /* Free the keys and values */
     for (int i = 0; i < map->capacity; i++) {
         if (map->table[i].key.size) {
@@ -222,14 +216,10 @@ int s2n_map_free(struct s2n_map *map)
     GUARD(s2n_hash_free(&map->sha256));
 
     /* Free the table */
-    mem.data = (void *) map->table;
-    mem.size = map->capacity * sizeof(struct s2n_map_entry);
-    GUARD(s2n_free(&mem));
+    GUARD(s2n_free_object((uint8_t **)&map->table, map->capacity * sizeof(struct s2n_map_entry)));
 
     /* And finally the map */
-    mem.data = (void *) map;
-    mem.size = sizeof(struct s2n_map);
-    GUARD(s2n_free(&mem));
+    GUARD(s2n_free_object((uint8_t **)&map, sizeof(struct s2n_map)));
 
     return 0;
 }

--- a/utils/s2n_mem.h
+++ b/utils/s2n_mem.h
@@ -24,4 +24,5 @@ int s2n_mem_cleanup(void);
 int s2n_alloc(struct s2n_blob *b, uint32_t size);
 int s2n_realloc(struct s2n_blob *b, uint32_t size);
 int s2n_free(struct s2n_blob *b);
+int s2n_free_object(uint8_t **p_data, uint32_t size);
 int s2n_dup(struct s2n_blob *from, struct s2n_blob *to);


### PR DESCRIPTION
There are some cases that s2n_free() would free the memory but returns an error.
The utilization of GAURD() macro in caller would return the function and in
many cases that would happen before finishing all the memory release operations.
In some usages this behavior might end up in a double-free and crash. For
example, if a program calls s2n_connection_wipe() and s2n_connection_free(),
in both calls, the function s2n_connection_free_io_contexts() is getting
called. If the first call fails becaus of a munlock() issue, the second call
would try to free a memory that the first one has already free'd and that
causes a crash.
This change fixes the issue by nullifying variables that are already free'd.

**Issue # (if available):** 

**Description of changes:** 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
