### PR TITLE
Basic tls1.3 handshake updates

### DIFF
--- a/tests/saw/s2n_handshake_io.saw
+++ b/tests/saw/s2n_handshake_io.saw
@@ -92,9 +92,14 @@ crucible_ghost_value corked {{ 0 : [2] }};
 // structs into a Cryptol record. It also deserializes the ghost state.
 let setup_connection = do {
    pconn <- crucible_alloc (llvm_struct "struct.s2n_connection");
+   
    // we assume that corking/uncorking is managed by s2n
    let corked_io = {{1 : [8]}};
    crucible_points_to (conn_corked_io pconn) (crucible_term corked_io); 
+   
+   // this proof is only valid for the tls1.2 version of the handshake
+   let tls12_version = {{33 : [8]}};
+   crucible_points_to (crucible_field pconn "actual_protocol_version") (crucible_term tls12_version);
    
    mode <- crucible_fresh_var "mode" (llvm_int 32);
    crucible_points_to (conn_mode pconn) (crucible_term mode);
@@ -406,7 +411,6 @@ let s2n_handshake_io_lowlevel = do {
     print "s2n_decrypt_session_ticket";
     s2n_decrypt_session_ticket <- crucible_llvm_unsafe_assume_spec llvm "s2n_decrypt_session_ticket" s2n_decrypt_session_ticket_spec;
     let dependencies = [s2n_socket_write_uncork, s2n_socket_write_cork, s2n_socket_was_corked, s2n_connection_is_managed_corked, s2n_socket_quickack];
-
 
     print "Proving correctness of get_auth_type";
     auth_type_proof <- crucible_llvm_verify llvm "s2n_connection_get_client_auth_type" dependencies false s2n_connection_get_client_auth_type_spec (do {simplify (addsimp equalNat_ite basic_ss); yices;});

--- a/tests/saw/spec/s2n_handshake_io.cry
+++ b/tests/saw/spec/s2n_handshake_io.cry
@@ -4,7 +4,7 @@
 
 module s2n_handshake_io where
 
-// This function modesl the update of the s2n_connection struct by the
+// This function models the update of the s2n_connection struct by the
 // s2n_conn_set_handshake_type function in s2n.
 conn_set_handshake_type : connection -> connection
 conn_set_handshake_type conn = conn'

--- a/tests/unit/s2n_tls13_handshake_test.c
+++ b/tests/unit/s2n_tls13_handshake_test.c
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "testlib/s2n_testlib.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <s2n.h>
+
+#include "crypto/s2n_fips.h"
+
+#include "tls/s2n_cipher_suites.h"
+#include "tls/s2n_connection.h"
+#include "tls/s2n_handshake.h"
+#include "tls/s2n_tls13.h"
+#include "utils/s2n_safety.h"
+
+/* Just to get access to the static functions / variables we need to test */
+#include "tls/s2n_handshake_io.c"
+
+static message_type_t invalid_handshake[S2N_MAX_HANDSHAKE_LENGTH];
+
+static int s2n_test_handler(struct s2n_connection* conn)
+{
+    return 0;
+}
+
+int s2n_test_write_header(struct s2n_stuffer *output, uint8_t record_type, uint8_t message_type)
+{
+    GUARD(s2n_stuffer_write_uint8(output, record_type));
+
+    /* TLS1.2 protocol version */
+    GUARD(s2n_stuffer_write_uint8(output, 3));
+    GUARD(s2n_stuffer_write_uint8(output, 3));
+
+    if (record_type == TLS_HANDSHAKE) {
+        /* Total message size */
+        GUARD(s2n_stuffer_write_uint16(output, 4));
+
+        GUARD(s2n_stuffer_write_uint8(output, message_type));
+
+        /* Handshake message data size */
+        GUARD(s2n_stuffer_write_uint24(output, 0));
+        return 0;
+    }
+
+    if (record_type == TLS_CHANGE_CIPHER_SPEC) {
+        /* Total message size */
+        GUARD(s2n_stuffer_write_uint16(output, 1));
+
+        /* change spec is always just 0x01 */
+        GUARD(s2n_stuffer_write_uint8(output, 1));
+        return 0;
+    }
+
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Construct an array of all valid tls1.3 handshake_types */
+    uint16_t valid_tls13_handshakes[S2N_HANDSHAKES_COUNT];
+    int valid_tls13_handshakes_size = 0;
+    for (int i = 0; i < S2N_HANDSHAKES_COUNT; i++) {
+        if( memcmp(tls13_handshakes, invalid_handshake, S2N_MAX_HANDSHAKE_LENGTH) != 0) {
+            valid_tls13_handshakes[valid_tls13_handshakes_size] = i;
+            valid_tls13_handshakes_size++;
+        }
+    }
+
+    /* Use handler stubs to avoid errors in handler implementation */
+    for (int i = 0; i < sizeof(tls13_state_machine) / sizeof(struct s2n_handshake_action); i++) {
+        tls13_state_machine[i].handler[0] = s2n_test_handler;
+        tls13_state_machine[i].handler[1] = s2n_test_handler;
+    }
+
+    /* Test: When using TLS 1.2, use the existing state machine and handshakes */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+        conn->actual_protocol_version = S2N_TLS12;
+        EXPECT_EQUAL(ACTIVE_STATE_MACHINE(conn), state_machine);
+        EXPECT_EQUAL(ACTIVE_HANDSHAKES(conn), handshakes);
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test: When using TLS 1.3, use the new state machine and handshakes */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+        conn->actual_protocol_version = S2N_TLS13;
+        EXPECT_EQUAL(ACTIVE_STATE_MACHINE(conn), tls13_state_machine);
+        EXPECT_EQUAL(ACTIVE_HANDSHAKES(conn), tls13_handshakes);
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test: TLS1.3 server does not wait for client cipher change requests */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+        conn->actual_protocol_version = S2N_TLS13;
+
+        for (int i = 0; i < valid_tls13_handshakes_size; i++) {
+            int handshake = valid_tls13_handshakes[i];
+
+            conn->handshake.handshake_type = handshake;
+
+            for (int j = 0; j < S2N_MAX_HANDSHAKE_LENGTH; j++) {
+                if (tls13_handshakes[i][j] == CLIENT_CHANGE_CIPHER_SPEC) {
+                    conn->handshake.message_number = j - 1;
+
+                    EXPECT_SUCCESS(s2n_advance_message(conn));
+
+                    EXPECT_EQUAL(conn->handshake.message_number, j + 1);
+                    EXPECT_NOT_EQUAL(ACTIVE_MESSAGE(conn), CLIENT_CHANGE_CIPHER_SPEC);
+
+                    break;
+                }
+            }
+        }
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test: TLS1.3 server does not skip server cipher change requests */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+        conn->actual_protocol_version = S2N_TLS13;
+
+        for (int i = 0; i < valid_tls13_handshakes_size; i++) {
+            int handshake = valid_tls13_handshakes[i];
+
+            conn->handshake.handshake_type = handshake;
+
+            for (int j = 0; j < S2N_MAX_HANDSHAKE_LENGTH; j++) {
+                if (tls13_handshakes[i][j] == SERVER_CHANGE_CIPHER_SPEC) {
+                    conn->handshake.message_number = j - 1;
+
+                    EXPECT_SUCCESS(s2n_advance_message(conn));
+
+                    EXPECT_EQUAL(conn->handshake.message_number, j);
+                    EXPECT_EQUAL(ACTIVE_MESSAGE(conn), SERVER_CHANGE_CIPHER_SPEC);
+
+                    break;
+                }
+            }
+        }
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test: TLS1.3 client does not wait for server cipher change requests */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+        conn->actual_protocol_version = S2N_TLS13;
+
+        for (int i = 0; i < valid_tls13_handshakes_size; i++) {
+            int handshake = valid_tls13_handshakes[i];
+
+            conn->handshake.handshake_type = handshake;
+
+            for (int j = 0; j < S2N_MAX_HANDSHAKE_LENGTH; j++) {
+                if (tls13_handshakes[i][j] == SERVER_CHANGE_CIPHER_SPEC) {
+                    conn->handshake.message_number = j - 1;
+
+                    EXPECT_SUCCESS(s2n_advance_message(conn));
+
+                    EXPECT_EQUAL(conn->handshake.message_number, j + 1);
+                    EXPECT_NOT_EQUAL(ACTIVE_MESSAGE(conn), SERVER_CHANGE_CIPHER_SPEC);
+
+                    break;
+                }
+            }
+        }
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test: TLS1.3 client does not skip client cipher change requests */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+        conn->actual_protocol_version = S2N_TLS13;
+
+        for (int i = 0; i < valid_tls13_handshakes_size; i++) {
+            int handshake = valid_tls13_handshakes[i];
+
+            conn->handshake.handshake_type = handshake;
+
+            for (int j = 0; j < S2N_MAX_HANDSHAKE_LENGTH; j++) {
+                if (tls13_handshakes[i][j] == CLIENT_CHANGE_CIPHER_SPEC) {
+                    conn->handshake.message_number = j - 1;
+
+                    EXPECT_SUCCESS(s2n_advance_message(conn));
+
+                    EXPECT_EQUAL(conn->handshake.message_number, j);
+                    EXPECT_EQUAL(ACTIVE_MESSAGE(conn), CLIENT_CHANGE_CIPHER_SPEC);
+
+                    break;
+                }
+            }
+        }
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test: TLS1.3 client can receive a cipher change spec at any time. */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+        conn->actual_protocol_version = S2N_TLS13;
+
+        struct s2n_stuffer input;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, NULL, conn));
+
+        for (int i = 0; i < valid_tls13_handshakes_size; i++) {
+            int handshake = valid_tls13_handshakes[i];
+
+            conn->handshake.handshake_type = handshake;
+            conn->in_status = ENCRYPTED;
+
+            for (int j = 1; j < S2N_MAX_HANDSHAKE_LENGTH; j++) {
+                conn->handshake.message_number = j;
+
+                EXPECT_SUCCESS(s2n_test_write_header(&input, TLS_CHANGE_CIPHER_SPEC, 0));
+
+                EXPECT_SUCCESS(handshake_read_io(conn));
+
+                EXPECT_EQUAL(conn->handshake.message_number, j);
+
+                EXPECT_SUCCESS(s2n_stuffer_wipe(&input));
+                break;
+            }
+        }
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&input));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test: TLS1.3 server can receive a cipher change request at any time. */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+        conn->actual_protocol_version = S2N_TLS13;
+
+        struct s2n_stuffer input;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, NULL, conn));
+
+        for (int i = 0; i < valid_tls13_handshakes_size; i++) {
+            int handshake = valid_tls13_handshakes[i];
+
+            conn->handshake.handshake_type = handshake;
+            conn->in_status = ENCRYPTED;
+
+            for (int j = 1; j < S2N_MAX_HANDSHAKE_LENGTH; j++) {
+                conn->handshake.message_number = j;
+
+                EXPECT_SUCCESS(s2n_test_write_header(&input, TLS_CHANGE_CIPHER_SPEC, 0));
+
+                EXPECT_SUCCESS(handshake_read_io(conn));
+
+                EXPECT_EQUAL(conn->handshake.message_number, j);
+
+                EXPECT_SUCCESS(s2n_stuffer_wipe(&input));
+                break;
+            }
+        }
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&input));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test: TLS1.3 s2n_conn_set_handshake_type doesn't set TLS12_PERFECT_FORWARD_SECRECY or OCSP_STATUS */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+
+        /* Ensure TLS12_PERFECT_FORWARD_SECRECY is set by choosing a cipher suite with is_ephemeral=1 on the kex */
+        conn->secure.cipher_suite = &s2n_dhe_rsa_with_chacha20_poly1305_sha256;
+
+        /* Ensure OCSP_STATUS is set by setting the connection status_type */
+        conn->status_type = S2N_STATUS_REQUEST_OCSP;
+
+        /* Verify setup: tls1.2 DOES set the flags */
+        conn->actual_protocol_version = S2N_TLS12;
+        EXPECT_SUCCESS(s2n_conn_set_handshake_type(conn));
+        EXPECT_TRUE(conn->handshake.handshake_type & TLS12_PERFECT_FORWARD_SECRECY );
+        EXPECT_TRUE(conn->handshake.handshake_type & OCSP_STATUS );
+
+        /* Verify that tls1.3 DOES NOT set the flags */
+        conn->actual_protocol_version = S2N_TLS13;
+        EXPECT_SUCCESS(s2n_conn_set_handshake_type(conn));
+        EXPECT_FALSE(conn->handshake.handshake_type & TLS12_PERFECT_FORWARD_SECRECY );
+        EXPECT_FALSE(conn->handshake.handshake_type & OCSP_STATUS );
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    END_TEST();
+    return 0;
+}

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -44,7 +44,11 @@ typedef enum {
     CLIENT_FINISHED,
     SERVER_CHANGE_CIPHER_SPEC,
     SERVER_FINISHED,
-    APPLICATION_DATA
+    APPLICATION_DATA,
+
+    /* TLS1.3 message types. Defined: https://tools.ietf.org/html/rfc8446#appendix-B.3 */
+    ENCRYPTED_EXTENSIONS,
+    SERVER_CERT_VERIFY,
 } message_type_t;
 
 struct s2n_handshake_parameters {
@@ -115,7 +119,7 @@ struct s2n_handshake {
 
     /* Handshake type is a bitset, with the following
        bit positions */
-    int handshake_type;
+    uint32_t handshake_type;
 
 /* Has the handshake been negotiated yet? */
 #define INITIAL                     0x00
@@ -128,7 +132,7 @@ struct s2n_handshake {
 #define IS_RESUMPTION_HANDSHAKE( type ) ( !IS_FULL_HANDSHAKE( (type) ) && IS_NEGOTIATED ( (type) ) )
 
 /* Handshake uses perfect forward secrecy */
-#define PERFECT_FORWARD_SECRECY     0x04
+#define TLS12_PERFECT_FORWARD_SECRECY 0x04
 
 /* Handshake needs OCSP status message */
 #define OCSP_STATUS                 0x08
@@ -150,8 +154,6 @@ struct s2n_handshake {
     /* Set to 1 if the RSA verification failed */
     uint8_t rsa_failed;
 };
-
-#define MAX_HANDSHAKE_TYPE_LEN 128
 
 extern message_type_t s2n_conn_get_current_message_type(struct s2n_connection *conn);
 extern int s2n_conn_set_handshake_type(struct s2n_connection *conn);

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -28,6 +28,7 @@
 #include "tls/s2n_resume.h"
 #include "tls/s2n_alerts.h"
 #include "tls/s2n_tls.h"
+#include "tls/s2n_tls13.h"
 #include "tls/s2n_kex.h"
 
 #include "stuffer/s2n_stuffer.h"
@@ -37,21 +38,19 @@
 #include "utils/s2n_random.h"
 #include "utils/s2n_str.h"
 
-/* From RFC 5246 7.4 */
+/* From RFC 8446: https://tools.ietf.org/html/rfc8446#appendix-B.3 */
 #define TLS_HELLO_REQUEST              0
 #define TLS_CLIENT_HELLO               1
 #define TLS_SERVER_HELLO               2
 #define TLS_SERVER_NEW_SESSION_TICKET  4
-#define TLS_SERVER_CERT               11
+#define TLS_ENCRYPTED_EXTENSIONS       8
+#define TLS_CERTIFICATE               11
 #define TLS_SERVER_KEY                12
-#define TLS_SERVER_CERT_REQ           13
-#define TLS_CLIENT_CERT_REQ           13 /* Same as SERVER_CERT_REQ */
+#define TLS_CERT_REQ                  13
 #define TLS_SERVER_HELLO_DONE         14
-#define TLS_CLIENT_CERT               11  /* Same as SERVER_CERT */
-#define TLS_CLIENT_CERT_VERIFY        15
+#define TLS_CERT_VERIFY               15
 #define TLS_CLIENT_KEY                16
-#define TLS_CLIENT_FINISHED           20
-#define TLS_SERVER_FINISHED           20  /* Same as CLIENT_FINISHED */
+#define TLS_FINISHED                  20
 #define TLS_SERVER_CERT_STATUS        22
 
 struct s2n_handshake_action {
@@ -69,19 +68,44 @@ static struct s2n_handshake_action state_machine[] = {
     [CLIENT_HELLO]              = {TLS_HANDSHAKE, TLS_CLIENT_HELLO, 'C', {s2n_client_hello_recv, s2n_client_hello_send}}, 
     [SERVER_HELLO]              = {TLS_HANDSHAKE, TLS_SERVER_HELLO, 'S', {s2n_server_hello_send, s2n_server_hello_recv}}, 
     [SERVER_NEW_SESSION_TICKET] = {TLS_HANDSHAKE, TLS_SERVER_NEW_SESSION_TICKET,'S', {s2n_server_nst_send, s2n_server_nst_recv}},
-    [SERVER_CERT]               = {TLS_HANDSHAKE, TLS_SERVER_CERT, 'S', {s2n_server_cert_send, s2n_server_cert_recv}},
+    [SERVER_CERT]               = {TLS_HANDSHAKE, TLS_CERTIFICATE, 'S', {s2n_server_cert_send, s2n_server_cert_recv}},
     [SERVER_CERT_STATUS]        = {TLS_HANDSHAKE, TLS_SERVER_CERT_STATUS, 'S', {s2n_server_status_send, s2n_server_status_recv}},
     [SERVER_KEY]                = {TLS_HANDSHAKE, TLS_SERVER_KEY, 'S', {s2n_server_key_send, s2n_server_key_recv}},
-    [SERVER_CERT_REQ]           = {TLS_HANDSHAKE, TLS_CLIENT_CERT_REQ, 'S', {s2n_client_cert_req_send, s2n_client_cert_req_recv}},
+    [SERVER_CERT_REQ]           = {TLS_HANDSHAKE, TLS_CERT_REQ, 'S', {s2n_client_cert_req_send, s2n_client_cert_req_recv}},
     [SERVER_HELLO_DONE]         = {TLS_HANDSHAKE, TLS_SERVER_HELLO_DONE, 'S', {s2n_server_done_send, s2n_server_done_recv}}, 
-    [CLIENT_CERT]               = {TLS_HANDSHAKE, TLS_CLIENT_CERT, 'C', {s2n_client_cert_recv, s2n_client_cert_send}},
+    [CLIENT_CERT]               = {TLS_HANDSHAKE, TLS_CERTIFICATE, 'C', {s2n_client_cert_recv, s2n_client_cert_send}},
     [CLIENT_KEY]                = {TLS_HANDSHAKE, TLS_CLIENT_KEY, 'C', {s2n_client_key_recv, s2n_client_key_send}},
-    [CLIENT_CERT_VERIFY]        = {TLS_HANDSHAKE, TLS_CLIENT_CERT_VERIFY, 'C', {s2n_client_cert_verify_recv, s2n_client_cert_verify_send}},
+    [CLIENT_CERT_VERIFY]        = {TLS_HANDSHAKE, TLS_CERT_VERIFY, 'C', {s2n_client_cert_verify_recv, s2n_client_cert_verify_send}},
     [CLIENT_CHANGE_CIPHER_SPEC] = {TLS_CHANGE_CIPHER_SPEC, 0, 'C', {s2n_client_ccs_recv, s2n_ccs_send}},
-    [CLIENT_FINISHED]           = {TLS_HANDSHAKE, TLS_CLIENT_FINISHED, 'C', {s2n_client_finished_recv, s2n_client_finished_send}},
+    [CLIENT_FINISHED]           = {TLS_HANDSHAKE, TLS_FINISHED, 'C', {s2n_client_finished_recv, s2n_client_finished_send}},
     [SERVER_CHANGE_CIPHER_SPEC] = {TLS_CHANGE_CIPHER_SPEC, 0, 'S', {s2n_ccs_send, s2n_server_ccs_recv}},
-    [SERVER_FINISHED]           = {TLS_HANDSHAKE, TLS_SERVER_FINISHED, 'S', {s2n_server_finished_send, s2n_server_finished_recv}},
+    [SERVER_FINISHED]           = {TLS_HANDSHAKE, TLS_FINISHED, 'S', {s2n_server_finished_send, s2n_server_finished_recv}},
     [APPLICATION_DATA]          = {TLS_APPLICATION_DATA, 0, 'B', {NULL, NULL}}
+};
+
+/*
+ * Client and Server handlers for TLS1.3.
+ */
+static struct s2n_handshake_action tls13_state_machine[] = {
+    /* message_type_t           = {Record type, Message type, Writer, {Server handler, client handler} }  */
+    [CLIENT_HELLO]              = {TLS_HANDSHAKE, TLS_CLIENT_HELLO, 'C', {s2n_client_hello_recv, s2n_client_hello_send}},
+
+    [SERVER_HELLO]              = {TLS_HANDSHAKE, TLS_SERVER_HELLO, 'S', {s2n_server_hello_send, s2n_server_hello_recv}},
+    [ENCRYPTED_EXTENSIONS]      = {TLS_HANDSHAKE, TLS_ENCRYPTED_EXTENSIONS, 'S', {s2n_encrypted_extensions_send, s2n_encrypted_extensions_recv}},
+    [SERVER_CERT_REQ]           = {TLS_HANDSHAKE, TLS_CERT_REQ, 'S', {s2n_client_cert_req_send, s2n_client_cert_req_recv}},
+    [SERVER_CERT]               = {TLS_HANDSHAKE, TLS_CERTIFICATE, 'S', {s2n_server_cert_send, s2n_server_cert_recv}},
+    [SERVER_CERT_VERIFY]        = {TLS_HANDSHAKE, TLS_CERT_VERIFY, 'S', {s2n_server_cert_verify_send, s2n_server_cert_verify_recv}},
+    [SERVER_FINISHED]           = {TLS_HANDSHAKE, TLS_FINISHED, 'S', {s2n_server_finished_send, s2n_server_finished_recv}},
+
+    [CLIENT_CERT]               = {TLS_HANDSHAKE, TLS_CERTIFICATE, 'C', {s2n_client_cert_recv, s2n_client_cert_send}},
+    [CLIENT_CERT_VERIFY]        = {TLS_HANDSHAKE, TLS_CERT_VERIFY, 'C', {s2n_client_cert_verify_recv, s2n_client_cert_verify_send}},
+    [CLIENT_FINISHED]           = {TLS_HANDSHAKE, TLS_FINISHED, 'C', {s2n_client_finished_recv, s2n_client_finished_send}},
+
+    /* Not used by TLS1.3, except to maintain middlebox compatibility */
+    [CLIENT_CHANGE_CIPHER_SPEC] = {TLS_CHANGE_CIPHER_SPEC, 0, 'C', {s2n_basic_ccs_recv, s2n_ccs_send}},
+    [SERVER_CHANGE_CIPHER_SPEC] = {TLS_CHANGE_CIPHER_SPEC, 0, 'S', {s2n_ccs_send, s2n_basic_ccs_recv}},
+
+    [APPLICATION_DATA]          = {TLS_APPLICATION_DATA, 0, 'B', {NULL, NULL}},
 };
 
 #define MESSAGE_NAME_ENTRY(msg) [msg] = #msg
@@ -89,9 +113,11 @@ static struct s2n_handshake_action state_machine[] = {
 static const char *message_names[] = {
     MESSAGE_NAME_ENTRY(CLIENT_HELLO),
     MESSAGE_NAME_ENTRY(SERVER_HELLO),
+    MESSAGE_NAME_ENTRY(ENCRYPTED_EXTENSIONS),
     MESSAGE_NAME_ENTRY(SERVER_NEW_SESSION_TICKET),
     MESSAGE_NAME_ENTRY(SERVER_CERT),
     MESSAGE_NAME_ENTRY(SERVER_CERT_STATUS),
+    MESSAGE_NAME_ENTRY(SERVER_CERT_VERIFY),
     MESSAGE_NAME_ENTRY(SERVER_KEY),
     MESSAGE_NAME_ENTRY(SERVER_CERT_REQ),
     MESSAGE_NAME_ENTRY(SERVER_HELLO_DONE),
@@ -105,10 +131,16 @@ static const char *message_names[] = {
     MESSAGE_NAME_ENTRY(APPLICATION_DATA),
 };
 
+/* Maximum number of valid handshakes */
+#define S2N_HANDSHAKES_COUNT        128
+
+/* Maximum number of messages in a handshake */
+#define S2N_MAX_HANDSHAKE_LENGTH    16
+
 /* We support different ordering of TLS Handshake messages, depending on what is being negotiated. There's also a dummy "INITIAL" handshake
  * that everything starts out as until we know better.
  */
-static message_type_t handshakes[128][16] = {
+static message_type_t handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_LENGTH] = {
     [INITIAL] = {
             CLIENT_HELLO,
             SERVER_HELLO
@@ -143,7 +175,7 @@ static message_type_t handshakes[128][16] = {
             APPLICATION_DATA
     },
 
-    [NEGOTIATED | FULL_HANDSHAKE | PERFECT_FORWARD_SECRECY ] = {
+    [NEGOTIATED | FULL_HANDSHAKE | TLS12_PERFECT_FORWARD_SECRECY ] = {
             CLIENT_HELLO,
             SERVER_HELLO, SERVER_CERT, SERVER_KEY, SERVER_HELLO_DONE,
             CLIENT_KEY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
@@ -151,7 +183,7 @@ static message_type_t handshakes[128][16] = {
             APPLICATION_DATA
     },
 
-    [NEGOTIATED | FULL_HANDSHAKE | PERFECT_FORWARD_SECRECY | WITH_SESSION_TICKET ] = {
+    [NEGOTIATED | FULL_HANDSHAKE | TLS12_PERFECT_FORWARD_SECRECY | WITH_SESSION_TICKET ] = {
             CLIENT_HELLO,
             SERVER_HELLO, SERVER_CERT, SERVER_KEY, SERVER_HELLO_DONE,
             CLIENT_KEY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
@@ -175,7 +207,7 @@ static message_type_t handshakes[128][16] = {
             APPLICATION_DATA
     },
 
-    [NEGOTIATED | FULL_HANDSHAKE | PERFECT_FORWARD_SECRECY | OCSP_STATUS ] = {
+    [NEGOTIATED | FULL_HANDSHAKE | TLS12_PERFECT_FORWARD_SECRECY | OCSP_STATUS ] = {
             CLIENT_HELLO,
             SERVER_HELLO, SERVER_CERT, SERVER_CERT_STATUS, SERVER_KEY, SERVER_HELLO_DONE,
             CLIENT_KEY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
@@ -183,7 +215,7 @@ static message_type_t handshakes[128][16] = {
             APPLICATION_DATA
     },
 
-    [NEGOTIATED | FULL_HANDSHAKE | PERFECT_FORWARD_SECRECY | OCSP_STATUS  | WITH_SESSION_TICKET ] ={
+    [NEGOTIATED | FULL_HANDSHAKE | TLS12_PERFECT_FORWARD_SECRECY | OCSP_STATUS  | WITH_SESSION_TICKET ] ={
             CLIENT_HELLO,
             SERVER_HELLO, SERVER_CERT, SERVER_CERT_STATUS, SERVER_KEY, SERVER_HELLO_DONE,
             CLIENT_KEY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
@@ -223,7 +255,7 @@ static message_type_t handshakes[128][16] = {
             APPLICATION_DATA
     },
 
-    [NEGOTIATED | FULL_HANDSHAKE | PERFECT_FORWARD_SECRECY | CLIENT_AUTH] = {
+    [NEGOTIATED | FULL_HANDSHAKE | TLS12_PERFECT_FORWARD_SECRECY | CLIENT_AUTH] = {
            CLIENT_HELLO,
            SERVER_HELLO, SERVER_CERT, SERVER_KEY, SERVER_CERT_REQ, SERVER_HELLO_DONE,
            CLIENT_CERT, CLIENT_KEY, CLIENT_CERT_VERIFY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
@@ -231,7 +263,7 @@ static message_type_t handshakes[128][16] = {
            APPLICATION_DATA
     },
 
-    [NEGOTIATED | FULL_HANDSHAKE | PERFECT_FORWARD_SECRECY | CLIENT_AUTH | NO_CLIENT_CERT ] = {
+    [NEGOTIATED | FULL_HANDSHAKE | TLS12_PERFECT_FORWARD_SECRECY | CLIENT_AUTH | NO_CLIENT_CERT ] = {
            CLIENT_HELLO,
            SERVER_HELLO, SERVER_CERT, SERVER_KEY, SERVER_CERT_REQ, SERVER_HELLO_DONE,
            CLIENT_CERT, CLIENT_KEY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
@@ -239,7 +271,7 @@ static message_type_t handshakes[128][16] = {
            APPLICATION_DATA
     },
 
-    [NEGOTIATED | FULL_HANDSHAKE | PERFECT_FORWARD_SECRECY | CLIENT_AUTH | WITH_SESSION_TICKET] = {
+    [NEGOTIATED | FULL_HANDSHAKE | TLS12_PERFECT_FORWARD_SECRECY | CLIENT_AUTH | WITH_SESSION_TICKET] = {
            CLIENT_HELLO,
            SERVER_HELLO, SERVER_CERT, SERVER_KEY, SERVER_CERT_REQ, SERVER_HELLO_DONE,
            CLIENT_CERT, CLIENT_KEY, CLIENT_CERT_VERIFY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
@@ -247,7 +279,7 @@ static message_type_t handshakes[128][16] = {
            APPLICATION_DATA
     },
 
-    [NEGOTIATED | FULL_HANDSHAKE | PERFECT_FORWARD_SECRECY | CLIENT_AUTH | NO_CLIENT_CERT | WITH_SESSION_TICKET ] = {
+    [NEGOTIATED | FULL_HANDSHAKE | TLS12_PERFECT_FORWARD_SECRECY | CLIENT_AUTH | NO_CLIENT_CERT | WITH_SESSION_TICKET ] = {
            CLIENT_HELLO,
            SERVER_HELLO, SERVER_CERT, SERVER_KEY, SERVER_CERT_REQ, SERVER_HELLO_DONE,
            CLIENT_CERT, CLIENT_KEY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
@@ -287,7 +319,7 @@ static message_type_t handshakes[128][16] = {
            APPLICATION_DATA
     },
 
-    [NEGOTIATED | FULL_HANDSHAKE | PERFECT_FORWARD_SECRECY | OCSP_STATUS | CLIENT_AUTH ] = {
+    [NEGOTIATED | FULL_HANDSHAKE | TLS12_PERFECT_FORWARD_SECRECY | OCSP_STATUS | CLIENT_AUTH ] = {
             CLIENT_HELLO,
             SERVER_HELLO, SERVER_CERT, SERVER_CERT_STATUS, SERVER_KEY, SERVER_CERT_REQ, SERVER_HELLO_DONE,
             CLIENT_CERT, CLIENT_KEY, CLIENT_CERT_VERIFY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
@@ -295,7 +327,7 @@ static message_type_t handshakes[128][16] = {
             APPLICATION_DATA
     },
 
-    [NEGOTIATED | FULL_HANDSHAKE | PERFECT_FORWARD_SECRECY | OCSP_STATUS | CLIENT_AUTH | NO_CLIENT_CERT ] = {
+    [NEGOTIATED | FULL_HANDSHAKE | TLS12_PERFECT_FORWARD_SECRECY | OCSP_STATUS | CLIENT_AUTH | NO_CLIENT_CERT ] = {
             CLIENT_HELLO,
             SERVER_HELLO, SERVER_CERT, SERVER_CERT_STATUS, SERVER_KEY, SERVER_CERT_REQ, SERVER_HELLO_DONE,
             CLIENT_CERT, CLIENT_KEY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
@@ -303,7 +335,7 @@ static message_type_t handshakes[128][16] = {
             APPLICATION_DATA
     },
 
-    [NEGOTIATED | FULL_HANDSHAKE | PERFECT_FORWARD_SECRECY | OCSP_STATUS | CLIENT_AUTH | WITH_SESSION_TICKET ] = {
+    [NEGOTIATED | FULL_HANDSHAKE | TLS12_PERFECT_FORWARD_SECRECY | OCSP_STATUS | CLIENT_AUTH | WITH_SESSION_TICKET ] = {
             CLIENT_HELLO,
             SERVER_HELLO, SERVER_CERT, SERVER_CERT_STATUS, SERVER_KEY, SERVER_CERT_REQ, SERVER_HELLO_DONE,
             CLIENT_CERT, CLIENT_KEY, CLIENT_CERT_VERIFY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
@@ -311,7 +343,7 @@ static message_type_t handshakes[128][16] = {
             APPLICATION_DATA
     },
 
-    [NEGOTIATED | FULL_HANDSHAKE | PERFECT_FORWARD_SECRECY | OCSP_STATUS | CLIENT_AUTH | NO_CLIENT_CERT | WITH_SESSION_TICKET ] = {
+    [NEGOTIATED | FULL_HANDSHAKE | TLS12_PERFECT_FORWARD_SECRECY | OCSP_STATUS | CLIENT_AUTH | NO_CLIENT_CERT | WITH_SESSION_TICKET ] = {
             CLIENT_HELLO,
             SERVER_HELLO, SERVER_CERT, SERVER_CERT_STATUS, SERVER_KEY, SERVER_CERT_REQ, SERVER_HELLO_DONE,
             CLIENT_CERT, CLIENT_KEY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
@@ -320,23 +352,72 @@ static message_type_t handshakes[128][16] = {
     },
 };
 
-static char handshake_type_str[128][MAX_HANDSHAKE_TYPE_LEN] = {0};
+/*
+ * This selection of handshakes resembles the standard set, but with changes made to support tls1.3.
+ *
+ * These are just the basic handshakes. At the moment hello retries, session resumption, and early data are not supported.
+ *
+ * The CHANGE_CIPHER_SPEC messages are included only for middlebox compatibility.
+ * See https://tools.ietf.org/html/rfc8446#appendix-D.4
+ */
+static message_type_t tls13_handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_LENGTH] = {
+    [INITIAL] = {
+            CLIENT_HELLO,
+            SERVER_HELLO
+    },
 
-static const char* handshake_type_names[] = { 
-    "NEGOTIATED|", 
+    [NEGOTIATED] = {
+            CLIENT_HELLO,
+            SERVER_HELLO, SERVER_CHANGE_CIPHER_SPEC, ENCRYPTED_EXTENSIONS, SERVER_FINISHED,
+            CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
+            APPLICATION_DATA
+    },
+
+    [NEGOTIATED | FULL_HANDSHAKE] = {
+            CLIENT_HELLO,
+            SERVER_HELLO, SERVER_CHANGE_CIPHER_SPEC, ENCRYPTED_EXTENSIONS, SERVER_CERT, SERVER_CERT_VERIFY, SERVER_FINISHED,
+            CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
+            APPLICATION_DATA
+    },
+
+    [NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH] = {
+            CLIENT_HELLO,
+            SERVER_HELLO, SERVER_CHANGE_CIPHER_SPEC, ENCRYPTED_EXTENSIONS, SERVER_CERT_REQ, SERVER_CERT, SERVER_CERT_VERIFY, SERVER_FINISHED,
+            CLIENT_CHANGE_CIPHER_SPEC, CLIENT_CERT, CLIENT_CERT_VERIFY, CLIENT_FINISHED,
+            APPLICATION_DATA
+    },
+
+    [NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH | NO_CLIENT_CERT] = {
+            CLIENT_HELLO,
+            SERVER_HELLO, SERVER_CHANGE_CIPHER_SPEC, ENCRYPTED_EXTENSIONS, SERVER_CERT_REQ, SERVER_CERT, SERVER_CERT_VERIFY, SERVER_FINISHED,
+            CLIENT_CHANGE_CIPHER_SPEC, CLIENT_CERT, CLIENT_FINISHED,
+            APPLICATION_DATA
+    },
+};
+
+#define MAX_HANDSHAKE_TYPE_LEN 128
+static char handshake_type_str[S2N_HANDSHAKES_COUNT][MAX_HANDSHAKE_TYPE_LEN] = {0};
+
+static const char* handshake_type_names[] = {
+    "NEGOTIATED|",
     "FULL_HANDSHAKE|",
-    "PERFECT_FORWARD_SECRECY|",
+    "TLS12_PERFECT_FORWARD_SECRECY|",
     "OCSP_STATUS|",
     "CLIENT_AUTH|",
     "WITH_SESSION_TICKET|",
     "NO_CLIENT_CERT|"
 };
 
-#define ACTIVE_MESSAGE( conn ) handshakes[ (conn)->handshake.handshake_type ][ (conn)->handshake.message_number ]
-#define PREVIOUS_MESSAGE( conn ) handshakes[ (conn)->handshake.handshake_type ][ (conn)->handshake.message_number - 1 ]
+#define IS_TLS13_HANDSHAKE( conn ) ((conn)->actual_protocol_version == S2N_TLS13)
 
-#define ACTIVE_STATE( conn ) state_machine[ ACTIVE_MESSAGE( (conn) ) ]
-#define PREVIOUS_STATE( conn ) state_machine[ PREVIOUS_MESSAGE( (conn) ) ]
+#define ACTIVE_STATE_MACHINE( conn )  (IS_TLS13_HANDSHAKE(conn) ? tls13_state_machine : state_machine)
+#define ACTIVE_HANDSHAKES( conn )      (IS_TLS13_HANDSHAKE(conn) ? tls13_handshakes : handshakes)
+
+#define ACTIVE_MESSAGE( conn )        ACTIVE_HANDSHAKES(conn)[ (conn)->handshake.handshake_type ][ (conn)->handshake.message_number ]
+#define PREVIOUS_MESSAGE( conn )      ACTIVE_HANDSHAKES(conn)[ (conn)->handshake.handshake_type ][ (conn)->handshake.message_number - 1 ]
+
+#define ACTIVE_STATE( conn )          ACTIVE_STATE_MACHINE(conn)[ ACTIVE_MESSAGE( (conn) ) ]
+#define PREVIOUS_STATE( conn )        ACTIVE_STATE_MACHINE(conn)[ PREVIOUS_MESSAGE( (conn) ) ]
 
 #define EXPECTED_MESSAGE_TYPE( conn ) ACTIVE_STATE( conn ).message_type
 
@@ -356,8 +437,15 @@ static int s2n_advance_message(struct s2n_connection *conn)
     /* Actually advance the message number */
     conn->handshake.message_number++;
 
-    /* Set TCP_QUICKACK to avoid artificial dealy during the handshake */
+    /* Set TCP_QUICKACK to avoid artificial delay during the handshake */
     GUARD(s2n_socket_quickack(conn));
+
+    /* When reading and using TLS1.3, skip optional change_cipher_spec states. */
+    if (ACTIVE_STATE(conn).writer != this &&
+            ACTIVE_STATE(conn).record_type == TLS_CHANGE_CIPHER_SPEC &&
+            IS_TLS13_HANDSHAKE(conn)) {
+        return s2n_advance_message(conn);
+    }
 
     /* If optimized io hasn't been enabled or if the caller started out with a corked socket,
      * we don't mess with it
@@ -455,8 +543,12 @@ skip_cache_lookup:
         conn->handshake.handshake_type |= CLIENT_AUTH;
     }
 
+    if (IS_TLS13_HANDSHAKE(conn)) {
+        return 0;
+    }
+
     if (s2n_kex_is_ephemeral(conn->secure.cipher_suite->key_exchange_alg)) {
-        conn->handshake.handshake_type |= PERFECT_FORWARD_SECRECY;
+        conn->handshake.handshake_type |= TLS12_PERFECT_FORWARD_SECRECY;
     }
 
     if (s2n_server_can_send_ocsp(conn) || s2n_server_sent_ocsp(conn)) {
@@ -466,7 +558,8 @@ skip_cache_lookup:
     return 0;
 }
 
-int s2n_conn_set_handshake_no_client_cert(struct s2n_connection *conn) {
+int s2n_conn_set_handshake_no_client_cert(struct s2n_connection *conn)
+{
     s2n_cert_auth_type client_cert_auth_type;
     GUARD(s2n_connection_get_client_auth_type(conn, &client_cert_auth_type));
     S2N_ERROR_IF(client_cert_auth_type != S2N_CERT_AUTH_OPTIONAL, S2N_ERR_BAD_MESSAGE);
@@ -482,7 +575,7 @@ const char *s2n_connection_get_last_message_name(struct s2n_connection *conn)
     return message_names[ACTIVE_MESSAGE(conn)];
 }
 
-const char *s2n_connection_get_handshake_type_name(struct s2n_connection *conn) 
+const char *s2n_connection_get_handshake_type_name(struct s2n_connection *conn)
 {
     notnull_check_ptr(conn);
 
@@ -729,7 +822,7 @@ static int handshake_read_io(struct s2n_connection *conn)
      * contain several messages.
      */
     S2N_ERROR_IF(record_type == TLS_APPLICATION_DATA, S2N_ERR_BAD_MESSAGE);
-    if(record_type == TLS_CHANGE_CIPHER_SPEC) {
+    if (record_type == TLS_CHANGE_CIPHER_SPEC) {
         S2N_ERROR_IF(s2n_stuffer_data_available(&conn->in) != 1, S2N_ERR_BAD_MESSAGE);
 
         GUARD(s2n_stuffer_copy(&conn->in, &conn->handshake.io, s2n_stuffer_data_available(&conn->in)));
@@ -742,7 +835,9 @@ static int handshake_read_io(struct s2n_connection *conn)
         conn->in_status = ENCRYPTED;
 
         /* Advance the state machine */
-        GUARD(s2n_advance_message(conn));
+        if (ACTIVE_STATE(conn).record_type == TLS_CHANGE_CIPHER_SPEC) {
+            GUARD(s2n_advance_message(conn));
+        }
 
         return 0;
     } else if (record_type != TLS_HANDSHAKE) {
@@ -779,12 +874,11 @@ static int handshake_read_io(struct s2n_connection *conn)
         s2n_cert_auth_type client_cert_auth_type;
         GUARD(s2n_connection_get_client_auth_type(conn, &client_cert_auth_type));
 
-        /* If we're a Client, and received a ClientCertRequest message instead of a ServerHelloDone, and ClientAuth
+        /* If we're a Client, and received a ClientCertRequest message, and ClientAuth
          * is set to optional, then switch the State Machine that we're using to expect the ClientCertRequest. */
         if (conn->mode == S2N_CLIENT
                 && client_cert_auth_type == S2N_CERT_AUTH_OPTIONAL
-                && actual_handshake_message_type == TLS_CLIENT_CERT_REQ
-                && EXPECTED_MESSAGE_TYPE(conn) == TLS_SERVER_HELLO_DONE) {
+                && actual_handshake_message_type == TLS_CERT_REQ) {
             conn->handshake.handshake_type |= CLIENT_AUTH;
         }
 


### PR DESCRIPTION
**Issue # (if available):** [968](https://github.com/awslabs/s2n/issues/968)

**Description of changes:** Just adds the simplest tls1.3 handshakes. Does not add hello retries, early data, session resumption, or any other handshake that requires a new handshake type flag -- new handshake flags are a slightly more complicated change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
