### PR TITLE
Add new APIs for memory reduction

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -200,6 +200,8 @@ extern ssize_t s2n_send(struct s2n_connection *conn, const void *buf, ssize_t si
 extern ssize_t s2n_recv(struct s2n_connection *conn,  void *buf, ssize_t size, s2n_blocked_status *blocked);
 extern uint32_t s2n_peek(struct s2n_connection *conn);
 
+extern int s2n_connection_free_handshake(struct s2n_connection *conn);
+extern int s2n_connection_release_buffers(struct s2n_connection *conn);
 extern int s2n_connection_wipe(struct s2n_connection *conn);
 extern int s2n_connection_free(struct s2n_connection *conn);
 extern int s2n_shutdown(struct s2n_connection *conn, s2n_blocked_status *blocked);

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1339,6 +1339,27 @@ int s2n_config_add_ticket_crypto_key(struct s2n_config *config, const uint8_t *n
 **s2n_config_add_ticket_crypto_key** adds session ticket key on the server side. It would be ideal to add new keys after every (encrypt_decrypt_key_lifetime_in_nanos/2) nanos because
 this will allow for gradual and linear transition of a key from encrypt-decrypt state to decrypt-only state.
 
+### s2n\_connection\_free\_handshake
+
+```c
+int s2n_connection_free_handshake(struct s2n_connection *conn);
+```
+
+**s2n_connection_free_handshake** wipes and releases buffers and memory
+allocated during the TLS handshake.  This function should be called after the
+handshake is successfully negotiated and logging or recording of handshake data
+is complete.
+
+### s2n\_connection\_release\_buffers
+
+```c
+int s2n_connection_release_buffers(struct s2n_connection *conn);
+```
+
+**s2n_connection_release_buffers** wipes and free the `in` and `out` buffers
+associated with a connection.  This function may be called when a connection is
+in keep-alive or idle state to reduce memory overhead of long lived connections.
+
 ### s2n\_connection\_wipe
 
 ```c

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -76,14 +76,17 @@ int s2n_stuffer_free(struct s2n_stuffer *stuffer)
 
 int s2n_stuffer_resize(struct s2n_stuffer *stuffer, const uint32_t size)
 {
-    S2N_ERROR_IF(stuffer->growable == 0, S2N_ERR_RESIZE_STATIC_STUFFER);
-    S2N_ERROR_IF(stuffer->tainted == 1, S2N_ERR_RESIZE_TAINTED_STUFFER);
     if (size == stuffer->blob.size) {
         return 0;
     }
+
+    S2N_ERROR_IF(stuffer->tainted == 1, S2N_ERR_RESIZE_TAINTED_STUFFER);
+
     if (size < stuffer->blob.size) {
         GUARD(s2n_stuffer_wipe_n(stuffer, stuffer->blob.size - size));
     }
+
+    S2N_ERROR_IF(stuffer->growable == 0, S2N_ERR_RESIZE_STATIC_STUFFER);
 
     GUARD(s2n_realloc(&stuffer->blob, size));
 

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -301,6 +301,13 @@ int main(int argc, char **argv)
         free(ext_data);
         ext_data = NULL;
 
+        /* Free all handshake data */
+        EXPECT_SUCCESS(s2n_connection_free_handshake(server_conn));
+
+        /* Verify connection_wipe resized the s2n_client_hello.raw_message stuffer back to 0 */
+        EXPECT_NULL(client_hello->raw_message.blob.data);
+        EXPECT_EQUAL(client_hello->raw_message.blob.size, 0);
+
         /* Not a real tls client but make sure we block on its close_notify */
         int shutdown_rc = s2n_shutdown(server_conn, &server_blocked);
         EXPECT_EQUAL(shutdown_rc, -1);

--- a/tests/unit/s2n_record_test.c
+++ b/tests/unit/s2n_record_test.c
@@ -113,6 +113,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(conn->out.blob.data[4], bytes_written & 0xff);
         EXPECT_EQUAL(memcmp(conn->out.blob.data + 5, random_data, bytes_written), 0);
 
+        EXPECT_SUCCESS(s2n_stuffer_resize(&conn->in, S2N_LARGE_FRAGMENT_LENGTH));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));

--- a/tls/s2n_record_write.c
+++ b/tls/s2n_record_write.c
@@ -166,6 +166,8 @@ int s2n_record_write(struct s2n_connection *conn, uint8_t content_type, struct s
     /* Start the MAC with the sequence number */
     GUARD(s2n_hmac_update(mac, sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
 
+    GUARD(s2n_stuffer_resize(&conn->out, S2N_LARGE_RECORD_LENGTH));
+
     /* Now that we know the length, start writing the record */
     GUARD(s2n_stuffer_write_uint8(&conn->out, content_type));
     GUARD(s2n_record_write_protocol_version(conn));

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -50,6 +50,8 @@ int s2n_read_full_record(struct s2n_connection *conn, uint8_t * record_type, int
         return 0;
     }
 
+    GUARD(s2n_stuffer_resize(&conn->in, S2N_LARGE_FRAGMENT_LENGTH));
+
     /* Read the record until we at least have a header */
     while (s2n_stuffer_data_available(&conn->header_in) < S2N_TLS_RECORD_HEADER_LENGTH) {
         int remaining = S2N_TLS_RECORD_HEADER_LENGTH - s2n_stuffer_data_available(&conn->header_in);


### PR DESCRIPTION
**Issue # (if available):** 

#1081

**Description of changes:**

1. `s2n_connection_free_hanshake`
  This API will release all data used during the TLS handhshake.
1. `s2n_connection_release_buffers`
  This API will release the in and out buffers, useful for long lived,
  idle connections

if `conn->in` or `conn->out` are NULL in `s2n_recv` and `s2n_send` respectively, we will resize the bbuffers to their initial size.

This enables these buffers to be truncated to 0 in s2n_connetion_wipe and removes the need for the application to reallocate them through a separate API call before resuming IO on the connection.


Addresses #1081 