### PR TITLE
Fixes to s2nd

### DIFF
--- a/bin/echo.c
+++ b/bin/echo.c
@@ -33,7 +33,7 @@
 
 void print_s2n_error(const char *app_error)
 {
-    fprintf(stderr, "%s: '%s' : '%s'\n", app_error, s2n_strerror(s2n_errno, "EN"),
+    fprintf(stderr, "[%d] %s: '%s' : '%s'\n", getpid(), app_error, s2n_strerror(s2n_errno, "EN"),
             s2n_strerror_debug(s2n_errno, "EN"));
 }
 

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -428,8 +428,6 @@ int handle_connection(int fd, struct s2n_config *config, struct conn_settings se
 
     GUARD_RETURN(s2n_connection_free(conn), "Error freeing connection");
 
-    close(fd);
-
     return 0;
 }
 
@@ -748,6 +746,15 @@ int main(int argc, char *const *argv)
         }
     }
 
+    if (parallelize) {
+        struct sigaction sa;
+
+        sa.sa_handler = SIG_IGN;
+        sa.sa_flags = SA_NOCLDWAIT;
+        sigemptyset(&sa.sa_mask);
+        sigaction(SIGCHLD, &sa, NULL);
+    }
+
     int fd;
     while ((fd = accept(sockfd, ai->ai_addr, &ai->ai_addrlen)) > 0) {
 
@@ -767,10 +774,12 @@ int main(int argc, char *const *argv)
                 close(fd);
                 _exit(rc);
             } else if (child_pid == -1) {
+                close(fd);
                 print_s2n_error("Error calling fork(). Acceptor unable to start handler.");
                 exit(1);
             } else {
                 /* This is the parent Acceptor Thread, continue listening for new connections */
+                close(fd);
                 continue;
             }
         }


### PR DESCRIPTION
**Issue # (if available):** 

N/A

**Description of changes:** 

1. Print `pid` in `print_s2n_error` function
2. Set `SA_NOCLDWAIT` to prevent creating zombies
3. close `fd` in the main event loop after `fork`ing


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
