### PR TITLE
Dynamically allocate raw memory for storing ClientHello

### DIFF
--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -311,13 +311,9 @@ int main(int argc, char **argv)
          /* Wipe connection */
         EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
 
-        /* Verify connection_wipe resized the s2n_client_hello.raw_message stuffer */
-        EXPECT_NOT_NULL(client_hello->raw_message.blob.data);
-        EXPECT_EQUAL(client_hello->raw_message.blob.size, S2N_LARGE_RECORD_LENGTH);
-
-        /* Verify connection_wipe cleared the s2n_client_hello.raw_message stuffer data */
-        uint8_t zero_buffer[S2N_LARGE_RECORD_LENGTH] = { 0 };
-        EXPECT_SUCCESS(memcmp(collected_client_hello, zero_buffer, S2N_LARGE_RECORD_LENGTH));
+        /* Verify connection_wipe resized the s2n_client_hello.raw_message stuffer back to 0 */
+        EXPECT_NULL(client_hello->raw_message.blob.data);
+        EXPECT_EQUAL(client_hello->raw_message.blob.size, 0);
 
         /* Verify the s2n blobs referencing cipher_suites and extensions have cleared */
         EXPECT_EQUAL(client_hello->cipher_suites.size, 0);

--- a/tests/unit/s2n_mem_usage_test.c
+++ b/tests/unit/s2n_mem_usage_test.c
@@ -31,10 +31,10 @@
 #define CONNECTIONS 250
 
 /* This is roughly the current memory usage per connection */
-#define MEM_PER_CONNECTION (128 * 1024)
+#define MEM_PER_CONNECTION (106 * 1024)
 
-/* This is the maximum  memory per conneciton including 16KB of slack */
-#define MAX_MEM_PER_CONNECTION (MEM_PER_CONNECTION + 16 * 1024)
+/* This is the maximum  memory per conneciton including 4KB of slack */
+#define MAX_MEM_PER_CONNECTION (MEM_PER_CONNECTION + 4 * 1024)
 
 #define MAX_ALLOWED_MEM_DIFF ((ssize_t) 2 * CONNECTIONS * MAX_MEM_PER_CONNECTION)
 

--- a/tests/unit/s2n_mem_usage_test.c
+++ b/tests/unit/s2n_mem_usage_test.c
@@ -76,6 +76,12 @@ int main(int argc, char **argv)
 
     BEGIN_TEST();
 
+    /* Skip the test when running under valgrind or address sanitizer, as those tools
+     * impact the memory usage. */
+    if (getenv("S2N_VALGRIND") != NULL || getenv("S2N_ADDRESS_SANITIZER") != NULL) {
+        END_TEST();
+    }
+
     EXPECT_SUCCESS(setenv("S2N_ENABLE_CLIENT_MODE", "1", 0));
 
     EXPECT_NOT_NULL(cert_chain = malloc(S2N_MAX_TEST_PEM_SIZE));
@@ -161,12 +167,9 @@ int main(int argc, char **argv)
     fprintf(stdout, "Max VmData diff allowed:  %10zu\n", MAX_ALLOWED_MEM_DIFF);
 #endif
 
-    /* Ignore expectations when running under valgrind, as valgrind allocates much more
-     * memory than we expect in this test. */
-    if (getenv("S2N_VALGRIND") == NULL) {
-        EXPECT_TRUE(vm_data_after_allocation - vm_data_initial < MAX_ALLOWED_MEM_DIFF);
-        EXPECT_TRUE(vm_data_after_handshakes - vm_data_initial < MAX_ALLOWED_MEM_DIFF);
-    }
+    EXPECT_TRUE(vm_data_after_allocation - vm_data_initial < MAX_ALLOWED_MEM_DIFF);
+    EXPECT_TRUE(vm_data_after_handshakes - vm_data_initial < MAX_ALLOWED_MEM_DIFF);
+
 
     END_TEST();
 

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -590,8 +590,8 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     /* Allocate memory for handling handshakes */
     GUARD(s2n_stuffer_resize(&conn->handshake.io, S2N_LARGE_RECORD_LENGTH));
 
-    /* Resize raw message buffer to max length */
-    GUARD(s2n_stuffer_resize(&conn->client_hello.raw_message, S2N_LARGE_RECORD_LENGTH));
+    /* Truncate the raw message buffer to save memory, we will dynamically resize it as needed */
+    GUARD(s2n_stuffer_resize(&conn->client_hello.raw_message, 0));
 
     /* Remove context associated with connection */
     conn->context = NULL;


### PR DESCRIPTION
**Issue # (if available):** 

**Description of changes:** 

Previously we allocated 16KB for storing ClientHello. Most of the time ClientHello is way smaller than 16KB, so to save some memory we can rely on growing the stuffer once we receive ClientHello instead of pre-allocating the maximum.

Mem usage before the change:

VmData initial:               720896
VmData after allocations:   66179072
VmData after handshakes:    66306048
Max VmData diff allowed:    73728000

Mem usage after the change:

VmData initial:               720896
VmData after allocations:   53993472
VmData after handshakes:    53993472
Max VmData diff allowed:    56320000



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
