### PR TITLE
Add Fall-Through comment in all fall-through cases

### DIFF
--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -398,6 +398,7 @@ static int s2n_evp_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *f
         if (s2n_digest_is_md5_allowed_for_fips(&from->digest.high_level.evp)) {
             GUARD(s2n_hash_allow_md5_for_fips(to));
         }
+    /* fall through */
     case S2N_HASH_SHA1:
     case S2N_HASH_SHA224:
     case S2N_HASH_SHA256:

--- a/utils/s2n_asn1_time.c
+++ b/utils/s2n_asn1_time.c
@@ -158,7 +158,7 @@ static parser_state process_state(parser_state state, char current_char, struct 
             if (current_char == '.' || isdigit(current_char)) {
                 return ON_SUBSECOND;
             }
-        /* this fallthrough is intentional */
+        /* fall through */
         case ON_TIMEZONE:
             if (current_char == 'Z' || current_char == 'z') {
                 args->local_time_assumed = 0;


### PR DESCRIPTION
**Issue # (if available):** https://github.com/awslabs/s2n/issues/1022

**Description of changes:** Compiled s2n locally with GCC 7 and `-Wimplicit-fallthrough` option enabled and fixed all cases in s2n's codebase. Also fixed the issue brought up in https://github.com/awslabs/s2n/issues/1022 that would cause s2n to accept a valid RSA Cert when a valid ECDSA Cert was expected due to implicit case statement fall through. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
