### PR TITLE
Add git-lfs apt signing key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,8 @@ matrix:
 
 before_install:
   - apt-key list
+  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 6B05F25D762E3157
+  - apt-key list
   - source .travis/s2n_setup_env.sh
 
 install:


### PR DESCRIPTION
**Issue # (if available):** 
N/A

**Description of changes:** 
Based on https://github.com/git-lfs/git-lfs/issues/3474 and https://packagecloud.io/app/github/git-lfs/gpg#gpg-apt this adds the new key so travis can download and install git-lfs and finish the build and avoid issues like https://travis-ci.org/awslabs/s2n/jobs/499061731.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
