### PR TITLE
Only allow tls1.3 to be enabled in tests

### DIFF
--- a/tests/unit/s2n_tls13_support_test.c
+++ b/tests/unit/s2n_tls13_support_test.c
@@ -143,6 +143,10 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_disable_tls13());
     EXPECT_FALSE(s2n_is_tls13_enabled());
 
+    /* TLS 1.3 can't be enabled outside of unit tests */
+    EXPECT_SUCCESS(unsetenv("S2N_UNIT_TEST"));
+    EXPECT_FAILURE_WITH_ERRNO(s2n_enable_tls13(), S2N_ERR_NOT_IN_UNIT_TEST);
+
     END_TEST();
     return 0;
 }

--- a/tls/s2n_tls13.c
+++ b/tls/s2n_tls13.c
@@ -16,6 +16,7 @@
 #include "api/s2n.h"
 #include "tls/s2n_tls.h"
 #include "tls/s2n_tls13.h"
+#include "utils/s2n_safety.h"
 
 int s2n_is_tls13_enabled()
 {
@@ -24,6 +25,7 @@ int s2n_is_tls13_enabled()
 
 int s2n_enable_tls13()
 {
+    S2N_ERROR_IF(!S2N_IN_TEST, S2N_ERR_NOT_IN_UNIT_TEST);
     s2n_highest_protocol_version = S2N_TLS13;
     return 0;
 }


### PR DESCRIPTION
**Issue # (if available):** 

**Description of changes:** 
I accidentally removed the "only in tests" restriction when we
swapped from a tls1.3 environment variable to the current setup.
Adding the restriction back and adding a unit test to keep it that way.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
