### PR TITLE
Add gnutls-bin to ubuntu dependencies

### DIFF
--- a/.travis/install_ubuntu_dependencies.sh
+++ b/.travis/install_ubuntu_dependencies.sh
@@ -18,7 +18,7 @@ set -ex
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 sudo apt-get update -o Acquire::CompressionTypes::Order::=gz
 
-DEPENDENCIES="unzip make indent kwstyle libssl-dev tcpdump valgrind lcov m4 nettle-dev nettle-bin pkg-config gcc g++ zlibc zlib1g-dev python-pip llvm"
+DEPENDENCIES="unzip make indent kwstyle libssl-dev tcpdump valgrind lcov m4 nettle-dev nettle-bin pkg-config gcc g++ zlibc zlib1g-dev python-pip llvm gnutls-bin"
 
 sudo apt-get install -y ${DEPENDENCIES}
 


### PR DESCRIPTION
- This is needed for gnutls integration tests

**Issue # (if available):** 
relates #751


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
