### PR TITLE
Add ELBSecurityPolicy-TLS-1-2-2019-05

### DIFF
--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -546,6 +546,22 @@ const struct s2n_cipher_preferences elb_security_policy_fs_2018_06 = {
     .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
+struct s2n_cipher_suite *cipher_suites_elb_security_policy_tls_1_2_2019_05[] = {
+    &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_rsa_with_aes_128_gcm_sha256,
+    &s2n_rsa_with_aes_256_gcm_sha384,
+};
+
+const struct s2n_cipher_preferences elb_security_policy_tls_1_2_2019_05 = {
+    .count = sizeof(cipher_suites_elb_security_policy_tls_1_2_2019_05) / sizeof(cipher_suites_elb_security_policy_tls_1_2_2019_05[0]),
+    .suites = cipher_suites_elb_security_policy_tls_1_2_2019_05,
+    .minimum_protocol_version = S2N_TLS12,
+    .extension_flag = S2N_ECC_EXTENSION_ENABLED
+};
+
 struct s2n_cipher_suite *cipher_suites_cloudfront_upstream[] = {
     &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
     &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
@@ -744,6 +760,7 @@ struct {
     { "ELBSecurityPolicy-TLS-1-2-2017-01", &elb_security_policy_tls_1_2_2017_01},
     { "ELBSecurityPolicy-TLS-1-2-Ext-2018-06", &elb_security_policy_tls_1_2_ext_2018_06},
     { "ELBSecurityPolicy-FS-2018-06", &elb_security_policy_fs_2018_06},
+    { "ELBSecurityPolicy-TLS-1-2-2019-05", &elb_security_policy_tls_1_2_2019_05},
     { "CloudFront-Upstream", &cipher_preferences_cloudfront_upstream },
     { "CloudFront-SSL-v-3", &cipher_preferences_cloudfront_ssl_v_3 },
     { "CloudFront-TLS-1-0-2014", &cipher_preferences_cloudfront_tls_1_0_2014 },

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -551,8 +551,6 @@ struct s2n_cipher_suite *cipher_suites_elb_security_policy_tls_1_2_2019_05[] = {
     &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
     &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
     &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
-    &s2n_rsa_with_aes_128_gcm_sha256,
-    &s2n_rsa_with_aes_256_gcm_sha384,
 };
 
 const struct s2n_cipher_preferences elb_security_policy_tls_1_2_2019_05 = {


### PR DESCRIPTION
**Issue # (if available):**

The latest TLS 1.2 security policy `ELBSecurityPolicy-TLS-1-2-2017-01` has Ciphers which support [Cipher Block Chaining (CBC)](https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Cipher_Block_Chaining_(CBC)) https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies` which are considered weak by [SSL Labs](https://www.ssllabs.com/ssltest/analyze.html?d=www.bongloy.com&s=13.229.185.21).

![image](https://user-images.githubusercontent.com/127583/57666291-b1309a80-7629-11e9-8407-6d26f1cc49e5.png)

This is causing PCI compliance issues for us as we're using an Application Load Balancer to terminate TLS.

**Description of changes:** 

Adds a new ELB Security Policy `ELBSecurityPolicy-TLS-1-2-2019-05`, removing weak ciphers that exist in `ELBSecurityPolicy-TLS-1-2-2017-01`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
