### PR TITLE
make guard safer if used inside an if

### DIFF
--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -89,9 +89,9 @@ static inline void* trace_memcpy_check(void *restrict to, const void *restrict f
     lt_check(__tmp_n, high);                    \
   } while (0)
 
-#define GUARD( x )              if ( (x) < 0 ) return -1
-#define GUARD_GOTO( x , label ) if ( (x) < 0 ) goto label
-#define GUARD_PTR( x )          if ( (x) < 0 ) return NULL
+#define GUARD( x )              do {if ( (x) < 0 ) return -1;} while (0)
+#define GUARD_GOTO( x , label ) do {if ( (x) < 0 ) goto label;} while (0)
+#define GUARD_PTR( x )          do {if ( (x) < 0 ) return NULL;} while (0)
 #define S2N_IN_UNIT_TEST ( getenv("S2N_UNIT_TEST") != NULL )
 
 /* TODO: use the OSSL error code in error reporting https://github.com/awslabs/s2n/issues/705 */


### PR DESCRIPTION
**Description of changes:** 
A bare ```if``` in a macro can capture an ```else``` (see http://www.bruceblinn.com/linuxinfo/DoWhile.html for an example) Fix by putting an explicit ```do while(0)```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
