### PR TITLE
Fix compilation for Android AArch64

### DIFF
--- a/pq-crypto/bike/utilities.h
+++ b/pq-crypto/bike/utilities.h
@@ -113,7 +113,6 @@ _INLINE_ uint32_t secure_cmp32(IN const uint32_t v1, IN const uint32_t v2)
 // Return 0 if v1 < v2, (-1) otherwise
 _INLINE_ uint32_t secure_l32_mask(IN const uint32_t v1, IN const uint32_t v2)
 {
-
 #if defined(__aarch64__)
     uint32_t res;
     __asm__ __volatile__("cmp  %w1, %w2; \n "
@@ -129,11 +128,9 @@ _INLINE_ uint32_t secure_l32_mask(IN const uint32_t v1, IN const uint32_t v2)
                          "setl %%dl; \n"
                          "dec %%edx; \n"
                          "mov %%edx, %0; \n"
-
                          : "=r" (res)
                          : "r"(v2), "r"(v1)
                          : "rdx");
-
     return res;
 #else
     // If v1 >= v2 then the subtraction result is 0^32||(v1-v2)

--- a/pq-crypto/bike/utilities.h
+++ b/pq-crypto/bike/utilities.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-* Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+* Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 *
 * Written by Nir Drucker and Shay Gueron
@@ -83,8 +83,8 @@ _INLINE_ uint32_t secure_cmp32(IN const uint32_t v1, IN const uint32_t v2)
 {
 #if defined(__aarch64__)
     uint32_t res;
-    __asm__ __volatile__("cmp  %1, %2; \n "
-                         "cset %0, EQ; \n"
+    __asm__ __volatile__("cmp  %w1, %w2; \n "
+                         "cset %w0, EQ; \n"
                          : "=r" (res)
                          : "r"(v1), "r"(v2)
                          :);
@@ -104,7 +104,7 @@ _INLINE_ uint32_t secure_cmp32(IN const uint32_t v1, IN const uint32_t v2)
     // branches and thus to prevent potential side channel attacks. To do that
     // we normally leverage some CPU special instructions such as "sete"
     // (for __x86_64__) and "cset" (for __aarch64__). When dealing with general
-    // CPU architectures, the interpretation of the line below is left for the 
+    // CPU architectures, the interpretation of the line below is left for the
     // compiler, which may lead to an insecure branch.
     return (v1 == v2 ? 1 : 0);
 #endif
@@ -113,11 +113,11 @@ _INLINE_ uint32_t secure_cmp32(IN const uint32_t v1, IN const uint32_t v2)
 // Return 0 if v1 < v2, (-1) otherwise
 _INLINE_ uint32_t secure_l32_mask(IN const uint32_t v1, IN const uint32_t v2)
 {
-    
+
 #if defined(__aarch64__)
     uint32_t res;
-    __asm__ __volatile__("cmp  %1, %2; \n "
-                         "cset %0, LS; \n"
+    __asm__ __volatile__("cmp  %w1, %w2; \n "
+                         "cset %w0, LS; \n"
                          : "=r" (res)
                          : "r"(v1), "r"(v2)
                          :);
@@ -129,15 +129,15 @@ _INLINE_ uint32_t secure_l32_mask(IN const uint32_t v1, IN const uint32_t v2)
                          "setl %%dl; \n"
                          "dec %%edx; \n"
                          "mov %%edx, %0; \n"
-                         
+
                          : "=r" (res)
                          : "r"(v2), "r"(v1)
                          : "rdx");
-    
+
     return res;
 #else
     // If v1 >= v2 then the subtraction result is 0^32||(v1-v2)
-    // else it will be 1^32||(v2-v1+1). Subsequently, negating the upper 
+    // else it will be 1^32||(v2-v1+1). Subsequently, negating the upper
     // 32 bits gives 0 if v1 < v2 and otherwise (-1).
     return ~((uint32_t)(((uint64_t)v1 - (uint64_t)v2) >> 32));
 #endif

--- a/utils/s2n_asn1_time.c
+++ b/utils/s2n_asn1_time.c
@@ -45,7 +45,7 @@ typedef enum parser_state {
 } parser_state;
 
 static inline long get_gmt_offset(struct tm *t) {
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__APPLE__) && defined(__MACH__)
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__ANDROID__) || defined(__APPLE__) && defined(__MACH__)
     return t->tm_gmtoff;
 #else
     return t->__tm_gmtoff;

--- a/utils/s2n_asn1_time.c
+++ b/utils/s2n_asn1_time.c
@@ -45,7 +45,7 @@ typedef enum parser_state {
 } parser_state;
 
 static inline long get_gmt_offset(struct tm *t) {
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__ANDROID__) || defined(__APPLE__) && defined(__MACH__)
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__ANDROID__) || defined(ANDROID) || defined(__APPLE__) && defined(__MACH__)
     return t->tm_gmtoff;
 #else
     return t->__tm_gmtoff;


### PR DESCRIPTION
* Change inline asm to explicitly use 32 bit registers for 32 bit ints (See section 1.1 of the [instruction set](https://static.docs.arm.com/100898/0100/the_a64_Instruction_set_100898_0100.pdf))
* Use `tm_gmtoff` instead of `__tm_gmtoff`
* Apparently I also removed some trailing whitespace

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
