### PR TITLE
Add EncryptedExtensions Handshake Message Handler

### DIFF
--- a/tests/unit/s2n_encrypted_extensions_test.c
+++ b/tests/unit/s2n_encrypted_extensions_test.c
@@ -16,14 +16,108 @@
 #include "s2n_test.h"
 
 #include "tls/s2n_tls.h"
+#include "tls/s2n_tls13.h"
+#include "tls/extensions/s2n_server_supported_versions.h"
+
 #include "error/s2n_errno.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
 
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
-    EXPECT_FAILURE_WITH_ERRNO(s2n_encrypted_extensions_send(NULL), S2N_ERR_UNIMPLEMENTED);
-    EXPECT_FAILURE_WITH_ERRNO(s2n_encrypted_extensions_recv(NULL), S2N_ERR_UNIMPLEMENTED);
+    EXPECT_SUCCESS(s2n_enable_tls13());
+    uint8_t latest_version = S2N_TLS13;
+
+    struct s2n_config *config;
+    EXPECT_NOT_NULL(config = s2n_config_new());
+
+    /* Server successfully sends empty encrypted extension */
+    {
+        struct s2n_connection *server_conn;
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        uint8_t encrypted_extensions_expected_size = 2;
+        uint16_t encrypted_extensions_expected_length = 0;
+
+        EXPECT_SUCCESS(s2n_encrypted_extensions_send(server_conn));
+
+        /* Check that size and data in server_conn->handshake.io are correct */
+        struct s2n_stuffer *server_out = &server_conn->handshake.io;
+        uint16_t encrypted_extensions_actual_length;
+
+        EXPECT_EQUAL(encrypted_extensions_expected_size, s2n_stuffer_data_available(server_out));
+        s2n_stuffer_read_uint16(server_out, &encrypted_extensions_actual_length);
+        EXPECT_EQUAL(encrypted_extensions_expected_length, encrypted_extensions_actual_length);
+        EXPECT_EQUAL(encrypted_extensions_actual_length, s2n_stuffer_data_available(server_out));
+
+        /* Clean up */
+        EXPECT_SUCCESS(s2n_stuffer_free(server_out));
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+    }
+
+    /* Client successfully receives empty encrypted extension */
+    {
+        struct s2n_connection *client_conn;
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
+        EXPECT_SUCCESS(s2n_encrypted_extensions_send(client_conn));
+        EXPECT_SUCCESS(s2n_encrypted_extensions_recv(client_conn));
+
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+    }
+
+    /* Client successefully parses a non-empty encrypted extension */
+    {
+        struct s2n_connection *client_conn;
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
+        /* Write length of ALPN extension, then write the extension itself */
+        strcpy(client_conn->application_protocol, "h2");
+        const uint8_t application_protocol_len = strlen(client_conn->application_protocol);
+        uint16_t alpn_extension_length = 7 + application_protocol_len;
+        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&client_conn->handshake.io, alpn_extension_length));
+
+        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&client_conn->handshake.io, TLS_EXTENSION_ALPN));
+        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&client_conn->handshake.io, application_protocol_len + 3));
+        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&client_conn->handshake.io, application_protocol_len + 1));
+        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&client_conn->handshake.io, application_protocol_len));
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&client_conn->handshake.io, (uint8_t *) client_conn->application_protocol, application_protocol_len));
+
+        /* Client parses encrypted extensions */
+        strcpy(client_conn->application_protocol, "");
+        EXPECT_SUCCESS(s2n_encrypted_extensions_recv(client_conn));
+        EXPECT_SUCCESS(strcmp(client_conn->application_protocol, "h2"));
+
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+    }
+
+    /* Client does not parse a non-EE extension */
+    {
+        struct s2n_connection *client_conn;
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+        client_conn->server_protocol_version = latest_version;
+
+        /* write length of supported versions extension (6) then write the extension itself */
+        uint16_t supported_versions_extension_length = 6;
+        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&client_conn->handshake.io, supported_versions_extension_length));
+        EXPECT_SUCCESS(s2n_extensions_server_supported_versions_send(client_conn, &client_conn->handshake.io));
+
+        client_conn->server_protocol_version = 0;
+        EXPECT_FAILURE_WITH_ERRNO(s2n_encrypted_extensions_recv(client_conn), S2N_ERR_BAD_MESSAGE);
+
+        EXPECT_EQUAL(client_conn->client_protocol_version, latest_version);
+        EXPECT_NOT_EQUAL(client_conn->server_protocol_version, latest_version);
+
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+    }
+
+    EXPECT_SUCCESS(s2n_config_free(config));
 
     END_TEST();
 }

