### PR TITLE
Add s2n_connection_get_selected_cert to public API

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -211,6 +211,8 @@ extern int s2n_connection_get_session_id_length(struct s2n_connection *conn);
 extern int s2n_connection_get_session_id(struct s2n_connection *conn, uint8_t *session_id, size_t max_length);
 extern int s2n_connection_is_session_resumed(struct s2n_connection *conn);
 extern int s2n_connection_is_ocsp_stapled(struct s2n_connection *conn);
+
+extern struct s2n_cert_chain_and_key *s2n_connection_get_selected_cert(struct s2n_connection *conn);
 
 /* RFC's that define below values:
  *  - https://tools.ietf.org/html/rfc5246#section-7.4.4

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -983,7 +983,7 @@ s2n_connection. Calling this function is not necessary unless you want to set th
 cipher preferences on the connection to something different than what is in the s2n_config.
 
 
-## s2n\_connection\_set\_protocol\_preferences
+### s2n\_connection\_set\_protocol\_preferences
 
 ```c
 int s2n_connection_set_protocol_preferences(struct s2n_connection *conn, const char * const *protocols, int protocol_count);
@@ -1224,6 +1224,23 @@ const char * s2n_connection_get_curve(struct s2n_connection *conn);
 
 **s2n_connection_get_curve** returns a string indicating the elliptic curve used during ECDHE key exchange. The string "NONE" is returned if no curve has was used.
 
+### s2n\_connection\_get\_selected\_cert
+
+```c
+struct s2n_cert_chain_and_key s2n_connection_get_selected_cert(struct s2n_connection *conn);
+```
+
+Return the certificate that was used during the TLS handshake.
+
+- If **conn** is a server connection, the certificate selected will depend on the
+  ServerName sent by the client and supported ciphers.
+- If **conn** is a client connection, the certificate sent in response to a CertificateRequest
+  message is returned. Currently s2n supports loading only one certificate in client mode. Note that
+  not all TLS endpoints will request a certificate.
+
+This function returns NULL if the certificate selection phase of the handshake has not completed
+ or if a certificate was not requested by the peer.
+
 ### Session Resumption Related calls
 
 ```c
@@ -1259,16 +1276,6 @@ handshake.
 **s2n_connection_get_session_id** get the session id from the connection and copies into the **session_id** buffer and returns the number of bytes that were copied.
 
 **s2n_connection_is_session_resumed** returns 1 if the handshake was abbreviated, otherwise returns 0.
-
-### s2n\_connection\_get\_selected\_cert
-
-```c
-struct s2n_cert_chain_and_key s2n_connection_get_selected_cert(struct s2n_connection *conn);
-```
-
-Return the certificate that was used during the TLS handshake. If **conn** is a server connection, the certificate selected will depend on the
-ServerName sent by the client and supported ciphers. This function returns NULL if certificate selection phase of the handshake has not completed.
-
 
 ### Session Ticket Specific calls
 

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -959,7 +959,7 @@ file-descriptor should be active and connected. s2n also supports setting the
 read and write file-descriptors to different values (for pipes or other unusual
 types of I/O).
 
-## s2n\_connection\_is\_valid\_for\_cipher\_preferences
+### s2n\_connection\_is\_valid\_for\_cipher\_preferences
 
 ```c
 int s2n_connection_is_valid_for_cipher_preferences(struct s2n_connection *conn, const char *version);
@@ -972,7 +972,7 @@ is supported by a given cipher preferences. It returns
 - -1 on any other errors
 
 
-## s2n\_connection\_set\_cipher\_preferences
+### s2n\_connection\_set\_cipher\_preferences
 
 ```c
 int s2n_connection_set_cipher_preferences(struct s2n_connection *conn, const char *version);
@@ -1259,6 +1259,16 @@ handshake.
 **s2n_connection_get_session_id** get the session id from the connection and copies into the **session_id** buffer and returns the number of bytes that were copied.
 
 **s2n_connection_is_session_resumed** returns 1 if the handshake was abbreviated, otherwise returns 0.
+
+### s2n\_connection\_get\_selected\_cert
+
+```c
+struct s2n_cert_chain_and_key s2n_connection_get_selected_cert(struct s2n_connection *conn);
+```
+
+Return the certificate that was used during the TLS handshake. If **conn** is a server connection, the certificate selected will depend on the
+ServerName sent by the client and supported ciphers. This function returns NULL if certificate selection phase of the handshake has not completed.
+
 
 ### Session Ticket Specific calls
 

--- a/tests/unit/s2n_self_talk_alpn_test.c
+++ b/tests/unit/s2n_self_talk_alpn_test.c
@@ -177,6 +177,8 @@ int main(int argc, char **argv)
     /* Negotiate the handshake. */
     EXPECT_SUCCESS(s2n_negotiate(conn, &blocked));
 
+    EXPECT_EQUAL(s2n_connection_get_selected_cert(conn), chain_and_key);
+
     /* Expect NULL negotiated protocol */
     EXPECT_EQUAL(s2n_get_application_protocol(conn), NULL);
 

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1161,3 +1161,10 @@ int s2n_connection_is_client_auth_enabled(struct s2n_connection *s2n_connection)
 
     return (auth_type != S2N_CERT_AUTH_NONE);
 }
+
+struct s2n_cert_chain_and_key *s2n_connection_get_selected_cert(struct s2n_connection *conn)
+{
+    notnull_check_ptr(conn);
+    return conn->handshake_params.our_chain_and_key;
+}
+


### PR DESCRIPTION
This function will allow the application to retrieve the certificate
that was selected during the handshake. This function is needed for use
cases where multiple certificates are configured in a single s2n_config
object.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
