### PR TITLE
Allow s2n server to send server_name extension

### DIFF
--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -753,8 +753,10 @@ ClientHello and context provided in **s2n_config_set_client_hello_cb**. The
 callback can get any ClientHello infromation from the connection and use
 **s2n_connection_set_config** call to change the config of the connection.
 
-The callback can return 0 to continue handshake in s2n or it can return negative
-value to make s2n terminate handshake early with fatal handshake failure alert.
+If any of the properties of the connection were changed based on server_name
+extension the callback must return 1, otherwise the callback can return 0
+to continue handshake in s2n or it can return negative value to make s2n
+terminate handshake early with fatal handshake failure alert.
 
 ### s2n\_config\_set\_alert\_behavior
 ```c

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -307,9 +307,13 @@ int s2n_client_hello_recv(struct s2n_connection *conn)
 
     /* Call client_hello_cb if exists, letting application to modify s2n_connection or swap s2n_config */
     if (conn->config->client_hello_cb) {
-        if (conn->config->client_hello_cb(conn, conn->config->client_hello_cb_ctx) < 0) {
+        int rc = conn->config->client_hello_cb(conn, conn->config->client_hello_cb_ctx);
+        if (rc < 0) {
             GUARD(s2n_queue_reader_handshake_failure_alert(conn));
             S2N_ERROR(S2N_ERR_CANCELLED);
+        }
+        if (rc) {
+            conn->server_name_used = 1;
         }
     }
 

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -92,6 +92,13 @@ struct s2n_connection {
      /* whether the connection address is ipv6 or not */
     unsigned ipv6:1;
 
+    /* Whether server_name extension was used to make a decision on cert selection.
+     * RFC6066 Section 3 states that server which used server_name to make a decision
+     * on certificate or security settings has to send an empty server_name.
+     */
+    unsigned server_name_used:1;
+
+
     /* Is this connection a client or a server connection */
     s2n_mode mode;
 


### PR DESCRIPTION
**Issue # (if available):** 

**Description of changes:** 

RFC6066 Section 3 requires server to send an empty server_name extension when client server_name extension was used to make a decision on a certificate or other security options:

   A server that receives a client hello containing the "server_name"
   extension MAY use the information contained in the extension to guide
   its selection of an appropriate certificate to return to the client,
   and/or other aspects of security policy.  In this event, the server
   SHALL include an extension of type "server_name" in the (extended)
   server hello.  The "extension_data" field of this extension SHALL be
   empty.

This change allows client hello callback to return 1 to indicate such usage.

https://tools.ietf.org/html/rfc6066#section-3

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
