### PR TITLE
Send back the ServerName extension on cert match

### DIFF
--- a/tests/integration/s2n_test_constants.py
+++ b/tests/integration/s2n_test_constants.py
@@ -243,7 +243,7 @@ MULTI_CERT_TEST_CASES= [
         client_sni=None,
         client_ciphers="ECDHE-RSA-AES128-SHA",
         expected_cert=SNI_CERTS["many_animals"],
-        expect_matching_hostname=True),
+        expect_matching_hostname=False),
     MultiCertTest(
         description="Test certificate match with CN",
         server_certs=[ SNI_CERTS["alligator"], SNI_CERTS["narwhal_cn"] ],

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -98,7 +98,6 @@ struct s2n_connection {
      */
     unsigned server_name_used:1;
 
-
     /* Is this connection a client or a server connection */
     s2n_mode mode;
 

--- a/tls/s2n_handshake.c
+++ b/tls/s2n_handshake.c
@@ -185,6 +185,6 @@ int s2n_conn_find_name_matching_certs(struct s2n_connection *conn)
     /* If we found a suitable cert, we should send back the ServerName extension.
      * Note that this may have already been set by the client hello callback, so we won't override its value
      */
-    conn->server_name_used |= conn->handshake_params.sni_match_exists;
+    conn->server_name_used = conn->server_name_used || conn->handshake_params.sni_match_exists;
     return 0;
 }

--- a/tls/s2n_handshake.c
+++ b/tls/s2n_handshake.c
@@ -182,5 +182,9 @@ int s2n_conn_find_name_matching_certs(struct s2n_connection *conn)
         }
     }
 
+    /* If we found a suitable cert, we should send back the ServerName extension.
+     * Note that this may have already been set by the client hello callback, so we won't override its value
+     */
+    conn->server_name_used |= conn->handshake_params.sni_match_exists;
     return 0;
 }

--- a/tls/s2n_server_extensions.c
+++ b/tls/s2n_server_extensions.c
@@ -37,6 +37,9 @@ static int s2n_recv_server_sct_list(struct s2n_connection *conn, struct s2n_stuf
 static int s2n_recv_server_max_frag_len(struct s2n_connection *conn, struct s2n_stuffer *extension);
 static int s2n_recv_server_session_ticket_ext(struct s2n_connection *conn, struct s2n_stuffer *extension);
 
+#define s2n_server_should_send_server_name(conn) ((conn)->server_name_used && \
+        !s2n_connection_is_session_resumed((conn)))
+
 int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
     uint16_t total_size = 0;
@@ -76,7 +79,7 @@ int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *
     GUARD(s2n_stuffer_write_uint16(out, total_size));
 
     /* Write server name extension */
-    if (conn->server_name_used && !s2n_connection_is_session_resumed(conn)) {
+    if (s2n_server_should_send_server_name(conn)) {
         GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_SERVER_NAME));
         GUARD(s2n_stuffer_write_uint16(out, 0));
     }

--- a/tls/s2n_server_extensions.c
+++ b/tls/s2n_server_extensions.c
@@ -37,7 +37,7 @@ static int s2n_recv_server_sct_list(struct s2n_connection *conn, struct s2n_stuf
 static int s2n_recv_server_max_frag_len(struct s2n_connection *conn, struct s2n_stuffer *extension);
 static int s2n_recv_server_session_ticket_ext(struct s2n_connection *conn, struct s2n_stuffer *extension);
 
-#define s2n_server_should_send_server_name(conn) ((conn)->server_name_used && \
+#define s2n_server_can_send_server_name(conn) ((conn)->server_name_used && \
         !s2n_connection_is_session_resumed((conn)))
 
 int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *out)
@@ -46,7 +46,7 @@ int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *
 
     const uint8_t application_protocol_len = strlen(conn->application_protocol);
 
-    if (conn->server_name_used && !s2n_connection_is_session_resumed(conn)) {
+    if (s2n_server_can_send_server_name(conn)) {
         total_size += 4;
     }
 
@@ -79,7 +79,7 @@ int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *
     GUARD(s2n_stuffer_write_uint16(out, total_size));
 
     /* Write server name extension */
-    if (s2n_server_should_send_server_name(conn)) {
+    if (s2n_server_can_send_server_name(conn)) {
         GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_SERVER_NAME));
         GUARD(s2n_stuffer_write_uint16(out, 0));
     }


### PR DESCRIPTION
**Description of changes:** 
 Send back the ServerName extension on cert match

When a matching certificate is found based on the ServerName extension,
s2n server will send the extension back to the client. If the
server_named_used field is already set by the application in the
ClientHello callback, s2n will not unset it.

This change applies to builtin certificate lookup. #1056 addresses this for certificate selection handled by the client hello callback.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
