### PR TITLE
Add cert tiebreaking callback for matching domains

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -99,6 +99,9 @@ extern int s2n_cert_chain_and_key_free(struct s2n_cert_chain_and_key *cert_and_k
 extern int s2n_cert_chain_and_key_set_ctx(struct s2n_cert_chain_and_key *cert_and_key, void *ctx);
 extern void *s2n_cert_chain_and_key_get_ctx(struct s2n_cert_chain_and_key *cert_and_key);
 
+typedef struct s2n_cert_chain_and_key* (*s2n_cert_tiebreak_callback) (struct s2n_cert_chain_and_key *cert1, struct s2n_cert_chain_and_key *cert2, uint8_t *name, uint32_t name_len);
+extern int s2n_config_set_cert_tiebreak_callback(struct s2n_config *config, s2n_cert_tiebreak_callback cert_tiebreak_cb);
+
 extern int s2n_config_add_cert_chain_and_key(struct s2n_config *config, const char *cert_chain_pem, const char *private_key_pem);
 extern int s2n_config_add_cert_chain_and_key_to_store(struct s2n_config *config, struct s2n_cert_chain_and_key *cert_key_pair);
 

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -561,6 +561,23 @@ int s2n_config_add_cert_chain_and_key_to_store(struct s2n_config *config,
 
 **s2n_config_add_cert_chain_and_key_to_store** may be called multiple times to support multiple key types(RSA, ECDSA) and multiple domains. On the server side, the certificate selected will be based on the incoming SNI value and the client's capabilities(supported ciphers). In the case of no certificate matching the client's SNI extension or if no SNI extension was sent by the client, the certificate from the **first** call to **s2n_config_add_cert_chain_and_key_to_store** will be selected.
 
+### s2n\_cert\_tiebreak\_callback
+```c
+typedef struct s2n_cert_chain_and_key* (*s2n_cert_tiebreak_callback) (struct s2n_cert_chain_and_key *cert1, struct s2n_cert_chain_and_key *cert2, uint8_t *name, uint32_t name_len);
+```
+
+**s2n_cert_tiebreak_callback** is invoked if s2n cannot resolve a conflict between two certificates with the same domain name. This function is invoked while certificates are added to an **s2n_config**.
+Currently, the only builtin resolution for domain name conflicts is certificate type(RSA, ECDSA, etc).
+The callback should return a pointer to the **s2n_cert_chain_and_key** that should be used for dns name **name**. If NULL is returned, the first certificate will be used.
+Typically an application will use properties like trust and expiry to implement tiebreaking.
+
+### s2n\_config\_set\_cert\_tiebreak\_callback
+```c
+int s2n_config_set_cert_tiebreak_callback(struct s2n_config *config, s2n_cert_tiebreak_callback tiebreak_fn);
+```
+
+**s2n_config_set_cert_tiebreak_callback** sets the **s2n_cert_tiebreak_callback** for resolving domain name conflicts. If no callback is set, the first certificate added for a domain name will always be preferred.
+
 ### s2n\_config\_add\_dhparams
 
 ```c

--- a/tests/unit/s2n_cert_chain_and_key_test.c
+++ b/tests/unit/s2n_cert_chain_and_key_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -25,6 +25,8 @@
 #include "crypto/s2n_fips.h"
 #include "utils/s2n_safety.h"
 
+#define NUM_TIED_CERTS 100
+
 struct s2n_connection *create_conn(s2n_mode mode, struct s2n_config *config, int s_to_c[], int c_to_s[]) {
     struct s2n_connection *conn = s2n_connection_new(mode);
     GUARD_PTR(s2n_connection_set_config(conn, config));
@@ -40,6 +42,18 @@ struct s2n_connection *create_conn(s2n_mode mode, struct s2n_config *config, int
     return conn;
 }
 
+static int num_times_cb_executed = 0;
+static struct s2n_cert_chain_and_key *test_cert_tiebreak_cb(struct s2n_cert_chain_and_key *cert1,
+        struct s2n_cert_chain_and_key *cert2,
+        uint8_t *name,
+        uint32_t name_len)
+{
+    const int priority1 = *((int *) s2n_cert_chain_and_key_get_ctx(cert1));
+    const int priority2 = *((int *) s2n_cert_chain_and_key_get_ctx(cert2));
+    num_times_cb_executed++;
+    return (priority1 > priority2 ? cert1 : cert2);
+}
+
 int main(int argc, char **argv)
 {
     struct s2n_config *server_config;
@@ -48,11 +62,17 @@ int main(int argc, char **argv)
     struct s2n_connection *client_conn;
     int server_to_client[2];
     int client_to_server[2];
+    char *alligator_cert;
+    char *alligator_key;
     char *cert_chain;
     char *private_key;
 
     BEGIN_TEST();
 
+    EXPECT_NOT_NULL(alligator_cert = malloc(S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_NOT_NULL(alligator_key = malloc(S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_SUCCESS(s2n_read_test_pem(S2N_ALLIGATOR_SAN_CERT, alligator_cert, S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_SUCCESS(s2n_read_test_pem(S2N_ALLIGATOR_SAN_KEY, alligator_key, S2N_MAX_TEST_PEM_SIZE));
     EXPECT_NOT_NULL(cert_chain = malloc(S2N_MAX_TEST_PEM_SIZE));
     EXPECT_NOT_NULL(private_key = malloc(S2N_MAX_TEST_PEM_SIZE));
     EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
@@ -71,33 +91,50 @@ int main(int argc, char **argv)
 
     EXPECT_NOT_NULL(client_config = s2n_config_new());
     EXPECT_SUCCESS(s2n_config_disable_x509_verification(client_config));
-
-    /* Create config with s2n_config_add_cert_chain_and_key_to_store API */
+    /* Create config with s2n_config_add_cert_chain_and_key_to_store API with multiple certs */
     {
-        struct s2n_cert_chain_and_key *chain_and_key;
-        /* Some data to retrieve from the cert after selection in handshake. */
-        int associated_cert_data = 7;
-        EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
-        EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain, private_key));
-        EXPECT_SUCCESS(s2n_cert_chain_and_key_set_ctx(chain_and_key, (void*) &associated_cert_data));
-
+        struct s2n_cert_chain_and_key *default_cert;
+        /* Associated data to attach to each certificate to use in the tiebreak callback. */
+        int tiebreak_priorites[NUM_TIED_CERTS] = { 0 };
+        /* Collection of certs with the same domain name that need to have ties resolved. */
+        struct s2n_cert_chain_and_key *tied_certs[NUM_TIED_CERTS] = { NULL };
         EXPECT_NOT_NULL(server_config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
+        EXPECT_SUCCESS(s2n_config_set_cert_tiebreak_callback(server_config, test_cert_tiebreak_cb));
+
+        /* Need to add at least one cert with a different domain name to make cert lookup utilize hashmap */
+        EXPECT_NOT_NULL(default_cert = s2n_cert_chain_and_key_new());
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(default_cert, cert_chain, private_key));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, default_cert));
+
+        /* Add NUM_TIED_CERTS that are actually the same certificate(www.alligator.com) to trigger the tiebreak callback. */
+        for (unsigned int i = 0; i < NUM_TIED_CERTS; i++) {
+            EXPECT_NOT_NULL(tied_certs[i] = s2n_cert_chain_and_key_new());
+            EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(tied_certs[i], alligator_cert, alligator_key));
+            tiebreak_priorites[i] = i;
+            EXPECT_SUCCESS(s2n_cert_chain_and_key_set_ctx(tied_certs[i], (void*) &tiebreak_priorites[i]));
+            EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, tied_certs[i]));
+        }
 
         EXPECT_NOT_NULL(server_conn = create_conn(S2N_SERVER, server_config, server_to_client, client_to_server));
         EXPECT_NOT_NULL(client_conn = create_conn(S2N_CLIENT, client_config, server_to_client, client_to_server));
-
+        EXPECT_SUCCESS(s2n_set_server_name(client_conn, "www.alligator.com"));
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
         EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn->handshake.handshake_type));
-        EXPECT_EQUAL(s2n_connection_get_selected_cert(server_conn), chain_and_key);
-        EXPECT_EQUAL(s2n_cert_chain_and_key_get_ctx(chain_and_key), &associated_cert_data);
-        EXPECT_EQUAL(*((int *) s2n_cert_chain_and_key_get_ctx(chain_and_key)), 7);
+        EXPECT_EQUAL(num_times_cb_executed, NUM_TIED_CERTS - 1);
+        struct s2n_cert_chain_and_key *selected_cert = s2n_connection_get_selected_cert(server_conn);
+        /* The last alligator certificate should have the highest priority */
+        EXPECT_EQUAL(selected_cert, tied_certs[(NUM_TIED_CERTS - 1)]);
+        EXPECT_EQUAL(s2n_cert_chain_and_key_get_ctx(selected_cert), (void*) &tiebreak_priorites[(NUM_TIED_CERTS - 1)]);
+        EXPECT_EQUAL(*((int *) s2n_cert_chain_and_key_get_ctx(selected_cert)), NUM_TIED_CERTS - 1);
         EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        for (int i = 0; i < NUM_TIED_CERTS; i++) {
+            EXPECT_SUCCESS(s2n_cert_chain_and_key_free(tied_certs[i]));
+        }
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(default_cert));
         EXPECT_SUCCESS(s2n_config_free(server_config));
-        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
     }
 
     /* Create config with deprecated s2n_config_add_cert_chain_and_key API */
@@ -126,6 +163,8 @@ int main(int argc, char **argv)
 
     free(cert_chain);
     free(private_key);
+    free(alligator_cert);
+    free(alligator_key);
     END_TEST();
     return 0;
 }

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -78,6 +78,9 @@ struct s2n_config {
     uint8_t (*verify_host) (const char *host_name, size_t host_name_len, void *data);
     void *data_for_verify_host;
 
+    /* Application supplied callback to resolve domain name conflicts when loading certs. */
+    s2n_cert_tiebreak_callback cert_tiebreak_cb;
+
     uint8_t mfl_code;
 
     /* if this is FALSE, server will ignore client's Maximum Fragment Length request */


### PR DESCRIPTION
This change adds a callback that is invoked when adding multiple certs
with the same domain name to an s2n_config. The callback should return
which certificate should be served for the domain name. Note that s2n
uses builtin tiebreaking based on the key type of the cert.

The default behavior of s2n without this callback set is to prefer
the *first* certificate added for a given domain name.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
