### PR TITLE
Preserve errno after trying to read an alert

### DIFF
--- a/tests/unit/s2n_handshake_preserve_errno.c
+++ b/tests/unit/s2n_handshake_preserve_errno.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include <errno.h>
+
+#include <s2n.h>
+
+int fake_recv(void *io_context, uint8_t *buf, uint32_t len)
+{
+    /* Pretend that we have no data availible to read for alert lookup. */
+    errno = EAGAIN;
+    return -1;
+}
+
+int fake_send(void *io_context, const uint8_t *buf, uint32_t len)
+{
+    /* Fail the write with non-retriable error. */
+    errno = ENOENT;
+    return -1;
+}
+
+int main(int argc, char **argv)
+{
+    struct s2n_connection *conn;
+    s2n_blocked_status blocked;
+
+    BEGIN_TEST();
+
+    EXPECT_SUCCESS(setenv("S2N_ENABLE_CLIENT_MODE", "1", 0));
+    EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+    /* Set custom recv/send callbacks. */
+    EXPECT_SUCCESS(s2n_connection_set_recv_cb(conn, &fake_recv));
+    EXPECT_SUCCESS(s2n_connection_set_send_cb(conn, &fake_send));
+
+    /* Perform the handshake and expect an error from write, instead of error from alert read. */
+    EXPECT_EQUAL(s2n_negotiate(conn, &blocked), -1);
+    EXPECT_EQUAL(errno, ENOENT);
+    EXPECT_EQUAL(s2n_errno, S2N_ERR_IO);
+
+    EXPECT_SUCCESS(s2n_connection_free(conn));
+
+    END_TEST();
+}

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -695,6 +695,7 @@ int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status * blocked)
             *blocked = S2N_BLOCKED_ON_WRITE;
             if (handshake_write_io(conn) < 0 && s2n_errno != S2N_ERR_BLOCKED) {
                 /* Non-retryable write error. The peer might have sent an alert. Try and read it. */
+                const int write_errno = errno;
                 const int write_s2n_errno = s2n_errno;
                 const char *write_s2n_debug_str = s2n_debug_str;
 
@@ -703,6 +704,7 @@ int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status * blocked)
                     return -1;
                 } else {
                     /* Let the write error take precedence if we didn't read an alert. */
+                    errno = write_errno;
                     s2n_errno = write_s2n_errno;
                     s2n_debug_str = write_s2n_debug_str;
                     return -1;


### PR DESCRIPTION
**Issue # (if available):** 

**Description of changes:**

Today errno might get overwritten by EAGAIN after trying to read an alert from the socket, leaving inaccurate result for the caller.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
