### PR TITLE
Make CertificateStatus optional in client mode

### DIFF
--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -709,11 +709,20 @@ static int handshake_read_io(struct s2n_connection *conn)
 
         /* If we're a Client, and received a ClientCertRequest message instead of a ServerHelloDone, and ClientAuth
          * is set to optional, then switch the State Machine that we're using to expect the ClientCertRequest. */
-        if(conn->mode == S2N_CLIENT
+        if (conn->mode == S2N_CLIENT
                 && client_cert_auth_type == S2N_CERT_AUTH_OPTIONAL
                 && actual_handshake_message_type == TLS_CLIENT_CERT_REQ
                 && EXPECTED_MESSAGE_TYPE(conn) == TLS_SERVER_HELLO_DONE) {
             conn->handshake.handshake_type |= CLIENT_AUTH;
+        }
+
+        /* According to rfc6066 section 8, server may choose not to send "CertificateStatus" message even if it has
+         * sent "status_request" extension in the ServerHello message.
+         */
+        if (conn->mode == S2N_CLIENT
+                && EXPECTED_MESSAGE_TYPE(conn) == TLS_SERVER_CERT_STATUS
+                && actual_handshake_message_type != TLS_SERVER_CERT_STATUS) {
+            conn->handshake.handshake_type &= ~OCSP_STATUS;
         }
 
         S2N_ERROR_IF(actual_handshake_message_type != EXPECTED_MESSAGE_TYPE(conn), S2N_ERR_BAD_MESSAGE);

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -717,8 +717,7 @@ static int handshake_read_io(struct s2n_connection *conn)
         }
 
         /* According to rfc6066 section 8, server may choose not to send "CertificateStatus" message even if it has
-         * sent "status_request" extension in the ServerHello message.
-         */
+         * sent "status_request" extension in the ServerHello message. */
         if (conn->mode == S2N_CLIENT
                 && EXPECTED_MESSAGE_TYPE(conn) == TLS_SERVER_CERT_STATUS
                 && actual_handshake_message_type != TLS_SERVER_CERT_STATUS) {


### PR DESCRIPTION
**Issue # (if available):** 

**Description of changes:** 
According to RFC6066 Section 8, server may choose not to send "CertificateStatus" message even if it has sent "status_request" extension in ServerHello message.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
