### PR TITLE
Check if source is zero-size or NULL in s2n_dup

### DIFF
--- a/tests/unit/s2n_map_test.c
+++ b/tests/unit/s2n_map_test.c
@@ -38,6 +38,16 @@ int main(int argc, char **argv)
     key.size = strlen(keystr) + 1;
     EXPECT_FAILURE(s2n_map_lookup(empty, &key, &val));
 
+    EXPECT_SUCCESS(snprintf(valstr, sizeof(valstr), "%05d", 1234));
+    val.data = (void *) valstr;
+    val.size = strlen(valstr) + 1;
+
+    /* Try to add/put key with zero-size data. Expect failures */
+    key.size = 0;
+    EXPECT_FAILURE(s2n_map_add(empty, &key, &val));
+    EXPECT_FAILURE(s2n_map_put(empty, &key, &val));
+    key.size = strlen(keystr) + 1;
+
     /* Make the empty map complete */
     EXPECT_SUCCESS(s2n_map_complete(empty));
 

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -149,6 +149,8 @@ int s2n_dup(struct s2n_blob *from, struct s2n_blob *to)
 {
     eq_check(to->size, 0);
     eq_check(to->data, NULL);
+    ne_check(from->size, 0);
+    ne_check(from->data, NULL);
 
     GUARD(s2n_alloc(to, from->size));
     


### PR DESCRIPTION
Previously, s2n_dup did not check if the source was zero-size or NULL,
which caused s2n_map_add and s2n_map_put to leak memory.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
