### PR TITLE
Optimize travis builds

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,7 +1,7 @@
 codecov:
   notify:
     require_ci_to_pass: no
-    after_n_builds: 3
+    after_n_builds: 2
 
 coverage:
   precision: 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ os:
   - linux
 
 env:
-  - TESTS=ctverif
+#  - TESTS=ctverif
   # Code Coverage Targets
   - S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=false TESTS=integration GCC_VERSION=6 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true
   - S2N_LIBCRYPTO=openssl-1.1.1 LATEST_CLANG=false TESTS=fuzz FUZZ_TIMEOUT_SEC=120 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,43 +8,39 @@ cache:
         # https://docs.travis-ci.com/user/caching/#Caches-and-build-matrices
         - test-deps
 
-osx_image: xcode8
+#osx_image: xcode8
 
 os:
-  - osx
+#  - osx
   - linux
 
 env:
   - TESTS=ctverif
   # Code Coverage Targets
-  - S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=unit GCC_VERSION=6 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true
-  - S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=6 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true
-  - S2N_LIBCRYPTO=openssl-1.1.1 LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=120 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true
+  - S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=false TESTS=integration GCC_VERSION=6 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true
+  - S2N_LIBCRYPTO=openssl-1.1.1 LATEST_CLANG=false TESTS=fuzz FUZZ_TIMEOUT_SEC=120 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true
   # Normal Build Targets
-  - S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=6
-  - S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=9
-  - S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=6 S2N_CORKED_IO=true
-  - S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=integration GCC_VERSION=6
-  - S2N_LIBCRYPTO=openssl-1.0.2-fips BUILD_S2N=true TESTS=integration GCC_VERSION=6
-  - S2N_LIBCRYPTO=libressl      BUILD_S2N=true TESTS=integration GCC_VERSION=6
+  - S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=7 S2N_CORKED_IO=true
+  - S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=false TESTS=integration GCC_VERSION=8
+  - S2N_LIBCRYPTO=openssl-1.0.2-fips BUILD_S2N=false TESTS=integration GCC_VERSION=9
+  - S2N_LIBCRYPTO=libressl      BUILD_S2N=false TESTS=integration GCC_VERSION=6
   # Force libcrypto to use "software only" crypto implementations for AES and AES-GCM. Verify s2n can gracefully use
   # unoptimized routines. See https://www.openssl.org/docs/man1.1.0/crypto/OPENSSL_ia32cap.html
   - S2N_LIBCRYPTO=openssl-1.1.1 OPENSSL_ia32cap="~0x200000200000000" BUILD_S2N=true TESTS=integration GCC_VERSION=6
-  - S2N_LIBCRYPTO=openssl-1.1.1 LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=120
   - S2N_LIBCRYPTO=openssl-1.0.2-fips LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=120
-  - S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=asan GCC_VERSION=6
-  - S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=valgrind GCC_VERSION=6
+  - S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=false TESTS=asan GCC_VERSION=6
+  - S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=false TESTS=valgrind GCC_VERSION=6
 
 matrix:
   exclude:
-  - os: osx
-    env: TESTS=ctverif
-  - os: osx
-    env: S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=valgrind GCC_VERSION=6
-  - os: osx
-    env: S2N_LIBCRYPTO=openssl-1.0.2-fips LATEST_CLANG=true TESTS=fuzz
-  - os: osx
-    env: S2N_LIBCRYPTO=openssl-1.0.2-fips BUILD_S2N=true TESTS=integration GCC_VERSION=6
+#  - os: osx
+#    env: TESTS=ctverif
+#  - os: osx
+#    env: S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=valgrind GCC_VERSION=6
+#  - os: osx
+#    env: S2N_LIBCRYPTO=openssl-1.0.2-fips LATEST_CLANG=true TESTS=fuzz
+#  - os: osx
+#    env: S2N_LIBCRYPTO=openssl-1.0.2-fips BUILD_S2N=true TESTS=integration GCC_VERSION=6
   include:
   - os : linux
     env: TESTS=sidetrail PART=1
