### PR TITLE
Move Travis Builds to 18.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 sudo: required
-dist: trusty
 language: c
 cache:
     directories:
@@ -8,96 +7,131 @@ cache:
         # https://docs.travis-ci.com/user/caching/#Caches-and-build-matrices
         - test-deps
 
-osx_image: xcode8
-
-os:
-  - osx
-  - linux
-
-env:
-  - TESTS=ctverif
-  # Code Coverage Targets
-  - S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=unit GCC_VERSION=6 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true
-  - S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=6 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true
-  - S2N_LIBCRYPTO=openssl-1.1.1 LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=120 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true
-  # Normal Build Targets
-  - S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=6
-  - S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=9
-  - S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=6 S2N_CORKED_IO=true
-  - S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=integration GCC_VERSION=6
-  - S2N_LIBCRYPTO=openssl-1.0.2-fips BUILD_S2N=true TESTS=integration GCC_VERSION=6
-  - S2N_LIBCRYPTO=libressl      BUILD_S2N=true TESTS=integration GCC_VERSION=6
-  # Force libcrypto to use "software only" crypto implementations for AES and AES-GCM. Verify s2n can gracefully use
-  # unoptimized routines. See https://www.openssl.org/docs/man1.1.0/crypto/OPENSSL_ia32cap.html
-  - S2N_LIBCRYPTO=openssl-1.1.1 OPENSSL_ia32cap="~0x200000200000000" BUILD_S2N=true TESTS=integration GCC_VERSION=6
-  - S2N_LIBCRYPTO=openssl-1.1.1 LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=120
-  - S2N_LIBCRYPTO=openssl-1.0.2-fips LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=120
-  - S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=asan GCC_VERSION=6
-  - S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=valgrind GCC_VERSION=6
-
-matrix:
-  exclude:
-  - os: osx
-    env: TESTS=ctverif
-  - os: osx
-    env: S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=valgrind GCC_VERSION=6
-  - os: osx
-    env: S2N_LIBCRYPTO=openssl-1.0.2-fips LATEST_CLANG=true TESTS=fuzz
-  - os: osx
-    env: S2N_LIBCRYPTO=openssl-1.0.2-fips BUILD_S2N=true TESTS=integration GCC_VERSION=6
+jobs:
   include:
+# Code Coverage Targets, will upload code coverage metrics during Pull Requests
+  - os: linux
+    dist: bionic
+    env: S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=unit GCC_VERSION=6 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true
+
+  - os: linux
+    dist: bionic
+    env: S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=6 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true
+
+  - os: linux
+    # coverage + fuzz flags don't work simultaneously on bionic
+    dist: trusty
+    env: S2N_LIBCRYPTO=openssl-1.1.1 LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=120 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true
+
+# Normal Build Targets
+  - os: linux
+    dist: bionic
+    env: S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=6
+
+  - os: linux
+    dist: bionic
+    env: S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=9
+
+  - os: linux
+    dist: bionic
+    env: S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=6 S2N_CORKED_IO=true
+
+  - os: linux
+    dist: bionic
+    env: S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=integration GCC_VERSION=6
+
+  - os: linux
+    dist: bionic
+    env: S2N_LIBCRYPTO=openssl-1.0.2-fips BUILD_S2N=true TESTS=integration GCC_VERSION=6
+
+  - os: linux
+    dist: bionic
+    env: S2N_LIBCRYPTO=libressl      BUILD_S2N=true TESTS=integration GCC_VERSION=6
+
+  - os: linux
+    dist: bionic
+    # Force libcrypto to use "software only" crypto implementations for AES and AES-GCM. Verify s2n can gracefully use
+    # unoptimized routines. See https://www.openssl.org/docs/man1.1.0/crypto/OPENSSL_ia32cap.html
+    env: S2N_LIBCRYPTO=openssl-1.1.1 OPENSSL_ia32cap="~0x200000200000000" BUILD_S2N=true TESTS=integration GCC_VERSION=6
+
+# Fuzz Tests
+  - os: linux
+    dist: bionic
+    env: S2N_LIBCRYPTO=openssl-1.1.1 LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=120
+
+  - os: linux
+    dist: bionic
+    env: S2N_LIBCRYPTO=openssl-1.0.2-fips LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=120
+  
+# ASAN and Valgrind Tests
+  - os: linux
+    dist: bionic
+    env: S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=asan GCC_VERSION=6
+
+  - os: linux
+    dist: bionic
+    env: S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=valgrind GCC_VERSION=6
+
+# Formal Verification - Sidetrail
   - os : linux
+    dist: trusty
     env: TESTS=sidetrail PART=1
+
   - os : linux
+    dist: trusty
     env: TESTS=sidetrail PART=2
+
+# Formal Verification - SAW
   - os : linux
