### PR TITLE
Add AES256 counter DRBG support

### DIFF
--- a/crypto/s2n_aead_cipher_aes_gcm.c
+++ b/crypto/s2n_aead_cipher_aes_gcm.c
@@ -148,7 +148,7 @@ static int s2n_aead_cipher_aes256_gcm_set_decryption_key(struct s2n_session_key 
 
 static int s2n_aead_cipher_aes_gcm_init(struct s2n_session_key *key)
 {
-    EVP_CIPHER_CTX_init(key->evp_cipher_ctx);
+    s2n_evp_ctx_init(key->evp_cipher_ctx);
 
     return 0;
 }

--- a/crypto/s2n_aead_cipher_chacha20_poly1305.c
+++ b/crypto/s2n_aead_cipher_chacha20_poly1305.c
@@ -145,7 +145,7 @@ static int s2n_aead_chacha20_poly1305_set_decryption_key(struct s2n_session_key 
 
 static int s2n_aead_chacha20_poly1305_init(struct s2n_session_key *key)
 {
-    EVP_CIPHER_CTX_init(key->evp_cipher_ctx);
+    s2n_evp_ctx_init(key->evp_cipher_ctx);
 
     return 0;
 }

--- a/crypto/s2n_cbc_cipher_3des.c
+++ b/crypto/s2n_cbc_cipher_3des.c
@@ -18,6 +18,7 @@
 #include "error/s2n_errno.h"
 
 #include "crypto/s2n_cipher.h"
+#include "crypto/s2n_openssl.h"
 
 #include "utils/s2n_safety.h"
 #include "utils/s2n_blob.h"
@@ -74,7 +75,7 @@ static int s2n_cbc_cipher_3des_set_encryption_key(struct s2n_session_key *key, s
 
 static int s2n_cbc_cipher_3des_init(struct s2n_session_key *key)
 {
-    EVP_CIPHER_CTX_init(key->evp_cipher_ctx);
+    s2n_evp_ctx_init(key->evp_cipher_ctx);
 
     return 0;
 }

--- a/crypto/s2n_cbc_cipher_aes.c
+++ b/crypto/s2n_cbc_cipher_aes.c
@@ -18,6 +18,7 @@
 #include "error/s2n_errno.h"
 
 #include "crypto/s2n_cipher.h"
+#include "crypto/s2n_openssl.h"
 
 #include "utils/s2n_safety.h"
 #include "utils/s2n_blob.h"
@@ -99,7 +100,7 @@ int s2n_cbc_cipher_aes256_set_encryption_key(struct s2n_session_key *key, struct
 
 static int s2n_cbc_cipher_aes_init(struct s2n_session_key *key)
 {
-    EVP_CIPHER_CTX_init(key->evp_cipher_ctx);
+    s2n_evp_ctx_init(key->evp_cipher_ctx);
 
     return 0;
 }

--- a/crypto/s2n_composite_cipher_aes_sha.c
+++ b/crypto/s2n_composite_cipher_aes_sha.c
@@ -257,7 +257,7 @@ static int s2n_composite_cipher_aes256_sha256_set_decryption_key(struct s2n_sess
 
 static int s2n_composite_cipher_aes_sha_init(struct s2n_session_key *key)
 {
-    EVP_CIPHER_CTX_init(key->evp_cipher_ctx);
+    s2n_evp_ctx_init(key->evp_cipher_ctx);
 
     return 0;
 }

--- a/crypto/s2n_drbg.h
+++ b/crypto/s2n_drbg.h
@@ -22,17 +22,13 @@
 
 #define S2N_DRBG_BLOCK_SIZE 16
 #define S2N_DRBG_MAX_KEY_SIZE 32
-#define S2N_MAX_SEED_SIZE (S2N_DRBG_BLOCK_SIZE + S2N_DRBG_MAX_KEY_SIZE)
+#define S2N_DRBG_MAX_SEED_SIZE (S2N_DRBG_BLOCK_SIZE + S2N_DRBG_MAX_KEY_SIZE)
 
 /* The maximum size of any one request: from NIST SP800-90A 10.2.1 Table 3 */
 #define S2N_DRBG_GENERATE_LIMIT 8192
 
 /* We reseed after 2^35 bytes have been generated: from NIST SP800-90A 10.2.1 Table 3 */
 #define S2N_DRBG_RESEED_LIMIT   34359738368
-
-#define s2n_drbg_key_size(drgb) EVP_CIPHER_CTX_key_length((drbg)->ctx)
-#define s2n_drbg_seed_size(drgb) (S2N_DRBG_BLOCK_SIZE + s2n_drbg_key_size(drgb))
-
 
 struct s2n_drbg {
     /* Track how many bytes have been used */
@@ -56,16 +52,23 @@ struct s2n_drbg {
     uint32_t generation;
 };
 
+/*
+ * S2N_AES_128_CTR_NO_DF_PR is a deterministic random bit generator using AES 128 in counter mode (AES_128_CTR). It does not
+ * use a derivation function (NO_DF) on the seed but does have prediction resistance (PR).
+ *
+ * S2N_AES_256_CTR_NO_DF_PR is a deterministic random bit generator using AES 256 in counter mode (AES_128_CTR). It does not
+ * use a derivation function on the seed but does have prediction resistance.
+ */
+enum s2n_drbg_mode {S2N_AES_128_CTR_NO_DF_PR, S2N_AES_256_CTR_NO_DF_PR};
+
 /* Per NIST SP 800-90C 6.3
  *
  * s2n's DRBG does provide prediction resistance
  * and does not support the additional_input parameter (which per 800-90C may be zero).
  *
-  * The security strength provided by s2n's DRBG is either 128 or 256 bits depending on if
-  * s2n_new_aes128_drbg or s2n_new_aes256_drbg is called.
+  * The security strength provided by s2n's DRBG is either 128 or 256 bits depending on the s2n_drbg_mode passed in.
  */
-extern int s2n_new_aes128_drbg(struct s2n_drbg *drbg, struct s2n_blob *personalization_string);
-extern int s2n_new_aes256_drbg(struct s2n_drbg *drbg, struct s2n_blob *personalization_string);
+extern int s2n_drbg_instantiate(struct s2n_drbg *drbg, struct s2n_blob *personalization_string, const enum s2n_drbg_mode mode);
 extern int s2n_drbg_generate(struct s2n_drbg *drbg, struct s2n_blob *returned_bits);
 extern int s2n_drbg_wipe(struct s2n_drbg *drbg);
 extern int s2n_drbg_bytes_used(struct s2n_drbg *drbg);

--- a/crypto/s2n_drbg.h
+++ b/crypto/s2n_drbg.h
@@ -59,7 +59,7 @@ struct s2n_drbg {
  * S2N_AES_256_CTR_NO_DF_PR is a deterministic random bit generator using AES 256 in counter mode (AES_128_CTR). It does not
  * use a derivation function on the seed but does have prediction resistance.
  */
-enum s2n_drbg_mode {S2N_AES_128_CTR_NO_DF_PR, S2N_AES_256_CTR_NO_DF_PR};
+typedef enum {S2N_AES_128_CTR_NO_DF_PR, S2N_AES_256_CTR_NO_DF_PR} s2n_drbg_mode;
 
 /* Per NIST SP 800-90C 6.3
  *
@@ -68,7 +68,7 @@ enum s2n_drbg_mode {S2N_AES_128_CTR_NO_DF_PR, S2N_AES_256_CTR_NO_DF_PR};
  *
   * The security strength provided by s2n's DRBG is either 128 or 256 bits depending on the s2n_drbg_mode passed in.
  */
-extern int s2n_drbg_instantiate(struct s2n_drbg *drbg, struct s2n_blob *personalization_string, const enum s2n_drbg_mode mode);
+extern int s2n_drbg_instantiate(struct s2n_drbg *drbg, struct s2n_blob *personalization_string, const s2n_drbg_mode mode);
 extern int s2n_drbg_generate(struct s2n_drbg *drbg, struct s2n_blob *returned_bits);
 extern int s2n_drbg_wipe(struct s2n_drbg *drbg);
 extern int s2n_drbg_bytes_used(struct s2n_drbg *drbg);

--- a/crypto/s2n_openssl.h
+++ b/crypto/s2n_openssl.h
@@ -35,3 +35,8 @@
 #define S2N_OPENSSL_VERSION_AT_LEAST(major, minor, fix) \
     (OPENSSL_VERSION_NUMBER >= ((major << 28) + (minor << 20) + (fix << 12)))
 
+#if (S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0))
+#define s2n_evp_ctx_init(ctx) GUARD_OSSL(EVP_CIPHER_CTX_init(ctx), S2N_ERR_DRBG)
+#else
+#define s2n_evp_ctx_init(ctx) EVP_CIPHER_CTX_init(ctx)
+#endif

--- a/crypto/s2n_stream_cipher_rc4.c
+++ b/crypto/s2n_stream_cipher_rc4.c
@@ -16,6 +16,7 @@
 #include <openssl/rc4.h>
 
 #include "crypto/s2n_cipher.h"
+#include "crypto/s2n_openssl.h"
 
 #include "utils/s2n_safety.h"
 #include "utils/s2n_blob.h"
@@ -67,7 +68,7 @@ static int s2n_stream_cipher_rc4_set_decryption_key(struct s2n_session_key *key,
 
 static int s2n_stream_cipher_rc4_init(struct s2n_session_key *key)
 {
-    EVP_CIPHER_CTX_init(key->evp_cipher_ctx);
+    s2n_evp_ctx_init(key->evp_cipher_ctx);
 
     return 0;
 }

--- a/tests/saw/spec/DRBG/DRBG_properties.cry
+++ b/tests/saw/spec/DRBG/DRBG_properties.cry
@@ -4,7 +4,7 @@ import AES
 import DRBG
 
 
-nist_reference_entropy_hex = [
+nist_aes128_reference_entropy_hex = [
   0x528ccd2d6c143800a34ad33e7f153cfaceaa2411abbaf4bfcfe9796898d0ece6
 , 0x478fd1eaa7ed293294d370979b0f0f1948d5a3161b12eeebf2cf6bd1bf059adf
 , 0x036bf1173977b323f60c6f0f603d9c50835b2afca8347dfb24e8f66604444951
@@ -51,7 +51,7 @@ nist_reference_entropy_hex = [
 , 0x9dfd31e3adc822b675c0a9c8702df12de4c3354ccdb5389ed481d910b3dbb51a
 , 0x2a1b1519d22d40ef4ec23c6d97dc148cfe171fb5f8b1c305ec6d8e83a1ef9064 ]
 
-nist_reference_personalization_strings_hex = [
+nist_aes128_reference_personalization_strings_hex = [
   0x07ca7a007b53f014d7f10461d6c97b5c8b0c502d3461d583f99efec69f121cd2
 , 0x99f2d501dd183f5657d8b8061bf4f0988de3bc2719f41281cf08d9bcc99f0dcb
 , 0x617d6463eaf3849e13b89a7f9805edff3ea1f0aa7ad71e7de7af3481bfeba7f5
@@ -68,7 +68,7 @@ nist_reference_personalization_strings_hex = [
 , 0x2c4e73ad2597b027dd04c6056db1189b7a0d8e9fece52237cb7fc2511509c4eb
 , 0x717c4de30c0ac7b831807cb1fcf4ab37f1734683a723d183fcfe5fc8a4c6c7e5 ]
 
-nist_reference_values_hex = [
+nist_aes128_reference_values_hex = [
   0x462eaef2ff6d82aec55f451776700e4c, 0x010cd7c293306adbe9798f2f65bdfb01, 0xf6f808dd7e199b3ce8497d63515092df
 , 0x1e574e0a9b220668776a109ecec959f5, 0xf47380b9e6d8ce485a5bb9f890331f89, 0xf2b475b29ed8aca7f3a69477212153e3
 , 0xd63aa6ddf10dfb6934b7a745456f2056, 0x29c05402d0dd6ff1d171c523e6066b3d, 0xfb15e2dfd607439797e29f9ea9a24788
@@ -85,7 +85,7 @@ nist_reference_values_hex = [
 , 0xa022dfed4c805b8f2c15d81693edfb53, 0x9d4f527ab03ff0c4abe7e442572fc0bb, 0x5fc9cb9e3cd694c6b08bb99256062814
 , 0xfaa46432da44e336bd782edd85ccfa83, 0xc17b86c7fd8e5a2131f515fb0ab62c9b, 0x619ff6d15579a1cb4bc9c96f6be8f4e5]
 
-nist_reference_returned_bits_hex  =[
+nist_aes128_reference_returned_bits_hex  =[
   0xbba1ef50b4bad288897f02ac2706ee1e01488dcbe9b3d8a637921f5e788faed3b23db63d590ceaa7607a2179192bea9aeaa85d048e7e108fee666dc646af5f0e
 , 0xb9ecf5521d38f9212578f9dd32af38089b45812ca96e661fc8e1be0b2f4b54215f52c9c93a6f76efee4521cb316378403108a6bf2724fdc93bc4d2db60a2de83
 , 0xce4bec8241dd1ce12d7fa18bd1a3188b43892392b7dcae7228a851afef9c9728c587167b6df28c895a67af35b6fd84ad076efcd70d1c59c49fa7c0f7ed87bc82
@@ -102,21 +102,21 @@ nist_reference_returned_bits_hex  =[
 , 0x7c41adf941656cfb9f24409d6cc4d578d43930b3e23ec801a59c53d999401bc0cb3e5b8797b2770a8a8f51ff594b7b17d9e694d5e36644508d16cb2554057adc
 , 0xac054570b081cf53b39b0a2faa21ee9b554c05ff9055843ac0eb9031d1de324701ad4cf2875623e0bf4184de4aea20070be1cb586880ac87fbb7e414b4b128d0]
 
-drbg = drbg_instantiate (nist_reference_entropy_hex @ 0) (nist_reference_personalization_strings_hex @ 0)
+drbg = drbg_instantiate (nist_aes128_reference_entropy_hex @ 0) (nist_aes128_reference_personalization_strings_hex @ 0)
 
 test_drbg : [8] -> Bit
 test_drbg n =
-  bits_out == nist_reference_returned_bits_hex @ n &&
-  drbg1.v == nist_reference_values_hex @ (3 * n) &&
-  drbg2.v == nist_reference_values_hex @ (3 * n + 1) &&
-  drbg3.v == nist_reference_values_hex @ (3 * n + 2)
+  bits_out == nist_aes128_reference_returned_bits_hex @ n &&
+  drbg1.v == nist_aes128_reference_values_hex @ (3 * n) &&
+  drbg2.v == nist_aes128_reference_values_hex @ (3 * n + 1) &&
+  drbg3.v == nist_aes128_reference_values_hex @ (3 * n + 2)
   where
-    drbg1 = drbg_instantiate (nist_reference_entropy_hex @ (3*n))
-                             (nist_reference_personalization_strings_hex @ n)
+    drbg1 = drbg_instantiate (nist_aes128_reference_entropy_hex @ (3*n))
+                             (nist_aes128_reference_personalization_strings_hex @ n)
     ((bits1, drbg2) : ([512], s2n_drbg)) =
-      drbg_generate drbg1 (nist_reference_entropy_hex @ (3 * n + 1)) True
+      drbg_generate drbg1 (nist_aes128_reference_entropy_hex @ (3 * n + 1)) True
     ((bits_out, drbg3) : ([512], s2n_drbg)) =
-      drbg_generate drbg2 (nist_reference_entropy_hex @ (3 * n + 2)) True
+      drbg_generate drbg2 (nist_aes128_reference_entropy_hex @ (3 * n + 2)) True
 
 property drbg_tests_pass =
   ~zero == [ test_drbg n | n <- [0 .. 14] ]

--- a/tests/unit/s2n_drbg_test.c
+++ b/tests/unit/s2n_drbg_test.c
@@ -43,8 +43,8 @@
  * [ReturnedBitsLen = 512]
  */
 
-struct s2n_stuffer nist_reference_entropy;
-const char nist_reference_entropy_hex[] =
+struct s2n_stuffer nist_aes128_reference_entropy;
+const char nist_aes128_reference_entropy_hex[] =
 "528ccd2d6c143800a34ad33e7f153cfaceaa2411abbaf4bfcfe9796898d0ece6"
 "478fd1eaa7ed293294d370979b0f0f1948d5a3161b12eeebf2cf6bd1bf059adf"
 "036bf1173977b323f60c6f0f603d9c50835b2afca8347dfb24e8f66604444951"
@@ -93,7 +93,7 @@ const char nist_reference_entropy_hex[] =
 
 int entropy_fd = -1;
 
-const char nist_reference_personalization_strings_hex[] =
+const char nist_aes128_reference_personalization_strings_hex[] =
 "07ca7a007b53f014d7f10461d6c97b5c8b0c502d3461d583f99efec69f121cd2"
 "99f2d501dd183f5657d8b8061bf4f0988de3bc2719f41281cf08d9bcc99f0dcb"
 "617d6463eaf3849e13b89a7f9805edff3ea1f0aa7ad71e7de7af3481bfeba7f5"
@@ -110,7 +110,7 @@ const char nist_reference_personalization_strings_hex[] =
 "2c4e73ad2597b027dd04c6056db1189b7a0d8e9fece52237cb7fc2511509c4eb"
 "717c4de30c0ac7b831807cb1fcf4ab37f1734683a723d183fcfe5fc8a4c6c7e5";
 
-const char nist_reference_values_hex[] =
+const char nist_aes128_reference_values_hex[] =
 "462eaef2ff6d82aec55f451776700e4c" "010cd7c293306adbe9798f2f65bdfb01" "f6f808dd7e199b3ce8497d63515092df"
 "1e574e0a9b220668776a109ecec959f5" "f47380b9e6d8ce485a5bb9f890331f89" "f2b475b29ed8aca7f3a69477212153e3"
 "d63aa6ddf10dfb6934b7a745456f2056" "29c05402d0dd6ff1d171c523e6066b3d" "fb15e2dfd607439797e29f9ea9a24788"
@@ -127,7 +127,7 @@ const char nist_reference_values_hex[] =
 "a022dfed4c805b8f2c15d81693edfb53" "9d4f527ab03ff0c4abe7e442572fc0bb" "5fc9cb9e3cd694c6b08bb99256062814"
 "faa46432da44e336bd782edd85ccfa83" "c17b86c7fd8e5a2131f515fb0ab62c9b" "619ff6d15579a1cb4bc9c96f6be8f4e5";
 
-const char nist_reference_returned_bits_hex[] =
+const char nist_aes128_reference_returned_bits_hex[] =
 "bba1ef50b4bad288897f02ac2706ee1e01488dcbe9b3d8a637921f5e788faed3b23db63d590ceaa7607a2179192bea9aeaa85d048e7e108fee666dc646af5f0e"
 "b9ecf5521d38f9212578f9dd32af38089b45812ca96e661fc8e1be0b2f4b54215f52c9c93a6f76efee4521cb316378403108a6bf2724fdc93bc4d2db60a2de83"
 "ce4bec8241dd1ce12d7fa18bd1a3188b43892392b7dcae7228a851afef9c9728c587167b6df28c895a67af35b6fd84ad076efcd70d1c59c49fa7c0f7ed87bc82"
@@ -144,87 +144,274 @@ const char nist_reference_returned_bits_hex[] =
 "7c41adf941656cfb9f24409d6cc4d578d43930b3e23ec801a59c53d999401bc0cb3e5b8797b2770a8a8f51ff594b7b17d9e694d5e36644508d16cb2554057adc"
 "ac054570b081cf53b39b0a2faa21ee9b554c05ff9055843ac0eb9031d1de324701ad4cf2875623e0bf4184de4aea20070be1cb586880ac87fbb7e414b4b128d0";
 
+/* Test vectors are taken from http://csrc.nist.gov/groups/STM/cavp/documents/drbg/drbgtestvectors.zip
+ * - drbgvectors_pr_true/CTR_DRBG.txt :
+ * [AES-256 no df]
+ * [PredictionResistance = True]
+ * [EntropyInputLen = 384]
+ * [NonceLen = 0]
+ * [PersonalizationStringLen = 384]
+ * [AdditionalInputLen = 0]
+ * [ReturnedBitsLen = 512]
+ */
+
+struct s2n_stuffer nist_aes256_reference_entropy;
+const char nist_aes256_reference_entropy_hex_part1[] =
+"c8f0c7b9bdf7e7d524c998aedeabb3b7dd4fa8f95c51b582010a5e09d0b4b1ad510302422df738fbef002a051543b4cc"
+"c1a7b160c8e33a01fbd49743dc1161539390d9ba6b876fe63b58e8fd605b98617322578b17aca9db71e858b154f97910"
+"d98b25eda41d15eacdecba586609d8c743704fa099ac37f9185bcb19652723d1648431a73c4399773c85caf12fcdd842"
+"5fb3f302c36d0d0e28efb065df595ea69a6b3eb45622f9d14038ebcc0d4a8b0d6aa45e681edd5c506e00f0dc12775ac4"
+"6440cc8c735ca9b05f261358e51b8b4f8c4bbdee9e2681c76fb552bb6b62334038bd8e0394a4d50f6af7a7a920379799"
+"2ed7e6118394ce10a842d609baabfaef9d1c1fea914be4b725822f943fda023244f806a47b944ea0c1b853f36bfa24f7"
+"f3fb24592e88aa2bb3921b46e198310fd269883eb68a7831e5627a5a6d21543864ede3fbc8badc1888b0daf37a97dd40"
+"deda2a043d035744b5d0e696e496382ff0c01cc79c9f8f588b40d934237fdf7d0f9ea389cf28a352917c724106417d92"
+"dccffb5e3cbf5e36eb1ca92db6247e1d6dc777e591893e220b5cf55c50c74bae2995affb003a8306197771737aaddf64"
+"8a0a52b1e228c26be6497b5cad0677cfaa2c42a4fc429c4bade7a468ce681a732f92dcebdf5b3d9a0dcfdb5c11a830d4"
+"51a2f38792fb87570747a54b7a3f5473583faaceacd70cd5b5336e8ecbbcc286627943999210573ee7f8f29437f74b02"
+"77efd90bf6faab8ed0bb32f138fec4fe8afd7e1a55b2e60d5d500ebd57ed382af97d9ea89375fc56b511cb674e76e4f4"
+"4256c1c6dcb9463f751d97c2b9a1df629d2f6db19dfce80da4624e5ceb2403ae6f1906f2d8e34cb015525b27bb25c262"
+"8ba03c2283b97a37063a4597f7ca15fb2df7b0de1e2236b8338f14539c059d1a47a947bc9a3ef954c833fffaff8fa8ff"
+"c5d3a88de9db79dd707187dfe5d35443f7eada1669d5daf39af4d78fff3fd35f0e81922a207e640cba2c9fb18280f62d"
+"6e92427a94816c838ef57f9d98941ffc3cd070c76fcc19e765f9b1f9d390ec99f0b5193fd72a3d700deaeffea6c2282e"
+"8e7159350759fe73e6c51ab224eda1cd769c703a42a79d3c4ce407aa99c8427f872b7c3e09559c789cb75c546ddeb988"
+"db12fb9c2f1cc022768f824dfd05edc6d57184ee0e51ce8decc74c390adee63ee401a7d3bb0a91c1d50fd2239dc3fa57"
+"14932f8ee3ec2119e03b65dde53c2c4156b8013c4d1c260227b240af61bbd0efedcdcd4fbc828dc688cef0b25bb12374"
+"a5d063e966ebfa8bb05fc0c0625a30d0a408e5e31ec9667374ccccbcc07f6c289ecdf3deb3f784925e7e72c75105bf54"
+"31d8ab37201b55662101ad235883c28ecfb5c9e3cf0498f6cd563db96f622e5656967256c7c3efc2ca3c577be02de3ce"
+"a7d7b56bdf38b57d7418ae3f3a90375d7aafc3839a2956f6824d1c55d615966207a5ef31e2bf8359db1070612ad6d775";
+const char nist_aes256_reference_entropy_hex_part2[] =
+"f480e7c970c02a5a64b09f0473d04b658e19332634043569e24996981f7d515d326ad1129661638753d117e8d31a540f"
+"0854d1a0aa78e3e60b6825d143eaa97ec7ddd1b8b85c26b625fe4da7973d643cd0629186c42928c8e46857a603e5ac0c"
+"89dfbb4a10bad1c269341b7815ac1388a7d28bff8393e078d99a0cdf12d0f28a24e45441c86584829ce37d4eb3b28873"
+"6d14b671eaa66e217dd973047b6180b7dbd2c29b709fce014bcfda25e269bf5a736d7154308aa0597c5f5adc3eb4cdd9"
+"7c0a71a8f56ac0b5766525b0f63afe48f4a0d282adf300f9da47ac62693f0d74f6739128c61024a22f7469d822382cfb"
+"d0daca073b0c1517b9d6643c518130580f254b482d4c44b735590e167b06b304e0664b8e12d9c8dd083f4b758e7b3d81"
+"4441277388baf0ae4d69b0c1db2b4d767647730e10cf1191cd10fd2eba570d348e544cea0641af89418c900ccbf2ca20"
+"2180dc1f5f17f5f8cbb8499e155de4bd50e0f2175041c24d1c72f654af8a08563b1c42a84c5ae126ef33e1909bcee38f"
+"48e6177813ad0dd8da8506a91fe0d4e615bdd068b423050a1dfc94e1cbaa2bbeb2f92561391a4f54143ac46a74d57c03"
+"f9d761f589d8e466123257d4b144e40106be6a063643547b8549733134b3375715157246a9bf9a91f854a37ce7efb3e1"
+"b774616e89a2297ce5feea2f5708eb0fd21f3ae188ae25c64c8bcee73be40db2af5d8e640ccd48b8cdc7375e5c53cad7"
+"3507214c359f4ab75904dd4e430ccfd484b853b40b7253d430111588410f1c9fc41e757f669d3de45a3c0efdeb250bd3"
+"8364b816f4c64359e54415082fd5b04cb896bd5de5527b0930fc6a855d2a31b55cba81ab25b019adc7cc7c7a6f308c4c"
+"ab2a1d12b1997f5a1b74d6608e60f09682924fcc4270fd5fab8e84f2be19306e49537a40add14ba9b1472f80a97ade7d"
+"e6a8dd29ea2f9f2a4595aa1b9600831d1647f53f366724517569e2848f5a7ccb4bd2f553f83f91c14c2361cbc3ece926"
+"ac25bc0603a569b90efc796aea338684d84c03240d1bb3c9d3b24627fb24235d6fb837fc382c6c949ebc911abadfe9b5"
+"60fe48c071073a815ee75a6b66e0cec21fa510eb721a10cea64eed977efe89af922f8bedade893212e6a253169821860"
+"7f1a2afae1e642c3348a0ee56a0f4ebf136d68f8f04de54b3beece7828aa43171d09570bb70fca53775e4770e3d4cb84"
+"edab61da555eeff611c0428a25200003a5ac1c4978a766514e9222c80adda7194b8414835f0fae94264d3d81d49bec13"
+"7810ed74bdb095e1a3a8a2b1fd885e21c3a23317b5a4514a9bae2d0072826bfc292a231500703ab0a1f04ce35bd3d808"
+"f72592e0626539903bfe7926f2df89428ffe4eceeb57f0be46f5d4bb0ab8c70633431c70056e051b2a44a99fb2decc80"
+"2b3877ed4d1b3174d36e784ad7b6b7991dd52979ca5b1c4cc5f415ea56aa78f2486e2b033570089aa0e8f5d4be3ee140"
+"91d421c3eb04de94099a7467254bad70e236d5c27616f766e85b4de3965001db854e61a80bfec2eacb4ff93ecafb8b83";
+
+const char nist_aes256_reference_personalization_strings_hex[] =
+"3b8f2ed03e4c4a857ebaf4730124ae5b3ffa67e294381fe085e1d5b25bb79c228f39b9912d8bf9e84cdb43fcefb552e0"
+"e4afd48a08355ccbd097bf5c87e9aa6cca5bce84b211ef0c783d7e05cd52caae4b4d83de53a84200a556b5aff5047b13"
+"a1a853ffa798f93a604874d4c2c7fcf2ac4a6ed1e07e03336b7e3ddbf603c19f9d8b3041cbe3ac09e96c86c8bdebaad6"
+"9367c213593e3a82059d3c80513c301f0c840c900ae8f18b5be558d1fb8bd528dbf93e6efb7f3cd8fed577a3e299bc76"
+"88d9b7c50d99c926f035085a7a8f02698fde845db85088e866187407bdf75b2c6cb628d5081c859a5d738826d2e8c1ee"
+"6d7621ae460ae10c8c8d0e11c80aa444e279f2cef7da2a0e52fe43edfa025c67ba0111b6a2774b0620eae65aa2bc292c"
+"3dc52487f866eef27a6aaa0f3da87c09c859babbb73e1771626ca434534a66b02e561363db90798edb55cced2746767a"
+"015c5a1d1f9e2aeb34713767a58d01b0055a27151bafbd0afc31fc22d765e57f65ffc282aba726a2ec5a7c36a33c0ecc"
+"5235d1b8ea0e83618a755c598fa8e74d6e425f946249e80f12d85d3e1c547d5048f235687dc93c86cbb691384f889408"
+"06170a3a66308cea0ab1f44e688e7a4f69a4fe435cc325dc554771b4156614c77d3c21377ca552e6d5ac9b7ffb52f1a3"
+"767fa94128aa6e71dfbfb4c16be33c48941c5ccbf96e8094365f581810ce94b3feb8960b99eb925b0c6184db40343849"
+"806f8ff25ac8c4d61fe8cc895f5c5d2e153701b5c2cc8ef6b4ff7ec5f6273b285695000016e7d5a6145f4f98f4a42bf9"
+"dfa7445d60ac908bb031bcb4f9feed626afab1e4aef021862e1fcdb34fddf9028b6226dfb11f677dca420ceb11930587"
+"b1805d90d9e43a9e509f5f71bad514b548808b993cfaef7a69279239e687f4cbe3a6ba579e11a4fa2b2450f82c2fd31a"
+"27b9250c01189a8a675d597cd2e476d11f4feaa29ce2d9e729eeede42d9b78521937d240b12db5493aee96b84102cd9c";
+
+const char nist_aes256_reference_values_hex[] =
+"ac5ab81937daeb6772799c778ff0d3a2" "0eebb4180d8410794daeaafc1847c923" "70c7d3292e845bdf82fd274edd68a653"
+"5389de7c7ad334241af4b0fd92751459" "75c74d6c01f589d3ad73a3a5b623e7bb" "d6c396bf4a3e833cd2d606fce7d81981"
+"8b06d07034ff5a65b07ea9b5b27a4218" "0ee02cd9df5f2bd1ada6f1f9ba7f6056" "8965850a9a42cb15dd40acdc5a9fb677"
+"860be14f13822b3622b859718637b92c" "9d344fb6d571418dbbfe63bed5bf948d" "3f86d6e5294dd831d702c43b8ef27b48"
+"71cf2dede759e35e9983268f1ccb3602" "4a656c7375adb348950a73236fd94f3c" "157ecd447d923208706e95561b3d882e"
+"38d40b4342fb5c02fca2fc2a7178348c" "65a6f202aec5a1fcdbdcf1cc456e1ec5" "1271bbfb300f823f19fedd138118fc60"
+"b1fbdde650b4de3c8239c9d109f16080" "78151d8dba8d945a0feea6b2e1adec27" "a3da7d1591fa63595a3c4cf7c4671bff"
+"103a2e797ebe8f8fe6e8f9d9fcecec37" "8067a5626c79baec12ba054032d6c5a7" "1f7232216822ed37039b6e46db4d81d5"
+"1e7662e3820a927086f719f8893c29f5" "3d8195aa8d54d162d3b8c7dd2194c9aa" "8b3b81b54c750c1f795dd6f009b9f0f9"
+"ef3a697359dab04f0c312584002ff9ac" "aba26d5d26ee7f035d3f87bf5886ebc5" "a14740caa86474ad9e2b843f49dcc482"
+"3e21b0a09757f77bc9f9b53f41e771c4" "bbb03998195593d46bdbe7b1be8533e4" "41ccfeb0a667ee27ae8370efb2afbd9f"
+"e0eb76b547dcc2369fc1b4eb6a8715a4" "1c4a394a564ce025ecd6278a7a314403" "3e37edd1aeb247aa4a6116b54ba29dae"
+"b2d0d0467e86dcc857c398aea779d92f" "695104cd3099d7f3320ee44505729da5" "55b9cb44f0a6d2b4a5ee6a8aa7d5c7c1"
+"8ccfee961eb844dd8dd8e206bafd2d10" "ea3a81303d10eb79c8b26cbb42969a4d" "cad6784d017fedabef3bbf374b06ac2b"
+"5814cdfa83e59a26c108caa986da3492" "503e3029d555fb6bcd4be394d8ed4638" "969f3ea8c1ab6986630149eff81d2162";
+
+const char nist_aes256_reference_returned_bits_hex[] =
+"338da59350a72bba94b217b99ff813fafa85f31fa7e991d4350d6fce39471aa249c6a9e7d189649ea6770a15be302b943ad403728b7387f5984c9bfb82597771"
+"be9333140428553231505e8ce3f789f2860f44647d97239c0d34cee98e0e4f5e5a5eb296d4cec508624913080a1b44990993a2ae63f61124c4d8184f191ca8ae"
+"cdecc083b5c4bd38b573c5e109fc1cbf2dbc92982ed6d24cf4d2cb06383ba27d51dc064a8cf42205420d1c62505b987c774502b93e837485284a137cf2380872"
+"ab1478cc75bbfdc930fefeff1e6f8e7b822213976fc556ee7f71550d128620766d8353b3c54c59934e7fa57e8b857c7daef8e9d82705fd1fec7b19d5c3b5af4f"
+"f64d6ac3fd9beda9ea4b3fc2921e967d126ab4e747eb4f29bfd949f94119271052ff52501cb45af6bf9499ef5926423f61bd4dac0b28fc95aa886c8226ea27b4"
+"45e3bfafaa00941459b373aa00e6096b7527110f4c6e4e7d6661829dfe4ad83ab23a5779dc7f8116b73b929fc3da43ad346a3e11364e1b453e66335b5cbf59b1"
+"8bc98d27050e713d19551eadae19d14f3b1304aa6f736d9bec6c7cc90c85412a4e6a7218b8a7ce46b1cb93fa1b296eee789aae0cb2a58fe7a80e26f0a1018dc8"
+"794128d681d355336148eeb4dd882d76ef984f2a8ceb4b451e9b37beac0fb50247bd595ede2de000f4397988d3f52e0b3b293208c16b5f45d6032bc5ef20b3c8"
+"3571383b971291e37616f1c6af623a1d576cc5f95090563654420f184fc6663242aeffb06052a29e84380db38d9f3ed09823dfef1774c14120fb010600b7b274"
+"b7723a01d35011a9a8e0e82a8ade37d5e992d8cc5390e2409e185a1bcede39b742fa1fa541572aa36b16be410f3ca0ca853ffd7cea2996e852b888fe9b1263f9"
+"0d42ad75a67008674be7d81bb2ca9f0625b55ea37e1985d3a27cac38e347824ff03caaaeae9b646a220a8a672cb28ba869d0f53e3317be00128fa965a8ea7b39"
+"d5be1698e011122874ea19c562859e552c68d2734a39f72d6f8eca8ce30916504bf224670f9a7b6afb57830a28fec0fe818df449f5e6eb8b49a3397df4bd3506"
+"c834a90e72a5ec0148942c9fbde8b90f058866ac3ff8cc854bda3d33f6072bc0e5a22c7d0cd801f091276ed7b7e3d6495df9546b9fc45e46aa6b89d3dda207cc"
+"6553c630a07ddf7dc2110c3aa3c5ac0c488a0345e07571cd71df115ba37ea4676935be72a6033aeca7ac6fcce5654dae38f5777b5cff34b156539b42ed6dc93c"
+"ed703d9273bb9462ac400ee8d587ea3c4d6c27aa014defcb6ca6fe885272bcb4b6ba0822f42941071bf635b41d997c631b680d91b23ee48351041dc274900821";
+
 
 /* This function over-rides the s2n internal copy of the same function */
-int nist_fake_urandom_data(struct s2n_blob *blob)
+int nist_fake_128_urandom_data(struct s2n_blob *blob)
 {
     /* At first, we use entropy data provided by the NIST test vectors */
-    GUARD(s2n_stuffer_read(&nist_reference_entropy, blob));
+    GUARD(s2n_stuffer_read(&nist_aes128_reference_entropy, blob));
+
+    return 0;
+}
+
+int nist_fake_256_urandom_data(struct s2n_blob *blob)
+{
+    /* At first, we use entropy data provided by the NIST test vectors */
+    GUARD(s2n_stuffer_read(&nist_aes256_reference_entropy, blob));
 
     return 0;
 }
 
 int main(int argc, char **argv)
 {
-    uint8_t data[256] = {0};
-    struct s2n_drbg drbg = {0};
-    struct s2n_blob blob = {.data = data, .size = 64 };
-    struct s2n_timer timer;
-    uint64_t drbg_nanoseconds;
-    uint64_t urandom_nanoseconds;
-    struct s2n_stuffer nist_reference_personalization_strings;
-    struct s2n_stuffer nist_reference_returned_bits;
-    struct s2n_stuffer nist_reference_values;
-    struct s2n_config *config;
-
     BEGIN_TEST();
-
-    EXPECT_NOT_NULL(config = s2n_config_new())
 
     /* Open /dev/urandom */
     EXPECT_TRUE(entropy_fd = open("/dev/urandom", O_RDONLY));
 
-    /* Convert the hex entropy data into binary */
-    EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&nist_reference_entropy, nist_reference_entropy_hex));
-    EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&nist_reference_personalization_strings, nist_reference_personalization_strings_hex));
-    EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&nist_reference_returned_bits, nist_reference_returned_bits_hex));
-    EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&nist_reference_values, nist_reference_values_hex));
+    {
+        /* Check everything against the NIST AES 128 vectors */
+        DEFER_CLEANUP(struct s2n_stuffer nist_aes128_reference_personalization_strings = {{0}}, s2n_stuffer_free);
+        DEFER_CLEANUP(struct s2n_stuffer nist_aes128_reference_returned_bits = {{0}}, s2n_stuffer_free);
+        DEFER_CLEANUP(struct s2n_stuffer nist_aes128_reference_values = {{0}}, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&nist_aes128_reference_entropy, nist_aes128_reference_entropy_hex));
+        EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&nist_aes128_reference_personalization_strings, nist_aes128_reference_personalization_strings_hex));
+        EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&nist_aes128_reference_returned_bits, nist_aes128_reference_returned_bits_hex));
+        EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&nist_aes128_reference_values, nist_aes128_reference_values_hex));
+        for (int i = 0; i < 14; i++) {
+            uint8_t ps[32] = {0};
+            struct s2n_drbg nist_drbg = {.entropy_generator = nist_fake_128_urandom_data};
+            struct s2n_blob personalization_string = {.data = ps, .size = 32};
+            /* Read the next personalization string */
+            EXPECT_SUCCESS(s2n_stuffer_read(&nist_aes128_reference_personalization_strings, &personalization_string));
 
-    /* Check everything against the NIST vectors */
-    for (int i = 0; i < 14; i++) {
-        uint8_t ps[32] = {0};
-        struct s2n_drbg nist_drbg = { .entropy_generator = nist_fake_urandom_data };
-        struct s2n_blob personalization_string = {.data = ps, .size = 32};
-        /* Read the next personalization string */
-        EXPECT_SUCCESS(s2n_stuffer_read(&nist_reference_personalization_strings, &personalization_string));
+            /* Instantiate the DRBG */
+            EXPECT_SUCCESS(s2n_new_aes128_drbg(&nist_drbg, &personalization_string));
 
-        /* Instantiate the DRBG */
-        EXPECT_SUCCESS(s2n_drbg_instantiate(&nist_drbg, &personalization_string));
+            uint8_t nist_v[16];
 
-        uint8_t nist_v[16];
+            GUARD(s2n_stuffer_read_bytes(&nist_aes128_reference_values, nist_v, sizeof(nist_v)));
+            EXPECT_TRUE(memcmp(nist_v, nist_drbg.v, sizeof(nist_drbg.v)) == 0);
 
-        GUARD(s2n_stuffer_read_bytes(&nist_reference_values, nist_v, sizeof(nist_v)));
-        EXPECT_TRUE(memcmp(nist_v, nist_drbg.v, sizeof(nist_drbg.v)) == 0);
+            /* Generate 512 bits (FIRST CALL) */
+            uint8_t out[64];
+            struct s2n_blob generated = {.data = out, .size = 64};
+            EXPECT_SUCCESS(s2n_drbg_generate(&nist_drbg, &generated));
 
-        /* Generate 512 bits (FIRST CALL) */
-        uint8_t out[64];
-        struct s2n_blob generated = {.data = out, .size = 64 };
-        EXPECT_SUCCESS(s2n_drbg_generate(&nist_drbg, &generated));
+            GUARD(s2n_stuffer_read_bytes(&nist_aes128_reference_values, nist_v, sizeof(nist_v)));
+            EXPECT_TRUE(memcmp(nist_v, nist_drbg.v, sizeof(nist_drbg.v)) == 0);
 
-        GUARD(s2n_stuffer_read_bytes(&nist_reference_values, nist_v, sizeof(nist_v)));
-        EXPECT_TRUE(memcmp(nist_v, nist_drbg.v, sizeof(nist_drbg.v)) == 0);
+            /* Generate another 512 bits (SECOND CALL) */
+            EXPECT_SUCCESS(s2n_drbg_generate(&nist_drbg, &generated));
 
-        /* Generate another 512 bits (SECOND CALL) */
-        EXPECT_SUCCESS(s2n_drbg_generate(&nist_drbg, &generated));
+            GUARD(s2n_stuffer_read_bytes(&nist_aes128_reference_values, nist_v, sizeof(nist_v)));
+            EXPECT_TRUE(memcmp(nist_v, nist_drbg.v, sizeof(nist_drbg.v)) == 0);
 
-        GUARD(s2n_stuffer_read_bytes(&nist_reference_values, nist_v, sizeof(nist_v)));
-        EXPECT_TRUE(memcmp(nist_v, nist_drbg.v, sizeof(nist_drbg.v)) == 0);
+            uint8_t nist_returned_bits[64];
+            GUARD(s2n_stuffer_read_bytes(&nist_aes128_reference_returned_bits, nist_returned_bits,
+                                         sizeof(nist_returned_bits)));
+            EXPECT_TRUE(memcmp(nist_returned_bits, out, sizeof(nist_returned_bits)) == 0);
 
-        uint8_t nist_returned_bits[64];
-        GUARD(s2n_stuffer_read_bytes(&nist_reference_returned_bits, nist_returned_bits, sizeof(nist_returned_bits)));
-        EXPECT_TRUE(memcmp(nist_returned_bits, out, sizeof(nist_returned_bits)) == 0);
-
-        EXPECT_SUCCESS(s2n_drbg_wipe(&nist_drbg));
+            EXPECT_SUCCESS(s2n_drbg_wipe(&nist_drbg));
+        }
     }
 
-    EXPECT_SUCCESS(s2n_drbg_instantiate(&drbg, &blob));
+    {
+        /* Check everything against the NIST AES 256 vectors */
+        DEFER_CLEANUP(struct s2n_stuffer temp1 = {{0}}, s2n_stuffer_free);
+        DEFER_CLEANUP(struct s2n_stuffer temp2 = {{0}}, s2n_stuffer_free);
+        DEFER_CLEANUP(struct s2n_stuffer nist_aes256_reference_personalization_strings = {{0}}, s2n_stuffer_free);
+        DEFER_CLEANUP(struct s2n_stuffer nist_aes256_reference_returned_bits = {{0}}, s2n_stuffer_free);
+        DEFER_CLEANUP(struct s2n_stuffer nist_aes256_reference_values = {{0}}, s2n_stuffer_free);
 
-    /* Use the DRBG for 32MB of data */
+        /* Combine nist_aes256_reference_entropy_hex_part1 and nist_aes256_reference_entropy_hex_part2 to avoid C99
+         * string length limit. */
+        EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&temp1, nist_aes256_reference_entropy_hex_part1));
+        EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&temp2, nist_aes256_reference_entropy_hex_part2));
+        EXPECT_SUCCESS(s2n_stuffer_alloc(&nist_aes256_reference_entropy, temp1.write_cursor + temp2.write_cursor));
+        EXPECT_SUCCESS(s2n_stuffer_copy(&temp1, &nist_aes256_reference_entropy, temp1.write_cursor));
+        EXPECT_SUCCESS(s2n_stuffer_copy(&temp2, &nist_aes256_reference_entropy, temp2.write_cursor));
+        EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&nist_aes256_reference_personalization_strings, nist_aes256_reference_personalization_strings_hex));
+        EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&nist_aes256_reference_returned_bits, nist_aes256_reference_returned_bits_hex));
+        EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&nist_aes256_reference_values, nist_aes256_reference_values_hex));
+
+        for (int i = 0; i < 14; i++) {
+            uint8_t ps[48] = {0};
+            struct s2n_drbg nist_drbg = {.entropy_generator = nist_fake_256_urandom_data};
+            struct s2n_blob personalization_string = {.data = ps, .size = 48};
+            /* Read the next personalization string */
+            EXPECT_SUCCESS(s2n_stuffer_read(&nist_aes256_reference_personalization_strings, &personalization_string));
+
+            /* Instantiate the DRBG */
+            EXPECT_SUCCESS(s2n_new_aes256_drbg(&nist_drbg, &personalization_string));
+
+            uint8_t nist_v[16];
+
+            GUARD(s2n_stuffer_read_bytes(&nist_aes256_reference_values, nist_v, sizeof(nist_v)));
+            EXPECT_TRUE(memcmp(nist_v, nist_drbg.v, sizeof(nist_drbg.v)) == 0);
+
+            /* Generate 512 bits (FIRST CALL) */
+            uint8_t out[64];
+            struct s2n_blob generated = {.data = out, .size = 64};
+            EXPECT_SUCCESS(s2n_drbg_generate(&nist_drbg, &generated));
+
+            GUARD(s2n_stuffer_read_bytes(&nist_aes256_reference_values, nist_v, sizeof(nist_v)));
+            EXPECT_TRUE(memcmp(nist_v, nist_drbg.v, sizeof(nist_drbg.v)) == 0);
+
+            /* Generate another 512 bits (SECOND CALL) */
+            EXPECT_SUCCESS(s2n_drbg_generate(&nist_drbg, &generated));
+
+            GUARD(s2n_stuffer_read_bytes(&nist_aes256_reference_values, nist_v, sizeof(nist_v)));
+            EXPECT_TRUE(memcmp(nist_v, nist_drbg.v, sizeof(nist_drbg.v)) == 0);
+
+            uint8_t nist_returned_bits[64];
+            GUARD(s2n_stuffer_read_bytes(&nist_aes256_reference_returned_bits, nist_returned_bits,
+                                         sizeof(nist_returned_bits)));
+            EXPECT_TRUE(memcmp(nist_returned_bits, out, sizeof(nist_returned_bits)) == 0);
+
+            EXPECT_SUCCESS(s2n_drbg_wipe(&nist_drbg));
+        }
+    }
+
+    uint8_t data[256] = {0};
+    struct s2n_drbg aes128_drbg = {0};
+    struct s2n_drbg aes256_drbg = {0};
+    struct s2n_blob blob = {.data = data, .size = 64 };
+    struct s2n_timer timer;
+    uint64_t aes128_drbg_nanoseconds;
+    uint64_t aes256_drbg_nanoseconds;
+    uint64_t urandom_nanoseconds;
+
+    EXPECT_SUCCESS(s2n_new_aes128_drbg(&aes128_drbg, &blob));
+    EXPECT_SUCCESS(s2n_new_aes256_drbg(&aes256_drbg, &blob));
+
+    struct s2n_config *config;
+    EXPECT_NOT_NULL(config = s2n_config_new());
+
+    /* Use the AES128 DRBG for 32MB of data */
     EXPECT_SUCCESS(s2n_timer_start(config, &timer));
     for (int i = 0; i < 500000; i++) {
-        EXPECT_SUCCESS(s2n_drbg_generate(&drbg, &blob));
+        EXPECT_SUCCESS(s2n_drbg_generate(&aes128_drbg, &blob));
     }