@@ -84,9 +80,9 @@ matrix:
   - os : linux
     env : TESTS=sawHMACFailure SAW=true
     addons : *sawaddons   
-  allow_failures:
-    - os: osx
-    - env: TESTS=ctverif
+#  allow_failures:
+#    - os: osx
+#    - env: TESTS=ctverif
 
   fast_finish: true
 

--- a/.travis/copyright_mistake_scanner.sh
+++ b/.travis/copyright_mistake_scanner.sh
@@ -25,7 +25,7 @@ FAILED=0
 
 for file in $S2N_FILES; do
     # The word "Copyright" should appear at least once in the first 3 lines of every file
-    COUNT=`head -3 $file | grep "Copyright" | wc -l`;
+    COUNT=$(head -3 "$file" | grep -c "Copyright");
     if [ "$COUNT" == "0" ];
     then
         FAILED=1;

--- a/.travis/install_clang.sh
+++ b/.travis/install_clang.sh
@@ -43,10 +43,8 @@ export GIT_CURL_VERBOSE=1
 echo "Downloading Clang..."
 git clone https://chromium.googlesource.com/chromium/src/tools/clang
 
-cd clang
 # Reset to known working version of Clang
-git reset --hard e96a7b48d35ab6a268c8372048781cdec903a794
-cd ..
+(cd clang && git reset --hard e96a7b48d35ab6a268c8372048781cdec903a794)
 
 echo "Updating Clang..."
 "$CLANG_DOWNLOAD_DIR"/clang/scripts/update.py

--- a/.travis/install_ctverif_dependencies.sh
+++ b/.travis/install_ctverif_dependencies.sh
@@ -36,7 +36,7 @@ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328
 
 #    echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
 sudo apt-get update -o Acquire::CompressionTypes::Order::=gz
-sudo apt-get install -y ${DEPENDENCIES}
+sudo apt-get install -y "${DEPENDENCIES}"
 sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.7 20
 sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.7 20
 sudo update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-3.7 20

--- a/.travis/install_libFuzzer.sh
+++ b/.travis/install_libFuzzer.sh
@@ -31,9 +31,7 @@ mkdir -p "$LIBFUZZER_DOWNLOAD_DIR"
 cd "$LIBFUZZER_DOWNLOAD_DIR"
 
 git clone https://chromium.googlesource.com/chromium/llvm-project/llvm/lib/Fuzzer
