### PR TITLE
Remove static limit on maximum number of certs

### DIFF
--- a/crypto/s2n_certificate.c
+++ b/crypto/s2n_certificate.c
@@ -27,6 +27,10 @@
 #include "utils/s2n_safety.h"
 #include "utils/s2n_mem.h"
 
+static const s2n_authentication_method cert_type_to_auth_method[] = {
+    [S2N_CERT_TYPE_RSA_SIGN] = S2N_AUTHENTICATION_RSA,
+    [S2N_CERT_TYPE_ECDSA_SIGN] = S2N_AUTHENTICATION_ECDSA,
+};
 
 int s2n_cert_public_key_set_rsa_from_openssl(s2n_cert_public_key *public_key, RSA *openssl_rsa)
 {
@@ -326,5 +330,14 @@ int s2n_cert_chain_and_key_matches_name(struct s2n_cert_chain_and_key *chain_and
     }
 
     return 0;
+}
+
+/*
+ * Note that this assumes there is a 1:1 relationship between cert type and auth method.
+ * This interface will need to be updated if s2n adds support for more than one auth method per certificate type.
+ */
+s2n_authentication_method s2n_cert_chain_and_key_get_auth_method(struct s2n_cert_chain_and_key *chain_and_key)
+{
+    return cert_type_to_auth_method[chain_and_key->cert_chain->head->cert_type];
 }
 

--- a/crypto/s2n_certificate.h
+++ b/crypto/s2n_certificate.h
@@ -46,6 +46,12 @@ struct s2n_cert_chain_and_key {
     X509 *x509_cert;
 };
 
+typedef enum {
+    S2N_AUTHENTICATION_RSA = 0,
+    S2N_AUTHENTICATION_ECDSA,
+    S2N_AUTHENTICATION_METHOD_SENTINEL
+} s2n_authentication_method;
+
 int s2n_cert_chain_and_key_set_ocsp_data(struct s2n_cert_chain_and_key *chain_and_key, const uint8_t *data, uint32_t length);
 int s2n_cert_chain_and_key_set_sct_list(struct s2n_cert_chain_and_key *chain_and_key, const uint8_t *data, uint32_t length);
 int s2n_cert_chain_and_key_matches_name(struct s2n_cert_chain_and_key *chain_and_key, const char *name);
@@ -55,3 +61,6 @@ int s2n_cert_set_cert_type(struct s2n_cert *cert, s2n_cert_type cert_type);
 int s2n_send_cert_chain(struct s2n_stuffer *out, struct s2n_cert_chain *chain);
 int s2n_send_empty_cert_chain(struct s2n_stuffer *out);
 int s2n_create_cert_chain_from_stuffer(struct s2n_cert_chain *cert_chain_out, struct s2n_stuffer *chain_in_stuffer);
+
+s2n_authentication_method s2n_cert_chain_and_key_get_auth_method(struct s2n_cert_chain_and_key *chain_and_key);
+

