### PR TITLE
Add missing GUARD checks to SIKE code

### DIFF
--- a/pq-crypto/sike/api.h
+++ b/pq-crypto/sike/api.h
@@ -39,27 +39,27 @@ void random_mod_order_B(unsigned char* random_digits);
 // Alice's ephemeral public key generation
 // Input:  a private key PrivateKeyA in the range [0, 2^250 - 1], stored in 32 bytes. 
 // Output: the public key PublicKeyA consisting of 3 GF(p503^2) elements encoded in 378 bytes.
-int EphemeralKeyGeneration_A(const digit_t* PrivateKeyA, unsigned char* PublicKeyA);
+void EphemeralKeyGeneration_A(const digit_t* PrivateKeyA, unsigned char* PublicKeyA);
 
 // Bob's ephemeral key-pair generation
 // It produces a private key PrivateKeyB and computes the public key PublicKeyB.
 // The private key is an integer in the range [0, 2^Floor(Log(2,3^159)) - 1], stored in 32 bytes. 
 // The public key consists of 3 GF(p503^2) elements encoded in 378 bytes.
-int EphemeralKeyGeneration_B(const digit_t* PrivateKeyB, unsigned char* PublicKeyB);
+void EphemeralKeyGeneration_B(const digit_t* PrivateKeyB, unsigned char* PublicKeyB);
 
 // Alice's ephemeral shared secret computation
 // It produces a shared secret key SharedSecretA using her secret key PrivateKeyA and Bob's public key PublicKeyB
 // Inputs: Alice's PrivateKeyA is an integer in the range [0, 2^250 - 1], stored in 32 bytes. 
 //         Bob's PublicKeyB consists of 3 GF(p503^2) elements encoded in 378 bytes.
 // Output: a shared secret SharedSecretA that consists of one element in GF(p503^2) encoded in 126 bytes.
-int EphemeralSecretAgreement_A(const digit_t* PrivateKeyA, const unsigned char* PublicKeyB, unsigned char* SharedSecretA);
+void EphemeralSecretAgreement_A(const digit_t* PrivateKeyA, const unsigned char* PublicKeyB, unsigned char* SharedSecretA);
 
 // Bob's ephemeral shared secret computation
 // It produces a shared secret key SharedSecretB using his secret key PrivateKeyB and Alice's public key PublicKeyA
 // Inputs: Bob's PrivateKeyB is an integer in the range [0, 2^Floor(Log(2,3^159)) - 1], stored in 32 bytes. 
 //         Alice's PublicKeyA consists of 3 GF(p503^2) elements encoded in 378 bytes.
 // Output: a shared secret SharedSecretB that consists of one element in GF(p503^2) encoded in 126 bytes.
-int EphemeralSecretAgreement_B(const digit_t* PrivateKeyB, const unsigned char* PublicKeyA, unsigned char* SharedSecretB);
+void EphemeralSecretAgreement_B(const digit_t* PrivateKeyB, const unsigned char* PublicKeyA, unsigned char* SharedSecretB);
 
 
 // Encoding of keys for KEX-based isogeny system "SIDHp503" (wire format):

--- a/pq-crypto/sike/sidh.c
+++ b/pq-crypto/sike/sidh.c
@@ -67,7 +67,7 @@ void random_mod_order_B(unsigned char* random_digits)
 }
 
 
