### PR TITLE
Initialize error table only after fips initializes

### DIFF
--- a/utils/s2n_init.c
+++ b/utils/s2n_init.c
@@ -36,9 +36,9 @@ unsigned long s2n_get_openssl_version(void)
 
 int s2n_init(void)
 {
-    GUARD(s2n_error_table_init()); /* initalize error table first so error look up is possible */
     GUARD(s2n_fips_init());
     GUARD(s2n_mem_init());
+    GUARD(s2n_error_table_init());
     GUARD(s2n_rand_init());
     GUARD(s2n_cipher_suites_init());
     GUARD(s2n_cipher_preferences_init());


### PR DESCRIPTION
**Issue # (if available):** 
#1185 causes a regression to fips tests as the error table requires usage of fips compatible SHA256 implementation in fips mode, which requires fips initialization to happen first.

**Description of changes:** 
- reorder s2n_error_table_init() to happen after s2n_fips_init()
- added a NULL check for error_translation_table lookup
- add fallback of iterating error codes if error map is null

We should also consider  guarding against NULL in s2n_strerror or s2n_map_lookup for other edge cases.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