-    EXPECT_SUCCESS(s2n_timer_reset(config, &timer, &drbg_nanoseconds));
+    EXPECT_SUCCESS(s2n_timer_reset(config, &timer, &aes128_drbg_nanoseconds));
+
+    /* Use the AES256 DRBG for 32MB of data */
+    EXPECT_SUCCESS(s2n_timer_start(config, &timer));
+    for (int i = 0; i < 500000; i++) {
+        EXPECT_SUCCESS(s2n_drbg_generate(&aes256_drbg, &blob));
+    }
+    EXPECT_SUCCESS(s2n_timer_reset(config, &timer, &aes256_drbg_nanoseconds));
 
     /* Use urandom for 32MB of data */
     EXPECT_SUCCESS(s2n_timer_start(config, &timer));
@@ -233,20 +420,23 @@ int main(int argc, char **argv)
     }
     EXPECT_SUCCESS(s2n_timer_reset(config, &timer, &urandom_nanoseconds));
 
+    printf("\nTime to generate 32 MB of random data per DRBG in nanoseconds\nAES 128 CTR: %"PRId64 "\nAES 256 CTR: %" PRId64" \nurandom:     %" PRId64" \n",
+            aes128_drbg_nanoseconds, aes256_drbg_nanoseconds, urandom_nanoseconds);
+
     /* NOTE: s2n_random_test also includes monobit tests for this DRBG */
 
     /* the DRBG state is 128 bytes, test that we can get more than that */
     blob.size = 129;
     for (int i = 0; i < 10; i++) {
-        EXPECT_SUCCESS(s2n_drbg_generate(&drbg, &blob));
+        EXPECT_SUCCESS(s2n_drbg_generate(&aes128_drbg, &blob));
+        EXPECT_SUCCESS(s2n_drbg_generate(&aes256_drbg, &blob));
     }
 
