### PR TITLE
Fix SIKE reference/optimized comments in pq-crypto/README

### DIFF
--- a/pq-crypto/README.md
+++ b/pq-crypto/README.md
@@ -24,8 +24,8 @@ See [this s2n issue](https://github.com/awslabs/s2n/issues/904) for more up-to-d
 
 ## SIKE (Supersingular Isogeny Key Encapsulation)
 The code in the pq-crypto/sike directory was taken from the [round 1 nist submission](https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-1/submissions/SIKE.zip).
-s2n uses the reference implementation to ensure maximum comparability and ease of review. The known answer tests are
-[here](https://github.com/awslabs/s2n/blob/master/tests/unit/s2n_sike_p503_kat_test.c) and use the known answer file
+s2n uses the optimized portable implementation to ensure maximum comparability and ease of review. The known answer tests
+are [here](https://github.com/awslabs/s2n/blob/master/tests/unit/s2n_sike_p503_kat_test.c) and use the known answer file
 from the SIKEp503 round 1 submission.
 
 ## BIKE (Bit Flipping Key Encapsulation)
@@ -33,7 +33,8 @@ The code in the pq-crypto/bike directory was taken from the [additional implemen
 s2n uses the "additional implementation" which ensures constant time primitives, does not use any external libraries
 besides libcrypto, and does not depend on any specific hardware instructions to ensure maximum comparability and ease of
 review. The known answer tests are [here](https://github.com/awslabs/s2n/blob/master/tests/unit/s2n_bike1_l1_kat_test.c)
-and use the BIKE1_L1.const.kat from the above Additional_Implementation.2019.03.30.zip. This implementation uses constant time primitives on x86 and aarch64 platforms.
+and use the BIKE1_L1.const.kat from the above Additional_Implementation.2019.03.30.zip. This implementation uses constant
+time primitives on x86 and aarch64 platforms.
 
 ## How to add another PQ KEM
 1. Add the code to `pq-crypto/KEM_NAME/`

--- a/pq-crypto/sike/Readme.md
+++ b/pq-crypto/sike/Readme.md
@@ -2,6 +2,7 @@
 Supersingular Isogeny Key Encapsulation  (SIKE)
 ================================================
 
-The code in this directory is mostly taken from the MIT Licensed SIKE Reference Implementation submitted to NIST here: https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-1/submissions/SIKE.zip
+The code in this directory is taken from the MIT Licensed SIKE optimized portable implementation submitted to NIST here:
+https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-1/submissions/SIKE.zip
 
 Only minor modifications were made in order to integrate this code into s2n's build system.


### PR DESCRIPTION
**Issue # (if available):** 
N/A

**Description of changes:** 
While reviewing the SIKE code it was pointed out that this wasn't the reference version but actually the optimized version that is still portable.

Verified all the comments in the real reference code include:
```
Supersingular Isogeny Key Encapsulation Ref. Library
```
and the version in s2n does not have that. `diff`'ing the s2n code with the reference and optimized version showed the code is mostly the optimized version except for the minor tweaks to work with s2n.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
