### PR TITLE
Add Missing notnull checks to DRBG

### DIFF
--- a/crypto/s2n_drbg.c
+++ b/crypto/s2n_drbg.c
@@ -44,6 +44,7 @@ int s2n_increment_drbg_counter(struct s2n_blob *counter)
 
 static int s2n_drbg_block_encrypt(EVP_CIPHER_CTX * ctx, uint8_t in[S2N_DRBG_BLOCK_SIZE], uint8_t out[S2N_DRBG_BLOCK_SIZE])
 {
+    notnull_check(ctx);
     int len = S2N_DRBG_BLOCK_SIZE;
     GUARD_OSSL(EVP_EncryptUpdate(ctx, out, &len, in, S2N_DRBG_BLOCK_SIZE), S2N_ERR_DRBG);
     eq_check(len, S2N_DRBG_BLOCK_SIZE);
@@ -53,6 +54,10 @@ static int s2n_drbg_block_encrypt(EVP_CIPHER_CTX * ctx, uint8_t in[S2N_DRBG_BLOC
 
 static int s2n_drbg_bits(struct s2n_drbg *drbg, struct s2n_blob *out)
 {
+    notnull_check(drbg);
+    notnull_check(drbg->ctx);
+    notnull_check(out);
+
     struct s2n_blob value = {.data = drbg->v,.size = sizeof(drbg->v) };
     int block_aligned_size = out->size - (out->size % S2N_DRBG_BLOCK_SIZE);
 
@@ -79,6 +84,9 @@ static int s2n_drbg_bits(struct s2n_drbg *drbg, struct s2n_blob *out)
 
 static int s2n_drbg_update(struct s2n_drbg *drbg, struct s2n_blob *provided_data)
 {
+    notnull_check(drbg);
+    notnull_check(drbg->ctx);
+
     s2n_stack_blob(temp_blob, s2n_drbg_seed_size(drgb), S2N_DRBG_MAX_SEED_SIZE);
 
     eq_check(provided_data->size, s2n_drbg_seed_size(drbg));
@@ -100,6 +108,8 @@ static int s2n_drbg_update(struct s2n_drbg *drbg, struct s2n_blob *provided_data
 
 static int s2n_drbg_seed(struct s2n_drbg *drbg, struct s2n_blob *ps)
 {
+    notnull_check(drbg);
+    notnull_check(drbg->ctx);
     s2n_stack_blob(blob, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
 
     if (drbg->entropy_generator) {
@@ -122,6 +132,7 @@ static int s2n_drbg_seed(struct s2n_drbg *drbg, struct s2n_blob *ps)
 
 int s2n_drbg_instantiate(struct s2n_drbg *drbg, struct s2n_blob *personalization_string, const s2n_drbg_mode mode)
 {
+    notnull_check(drbg);
     S2N_ERROR_IF(mode == S2N_DANGEROUS_AES_256_CTR_NO_DF_NO_PR && !S2N_IN_UNIT_TEST, S2N_ERR_NOT_IN_UNIT_TEST);
     S2N_ERROR_IF(drbg->entropy_generator != NULL && !S2N_IN_UNIT_TEST, S2N_ERR_NOT_IN_UNIT_TEST);
 
@@ -175,6 +186,8 @@ int s2n_drbg_instantiate(struct s2n_drbg *drbg, struct s2n_blob *personalization
 
 int s2n_drbg_generate(struct s2n_drbg *drbg, struct s2n_blob *blob)
 {
+    notnull_check(drbg);
+    notnull_check(drbg->ctx);
     s2n_stack_blob(zeros, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
 
     S2N_ERROR_IF(blob->size > S2N_DRBG_GENERATE_LIMIT, S2N_ERR_DRBG_REQUEST_SIZE);
@@ -194,6 +207,7 @@ int s2n_drbg_generate(struct s2n_drbg *drbg, struct s2n_blob *blob)
 
 int s2n_drbg_wipe(struct s2n_drbg *drbg)
 {
+    notnull_check(drbg);
     struct s2n_blob state = {.data = (void *)drbg,.size = sizeof(struct s2n_drbg) };
 
     if (drbg->ctx) {
@@ -210,5 +224,6 @@ int s2n_drbg_wipe(struct s2n_drbg *drbg)
 
 int s2n_drbg_bytes_used(struct s2n_drbg *drbg)
 {
+    notnull_check(drbg);
     return drbg->bytes_used;
 }


### PR DESCRIPTION
**Issue # (if available):**  N/A

**Description of changes:** 
Adds missing `notnull_check()` calls to DRBG code

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
