### PR TITLE
Add client supported_versions extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ file(GLOB STUFFER_HEADERS
     "stuffer/*.h"
 )
 
-file(GLOB TLS_HEADERS
+file(GLOB_RECURSE TLS_HEADERS
     "tls/*.h"
 )
 
@@ -62,7 +62,7 @@ file(GLOB STUFFER_SRC
     "stuffer/*.c"
 )
 
-file(GLOB TLS_SRC
+file(GLOB_RECURSE TLS_SRC
     "tls/*.c"
 )
 

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ run-lcov:
 	$(MAKE) -C tests lcov
 	$(MAKE) -C tls run-lcov
 	$(MAKE) -C utils lcov
-	lcov -a crypto/coverage.info -a error/coverage.info -a pq-crypto/coverage.info -a pq-crypto/sike/coverage.info -a stuffer/coverage.info -a tls/coverage.info -a tls/extensions/coverage.info -a utils/coverage.info --output ${COVERAGE_DIR}/all_coverage.info
+	lcov -a crypto/coverage.info -a error/coverage.info -a pq-crypto/coverage.info -a pq-crypto/sike/coverage.info -a stuffer/coverage.info -a tls/coverage.info -a $(wildcard tls/*/coverage.info) -a utils/coverage.info --output ${COVERAGE_DIR}/all_coverage.info
 
 .PHONY : run-genhtml
 run-genhtml:

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ run-gcov:
 	$(MAKE) -C pq-crypto run-gcov
 	$(MAKE) -C stuffer gcov
 	$(MAKE) -C tests gcov
-	$(MAKE) -C tls gcov
+	$(MAKE) -C tls run-gcov
 	$(MAKE) -C utils gcov
 
 .PHONY : run-lcov
@@ -107,9 +107,9 @@ run-lcov:
 	$(MAKE) -C pq-crypto run-lcov
 	$(MAKE) -C stuffer lcov
 	$(MAKE) -C tests lcov
-	$(MAKE) -C tls lcov
+	$(MAKE) -C tls run-lcov
 	$(MAKE) -C utils lcov
-	lcov -a crypto/coverage.info -a error/coverage.info -a pq-crypto/coverage.info -a pq-crypto/sike/coverage.info -a stuffer/coverage.info -a tls/coverage.info -a utils/coverage.info --output ${COVERAGE_DIR}/all_coverage.info
+	lcov -a crypto/coverage.info -a error/coverage.info -a pq-crypto/coverage.info -a pq-crypto/sike/coverage.info -a stuffer/coverage.info -a tls/coverage.info -a tls/extensions/coverage.info -a utils/coverage.info --output ${COVERAGE_DIR}/all_coverage.info
 
 .PHONY : run-genhtml
 run-genhtml:
@@ -124,7 +124,7 @@ indent:
 	$(MAKE) -C crypto indentsource
 	$(MAKE) -C utils indentsource
 	$(MAKE) -C error indentsource
-	$(MAKE) -C tls indentsource
+	$(MAKE) -C tls indent
 	$(MAKE) -C bin indentsource
 
 .PHONY : pre_commit_check
@@ -138,7 +138,7 @@ clean:
 	$(MAKE) -C crypto decruft
 	$(MAKE) -C utils decruft
 	$(MAKE) -C error decruft
-	$(MAKE) -C tls decruft
+	$(MAKE) -C tls clean
 	$(MAKE) -C bin decruft
 	$(MAKE) -C lib decruft
 	$(MAKE) -C coverage clean

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -30,6 +30,7 @@ extern "C" {
 #define S2N_TLS10 31
 #define S2N_TLS11 32
 #define S2N_TLS12 33
+#define S2N_TLS13 34
 #define S2N_UNKNOWN_PROTOCOL_VERSION 0
 
 extern __thread int s2n_errno;

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -13,7 +13,7 @@
 # permissions and limitations under the License.
 #
 
-OBJS = $(wildcard ../utils/*.o ../stuffer/*.o ../tls/*.o ../iana/*.o ../crypto/*.o ../error/*.o ../pq-crypto/*.o ../pq-crypto/bike/*.o ../pq-crypto/sike/*.o)
+OBJS = $(wildcard ../utils/*.o ../stuffer/*.o ../tls/*.o ../tls/*/*.o ../iana/*.o ../crypto/*.o ../error/*.o ../pq-crypto/*.o ../pq-crypto/bike/*.o ../pq-crypto/sike/*.o)
 
 .PHONY : all
 all: libs2n.a libs2n.so libs2n.dylib

--- a/tests/integration/Makefile
+++ b/tests/integration/Makefile
@@ -34,41 +34,48 @@ all:
 	( \
 	DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" \
 	LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
+	S2N_INTEG_TEST=1 \
 	python3 s2n_client_endpoint_handshake_test.py $(S2ND_HOST) $(S2ND_PORT); \
 	)
 	# Run dynamic record size tests
 	( \
 	DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" \
 	LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
+	S2N_INTEG_TEST=1 \
 	python3 s2n_dynamic_record_size_test.py --libcrypto $(S2N_LIBCRYPTO) $(S2ND_HOST) $(S2ND_PORT); \
 	)
 	# Run s_client handshake tests
 	( \
 	DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" \
 	LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
+	S2N_INTEG_TEST=1 \
 	python3 s2n_handshake_test_s_client.py $(HANDSHAKE_TEST_PARAMS); \
 	)
 	# Run s_server handshake tests
 	( \
 	DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" \
 	LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
+	S2N_INTEG_TEST=1 \
 	python3 s2n_handshake_test_s_server.py $(HANDSHAKE_TEST_PARAMS); \
 	)
 	# Run gnutls-cli handshake tests
 	( \
 	DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLID_LIBRARY_PATH" \
 	LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
+	S2N_INTEG_TEST=1 \
 	python3 s2n_handshake_test_gnutls-cli.py --libcrypto $(S2N_LIBCRYPTO) $(S2ND_HOST) $(S2ND_PORT); \
 	)
 	# Run gnutls-serv handshake tests
 	( \
 	DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLID_LIBRARY_PATH" \
 	LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
+	S2N_INTEG_TEST=1 \
 	python3 s2n_handshake_test_gnutls-serv.py --libcrypto $(S2N_LIBCRYPTO) $(S2ND_HOST) $(S2ND_PORT); \
 	)
 	# Run SSLyze Tests
 	( \
 	DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLID_LIBRARY_PATH" \
 	LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
+	S2N_INTEG_TEST=1 \
 	python3 s2n_sslyze_test.py --libcrypto $(S2N_LIBCRYPTO) $(S2ND_HOST) $(S2ND_PORT); \
 	)

--- a/tests/integration/s2n_test_constants.py
+++ b/tests/integration/s2n_test_constants.py
@@ -19,6 +19,7 @@ S2N_SSLv3 = 30
 S2N_TLS10 = 31
 S2N_TLS11 = 32
 S2N_TLS12 = 33
+S2N_TLS13 = 34
 
 # namedtuple makes iterating through ciphers across client libraries easier. The openssl_1_1_1_compatible flag is for
 # s_client tests. s_client won't be able to use those ciphers.
@@ -110,6 +111,7 @@ S2N_PROTO_VERS_TO_STR = {
     S2N_TLS10 : "TLSv1.0",
     S2N_TLS11 : "TLSv1.1",
     S2N_TLS12 : "TLSv1.2",
+    S2N_TLS13 : "TLSv1.3",
 }
 
 S2N_PROTO_VERS_TO_GNUTLS = {
@@ -117,6 +119,7 @@ S2N_PROTO_VERS_TO_GNUTLS = {
     S2N_TLS10 : "VERS-TLS1.0",
     S2N_TLS11 : "VERS-TLS1.1",
     S2N_TLS12 : "VERS-TLS1.2",
+    S2N_TLS13 : "VERS-TLS1.3",
 }
 
 TEST_CERT_DIRECTORY="../pems/"

--- a/tests/saw/Makefile
+++ b/tests/saw/Makefile
@@ -191,23 +191,23 @@ CRYPTO_C = $(wildcard ../../crypto/*.c) $(wildcard ../../crypto/*.h) ../../crypt
 CRYPTO_COPY = $(addprefix s2n/crypto/, $(notdir $(CRYPTO_C)))
 
 PQ_CRYPTO_C = $(wildcard ../../pq-crypto/*.c) $(wildcard ../../pq-crypto/*.h) ../../pq-crypto/Makefile
-
 PQ_CRYPTO_COPY = $(addprefix s2n/pq-crypto/, $(notdir $(PQ_CRYPTO_C)))
 
 SIKE_C = $(wildcard ../../pq-crypto/sike/*.c) $(wildcard ../../pq-crypto/sike/*.h) ../../pq-crypto/sike/Makefile
-
 SIKE_COPY = $(addprefix s2n/pq-crypto/sike/, $(notdir $(SIKE_C)))
 
 UTILS_C = $(wildcard ../../utils/*.c) $(wildcard ../../utils/*.h) ../../utils/Makefile
 UTILS_COPY =$(addprefix s2n/utils/, $(notdir $(UTILS_C)))
 
-TLS_C = $(wildcard ../../tls/*.c) $(wildcard ../../tls/*.h) ../../tls/Makefile
-TLS_COPY =$(addprefix s2n/tls/, $(notdir $(TLS_C)))
+TLS_C = $(wildcard ../../tls/*.c ../../tls/*/*.c ../../tls/*.h ../../tls/*/*.h ../../tls/*/Makefile) ../../tls/Makefile
+TLS_COPY = $(subst ../../tls/, s2n/tls/, $(TLS_C))
+TLS_DIRS = $(sort $(dir $(TLS_COPY)))
 
 STUFFER_C = $(wildcard ../../stuffer/*.c) $(wildcard ../../stuffer/*.h) ../../stuffer/Makefile
 STUFFER_COPY =$(addprefix s2n/stuffer/, $(notdir $(STUFFER_C)))
 
 API_COPY =$(addprefix s2n/api/, $(notdir $(wildcard ../../api/*.h)))
+
 ERROR_COPY =$(addprefix s2n/error/, $(notdir $(wildcard ../../error/*.h)))
 
 s2n/error :
@@ -229,7 +229,7 @@ s2n/utils :
 	mkdir -p $@
 
 s2n/tls :
-	mkdir -p $@
+	mkdir -p $(TLS_DIRS)
 
 s2n/stuffer :
 	mkdir -p $@

--- a/tests/unit/s2n_client_supported_versions_extension_test.c
+++ b/tests/unit/s2n_client_supported_versions_extension_test.c
@@ -35,7 +35,7 @@ int get_alert(struct s2n_connection *conn) {
 }
 
 int write_test_supported_versions_list(struct s2n_stuffer *list, uint8_t *supported_versions, uint8_t length) {
-    GUARD(s2n_stuffer_write_uint8(list, length*S2N_TLS_PROTOCOL_VERSION_LEN));
+    GUARD(s2n_stuffer_write_uint8(list, length * S2N_TLS_PROTOCOL_VERSION_LEN));
 
     for (int i = 0; i < length; i++) {
         GUARD(s2n_stuffer_write_uint8(list, supported_versions[i] / 10));
@@ -49,10 +49,8 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
-    EXPECT_SUCCESS(setenv("S2N_DONT_MLOCK", "1", 0));
     EXPECT_SUCCESS(setenv("S2N_ENABLE_TLS13_FOR_TESTING", "1", 0));
-
-    uint8_t latest_version = s2n_supported_protocol_versions[0];
+    uint8_t latest_version = S2N_TLS13;
 
     struct s2n_config *config;
     EXPECT_NOT_NULL(config = s2n_config_new());

--- a/tests/unit/s2n_client_supported_versions_extension_test.c
+++ b/tests/unit/s2n_client_supported_versions_extension_test.c
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include <stdint.h>
+
+#include "tls/s2n_alerts.h"
+#include "tls/s2n_config.h"
+#include "tls/s2n_connection.h"
+#include "tls/s2n_tls.h"
+#include "tls/extensions/s2n_client_supported_versions.h"
+
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+#define PROTOCOL_VERSION_ALERT 70
+
+int get_alert(struct s2n_connection *conn) {
+    uint8_t error[2];
+    GUARD(s2n_stuffer_read_bytes(&conn->reader_alert_out, error, 2));
+    return error[1];
+}
+
+int write_test_supported_versions_list(struct s2n_stuffer *list, uint8_t *supported_versions, uint8_t length) {
+    GUARD(s2n_stuffer_write_uint8(list, length*S2N_TLS_PROTOCOL_VERSION_LEN));
+
+    for (int i = 0; i < length; i++) {
+        GUARD(s2n_stuffer_write_uint8(list, supported_versions[i] / 10));
+        GUARD(s2n_stuffer_write_uint8(list, supported_versions[i] % 10));
+    }
+
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    EXPECT_SUCCESS(setenv("S2N_DONT_MLOCK", "1", 0));
+    EXPECT_SUCCESS(setenv("S2N_ENABLE_TLS13_FOR_TESTING", "1", 0));
+
+    uint8_t latest_version = s2n_supported_protocol_versions[0];
+
+    struct s2n_config *config;
+    EXPECT_NOT_NULL(config = s2n_config_new());
+
+    /* Client produces a version list that the server can parse */
+    {
+        struct s2n_connection *client_conn;
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
+        int size_result = s2n_extensions_client_supported_versions_size(client_conn);
+        EXPECT_NOT_EQUAL(size_result, -1);
+        uint16_t expected_length = (uint16_t) size_result;
+
+        struct s2n_stuffer extension;
+        s2n_stuffer_alloc(&extension, expected_length);
+
+        EXPECT_SUCCESS(s2n_extensions_client_supported_versions_send(client_conn, &extension));
+
+        /* Check that the type and size are correct */
+        uint16_t extension_type;
+        s2n_stuffer_read_uint16(&extension, &extension_type);
+        EXPECT_EQUAL(extension_type, TLS_EXTENSION_SUPPORTED_VERSIONS);
+        uint16_t extension_length;
+        s2n_stuffer_read_uint16(&extension, &extension_length);
+        EXPECT_EQUAL(extension_length, s2n_stuffer_data_available(&extension));
+
+        /* Check that the server can process the version list */
+        struct s2n_connection *server_conn;
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        /* Server should negotiate the most recent version */
+        EXPECT_SUCCESS(s2n_extensions_client_supported_versions_recv(server_conn, &extension));
+        EXPECT_EQUAL(server_conn->client_protocol_version, latest_version);
+        EXPECT_EQUAL(server_conn->server_protocol_version, latest_version);
+        EXPECT_EQUAL(server_conn->actual_protocol_version, latest_version);
+
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_stuffer_free(&extension));
+    }
+
+    /* Server selects highest supported version shared by client */
+    {
+        struct s2n_connection *server_conn;
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        uint8_t unsupported_client_version = 255;
+        uint8_t supported_version_list[] = { S2N_TLS11, S2N_TLS12, unsupported_client_version };
+        uint8_t supported_version_list_length = sizeof(supported_version_list);
+
+        struct s2n_stuffer extension;
+        s2n_stuffer_alloc(&extension, supported_version_list_length * 2 + 1);
+
+        EXPECT_SUCCESS(write_test_supported_versions_list(&extension, supported_version_list,
+                supported_version_list_length));
+
+        EXPECT_SUCCESS(s2n_extensions_client_supported_versions_recv(server_conn, &extension));
+        EXPECT_EQUAL(server_conn->client_protocol_version, unsupported_client_version);
+        EXPECT_EQUAL(server_conn->server_protocol_version, latest_version);
+        EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS12);
+
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_stuffer_free(&extension));
+    }
+
+    /* Server alerts if no shared supported version found */
+    {
+        struct s2n_connection *server_conn;
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        uint8_t supported_version_list[] = { S2N_UNKNOWN_PROTOCOL_VERSION };
+        uint8_t supported_version_list_length = sizeof(supported_version_list);
+
+        struct s2n_stuffer extension;
+        s2n_stuffer_alloc(&extension, supported_version_list_length * 2 + 1);
+
+        EXPECT_SUCCESS(write_test_supported_versions_list(&extension, supported_version_list,
+                supported_version_list_length));
+
+        EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_client_supported_versions_recv(server_conn, &extension), S2N_ERR_BAD_MESSAGE);
+        EXPECT_EQUAL(get_alert(server_conn), PROTOCOL_VERSION_ALERT);
+
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_stuffer_free(&extension));
+    }
+
+    /* Server alerts if supported version list is empty */
+    {
+        struct s2n_connection *server_conn;
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        struct s2n_stuffer extension;
+        s2n_stuffer_alloc(&extension, 1);
+
+        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&extension, 0));
+
+        EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_client_supported_versions_recv(server_conn, &extension), S2N_ERR_BAD_MESSAGE);
+        EXPECT_EQUAL(get_alert(server_conn), PROTOCOL_VERSION_ALERT);
+
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_stuffer_free(&extension));
+    }
+
+    /* Server alerts if extension is malformed */
+    {
+        struct s2n_connection *server_conn;
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        struct s2n_stuffer extension;
+        s2n_stuffer_alloc(&extension, 1);
+
+        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&extension, 13));
+
+        EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_client_supported_versions_recv(server_conn, &extension), S2N_ERR_BAD_MESSAGE);
+        EXPECT_EQUAL(get_alert(server_conn), PROTOCOL_VERSION_ALERT);
+
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_stuffer_free(&extension));
+    }
+
+    /* Since the supported_version extension replaces the version field
+     * in the client hello, for backwards compatibility the version field
+     * should be set to 1.2 even when a higher version is supported. */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_client_hello_send(conn));
+
+        struct s2n_stuffer client_hello = conn->handshake.io;
+        uint8_t version[2];
+        s2n_stuffer_read_bytes(&client_hello, version, 2);
+
+        EXPECT_EQUAL(version[0], 0x03);
+        EXPECT_EQUAL(version[1], 0x03);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    EXPECT_SUCCESS(s2n_config_free(config));
+
+    END_TEST();
+    return 0;
+}