-    EXPECT_SUCCESS(s2n_drbg_wipe(&drbg));
+    EXPECT_SUCCESS(s2n_drbg_wipe(&aes128_drbg));
+    EXPECT_SUCCESS(s2n_drbg_wipe(&aes256_drbg));
 
-    EXPECT_SUCCESS(s2n_stuffer_free(&nist_reference_entropy));
-    EXPECT_SUCCESS(s2n_stuffer_free(&nist_reference_personalization_strings));
-    EXPECT_SUCCESS(s2n_stuffer_free(&nist_reference_returned_bits));
-    EXPECT_SUCCESS(s2n_stuffer_free(&nist_reference_values));
+    EXPECT_SUCCESS(s2n_stuffer_free(&nist_aes128_reference_entropy));
+    EXPECT_SUCCESS(s2n_stuffer_free(&nist_aes256_reference_entropy));
 
     EXPECT_SUCCESS(s2n_config_free(config));
 

--- a/tests/unit/s2n_drbg_test.c
+++ b/tests/unit/s2n_drbg_test.c
@@ -273,7 +273,7 @@ int nist_fake_256_urandom_data(struct s2n_blob *blob)
     return 0;
 }
 
-int check_drgb_version(enum s2n_drbg_mode mode, int (*generator)(struct s2n_blob *), int personalization_size,
+int check_drgb_version(s2n_drbg_mode mode, int (*generator)(struct s2n_blob *), int personalization_size,
         const char personalization_hex[], const char reference_values_hex[], const char returned_bits_hex[]) {
 
     DEFER_CLEANUP(struct s2n_stuffer personalization = {{0}}, s2n_stuffer_free);
@@ -382,9 +382,6 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_get_urandom_data(&blob));
     }
     EXPECT_SUCCESS(s2n_timer_reset(config, &timer, &urandom_nanoseconds));
