### PR TITLE
Fix conn->in buffer truncation

### DIFF
--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -76,21 +76,29 @@ int s2n_stuffer_free(struct s2n_stuffer *stuffer)
 
 int s2n_stuffer_resize(struct s2n_stuffer *stuffer, const uint32_t size)
 {
+    S2N_ERROR_IF(stuffer->tainted == 1, S2N_ERR_RESIZE_TAINTED_STUFFER);
+    S2N_ERROR_IF(stuffer->growable == 0, S2N_ERR_RESIZE_STATIC_STUFFER);
+
     if (size == stuffer->blob.size) {
         return 0;
     }
-
-    S2N_ERROR_IF(stuffer->tainted == 1, S2N_ERR_RESIZE_TAINTED_STUFFER);
 
     if (size < stuffer->blob.size) {
         GUARD(s2n_stuffer_wipe_n(stuffer, stuffer->blob.size - size));
     }
 
-    S2N_ERROR_IF(stuffer->growable == 0, S2N_ERR_RESIZE_STATIC_STUFFER);
-
     GUARD(s2n_realloc(&stuffer->blob, size));
 
     stuffer->blob.size = size;
+
+    return 0;
+}
+
+int s2n_stuffer_resize_if_empty(struct s2n_stuffer *stuffer, const uint32_t size)
+{
+    if (stuffer->blob.data == NULL) {
+        GUARD(s2n_stuffer_resize(stuffer, size));
+    }
 
     return 0;
 }

--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -51,6 +51,7 @@ extern int s2n_stuffer_alloc(struct s2n_stuffer *stuffer, const uint32_t size);
 extern int s2n_stuffer_growable_alloc(struct s2n_stuffer *stuffer, const uint32_t size);
 extern int s2n_stuffer_free(struct s2n_stuffer *stuffer);
 extern int s2n_stuffer_resize(struct s2n_stuffer *stuffer, const uint32_t size);
+extern int s2n_stuffer_resize_if_empty(struct s2n_stuffer *stuffer, const uint32_t size);
 extern int s2n_stuffer_rewind_read(struct s2n_stuffer *stuffer, const uint32_t size);
 extern int s2n_stuffer_reread(struct s2n_stuffer *stuffer);
 extern int s2n_stuffer_rewrite(struct s2n_stuffer *stuffer);

--- a/tests/unit/s2n_record_test.c
+++ b/tests/unit/s2n_record_test.c
@@ -113,7 +113,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(conn->out.blob.data[4], bytes_written & 0xff);
         EXPECT_EQUAL(memcmp(conn->out.blob.data + 5, random_data, bytes_written), 0);
 
-        EXPECT_SUCCESS(s2n_stuffer_resize(&conn->in, S2N_LARGE_FRAGMENT_LENGTH));
+        EXPECT_SUCCESS(s2n_stuffer_resize_if_empty(&conn->in, S2N_LARGE_FRAGMENT_LENGTH));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));

--- a/tls/s2n_record_write.c
+++ b/tls/s2n_record_write.c
@@ -166,7 +166,7 @@ int s2n_record_write(struct s2n_connection *conn, uint8_t content_type, struct s
     /* Start the MAC with the sequence number */
     GUARD(s2n_hmac_update(mac, sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
 
-    GUARD(s2n_stuffer_resize(&conn->out, S2N_LARGE_RECORD_LENGTH));
+    GUARD(s2n_stuffer_resize_if_empty(&conn->out, S2N_LARGE_RECORD_LENGTH));
 
     /* Now that we know the length, start writing the record */
     GUARD(s2n_stuffer_write_uint8(&conn->out, content_type));

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -50,7 +50,7 @@ int s2n_read_full_record(struct s2n_connection *conn, uint8_t * record_type, int
         return 0;
     }
 
-    GUARD(s2n_stuffer_resize(&conn->in, S2N_LARGE_FRAGMENT_LENGTH));
+    GUARD(s2n_stuffer_resize_if_empty(&conn->in, S2N_LARGE_FRAGMENT_LENGTH));
 
     /* Read the record until we at least have a header */
     while (s2n_stuffer_data_available(&conn->header_in) < S2N_TLS_RECORD_HEADER_LENGTH) {


### PR DESCRIPTION
**Issue # (if available):** 

**Description of changes:** 

`in` buffer can grow beyond 16KB, if the received record size exceeds this limit, so this change ensures that we don't truncate the in buffer to a smaller size.

While `out` buffer shouldn't suffer from this problem, this change adds a similar check to it as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