--- a/tests/unit/s2n_tls13_support_test.c
+++ b/tests/unit/s2n_tls13_support_test.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "tls/s2n_tls.h"
+#include "tls/s2n_config.h"
+#include "tls/s2n_connection.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    uint8_t expected_version = s2n_supported_protocol_versions[0];
+    EXPECT_EQUAL(expected_version, S2N_TLS13);
+
+    /* Client does not use TLS 1.3 by default */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+        EXPECT_NOT_EQUAL(conn->client_protocol_version, S2N_TLS13);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    EXPECT_SUCCESS(setenv("S2N_ENABLE_TLS13_FOR_TESTING", "1", 0));
+
+    /* Client does use TLS 1.3 if enabled */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+        EXPECT_EQUAL(conn->client_protocol_version, S2N_TLS13);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    END_TEST();
+    return 0;
+}

--- a/tests/unit/s2n_tls13_support_test.c
+++ b/tests/unit/s2n_tls13_support_test.c
@@ -23,15 +23,22 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
-    uint8_t expected_version = s2n_supported_protocol_versions[0];
-    EXPECT_EQUAL(expected_version, S2N_TLS13);
-
     /* Client does not use TLS 1.3 by default */
     {
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
         EXPECT_NOT_EQUAL(conn->client_protocol_version, S2N_TLS13);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Server does not use TLS 1.3 by default */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+
+        EXPECT_NOT_EQUAL(conn->server_protocol_version, S2N_TLS13);
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
@@ -44,6 +51,16 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
         EXPECT_EQUAL(conn->client_protocol_version, S2N_TLS13);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Server does use TLS 1.3 if enabled */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+
+        EXPECT_EQUAL(conn->server_protocol_version, S2N_TLS13);
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }

