### PR TITLE
Tolerate unexpected large legacy protocol versions

### DIFF
--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -173,11 +173,11 @@ static int s2n_parse_client_hello(struct s2n_connection *conn)
     GUARD(s2n_stuffer_read_uint8(in, &conn->session_id_len));
 
     conn->client_protocol_version = (client_protocol_version[0] * 10) + client_protocol_version[1];
-    if (conn->client_protocol_version > conn->server_protocol_version) {
-        GUARD(s2n_queue_reader_unsupported_protocol_version_alert(conn));
-        S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-    }
     conn->client_hello_version = conn->client_protocol_version;
+    /* Protocol version in the ClientHello is fixed at 0x0303(TLS 1.2) for
+     * future versions of TLS. Still, we will negotiate down if a client sends
+     * an unexpected value above 0x0303.
+     */
     conn->actual_protocol_version = MIN(conn->client_protocol_version, conn->server_protocol_version);
 
     S2N_ERROR_IF(conn->session_id_len > S2N_TLS_SESSION_ID_MAX_LEN || conn->session_id_len > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);
@@ -428,7 +428,7 @@ int s2n_sslv2_client_hello_recv(struct s2n_connection *conn)
     const struct s2n_cipher_preferences *cipher_preferences;
     GUARD(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
 
-    if (conn->client_protocol_version < cipher_preferences->minimum_protocol_version || conn->client_protocol_version > conn->server_protocol_version) {
+    if (conn->client_protocol_version < cipher_preferences->minimum_protocol_version) {
         GUARD(s2n_queue_reader_unsupported_protocol_version_alert(conn));
         S2N_ERROR(S2N_ERR_BAD_MESSAGE);
     }


### PR DESCRIPTION
The ProtocolVersion field in the ClientHello is fixed at 0x0303 for
versions above TLS 1.2. If a strangely configured client or scanner
sends a version above this value, s2n should still try to continue the
negotiation with the highest mutually supported value. This is in line
with the suggestion in https://tools.ietf.org/html/rfc8446#section-4.2.1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
