### PR TITLE
Improve Fuzz Test Output and Minimize Corpus files

### DIFF
--- a/tests/fuzz/Makefile
+++ b/tests/fuzz/Makefile
@@ -36,7 +36,7 @@ all : run_tests
 
 include ../../s2n.mk
 
-CRUFT += $(wildcard *_test) $(wildcard fuzz-*.log) $(wildcard *_test_output.txt) $(wildcard LD_PRELOAD/*.so)
+CRUFT += $(wildcard *_test) $(wildcard fuzz-*.log) $(wildcard *_test_output.txt) $(wildcard *_test_results.txt) $(wildcard LD_PRELOAD/*.so)
 LIBS += -lm
 
 CFLAGS += -Wno-unreachable-code -O0 -I$(LIBCRYPTO_ROOT)/include/ -I../../ -I../../api/

--- a/tests/fuzz/runFuzzTest.sh
+++ b/tests/fuzz/runFuzzTest.sh
@@ -27,7 +27,7 @@ fi
 TEST_NAME=$1
 FUZZ_TIMEOUT_SEC=$2
 MIN_TEST_PER_SEC="1000"
-MIN_BRANCHES_COVERED="100"
+MIN_FEATURES_COVERED="100"
 
 if [[ $TEST_NAME == *_negative_test ]];
 then
@@ -62,45 +62,50 @@ fi
 mkdir -p "./corpus/${TEST_NAME}"
 
 ACTUAL_TEST_FAILURE=0
-CORPUS_DIR="./corpus/${TEST_NAME}"
+
+# Copy existing Corpus to a temp directory so that new inputs from fuzz tests runs will add new inputs to the temp directory. 
+# This allows us to minimize new inputs before merging to the original corpus directory.
+TEMP_CORPUS_DIR="$(mktemp -d)"
+cp ./corpus/${TEST_NAME}/* "${TEMP_CORPUS_DIR}"
+
+
 printf "Running %-s %-40s for %5d sec with %2d threads... " "${FIPS_TEST_MSG}" ${TEST_NAME} ${FUZZ_TIMEOUT_SEC} ${NUM_CPU_THREADS}
-./${TEST_NAME} ${LIBFUZZER_ARGS} ${CORPUS_DIR} > ${TEST_NAME}_output.txt 2>&1 || ACTUAL_TEST_FAILURE=1
+./${TEST_NAME} ${LIBFUZZER_ARGS} ${TEMP_CORPUS_DIR} > ${TEST_NAME}_output.txt 2>&1 || ACTUAL_TEST_FAILURE=1
 
 TEST_COUNT=`grep -o "stat::number_of_executed_units: [0-9]*" ${TEST_NAME}_output.txt | awk '{test_count += $2} END {print test_count}'`
 TESTS_PER_SEC=`echo $(($TEST_COUNT / $FUZZ_TIMEOUT_SEC))`
-BRANCH_COVERAGE=`grep -o "cov: [0-9]*" ${TEST_NAME}_output.txt | awk '{print $2}' | sort | tail -1`
+FEATURE_COVERAGE=`grep -o "ft: [0-9]*" ${TEST_NAME}_output.txt | awk '{print $2}' | sort | tail -1`
 
 if [ $ACTUAL_TEST_FAILURE == $EXPECTED_TEST_FAILURE ];
 then
-    printf "\033[32;1mPASSED\033[0m %8d tests, %6d test/sec, %5d branches covered\n" $TEST_COUNT $TESTS_PER_SEC $BRANCH_COVERAGE
+    printf "\033[32;1mPASSED\033[0m %8d tests, %6d test/sec, %5d features covered" $TEST_COUNT $TESTS_PER_SEC $FEATURE_COVERAGE
     
     if [ $EXPECTED_TEST_FAILURE == 1 ];
     then
         # Clean up LibFuzzer corpus files if the test is negative.
+        printf "\n"
         rm -f leak-* crash-*
     else
-        if [ "$MINIMIZE_FUZZ_CORPUS" == "1" ];
-        then
-            # Make temp dir and move all corpus files to it
-            tmpdir="$(mktemp -d)"
-            mv "${CORPUS_DIR}"/* "$tmpdir"
-            
-            # Move back minimum number of files that cover all branches
-            ./${TEST_NAME} -merge=1 "${CORPUS_DIR}" "$tmpdir"
-        fi
+        # TEMP_CORPUS_DIR may contain many new inputs that only covers a small set of new branches. 
+        # Instead of copying all new inputs to the corpus directory,  only copy back minimum number of new inputs that reach new branches.
+        ./${TEST_NAME} -merge=1 "./corpus/${TEST_NAME}" "${TEMP_CORPUS_DIR}" > ${TEST_NAME}_results.txt 2>&1
         
+        # Print number of new files and branches found in new Inputs (if any)
+        RESULTS=`grep -Eo "[0-9]+ new files .*$" ${TEST_NAME}_results.txt | tail -1`
+        printf ", ${RESULTS}\n"
+       
         if [ "$TESTS_PER_SEC" -lt $MIN_TEST_PER_SEC ]; then
             printf "\033[33;1mWARNING!\033[0m ${TEST_NAME} is only ${TESTS_PER_SEC} tests/sec, which is below ${MIN_TEST_PER_SEC}/sec! Fuzz tests are more effective at higher rates.\n\n"
         fi
 
-        if [ "$BRANCH_COVERAGE" -lt $MIN_BRANCHES_COVERED ]; then
-            printf "\033[33;1mWARNING!\033[0m ${TEST_NAME} only covers ${BRANCH_COVERAGE} branches, which is below ${MIN_BRANCHES_COVERED} branches! This is likely a bug.\n"
+        if [ "$FEATURE_COVERAGE" -lt $MIN_FEATURES_COVERED ]; then
+            printf "\033[33;1mWARNING!\033[0m ${TEST_NAME} only covers ${FEATURE_COVERAGE} features, which is below ${MIN_FEATURES_COVERED}! This is likely a bug.\n"
             exit -1;
         fi
     fi
     
 else
     cat ${TEST_NAME}_output.txt
-    printf "\033[31;1mFAILED\033[0m %10d tests, %6d branches covered\n" $TEST_COUNT $BRANCH_COVERAGE
+    printf "\033[31;1mFAILED\033[0m %10d tests, %6d features covered\n" $TEST_COUNT $FEATURE_COVERAGE
     exit -1
 fi


### PR DESCRIPTION
**Issue # (if available):** N/A

**Description of changes:** 
Includes several small improvements to Fuzz Testing build scripts:
 1. New input files are minimized before being adding to the Corpus directory, so that only the minimum required number of new files are added to the Corpus directory.
2. Test output now uses LibFuzzers "Feature" Coverage metrics instead of the "BasicBlock" coverage metrics, which is more accurate. More info [can be found here](https://llvm.org/docs/LibFuzzer.html#output).
3. Test output now also prints number of new files added to the Corpus

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
