### PR TITLE
s2n_socket_read_io_context: Initialize heap memory to avoid jump based on uninitialized jump

### DIFF
--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -806,6 +806,7 @@ int s2n_connection_set_read_fd(struct s2n_connection *conn, int rfd)
     GUARD(s2n_alloc(&ctx_mem, sizeof(struct s2n_socket_read_io_context)));
 
     peer_socket_ctx = (struct s2n_socket_read_io_context *)(void *)ctx_mem.data;
+    *peer_socket_ctx = (struct s2n_socket_read_io_context){0};
     peer_socket_ctx->fd = rfd;
 
     s2n_connection_set_recv_cb(conn, s2n_socket_read);

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -804,9 +804,9 @@ int s2n_connection_set_read_fd(struct s2n_connection *conn, int rfd)
     struct s2n_socket_read_io_context *peer_socket_ctx;
 
     GUARD(s2n_alloc(&ctx_mem, sizeof(struct s2n_socket_read_io_context)));
+    GUARD(s2n_blob_zero(&ctx_mem));
 
     peer_socket_ctx = (struct s2n_socket_read_io_context *)(void *)ctx_mem.data;
-    *peer_socket_ctx = (struct s2n_socket_read_io_context){0};
     peer_socket_ctx->fd = rfd;
 
     s2n_connection_set_recv_cb(conn, s2n_socket_read);


### PR DESCRIPTION
Valgrind complained that in [`s2n_socket_quickack`](https://github.com/awslabs/s2n/blob/master/utils/s2n_socket.c#L48) the `tcp_quickack_set` member is read, but in [`s2n_connection_set_read_fd`](https://github.com/awslabs/s2n/blob/master/tls/s2n_connection.c#L806-L809) the memory for that field is not initialized to any value. As far as I can tell, that's the only place this structure is allocated.

**Issue # (if available):** I've not opened one.

**Description of changes:** I've simply set the structure to zero.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
