### PR TITLE
Update apt before installing shellcheck

### DIFF
--- a/.travis/install_shellcheck.sh
+++ b/.travis/install_shellcheck.sh
@@ -28,7 +28,7 @@ fi
 TRAVIS_PLATFORM=$1
 
 if [ "$TRAVIS_PLATFORM" == "linux" ]; then
-    which shellcheck || sudo apt-get -qq install shellcheck -y
+    which shellcheck || sudo apt-get -qq update && sudo apt-get -qq install shellcheck -y
 elif [ "$TRAVIS_PLATFORM" == "osx" ]; then
     # Installing an existing package is a "failure" in brew
     brew install shellcheck || true ;


### PR DESCRIPTION
**Issue # (if available):** 
running `.travis/s2n_install_test_dependencies.sh` on a fresh ubuntu fails on attempting to apt-install shell check. 

```sh
Installing ShellCheck...
+ .travis/install_shellcheck.sh linux

No apt package "shellcheck", but there is a snap with that name.
Try "snap install shellcheck"

E: Unable to locate package shellcheck
ubuntu@ip-172-31-16-130:~/s2n$ .travis/s2n_travis_build.sh
```

part of #751 effort to run on fresh ubuntu installs.

**Description of changes:** 
Run apt-update in `install_shellcheck.sh` before install shellcheck


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
