### PR TITLE
Initialize error table first in s2n_init()

### DIFF
--- a/utils/s2n_init.c
+++ b/utils/s2n_init.c
@@ -36,13 +36,13 @@ unsigned long s2n_get_openssl_version(void)
 
 int s2n_init(void)
 {
+    GUARD(s2n_error_table_init()); /* initalize error table first so error look up is possible */
     GUARD(s2n_fips_init());
     GUARD(s2n_mem_init());
     GUARD(s2n_rand_init());
     GUARD(s2n_cipher_suites_init());
     GUARD(s2n_cipher_preferences_init());
     GUARD(s2n_client_key_share_init());
-    GUARD(s2n_error_table_init());
 
     S2N_ERROR_IF(atexit(s2n_cleanup_atexit) != 0, S2N_ERR_ATEXIT);
 


### PR DESCRIPTION
**Issue # (if available):**
If s2n_init() crashes before s2n_error_table_init(), the lookup error crashes as error map is uninitialized. 

**Description of changes:** 
Reorder s2n_init so error map will first initialized and allow an error message to be returned.

For example, debugging a fips test case that segfaults in BEGIN_TEST() and s2n_init(), it allows error to be displayed

```
 sha256.c(34): OpenSSL internal error, assertion failed: Low level API call to digest SHA256 forbidden in FIPS mode!
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