--- a/tls/Makefile
+++ b/tls/Makefile
@@ -15,6 +15,7 @@
 
 SRCS=$(wildcard *.c)
 OBJS=$(SRCS:.c=.o)
+SUB_BUILDS = $(patsubst %/Makefile, %, $(wildcard */Makefile))
 
 BITCODE_DIR?=../tests/saw/bitcode/
 
@@ -23,26 +24,26 @@ BCS=$(addprefix $(BITCODE_DIR), $(BCS_1))
 
 .PHONY : all
 all: $(OBJS)
-	$(MAKE) -C extensions
+	$(foreach subfolder, $(SUB_BUILDS), $(MAKE) -C $(subfolder))
 
 .PHONY : bc
 bc: $(BCS)
-	$(MAKE) -C extensions bc
+	$(foreach subfolder, $(SUB_BUILDS), $(MAKE) -C $(subfolder) bc)
 
 .PHONY : run-gcov
 run-gcov: gcov
-	$(MAKE) -C extensions gcov
+	$(foreach subfolder, $(SUB_BUILDS), $(MAKE) -C $(subfolder) gcov)
 
 .PHONY : run-lcov
 run-lcov: lcov
-	$(MAKE) -C extensions lcov
+	$(foreach subfolder, $(SUB_BUILDS), $(MAKE) -C $(subfolder) lcov)
 	
 .PHONY : indent
 indent: indentsource
