### PR TITLE
Fix install prlimit error

### DIFF
--- a/.travis/install_prlimit.sh
+++ b/.travis/install_prlimit.sh
@@ -28,6 +28,8 @@ BUILD_DIR=$1
 INSTALL_DIR=$2
 NUM_CORES=$(nproc)
 
+sudo apt-get install -y libncurses5-dev
+
 cd "$BUILD_DIR"
 # Originally from: https://www.kernel.org/pub/linux/utils/util-linux/v2.25/util-linux-2.25.2.tar.gz
 curl --retry 3 https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/2017-08-29_util-linux-2.25.2.tar.gz --output util-linux-2.25.2.tar.gz


### PR DESCRIPTION
**Issue # (if available):** 
`.travis/install_prlimit.sh` fails if ncurses lib is not present in ubuntu.

**Description of changes:** 
Even though `util-linux` is configured `--without-ncurses`, running `make` fails compiling `more.c`.

```
text-utils/more.c:256:11: fatal error: termcap.h: No such file or directory
 # include <termcap.h>
           ^~~~~~~~~~~
compilation terminated.
Makefile:8601: recipe for target 'text-utils/more-more.o' failed
make[2]: *** [text-utils/more-more.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: Leaving directory '/home/ubuntu/s2n/tmp/util-linux-2.25.2'
Makefile:10057: recipe for target 'all-recursive' failed
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory '/home/ubuntu/s2n/tmp/util-linux-2.25.2'
Makefile:4362: recipe for target 'all' failed
make: *** [all] Error 2
```

This fixes the error by ensuring `libncurses5-dev` is present.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
