### PR TITLE
Add support for additional GCC versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,68 +17,69 @@ os:
 env:
   - TESTS=ctverif
   # Code Coverage Targets
-  - S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=unit GCC6_REQUIRED=true S2N_COVERAGE=true CODECOV_IO_UPLOAD=true
-  - S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC6_REQUIRED=true S2N_COVERAGE=true CODECOV_IO_UPLOAD=true
+  - S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=unit GCC_VERSION=6 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true
+  - S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=6 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true
   - S2N_LIBCRYPTO=openssl-1.1.1 LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=120 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true
   # Normal Build Targets
-  - S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC6_REQUIRED=true
-  - S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC6_REQUIRED=true S2N_CORKED_IO=true
-  - S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=integration GCC6_REQUIRED=true
-  - S2N_LIBCRYPTO=openssl-1.0.2-fips BUILD_S2N=true TESTS=integration GCC6_REQUIRED=true
-  - S2N_LIBCRYPTO=libressl      BUILD_S2N=true TESTS=integration GCC6_REQUIRED=true
+  - S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=6
+  - S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=9
+  - S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=6 S2N_CORKED_IO=true
+  - S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=integration GCC_VERSION=6
+  - S2N_LIBCRYPTO=openssl-1.0.2-fips BUILD_S2N=true TESTS=integration GCC_VERSION=6
+  - S2N_LIBCRYPTO=libressl      BUILD_S2N=true TESTS=integration GCC_VERSION=6
   # Force libcrypto to use "software only" crypto implementations for AES and AES-GCM. Verify s2n can gracefully use
   # unoptimized routines. See https://www.openssl.org/docs/man1.1.0/crypto/OPENSSL_ia32cap.html
-  - S2N_LIBCRYPTO=openssl-1.1.1 OPENSSL_ia32cap="~0x200000200000000" BUILD_S2N=true TESTS=integration GCC6_REQUIRED=true
+  - S2N_LIBCRYPTO=openssl-1.1.1 OPENSSL_ia32cap="~0x200000200000000" BUILD_S2N=true TESTS=integration GCC_VERSION=6
   - S2N_LIBCRYPTO=openssl-1.1.1 LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=120
   - S2N_LIBCRYPTO=openssl-1.0.2-fips LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=120
-  - S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=asan GCC6_REQUIRED=true
-  - S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=valgrind GCC6_REQUIRED=true
+  - S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=asan GCC_VERSION=6
+  - S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=valgrind GCC_VERSION=6
 
 matrix:
   exclude:
   - os: osx
     env: TESTS=ctverif
   - os: osx
-    env: S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=valgrind GCC6_REQUIRED=true
+    env: S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=valgrind GCC_VERSION=6
   - os: osx
     env: S2N_LIBCRYPTO=openssl-1.0.2-fips LATEST_CLANG=true TESTS=fuzz
   - os: osx
-    env: S2N_LIBCRYPTO=openssl-1.0.2-fips BUILD_S2N=true TESTS=integration GCC6_REQUIRED=true
+    env: S2N_LIBCRYPTO=openssl-1.0.2-fips BUILD_S2N=true TESTS=integration GCC_VERSION=6
   include:
   - os : linux
     env: TESTS=sidetrail PART=1
   - os : linux
     env: TESTS=sidetrail PART=2
   - os : linux
-    env : TESTS=sawHMAC SAW_HMAC_TEST=md5    SAW=true GCC6_REQUIRED=false
+    env : TESTS=sawHMAC SAW_HMAC_TEST=md5    SAW=true GCC_VERSION=NONE
     addons: &sawaddons
       apt:
         packages:
           - clang-3.8
           - llvm-3.8
   - os : linux
-    env : TESTS=sawHMAC SAW_HMAC_TEST=sha1   SAW=true GCC6_REQUIRED=false
+    env : TESTS=sawHMAC SAW_HMAC_TEST=sha1   SAW=true GCC_VERSION=NONE
     addons : *sawaddons
   - os : linux
-    env : TESTS=sawHMAC SAW_HMAC_TEST=sha224 SAW=true GCC6_REQUIRED=false
+    env : TESTS=sawHMAC SAW_HMAC_TEST=sha224 SAW=true GCC_VERSION=NONE
     addons : *sawaddons
   - os : linux
-    env : TESTS=sawHMAC SAW_HMAC_TEST=sha256 SAW=true GCC6_REQUIRED=false
+    env : TESTS=sawHMAC SAW_HMAC_TEST=sha256 SAW=true GCC_VERSION=NONE
     addons : *sawaddons
   - os : linux
-    env : TESTS=sawHMAC SAW_HMAC_TEST=sha384 SAW=true GCC6_REQUIRED=false
+    env : TESTS=sawHMAC SAW_HMAC_TEST=sha384 SAW=true GCC_VERSION=NONE
     addons : *sawaddons
   - os : linux
-    env : TESTS=sawHMAC SAW_HMAC_TEST=sha512 SAW=true GCC6_REQUIRED=false
+    env : TESTS=sawHMAC SAW_HMAC_TEST=sha512 SAW=true GCC_VERSION=NONE
     addons : *sawaddons
   - os : linux
-    env: TESTS=sawDRBG                       SAW=true GCC6_REQUIRED=false
+    env: TESTS=sawDRBG                       SAW=true GCC_VERSION=NONE
     addons : *sawaddons
   - os : linux
-    env: TESTS=sawSIKE                       SAW=true GCC6_REQUIRED=false
+    env: TESTS=sawSIKE                       SAW=true GCC_VERSION=NONE
     addons : *sawaddons
   - os : linux
-    env : TESTS=tls SAW=true GCC6_REQUIRED=false
+    env : TESTS=tls SAW=true GCC_VERSION=NONE
     addons : *sawaddons    
   - os : linux
     env : TESTS=sawHMACFailure SAW=true

