### PR TITLE
Add three new ELB TLS policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ source .travis/s2n_setup_env.sh
 .travis/s2n_travis_build.sh
 ```
 
+* For OSX 10 Mojave users, if you are facing ```Undefined symbols for architecture x86_64:``` error in building. Starting with Mojave, the headers are no longer installed under ```/usr/include``` by default -- look under ```Command Line Tools -> New Features``` in the [release notes](https://developer.apple.com/documentation/xcode_release_notes/xcode_10_release_notes).
+  
+  Running
+
+  ```open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg```
+
+  from the command line fixes the issue.
+
+  Thanks for solution provider [@clason](https://github.com/clason), whose original answer could be found [here](https://github.com/neovim/neovim/issues/9050#issuecomment-424417456).
+
 ### Have a Question?
 If you have any questions about Submitting PR's, Opening Issues, s2n API usage, or something similar, we have a public chatroom available here to answer your questions: https://gitter.im/awslabs/s2n
 

--- a/README.md
+++ b/README.md
@@ -26,16 +26,6 @@ source .travis/s2n_setup_env.sh
 .travis/s2n_travis_build.sh
 ```
 
-* For OSX 10 Mojave users, if you are facing ```Undefined symbols for architecture x86_64:``` error in building. Starting with Mojave, the headers are no longer installed under ```/usr/include``` by default -- look under ```Command Line Tools -> New Features``` in the [release notes](https://developer.apple.com/documentation/xcode_release_notes/xcode_10_release_notes).
-  
-  Running
-
-  ```open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg```
-
-  from the command line fixes the issue.
-
-  Thanks for solution provider [@clason](https://github.com/clason), whose original answer could be found [here](https://github.com/neovim/neovim/issues/9050#issuecomment-424417456).
-
 ### Have a Question?
 If you have any questions about Submitting PR's, Opening Issues, s2n API usage, or something similar, we have a public chatroom available here to answer your questions: https://gitter.im/awslabs/s2n
 

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -524,6 +524,82 @@ const struct s2n_cipher_preferences elb_security_policy_fs_2018_06 = {
     .minimum_protocol_version = S2N_TLS10,
 };
 
+struct s2n_cipher_preferences *cipher_suites_elb_security_policy_fs_1_2_2019_08[] = {
+    &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha,
+    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha,
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha,
+};
+
+const struct s2n_cipher_preferences elb_security_policy_fs_1_2_2019_08 = {
+    .count = sizeof(cipher_suites_elb_security_policy_fs_1_2_2019_08) / sizeof(cipher_suites_elb_security_policy_fs_1_2_2019_08[0]), 
+    .suites = cipher_suites_elb_security_policy_fs_1_2_2019_08, 
+    .minimum_protocol_version = S2N_TLS12,
+};
+
+struct s2n_cipher_preferences *cipher_suites_elb_security_policy_fs_1_1_2019_08[] = {
+    &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha,
+    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha,
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha,
+};
+
+const struct s2n_cipher_preferences elb_security_policy_fs_1_1_2019_08 = {
+    .count = sizeof(cipher_suites_elb_security_policy_fs_1_1_2019_08) / sizeof(cipher_suites_elb_security_policy_fs_1_1_2019_08[0]), 
+    .suites = cipher_suites_elb_security_policy_fs_1_1_2019_08, 
+    .minimum_protocol_version = S2N_TLS11,
+};
+
+struct s2n_cipher_preferences *cipher_suites_elb_security_policy_fs_Res_2019_08[] = {
+    &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+};
+
+const struct s2n_cipher_preferences elb_security_policy_fs_Res_2019_08 = {
+    .count = sizeof(cipher_suites_elb_security_policy_fs_Res_2019_08) / sizeof(cipher_suites_elb_security_policy_fs_Res_2019_08[0]), 
+    .suites = cipher_suites_elb_security_policy_fs_Res_2019_08, 
+    .minimum_protocol_version = S2N_TLS10,
+};
+
+struct s2n_cipher_preferences *cipher_suites_elb_security_policy_fs_1_2_Res_2019_08[] = {
+    &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+};
+
+const struct s2n_cipher_preferences elb_security_policy_fs_1_2_Res_2019_08 = {
+    .count = sizeof(cipher_suites_elb_security_policy_fs_1_2_Res_2019_08) / sizeof(cipher_suites_elb_security_policy_fs_1_2_Res_2019_08[0]), 
+    .suites = cipher_suites_elb_security_policy_fs_1_2_Res_2019_08, 
+    .minimum_protocol_version = S2N_TLS12,
+};
+
 struct s2n_cipher_suite *cipher_suites_cloudfront_upstream[] = {
     &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
     &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
@@ -737,6 +813,10 @@ struct {
     { .version="ELBSecurityPolicy-TLS-1-2-2017-01", .preferences=&elb_security_policy_tls_1_2_2017_01, .ecc_extension_required=0, .pq_kem_extension_required=0},
     { .version="ELBSecurityPolicy-TLS-1-2-Ext-2018-06", .preferences=&elb_security_policy_tls_1_2_ext_2018_06, .ecc_extension_required=0, .pq_kem_extension_required=0},
     { .version="ELBSecurityPolicy-FS-2018-06", .preferences=&elb_security_policy_fs_2018_06, .ecc_extension_required=0, .pq_kem_extension_required=0},
+    { .version="ELBSecurityPolicy-FS-1-2-2019-08", .preferences=&elb_security_policy_fs_1_2_2019_08, .ecc_extension_required=0, .pq_kem_extension_required=0}, 
+    { .version="ELBSecurityPolicy-FS-1-1-2019-08", .preferences=&elb_security_policy_fs_1_1_2019_08, .ecc_extension_required=0, .pq_kem_extension_required=0}, 
+    { .version="ELBSecurityPolicy-FS-Res-2019-08", .preferences=&elb_security_policy_fs_Res_2019_08, .ecc_extension_required=0, .pq_kem_extension_required=0}, 
+    { .version="ELBSecurityPolicy-FS-1-2-Res-2019-08", .preferences=&elb_security_policy_fs_1_2_Res_2019_08, .ecc_extension_required=0, .pq_kem_extension_required=0}, 
     { .version="CloudFront-Upstream", .preferences=&cipher_preferences_cloudfront_upstream, .ecc_extension_required=0, .pq_kem_extension_required=0},
     { .version="CloudFront-SSL-v-3", .preferences=&cipher_preferences_cloudfront_ssl_v_3, .ecc_extension_required=0, .pq_kem_extension_required=0},
     { .version="CloudFront-TLS-1-0-2014", .preferences=&cipher_preferences_cloudfront_tls_1_0_2014, .ecc_extension_required=0, .pq_kem_extension_required=0},

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -524,7 +524,7 @@ const struct s2n_cipher_preferences elb_security_policy_fs_2018_06 = {
     .minimum_protocol_version = S2N_TLS10,
 };
 
-struct s2n_cipher_preferences *cipher_suites_elb_security_policy_fs_1_2_2019_08[] = {
+struct s2n_cipher_suite *cipher_suites_elb_security_policy_fs_1_2_2019_08[] = {
     &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
     &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
     &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
@@ -545,7 +545,7 @@ const struct s2n_cipher_preferences elb_security_policy_fs_1_2_2019_08 = {
     .minimum_protocol_version = S2N_TLS12,
 };
 
-struct s2n_cipher_preferences *cipher_suites_elb_security_policy_fs_1_1_2019_08[] = {
+struct s2n_cipher_suite *cipher_suites_elb_security_policy_fs_1_1_2019_08[] = {
     &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
     &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
     &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
@@ -566,7 +566,7 @@ const struct s2n_cipher_preferences elb_security_policy_fs_1_1_2019_08 = {
     .minimum_protocol_version = S2N_TLS11,
 };
 
-struct s2n_cipher_preferences *cipher_suites_elb_security_policy_fs_Res_2019_08[] = {
+struct s2n_cipher_suite *cipher_suites_elb_security_policy_fs_Res_2019_08[] = {
     &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
     &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
     &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
@@ -583,7 +583,7 @@ const struct s2n_cipher_preferences elb_security_policy_fs_Res_2019_08 = {
     .minimum_protocol_version = S2N_TLS10,
 };
 
-struct s2n_cipher_preferences *cipher_suites_elb_security_policy_fs_1_2_Res_2019_08[] = {
+struct s2n_cipher_suite *cipher_suites_elb_security_policy_fs_1_2_Res_2019_08[] = {
     &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
     &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
     &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -798,7 +798,6 @@ struct {
     { .version="ELBSecurityPolicy-FS-2018-06", .preferences=&elb_security_policy_fs_2018_06, .ecc_extension_required=0, .pq_kem_extension_required=0},
     { .version="ELBSecurityPolicy-FS-1-2-2019-08", .preferences=&elb_security_policy_fs_1_2_2019_08, .ecc_extension_required=0, .pq_kem_extension_required=0}, 
     { .version="ELBSecurityPolicy-FS-1-1-2019-08", .preferences=&elb_security_policy_fs_1_1_2019_08, .ecc_extension_required=0, .pq_kem_extension_required=0}, 
-    { .version="ELBSecurityPolicy-FS-Res-2019-08", .preferences=&elb_security_policy_fs_Res_2019_08, .ecc_extension_required=0, .pq_kem_extension_required=0}, 
     { .version="ELBSecurityPolicy-FS-1-2-Res-2019-08", .preferences=&elb_security_policy_fs_1_2_Res_2019_08, .ecc_extension_required=0, .pq_kem_extension_required=0}, 
     { .version="CloudFront-Upstream", .preferences=&cipher_preferences_cloudfront_upstream, .ecc_extension_required=0, .pq_kem_extension_required=0},
     { .version="CloudFront-SSL-v-3", .preferences=&cipher_preferences_cloudfront_ssl_v_3, .ecc_extension_required=0, .pq_kem_extension_required=0},

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -566,23 +566,6 @@ const struct s2n_cipher_preferences elb_security_policy_fs_1_1_2019_08 = {
     .minimum_protocol_version = S2N_TLS11,
 };
 
-struct s2n_cipher_suite *cipher_suites_elb_security_policy_fs_Res_2019_08[] = {
-    &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
-    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
-    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
-    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
-    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
-    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
-    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384,
-    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
-};
-
-const struct s2n_cipher_preferences elb_security_policy_fs_Res_2019_08 = {
-    .count = sizeof(cipher_suites_elb_security_policy_fs_Res_2019_08) / sizeof(cipher_suites_elb_security_policy_fs_Res_2019_08[0]), 
-    .suites = cipher_suites_elb_security_policy_fs_Res_2019_08, 
-    .minimum_protocol_version = S2N_TLS10,
-};
-
 struct s2n_cipher_suite *cipher_suites_elb_security_policy_fs_1_2_Res_2019_08[] = {
     &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
     &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -53,7 +53,6 @@ extern const struct s2n_cipher_preferences elb_security_policy_fs_2018_06;
 
 extern const struct s2n_cipher_preferences elb_security_policy_fs_1_2_2019_08;
 extern const struct s2n_cipher_preferences elb_security_policy_fs_1_1_2019_08;
-extern const struct s2n_cipher_preferences elb_security_policy_fs_res_2019_08;
 extern const struct s2n_cipher_preferences elb_security_policy_fs_1_2_res_2019_08;
 
 extern int s2n_cipher_preferences_init();

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -53,8 +53,8 @@ extern const struct s2n_cipher_preferences elb_security_policy_fs_2018_06;
 
 extern const struct s2n_cipher_preferences elb_security_policy_fs_1_2_2019_08;
 extern const struct s2n_cipher_preferences elb_security_policy_fs_1_1_2019_08;
-extern const struct s2n_cipher_preferences elb_security_policy_fs_Res_2019_08;
-extern const struct s2n_cipher_preferences elb_security_policy_fs_1_2_Res_2019_08;
+extern const struct s2n_cipher_preferences elb_security_policy_fs_res_2019_08;
+extern const struct s2n_cipher_preferences elb_security_policy_fs_1_2_res_2019_08;
 
 extern int s2n_cipher_preferences_init();
 extern int s2n_find_cipher_pref_from_version(const char *version, const struct s2n_cipher_preferences **cipher_preferences);

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -51,6 +51,11 @@ extern const struct s2n_cipher_preferences elb_security_policy_tls_1_1_2017_01;
 extern const struct s2n_cipher_preferences elb_security_policy_tls_1_2_ext_2018_06;
 extern const struct s2n_cipher_preferences elb_security_policy_fs_2018_06;
 
+extern const struct s2n_cipher_preferences elb_security_policy_fs_1_2_2019_08;
+extern const struct s2n_cipher_preferences elb_security_policy_fs_1_1_2019_08;
+extern const struct s2n_cipher_preferences elb_security_policy_fs_Res_2019_08;
+extern const struct s2n_cipher_preferences elb_security_policy_fs_1_2_Res_2019_08;
+
 extern int s2n_cipher_preferences_init();
 extern int s2n_find_cipher_pref_from_version(const char *version, const struct s2n_cipher_preferences **cipher_preferences);
 extern int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *version);


### PR DESCRIPTION
**Description of changes:** 

In the previous [pull request](https://github.com/awslabs/s2n/pull/1113), one TLS policy (ELBSecurityPolicy-FS-Res-2019-08) whose minimum TLS version cannot support its ciphers. We contacted and confirmed with related personnel and decided to remove it. This new pull request reflect this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