-	${MAKE} -C extensions indentsource
+	$(foreach subfolder, $(SUB_BUILDS), ${MAKE} -C $(subfolder) indentsource)
 
 .PHONY : clean
 clean: decruft
-	${MAKE} -C extensions decruft
+	$(foreach subfolder, $(SUB_BUILDS), ${MAKE} -C $(subfolder) decruft)
 
 include ../s2n.mk

--- a/tls/extensions/Makefile
+++ b/tls/extensions/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").
 # You may not use this file except in compliance with the License.
@@ -16,33 +16,13 @@
 SRCS=$(wildcard *.c)
 OBJS=$(SRCS:.c=.o)
 
-BITCODE_DIR?=../tests/saw/bitcode/
-
-BCS_1=s2n_handshake_io.bc s2n_connection.bc s2n_kex.bc
+BCS_1=$(SRCS:.c=.bc)
 BCS=$(addprefix $(BITCODE_DIR), $(BCS_1))
 
 .PHONY : all
 all: $(OBJS)
-	$(MAKE) -C extensions
 
 .PHONY : bc
 bc: $(BCS)
-	$(MAKE) -C extensions bc
 
-.PHONY : run-gcov
-run-gcov: gcov
-	$(MAKE) -C extensions gcov
-
-.PHONY : run-lcov
-run-lcov: lcov
-	$(MAKE) -C extensions lcov
-	
-.PHONY : indent
-indent: indentsource
-	${MAKE} -C extensions indentsource
-
-.PHONY : clean
-clean: decruft
-	${MAKE} -C extensions decruft
-
-include ../s2n.mk
+include ../../s2n.mk

