### PR TITLE
Add send for client key_share extension

### DIFF
--- a/crypto/s2n_ecc.h
+++ b/crypto/s2n_ecc.h
@@ -21,16 +21,19 @@
 #include "stuffer/s2n_stuffer.h"
 #include "crypto/s2n_hash.h"
 
+#define S2N_ECC_SUPPORTED_CURVES_COUNT 2
+
 struct s2n_ecc_named_curve {
     /* See https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8 */
     uint16_t iana_id;
     /* See nid_list in openssl/ssl/t1_lib.c */
     int libcrypto_nid;
     const char *name;
+    const uint8_t share_size;
 };
 
 /* An array of supported curves in order of descending preference */
-extern const struct s2n_ecc_named_curve s2n_ecc_supported_curves[2];
+extern const struct s2n_ecc_named_curve s2n_ecc_supported_curves[S2N_ECC_SUPPORTED_CURVES_COUNT];
 
 struct s2n_ecc_params {
     /* Negotiated named curve from s2n_ecc_supported_curves, or NULL if ECC can't be used */
@@ -41,6 +44,7 @@ struct s2n_ecc_params {
 
 int s2n_ecc_generate_ephemeral_key(struct s2n_ecc_params *server_ecc_params);
 int s2n_ecc_write_ecc_params(struct s2n_ecc_params *server_ecc_params, struct s2n_stuffer *out, struct s2n_blob *written);
+int s2n_ecc_write_ecc_params_point(struct s2n_ecc_params *server_ecc_params, struct s2n_stuffer *out);
 int s2n_ecc_read_ecc_params(struct s2n_stuffer *in, struct s2n_blob *data_to_verify, struct s2n_ecdhe_raw_server_params *data);
 int s2n_ecc_parse_ecc_params(struct s2n_ecc_params *server_ecc_params, struct s2n_ecdhe_raw_server_params *data);
 int s2n_ecc_compute_shared_secret_as_server(struct s2n_ecc_params *server_ecc_params, struct s2n_stuffer *Yc_in, struct s2n_blob *shared_key);

--- a/tests/unit/s2n_client_key_share_extension_test.c
+++ b/tests/unit/s2n_client_key_share_extension_test.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include <stdint.h>
+
+#include "tls/s2n_alerts.h"
+#include "tls/s2n_config.h"
+#include "tls/s2n_connection.h"
+#include "tls/s2n_tls.h"
+#include "tls/extensions/s2n_client_key_share.h"
+
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    struct s2n_connection *conn;
+
+    /* Test that s2n_extensions_key_share_recv isn't implemented yet */
+    {
+        EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_client_key_share_recv(NULL, NULL), S2N_ERR_UNIMPLEMENTED);
+    }
+
+    /* Test that s2n_extensions_key_share_size produces the expected constant result */
+    {
+        struct s2n_stuffer key_share_extension;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+        int key_share_size;
+        EXPECT_SUCCESS(key_share_size = s2n_extensions_client_key_share_size(conn));
+
+        /* should produce the same result if called twice */
+        int key_share_size_again;
+        EXPECT_SUCCESS(key_share_size_again = s2n_extensions_client_key_share_size(conn));
+        EXPECT_EQUAL(key_share_size, key_share_size_again);
+
+        /* should equal the size of the data written on send */
+        EXPECT_SUCCESS(s2n_stuffer_alloc(&key_share_extension, key_share_size));
+        EXPECT_SUCCESS(s2n_extensions_client_key_share_send(conn, &key_share_extension));
+        EXPECT_EQUAL(key_share_size, s2n_stuffer_data_available(&key_share_extension));
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&key_share_extension));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test s2n_extensions_key_share_send */
+    {
+        /* Test that s2n_extensions_key_share_send initializes the client key share list */
+        {
+            struct s2n_stuffer key_share_extension;
+            EXPECT_SUCCESS(s2n_stuffer_alloc(&key_share_extension, s2n_extensions_client_key_share_size(conn)));
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+            EXPECT_SUCCESS(s2n_extensions_client_key_share_send(conn, &key_share_extension));
+
+            for (int i = 0; i < S2N_ECC_SUPPORTED_CURVES_COUNT; i++) {
+                struct s2n_ecc_params *ecc_params = &conn->secure.client_ecc_params[i];
+                EXPECT_EQUAL(ecc_params->negotiated_curve, &s2n_ecc_supported_curves[i]);
+                EXPECT_NOT_NULL(ecc_params->ec_key);
+            }
+
+            EXPECT_SUCCESS(s2n_stuffer_free(&key_share_extension));
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Test that s2n_extensions_key_share_send writes a well-formed list of key shares */
+        {
+            struct s2n_stuffer key_share_extension;
+            EXPECT_SUCCESS(s2n_stuffer_alloc(&key_share_extension, s2n_extensions_client_key_share_size(conn)));
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+            EXPECT_SUCCESS(s2n_extensions_client_key_share_send(conn, &key_share_extension));
+
+            /* should start with correct extension type */
+            uint16_t extension_type;
+            EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &extension_type));
+            EXPECT_EQUAL(extension_type, TLS_EXTENSION_KEY_SHARE);
+
+            /* should start with correct extension size */
+            uint16_t extension_size;
+            EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &extension_size));
+            uint16_t actual_extension_size = s2n_stuffer_data_available(&key_share_extension);
+            EXPECT_EQUAL(extension_size, actual_extension_size);
+
+            /* should have correct shares size */
+            uint16_t key_shares_size;
+            EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &key_shares_size));
+            uint16_t actual_key_shares_size = s2n_stuffer_data_available(&key_share_extension);
+            EXPECT_EQUAL(key_shares_size, actual_key_shares_size);
+
+            /* should contain every supported curve, in order, with their sizes */
+            for (int i = 0; i < S2N_ECC_SUPPORTED_CURVES_COUNT; i++) {
+                uint16_t iana_value, share_size;
+                EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &iana_value));
+                EXPECT_EQUAL(iana_value, s2n_ecc_supported_curves[i].iana_id);
+                EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &share_size));
+                EXPECT_EQUAL(share_size, s2n_ecc_supported_curves[i].share_size);
+
+                EXPECT_SUCCESS(s2n_stuffer_skip_read(&key_share_extension, share_size));
+            }
+
+            EXPECT_SUCCESS(s2n_stuffer_free(&key_share_extension));
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+    }
+
+    END_TEST();
+    return 0;
+}

