### PR TITLE
Update License files for new SIKE algorithms

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -200,3 +200,25 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+   
+   
+============================================================================
+    S2N SUBCOMPONENTS:
+
+    The s2n Project contains subcomponents with seperate copyright notices
+    and license terms. Your use of the source code for these subcomponents is
+    subject to the terms and conditions of the following licenses.
+
+
+========================================================================
+Third party MIT licenses
+========================================================================
+
+The following components are provided under the MIT License. See project link for details.
+
+
+    SIKE
+      -> s2n/pq-crypto/sike/LICENSE.txt
+
+   
+   

--- a/pq-crypto/sike/LICENSE.txt
+++ b/pq-crypto/sike/LICENSE.txt
@@ -1,0 +1,28 @@
+Supersingular Isogeny Key Encapsulation (SIKE)
+
+Copyright (c) 2016-2017 Microsoft Corporation
+Copyright (c) 2017      InfoSec Global, Reza Azarderakhsh, Matthew
+                        Campagna, Luca De Feo, Amir Jalali, David Jao,
+                        Brian Koziel, Joost Renes, and David Urbanik
+All rights reserved. 
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+""Software""), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/pq-crypto/sike/Readme.md
+++ b/pq-crypto/sike/Readme.md
@@ -1,0 +1,7 @@
+
+Supersingular Isogeny Key Encapsulation  (SIKE)
+================================================
+
+The code in this directory is mostly taken from the MIT Licensed SIKE Reference Implementation submitted to NIST here: https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-1/submissions/SIKE.zip
+
+Only minor modifications were made in order to integrate this code into s2n's build system.


### PR DESCRIPTION
**Issue # (if available):** N/A

**Description of changes:** 
SIKE code is MIT Licensed. Already got Amazon Open Source team approval, but we forgot to update the License files when we merged the [SIKE change](https://github.com/awslabs/s2n/pull/905) a couple of days ago.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
