### PR TITLE
Add PQ cipher suites to a new PQ KMS cipher prefrence list, add a new…

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -253,7 +253,7 @@ extern int s2n_connection_client_cert_used(struct s2n_connection *conn);
 extern const char *s2n_connection_get_cipher(struct s2n_connection *conn);
 extern int s2n_connection_is_valid_for_cipher_preferences(struct s2n_connection *conn, const char *version);
 extern const char *s2n_connection_get_curve(struct s2n_connection *conn);
-extern const char *s2n_connection_get_kem(struct s2n_connection *conn);
+extern const char *s2n_connection_get_kem_name(struct s2n_connection *conn);
 extern int s2n_connection_get_alert(struct s2n_connection *conn);
 
 #ifdef __cplusplus

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -253,6 +253,7 @@ extern int s2n_connection_client_cert_used(struct s2n_connection *conn);
 extern const char *s2n_connection_get_cipher(struct s2n_connection *conn);
 extern int s2n_connection_is_valid_for_cipher_preferences(struct s2n_connection *conn, const char *version);
 extern const char *s2n_connection_get_curve(struct s2n_connection *conn);
+extern const char *s2n_connection_get_kem(struct s2n_connection *conn);
 extern int s2n_connection_get_alert(struct s2n_connection *conn);
 
 #ifdef __cplusplus

--- a/bin/echo.c
+++ b/bin/echo.c
@@ -85,7 +85,7 @@ int negotiate(struct s2n_connection *conn)
     }
 
     printf("Curve: %s\n", s2n_connection_get_curve(conn));
-    printf("KEM: %s\n", s2n_connection_get_kem(conn));
+    printf("KEM: %s\n", s2n_connection_get_kem_name(conn));
 
     uint32_t length;
     const uint8_t *status = s2n_connection_get_ocsp_response(conn, &length);

--- a/bin/echo.c
+++ b/bin/echo.c
@@ -85,6 +85,7 @@ int negotiate(struct s2n_connection *conn)
     }
 
     printf("Curve: %s\n", s2n_connection_get_curve(conn));
+    printf("KEM: %s\n", s2n_connection_get_kem(conn));
 
     uint32_t length;
     const uint8_t *status = s2n_connection_get_ocsp_response(conn, &length);

--- a/pq-crypto/README.md
+++ b/pq-crypto/README.md
@@ -56,13 +56,17 @@ and use the BIKE1_L1.const.kat from the above Additional_Implementation.2019.03.
 1. Use the sample server and client in the bin directory:
 ```bash
 # Terminal 1
-export LD_LIBRARY_PATH=/path-to-s2n/s2n/test-deps/openssl-1.1.1/lib:/path-to-s2n/s2n/test-deps/openssl-1.1.1/lib:/path-to-s2n/s2n/lib:/path-to-s2n/s2n/bin
-export PATH=/path-to-s2n/s2n/bin:$PATH
-s2nd --cert tests/pems/rsa_2048_sha256_wildcard_cert.pem --key tests/pems/rsa_2048_sha256_wildcard_key.pem --negotiate --ciphers KMS-PQ-TLS-1-0-2019-06 0.0.0.0 8888
+# Use the s2nd CLI tool to start a TLS daemon with the KMS-PQ-TLS-1-0-2019-06 cipher preferences listening on port 8888
+export PATH_TO_S2N=/path/to/s2n
+export LD_LIBRARY_PATH=${PATH_TO_S2N}/test-deps/openssl-1.1.1/lib:${PATH_TO_S2N}/test-deps/openssl-1.1.1/lib:${PATH_TO_S2N}/lib:${PATH_TO_S2N}/bin
+export PATH=${PATH_TO_S2N}/bin:$PATH
+s2nd --cert ${PATH_TO_S2N}/tests/pems/rsa_2048_sha256_wildcard_cert.pem --key ${PATH_TO_S2N}/tests/pems/rsa_2048_sha256_wildcard_key.pem --negotiate --ciphers KMS-PQ-TLS-1-0-2019-06 0.0.0.0 8888
 
 # Terminal 2
-export LD_LIBRARY_PATH=/path-to-s2n/s2n/test-deps/openssl-1.1.1/lib:/path-to-s2n/s2n/test-deps/openssl-1.1.1/lib:/path-to-s2n/s2n/lib:/path-to-s2n/s2n/bin
-export PATH=/path-to-s2n/s2n/bin:$PATH
+# Use the s2nc TLS CLI client to connect to the TLS server daemon started in Terminal 1 on port 8888
+export PATH_TO_S2N=/path/to/s2n
+export LD_LIBRARY_PATH=${PATH_TO_S2N}/test-deps/openssl-1.1.1/lib:${PATH_TO_S2N}/test-deps/openssl-1.1.1/lib:${PATH_TO_S2N}/lib:${PATH_TO_S2N}/bin
+export PATH=${PATH_TO_S2N}/bin:$PATH
 export S2N_ENABLE_CLIENT_MODE=1
 s2nc -i --ciphers KMS-PQ-TLS-1-0-2019-06 0.0.0.0 8888
 ```

