### PR TITLE
Add Link to AWS Vuln Reporting Guide to Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,8 @@
-**Problem:** 
+## **Problem:**
 
 
-**Proposed Solution:** 
+## **Proposed Solution:**
 
+
+
+[//]: #  (NOTE: If you believe this might be a security issue, please email aws-security@amazon.com instead of creating a GitHub issue. For more details, see the AWS Vulnerability Reporting Guide: https://aws.amazon.com/security/vulnerability-reporting/ )


### PR DESCRIPTION
**Issue # (if available):** N/A

**Description of changes:** 
Adds a link to the [AWS Vulnerability Reporting Guide](https://aws.amazon.com/security/vulnerability-reporting/) in the default Issue template.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