--- a/tls/extensions/s2n_client_key_share.c
+++ b/tls/extensions/s2n_client_key_share.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "tls/extensions/s2n_client_key_share.h"
+
+#include "crypto/s2n_ecc.h"
+#include "error/s2n_errno.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+#define S2N_SIZE_OF_EXTENSION_TYPE          2
+#define S2N_SIZE_OF_EXTENSION_DATA_SIZE     2
+#define S2N_SIZE_OF_CLIENT_SHARES_SIZE      2
+#define S2N_SIZE_OF_NAMED_GROUP             2
+#define S2N_SIZE_OF_KEY_SHARE_SIZE          2
+
+/**
+ * Specified in https://tools.ietf.org/html/rfc8446#section-4.2.8
+ * "The "key_share" extension contains the endpoint's cryptographic parameters."
+ *
+ * Structure:
+ * Extension type (2 bytes)
+ * Extension data size (2 bytes)
+ * Client shares size (2 bytes)
+ * Client shares:
+ *      Named group (2 bytes)
+ *      Key share size (2 bytes)
+ *      Key share (variable size)
+ **/
+
+static int s2n_ecdhe_parameters_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+
+int s2n_client_key_share_extension_size;
+
+int s2n_client_key_share_init()
+{
+    s2n_client_key_share_extension_size = S2N_SIZE_OF_EXTENSION_TYPE
+            + S2N_SIZE_OF_EXTENSION_DATA_SIZE
+            + S2N_SIZE_OF_CLIENT_SHARES_SIZE;
+
+    for (int i = 0; i < S2N_ECC_SUPPORTED_CURVES_COUNT; i++) {
+        s2n_client_key_share_extension_size += S2N_SIZE_OF_KEY_SHARE_SIZE + S2N_SIZE_OF_NAMED_GROUP;
+        s2n_client_key_share_extension_size += s2n_ecc_supported_curves[i].share_size;
+    }
+
+    return 0;
+}
+
+int s2n_extensions_client_key_share_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    S2N_ERROR(S2N_ERR_UNIMPLEMENTED);
+}
+
+int s2n_extensions_client_key_share_size(struct s2n_connection *conn)
+{
+    return s2n_client_key_share_extension_size;
+}
+
+int s2n_extensions_client_key_share_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    const uint16_t extension_type = TLS_EXTENSION_KEY_SHARE;
+    const uint16_t extension_data_size =
+            s2n_client_key_share_extension_size - S2N_SIZE_OF_EXTENSION_TYPE - S2N_SIZE_OF_EXTENSION_DATA_SIZE;
+    const uint16_t client_shares_size =
+            extension_data_size - S2N_SIZE_OF_CLIENT_SHARES_SIZE;
+
+    GUARD(s2n_stuffer_write_uint16(out, extension_type));
+    GUARD(s2n_stuffer_write_uint16(out, extension_data_size));
+    GUARD(s2n_stuffer_write_uint16(out, client_shares_size));
+
+    GUARD(s2n_ecdhe_parameters_send(conn, out));
+
+    return 0;
+}
+
+static int s2n_ecdhe_parameters_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    const struct s2n_ecc_named_curve *named_curve = NULL;
+    struct s2n_ecc_params *ecc_params = NULL;
+
+    for (int i = 0; i < S2N_ECC_SUPPORTED_CURVES_COUNT; i++) {
+        ecc_params = &conn->secure.client_ecc_params[i];
+        named_curve = &s2n_ecc_supported_curves[i];
+
+        ecc_params->negotiated_curve = named_curve;
+
+        GUARD(s2n_stuffer_write_uint16(out, named_curve->iana_id));
+        GUARD(s2n_stuffer_write_uint16(out, named_curve->share_size));
+
+        GUARD(s2n_ecc_generate_ephemeral_key(ecc_params));
+        GUARD(s2n_ecc_write_ecc_params_point(ecc_params, out));
+    }
+
+    return 0;
+}