--- a/pq-crypto/README.md
+++ b/pq-crypto/README.md
@@ -49,3 +49,20 @@ and use the BIKE1_L1.const.kat from the above Additional_Implementation.2019.03.
 1. Add formal verification in `tests/saw/KEM_NAME/verify.saw`
 1. Create a new `s2n_cipher_suite` in `tls/s2n_cipher_suites.c`
 1. Create a new `s2n_cipher_preferences` in `tls/s2n_cipher_prefrences.c` that uses the new cipher suite
+
+## How to use PQ cipher suites
+1. Checkout s2n `git clone https://github.com/awslabs/s2n.git`
+1. Following the docs/USAGE-GUIDE.md build s2n
+1. Use the sample server and client in the bin directory:
+```bash
+# Terminal 1
+export LD_LIBRARY_PATH=/path-to-s2n/s2n/test-deps/openssl-1.1.1/lib:/path-to-s2n/s2n/test-deps/openssl-1.1.1/lib:/path-to-s2n/s2n/lib:/path-to-s2n/s2n/bin
+export PATH=/path-to-s2n/s2n/bin:$PATH
+s2nd --cert tests/pems/rsa_2048_sha256_wildcard_cert.pem --key tests/pems/rsa_2048_sha256_wildcard_key.pem --negotiate --ciphers KMS-PQ-TLS-1-0-2019-06 0.0.0.0 8888
+
+# Terminal 2
+export LD_LIBRARY_PATH=/path-to-s2n/s2n/test-deps/openssl-1.1.1/lib:/path-to-s2n/s2n/test-deps/openssl-1.1.1/lib:/path-to-s2n/s2n/lib:/path-to-s2n/s2n/bin
+export PATH=/path-to-s2n/s2n/bin:$PATH
+export S2N_ENABLE_CLIENT_MODE=1
+s2nc -i --ciphers KMS-PQ-TLS-1-0-2019-06 0.0.0.0 8888
+```

--- a/tests/unit/s2n_cipher_suite_match_test.c
+++ b/tests/unit/s2n_cipher_suite_match_test.c
@@ -108,6 +108,8 @@ int main(int argc, char **argv)
             TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
             TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
             TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+            TLS_ECDHE_BIKE_RSA_WITH_AES_256_GCM_SHA384,
+            TLS_ECDHE_BIKE_RSA_WITH_AES_256_GCM_SHA384,
         };
         const uint8_t cipher_count = sizeof(wire_ciphers) / S2N_TLS_CIPHER_SUITE_LEN;
 
@@ -233,6 +235,34 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(conn->secure_renegotiation, 0);
         EXPECT_EQUAL(conn->secure.cipher_suite, s2n_cipher_suite_from_wire(expected_rsa_wire_choice));
         EXPECT_SUCCESS(s2n_connection_wipe(conn));
+
+        /* Test that clients that support PQ ciphers can negioatate them. */
+        const uint8_t expected_pq_wire_choice[] = { TLS_ECDHE_BIKE_RSA_WITH_AES_256_GCM_SHA384 };
+        uint8_t client_extensions_data[] = { 0xFE, 0x01, 0x00, 0x04, 0x00, 0x02, 0x00, 0x01 };
+        int client_extensions_len = sizeof(client_extensions_data);
+        s2n_connection_set_cipher_preferences(conn, "KMS-PQ-TLS-1-0-2019-06");
+        conn->client_protocol_version = S2N_TLS12;
+        conn->secure.server_ecc_params.negotiated_curve = &s2n_ecc_supported_curves[0];
+        conn->secure.client_pq_kem_extension.data = client_extensions_data;
+        conn->secure.client_pq_kem_extension.size = client_extensions_len;
+        EXPECT_SUCCESS(s2n_set_cipher_and_cert_as_tls_server(conn, wire_ciphers, cipher_count));
+        EXPECT_EQUAL(conn->secure.cipher_suite, s2n_cipher_suite_from_wire(expected_pq_wire_choice));
+        EXPECT_SUCCESS(s2n_connection_wipe(conn));
+
+        /* Test cipher preferences that use PQ cipher suites that require TLS 1.2 fall back to classic ciphers if a client
+         * only supports TLS 1.1 or below, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA is the first cipher suite that supports
+         * TLS 1.1 in KMS-PQ-TLS-1-0-2019-06 */
+        for (int i = S2N_TLS10; i <= S2N_TLS11; i++) {
+            const uint8_t expected_classic_wire_choice[] = { TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA };
+            s2n_connection_set_cipher_preferences(conn, "KMS-PQ-TLS-1-0-2019-06");
+            conn->client_protocol_version = i;
+            conn->secure.server_ecc_params.negotiated_curve = &s2n_ecc_supported_curves[0];
+            conn->secure.client_pq_kem_extension.data = client_extensions_data;
+            conn->secure.client_pq_kem_extension.size = client_extensions_len;
+            EXPECT_SUCCESS(s2n_set_cipher_and_cert_as_tls_server(conn, wire_ciphers, cipher_count));
+            EXPECT_EQUAL(conn->secure.cipher_suite, s2n_cipher_suite_from_wire(expected_classic_wire_choice));
+            EXPECT_SUCCESS(s2n_connection_wipe(conn));
+        }
 
         /* Clean+free to setup for ECDSA tests */
         EXPECT_SUCCESS(s2n_config_free(server_config));

