### PR TITLE
Improve readability of Usage Guide's Enums section

### DIFF
--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -250,7 +250,9 @@ but does accept SSL2.0 hello messages.
 
 ## Enums
 
-s2n defines five enum types:
+s2n defines the following enum types:
+
+### s2n_error_type
 
 ```c
 typedef enum {
@@ -269,6 +271,7 @@ typedef enum {
 This enum is optimized for use in C switch statements. Each value in the enum represents
 an error "category". See [Error Handling](#error-handling) for more detail.
 
+### s2n_mode
 
 ```c
 typedef enum { S2N_SERVER, S2N_CLIENT } s2n_mode;
@@ -278,6 +281,8 @@ typedef enum { S2N_SERVER, S2N_CLIENT } s2n_mode;
 respectively.  At this time, s2n does not function as a client and only
 S2N_SERVER should be used.
 
+### s2n_blocked_status
+
 ```c
 typedef enum { S2N_NOT_BLOCKED, S2N_BLOCKED_ON_READ, S2N_BLOCKED_ON_WRITE } s2n_blocked_status;
 ```
@@ -286,6 +291,8 @@ typedef enum { S2N_NOT_BLOCKED, S2N_BLOCKED_ON_READ, S2N_BLOCKED_ON_WRITE } s2n_
 direction s2n became blocked on I/O before it returned control to the caller.
 This allows an application to avoid retrying s2n operations until I/O is 
 possible in that direction.
+
+### s2n_blinding
 
 ```c
 typedef enum { S2N_BUILT_IN_BLINDING, S2N_SELF_SERVICE_BLINDING } s2n_blinding;
@@ -303,6 +310,8 @@ self-service applications should call **s2n_connection_get_delay** and pause
 activity on the connection  for the specified number of nanoseconds before calling
 close() or shutdown().
 
+### s2n_status_request_type
+
 ```c
 typedef enum { S2N_STATUS_REQUEST_NONE, S2N_STATUS_REQUEST_OCSP } s2n_status_request_type;
 ```
@@ -311,12 +320,15 @@ typedef enum { S2N_STATUS_REQUEST_NONE, S2N_STATUS_REQUEST_OCSP } s2n_status_req
 status request an S2N_CLIENT should make during the handshake. The only
 supported status request type is OCSP, **S2N_STATUS_REQUEST_OCSP**.
 
+### s2n_cert_auth_type
 
 ```c
 typedef enum { S2N_CERT_AUTH_NONE, S2N_CERT_AUTH_REQUIRED, S2N_CERT_AUTH_OPTIONAL } s2n_cert_auth_type;
 ```
 **s2n_cert_auth_type** is used to declare what type of client certificiate authentication to use.
 Currently the default for s2n is for neither the server side or the client side to use Client (aka Mutual) authentication.
+
+### s2n_cert_type
 
 ```c
 typedef enum {


### PR DESCRIPTION
**Issue # (if available):** 
N/A

**Description of changes:** 
Updating the enum section description as there are now more than five enum types.

Also added sub headings to improve readability as with other sections (I had initially misread the enums of `s2n_error_type` as  the 5 enum types). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
