### PR TITLE
Fix receiving of signature algorithms

### DIFF
--- a/tls/s2n_signature_algorithms.c
+++ b/tls/s2n_signature_algorithms.c
@@ -144,8 +144,9 @@ int s2n_recv_supported_signature_algorithms(struct s2n_connection *conn, struct 
         return 0;
     }
 
-    if (length_of_all_pairs % 2 || s2n_stuffer_data_available(in) % 2) {
-        /* Pairs occur in two byte lengths. Malformed length, ignore the extension. */
+    if (length_of_all_pairs % 2) {
+        /* Pairs occur in two byte lengths. Malformed length, ignore the extension and skip ahead */
+        GUARD(s2n_stuffer_skip_read(in, length_of_all_pairs));
         return 0;
     }
 


### PR DESCRIPTION

**Issue # N/A:** 

s2n erroneously assumed this was the last part of the message we are parsing, however there may be unrelated data to the signature algorithms in the stuffer which is not an even length.

**Description of changes:** 

There are two parts to addressing this, the first is to not check the remainder of the stuffer is an even length, as we have already validated the input is at least big enough for the data we need.  Next, we skip the number of bytes in the stuffer if we are ignoring an invalid length so as not to leave the stuffer in an incorrect state.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
