### PR TITLE
Fix the install_sslyze.sh Script to work on fresh Ubuntu 16.04 install

### DIFF
--- a/.travis/install_sslyze.sh
+++ b/.travis/install_sslyze.sh
@@ -14,6 +14,9 @@
 #
 set -e
 
+# Need to upgrade pyOpenSSL before pip on a fresh Ubuntu 16.04 install: https://stackoverflow.com/a/48569233
+sudo python -m easy_install --upgrade pyOpenSSL
+
 pip install --user --upgrade pip setuptools
 pip install --user --upgrade nassl sslyze==1.4.0
 


### PR DESCRIPTION
**Issue # (if available):** N/A

**Description of changes:** 
Attempted to install s2n on a fresh Ubuntu 16.04 VM and ran into an error in the `install_sslyze.sh` script. Upgrading pyOpenSSL before attempting to upgrade `pip` and `setuptools` fixed the issue.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