--- a/tls/extensions/s2n_client_supported_versions.c
+++ b/tls/extensions/s2n_client_supported_versions.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <sys/param.h>
+#include <stdint.h>
+
+#include "tls/s2n_alerts.h"
+#include "tls/s2n_tls_parameters.h"
+#include "tls/s2n_tls.h"
+#include "tls/extensions/s2n_client_supported_versions.h"
+
+#include "utils/s2n_safety.h"
+
+/**
+ * Specified in https://tools.ietf.org/html/rfc8446#section-4.2.1
+ *
+ * "The "supported_versions" extension is used by the client to indicate
+ * which versions of TLS it supports and by the server to indicate which
+ * version it is using. The extension contains a list of supported
+ * versions in preference order, with the most preferred version first."
+ **/
+
+uint8_t s2n_supported_protocol_versions[] = { S2N_TLS13, S2N_TLS12, S2N_TLS11, S2N_TLS10, S2N_SSLv3, S2N_SSLv2 };
+
+int s2n_extensions_client_supported_versions_process(struct s2n_connection *conn, struct s2n_stuffer *extension) {
+    uint8_t size_of_version_list = 0;
+    GUARD(s2n_stuffer_read_uint8(extension, &size_of_version_list));
+
+    conn->client_protocol_version = s2n_unknown_protocol_version;
+    conn->actual_protocol_version = s2n_unknown_protocol_version;
+
+    for (int i = 0; i < size_of_version_list; i += S2N_TLS_PROTOCOL_VERSION_LEN) {
+        uint8_t client_version_parts[S2N_TLS_PROTOCOL_VERSION_LEN];
+        GUARD(s2n_stuffer_read_bytes(extension, client_version_parts, S2N_TLS_PROTOCOL_VERSION_LEN));
+
+        uint16_t client_version = (client_version_parts[0] * 10) + client_version_parts[1];
+
+        conn->client_protocol_version = MAX(client_version, conn->client_protocol_version);
+
+        if (client_version > s2n_supported_protocol_versions[0]) {
+            continue;
+        }
+
+        /* We ignore the client's preferred order and instead choose
+         * the highest version that both client and server support. */
+        conn->actual_protocol_version = MAX(client_version, conn->actual_protocol_version);
+    }
+
+    if (conn->actual_protocol_version == s2n_unknown_protocol_version) {
+        return -1;
+    }
+
+    return 0;
+}
+
+int get_supported_version_list_length() {
+    return sizeof(s2n_supported_protocol_versions);
+}
+
+int get_supported_version_list_size() {
+    return get_supported_version_list_length() * S2N_TLS_PROTOCOL_VERSION_LEN;
+}
+
+int get_extension_data_size() {
+    /*
+     * Full size:
+     * Version list size (1 byte)
+     * Version list (variable)
+     */
+    return get_supported_version_list_size() + 1;
+}
+
+int s2n_extensions_client_supported_versions_size(struct s2n_connection *conn) {
+    /*
+     * Full size:
+     * Extension type (2 bytes) +
+     * Extension data size (2 bytes) +
+     * Extension data (variable)
+     */
+    return get_extension_data_size() + 4;
+}
+
+int s2n_extensions_client_supported_versions_recv(struct s2n_connection *conn, struct s2n_stuffer *extension) {
+    if (s2n_extensions_client_supported_versions_process(conn, extension) < 0) {
+        s2n_queue_reader_unsupported_protocol_version_alert(conn);
+        S2N_ERROR(S2N_ERR_BAD_MESSAGE);
+    }
+    return 0;
+}
+
+int s2n_extensions_client_supported_versions_send(struct s2n_connection *conn, struct s2n_stuffer *out) {
+    GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_SUPPORTED_VERSIONS));
+
+    GUARD(s2n_stuffer_write_uint16(out, get_extension_data_size()));
+    GUARD(s2n_stuffer_write_uint8(out, get_supported_version_list_size()));
+
+    for (int i = 0; i < get_supported_version_list_length(); i++) {
+        GUARD(s2n_stuffer_write_uint8(out, s2n_supported_protocol_versions[i] / 10));
+        GUARD(s2n_stuffer_write_uint8(out, s2n_supported_protocol_versions[i] % 10));
+    }
+
+    return 0;
+}