--- a/tls/extensions/s2n_server_alpn.c
+++ b/tls/extensions/s2n_server_alpn.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "stuffer/s2n_stuffer.h"
+
+#include "utils/s2n_safety.h"
+
+#include "tls/s2n_connection.h"
+#include "tls/s2n_tls.h"
+
+#include "tls/extensions/s2n_server_alpn.h"
+
+int s2n_recv_server_alpn(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    uint16_t size_of_all;
+    GUARD(s2n_stuffer_read_uint16(extension, &size_of_all));
+    if (size_of_all > s2n_stuffer_data_available(extension) || size_of_all < 3) {
+        /* ignore invalid extension size */
+        return 0;
+    }
+
+    uint8_t protocol_len;
+    GUARD(s2n_stuffer_read_uint8(extension, &protocol_len));
+
+    uint8_t *protocol = s2n_stuffer_raw_read(extension, protocol_len);
+    notnull_check(protocol);
+
+    /* copy the first protocol name */
+    memcpy_check(conn->application_protocol, protocol, protocol_len);
+    conn->application_protocol[protocol_len] = '\0';
+
+    return 0;
+}

--- a/tls/extensions/s2n_server_alpn.h
+++ b/tls/extensions/s2n_server_alpn.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+extern int s2n_recv_server_alpn(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_server_max_fragment_length.c
+++ b/tls/extensions/s2n_server_max_fragment_length.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "error/s2n_errno.h"
+
+#include "stuffer/s2n_stuffer.h"
+
+#include "utils/s2n_safety.h"
+
+#include "tls/s2n_tls_parameters.h"
+#include "tls/s2n_connection.h"
+
+#include "tls/extensions/s2n_server_max_fragment_length.h"
+
+int s2n_recv_server_max_fragment_length(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    uint8_t mfl_code;
+    GUARD(s2n_stuffer_read_uint8(extension, &mfl_code));
+    S2N_ERROR_IF(mfl_code != conn->config->mfl_code, S2N_ERR_MAX_FRAG_LEN_MISMATCH);
+
+    return 0;
+}

--- a/tls/extensions/s2n_server_max_fragment_length.h
+++ b/tls/extensions/s2n_server_max_fragment_length.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+extern int s2n_recv_server_max_fragment_length(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_server_renegotiation_info.c
+++ b/tls/extensions/s2n_server_renegotiation_info.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "error/s2n_errno.h"
+
+#include "stuffer/s2n_stuffer.h"
+
+#include "utils/s2n_safety.h"
+
+#include "tls/s2n_tls_parameters.h"
+#include "tls/s2n_connection.h"
+
+#include "tls/extensions/s2n_server_renegotiation_info.h"
+
+int s2n_recv_server_renegotiation_info_ext(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    /* RFC5746 Section 3.4: The client MUST then verify that the length of
+     * the "renegotiated_connection" field is zero, and if it is not, MUST
+     * abort the handshake. */
+    uint8_t renegotiated_connection_len;
+    GUARD(s2n_stuffer_read_uint8(extension, &renegotiated_connection_len));
+    S2N_ERROR_IF(s2n_stuffer_data_available(extension), S2N_ERR_NON_EMPTY_RENEGOTIATION_INFO);
+    S2N_ERROR_IF(renegotiated_connection_len, S2N_ERR_NON_EMPTY_RENEGOTIATION_INFO);
+
+    conn->secure_renegotiation = 1;
+    return 0;
+}

--- a/tls/extensions/s2n_server_renegotiation_info.h
+++ b/tls/extensions/s2n_server_renegotiation_info.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+extern int s2n_recv_server_renegotiation_info_ext(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_server_sct_list.c
+++ b/tls/extensions/s2n_server_sct_list.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "stuffer/s2n_stuffer.h"
+
+#include "utils/s2n_safety.h"
+#include "utils/s2n_blob.h"
+
+#include "tls/s2n_connection.h"
+#include "tls/extensions/s2n_server_sct_list.h"
+
+int s2n_recv_server_sct_list(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    struct s2n_blob sct_list = { .data = NULL, .size = 0 };
+
+    sct_list.size = s2n_stuffer_data_available(extension);
+    sct_list.data = s2n_stuffer_raw_read(extension, sct_list.size);
+    notnull_check(sct_list.data);
+
+    GUARD(s2n_dup(&sct_list, &conn->ct_response));
+
+    return 0;
+}

--- a/tls/extensions/s2n_server_sct_list.h
+++ b/tls/extensions/s2n_server_sct_list.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+extern int s2n_recv_server_sct_list(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_server_server_name.c
+++ b/tls/extensions/s2n_server_server_name.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "stuffer/s2n_stuffer.h"
+
+#include "tls/s2n_connection.h"
+#include "tls/extensions/s2n_server_server_name.h"
+
+int s2n_recv_server_server_name(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    conn->server_name_used = 1;
+    return 0;
+}

--- a/tls/extensions/s2n_server_server_name.h
+++ b/tls/extensions/s2n_server_server_name.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+extern int s2n_recv_server_server_name(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_server_session_ticket.c
+++ b/tls/extensions/s2n_server_session_ticket.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "stuffer/s2n_stuffer.h"
+
+#include "tls/s2n_tls_parameters.h"
+#include "tls/s2n_connection.h"
+
+#include "tls/extensions/s2n_server_session_ticket.h"
+
+int s2n_recv_server_session_ticket_ext(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    conn->session_ticket_status = S2N_NEW_TICKET;
+
+    return 0;
+}

--- a/tls/extensions/s2n_server_session_ticket.h
+++ b/tls/extensions/s2n_server_session_ticket.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+extern int s2n_recv_server_session_ticket_ext(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_server_status_request.c
+++ b/tls/extensions/s2n_server_status_request.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "stuffer/s2n_stuffer.h"
+
+#include "tls/s2n_tls_parameters.h"
+#include "tls/s2n_connection.h"
+
+#include "tls/extensions/s2n_server_status_request.h"
+
+int s2n_recv_server_status_request(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    conn->status_type = S2N_STATUS_REQUEST_OCSP;
+
+    return 0;
+}

--- a/tls/extensions/s2n_server_status_request.h
+++ b/tls/extensions/s2n_server_status_request.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+extern int s2n_recv_server_status_request(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/s2n_encrypted_extensions.c
+++ b/tls/s2n_encrypted_extensions.c
@@ -14,13 +14,128 @@
  */
 
 #include "error/s2n_errno.h"
+#include "utils/s2n_safety.h"
+#include "stuffer/s2n_stuffer.h"
+
+#include "tls/s2n_tls.h"
+#include "tls/s2n_tls13.h"
+
+#include "tls/extensions/s2n_server_alpn.h"
+#include "tls/extensions/s2n_server_sct_list.h"
+#include "tls/extensions/s2n_server_max_fragment_length.h"
+#include "tls/extensions/s2n_server_server_name.h"
+
+/**
+  * Specified in https://tools.ietf.org/html/rfc8446#section-4.3.1
+  * 
+  * In all handshakes, the server MUST send the EncryptedExtensions
+  * message immediately after the ServerHello message.  
+  *
+  * The EncryptedExtensions message contains extensions that can be
+  * protected, i.e., any which are not needed to establish the
+  * cryptographic context but which are not associated with individual
+  * certificates. 
+  **/
+
+static int s2n_server_encrypted_extensions_parse(struct s2n_connection *conn, struct s2n_blob *extensions);
 
 int s2n_encrypted_extensions_send(struct s2n_connection *conn)
 {
-    S2N_ERROR(S2N_ERR_UNIMPLEMENTED);
+    struct s2n_stuffer *out = &conn->handshake.io;
+
+    /* Calculate size of encrypted extensions. For minimal TLS 1.3, this is 0
+     * as we are sending an empty EE message
+     */
+    uint16_t total_size = 0;
+
+    /* Write length of extensions */
+    GUARD(s2n_stuffer_write_uint16(out, total_size));
+
+    if (total_size == 0) {
+        return 0;
+    }
+
+    /* Write the extensions to the out buffer. For minimal TLS 1.3, this is
+     * a noop, as we are sending an empty EE message
+     */
+    
+    return 0;
 }
 
 int s2n_encrypted_extensions_recv(struct s2n_connection *conn)
 {
-    S2N_ERROR(S2N_ERR_UNIMPLEMENTED);
+    struct s2n_stuffer *in = &conn->handshake.io;
+    uint16_t extensions_size;
+
+    /* Read encrypted extensions size */
+    S2N_ERROR_IF(2 > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);
+    GUARD(s2n_stuffer_read_uint16(in, &extensions_size));
+    S2N_ERROR_IF(extensions_size > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);
+
+    /* Process extensions */
+    if (extensions_size > 0) {
+        struct s2n_blob extensions = {0};
+        extensions.size = extensions_size;
+        extensions.data = s2n_stuffer_raw_read(in, extensions.size);
+        notnull_check(extensions.data);
+
+        GUARD(s2n_server_encrypted_extensions_parse(conn, &extensions));
+    }
+
+    return 0;
+}
+
+/* Note the following is a modified duplication of s2n_server_extensions_recv()
+ * This will be updated with the following issue to consolidate the functions and remove
+ * duplication: https://github.com/awslabs/s2n/issues/1189
+ */
+int s2n_server_encrypted_extensions_parse(struct s2n_connection *conn, struct s2n_blob *extensions)
+{
+    struct s2n_stuffer in = {0};
+
+    GUARD(s2n_stuffer_init(&in, extensions));
+    GUARD(s2n_stuffer_write(&in, extensions));
+
+    while (s2n_stuffer_data_available(&in)) {
+        struct s2n_blob ext = {0};
+        uint16_t extension_type, extension_size;
+        struct s2n_stuffer extension = {0};
+
+        GUARD(s2n_stuffer_read_uint16(&in, &extension_type));
+        GUARD(s2n_stuffer_read_uint16(&in, &extension_size));
+
+        ext.size = extension_size;
+        ext.data = s2n_stuffer_raw_read(&in, ext.size);
+        notnull_check(ext.data);
+
+        GUARD(s2n_stuffer_init(&extension, &ext));
+        GUARD(s2n_stuffer_write(&extension, &ext));
+
+        switch (extension_type) {
+        case TLS_EXTENSION_SERVER_NAME:
+            GUARD(s2n_recv_server_server_name(conn, &extension));
+            break;
+        case TLS_EXTENSION_ALPN:
+            GUARD(s2n_recv_server_alpn(conn, &extension));
+            break;
+        case TLS_EXTENSION_SCT_LIST:
+            GUARD(s2n_recv_server_sct_list(conn, &extension));
+            break;
+        case TLS_EXTENSION_MAX_FRAG_LEN:
+            GUARD(s2n_recv_server_max_fragment_length(conn, &extension));
+            break;
+        /* Error on known extensions that are not supposed to appear in EE
+         * https://tools.ietf.org/html/rfc8446#page-37
+         */
+        case TLS_EXTENSION_RENEGOTIATION_INFO:
+        case TLS_EXTENSION_STATUS_REQUEST:
+        case TLS_EXTENSION_SESSION_TICKET:
+        case TLS_EXTENSION_SUPPORTED_VERSIONS:
+        case TLS_EXTENSION_KEY_SHARE:
+            S2N_ERROR(S2N_ERR_BAD_MESSAGE);
+            break;
+        }
+    }
+
+    return 0;
 }


### PR DESCRIPTION
**Issue # (if available):** https://github.com/awslabs/s2n/issues/890

**Description of changes:** 

Add the minimal implementation of EncryptedExtensions message handler for TLS 1.3. Wrapper and state machine changes are being handled separately


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
