### PR TITLE
Allow travis build to run make with more jobs if possible

### DIFF
--- a/.travis/s2n_travis_build.sh
+++ b/.travis/s2n_travis_build.sh
@@ -38,25 +38,36 @@ if [[ -n "$GCC_VERSION" ]] && [[ "$GCC_VERSION" != "NONE" ]]; then
     alias gcc=$(which gcc-$GCC_VERSION);
 fi
 
+# Find if the environment has more than 8 cores
+JOBS=8
+if [[ -x "$(command -v nproc)" ]]; then
+    UNITS=$(nproc);
+    if [[ $UNITS -gt $JOBS ]]; then
+        JOBS=$UNITS;
+    fi
+fi
+
+echo "Using $JOBS jobs for make..";
+
 if [[ "$TRAVIS_OS_NAME" == "linux" && "$TESTS" == "valgrind" ]]; then
     # For linux make a build with debug symbols and run valgrind
     # We have to output something every 9 minutes, as some test may run longer than 10 minutes
     # and will not produce any output
     while sleep 9m; do echo "=====[ $SECONDS seconds still running ]====="; done &
-    S2N_DEBUG=true make -j 8 valgrind
+    S2N_DEBUG=true make -j $JOBS valgrind
     kill %1
 fi
 
 if [[ "$TRAVIS_OS_NAME" == "linux" && (("$TESTS" == "integration") || ("$TESTS" == "unit")) ]]; then
-    make -j 8
+    make -j $JOBS
 fi
 
 # Build and run unit tests with scan-build for osx. scan-build bundle isn't available for linux
 if [[ "$TRAVIS_OS_NAME" == "osx" && "$TESTS" == "integration" ]]; then  
-    scan-build --status-bugs -o /tmp/scan-build make -j8; STATUS=$?; test $STATUS -ne 0 && cat /tmp/scan-build/*/* ; [ "$STATUS" -eq "0" ]; 
+    scan-build --status-bugs -o /tmp/scan-build make -j$JOBS; STATUS=$?; test $STATUS -ne 0 && cat /tmp/scan-build/*/* ; [ "$STATUS" -eq "0" ];
 fi
 
-if [[ "$TESTS" == "ALL" || "$TESTS" == "asan" ]]; then make clean; S2N_ADDRESS_SANITIZER=1 make -j 8 ; fi
+if [[ "$TESTS" == "ALL" || "$TESTS" == "asan" ]]; then make clean; S2N_ADDRESS_SANITIZER=1 make -j $JOBS ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "integration" ]]; then make clean; make integration ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "fuzz" ]]; then (make clean && make fuzz) ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "sawHMAC" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make -C tests/saw/ tmp/"verify_s2n_hmac_$SAW_HMAC_TEST".log ; fi


### PR DESCRIPTION
**Issue # (if available):** 
The current travis build script uses 8 job. When running .travis/s2n_travis_build.sh on faster machines >8 cores, the build time is still pegged to the performance of 8 cores.

**Description of changes:** 
This change uses nprocs is check number of cores and run make -j with more threads when possible. This helps to speed up build process on more powerful machines.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
