### PR TITLE
Add s2n_connection_get_last_message_name to get the last message name in TLS state machine

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -262,6 +262,7 @@ extern const char *s2n_connection_get_curve(struct s2n_connection *conn);
 extern const char *s2n_connection_get_kem_name(struct s2n_connection *conn);
 extern int s2n_connection_get_alert(struct s2n_connection *conn);
 extern const char *s2n_connection_get_handshake_type_name(struct s2n_connection *conn);
+extern const char *s2n_connection_get_last_message_name(struct s2n_connection *conn);
 
 #ifdef __cplusplus
 }

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1254,6 +1254,14 @@ const char *s2n_connection_get_handshake_type_name(struct s2n_connection *conn);
 
 **s2n_connection_get_handshake_type_name** returns a human-readable handshake type name, e.g. "NEGOTIATED|FULL_HANDSHAKE|PERFECT_FORWARD_SECRECY"
 
+### s2n\_connection\_get\_last\_message\_name
+
+```c
+const char *s2n_connection_get_last_message_name(struct s2n_connection *conn);
+```
+
+**s2n_connection_get_last_message_name** returns the last message name in TLS state machine, e.g. "SERVER_HELLO", "APPLICATION_DATA".
+
 ### s2n\_connection\_get\_alert
 
 ```c

--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -145,6 +145,7 @@ int test_cipher_preferences(struct s2n_config *server_config, struct s2n_config 
         server_conn->client_protocol_version = S2N_TLS12;
         server_conn->actual_protocol_version = S2N_TLS12;
 
+        const char* app_data_str = "APPLICATION_DATA";
         if (!expect_failure) {
             GUARD(try_handshake(server_conn, client_conn));
             const char* actual_cipher = s2n_connection_get_cipher(server_conn);
@@ -170,8 +171,17 @@ int test_cipher_preferences(struct s2n_config *server_config, struct s2n_config 
             if (strcmp(s2n_connection_get_handshake_type_name(server_conn), handshake_type_name) != 0) {
                 return -1;
             }
+
+            if (strcmp(app_data_str, s2n_connection_get_last_message_name(client_conn)) != 0 ||
+                strcmp(app_data_str, s2n_connection_get_last_message_name(server_conn)) != 0) {
+                return -1;
+            }
         } else {
             eq_check(try_handshake(server_conn, client_conn), -1);
+            if (0 == strcmp(app_data_str, s2n_connection_get_last_message_name(client_conn)) ||
+                0 == strcmp(app_data_str, s2n_connection_get_last_message_name(server_conn))) {
+                return -1;
+            }
         }
 
         GUARD(s2n_connection_free(server_conn));

--- a/tests/unit/s2n_str_test.c
+++ b/tests/unit/s2n_str_test.c
@@ -16,15 +16,16 @@
 #include "s2n_test.h"
 #include "utils/s2n_str.h"
 
+#define BUF_SIZE 10
+
 int main(int argc, char **argv)
 {
-    const int buf_size = 10;
-    char buf[buf_size];
+    char buf[BUF_SIZE];
 
     BEGIN_TEST();
 
     char *p = buf;
-    char *last = buf + buf_size;
+    char *last = buf + BUF_SIZE;
     const char *hello = "Hello";
     const char *world = " World!";
     const char *expect_result = "Hello Wor";

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -84,6 +84,27 @@ static struct s2n_handshake_action state_machine[] = {
     [APPLICATION_DATA]          = {TLS_APPLICATION_DATA, 0, 'B', {NULL, NULL}}
 };
 
+#define MESSAGE_NAME_ENTRY(msg) [msg] = #msg
+
+static const char *message_names[] = {
+    MESSAGE_NAME_ENTRY(CLIENT_HELLO),
+    MESSAGE_NAME_ENTRY(SERVER_HELLO),
+    MESSAGE_NAME_ENTRY(SERVER_NEW_SESSION_TICKET),
+    MESSAGE_NAME_ENTRY(SERVER_CERT),
+    MESSAGE_NAME_ENTRY(SERVER_CERT_STATUS),
+    MESSAGE_NAME_ENTRY(SERVER_KEY),
+    MESSAGE_NAME_ENTRY(SERVER_CERT_REQ),
+    MESSAGE_NAME_ENTRY(SERVER_HELLO_DONE),
+    MESSAGE_NAME_ENTRY(CLIENT_CERT),
+    MESSAGE_NAME_ENTRY(CLIENT_KEY),
+    MESSAGE_NAME_ENTRY(CLIENT_CERT_VERIFY),
+    MESSAGE_NAME_ENTRY(CLIENT_CHANGE_CIPHER_SPEC),
+    MESSAGE_NAME_ENTRY(CLIENT_FINISHED),
+    MESSAGE_NAME_ENTRY(SERVER_CHANGE_CIPHER_SPEC),
+    MESSAGE_NAME_ENTRY(SERVER_FINISHED),
+    MESSAGE_NAME_ENTRY(APPLICATION_DATA),
+};
+
 /* We support different ordering of TLS Handshake messages, depending on what is being negotiated. There's also a dummy "INITIAL" handshake
  * that everything starts out as until we know better.
  */
@@ -452,6 +473,11 @@ int s2n_conn_set_handshake_no_client_cert(struct s2n_connection *conn) {
 
     conn->handshake.handshake_type |= NO_CLIENT_CERT;
     return 0;
+}
+
+const char *s2n_connection_get_last_message_name(struct s2n_connection *conn)
+{
+    return message_names[ACTIVE_MESSAGE(conn)];
 }
 
 const char *s2n_connection_get_handshake_type_name(struct s2n_connection *conn) 

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -477,6 +477,8 @@ int s2n_conn_set_handshake_no_client_cert(struct s2n_connection *conn) {
 
 const char *s2n_connection_get_last_message_name(struct s2n_connection *conn)
 {
+    notnull_check_ptr(conn);
+    
     return message_names[ACTIVE_MESSAGE(conn)];
 }
 


### PR DESCRIPTION
**Issue # (if available):** 
We need visibility of the last message name in TLS state machine for handshake failure requests. 

**Description of changes:** 
Add s2n_connection_get_last_message_name to get the last message name in TLS state machine.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
