### PR TITLE
Add server supported_versions extension for ServerHello

### DIFF
--- a/tests/unit/s2n_server_supported_versions_extension_test.c
+++ b/tests/unit/s2n_server_supported_versions_extension_test.c
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include <stdint.h>
+
+#include "tls/s2n_config.h"
+#include "tls/s2n_connection.h"
+#include "tls/s2n_tls.h"
+#include "tls/s2n_tls13.h"
+#include "tls/extensions/s2n_server_supported_versions.h"
+
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+int write_test_supported_version(struct s2n_stuffer *list, uint8_t supported_version) {
+    GUARD(s2n_stuffer_write_uint8(list, S2N_TLS_PROTOCOL_VERSION_LEN));
+
+    GUARD(s2n_stuffer_write_uint8(list, supported_version / 10));
+    GUARD(s2n_stuffer_write_uint8(list, supported_version % 10));
+
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    EXPECT_SUCCESS(s2n_enable_tls13());
+    uint8_t latest_version = S2N_TLS13;
+
+    struct s2n_config *config;
+    EXPECT_NOT_NULL(config = s2n_config_new());
+
+    /* Server sends a supported_version the client can parse */
+    {
+        struct s2n_connection *server_conn;
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        uint16_t expected_length = 6;
+
+        struct s2n_stuffer extension;
+        s2n_stuffer_alloc(&extension, expected_length);
+
+        EXPECT_SUCCESS(s2n_extensions_server_supported_versions_send(server_conn, &extension));
+
+        /* Check that type and size are correct */
+        uint16_t extension_type;
+        s2n_stuffer_read_uint16(&extension, &extension_type);
+        EXPECT_EQUAL(extension_type, TLS_EXTENSION_SUPPORTED_VERSIONS);
+        uint16_t extension_length;
+        s2n_stuffer_read_uint16(&extension, &extension_length);
+        EXPECT_EQUAL(extension_length, s2n_stuffer_data_available(&extension));
+
+        /* Check that the client can process the version */
+        struct s2n_connection *client_conn;
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
+        EXPECT_SUCCESS(s2n_extensions_server_supported_versions_recv(client_conn, &extension));
+        EXPECT_EQUAL(client_conn->client_protocol_version, latest_version);
+        EXPECT_EQUAL(client_conn->server_protocol_version, latest_version);
+        EXPECT_EQUAL(client_conn->actual_protocol_version, latest_version);
+
+        /* Clean up */
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_stuffer_free(&extension));
+    }
+
+    /* Client alerts if supported_version less than min supported by client */
+    {
+        struct s2n_connection *client_conn;
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
+        uint8_t unsupported_version_unknown = S2N_UNKNOWN_PROTOCOL_VERSION;
+
+        uint16_t supported_version_length = 6;
+
+        struct s2n_stuffer extension;
+        s2n_stuffer_alloc(&extension, supported_version_length);
+
+        EXPECT_SUCCESS(write_test_supported_version(&extension, unsupported_version_unknown));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_server_supported_versions_recv(client_conn, &extension), S2N_ERR_BAD_MESSAGE);
+
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_stuffer_free(&extension));
+    }
+
+    /* Client alerts if supported_version greater than max supported by client */
+    {
+        struct s2n_connection *client_conn;
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
+        uint8_t unsupported_version_gt_tls13 = 255;
+
+        uint16_t supported_version_length = 6;
+
+        struct s2n_stuffer extension;
+        s2n_stuffer_alloc(&extension, supported_version_length);
+
+        EXPECT_SUCCESS(write_test_supported_version(&extension, unsupported_version_gt_tls13));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_server_supported_versions_recv(client_conn, &extension), S2N_ERR_BAD_MESSAGE);
+
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_stuffer_free(&extension));
+    }
+
+    /* Client alerts if supported_version is empty */
+    {
+        struct s2n_connection *client_conn;
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
+        struct s2n_stuffer extension;
+        s2n_stuffer_alloc(&extension, 1);
+        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&extension, 0));
+
+        EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_server_supported_versions_recv(client_conn, &extension), S2N_ERR_BAD_MESSAGE);
+
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_stuffer_free(&extension));
+    }
+
+    /* Client alerts if supported_version is malformed */
+    {
+        struct s2n_connection *client_conn;
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
+        struct s2n_stuffer extension;
+        s2n_stuffer_alloc(&extension, 1);
+
+        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&extension, 13));
+
+        EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_server_supported_versions_recv(client_conn, &extension), S2N_ERR_BAD_MESSAGE);
+
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_stuffer_free(&extension));
+    }
+
+    EXPECT_SUCCESS(s2n_config_free(config));
+
+    END_TEST();
+    return 0;
+}