-cd Fuzzer
-git checkout 651ead
-cd ..
+(cd Fuzzer && git checkout 651ead)
 
 echo "Compiling LibFuzzer..."
 clang++ -c -g -v -O2 -lstdc++ -std=c++11 Fuzzer/*.cpp -IFuzzer

--- a/.travis/install_openssl_1_0_2_fips.sh
+++ b/.travis/install_openssl_1_0_2_fips.sh
@@ -67,7 +67,7 @@ cd openssl-OpenSSL_1_0_2-stable
 
 FIPS_OPTIONS="fips --with-fipsdir=$FIPSDIR shared"
 
-$CONFIGURE $FIPS_OPTIONS -g3 -fPIC no-libunbound no-gmp no-jpake no-krb5 no-md2 no-rc5 \
+$CONFIGURE "$FIPS_OPTIONS" -g3 -fPIC no-libunbound no-gmp no-jpake no-krb5 no-md2 no-rc5 \
          no-rfc3779 no-sctp no-ssl-trace no-store no-zlib no-hw no-mdc2 no-seed no-idea \
          enable-ec_nistp_64_gcc_128 no-camellia no-bf no-ripemd no-dsa no-ssl2 no-capieng -DSSL_FORBID_ENULL \
          -DOPENSSL_NO_DTLS1 -DOPENSSL_NO_HEARTBEATS --prefix="$INSTALL_DIR"

--- a/.travis/install_osx_dependencies.sh
+++ b/.travis/install_osx_dependencies.sh
@@ -16,7 +16,7 @@
 set -ex
 
 function brew_install_if_not_installed () {
-    brew list $1 &>/dev/null || brew install $1
+    brew list "$1" &>/dev/null || brew install "$1"
 }
 
 brew update

--- a/.travis/install_sidetrail_dependencies.sh
+++ b/.travis/install_sidetrail_dependencies.sh
@@ -22,10 +22,7 @@ sudo apt-get install -y figlet
 #Install boogieman
 #sudo gem install --pre bam-bam-boogieman
 git clone https://github.com/Qthan/bam-bam-boogieman.git -b cost-modeling
-cd bam-bam-boogieman
-bundle update
-bundle exec rake install
-cd ..
+(cd bam-bam-boogieman && bundle update && bundle exec rake install)
 which bam
 
 
@@ -40,7 +37,7 @@ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328
 echo "deb http://download.mono-project.com/repo/ubuntu trusty main" | sudo tee /etc/apt/sources.list.d/mono-official.list
 
 sudo apt-get update -o Acquire::CompressionTypes::Order::=gz
-sudo apt-get install -y ${DEPENDENCIES}
+sudo apt-get install -y "${DEPENDENCIES}"
 pip install pyyaml
 
 LLVM_SHORT_VERSION=3.9

--- a/.travis/install_ubuntu_dependencies.sh
+++ b/.travis/install_ubuntu_dependencies.sh
@@ -20,10 +20,10 @@ sudo apt-get update -o Acquire::CompressionTypes::Order::=gz
 
 DEPENDENCIES="unzip make indent kwstyle libssl-dev tcpdump valgrind lcov m4 nettle-dev nettle-bin pkg-config gcc g++ zlibc zlib1g-dev python-pip llvm"
 
-sudo apt-get install -y ${DEPENDENCIES}
+sudo apt-get install -y "${DEPENDENCIES}"
 
 if [[ -n "$GCC_VERSION" ]] && [[ "$GCC_VERSION" != "NONE" ]]; then
-    sudo apt-get -y install gcc-$GCC_VERSION;
+    sudo apt-get -y install "gcc-$GCC_VERSION";
 fi
 
 # Download and Install prlimit for memlock

--- a/.travis/install_ubuntu_dependencies.sh
+++ b/.travis/install_ubuntu_dependencies.sh
@@ -18,9 +18,9 @@ set -ex
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 sudo apt-get update -o Acquire::CompressionTypes::Order::=gz
 
-DEPENDENCIES="unzip make indent kwstyle libssl-dev tcpdump valgrind lcov m4 nettle-dev nettle-bin pkg-config gcc g++ zlibc zlib1g-dev python-pip llvm"
+DEPENDENCIES=(unzip make indent kwstyle libssl-dev tcpdump valgrind lcov m4 nettle-dev nettle-bin pkg-config gcc g++ zlibc zlib1g-dev python-pip llvm)
 
-sudo apt-get install -y "${DEPENDENCIES}"
+sudo apt-get install -y "${DEPENDENCIES[@]}"
 
 if [[ -n "$GCC_VERSION" ]] && [[ "$GCC_VERSION" != "NONE" ]]; then
     sudo apt-get -y install "gcc-$GCC_VERSION";

--- a/.travis/llvm-gcov.sh
+++ b/.travis/llvm-gcov.sh
@@ -22,7 +22,7 @@ usage() {
     exit 1
 }
 
-if [ "$#" -l "1" ]; then
+if [ "$#" -lt "1" ]; then
     usage
 fi
 

--- a/.travis/s2n_setup_env.sh
+++ b/.travis/s2n_setup_env.sh
@@ -78,8 +78,9 @@ export S2N_CORKED_IO
 
 # Add all of our test dependencies to the PATH. Use Openssl 1.1.1 so the latest openssl is used for s_client
 # integration tests.
-export PATH=$PYTHON_INSTALL_DIR/bin:$OPENSSL_1_1_1_INSTALL_DIR/bin:$GNUTLS_INSTALL_DIR/bin:$SAW_INSTALL_DIR/bin:$Z3_INSTALL_DIR/bin:$SCAN_BUILD_INSTALL_DIR/bin:$LATEST_CLANG_INSTALL_DIR/bin:`pwd`/.travis/:$PATH
-export LD_LIBRARY_PATH=$OPENSSL_1_1_1_INSTALL_DIR/lib:$LD_LIBRARY_PATH; 
+PATH=$PYTHON_INSTALL_DIR/bin:$OPENSSL_1_1_1_INSTALL_DIR/bin:$GNUTLS_INSTALL_DIR/bin:$SAW_INSTALL_DIR/bin:$Z3_INSTALL_DIR/bin:$SCAN_BUILD_INSTALL_DIR/bin:$LATEST_CLANG_INSTALL_DIR/bin:$(pwd)/.travis/:$PATH
+export PATH
+export LD_LIBRARY_PATH=$OPENSSL_1_1_1_INSTALL_DIR/lib:$LD_LIBRARY_PATH;
 export DYLD_LIBRARY_PATH=$OPENSSL_1_1_1_INSTALL_DIR/lib:$LD_LIBRARY_PATH;
 
 # Select the libcrypto to build s2n against. If this is unset, default to the latest stable version(Openssl 1.1.1)

--- a/.travis/s2n_travis_build.sh
+++ b/.travis/s2n_travis_build.sh
@@ -34,7 +34,7 @@ fi
 
 # Set the version of GCC as Default if it's required
 if [[ -n "$GCC_VERSION" ]] && [[ "$GCC_VERSION" != "NONE" ]]; then
-    alias gcc=$(which "gcc-$GCC_VERSION");
+    alias gcc='$(which "gcc-$GCC_VERSION")';
 fi
 
 if [[ "$TRAVIS_OS_NAME" == "linux" && "$TESTS" == "valgrind" ]]; then

--- a/.travis/s2n_travis_build.sh
+++ b/.travis/s2n_travis_build.sh
@@ -34,7 +34,7 @@ fi
 
 # Set the version of GCC as Default if it's required
 if [[ -n "$GCC_VERSION" ]] && [[ "$GCC_VERSION" != "NONE" ]]; then
-    alias gcc=$(which gcc-$GCC_VERSION);
+    alias gcc=$(which "gcc-$GCC_VERSION");
 fi
 
 if [[ "$TRAVIS_OS_NAME" == "linux" && "$TESTS" == "valgrind" ]]; then
@@ -73,5 +73,5 @@ if [[ -n "$CODECOV_IO_UPLOAD" ]]; then
     make run-gcov;
 
     # Upload coverage metrics to codecov.io site
-    bash <(curl -s https://codecov.io/bash) -F ${TESTS};
+    bash <(curl -s https://codecov.io/bash) -F "${TESTS}";
 fi

--- a/.travis/zero_init_struct_helper.sh
+++ b/.travis/zero_init_struct_helper.sh
@@ -27,11 +27,11 @@ fi
 STRUCT_NAME=$1
 INIT_VALUE=$2
 
-LINES_WITH_UNINITIALIZED_STRUCTS=`grep -En "struct ${STRUCT_NAME} [a-z0-9_]+;" ./**/s2n*.c | cut -d: -f1-2`;
-LINE_COUNT=`echo "$LINES_WITH_UNINITIALIZED_STRUCTS" | wc -l`
-WORD_COUNT=`echo "$LINES_WITH_UNINITIALIZED_STRUCTS" | wc -w`
+LINES_WITH_UNINITIALIZED_STRUCTS=$(grep -En "struct ${STRUCT_NAME} [a-z0-9_]+;" ./**/s2n*.c | cut -d: -f1-2);
+LINE_COUNT=$(echo "$LINES_WITH_UNINITIALIZED_STRUCTS" | wc -l)
+WORD_COUNT=$(echo "$LINES_WITH_UNINITIALIZED_STRUCTS" | wc -w)
 
-if [ $WORD_COUNT -eq 0 ]; then
+if [ "$WORD_COUNT" -eq 0 ]; then
     echo "Found zero uninitialized ${STRUCT_NAME} structs."
     exit
 fi
@@ -41,8 +41,8 @@ echo "Found $LINE_COUNT uninitialized ${STRUCT_NAME} structs..."
 for line in $LINES_WITH_UNINITIALIZED_STRUCTS
 do
   # Line Format: "${file_name}:${line_num}"
-  FILENAME=`echo "${line}" | cut -d: -f 1`
-  LINE_NUM=`echo "${line}" | cut -d: -f 2`
+  FILENAME=$(echo "${line}" | cut -d: -f 1)
+  LINE_NUM=$(echo "${line}" | cut -d: -f 2)
   
   # Use sed to replace ";" with " = {0};"
   SED_ARGS="-i '' '${LINE_NUM}s/;/ = ${INIT_VALUE};/' ${FILENAME}"

--- a/.travis/zero_init_structs.sh
+++ b/.travis/zero_init_structs.sh
@@ -13,18 +13,18 @@
 # permissions and limitations under the License.
 #
 
-./.travis/zero_init_struct_helper.sh s2n_blob {0}
-./.travis/zero_init_struct_helper.sh s2n_stuffer {{0}}
-./.travis/zero_init_struct_helper.sh s2n_config {0}
-./.travis/zero_init_struct_helper.sh s2n_pkey {{{0}}}
-./.travis/zero_init_struct_helper.sh s2n_session_key {0}
-./.travis/zero_init_struct_helper.sh s2n_connection_prf_handles {{{{0}}}}
-./.travis/zero_init_struct_helper.sh s2n_connection_hash_handles {{{0}}}
-./.travis/zero_init_struct_helper.sh s2n_connection_hmac_handles {{{{0}}}}
-./.travis/zero_init_struct_helper.sh s2n_client_hello_parsed_extension {0}
-./.travis/zero_init_struct_helper.sh s2n_hash_state {0}
-./.travis/zero_init_struct_helper.sh s2n_dh_params {0}
-./.travis/zero_init_struct_helper.sh s2n_map {0}
-./.travis/zero_init_struct_helper.sh timespec {0}
-./.travis/zero_init_struct_helper.sh tm {0}
-./.travis/zero_init_struct_helper.sh stat {0}
+./.travis/zero_init_struct_helper.sh s2n_blob "{0}"
+./.travis/zero_init_struct_helper.sh s2n_stuffer "{{0}}"
+./.travis/zero_init_struct_helper.sh s2n_config "{0}"
+./.travis/zero_init_struct_helper.sh s2n_pkey "{{{0}}}"
+./.travis/zero_init_struct_helper.sh s2n_session_key "{0}"
+./.travis/zero_init_struct_helper.sh s2n_connection_prf_handles "{{{{0}}}}"
+./.travis/zero_init_struct_helper.sh s2n_connection_hash_handles "{{{0}}}"
+./.travis/zero_init_struct_helper.sh s2n_connection_hmac_handles "{{{{0}}}}"
+./.travis/zero_init_struct_helper.sh s2n_client_hello_parsed_extension "{0}"
+./.travis/zero_init_struct_helper.sh s2n_hash_state "{0}"
+./.travis/zero_init_struct_helper.sh s2n_dh_params "{0}"
+./.travis/zero_init_struct_helper.sh s2n_map "{0}"
+./.travis/zero_init_struct_helper.sh timespec "{0}"
+./.travis/zero_init_struct_helper.sh tm "{0}"
+./.travis/zero_init_struct_helper.sh stat "{0}"

--- a/s2n.mk
+++ b/s2n.mk
@@ -37,7 +37,7 @@ INDENT  = $(shell (if indent --version 2>&1 | grep GNU > /dev/null; then echo in
 
 DEFAULT_CFLAGS = -pedantic -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-subscripts -Wuninitialized \
                  -Wshadow -Wcast-qual -Wcast-align -Wwrite-strings -fPIC \
-                 -Wunknown-pragmas -Wshift-negative-value -Wformat=2 \
+                  -Wshift-negative-value -Wunknown-pragmas -Wformat=2 \
                  -std=c99 -D_POSIX_C_SOURCE=200809L -O2 -I$(LIBCRYPTO_ROOT)/include/ \
                  -I$(S2N_ROOT)/api/ -I$(S2N_ROOT) -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security \
                  -D_FORTIFY_SOURCE=2 -fgnu89-inline
@@ -66,11 +66,14 @@ CFLAGS += ${DEFAULT_CFLAGS}
 ifdef GCC_VERSION
 	ifneq ("$(GCC_VERSION)","NONE")
 		CC=gcc-$(GCC_VERSION)
-	endif
-# Make doesn't support greater than checks, this uses `test` to compare values, then `echo $$?` to return the value of test's
-# exit code and finally using the built in make `ifeq` to check if it was true and then add the extra flag.
-	ifeq ($(shell test $(GCC_VERSION) -gt 7; echo $$?),0)
-		CFLAGS += -Wimplicit-fallthrough -Wmultistatement-macros -Wduplicated-branches
+		# These flags are unsupported by clang and only added when building with GCC
+		CFLAGS += -Wduplicated-cond -Warray-bounds=2 -Wc99-c11-compat -Wmaybe-uninitialized
+
+		# Make doesn't support greater than checks, this uses `test` to compare values, then `echo $$?` to return the value of test's
+		# exit code and finally using the built in make `ifeq` to check if it was true and then add the extra flag.
+		ifeq ($(shell test $(GCC_VERSION) -gt 7; echo $$?),0)
+			CFLAGS += -Wimplicit-fallthrough -Wmultistatement-macros -Wduplicated-branches
+		endif
 	endif
 endif
 

--- a/s2n.mk
+++ b/s2n.mk
@@ -37,9 +37,10 @@ INDENT  = $(shell (if indent --version 2>&1 | grep GNU > /dev/null; then echo in
 
 DEFAULT_CFLAGS = -pedantic -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-subscripts -Wuninitialized \
                  -Wshadow -Wcast-qual -Wcast-align -Wwrite-strings -fPIC \
+                 -Wunknown-pragmas -Wshift-negative-value -Wformat=2 \
                  -std=c99 -D_POSIX_C_SOURCE=200809L -O2 -I$(LIBCRYPTO_ROOT)/include/ \
                  -I$(S2N_ROOT)/api/ -I$(S2N_ROOT) -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security \
-                 -D_FORTIFY_SOURCE=2 -fgnu89-inline 
+                 -D_FORTIFY_SOURCE=2 -fgnu89-inline
 
 COVERAGE_CFLAGS = -fprofile-arcs -ftest-coverage
 COVERAGE_LDFLAGS = --coverage
@@ -69,7 +70,7 @@ ifdef GCC_VERSION
 # Make doesn't support greater than checks, this uses `test` to compare values, then `echo $$?` to return the value of test's
 # exit code and finally using the built in make `ifeq` to check if it was true and then add the extra flag.
 	ifeq ($(shell test $(GCC_VERSION) -gt 7; echo $$?),0)
-		CFLAGS += -Wimplicit-fallthrough
+		CFLAGS += -Wimplicit-fallthrough -Wmultistatement-macros -Wduplicated-branches
 	endif
 endif
 


### PR DESCRIPTION
**Issue # (if available):** 
N/A
**Description of changes:** 
Currently there is a lot of duplicated and wasted effort in our travis builds that results in long build times and large backlogs of pull request builds. This change:
* Removes all of the allowed to fail builds that have been failing for months
* Remove the unit test build which is just a subset of the integration test build
* Only have one build run the validation from BUILD_S2N which is just static analysis of the source code and not build dependent
* Add new compiler warning flags
* Update travis to use gcc 6-9 to build the various builds to check compatibility and add new compiler warnings as appropriate 
* Fix all the ShellCheck warnings it has been complaining about for months

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
