### PR TITLE
Update pq-crypto's readme with instructions on how to add another KEM

### DIFF
--- a/pq-crypto/README.md
+++ b/pq-crypto/README.md
@@ -34,3 +34,18 @@ s2n uses the "additional implementation" which ensures constant time primitives,
 besides libcrypto, and does not depend on any specific hardware instructions to ensure maximum comparability and ease of
 review. The known answer tests are [here](https://github.com/awslabs/s2n/blob/master/tests/unit/s2n_bike1_l1_kat_test.c)
 and use the BIKE1_L1.const.kat from the above Additional_Implementation.2019.03.30.zip.
+
+# How to add another PQ KEM
+1. Add the code to `pq-crypto/KEM_NAME/`
+    1. Update `pq-crypto/Makefile` to build that directory
+    1. Update `lib/Makefile` to also include that directory
+    1. Update the KEM code to include `pq-crypto/pq_random.h` and use that `get_random_bytes` for any random data the KEM needs
+    1. Create a `pq-crypto/KEM_NAME/KEM_NAME.h` with the size of objects and method definitions
+1. Define the new cipher suite and KEM extension value in `tls/s2n_tls_parameters.h`
+1. Create the `KEM_NAME` `s2n_kem` struct in `tls/s2n_kem.c`
+    1. Add the new kem to the `kem_mapping` with the correct cipher suite value
+1. Add known answer tests using `s2n_test_kem_with_kat()` in `tests/unit/s2n_KEM_NAME_kat_test.c`
+1. Add fuzz testing in `tests/fuzz/s2n_KEM_NAME_fuzz_test.c`
+1. Add formal verification in `tests/saw/KEM_NAME/verify.saw`
+1. Create a new `s2n_cipher_suite` in `tls/s2n_cipher_suites.c`
+1. Create a new `s2n_cipher_preferences` in `tls/s2n_cipher_prefrences.c` that uses the new cipher suite


### PR DESCRIPTION
**Issue # (if available):** 
https://github.com/awslabs/s2n/issues/904

**Description of changes:** 
This covers the high level steps involved with getting a new PQ KEM add to s2n for hybrid key exchanges.

This depends on changes in https://github.com/awslabs/s2n/pull/1070 and https://github.com/awslabs/s2n/pull/1084.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
