### PR TITLE
Automatically configure extension flags

### DIFF
--- a/tests/unit/s2n_cipher_prefrence_test.c
+++ b/tests/unit/s2n_cipher_prefrence_test.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "tls/s2n_cipher_preferences.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Test common known good cipher suites for expected configuration */
+    const struct s2n_cipher_preferences *preferences = NULL;
+    EXPECT_SUCCESS(s2n_find_cipher_pref_from_version("test_all", &preferences));
+    EXPECT_TRUE(s2n_ecc_extension_required(preferences));
+    EXPECT_TRUE(s2n_pq_kem_extension_required(preferences));
+
+    preferences = NULL;
+    EXPECT_SUCCESS(s2n_find_cipher_pref_from_version("KMS-TLS-1-0-2018-10", &preferences));
+    EXPECT_TRUE(s2n_ecc_extension_required(preferences));
+    EXPECT_FALSE(s2n_pq_kem_extension_required(preferences));
+
+    preferences = NULL;
+    EXPECT_SUCCESS(s2n_find_cipher_pref_from_version("KMS-PQ-TLS-1-0-2019-06", &preferences));
+    EXPECT_TRUE(s2n_ecc_extension_required(preferences));
+    EXPECT_TRUE(s2n_pq_kem_extension_required(preferences));
+
+    preferences = NULL;
+    EXPECT_SUCCESS(s2n_find_cipher_pref_from_version("20141001", &preferences));
+    EXPECT_FALSE(s2n_ecc_extension_required(preferences));
+    EXPECT_FALSE(s2n_pq_kem_extension_required(preferences));
+
+    preferences = NULL;
+    preferences = NULL;
+    EXPECT_FAILURE(s2n_ecc_extension_required(preferences));
+    EXPECT_FAILURE(s2n_pq_kem_extension_required(preferences));
+
+    /* Test that anything not automatically configured in s2n_cipher_preferences_init fails */
+    struct s2n_cipher_suite *fake_suites[] = {
+            &s2n_ecdhe_bike_rsa_with_aes_256_gcm_sha384,
+    };
+    const struct s2n_cipher_preferences fake_preferences = {
+            .count = 1,
+            .suites = fake_suites,
+            .minimum_protocol_version = S2N_TLS10,
+    };
+    preferences = &fake_preferences;
+    EXPECT_FAILURE(s2n_ecc_extension_required(preferences));
+    EXPECT_FAILURE(s2n_pq_kem_extension_required(preferences));
+
+    /* null also fails */
+    preferences = NULL;
+    EXPECT_FAILURE(s2n_ecc_extension_required(preferences));
+    EXPECT_FAILURE(s2n_pq_kem_extension_required(preferences));
+
+    END_TEST();
+}

--- a/tests/unit/s2n_cipher_prefrence_test.c
+++ b/tests/unit/s2n_cipher_prefrence_test.c
@@ -43,7 +43,6 @@ int main(int argc, char **argv)
     EXPECT_FALSE(s2n_pq_kem_extension_required(preferences));
 
     preferences = NULL;
-    preferences = NULL;
     EXPECT_FAILURE(s2n_ecc_extension_required(preferences));
     EXPECT_FAILURE(s2n_pq_kem_extension_required(preferences));
 

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -17,6 +17,7 @@
 #include <stdint.h>
 #include <s2n.h>
 #include "tls/s2n_cipher_preferences.h"
+#include "tls/s2n_kex.h"
 #include "tls/s2n_config.h"
 
 #include "error/s2n_errno.h"
@@ -38,7 +39,6 @@ const struct s2n_cipher_preferences cipher_preferences_20140601 = {
     .count = sizeof(cipher_suites_20140601) / sizeof(cipher_suites_20140601[0]),
     .suites = cipher_suites_20140601,
     .minimum_protocol_version = S2N_SSLv3,
-    .extension_flag = 0
 };
 
 /* Disable SSLv3 due to POODLE */
@@ -46,7 +46,6 @@ const struct s2n_cipher_preferences cipher_preferences_20141001 = {
     .count = sizeof(cipher_suites_20140601) / sizeof(cipher_suites_20140601[0]),
     .suites = cipher_suites_20140601,
     .minimum_protocol_version = S2N_TLS10,
-    .extension_flag = 0
 };
 
 /* Disable RC4 */
