### PR TITLE
Fix s2n_connection_is_session_resumed for unegotiated

### DIFF
--- a/tests/unit/s2n_session_ticket_test.c
+++ b/tests/unit/s2n_session_ticket_test.c
@@ -144,6 +144,9 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
+        /* A newly created connection should not be considered resumed */
+        EXPECT_FALSE(s2n_connection_is_session_resumed(server_conn));
+        EXPECT_FALSE(s2n_connection_is_session_resumed(client_conn));
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
         /* Verify that the server did a full handshake and issued NST */
@@ -240,12 +243,13 @@ int main(int argc, char **argv)
 
         /* Verify that the server did an abbreviated handshake and not issue NST */
         EXPECT_TRUE(IS_RESUMPTION_HANDSHAKE(server_conn->handshake.handshake_type));
+        EXPECT_TRUE(s2n_connection_is_session_resumed(server_conn));
         EXPECT_FALSE(IS_ISSUING_NEW_SESSION_TICKET(server_conn->handshake.handshake_type));
 
         /* Verify that client_ticket is same as before because server didn't issue a NST */
         uint8_t old_session_ticket[S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES + S2N_TICKET_SIZE_IN_BYTES];
         memcpy_check(old_session_ticket, serialized_session_state, S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES + S2N_TICKET_SIZE_IN_BYTES);
-
+        EXPECT_TRUE(s2n_connection_is_session_resumed(client_conn));
         s2n_connection_get_session(client_conn, serialized_session_state, serialized_session_state_length);
         EXPECT_BYTEARRAY_EQUAL(old_session_ticket, serialized_session_state, S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES + S2N_TICKET_SIZE_IN_BYTES);
 

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -120,11 +120,12 @@ struct s2n_handshake {
 /* Has the handshake been negotiated yet? */
 #define INITIAL                     0x00
 #define NEGOTIATED                  0x01
+#define IS_NEGOTIATED( type ) ( (type) & NEGOTIATED )
 
 /* Handshake is a full handshake  */
 #define FULL_HANDSHAKE              0x02
 #define IS_FULL_HANDSHAKE( type )   ( (type) & FULL_HANDSHAKE )
-#define IS_RESUMPTION_HANDSHAKE( type ) ( !IS_FULL_HANDSHAKE( (type) ) )
+#define IS_RESUMPTION_HANDSHAKE( type ) ( !IS_FULL_HANDSHAKE( (type) ) && IS_NEGOTIATED ( (type) ) )
 
 /* Handshake uses perfect forward secrecy */
 #define PERFECT_FORWARD_SECRECY     0x04


### PR DESCRIPTION
Previously, this function would evaluate true for connections that did
not finish processing the ClientHello for server mode and ServerHello
for client mode.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