-int EphemeralKeyGeneration_A(const digit_t* PrivateKeyA, unsigned char* PublicKeyA)
+void EphemeralKeyGeneration_A(const digit_t* PrivateKeyA, unsigned char* PublicKeyA)
 { // Alice's ephemeral public key generation
   // Input:  a private key PrivateKeyA in the range [0, 2^eA - 1]. 
   // Output: the public key PublicKeyA consisting of 3 elements in GF(p^2) which are encoded by removing leading 0 bytes.
@@ -132,11 +132,11 @@ int EphemeralKeyGeneration_A(const digit_t* PrivateKeyA, unsigned char* PublicKe
     fp2_encode(&phiQ->X, PublicKeyA + FP2_ENCODED_BYTES);
     fp2_encode(&phiR->X, PublicKeyA + 2*FP2_ENCODED_BYTES);
 
-    return 0;
+    return;
 }
 
 
-int EphemeralKeyGeneration_B(const digit_t* PrivateKeyB, unsigned char* PublicKeyB)
+void EphemeralKeyGeneration_B(const digit_t* PrivateKeyB, unsigned char* PublicKeyB)
 { // Bob's ephemeral public key generation
   // Input:  a private key PrivateKeyB in the range [0, 2^Floor(Log(2,oB)) - 1]. 
   // Output: the public key PublicKeyB consisting of 3 elements in GF(p^2) which are encoded by removing leading 0 bytes.
@@ -202,11 +202,11 @@ int EphemeralKeyGeneration_B(const digit_t* PrivateKeyB, unsigned char* PublicKe
     fp2_encode(&phiQ->X, PublicKeyB + FP2_ENCODED_BYTES);
     fp2_encode(&phiR->X, PublicKeyB + 2*FP2_ENCODED_BYTES);
 
-    return 0;
+    return;
 }
 
 
-int EphemeralSecretAgreement_A(const digit_t* PrivateKeyA, const unsigned char* PublicKeyB, unsigned char* SharedSecretA)
+void EphemeralSecretAgreement_A(const digit_t* PrivateKeyA, const unsigned char* PublicKeyB, unsigned char* SharedSecretA)
 { // Alice's ephemeral shared secret computation
   // It produces a shared secret key SharedSecretA using her secret key PrivateKeyA and Bob's public key PublicKeyB
   // Inputs: Alice's PrivateKeyA is an integer in the range [0, oA-1]. 
@@ -262,11 +262,11 @@ int EphemeralSecretAgreement_A(const digit_t* PrivateKeyA, const unsigned char* 
     j_inv(A24plus, C24, jinv);
     fp2_encode(jinv, SharedSecretA);    // Format shared secret
 
-    return 0;
+    return;
 }
 
 
-int EphemeralSecretAgreement_B(const digit_t* PrivateKeyB, const unsigned char* PublicKeyA, unsigned char* SharedSecretB)
+void EphemeralSecretAgreement_B(const digit_t* PrivateKeyB, const unsigned char* PublicKeyA, unsigned char* SharedSecretB)
 { // Bob's ephemeral shared secret computation
   // It produces a shared secret key SharedSecretB using his secret key PrivateKeyB and Alice's public key PublicKeyA
   // Inputs: Bob's PrivateKeyB is an integer in the range [0, 2^Floor(Log(2,oB)) - 1]. 
@@ -322,5 +322,5 @@ int EphemeralSecretAgreement_B(const digit_t* PrivateKeyB, const unsigned char* 
     j_inv(A, A24plus, jinv);
     fp2_encode(jinv, SharedSecretB);    // Format shared secret
 
-    return 0;
+    return;
 }

--- a/pq-crypto/sike/sike_p503_kem.c
+++ b/pq-crypto/sike/sike_p503_kem.c
@@ -24,7 +24,7 @@ int SIKE_P503_crypto_kem_keypair(unsigned char *pk, unsigned char *sk)
     random_mod_order_B((unsigned char*)_sk);
 
     // Generate public key pk
-    GUARD(EphemeralKeyGeneration_B(_sk, pk));
+    EphemeralKeyGeneration_B(_sk, pk);
 
     memcpy(sk + MSG_BYTES, _sk, SECRETKEY_B_BYTES);
     // Append public key pk to secret key sk
@@ -58,8 +58,8 @@ int SIKE_P503_crypto_kem_enc(unsigned char *ct, unsigned char *ss, const unsigne
     ephemeralsk.b[SECRETKEY_A_BYTES - 1] &= MASK_ALICE;
 
     // Encrypt
-    GUARD(EphemeralKeyGeneration_A(ephemeralsk.d, ct));
-    GUARD(EphemeralSecretAgreement_A(ephemeralsk.d, pk, jinvariant));
+    EphemeralKeyGeneration_A(ephemeralsk.d, ct);
+    EphemeralSecretAgreement_A(ephemeralsk.d, pk, jinvariant);
     cshake256_simple(h, MSG_BYTES, P, jinvariant, FP2_ENCODED_BYTES);
     for (i = 0; i < MSG_BYTES; i++) ct[i + SIKE_P503_PUBLIC_KEY_BYTES] = temp[i] ^ h[i];
 
@@ -94,7 +94,7 @@ int SIKE_P503_crypto_kem_dec(unsigned char *ss, const unsigned char *ct, const u
 	memcpy(_sk, sk + MSG_BYTES, SECRETKEY_B_BYTES);
 
     // Decrypt
-    GUARD(EphemeralSecretAgreement_B(_sk, ct, jinvariant_));
+    EphemeralSecretAgreement_B(_sk, ct, jinvariant_);
     cshake256_simple(h_, MSG_BYTES, P, jinvariant_, FP2_ENCODED_BYTES);
     for (i = 0; i < MSG_BYTES; i++) temp[i] = ct[i + SIKE_P503_PUBLIC_KEY_BYTES] ^ h_[i];
 
@@ -104,7 +104,7 @@ int SIKE_P503_crypto_kem_dec(unsigned char *ss, const unsigned char *ct, const u
     ephemeralsk_.b[SECRETKEY_A_BYTES - 1] &= MASK_ALICE;
     
     // Generate shared secret ss <- H(m||ct) or output ss <- H(s||ct)
-    GUARD(EphemeralKeyGeneration_A(ephemeralsk_.d, c0_));
+    EphemeralKeyGeneration_A(ephemeralsk_.d, c0_);
     if (memcmp(c0_, ct, SIKE_P503_PUBLIC_KEY_BYTES) != 0) {
         memcpy(temp, sk, MSG_BYTES);
     }


### PR DESCRIPTION
**Issue # (if available):** N/A

**Description of changes:** 
Adds a few missing `GUARD()` checks to the Post Quantum SIKE code

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