--- a/tests/unit/s2n_cipher_suite_match_test.c
+++ b/tests/unit/s2n_cipher_suite_match_test.c
@@ -236,9 +236,14 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(conn->secure.cipher_suite, s2n_cipher_suite_from_wire(expected_rsa_wire_choice));
         EXPECT_SUCCESS(s2n_connection_wipe(conn));
 
-        /* Test that clients that support PQ ciphers can negioatate them. */
+        /* Test that clients that support PQ ciphers can negotiate them. */
         const uint8_t expected_pq_wire_choice[] = { TLS_ECDHE_BIKE_RSA_WITH_AES_256_GCM_SHA384 };
-        uint8_t client_extensions_data[] = { 0xFE, 0x01, 0x00, 0x04, 0x00, 0x02, 0x00, 0x01 };
+        uint8_t client_extensions_data[] = {
+                0xFE, 0x01, /* PQ KEM extension ID */
+                0x00, 0x04, /* Total extension length in bytes */
+                0x00, 0x02, /* Length of the supported parameters list in bytes */
+                0x00, 0x01  /* BIKE1r1-Level1 */
+        };
         int client_extensions_len = sizeof(client_extensions_data);
         s2n_connection_set_cipher_preferences(conn, "KMS-PQ-TLS-1-0-2019-06");
         conn->client_protocol_version = S2N_TLS12;

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -713,6 +713,28 @@ const struct s2n_cipher_preferences cipher_preferences_kms_tls_1_0_2018_10 = {
         .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
+struct s2n_cipher_suite *cipher_suites_kms_pq_tls_1_0_2019_06[] = {
+        &s2n_ecdhe_bike_rsa_with_aes_256_gcm_sha384,
+        &s2n_ecdhe_sike_rsa_with_aes_256_gcm_sha384,
+        &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+        &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+        &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+        &s2n_ecdhe_rsa_with_aes_256_cbc_sha,
+        &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
+        &s2n_ecdhe_rsa_with_3des_ede_cbc_sha,
+        &s2n_dhe_rsa_with_aes_256_cbc_sha256,
+        &s2n_dhe_rsa_with_aes_128_cbc_sha256,
+        &s2n_dhe_rsa_with_aes_256_cbc_sha,
+        &s2n_dhe_rsa_with_aes_128_cbc_sha,
+};
+
+const struct s2n_cipher_preferences cipher_preferences_kms_pq_tls_1_0_2019_06 = {
+        .count = sizeof(cipher_suites_kms_pq_tls_1_0_2019_06) / sizeof(cipher_suites_kms_pq_tls_1_0_2019_06[0]),
+        .suites = cipher_suites_kms_pq_tls_1_0_2019_06,
+        .minimum_protocol_version = S2N_TLS10,
+        .extension_flag = S2N_ECC_EXTENSION_ENABLED
+};
+
 struct s2n_cipher_suite *cipher_suites_kms_fips_tls_1_2_2018_10[] = {
         &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
         &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
@@ -752,6 +774,7 @@ struct {
     { "CloudFront-TLS-1-2-2018", &cipher_preferences_cloudfront_tls_1_2_2018 },
     { "CloudFront-TLS-1-2-2019", &cipher_preferences_cloudfront_tls_1_2_2019 },
     { "KMS-TLS-1-0-2018-10", &cipher_preferences_kms_tls_1_0_2018_10 },
+    { "KMS-PQ-TLS-1-0-2019-06", &cipher_preferences_kms_pq_tls_1_0_2019_06 },
     { "KMS-FIPS-TLS-1-2-2018-10", &cipher_preferences_kms_fips_tls_1_2_2018_10 },
     { "20140601", &cipher_preferences_20140601 },
     { "20141001", &cipher_preferences_20141001 },

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -854,7 +854,7 @@ const char *s2n_connection_get_curve(struct s2n_connection *conn)
     return conn->secure.server_ecc_params.negotiated_curve->name;
 }
 
-const char *s2n_connection_get_kem(struct s2n_connection *conn)
+const char *s2n_connection_get_kem_name(struct s2n_connection *conn)
 {
     notnull_check_ptr(conn);
 

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -854,6 +854,17 @@ const char *s2n_connection_get_curve(struct s2n_connection *conn)
     return conn->secure.server_ecc_params.negotiated_curve->name;
 }
 
+const char *s2n_connection_get_kem(struct s2n_connection *conn)
+{
+    notnull_check_ptr(conn);
+
+    if (!conn->secure.s2n_kem_keys.negotiated_kem) {
+        return "NONE";
+    }
+
+    return conn->secure.s2n_kem_keys.negotiated_kem->name;
+}
+
 int s2n_connection_get_client_protocol_version(struct s2n_connection *conn)
 {
     notnull_check(conn);

--- a/tls/s2n_kem.c
+++ b/tls/s2n_kem.c
@@ -25,6 +25,7 @@
 #include "utils/s2n_safety.h"
 
 const struct s2n_kem s2n_bike_1_level_1_r1 = {
+        .name = "BIKE1r1-Level1",
         .kem_extension_id = TLS_PQ_KEM_EXTENSION_ID_BIKE1_R1_LEVEL_1,
         .public_key_length = BIKE1_L1_PUBLIC_KEY_BYTES,
         .private_key_length = BIKE1_L1_SECRET_KEY_BYTES,
@@ -36,6 +37,7 @@ const struct s2n_kem s2n_bike_1_level_1_r1 = {
 };
 
 const struct s2n_kem s2n_sike_p503_r1 = {
+        .name = "SIKEp503r1-KEM",
         .kem_extension_id = TLS_PQ_KEM_EXTENSION_ID_SIKE_P503_R1_KEM,
         .public_key_length = SIKE_P503_PUBLIC_KEY_BYTES,
         .private_key_length = SIKE_P503_SECRET_KEY_BYTES,

--- a/tls/s2n_kem.c
+++ b/tls/s2n_kem.c
@@ -24,6 +24,7 @@
 #include "utils/s2n_mem.h"
 #include "utils/s2n_safety.h"
 
+/* The names below come from https://tools.ietf.org/html/draft-campagna-tls-bike-sike-hybrid-01#section-5.1.6 */
 const struct s2n_kem s2n_bike_1_level_1_r1 = {
         .name = "BIKE1r1-Level1",
         .kem_extension_id = TLS_PQ_KEM_EXTENSION_ID_BIKE1_R1_LEVEL_1,

--- a/tls/s2n_kem.h
+++ b/tls/s2n_kem.h
@@ -26,6 +26,7 @@ typedef uint16_t kem_shared_secret_size;
 typedef uint16_t kem_ciphertext_key_size;
 
 struct s2n_kem {
+    const char *name;
     const kem_extension_size kem_extension_id;
     const kem_public_key_size public_key_length;
     const kem_private_key_size private_key_length;


### PR DESCRIPTION
… public api to get the name of the kem from a connection

**Issue # (if available):** 
https://github.com/awslabs/s2n/issues/904
**Description of changes:** 
* Add new PQ KMS cipher preference list, the cipher suites are the same as the current `KMS-PQ-TLS-1-0-2019-06` with the addition of `s2n_ecdhe_bike_rsa_with_aes_256_gcm_sha384` and `s2n_ecdhe_sike_rsa_with_aes_256_gcm_sha384` first so server order chooses them without clients having to remove all other viable cipher suites
* Add new api to get the name of the KEM parameters that were negotiated in a connection
* Update pq-crypto readme with instructions to use new cipher suites

Sample output:
```
s2nc -i --ciphers KMS-PQ-TLS-1-0-2019-06 0.0.0.0 8888
CONNECTED:
Client hello version: 33
Client protocol version: 33
Server protocol version: 33
Actual protocol version: 33
Server name: 0.0.0.0
Curve: secp256r1
KEM: BIKE1r1-Level1
Cipher negotiated: ECDHE-BIKE-RSA-AES256-GCM-SHA384
Connected to 0.0.0.0:8888
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
