### PR TITLE
Cleanup test macros to require proper semicolon usage

### DIFF
--- a/tests/s2n_test.h
+++ b/tests/s2n_test.h
@@ -25,7 +25,7 @@
 
 /* Macro definitions for calls that occur within BEGIN_TEST() and END_TEST() to preserve the SKIPPED test behavior
  * by ignoring the test_count, keeping it as 0 to indicate that a test was skipped. */
-#define EXPECT_TRUE_WITHOUT_COUNT( condition )    { if ( !(condition) ) { FAIL_MSG( #condition " is not true "); } }
+#define EXPECT_TRUE_WITHOUT_COUNT( condition )    do { if ( !(condition) ) { FAIL_MSG( #condition " is not true "); } } while(0)
 #define EXPECT_FALSE_WITHOUT_COUNT( condition )   EXPECT_TRUE_WITHOUT_COUNT( !(condition) )
 
 #define EXPECT_NOT_EQUAL_WITHOUT_COUNT( p1, p2 )  EXPECT_FALSE_WITHOUT_COUNT( (p1) == (p2) )
@@ -37,12 +37,14 @@
  * happen in main() and start with a BEGIN_TEST() and end with an END_TEST();
  */
 #ifdef S2N_TEST_IN_FIPS_MODE
-#define BEGIN_TEST() int test_count = 0; EXPECT_NOT_EQUAL_WITHOUT_COUNT(FIPS_mode_set(1), 0); EXPECT_SUCCESS_WITHOUT_COUNT(s2n_init());\
-                            { fprintf(stdout, "Running FIPS test %-50s ... ", __FILE__); }
+#define BEGIN_TEST() int test_count = 0; do { EXPECT_NOT_EQUAL_WITHOUT_COUNT(FIPS_mode_set(1), 0); \
+                            EXPECT_SUCCESS_WITHOUT_COUNT(s2n_init()); \
+                            fprintf(stdout, "Running FIPS test %-50s ... ", __FILE__); } while(0)
 #else
-#define BEGIN_TEST() int test_count = 0; EXPECT_SUCCESS_WITHOUT_COUNT(s2n_init()); { fprintf(stdout, "Running %-50s ... ", __FILE__); }
+#define BEGIN_TEST() int test_count = 0; do { EXPECT_SUCCESS_WITHOUT_COUNT(s2n_init());  fprintf(stdout, "Running %-50s ... ", __FILE__); } while(0)
 #endif
-#define END_TEST()   EXPECT_SUCCESS_WITHOUT_COUNT(s2n_cleanup()); { if (isatty(fileno(stdout))) { \
+#define END_TEST()   do { EXPECT_SUCCESS_WITHOUT_COUNT(s2n_cleanup()); \
+                        if (isatty(fileno(stdout))) { \
                             if (test_count) { \
                                 fprintf(stdout, "\033[32;1mPASSED\033[0m %10d tests\n", test_count ); \
                             }\
@@ -59,20 +61,20 @@
                             }\
                        } \
                        return 0;\
-                    }
+                    } while(0)
 
-#define FAIL()      FAIL_MSG("");
+#define FAIL()      FAIL_MSG("")
 
-#define FAIL_MSG( msg ) { if (isatty(fileno(stdout))) { \
+#define FAIL_MSG( msg ) do { if (isatty(fileno(stdout))) { \
                             fprintf(stdout, "\033[31;1mFAILED test %d\033[0m\n%s (%s line %d)\nError Message: '%s'\n Debug String: '%s'\n", test_count, (msg), __FILE__, __LINE__, s2n_strerror(s2n_errno, "EN"), s2n_debug_str); \
                           } \
                           else { \
                             fprintf(stdout, "FAILED test %d\n%s (%s line %d)\nError Message: '%s'\n Debug String: '%s'\n", test_count, (msg), __FILE__, __LINE__, s2n_strerror(s2n_errno, "EN"), s2n_debug_str); \
                           } \
                           exit(1);  \
-                        }
+                        } while(0)
 
-#define EXPECT_TRUE( condition )    { test_count++; if ( !(condition) ) { FAIL_MSG( #condition " is not true "); } }
+#define EXPECT_TRUE( condition )    do { test_count++; if ( !(condition) ) { FAIL_MSG( #condition " is not true "); } } while(0)
 #define EXPECT_FALSE( condition )   EXPECT_TRUE( !(condition) )
 
 #define EXPECT_EQUAL( p1, p2 )      EXPECT_TRUE( (p1) == (p2) )
@@ -81,7 +83,7 @@
 #define EXPECT_NULL( ptr )      EXPECT_EQUAL( ptr, NULL )
 #define EXPECT_NOT_NULL( ptr )  EXPECT_NOT_EQUAL( ptr, NULL )
 
-#define EXPECT_FAILURE( function_call )  { EXPECT_EQUAL( (function_call) ,  -1 ); EXPECT_NOT_EQUAL(s2n_errno, 0); EXPECT_NOT_NULL(s2n_debug_str); s2n_errno = 0; s2n_debug_str = NULL; }
+#define EXPECT_FAILURE( function_call )  do { EXPECT_EQUAL( (function_call) ,  -1 ); EXPECT_NOT_EQUAL(s2n_errno, 0); EXPECT_NOT_NULL(s2n_debug_str); s2n_errno = 0; s2n_debug_str = NULL; } while(0)
 #define EXPECT_SUCCESS( function_call )  EXPECT_NOT_EQUAL( (function_call) ,  -1 )
 
 #define EXPECT_BYTEARRAY_EQUAL( p1, p2, l ) EXPECT_EQUAL( memcmp( (p1), (p2), (l) ), 0 )