--- a/tls/extensions/s2n_server_supported_versions.c
+++ b/tls/extensions/s2n_server_supported_versions.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <sys/param.h>
+#include <stdint.h>
+
+#include "tls/extensions/s2n_server_supported_versions.h"
+#include "tls/extensions/s2n_supported_versions.h"
+#include "tls/s2n_alerts.h"
+#include "tls/s2n_cipher_preferences.h"
+#include "tls/s2n_tls.h"
+#include "tls/s2n_tls_parameters.h"
+
+#include "utils/s2n_safety.h"
+
+/**
+ * Specified in https://tools.ietf.org/html/rfc8446#section-4.2.1
+ *
+ * "A server which negotiates TLS 1.3 MUST respond by sending a 
+ * "supported_versions" extension containing the selected version value 
+ * (0x0304)."
+ *
+ * Structure:
+ * Extension type (2 bytes)
+ * Extension size (2 bytes)
+ * Selected Version (2 byte)
+ **/
+
+int s2n_extensions_server_supported_versions_size()
+{
+    return 6;
+}
+
+int s2n_extensions_server_supported_versions_process(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    uint8_t highest_supported_version = conn->client_protocol_version;
+    uint8_t minimum_supported_version;
+    GUARD(s2n_connection_get_minimum_supported_version(conn, &minimum_supported_version));
+
+    uint8_t server_version_parts[S2N_TLS_PROTOCOL_VERSION_LEN];
+    GUARD(s2n_stuffer_read_bytes(extension, server_version_parts, S2N_TLS_PROTOCOL_VERSION_LEN));
+
+    uint16_t server_version = (server_version_parts[0] * 10) + server_version_parts[1];
+
+    gte_check(server_version, S2N_TLS13);
+    lte_check(server_version, highest_supported_version);
+    gte_check(server_version, minimum_supported_version);
+
+    conn->server_protocol_version = server_version;
+    
+    return 0;
+}
+
+int s2n_extensions_server_supported_versions_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    S2N_ERROR_IF(s2n_extensions_server_supported_versions_process(conn, extension) < 0, S2N_ERR_BAD_MESSAGE);
+
+    return 0;
+}
+
+int s2n_extensions_server_supported_versions_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    int extension_length = s2n_extensions_server_supported_versions_size();
+
+    GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_SUPPORTED_VERSIONS));
+    GUARD(s2n_stuffer_write_uint16(out, extension_length - 4));
+
+    GUARD(s2n_stuffer_write_uint8(out, conn->server_protocol_version / 10));
+    GUARD(s2n_stuffer_write_uint8(out, conn->server_protocol_version % 10));
+
+    return 0;
+}

--- a/tls/extensions/s2n_server_supported_versions.h
+++ b/tls/extensions/s2n_server_supported_versions.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+
+#pragma once
+
+#include "tls/s2n_connection.h"
+#include "stuffer/s2n_stuffer.h"
+
+extern int s2n_extensions_server_supported_versions_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
+extern int s2n_extensions_server_supported_versions_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+extern int s2n_extensions_server_supported_versions_size();

--- a/tls/extensions/s2n_supported_versions.c
+++ b/tls/extensions/s2n_supported_versions.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <sys/param.h>
+#include <stdint.h>
+
+#include "tls/extensions/s2n_supported_versions.h"
+#include "tls/s2n_cipher_preferences.h"
+
+#include "utils/s2n_safety.h"
+
+int s2n_connection_get_minimum_supported_version(struct s2n_connection *conn, uint8_t *min_version) 
+{
+    const struct s2n_cipher_preferences *cipher_preferences;
+    GUARD(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
+    *min_version = cipher_preferences->minimum_protocol_version;
+
+    return 0;
+}

--- a/tls/extensions/s2n_supported_versions.h
+++ b/tls/extensions/s2n_supported_versions.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include "tls/s2n_connection.h"
+#include "stuffer/s2n_stuffer.h"
+
+extern int s2n_connection_get_minimum_supported_version(struct s2n_connection *conn, uint8_t *min_version);

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -44,7 +44,6 @@ int s2n_server_hello_recv(struct s2n_connection *conn)
     uint16_t extensions_size;
     uint8_t protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN];
     uint8_t session_id[S2N_TLS_SESSION_ID_MAX_LEN];
-    uint8_t actual_protocol_version;
 
     GUARD(s2n_stuffer_read_bytes(in, protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));
     GUARD(s2n_stuffer_read_bytes(in, conn->secure.server_random, S2N_TLS_RANDOM_DATA_LEN));
@@ -59,41 +58,6 @@ int s2n_server_hello_recv(struct s2n_connection *conn)
     GUARD(s2n_stuffer_read_uint8(in, &compression_method));
     S2N_ERROR_IF(compression_method != S2N_TLS_COMPRESSION_METHOD_NULL, S2N_ERR_BAD_MESSAGE);
 
