### PR TITLE
Additional build fixes in pq

### DIFF
--- a/pq-crypto/bike/utilities.c
+++ b/pq-crypto/bike/utilities.c
@@ -9,6 +9,8 @@
 * The license is detailed in the file LICENSE.md, and applies to this file.
 * ***************************************************************************/
 
+#include <inttypes.h>
+
 #include "utilities.h"
 
 #define BITS_IN_QW 64ULL
@@ -38,7 +40,7 @@ _INLINE_ void print_uint64(IN const uint64_t val)
 #ifdef WIN32
     printf("%.16I64x", tmp);
 #else
-    printf("%.16lx",  tmp);
+    printf("%.16"PRIu64,  tmp);
 #endif
 
 #ifndef NO_SPACE

--- a/tests/unit/s2n_bike_test.c
+++ b/tests/unit/s2n_bike_test.c
@@ -38,3 +38,4 @@ int main(int argc, char **argv)
 
     END_TEST();
 }
+


### PR DESCRIPTION
**Description of changes:** 
```
s2n_bike_test.c:40:2: error: no newline at end of file [-Werror,-Wnewline-eof]
}
 ^
```

```
utilities.c:41:23: error: format specifies type 'unsigned long' but the argument has type 'uint64_t' (aka 'unsigned long long') [-Werror,-Wformat]
    printf("%.16lx",  tmp);
            ~~~~~~    ^~~
            %.16llx
1 error generated.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