--- a/tls/extensions/s2n_client_key_share.h
+++ b/tls/extensions/s2n_client_key_share.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include "tls/s2n_connection.h"
+#include "stuffer/s2n_stuffer.h"
+
+extern int s2n_client_key_share_init();
+extern int s2n_extensions_client_key_share_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
+extern int s2n_extensions_client_key_share_size(struct s2n_connection *conn);
+extern int s2n_extensions_client_key_share_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+

--- a/tls/s2n_client_extensions.c
+++ b/tls/s2n_client_extensions.c
@@ -28,6 +28,7 @@
 #include "tls/s2n_resume.h"
 
 #include "extensions/s2n_client_supported_versions.h"
+#include "extensions/s2n_client_key_share.h"
 #include "stuffer/s2n_stuffer.h"
 
 #include "tls/s2n_tls.h"
@@ -129,12 +130,14 @@ int s2n_client_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *
 
     if (conn->client_protocol_version >= S2N_TLS13) {
         total_size += s2n_extensions_client_supported_versions_size(conn);
+        total_size += s2n_extensions_client_key_share_size(conn);
     }
 
     GUARD(s2n_stuffer_write_uint16(out, total_size));
 
     if (conn->client_protocol_version >= S2N_TLS13) {
         GUARD(s2n_extensions_client_supported_versions_send(conn, out));
+        GUARD(s2n_extensions_client_key_share_send(conn, out));
     }
 
     if (conn->actual_protocol_version >= S2N_TLS12) {

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -298,6 +298,9 @@ static int s2n_connection_wipe_keys(struct s2n_connection *conn)
     s2n_x509_validator_wipe(&conn->x509_validator);
     GUARD(s2n_dh_params_free(&conn->secure.server_dh_params));
     GUARD(s2n_ecc_params_free(&conn->secure.server_ecc_params));
+    for (int i=0; i< S2N_ECC_SUPPORTED_CURVES_COUNT; i++) {
+        GUARD(s2n_ecc_params_free(&conn->secure.client_ecc_params[i]));
+    }
     GUARD(s2n_kem_free(&conn->secure.s2n_kem_keys));
     GUARD(s2n_free(&conn->secure.client_cert_chain));
     GUARD(s2n_free(&conn->ct_response));

--- a/tls/s2n_crypto.h
+++ b/tls/s2n_crypto.h
@@ -64,6 +64,7 @@ struct s2n_crypto_parameters {
     struct s2n_pkey client_public_key;
     struct s2n_dh_params server_dh_params;
     struct s2n_ecc_params server_ecc_params;
+    struct s2n_ecc_params client_ecc_params[S2N_ECC_SUPPORTED_CURVES_COUNT];
     struct s2n_kem_keypair s2n_kem_keys;
     struct s2n_blob client_key_exchange_message;
     struct s2n_blob client_pq_kem_extension;

--- a/tls/s2n_tls_parameters.h
+++ b/tls/s2n_tls_parameters.h
@@ -90,6 +90,7 @@
 
 /* TLS 1.3 extensions from https://tools.ietf.org/html/rfc8446#section-4.2 */
 #define TLS_EXTENSION_SUPPORTED_VERSIONS   43
+#define TLS_EXTENSION_KEY_SHARE            51
 
 /* TLS Signature Algorithms - RFC 5246 7.4.1.4.1*/
 #define TLS_SIGNATURE_ALGORITHM_ANONYMOUS   0

--- a/utils/s2n_init.c
+++ b/utils/s2n_init.c
@@ -17,6 +17,7 @@
 #include "tls/s2n_cipher_preferences.h"
 #include "tls/s2n_cipher_suites.h"
 #include "tls/s2n_client_extensions.h"
+#include "tls/extensions/s2n_client_key_share.h"
 
 #include "utils/s2n_mem.h"
 #include "utils/s2n_random.h"
@@ -38,6 +39,7 @@ int s2n_init(void)
     GUARD(s2n_rand_init());
     GUARD(s2n_cipher_suites_init());
     GUARD(s2n_cipher_preferences_init());
+    GUARD(s2n_client_key_share_init());
 
     S2N_ERROR_IF(atexit(s2n_cleanup_atexit) != 0, S2N_ERR_ATEXIT);
 


### PR DESCRIPTION
**Issue # (if available):** [893](https://github.com/awslabs/s2n/issues/893)

**Description of changes:** 
Initial key_share implementation that just generates and saves ecc_params for all supported curves. It does NOT support DH key exchange, but DH is only currently used in the KMS TLS1.2 cipher preferences as a final fallback.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