-    conn->server_protocol_version = (uint8_t)(protocol_version[0] * 10) + protocol_version[1];
-    const struct s2n_cipher_preferences *cipher_preferences;
-    GUARD(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
-
-    if (conn->server_protocol_version < cipher_preferences->minimum_protocol_version
-            || conn->server_protocol_version > conn->client_protocol_version) {
-        GUARD(s2n_queue_reader_unsupported_protocol_version_alert(conn));
-        S2N_ERROR(S2N_ERR_BAD_MESSAGE);
-    }
-
-    actual_protocol_version = MIN(conn->server_protocol_version, conn->client_protocol_version);
-
-    /* Use the session state if server sent same session id as client sent in client hello */
-    if (session_id_len != 0  && session_id_len == conn->session_id_len
-            && !memcmp(session_id, conn->session_id, session_id_len)) {
-        /* check if the resumed session state is valid */
-        S2N_ERROR_IF(conn->actual_protocol_version != actual_protocol_version, S2N_ERR_BAD_MESSAGE);
-        S2N_ERROR_IF(memcmp(conn->secure.cipher_suite->iana_value, cipher_suite_wire, S2N_TLS_CIPHER_SUITE_LEN) != 0, S2N_ERR_BAD_MESSAGE);
-
-        /* Session is resumed */
-        conn->client_session_resumed = 1;
-    } else {
-        conn->session_id_len = session_id_len;
-        memcpy_check(conn->session_id, session_id, session_id_len);
-        conn->actual_protocol_version = actual_protocol_version;
-        GUARD(s2n_set_cipher_as_client(conn, cipher_suite_wire));
-        /* Erase master secret which might have been set for session resumption */
-        memset_check((uint8_t *)conn->secure.master_secret, 0, S2N_TLS_SECRET_LEN);
-
-        /* Erase client session ticket which might have been set for session resumption */
-        conn->client_ticket.size = 0;
-    }
-
-    conn->actual_protocol_version_established = 1;
-
     if (s2n_stuffer_data_available(in) >= 2) {
         GUARD(s2n_stuffer_read_uint16(in, &extensions_size));
 
@@ -106,6 +70,50 @@ int s2n_server_hello_recv(struct s2n_connection *conn)
 
         GUARD(s2n_server_extensions_recv(conn, &extensions));
     }
+
+    if (conn->server_protocol_version >= S2N_TLS13) {
+        /* Check echoed session ID matches */
+        S2N_ERROR_IF(session_id_len != conn->session_id_len || !memcmp(session_id, conn->session_id, session_id_len), S2N_ERR_BAD_MESSAGE);
+        conn->actual_protocol_version = conn->server_protocol_version;
+        GUARD(s2n_set_cipher_as_client(conn, cipher_suite_wire));
+    } else {
+        uint8_t actual_protocol_version;
+
+        conn->server_protocol_version = (uint8_t)(protocol_version[0] * 10) + protocol_version[1];
+        const struct s2n_cipher_preferences *cipher_preferences;
+        GUARD(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
+
+        if (conn->server_protocol_version < cipher_preferences->minimum_protocol_version
+                || conn->server_protocol_version > conn->client_protocol_version) {
+            GUARD(s2n_queue_reader_unsupported_protocol_version_alert(conn));
+            S2N_ERROR(S2N_ERR_BAD_MESSAGE);
+        }
+
+        actual_protocol_version = MIN(conn->server_protocol_version, conn->client_protocol_version);
+
+        /* Use the session state if server sent same session id as client sent in client hello */
+        if (session_id_len != 0  && session_id_len == conn->session_id_len
+                && !memcmp(session_id, conn->session_id, session_id_len)) {
+            /* check if the resumed session state is valid */
+            S2N_ERROR_IF(conn->actual_protocol_version != actual_protocol_version, S2N_ERR_BAD_MESSAGE);
+            S2N_ERROR_IF(memcmp(conn->secure.cipher_suite->iana_value, cipher_suite_wire, S2N_TLS_CIPHER_SUITE_LEN) != 0, S2N_ERR_BAD_MESSAGE);
+
+            /* Session is resumed */
+            conn->client_session_resumed = 1;
+        } else {
+            conn->session_id_len = session_id_len;
+            memcpy_check(conn->session_id, session_id, session_id_len);
+            conn->actual_protocol_version = actual_protocol_version;
+            GUARD(s2n_set_cipher_as_client(conn, cipher_suite_wire));
+            /* Erase master secret which might have been set for session resumption */
+            memset_check((uint8_t *)conn->secure.master_secret, 0, S2N_TLS_SECRET_LEN);
+
+            /* Erase client session ticket which might have been set for session resumption */
+            conn->client_ticket.size = 0;
+        }
+    }
+
+    conn->actual_protocol_version_established = 1;
 
     GUARD(s2n_conn_set_handshake_type(conn));
 


### PR DESCRIPTION
**Issue # (if available):** https://github.com/awslabs/s2n/issues/1146

**Description of changes:** 

 - Add server supported_versions extension for ServerHello

 - Address get_minimum_supported_version comments from PR #1112


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
