### PR TITLE
Disable all composite ciphers with LibreSSL

### DIFF
--- a/crypto/s2n_composite_cipher_aes_sha.c
+++ b/crypto/s2n_composite_cipher_aes_sha.c
@@ -30,10 +30,9 @@
 static const EVP_CIPHER *s2n_evp_aes_128_cbc_hmac_sha1(void)
 {
     /* Symbols for AES-SHA1-CBC composite ciphers were added in Openssl 1.0.1:
-     * See https://www.openssl.org/news/cl101.txt. LibreSSL defines OPENSSL_VERSION_NUMBER to be
-     * 0x20000000L but AES-SHA1-CBC is in LibreSSL since first major release(2.0.0).
+     * See https://www.openssl.org/news/cl101.txt.
      */
-    #if S2N_OPENSSL_VERSION_AT_LEAST(1,0,1)
+    #if S2N_OPENSSL_VERSION_AT_LEAST(1,0,1) && !defined LIBRESSL_VERSION_NUMBER
         return EVP_aes_128_cbc_hmac_sha1();
     #else
         return NULL;
@@ -42,7 +41,7 @@ static const EVP_CIPHER *s2n_evp_aes_128_cbc_hmac_sha1(void)
 
 static const EVP_CIPHER *s2n_evp_aes_256_cbc_hmac_sha1(void)
 {
-    #if S2N_OPENSSL_VERSION_AT_LEAST(1,0,1)
+    #if S2N_OPENSSL_VERSION_AT_LEAST(1,0,1) && !defined LIBRESSL_VERSION_NUMBER
         return EVP_aes_256_cbc_hmac_sha1();
     #else
         return NULL;


### PR DESCRIPTION
These cipher isn't planned to be well supported in LibreSSL for TLS
usage.

closes #1021 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
