### PR TITLE
Add associated context to s2n_cert_chain_and_key

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -96,6 +96,9 @@ struct s2n_cert_chain_and_key;
 extern struct s2n_cert_chain_and_key *s2n_cert_chain_and_key_new(void);
 extern int s2n_cert_chain_and_key_load_pem(struct s2n_cert_chain_and_key *chain_and_key, const char *chain_pem, const char *private_key_pem);
 extern int s2n_cert_chain_and_key_free(struct s2n_cert_chain_and_key *cert_and_key);
+extern int s2n_cert_chain_and_key_set_ctx(struct s2n_cert_chain_and_key *cert_and_key, void *ctx);
+extern void *s2n_cert_chain_and_key_get_ctx(struct s2n_cert_chain_and_key *cert_and_key);
+
 extern int s2n_config_add_cert_chain_and_key(struct s2n_config *config, const char *cert_chain_pem, const char *private_key_pem);
 extern int s2n_config_add_cert_chain_and_key_to_store(struct s2n_config *config, struct s2n_cert_chain_and_key *cert_key_pair);
 

--- a/crypto/s2n_certificate.c
+++ b/crypto/s2n_certificate.c
@@ -162,14 +162,14 @@ struct s2n_cert_chain_and_key *s2n_cert_chain_and_key_new(void)
 {
     struct s2n_cert_chain_and_key *chain_and_key;
     struct s2n_blob chain_and_key_mem, cert_chain_mem, pkey_mem;
-    
+
     GUARD_PTR(s2n_alloc(&chain_and_key_mem, sizeof(struct s2n_cert_chain_and_key)));
     chain_and_key = (struct s2n_cert_chain_and_key *)(void *)chain_and_key_mem.data;
-    
+
     /* Allocate the memory for the chain and key */
     GUARD_PTR(s2n_alloc(&cert_chain_mem, sizeof(struct s2n_cert_chain)));
     chain_and_key->cert_chain = (struct s2n_cert_chain *)(void *)cert_chain_mem.data;
-    
+
     GUARD_PTR(s2n_alloc(&pkey_mem, sizeof(s2n_cert_private_key)));
     chain_and_key->private_key = (s2n_cert_private_key *)(void *)pkey_mem.data;
 
@@ -186,6 +186,8 @@ struct s2n_cert_chain_and_key *s2n_cert_chain_and_key_new(void)
     if (!chain_and_key->san_names) {
         return NULL;
     }
+
+    chain_and_key->context = NULL;
 
     return chain_and_key;
 }
@@ -463,3 +465,13 @@ s2n_authentication_method s2n_cert_chain_and_key_get_auth_method(struct s2n_cert
     return cert_type_to_auth_method[chain_and_key->cert_chain->head->cert_type];
 }
 
+int s2n_cert_chain_and_key_set_ctx(struct s2n_cert_chain_and_key *cert_and_key, void *ctx)
+{
+    cert_and_key->context = ctx;
+    return 0;
+}
+
+void *s2n_cert_chain_and_key_get_ctx(struct s2n_cert_chain_and_key *cert_and_key)
+{
+    return cert_and_key->context;
+}

--- a/crypto/s2n_certificate.h
+++ b/crypto/s2n_certificate.h
@@ -49,6 +49,8 @@ struct s2n_cert_chain_and_key {
      * server_name extension. Decoded as UTF8.
      */
     struct s2n_array *cn_names;
+    /* Application defined data related to this cert. */
+    void *context;
 };
 
 typedef enum {

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -788,11 +788,29 @@ int s2n_cert_chain_and_key_free(struct s2n_cert_chain_and_key *cert_and_key);
 int s2n_cert_chain_and_key_load_pem(struct s2n_cert_chain_and_key *chain_and_key, const char *chain_pem, const char *private_key_pem);
 ```
 
-**s2n_cert_chain_and_key_load_pem** associates a certificate chain and private key with an **s2n_cert_chain_and_key** object. 
+**s2n_cert_chain_and_key_load_pem** associates a certificate chain and private key with an **s2n_cert_chain_and_key** object.
 
 **cert_chain_pem** should be a PEM encoded certificate chain, with the first
 certificate in the chain being your leaf certificate. **private_key_pem**
 should be a PEM encoded private key corresponding to the leaf certificate.
+
+### s2n\_cert\_chain\_and\_key\_set\_ctx
+
+```c
+int s2n_cert_chain_and_key_set_ctx(struct s2n_cert_chain_and_key *chain_and_key, void *ctx);
+```
+
+**s2n_cert_chain_and_key_set_ctx** associates an application defined context with a **s2n_cert_chain_and_key** object.
+This is useful when multiple s2n_cert_chain_and_key objects are used and the application would like to associate unique data
+with each certificate.
+
+### s2n\_cert\_chain\_and\_key\_get\_ctx
+
+```c
+int s2n_cert_chain_and_key_get_ctx(struct s2n_cert_chain_and_key *chain_and_key);
+```
+
+**s2n_cert_chain_and_key_set_ctx** returns a previously set context pointer or NULL if no context was set.
 
 ## Client Auth Related calls
 Client Auth Related API's are not recommended for normal users. Use of these API's is discouraged.

--- a/tests/unit/s2n_cert_chain_and_key_test.c
+++ b/tests/unit/s2n_cert_chain_and_key_test.c
@@ -91,6 +91,7 @@ int main(int argc, char **argv)
         EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn->handshake.handshake_type));
         EXPECT_EQUAL(s2n_connection_get_selected_cert(server_conn), chain_and_key);
         EXPECT_EQUAL(s2n_cert_chain_and_key_get_ctx(chain_and_key), &associated_cert_data);
+        EXPECT_EQUAL(*((int *) s2n_cert_chain_and_key_get_ctx(chain_and_key)), 7);
         EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));


### PR DESCRIPTION
To allow applications to associate arbitrary data to a
s2n_cert_chain_and_key object, for use cases like logging.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