--- a/tls/extensions/s2n_client_supported_versions.c
+++ b/tls/extensions/s2n_client_supported_versions.c
@@ -16,10 +16,11 @@
 #include <sys/param.h>
 #include <stdint.h>
 
-#include "tls/s2n_alerts.h"
-#include "tls/s2n_tls_parameters.h"
-#include "tls/s2n_tls.h"
 #include "tls/extensions/s2n_client_supported_versions.h"
+#include "tls/s2n_alerts.h"
+#include "tls/s2n_cipher_preferences.h"
+#include "tls/s2n_tls.h"
+#include "tls/s2n_tls_parameters.h"
 
 #include "utils/s2n_safety.h"
 
@@ -30,12 +31,41 @@
  * which versions of TLS it supports and by the server to indicate which
  * version it is using. The extension contains a list of supported
  * versions in preference order, with the most preferred version first."
+ *
+ * Structure:
+ * Extension type (2 bytes)
+ * Extension size (2 bytes)
+ * Version list length (1 byte)
+ * Version list (number of versions * 2 bytes)
+ *
+ * Note: We assume in these functions that the supported version numbers
+ * are consecutive. This is true because S2N does not support SSLv2, and
+ * is already an assumption made in the old client hello version handling.
  **/
 
-uint8_t s2n_supported_protocol_versions[] = { S2N_TLS13, S2N_TLS12, S2N_TLS11, S2N_TLS10, S2N_SSLv3, S2N_SSLv2 };
+static uint8_t get_minimum_supported_version(struct s2n_connection *conn) {
+    const struct s2n_cipher_preferences *cipher_preferences;
+    if (s2n_connection_get_cipher_preferences(conn, &cipher_preferences) < 0) {
+        return S2N_TLS13;
+    }
+
+    return cipher_preferences->minimum_protocol_version;
+}
+
+int s2n_extensions_client_supported_versions_size(struct s2n_connection *conn) {
+    uint8_t minimum_supported_version = get_minimum_supported_version(conn);
+    uint8_t highest_supported_version = conn->client_protocol_version;
+
+    uint8_t version_list_length = highest_supported_version - minimum_supported_version + 1;
+
+    return version_list_length * S2N_TLS_PROTOCOL_VERSION_LEN + 5;
+}
 
 int s2n_extensions_client_supported_versions_process(struct s2n_connection *conn, struct s2n_stuffer *extension) {
-    uint8_t size_of_version_list = 0;
+    uint8_t highest_supported_version = conn->server_protocol_version;
+    uint8_t minimum_supported_version = get_minimum_supported_version(conn);
+
+    uint8_t size_of_version_list;
     GUARD(s2n_stuffer_read_uint8(extension, &size_of_version_list));
 
     conn->client_protocol_version = s2n_unknown_protocol_version;
@@ -49,7 +79,11 @@ int s2n_extensions_client_supported_versions_process(struct s2n_connection *conn
 
         conn->client_protocol_version = MAX(client_version, conn->client_protocol_version);
 
-        if (client_version > s2n_supported_protocol_versions[0]) {
+        if (client_version > highest_supported_version) {
+            continue;
+        }
+
+        if (client_version < minimum_supported_version) {
             continue;
         }
 
@@ -65,33 +99,6 @@ int s2n_extensions_client_supported_versions_process(struct s2n_connection *conn
     return 0;
 }
 
-int get_supported_version_list_length() {
-    return sizeof(s2n_supported_protocol_versions);
-}
-
-int get_supported_version_list_size() {
-    return get_supported_version_list_length() * S2N_TLS_PROTOCOL_VERSION_LEN;
-}
-
-int get_extension_data_size() {
-    /*
-     * Full size:
-     * Version list size (1 byte)
-     * Version list (variable)
-     */
-    return get_supported_version_list_size() + 1;
-}
-
-int s2n_extensions_client_supported_versions_size(struct s2n_connection *conn) {
-    /*
-     * Full size:
-     * Extension type (2 bytes) +
-     * Extension data size (2 bytes) +
-     * Extension data (variable)
-     */
-    return get_extension_data_size() + 4;
-}
-
 int s2n_extensions_client_supported_versions_recv(struct s2n_connection *conn, struct s2n_stuffer *extension) {
     if (s2n_extensions_client_supported_versions_process(conn, extension) < 0) {
         s2n_queue_reader_unsupported_protocol_version_alert(conn);
@@ -101,14 +108,18 @@ int s2n_extensions_client_supported_versions_recv(struct s2n_connection *conn, s
 }
 
 int s2n_extensions_client_supported_versions_send(struct s2n_connection *conn, struct s2n_stuffer *out) {
+    uint8_t highest_supported_version = conn->client_protocol_version;
+    uint8_t minimum_supported_version = get_minimum_supported_version(conn);
+
+    int extension_length = s2n_extensions_client_supported_versions_size(conn);
+
     GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_SUPPORTED_VERSIONS));
+    GUARD(s2n_stuffer_write_uint16(out, extension_length - 4));
 
-    GUARD(s2n_stuffer_write_uint16(out, get_extension_data_size()));
-    GUARD(s2n_stuffer_write_uint8(out, get_supported_version_list_size()));
-
-    for (int i = 0; i < get_supported_version_list_length(); i++) {
-        GUARD(s2n_stuffer_write_uint8(out, s2n_supported_protocol_versions[i] / 10));
-        GUARD(s2n_stuffer_write_uint8(out, s2n_supported_protocol_versions[i] % 10));
+    GUARD(s2n_stuffer_write_uint8(out, extension_length - 5));
+    for (uint8_t i = highest_supported_version; i >= minimum_supported_version; i--) {
+        GUARD(s2n_stuffer_write_uint8(out, i / 10));
+        GUARD(s2n_stuffer_write_uint8(out, i % 10));
     }
 
     return 0;

--- a/tls/extensions/s2n_client_supported_versions.h
+++ b/tls/extensions/s2n_client_supported_versions.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include "tls/s2n_connection.h"
+#include "stuffer/s2n_stuffer.h"
+
+extern int s2n_extensions_client_supported_versions_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
+extern int s2n_extensions_client_supported_versions_size(struct s2n_connection *conn);
+extern int s2n_extensions_client_supported_versions_send(struct s2n_connection *conn, struct s2n_stuffer *out);

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -340,8 +340,9 @@ int s2n_client_hello_send(struct s2n_connection *conn)
     notnull_check(r.data);
     GUARD(s2n_get_public_random_data(&r));
 
-    client_protocol_version[0] = conn->client_protocol_version / 10;
-    client_protocol_version[1] = conn->client_protocol_version % 10;
+    uint8_t reported_protocol_version = MIN(conn->client_protocol_version, S2N_TLS12);
+    client_protocol_version[0] = reported_protocol_version / 10;
+    client_protocol_version[1] = reported_protocol_version % 10;
     conn->client_hello_version = conn->client_protocol_version;
 
     GUARD(s2n_stuffer_write_bytes(out, client_protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -127,6 +127,9 @@ struct s2n_connection {
     uint8_t client_protocol_version;
     uint8_t server_protocol_version;
     uint8_t actual_protocol_version;
+
+    /* Flag indicating whether a protocol version has been
+     * negotiated yet. */
     uint8_t actual_protocol_version_established;
 
     /* Our crypto parameters */

--- a/tls/s2n_tls.c
+++ b/tls/s2n_tls.c
@@ -18,7 +18,6 @@
 #include "tls/s2n_tls.h"
 #include "tls/s2n_tls_parameters.h"
 
-/* Highest version supported by s2n is TLS1.2 */
 uint8_t s2n_highest_protocol_version = S2N_TLS12;
 uint8_t s2n_unknown_protocol_version = S2N_UNKNOWN_PROTOCOL_VERSION;
 

--- a/tls/s2n_tls.h
+++ b/tls/s2n_tls.h
@@ -19,8 +19,9 @@
 
 #include "tls/s2n_connection.h"
 
-extern uint8_t s2n_highest_protocol_version;
 extern uint8_t s2n_unknown_protocol_version;
+extern uint8_t s2n_supported_protocol_versions[];
+extern uint8_t s2n_highest_protocol_version;
 
 extern int s2n_flush(struct s2n_connection *conn, s2n_blocked_status * more);
 extern int s2n_client_hello_send(struct s2n_connection *conn);

--- a/tls/s2n_tls.h
+++ b/tls/s2n_tls.h
@@ -20,7 +20,6 @@
 #include "tls/s2n_connection.h"
 
 extern uint8_t s2n_unknown_protocol_version;
-extern uint8_t s2n_supported_protocol_versions[];
 extern uint8_t s2n_highest_protocol_version;
 
 extern int s2n_flush(struct s2n_connection *conn, s2n_blocked_status * more);

--- a/tls/s2n_tls_parameters.h
+++ b/tls/s2n_tls_parameters.h
@@ -81,6 +81,9 @@
 #define TLS_EXTENSION_RENEGOTIATION_INFO   65281
 #define TLS_EXTENSION_SESSION_TICKET       35
 
+/* TLS 1.3 extensions from https://tools.ietf.org/html/rfc8446#section-4.2 */
+#define TLS_EXTENSION_SUPPORTED_VERSIONS   43
+
 /* TLS Signature Algorithms - RFC 5246 7.4.1.4.1*/
 #define TLS_SIGNATURE_ALGORITHM_ANONYMOUS   0
 #define TLS_SIGNATURE_ALGORITHM_RSA         1

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -92,7 +92,10 @@ static inline void* trace_memcpy_check(void *restrict to, const void *restrict f
 #define GUARD( x )              do {if ( (x) < 0 ) return -1;} while (0)
 #define GUARD_GOTO( x , label ) do {if ( (x) < 0 ) goto label;} while (0)
 #define GUARD_PTR( x )          do {if ( (x) < 0 ) return NULL;} while (0)
+
 #define S2N_IN_UNIT_TEST ( getenv("S2N_UNIT_TEST") != NULL )
+#define S2N_IN_INTEG_TEST ( getenv("S2N_INTEG_TEST") != NULL )
+#define S2N_IN_TEST ( S2N_IN_UNIT_TEST || S2N_IN_INTEG_TEST )
 
 /* TODO: use the OSSL error code in error reporting https://github.com/awslabs/s2n/issues/705 */
 #define GUARD_OSSL( x , errcode )               \


### PR DESCRIPTION
**Issue # (if available):** [892](https://github.com/awslabs/s2n/issues/892)

**Description of changes:**
This is the first of the new TLS 1.3 extensions, and is required to get the TLS 1.3 handshake working. I also created a new subfolder for extensions so that they can each be in their own file instead of putting them all in tls/s2n_client_extensions.c, which is getting a bit long.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