-    env : TESTS=sawHMAC SAW_HMAC_TEST=md5    SAW=true GCC_VERSION=NONE
+    dist: trusty
+    env: TESTS=sawHMAC SAW_HMAC_TEST=md5 SAW=true GCC_VERSION=NONE
     addons: &sawaddons
       apt:
         packages:
           - clang-3.8
           - llvm-3.8
   - os : linux
-    env : TESTS=sawHMAC SAW_HMAC_TEST=sha1   SAW=true GCC_VERSION=NONE
+    dist: trusty
+    env: TESTS=sawHMAC SAW_HMAC_TEST=sha1   SAW=true GCC_VERSION=NONE
     addons : *sawaddons
   - os : linux
-    env : TESTS=sawHMAC SAW_HMAC_TEST=sha224 SAW=true GCC_VERSION=NONE
+    dist: trusty
+    env: TESTS=sawHMAC SAW_HMAC_TEST=sha224 SAW=true GCC_VERSION=NONE
     addons : *sawaddons
   - os : linux
-    env : TESTS=sawHMAC SAW_HMAC_TEST=sha256 SAW=true GCC_VERSION=NONE
+    dist: trusty
+    env: TESTS=sawHMAC SAW_HMAC_TEST=sha256 SAW=true GCC_VERSION=NONE
     addons : *sawaddons
   - os : linux
-    env : TESTS=sawHMAC SAW_HMAC_TEST=sha384 SAW=true GCC_VERSION=NONE
+    dist: trusty
+    env: TESTS=sawHMAC SAW_HMAC_TEST=sha384 SAW=true GCC_VERSION=NONE
     addons : *sawaddons
   - os : linux
-    env : TESTS=sawHMAC SAW_HMAC_TEST=sha512 SAW=true GCC_VERSION=NONE
+    dist: trusty
+    env: TESTS=sawHMAC SAW_HMAC_TEST=sha512 SAW=true GCC_VERSION=NONE
     addons : *sawaddons
   - os : linux
-    env: TESTS=sawDRBG                       SAW=true GCC_VERSION=NONE
+    dist: trusty
+    env: TESTS=sawDRBG SAW=true GCC_VERSION=NONE
     addons : *sawaddons
   - os : linux
-    env: TESTS=sawSIKE                       SAW=true GCC_VERSION=NONE
+    dist: trusty
+    env: TESTS=sawSIKE SAW=true GCC_VERSION=NONE
     addons : *sawaddons
   - os : linux
-    env : TESTS=tls SAW=true GCC_VERSION=NONE
-    addons : *sawaddons    
+    dist: trusty
+    env: TESTS=tls SAW=true GCC_VERSION=NONE
+    addons : *sawaddons
   - os : linux
-    env : TESTS=sawHMACFailure SAW=true
-    addons : *sawaddons   
-  allow_failures:
-    - os: osx
-    - env: TESTS=ctverif
-
-  fast_finish: true
+    dist: trusty
+    env: TESTS=sawHMACFailure SAW=true
+    addons : *sawaddons
 
 before_install:
-  - apt-key list
-  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 6B05F25D762E3157
-  - apt-key list
   - source .travis/s2n_setup_env.sh
 
 install:
   - travis_retry .travis/s2n_install_test_dependencies.sh
-  
+
 script:
   - .travis/s2n_travis_build.sh

--- a/.travis/install_sslyze.sh
+++ b/.travis/install_sslyze.sh
@@ -12,13 +12,11 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 #
+
 set -e
 
-# Need to upgrade pyOpenSSL before pip on a fresh Ubuntu 16.04 install: https://stackoverflow.com/a/48569233
-sudo python -m easy_install --upgrade pyOpenSSL
-
-pip install --user --upgrade pip setuptools
-pip install --user --upgrade nassl sslyze==1.4.0
+pip3 install --user --upgrade pip setuptools
+pip3 install --user sslyze
 
 which sslyze
 sslyze --version

--- a/.travis/install_ubuntu_dependencies.sh
+++ b/.travis/install_ubuntu_dependencies.sh
@@ -15,20 +15,25 @@
 
 set -ex
 
+apt-key list
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 6B05F25D762E3157
+apt-key list
+
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 sudo apt-get update -o Acquire::CompressionTypes::Order::=gz
 
-DEPENDENCIES="unzip make indent kwstyle libssl-dev tcpdump valgrind lcov m4 nettle-dev nettle-bin pkg-config gcc g++ zlibc zlib1g-dev python-pip llvm"
+DEPENDENCIES="unzip make indent kwstyle libssl-dev tcpdump valgrind lcov m4 nettle-dev nettle-bin pkg-config gcc g++ zlibc zlib1g-dev python3-pip llvm"
 
 sudo apt-get install -y ${DEPENDENCIES}
 
 if [[ -n "$GCC_VERSION" ]] && [[ "$GCC_VERSION" != "NONE" ]]; then
-    sudo apt-get -y install gcc-$GCC_VERSION;
+    sudo apt-get -y install gcc-$GCC_VERSION g++-$GCC_VERSION;
 fi
 
