### PR TITLE
Fix Race Condition in s_client Python Integ Tests

### DIFF
--- a/bin/echo.c
+++ b/bin/echo.c
@@ -70,6 +70,7 @@ int negotiate(struct s2n_connection *conn)
         fprintf(stderr, "Could not get actual protocol version\n");
         return -1;
     }
+    printf("CONNECTED:\n");
     printf("Client hello version: %d\n", client_hello_version);
     printf("Client protocol version: %d\n", client_protocol_version);
     printf("Server protocol version: %d\n", server_protocol_version);


### PR DESCRIPTION
**Issue # (if available):** https://github.com/awslabs/s2n/issues/1014

**Description of changes:** 
This PR removes an existing race condition in the `s2n_handshake_test_s_client.py` integration tests, and removes all existing `sleep()` calls that attempt to make the race conditions less likely to happen. 

First Draft PR: https://github.com/awslabs/s2n/pull/1016 which is now discarded since that wasn't the long term solution.

The problem is that Python's SubProcess `communicate` API is one-shot and only works after killing the process and gets all the stdin/stdout at once, but we don't know how long to wait before killing the process to read it's output. Python's other API to read the stdin/stdout line by line has a [known deadlock](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.wait) that we've [run into in the past](https://github.com/awslabs/s2n/pull/831) that causes Integration tests to hang if too much data is written too quickly and fills up the OS's IO buffers. We aren't writing a lot of data in these integration tests, so it should be safe to make this change here. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
