### PR TITLE
Freeze maximum record protocol version to 33 (TLS 1.2)

### DIFF
--- a/tests/unit/s2n_record_test.c
+++ b/tests/unit/s2n_record_test.c
@@ -353,6 +353,37 @@ int main(int argc, char **argv)
     /* Sequence number should wrap around */
     EXPECT_FAILURE(s2n_record_write(conn, TLS_APPLICATION_DATA, &empty_blob));
 
+    /* Test TLS 1.3 Record should reflect as TLS 1.2 version on the wire */
+    {
+        EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
+
+        conn->actual_protocol_version = S2N_TLS13;
+        EXPECT_SUCCESS(s2n_record_write(conn, TLS_APPLICATION_DATA, &empty_blob));
+
+        /* Make sure that TLS 1.3 records appear as TLS 1.2 version */
+        EXPECT_EQUAL(conn->out.blob.data[1], 3);
+        EXPECT_EQUAL(conn->out.blob.data[2], 3);
+
+        /* Copy written bytes for reading */
+        EXPECT_SUCCESS(s2n_stuffer_resize_if_empty(&conn->in, S2N_LARGE_FRAGMENT_LENGTH));
+        EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
+        EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
+        EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
+        EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
+
+        /* Trigger condition to check for protocol version */
+        conn->actual_protocol_version_established = 1;
+        uint8_t content_type;
+        uint16_t fragment_length;
+        EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
+
+        /* If record version on wire is TLS 1.3, check s2n_record_header_parse fails */
+        EXPECT_SUCCESS(s2n_stuffer_reread(&conn->header_in));
+        conn->header_in.blob.data[1] = 3;
+        conn->header_in.blob.data[2] = 4;
+        EXPECT_FAILURE(s2n_record_header_parse(conn, &content_type, &fragment_length));
+    }
+
     EXPECT_SUCCESS(s2n_hmac_free(&check_mac));
 
     EXPECT_SUCCESS(s2n_connection_free(conn));

--- a/tls/s2n_record_read.c
+++ b/tls/s2n_record_read.c
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+#include <sys/param.h>
+
 #include "crypto/s2n_sequence.h"
 #include "crypto/s2n_cipher.h"
 #include "crypto/s2n_hmac.h"
@@ -77,7 +79,9 @@ int s2n_record_header_parse(
      * match the negotiated version.
      */
 
-    S2N_ERROR_IF(conn->actual_protocol_version_established && conn->actual_protocol_version != version, S2N_ERR_BAD_MESSAGE);
+    S2N_ERROR_IF(conn->actual_protocol_version_established &&
+        MIN(conn->actual_protocol_version, S2N_TLS12) /* check against legacy record version (1.2) in tls 1.3 */
+        != version, S2N_ERR_BAD_MESSAGE);
     GUARD(s2n_stuffer_read_uint16(in, fragment_length));
 
     /* Some servers send fragments that are above the maximum length.  (e.g.

--- a/tls/s2n_record_write.c
+++ b/tls/s2n_record_write.c
@@ -110,6 +110,11 @@ int s2n_record_write_protocol_version(struct s2n_connection *conn)
         record_protocol_version = MIN(record_protocol_version, S2N_TLS10);
     }
 
+    /* In accordance to TLS 1.3 spec, https://tools.ietf.org/html/rfc8446#section-5.1
+     * tls record version should never be greater than 33 (legacy TLS 1.2 version).
+     */
+    record_protocol_version = MIN(record_protocol_version, S2N_TLS12);
+
     uint8_t protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN];
     protocol_version[0] = record_protocol_version / 10;
     protocol_version[1] = record_protocol_version % 10;


### PR DESCRIPTION
**Issue # (if available):** 
#1167 

With the introduction of TLS 1.3 spec, a maximum record version number on the wire is now frozen on 33.

https://tools.ietf.org/html/rfc8446#section-5.1

> legacy_record_version:  MUST be set to 0x0303 for all records
generated by a TLS 1.3 implementation other than an initial
ClientHello (i.e., one not generated after a HelloRetryRequest),
where it MAY also be 0x0301 for compatibility purposes.  This
field is deprecated and MUST be ignored for all purposes.
Previous versions of TLS would use other values in this field
under some circumstances.

**Description of changes:** 
- s2n_record_write now ensures that record version number never exceed TLS 1.2
- also make a relevant conditional in s2n_record_read version checking code

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
