### PR TITLE
Improve unsafe_verify_host to work with wildcard certificates

### DIFF
--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -86,7 +86,9 @@ static uint8_t unsafe_verify_host(const char *host_name, size_t host_name_len, v
 
     char *offset = strstr(host_name, "*.");
     if (offset) {
-        return (uint8_t)(strcasecmp(verify_data->trusted_host, offset + 2) == 0);
+          char *label = strchr(verify_data->trusted_host, '.');
+          return (uint8_t)(strcasecmp(verify_data->trusted_host, offset + 2) == 0) ||
+              (label && (uint8_t)(strcasecmp(label + 1, offset + 2) == 0));
     }
 
     int equals = strcasecmp(host_name, verify_data->trusted_host);

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -86,9 +86,9 @@ static uint8_t unsafe_verify_host(const char *host_name, size_t host_name_len, v
 
     char *offset = strstr(host_name, "*.");
     if (offset) {
-          char *label = strchr(verify_data->trusted_host, '.');
-          return (uint8_t)(strcasecmp(verify_data->trusted_host, offset + 2) == 0) ||
-              (label && (uint8_t)(strcasecmp(label + 1, offset + 2) == 0));
+        char *label = strchr(verify_data->trusted_host, '.');
+        return (uint8_t)(strcasecmp(verify_data->trusted_host, offset + 2) == 0) ||
+            (label && (uint8_t)(strcasecmp(label + 1, offset + 2) == 0));
     }
 
     int equals = strcasecmp(host_name, verify_data->trusted_host);

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -260,6 +260,10 @@ static int s2n_advance_message(struct s2n_connection *conn)
 
     /* Actually advance the message number */
     conn->handshake.message_number++;
+
+    /* Set TCP_QUICKACK to avoid artificial dealy during the handshake */
+    GUARD(s2n_socket_quickack(conn));
+
     /* If optimized io hasn't been enabled or if the caller started out with a corked socket,
      * we don't mess with it
      */

--- a/utils/s2n_socket.c
+++ b/utils/s2n_socket.c
@@ -37,6 +37,24 @@
     #define S2N_CORK_OFF    1
 #endif
 
+int s2n_socket_quickack(struct s2n_connection *conn)
+{
+#ifdef TCP_QUICKACK
+    int optval = 1;
+
+    struct s2n_socket_read_io_context *r_io_ctx = (struct s2n_socket_read_io_context *) conn->recv_io_context;
+    if (r_io_ctx->tcp_quickack_set) {
+        return 0;
+    }
+
+    /* Ignore the return value, if it fails it fails */
+    setsockopt(r_io_ctx->fd, IPPROTO_TCP, TCP_QUICKACK, &optval, sizeof(optval));
+    r_io_ctx->tcp_quickack_set = 1;
+#endif
+
+    return 0;
+}
+
 int s2n_socket_write_snapshot(struct s2n_connection *conn)
 {
 #ifdef S2N_CORK
@@ -164,6 +182,9 @@ int s2n_socket_read(void *io_context, uint8_t *buf, uint32_t len)
         errno = EBADF;
         return -1;
     }
+
+    /* Clear the quickack flag so we know to reset it */
+    ((struct s2n_socket_read_io_context*) io_context)->tcp_quickack_set = 0;
 
     /* On success, the number of bytes read is returned. On failure, -1 is
      * returned and errno is set appropriately. */

--- a/utils/s2n_socket.h
+++ b/utils/s2n_socket.h
@@ -22,6 +22,8 @@ struct s2n_socket_read_io_context {
     /* The peer's fd */
     int fd;
 
+    /* Has TCP_QUICKACK been set since the last read */
+    unsigned int tcp_quickack_set:1;
     /* Original SO_RCVLOWAT socket option settings before s2n takes over the fd */
     unsigned int original_rcvlowat_is_set:1;
     int original_rcvlowat_val;
@@ -37,6 +39,7 @@ struct s2n_socket_write_io_context {
     int original_cork_val;
 };
 
+extern int s2n_socket_quickack(struct s2n_connection *conn);
 extern int s2n_socket_read_snapshot(struct s2n_connection *conn);
 extern int s2n_socket_write_snapshot(struct s2n_connection *conn);
 extern int s2n_socket_read_restore(struct s2n_connection *conn);


### PR DESCRIPTION
**Issue # (if available):**

N/A

**Description of changes:** 

s2nc wouldn't connect to a server presenting a wildcard certificate.  This commit makes a slight improvement to `unsafe_verify_host ` so that it will work.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