--- a/tests/unit/s2n_3des_test.c
+++ b/tests/unit/s2n_3des_test.c
@@ -90,8 +90,8 @@ int main(int argc, char **argv)
         /* Copy the encrypted out data to the in data */
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
-        EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5))
-        EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)))
+        EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
+        EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
         /* Let's decrypt it */
         uint8_t content_type;

--- a/tests/unit/s2n_aes_sha_composite_test.c
+++ b/tests/unit/s2n_aes_sha_composite_test.c
@@ -117,8 +117,8 @@ int main(int argc, char **argv)
             /* Copy the encrypted out data to the in data */
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
-            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5))
-            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)))
+            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
+            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
             /* Let's decrypt it */
             uint8_t content_type;
@@ -182,8 +182,8 @@ int main(int argc, char **argv)
             /* Copy the encrypted out data to the in data */
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
-            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5))
-            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)))
+            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
+            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
             /* Let's decrypt it */
             uint8_t content_type;
@@ -248,8 +248,8 @@ int main(int argc, char **argv)
             /* Copy the encrypted out data to the in data */
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
-            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5))
-            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)))
+            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
+            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
             /* Let's decrypt it */
             uint8_t content_type;
@@ -313,8 +313,8 @@ int main(int argc, char **argv)
             /* Copy the encrypted out data to the in data */
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
-            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5))
-            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)))
+            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
+            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
             /* Let's decrypt it */
             uint8_t content_type;

--- a/tests/unit/s2n_aes_test.c
+++ b/tests/unit/s2n_aes_test.c
@@ -92,8 +92,8 @@ int main(int argc, char **argv)
         /* Copy the encrypted out data to the in data */
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
-        EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5))
-        EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)))
+        EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
+        EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
             /* Let's decrypt it */
         uint8_t content_type;
@@ -156,8 +156,8 @@ int main(int argc, char **argv)
         /* Copy the encrypted out data to the in data */
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
-        EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5))
-            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)))
+        EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
+            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
             /* Let's decrypt it */
         uint8_t content_type;

--- a/tests/unit/s2n_override_openssl_random_test.c
+++ b/tests/unit/s2n_override_openssl_random_test.c
@@ -92,8 +92,8 @@ int main(int argc, char **argv)
 
     DEFER_CLEANUP(struct s2n_stuffer dhe_key_stuffer = {{0}}, s2n_stuffer_free);
     EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&dhe_key_stuffer, expected_dhe_key_hex));
-    EXPECT_EQUAL(dhe_key_stuffer.blob.size, 519)
-    EXPECT_EQUAL(out_blob.size, 519)
+    EXPECT_EQUAL(dhe_key_stuffer.blob.size, 519);
+    EXPECT_EQUAL(out_blob.size, 519);
 
     EXPECT_BYTEARRAY_EQUAL(dhe_key_stuffer.blob.data, out_blob.data, out_blob.size);
 

--- a/tests/unit/s2n_rc4_test.c
+++ b/tests/unit/s2n_rc4_test.c
@@ -92,8 +92,8 @@ int main(int argc, char **argv)
         /* Copy the encrypted out data to the in data */
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
-        EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5))
-        EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)))
+        EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
+        EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
         /* Check that the data looks right */
         EXPECT_EQUAL(bytes_written + 20, s2n_stuffer_data_available(&conn->in));

--- a/tests/unit/s2n_record_test.c
+++ b/tests/unit/s2n_record_test.c
@@ -155,7 +155,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(conn->out.blob.data[2], 2);
         EXPECT_EQUAL(conn->out.blob.data[3], (predicted_length >> 8) & 0xff);
         EXPECT_EQUAL(conn->out.blob.data[4], predicted_length & 0xff);
-        EXPECT_EQUAL(memcmp(conn->out.blob.data + 5, random_data, bytes_written), 0)
+        EXPECT_EQUAL(memcmp(conn->out.blob.data + 5, random_data, bytes_written), 0);
 
         uint8_t top = bytes_written >> 8;
         uint8_t bot = bytes_written & 0xff;

--- a/tests/unit/s2n_session_ticket_test.c
+++ b/tests/unit/s2n_session_ticket_test.c
@@ -133,7 +133,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(server_config, 1))
+        EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(server_config, 1));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
 
         /* Set session state lifetime for 15 hours which is equal to the default lifetime of a ticket key */
@@ -185,7 +185,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(server_config, 1))
+        EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(server_config, 1));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
 
         /* Set session state lifetime for 15 hours which is equal to the default lifetime of a ticket key */
@@ -226,7 +226,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(server_config, 1))
+        EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(server_config, 1));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
 
         /* Set session state lifetime for 15 hours which is equal to the default lifetime of a ticket key */


### PR DESCRIPTION
**Issue # (if available):** 
N/A
**Description of changes:** 
Without the do/while macro trick these test macros expand as complete statements and you can omit the final `;` on a line, or if you add a `;` your IDE might give you a `empty statement` warning. The only thing outside of the `do` is the `test_count` declaration  so it stays in scope.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