-# Download and Install prlimit for memlock
-if [[ ! -d "$PRLIMIT_INSTALL_DIR" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-    mkdir -p "$PRLIMIT_INSTALL_DIR" && sudo .travis/install_prlimit.sh "$(mktemp -d)" "$PRLIMIT_INSTALL_DIR";
+# If prlimit is not on our current PATH, download and compile prlimit manually. s2n needs prlimit to memlock pages
+if ! type prlimit > /dev/null && [[ ! -d "$PRLIMIT_INSTALL_DIR" ]]; then
+    mkdir -p "$PRLIMIT_INSTALL_DIR";
+    sudo .travis/install_prlimit.sh "$(mktemp -d)" "$PRLIMIT_INSTALL_DIR";
 fi
 
 if [[ "$TESTS" == "ctverif" || "$TESTS" == "ALL" ]] ; then

--- a/.travis/s2n_override_paths.sh
+++ b/.travis/s2n_override_paths.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+set -ex
+
+# Add all of our test dependencies to the PATH. Use Openssl 1.1.1 so the latest openssl is used for s_client
+# integration tests.
+export PATH=$PYTHON_INSTALL_DIR/bin:$OPENSSL_1_1_1_INSTALL_DIR/bin:$GNUTLS_INSTALL_DIR/bin:$SAW_INSTALL_DIR/bin:$Z3_INSTALL_DIR/bin:$SCAN_BUILD_INSTALL_DIR/bin:$PRLIMIT_INSTALL_DIR/bin:$LATEST_CLANG_INSTALL_DIR/bin:`pwd`/.travis/:~/.local/bin:$PATH
+export LD_LIBRARY_PATH=$OPENSSL_1_1_1_INSTALL_DIR/lib:$LD_LIBRARY_PATH; 
+export DYLD_LIBRARY_PATH=$OPENSSL_1_1_1_INSTALL_DIR/lib:$LD_LIBRARY_PATH;

--- a/.travis/s2n_setup_env.sh
+++ b/.travis/s2n_setup_env.sh
@@ -45,6 +45,7 @@
 unamestr=$(uname)
 if [[ "$unamestr" == 'Linux' ]]; then
    : "${TRAVIS_OS_NAME:=linux}"
+   : "${UBUNTU_VERSION:=$(lsb_release -rs)}"
 elif [[ "$unamestr" == 'Darwin' ]]; then
    : "${TRAVIS_OS_NAME:=osx}"
 fi
@@ -74,13 +75,9 @@ export SIDETRAIL_INSTALL_DIR
 export OPENSSL_1_1_X_MASTER_INSTALL_DIR
 export FUZZ_TIMEOUT_SEC
 export TRAVIS_OS_NAME
+export UBUNTU_VERSION
 export S2N_CORKED_IO
 
-# Add all of our test dependencies to the PATH. Use Openssl 1.1.1 so the latest openssl is used for s_client
-# integration tests.
-export PATH=$PYTHON_INSTALL_DIR/bin:$OPENSSL_1_1_1_INSTALL_DIR/bin:$GNUTLS_INSTALL_DIR/bin:$SAW_INSTALL_DIR/bin:$Z3_INSTALL_DIR/bin:$SCAN_BUILD_INSTALL_DIR/bin:$LATEST_CLANG_INSTALL_DIR/bin:`pwd`/.travis/:$PATH
-export LD_LIBRARY_PATH=$OPENSSL_1_1_1_INSTALL_DIR/lib:$LD_LIBRARY_PATH; 
-export DYLD_LIBRARY_PATH=$OPENSSL_1_1_1_INSTALL_DIR/lib:$LD_LIBRARY_PATH;
 
 # Select the libcrypto to build s2n against. If this is unset, default to the latest stable version(Openssl 1.1.1)
 if [[ -z $S2N_LIBCRYPTO ]]; then export LIBCRYPTO_ROOT=$OPENSSL_1_1_1_INSTALL_DIR ; fi
@@ -101,6 +98,7 @@ rm -rf libcrypto-root && ln -s "$LIBCRYPTO_ROOT" libcrypto-root
 export LIBFUZZER_ROOT=$LIBFUZZER_INSTALL_DIR
 
 echo "TRAVIS_OS_NAME=$TRAVIS_OS_NAME"
+echo "UBUNTU_VERSION=$UBUNTU_VERSION"
 echo "S2N_LIBCRYPTO=$S2N_LIBCRYPTO"
 echo "BUILD_S2N=$BUILD_S2N"
 echo "GCC_VERSION=$GCC_VERSION"


### PR DESCRIPTION
**Issue # (if available):** 

**Description of changes:** 
Migrate Travis Builds to Ubuntu 18.04
 - Moved `LD_LIBRARY_PATH` overrides to just before the build starts since it was interfering with the test install scripts
 - Made sure everything's using Python3 (including sslyze install script)
 - Updated Travis.yml config file to use Ubuntu 18.04 build environment for Unit, Integration, and Fuzz Tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
