### PR TITLE
Add _GNU_SOURCE to s2n_certificate.c

### DIFF
--- a/crypto/s2n_certificate.c
+++ b/crypto/s2n_certificate.c
@@ -13,6 +13,10 @@
  * permissions and limitations under the License.
  */
 
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE
+#endif
+
 #include <s2n.h>
 #include <openssl/x509v3.h>
 #include <openssl/pem.h>


### PR DESCRIPTION
Need this for platforms with glibc < 2.10

**Issue # (if available):** 

**Description of changes:** 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