-
-    printf("\nTime to generate 32 MB of random data per DRBG in nanoseconds\nAES 128 CTR: %"PRId64 "\nAES 256 CTR: %" PRId64" \nurandom:     %" PRId64" \n",
-            aes128_drbg_nanoseconds, aes256_drbg_nanoseconds, urandom_nanoseconds);
 
     /* NOTE: s2n_random_test also includes monobit tests for this DRBG */
 

--- a/tests/unit/s2n_utils_test.c
+++ b/tests/unit/s2n_utils_test.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "utils/s2n_safety.h"
+#include "utils/s2n_blob.h"
+#include "testlib/s2n_testlib.h"
+
+#define test_stack_blob_success(test_name, macro_name, requested, max) int test_name() {\
+macro_name(test_name ## blob, requested, max); \
+eq_check(test_name ## blob.size, requested); \
+return 0; \
+}
+
+test_stack_blob_success(success_equal, s2n_stack_blob, 10, 10)
+
+
+test_stack_blob_success(success_equal_smaller, s2n_stack_blob, 10, 100)
+
+int requested_bigger_than_max() {
+    s2n_stack_blob(foo, 11, 10);
+    /* This should never be reached due to the above failure */
+    eq_check(foo.allocated, 0);
+
+    return 0;
+}
+
+int succesful_stack_blob() {
+    s2n_stack_blob(foo, 10, 10);
+    eq_check(foo.size, 10);
+    eq_check(foo.allocated, 0);
+
+    s2n_stack_blob(foo2, 1, 10);
+    eq_check(foo2.size, 1);
+    eq_check(foo2.allocated, 0);
+
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+    EXPECT_FAILURE(requested_bigger_than_max());
+    EXPECT_SUCCESS(succesful_stack_blob());
+    END_TEST();
+}

--- a/utils/s2n_blob.h
+++ b/utils/s2n_blob.h
@@ -26,3 +26,9 @@ struct s2n_blob {
 
 extern int s2n_blob_init(struct s2n_blob *b, uint8_t * data, uint32_t size);
 extern int s2n_blob_zero(struct s2n_blob *b);
+
+#define s2n_stack_blob(name, requested_size, maximum)                               \
+    size_t name ## _requested_size = (requested_size);                              \
+    uint8_t name ## _buf[(maximum)] = {0};                                          \
+    lte_check(name ## _requested_size, (maximum));                                  \
+    struct s2n_blob name = {.data = name ## _buf, .size = name ## _requested_size}

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -85,8 +85,8 @@ static inline int s2n_defend_if_forked(void)
         /* Clean up the old drbg first */
         GUARD(s2n_rand_cleanup_thread());
         /* Instantiate the new ones */
-        GUARD(s2n_new_aes128_drbg(&per_thread_public_drbg, &public));
-        GUARD(s2n_new_aes128_drbg(&per_thread_private_drbg, &private));
+        GUARD(s2n_drbg_instantiate(&per_thread_public_drbg, &public, S2N_AES_128_CTR_NO_DF_PR));
+        GUARD(s2n_drbg_instantiate(&per_thread_private_drbg, &private, S2N_AES_128_CTR_NO_DF_PR));
         zero_if_forked = 1;
     }
 

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -85,8 +85,8 @@ static inline int s2n_defend_if_forked(void)
         /* Clean up the old drbg first */
         GUARD(s2n_rand_cleanup_thread());
         /* Instantiate the new ones */
-        GUARD(s2n_drbg_instantiate(&per_thread_public_drbg, &public));
-        GUARD(s2n_drbg_instantiate(&per_thread_private_drbg, &private));
+        GUARD(s2n_new_aes128_drbg(&per_thread_public_drbg, &public));
+        GUARD(s2n_new_aes128_drbg(&per_thread_private_drbg, &private));
         zero_if_forked = 1;
     }
 


### PR DESCRIPTION
**Issue # (if available):** 
https://github.com/awslabs/s2n/issues/904

**Description of changes:** 
In https://github.com/awslabs/s2n/pull/905 we identified that s2n already uses an AES128 Counter DRBG and instead of copying in the NIST version AES256 could we extend our own.

I have maintained all stack allocations for temporary buffers with the following pattern:
```c
uint8_t temp_seed[S2N_MAX_SEED_SIZE];
struct s2n_blob seed_blob = {.data = temp, .size = s2n_drbg_seed_size(temp) };
``` 
In practice this increases the memory required for each call by 16 bytes (32->48). I also marked a few more methods in s2n_drbg.c as static to ensure no one uses the old internal methods. 

I also added the random generation time output because I was curious but I could also remove it since its not a very scientific benchmark :
```
c5.large running Ubuntu 16.04.5 LTS:
AES 128 CTR: 1754489254
AES 256 CTR: 2360710791
urandom:     10284074474

macOS 10.12.6 i7-5557U CPU @ 3.10GHz:
AES 128 CTR: 963281000
AES 256 CTR: 949144000 
urandom:     4135472000

Travis:
AES 128 CTR: 3685042751
AES 256 CTR: 4578843350 
urandom:     15073795963
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