--- a/.travis/install_ubuntu_dependencies.sh
+++ b/.travis/install_ubuntu_dependencies.sh
@@ -22,8 +22,8 @@ DEPENDENCIES="unzip make indent kwstyle libssl-dev tcpdump valgrind lcov m4 nett
 
 sudo apt-get install -y ${DEPENDENCIES}
 
-if [[ "$GCC6_REQUIRED" == "true" ]]; then
-    sudo apt-get -y install gcc-6;
+if [[ -n "$GCC_VERSION" ]] && [[ "$GCC_VERSION" != "NONE" ]]; then
+    sudo apt-get -y install gcc-$GCC_VERSION;
 fi
 
 # Download and Install prlimit for memlock

--- a/.travis/s2n_setup_env.sh
+++ b/.travis/s2n_setup_env.sh
@@ -17,7 +17,7 @@
 # Setup Default Build Config
 : "${S2N_LIBCRYPTO:=openssl-1.1.1}"
 : "${BUILD_S2N:=false}"
-: "${GCC6_REQUIRED:=false}"
+: "${GCC_VERSION:=NONE}"
 : "${LATEST_CLANG:=false}"
 : "${TESTS:=integration}"
 
@@ -52,7 +52,7 @@ fi
 # Export all Env Variables
 export S2N_LIBCRYPTO
 export BUILD_S2N
-export GCC6_REQUIRED
+export GCC_VERSION
 export LATEST_CLANG
 export TESTS
 export BASE_S2N_DIR
@@ -103,7 +103,7 @@ export LIBFUZZER_ROOT=$LIBFUZZER_INSTALL_DIR
 echo "TRAVIS_OS_NAME=$TRAVIS_OS_NAME"
 echo "S2N_LIBCRYPTO=$S2N_LIBCRYPTO"
 echo "BUILD_S2N=$BUILD_S2N"
-echo "GCC6_REQUIRED=$GCC6_REQUIRED"
+echo "GCC_VERSION=$GCC_VERSION"
 echo "LATEST_CLANG=$LATEST_CLANG"
 echo "TESTS=$TESTS"
 echo "PATH=$PATH"

--- a/.travis/s2n_travis_build.sh
+++ b/.travis/s2n_travis_build.sh
@@ -32,9 +32,9 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     sudo -E "$PRLIMIT_INSTALL_DIR"/bin/prlimit --pid "$$" --memlock=unlimited:unlimited;
 fi
 
-# Set GCC 6 as Default if it's required
-if [[ "$GCC6_REQUIRED" == "true" ]]; then
-    alias gcc=$(which gcc-6);
+# Set the version of GCC as Default if it's required
+if [[ -n "$GCC_VERSION" ]] && [[ "$GCC_VERSION" != "NONE" ]]; then
+    alias gcc=$(which gcc-$GCC_VERSION);
 fi
 
 if [[ "$TRAVIS_OS_NAME" == "linux" && "$TESTS" == "valgrind" ]]; then

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ s2n is a C99 implementation of the TLS/SSL protocols that is designed to be simp
 git clone https://github.com/${YOUR_GITHUB_ACCOUNT_NAME}/s2n.git
 cd s2n
 
-# Pick an "env" line from the .travis.yml file and run it, in this case choose the openssl-1.1.0 build
-S2N_LIBCRYPTO=openssl-1.1.0 BUILD_S2N=true TESTS=integration GCC6_REQUIRED=true
+# Pick an "env" line from the .travis.yml file and run it, in this case choose the openssl-1.1.1 with GCC 9 build
+S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=9
 
 source .travis/s2n_setup_env.sh
 .travis/s2n_install_test_dependencies.sh

--- a/s2n.mk
+++ b/s2n.mk
@@ -76,7 +76,7 @@ endif
 DEBUG_CFLAGS = -g3 -ggdb -fno-omit-frame-pointer -fno-optimize-sibling-calls
 
 ifdef S2N_ADDRESS_SANITIZER
-	CFLAGS += -fsanitize=address ${DEBUG_CFLAGS}
+	CFLAGS += -fsanitize=address -fuse-ld=gold ${DEBUG_CFLAGS}
 endif
 
 ifdef S2N_DEBUG

--- a/s2n.mk
+++ b/s2n.mk
@@ -62,6 +62,17 @@ endif
 
 CFLAGS += ${DEFAULT_CFLAGS}
 
+ifdef GCC_VERSION
+	ifneq ("$(GCC_VERSION)","NONE")
+		CC=gcc-$(GCC_VERSION)
+	endif
+# Make doesn't support greater than checks, this uses `test` to compare values, then `echo $$?` to return the value of test's
+# exit code and finally using the built in make `ifeq` to check if it was true and then add the extra flag.
+	ifeq ($(shell test $(GCC_VERSION) -gt 7; echo $$?),0)
+		CFLAGS += -Wimplicit-fallthrough
+	endif
+endif
+
 DEBUG_CFLAGS = -g3 -ggdb -fno-omit-frame-pointer -fno-optimize-sibling-calls
 
 ifdef S2N_ADDRESS_SANITIZER

--- a/tests/unit/s2n_random_test.c
+++ b/tests/unit/s2n_random_test.c
@@ -30,6 +30,8 @@ void *thread_safety_tester(void *slot)
 
     s2n_get_public_random_data(&blob);
 
+    s2n_rand_cleanup_thread();
+
     return NULL;
 }
 


### PR DESCRIPTION
**Issue # (if available):** 
https://github.com/awslabs/s2n/issues/1031
**Description of changes:** 
This changes how we build with different versions of GCC and adds a build with version 6 and 9. It also adds support for new compiler flags for GCC 9. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