--- a/error/s2n_errno.c
+++ b/error/s2n_errno.c
@@ -105,7 +105,6 @@ struct s2n_error_translation S2N_ERROR_EN[] = {
     {S2N_ERR_CLIENT_MODE, "operation not allowed in client mode"},
     {S2N_ERR_SERVER_NAME_TOO_LONG, "server name is too long"},
     {S2N_ERR_CLIENT_MODE_DISABLED, "client connections not allowed"},
-    {S2N_ERR_TOO_MANY_CERTIFICATES, "Too many certificates configured"},
     {S2N_ERR_CLIENT_AUTH_NOT_SUPPORTED_IN_FIPS_MODE, "Client Auth is not supported when in FIPS mode"},
     {S2N_ERR_HANDSHAKE_STATE, "Invalid handshake state encountered"},
     {S2N_ERR_FALLBACK_DETECTED, "TLS fallback detected"},

--- a/tests/fuzz/s2n_client_cert_verify_recv_test.c
+++ b/tests/fuzz/s2n_client_cert_verify_recv_test.c
@@ -143,8 +143,10 @@ int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
     GUARD(s2n_config_add_cert_chain_and_key(server_config, certificate_chain, private_key));
 
     s2n_cert_type cert_type;
-    GUARD(s2n_asn1der_to_public_key_and_type(&public_key, &cert_type, &server_config->cert_and_key_pairs[0]->cert_chain->head->raw));
-    
+    struct s2n_array *certs = server_config->cert_and_key_pairs;
+    struct s2n_cert_chain_and_key *cert = *((struct s2n_cert_chain_and_key**) s2n_array_get(certs, 0));
+    GUARD(s2n_asn1der_to_public_key_and_type(&public_key, &cert_type, &cert->cert_chain->head->raw));
+
     return 0;
 }
 

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -956,8 +956,9 @@ static struct s2n_cert_chain_and_key *s2n_get_compatible_cert_chain_and_key(stru
 
 static struct s2n_cert_chain_and_key *s2n_conn_get_compatible_cert_chain_and_key(struct s2n_connection *conn, struct s2n_cipher_suite *cipher_suite)
 {
-    if (conn->handshake_params.num_sni_matching_certs > 0) {
-        return s2n_get_compatible_cert_chain_and_key(conn->handshake_params.sni_matching_certs, conn->handshake_params.num_sni_matching_certs, cipher_suite);
+    if (conn->handshake_params.sni_match_exists > 0) {
+        /* This may return NULL if there was an SNI match, but not a match the cipher_suite's authentication type. */
+        return conn->handshake_params.sni_matching_certs[cipher_suite->auth_method];
     } else {
         /* We don't have any name matches. Use the first certificate that works with the key type. */
         return s2n_get_compatible_cert_chain_and_key(conn->config->cert_and_key_pairs, conn->config->num_certificates, cipher_suite);

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -939,10 +939,10 @@ static int s2n_cipher_is_compatible_with_cert(struct s2n_cipher_suite *cipher, s
     return 0;
 }
 
-static struct s2n_cert_chain_and_key *s2n_get_compatible_cert_chain_and_key(struct s2n_cert_chain_and_key **certs, int num_certificates, struct s2n_cipher_suite *cipher_suite)
+static struct s2n_cert_chain_and_key *s2n_get_compatible_cert_chain_and_key(struct s2n_array *certs, struct s2n_cipher_suite *cipher_suite)
 {
-    for (int i = 0; i < num_certificates; i++) {
-        struct s2n_cert_chain_and_key *cert_chain_and_key = certs[i];
+    for (int i = 0; i < s2n_array_num_elements(certs); i++) {
+        struct s2n_cert_chain_and_key *cert_chain_and_key = *((struct s2n_cert_chain_and_key**) s2n_array_get(certs, i));
         struct s2n_cert *leaf_cert = cert_chain_and_key->cert_chain->head;
         uint8_t cert_compatibility = 0;
         GUARD_PTR(s2n_cipher_is_compatible_with_cert(cipher_suite, leaf_cert, &cert_compatibility));
@@ -961,7 +961,7 @@ static struct s2n_cert_chain_and_key *s2n_conn_get_compatible_cert_chain_and_key
         return conn->handshake_params.sni_matching_certs[cipher_suite->auth_method];
     } else {
         /* We don't have any name matches. Use the first certificate that works with the key type. */
-        return s2n_get_compatible_cert_chain_and_key(conn->config->cert_and_key_pairs, conn->config->num_certificates, cipher_suite);
+        return s2n_get_compatible_cert_chain_and_key(conn->config->cert_and_key_pairs, cipher_suite);
     }
 }
 

--- a/tls/s2n_cipher_suites.h
+++ b/tls/s2n_cipher_suites.h
@@ -17,7 +17,9 @@
 
 #include "tls/s2n_tls_parameters.h"
 #include "tls/s2n_connection.h"
+#include "tls/s2n_crypto.h"
 
+#include "crypto/s2n_certificate.h"
 #include "crypto/s2n_cipher.h"
 #include "crypto/s2n_hmac.h"
 
@@ -27,11 +29,6 @@
 #define S2N_KEY_EXCHANGE_DH       0x01  /* Diffie-Hellman key exchange, including ephemeral */
 #define S2N_KEY_EXCHANGE_EPH      0x02  /* Ephemeral key exchange */
 #define S2N_KEY_EXCHANGE_ECC      0x04  /* Elliptic curve cryptography */
-
-typedef enum {
-    S2N_AUTHENTICATION_RSA = 0,
-    S2N_AUTHENTICATION_ECDSA
-} s2n_authentication_method;
 
 #define S2N_MAX_POSSIBLE_RECORD_ALGS  2
 

--- a/tls/s2n_client_cert_request.c
+++ b/tls/s2n_client_cert_request.c
@@ -25,11 +25,13 @@
 #include "tls/s2n_tls.h"
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_safety.h"
+#include "utils/s2n_array.h"
 
 static int s2n_set_cert_chain_as_client(struct s2n_connection *conn)
 {
-    if (conn->config->num_certificates > 0) {
-        conn->handshake_params.our_chain_and_key = conn->config->cert_and_key_pairs[0];
+    struct s2n_array *certs = conn->config->cert_and_key_pairs;
+    if (s2n_array_num_elements(certs) > 0) {
+        conn->handshake_params.our_chain_and_key = *((struct s2n_cert_chain_and_key**) s2n_array_get(certs, 0));
     }
 
     return 0;

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -27,12 +27,6 @@
 #define S2N_MAX_TICKET_KEYS 48
 #define S2N_MAX_TICKET_KEY_HASHES 500 /* 10KB */
 
-/* This is 2 to match the number of certificate types s2n supports(RSA, ECDSA)
- * This will increase once we support more lookup methods(server_name). Since this value is
- * a factor in memory footprint, the application will also need a way to control the max.
- */
-#define S2N_MAX_CERTIFICATES 50
-
 struct s2n_cipher_preferences;
 
 struct s2n_config {
@@ -41,8 +35,7 @@ struct s2n_config {
      * used to release memory allocated only in the deprecated API that the application 
      * does not have a reference to. */
     unsigned cert_allocated:1;
-    unsigned int num_certificates;
-    struct s2n_cert_chain_and_key *cert_and_key_pairs[S2N_MAX_CERTIFICATES];
+    struct s2n_array *cert_and_key_pairs;
     const struct s2n_cipher_preferences *cipher_preferences;
     struct s2n_blob application_protocols;
     s2n_status_request_type status_request_type;

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -487,7 +487,7 @@ int s2n_connection_set_config(struct s2n_connection *conn, struct s2n_config *co
     }
 
     /* We only support one client certificate */
-    if (config->num_certificates > 1 && conn->mode == S2N_CLIENT) {
+    if (s2n_array_num_elements(config->cert_and_key_pairs) > 1 && conn->mode == S2N_CLIENT) {
         S2N_ERROR(S2N_ERR_TOO_MANY_CERTIFICATES);
     }
 

--- a/tls/s2n_handshake.c
+++ b/tls/s2n_handshake.c
@@ -161,10 +161,11 @@ int s2n_conn_find_name_matching_certs(struct s2n_connection *conn)
     const char *name = conn->server_name;
     for (int i = 0; i < conn->config->num_certificates; i++) {
         struct s2n_cert_chain_and_key *chain_and_key = conn->config->cert_and_key_pairs[i];
-        if (s2n_cert_chain_and_key_matches_name(chain_and_key, name)) {
-            /* Found a match, add it to the list for this session. */
-            conn->handshake_params.sni_matching_certs[conn->handshake_params.num_sni_matching_certs] = chain_and_key;
-            conn->handshake_params.num_sni_matching_certs++;
+        s2n_authentication_method auth_method = s2n_cert_chain_and_key_get_auth_method(chain_and_key);
+        if (s2n_cert_chain_and_key_matches_name(chain_and_key, name) &&
+                !conn->handshake_params.sni_matching_certs[auth_method]) {
+            conn->handshake_params.sni_matching_certs[auth_method] = chain_and_key;
+            conn->handshake_params.sni_match_exists = 1;
         }
     }
 

--- a/tls/s2n_handshake.c
+++ b/tls/s2n_handshake.c
@@ -159,8 +159,9 @@ int s2n_conn_update_required_handshake_hashes(struct s2n_connection *conn)
 int s2n_conn_find_name_matching_certs(struct s2n_connection *conn)
 {
     const char *name = conn->server_name;
-    for (int i = 0; i < conn->config->num_certificates; i++) {
-        struct s2n_cert_chain_and_key *chain_and_key = conn->config->cert_and_key_pairs[i];
+    struct s2n_array *certs = conn->config->cert_and_key_pairs;
+    for (int i = 0; i < s2n_array_num_elements(certs); i++) {
+        struct s2n_cert_chain_and_key *chain_and_key = *((struct s2n_cert_chain_and_key**) s2n_array_get(certs, i));
         s2n_authentication_method auth_method = s2n_cert_chain_and_key_get_auth_method(chain_and_key);
         if (s2n_cert_chain_and_key_matches_name(chain_and_key, name) &&
                 !conn->handshake_params.sni_matching_certs[auth_method]) {

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -18,6 +18,7 @@
 #include <stdint.h>
 #include <s2n.h>
 
+#include "tls/s2n_cipher_suites.h"
 #include "tls/s2n_crypto.h"
 #include "tls/s2n_signature_algorithms.h"
 #include "tls/s2n_tls_parameters.h"
@@ -62,6 +63,10 @@ struct s2n_handshake_parameters {
      * In the case of multiple certificates matching a server_name, s2n will prefer certificates
      * in FIFO order based on calls to s2n_config_add_cert_chain_and_key_to_store
      *
+     * Note that in addition to domain matching, the key type for the certificate must also be
+     * suitable for a negotiation in order to be selected. The set of matching certs here are indexed
+     * by s2n_authentication_method.
+     *
      * Example:
      *    - Assume certA is added to s2n_config via s2n_config_add_cert_chain_and_key_to_store
      *    - Next certB is added.
@@ -76,8 +81,8 @@ struct s2n_handshake_parameters {
      *    - Client only supports RSA ciphers
      *    - certB will be selected.
      */
-    unsigned int num_sni_matching_certs;
-    struct s2n_cert_chain_and_key *sni_matching_certs[S2N_MAX_CERTIFICATES];
+    struct s2n_cert_chain_and_key *sni_matching_certs[S2N_AUTHENTICATION_METHOD_SENTINEL];
+    uint8_t sni_match_exists;
 };
 
 struct s2n_handshake {

--- a/utils/s2n_array.h
+++ b/utils/s2n_array.h
@@ -30,6 +30,8 @@ struct s2n_array {
     size_t element_size;
 };
 
+#define s2n_array_num_elements( a )   ((a)->num_of_elements)
+
 extern struct s2n_array *s2n_array_new(size_t element_size);
 extern void *s2n_array_add(struct s2n_array *array);
 extern void *s2n_array_get(struct s2n_array *array, uint32_t index);


### PR DESCRIPTION
**Description of changes:** 
This change removes the static limit on the number of certificates that can be added to an `s2n_config` object. Previously we sized the limit based on a compile time constant, which would unnecessarily increase memory utilization for applications that do not wish to configure a large number of certificates.