### PR TITLE
Using wall_clock instead of monotonic_clock for session resumption

### DIFF
--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -621,7 +621,6 @@ int s2n_config_add_ticket_crypto_key(struct s2n_config *config,
 
     S2N_ERROR_IF(name_len == 0 || name_len > S2N_TICKET_KEY_NAME_LEN || s2n_find_ticket_key(config, name), S2N_ERR_INVALID_TICKET_KEY_NAME_OR_NAME_LENGTH);
 
-    uint64_t now;
     uint16_t insert_index = 0;
     uint8_t output_pad[S2N_AES256_KEY_LEN + S2N_TICKET_AAD_IMPLICIT_LEN];
     struct s2n_blob out_key = { .data = output_pad, .size = sizeof(output_pad) };
@@ -664,7 +663,8 @@ int s2n_config_add_ticket_crypto_key(struct s2n_config *config,
     memcpy_check(session_ticket_key->implicit_aad, out_key.data, S2N_TICKET_AAD_IMPLICIT_LEN);
 
     if (intro_time_in_seconds_from_epoch == 0) {
-        GUARD(config->monotonic_clock(config->monotonic_clock_ctx, &now));
+        uint64_t now;
+        GUARD(config->wall_clock(config->sys_clock_ctx, &now));
         session_ticket_key->intro_timestamp = now;
     } else {
         session_ticket_key->intro_timestamp = (intro_time_in_seconds_from_epoch * ONE_SEC_IN_NANOS);


### PR DESCRIPTION
**Issue # (if available):** 

https://github.com/awslabs/s2n/issues/953

**Description of changes:** 

Switching to `wall_clock` for session ticket resumption.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
