### PR TITLE
Fix Multiple SAN server cert integration test

### DIFF
--- a/tests/integration/s2n_test_constants.py
+++ b/tests/integration/s2n_test_constants.py
@@ -274,7 +274,7 @@ MULTI_CERT_TEST_CASES= [
         expect_matching_hostname=False)]
 MULTI_CERT_TEST_CASES.extend([MultiCertTest(
         description="Match SAN " + many_animal_domain + " in many_animals cert",
-        server_certs= [SNI_CERTS["many_animals"] , SNI_CERTS["alligator"]],
+        server_certs= [ SNI_CERTS["alligator"], SNI_CERTS["many_animals"] ],
         client_sni=many_animal_domain,
         client_ciphers="ECDHE-RSA-AES128-SHA",
         expected_cert=SNI_CERTS["many_animals"],


### PR DESCRIPTION
Previously, this test had the multiple SAN cert as the "default"
certificate so some tests would have missed a regression in SAN matching
since the multisan cert would be served on a mismatch.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