@@ -63,7 +62,6 @@ const struct s2n_cipher_preferences cipher_preferences_20150202 = {
     .count = sizeof(cipher_suites_20150202) / sizeof(cipher_suites_20150202[0]),
     .suites = cipher_suites_20150202,
     .minimum_protocol_version = S2N_TLS10,
-    .extension_flag = 0
 };
 
 /* Support AES-GCM modes */
@@ -82,7 +80,6 @@ const struct s2n_cipher_preferences cipher_preferences_20150214 = {
     .count = sizeof(cipher_suites_20150214) / sizeof(cipher_suites_20150214[0]),
     .suites = cipher_suites_20150214,
     .minimum_protocol_version = S2N_TLS10,
-    .extension_flag = 0
 };
 
 /* Make a CBC cipher #1 to avoid negotiating GCM with buggy Java clients */
@@ -106,7 +103,6 @@ const struct s2n_cipher_preferences cipher_preferences_20160411 = {
     .count = sizeof(cipher_suites_20160411) / sizeof(cipher_suites_20160411[0]),
     .suites = cipher_suites_20160411,
     .minimum_protocol_version = S2N_TLS10,
-    .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 /* Use ECDHE instead of plain DHE. Prioritize ECDHE in favour of non ECDHE; GCM in favour of CBC; AES128 in favour of AES256. */
@@ -127,7 +123,6 @@ const struct s2n_cipher_preferences cipher_preferences_20150306 = {
     .count = sizeof(cipher_suites_20150306) / sizeof(cipher_suites_20150306[0]),
     .suites = cipher_suites_20150306,
     .minimum_protocol_version = S2N_TLS10,
-    .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 struct s2n_cipher_suite *cipher_suites_20160804[] = {
@@ -150,7 +145,6 @@ const struct s2n_cipher_preferences cipher_preferences_20160804 = {
     .count = sizeof(cipher_suites_20160804) / sizeof(cipher_suites_20160804[0]),
     .suites = cipher_suites_20160804,
     .minimum_protocol_version = S2N_TLS10,
-    .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 struct s2n_cipher_suite *cipher_suites_20160824[] = {
@@ -168,7 +162,6 @@ const struct s2n_cipher_preferences cipher_preferences_20160824 = {
     .count = sizeof(cipher_suites_20160824) / sizeof(cipher_suites_20160824[0]),
     .suites = cipher_suites_20160824,
     .minimum_protocol_version = S2N_TLS10,
-    .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 /* Add ChaCha20 suite */
@@ -188,7 +181,6 @@ const struct s2n_cipher_preferences cipher_preferences_20170210 = {
     .count = sizeof(cipher_suites_20170210) / sizeof(cipher_suites_20170210[0]),
     .suites = cipher_suites_20170210,
     .minimum_protocol_version = S2N_TLS10,
-    .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 /* Same as 20160411, but with ChaCha20 added as 1st in Preference List */
@@ -213,7 +205,6 @@ const struct s2n_cipher_preferences cipher_preferences_20190122 = {
     .count = sizeof(cipher_suites_20190122) / sizeof(cipher_suites_20190122[0]),
     .suites = cipher_suites_20190122,
     .minimum_protocol_version = S2N_TLS10,
-    .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 /* Same as 20160804, but with ChaCha20 added as 2nd in Preference List */
@@ -238,7 +229,6 @@ const struct s2n_cipher_preferences cipher_preferences_20190121 = {
     .count = sizeof(cipher_suites_20190121) / sizeof(cipher_suites_20190121[0]),
     .suites = cipher_suites_20190121,
     .minimum_protocol_version = S2N_TLS10,
-    .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 /* Same as 20160411, but with ChaCha20 in 3rd Place after CBC and GCM */
@@ -263,7 +253,6 @@ const struct s2n_cipher_preferences cipher_preferences_20190120 = {
     .count = sizeof(cipher_suites_20190120) / sizeof(cipher_suites_20190120[0]),
     .suites = cipher_suites_20190120,
     .minimum_protocol_version = S2N_TLS10,
-    .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 /* Preferences optimized for interop, includes ECDSA priortitized. DHE and 3DES are added(at the lowest preference). */
@@ -299,7 +288,6 @@ const struct s2n_cipher_preferences cipher_preferences_20190214 = {
     .count = sizeof(cipher_suites_20190214) / sizeof(cipher_suites_20190214[0]),
     .suites = cipher_suites_20190214,
     .minimum_protocol_version = S2N_TLS10,
-    .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 struct s2n_cipher_suite *cipher_suites_null[] = {
@@ -310,7 +298,6 @@ const struct s2n_cipher_preferences cipher_preferences_null = {
     .count = sizeof(cipher_suites_null) / sizeof(cipher_suites_null[0]),
     .suites = cipher_suites_null,
     .minimum_protocol_version = S2N_TLS10,
-    .extension_flag = 0
 };
 
 /* Preferences optimized for interop. DHE and 3DES are added(at the lowest preference). */
@@ -340,7 +327,6 @@ const struct s2n_cipher_preferences cipher_preferences_20170328 = {
     .count = sizeof(cipher_suites_20170328) / sizeof(cipher_suites_20170328[0]),
     .suites = cipher_suites_20170328,
     .minimum_protocol_version = S2N_TLS10,
-    .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 /* Preferences optimized for FIPS compatibility. */
@@ -362,7 +348,6 @@ const struct s2n_cipher_preferences cipher_preferences_20170405 = {
     .count = sizeof(cipher_suites_20170405) / sizeof(cipher_suites_20170405[0]),
     .suites = cipher_suites_20170405,
     .minimum_protocol_version = S2N_TLS10,
-    .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 /* Equivalent to cipher_suite_20160411 with 3DES removed.
@@ -386,7 +371,6 @@ const struct s2n_cipher_preferences cipher_preferences_20170718 = {
     .count = sizeof(cipher_suites_20170718) / sizeof(cipher_suites_20170718[0]),
     .suites = cipher_suites_20170718,
     .minimum_protocol_version = S2N_TLS10,
-    .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 struct s2n_cipher_suite *cipher_suites_elb_security_policy_2015_04[] = {
@@ -415,7 +399,6 @@ const struct s2n_cipher_preferences elb_security_policy_2015_04 = {
     .count = sizeof(cipher_suites_elb_security_policy_2015_04) / sizeof(cipher_suites_elb_security_policy_2015_04[0]),
     .suites = cipher_suites_elb_security_policy_2015_04,
     .minimum_protocol_version = S2N_TLS10,
-    .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 struct s2n_cipher_suite *cipher_suites_elb_security_policy_2016_08[] = {
@@ -443,7 +426,6 @@ const struct s2n_cipher_preferences elb_security_policy_2016_08 = {
     .count = sizeof(cipher_suites_elb_security_policy_2016_08) / sizeof(cipher_suites_elb_security_policy_2016_08[0]),
     .suites = cipher_suites_elb_security_policy_2016_08,
     .minimum_protocol_version = S2N_TLS10,
-    .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 struct s2n_cipher_suite *cipher_suites_elb_security_policy_tls_1_2_2017_01[] = {
@@ -465,7 +447,6 @@ const struct s2n_cipher_preferences elb_security_policy_tls_1_2_2017_01 = {
     .count = sizeof(cipher_suites_elb_security_policy_tls_1_2_2017_01) / sizeof(cipher_suites_elb_security_policy_tls_1_2_2017_01[0]),
     .suites = cipher_suites_elb_security_policy_tls_1_2_2017_01,
     .minimum_protocol_version = S2N_TLS12,
-    .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 struct s2n_cipher_suite *cipher_suites_elb_security_policy_tls_1_1_2017_01[] = {
@@ -493,7 +474,6 @@ const struct s2n_cipher_preferences elb_security_policy_tls_1_1_2017_01 = {
     .count = sizeof(cipher_suites_elb_security_policy_tls_1_1_2017_01) / sizeof(cipher_suites_elb_security_policy_tls_1_1_2017_01[0]),
     .suites = cipher_suites_elb_security_policy_tls_1_1_2017_01,
     .minimum_protocol_version = S2N_TLS11,
-    .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 struct s2n_cipher_suite *cipher_suites_elb_security_policy_tls_1_2_ext_2018_06[] = {
@@ -521,7 +501,6 @@ const struct s2n_cipher_preferences elb_security_policy_tls_1_2_ext_2018_06 = {
     .count = sizeof(cipher_suites_elb_security_policy_tls_1_2_ext_2018_06) / sizeof(cipher_suites_elb_security_policy_tls_1_2_ext_2018_06[0]),
     .suites = cipher_suites_elb_security_policy_tls_1_2_ext_2018_06,
     .minimum_protocol_version = S2N_TLS12,
-    .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 struct s2n_cipher_suite *cipher_suites_elb_security_policy_fs_2018_06[] = {
@@ -543,7 +522,6 @@ const struct s2n_cipher_preferences elb_security_policy_fs_2018_06 = {
     .count = sizeof(cipher_suites_elb_security_policy_fs_2018_06) / sizeof(cipher_suites_elb_security_policy_fs_2018_06[0]),
     .suites = cipher_suites_elb_security_policy_fs_2018_06,
     .minimum_protocol_version = S2N_TLS10,
-    .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 struct s2n_cipher_suite *cipher_suites_cloudfront_upstream[] = {
@@ -572,7 +550,6 @@ const struct s2n_cipher_preferences cipher_preferences_cloudfront_upstream = {
     .count = sizeof(cipher_suites_cloudfront_upstream) / sizeof(cipher_suites_cloudfront_upstream[0]),
     .suites = cipher_suites_cloudfront_upstream,
     .minimum_protocol_version = S2N_SSLv3,
-    .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 struct s2n_cipher_suite *cipher_suites_cloudfront_ssl_v_3[] = {
@@ -595,7 +572,6 @@ const struct s2n_cipher_preferences cipher_preferences_cloudfront_ssl_v_3 = {
     .count = sizeof(cipher_suites_cloudfront_ssl_v_3) / sizeof(cipher_suites_cloudfront_ssl_v_3[0]),
     .suites = cipher_suites_cloudfront_ssl_v_3,
     .minimum_protocol_version = S2N_SSLv3,
-    .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 struct s2n_cipher_suite *cipher_suites_cloudfront_tls_1_0_2014[] = {
@@ -617,7 +593,6 @@ const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_0_2014 =
     .count = sizeof(cipher_suites_cloudfront_tls_1_0_2014) / sizeof(cipher_suites_cloudfront_tls_1_0_2014[0]),
     .suites = cipher_suites_cloudfront_tls_1_0_2014,
     .minimum_protocol_version = S2N_TLS10,
-    .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 struct s2n_cipher_suite *cipher_suites_cloudfront_tls_1_0_2016[] = {
@@ -638,7 +613,6 @@ const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_0_2016 =
     .count = sizeof(cipher_suites_cloudfront_tls_1_0_2016) / sizeof(cipher_suites_cloudfront_tls_1_0_2016[0]),
     .suites = cipher_suites_cloudfront_tls_1_0_2016,
     .minimum_protocol_version = S2N_TLS10,
-    .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 struct s2n_cipher_suite *cipher_suites_cloudfront_tls_1_1_2016[] = {
@@ -659,7 +633,6 @@ const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_1_2016 =
     .count = sizeof(cipher_suites_cloudfront_tls_1_1_2016) / sizeof(cipher_suites_cloudfront_tls_1_1_2016[0]),
     .suites = cipher_suites_cloudfront_tls_1_1_2016,
     .minimum_protocol_version = S2N_TLS11,
-    .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 struct s2n_cipher_suite *cipher_suites_cloudfront_tls_1_2_2018[] = {
@@ -676,7 +649,6 @@ const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_2_2018 =
     .count = sizeof(cipher_suites_cloudfront_tls_1_2_2018) / sizeof(cipher_suites_cloudfront_tls_1_2_2018[0]),
     .suites = cipher_suites_cloudfront_tls_1_2_2018,
     .minimum_protocol_version = S2N_TLS12,
-    .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 struct s2n_cipher_suite *cipher_suites_cloudfront_tls_1_2_2019[] = {
@@ -690,7 +662,6 @@ const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_2_2019 =
     .count = sizeof(cipher_suites_cloudfront_tls_1_2_2019) / sizeof(cipher_suites_cloudfront_tls_1_2_2019[0]),
     .suites = cipher_suites_cloudfront_tls_1_2_2019,
     .minimum_protocol_version = S2N_TLS12,
-    .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 struct s2n_cipher_suite *cipher_suites_kms_tls_1_0_2018_10[] = {
@@ -710,7 +681,6 @@ const struct s2n_cipher_preferences cipher_preferences_kms_tls_1_0_2018_10 = {
         .count = sizeof(cipher_suites_kms_tls_1_0_2018_10) / sizeof(cipher_suites_kms_tls_1_0_2018_10[0]),
         .suites = cipher_suites_kms_tls_1_0_2018_10,
         .minimum_protocol_version = S2N_TLS10,
-        .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 struct s2n_cipher_suite *cipher_suites_kms_pq_tls_1_0_2019_06[] = {
@@ -732,7 +702,6 @@ const struct s2n_cipher_preferences cipher_preferences_kms_pq_tls_1_0_2019_06 = 
         .count = sizeof(cipher_suites_kms_pq_tls_1_0_2019_06) / sizeof(cipher_suites_kms_pq_tls_1_0_2019_06[0]),
         .suites = cipher_suites_kms_pq_tls_1_0_2019_06,
         .minimum_protocol_version = S2N_TLS10,
-        .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 struct s2n_cipher_suite *cipher_suites_kms_fips_tls_1_2_2018_10[] = {
@@ -748,13 +717,14 @@ const struct s2n_cipher_preferences cipher_preferences_kms_fips_tls_1_2_2018_10 
         .count = sizeof(cipher_suites_kms_fips_tls_1_2_2018_10) / sizeof(cipher_suites_kms_fips_tls_1_2_2018_10[0]),
         .suites = cipher_suites_kms_fips_tls_1_2_2018_10,
         .minimum_protocol_version = S2N_TLS12,
-        .extension_flag = S2N_ECC_EXTENSION_ENABLED
 
 };
 
 struct {
     const char *version;
     const struct s2n_cipher_preferences *preferences;
+    uint8_t ecc_extension_required;
+    uint8_t pq_kem_extension_required;
 } selection[] = {
     { "default", &cipher_preferences_20170210 },
     { "default_fips", &cipher_preferences_20170405},
@@ -850,7 +820,42 @@ int s2n_connection_is_valid_for_cipher_preferences(struct s2n_connection *conn, 
 
     return 0;
 }
-int s2n_is_ecc_enabled(const struct s2n_cipher_preferences *preferences)
+
+int s2n_cipher_preferences_init()
 {
-    return preferences->extension_flag & S2N_ECC_EXTENSION_ENABLED;
+    for (int i = 0; selection[i].version != NULL; i++) {
+        const struct s2n_cipher_preferences *preferences = selection[i].preferences;
+        for (int j = 0; j < preferences->count; j++) {
+            struct s2n_cipher_suite *cipher = preferences->suites[j];
+            if (cipher->key_exchange_alg == &s2n_ecdhe || cipher->key_exchange_alg == &s2n_hybrid_ecdhe_kem){
+                selection[i].ecc_extension_required = 1;
+            }
+            if (cipher->key_exchange_alg == &s2n_hybrid_ecdhe_kem) {
+                selection[i].pq_kem_extension_required = 1;
+            }
+        }
+    }
+    return 0;
+}
+
+int s2n_ecc_extension_required(const struct s2n_cipher_preferences *preferences)
+{
+    notnull_check(preferences);
+    for (int i = 0; selection[i].version != NULL; i++) {
+        if (selection[i].preferences == preferences) {
+            return selection[i].ecc_extension_required & 1;
+        }
+    }
+    S2N_ERROR(S2N_ERR_INVALID_CIPHER_PREFERENCES);
+}
+
+int s2n_pq_kem_extension_required(const struct s2n_cipher_preferences *preferences)
+{
+    notnull_check(preferences);
+    for (int i = 0; selection[i].version != NULL; i++) {
+        if (selection[i].preferences == preferences) {
+            return selection[i].pq_kem_extension_required & 1;
+        }
+    }
+    S2N_ERROR(S2N_ERR_INVALID_CIPHER_PREFERENCES);
 }

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -723,8 +723,8 @@ const struct s2n_cipher_preferences cipher_preferences_kms_fips_tls_1_2_2018_10 
 struct {
     const char *version;
     const struct s2n_cipher_preferences *preferences;
-    uint8_t ecc_extension_required;
-    uint8_t pq_kem_extension_required;
+    unsigned ecc_extension_required:1;
+    unsigned pq_kem_extension_required:1;
 } selection[] = {
     { "default", &cipher_preferences_20170210 },
     { "default_fips", &cipher_preferences_20170405},

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -843,7 +843,7 @@ int s2n_ecc_extension_required(const struct s2n_cipher_preferences *preferences)
     notnull_check(preferences);
     for (int i = 0; selection[i].version != NULL; i++) {
         if (selection[i].preferences == preferences) {
-            return selection[i].ecc_extension_required & 1;
+            return 1 == selection[i].ecc_extension_required;
         }
     }
     S2N_ERROR(S2N_ERR_INVALID_CIPHER_PREFERENCES);
@@ -854,7 +854,7 @@ int s2n_pq_kem_extension_required(const struct s2n_cipher_preferences *preferenc
     notnull_check(preferences);
     for (int i = 0; selection[i].version != NULL; i++) {
         if (selection[i].preferences == preferences) {
-            return selection[i].pq_kem_extension_required & 1;
+            return 1 == selection[i].pq_kem_extension_required;
         }
     }
     S2N_ERROR(S2N_ERR_INVALID_CIPHER_PREFERENCES);

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -19,14 +19,10 @@
 
 #include "tls/s2n_cipher_suites.h"
 
-
-#define S2N_ECC_EXTENSION_ENABLED 0x01
-
 struct s2n_cipher_preferences {
     uint8_t count;
     struct s2n_cipher_suite **suites;
     int minimum_protocol_version;
-    uint8_t extension_flag;
 };
 
 extern const struct s2n_cipher_preferences cipher_preferences_20140601;
@@ -55,6 +51,8 @@ extern const struct s2n_cipher_preferences elb_security_policy_tls_1_1_2017_01;
 extern const struct s2n_cipher_preferences elb_security_policy_tls_1_2_ext_2018_06;
 extern const struct s2n_cipher_preferences elb_security_policy_fs_2018_06;
 
+extern int s2n_cipher_preferences_init();
 extern int s2n_find_cipher_pref_from_version(const char *version, const struct s2n_cipher_preferences **cipher_preferences);
 extern int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *version);
-extern int s2n_is_ecc_enabled(const struct s2n_cipher_preferences *preferences);
+extern int s2n_ecc_extension_required(const struct s2n_cipher_preferences *preferences);
+extern int s2n_pq_kem_extension_required(const struct s2n_cipher_preferences *preferences);

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -700,7 +700,6 @@ const struct s2n_cipher_preferences cipher_preferences_test_all = {
     .count = sizeof(s2n_all_cipher_suites) / sizeof(s2n_all_cipher_suites[0]),
     .suites = s2n_all_cipher_suites,
     .minimum_protocol_version = S2N_SSLv3,
-    .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 /* All of the cipher suites that s2n can negotiate when in FIPS mode,
@@ -733,7 +732,6 @@ const struct s2n_cipher_preferences cipher_preferences_test_all_fips = {
     .count = sizeof(s2n_all_fips_cipher_suites) / sizeof(s2n_all_fips_cipher_suites[0]),
     .suites = s2n_all_fips_cipher_suites,
     .minimum_protocol_version = S2N_TLS10,
-    .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 /* All of the ECDSA cipher suites that s2n can negotiate, in order of IANA
@@ -754,7 +752,6 @@ const struct s2n_cipher_preferences cipher_preferences_test_all_ecdsa = {
     .count = sizeof(s2n_all_ecdsa_cipher_suites) / sizeof(s2n_all_ecdsa_cipher_suites[0]),
     .suites = s2n_all_ecdsa_cipher_suites,
     .minimum_protocol_version = S2N_TLS10,
-    .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 /* All ECDSA cipher suites first, then the rest of the supported ciphers that s2n can negotiate.
@@ -801,7 +798,6 @@ const struct s2n_cipher_preferences cipher_preferences_test_ecdsa_priority = {
     .count = sizeof(s2n_ecdsa_priority_cipher_suites) / sizeof(s2n_ecdsa_priority_cipher_suites[0]),
     .suites = s2n_ecdsa_priority_cipher_suites,
     .minimum_protocol_version = S2N_SSLv3,
-    .extension_flag = S2N_ECC_EXTENSION_ENABLED
 };
 
 /* Determines cipher suite availability and selects record algorithms */

--- a/utils/s2n_init.c
+++ b/utils/s2n_init.c
@@ -14,6 +14,7 @@
  */
 #include "crypto/s2n_fips.h"
 
+#include "tls/s2n_cipher_preferences.h"
 #include "tls/s2n_cipher_suites.h"
 
 #include "utils/s2n_mem.h"
@@ -35,6 +36,7 @@ int s2n_init(void)
     GUARD(s2n_mem_init());
     GUARD(s2n_rand_init());
     GUARD(s2n_cipher_suites_init());
+    GUARD(s2n_cipher_preferences_init());
 
     S2N_ERROR_IF(atexit(s2n_cleanup_atexit) != 0, S2N_ERR_ATEXIT);
 


### PR DESCRIPTION
**Issue # (if available):** 
N/A
**Description of changes:** 
This change configures which extensions to send in the client hello in s2n_init. This avoids relying on code reviews and humans to configure the ECC extension and PQ KEM extension correctly. 

I investigated adding the extension configuration to s2n_cipher_preferences but the struct is constant and can not be modified at runtime. This change keeps them constant and puts the config in the selection array which is not exported and does a lookup based on cipher_preferences address.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
