### PR TITLE
TLS 1.3 AEAD Record Encryption

### DIFF
--- a/tests/unit/s2n_tls13_record_aead_test.c
+++ b/tests/unit/s2n_tls13_record_aead_test.c
@@ -319,7 +319,7 @@ int main(int argc, char **argv)
         /* Reset sequence number */
         conn->secure.client_sequence_number[7] = 0;
 
-        s2n_stuffer_write_bytes(&conn->in, &conn->out.blob.data[S2N_TLS13_AAD_LEN], plaintext.size + 16 + 1); /* tag length + content type */;
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&conn->in, &conn->out.blob.data[S2N_TLS13_AAD_LEN], plaintext.size + 16 + 1)); /* tag length + content type */;
 
         /* Make a slice of output bytes to verify */
         struct s2n_blob encrypted = {

--- a/tls/s2n_record_write.c
+++ b/tls/s2n_record_write.c
@@ -64,7 +64,7 @@ static uint16_t overhead(struct s2n_connection *conn)
     return extra;
 }
 
-int s2n_record_rounded_write_payload_size(struct s2n_connection *conn, uint16_t size_without_overhead) 
+int s2n_record_rounded_write_payload_size(struct s2n_connection *conn, uint16_t size_without_overhead)
 {
     uint16_t max_fragment_size = size_without_overhead;
     struct s2n_crypto_parameters *active = conn->server;
@@ -94,7 +94,7 @@ int s2n_record_max_write_payload_size(struct s2n_connection *conn)
 
 int s2n_record_min_write_payload_size(struct s2n_connection *conn)
 {
-    uint16_t min_outgoing_fragement_length = ETH_MTU - (conn->ipv6 ? IP_V6_HEADER_LENGTH : IP_V4_HEADER_LENGTH) 
+    uint16_t min_outgoing_fragement_length = ETH_MTU - (conn->ipv6 ? IP_V6_HEADER_LENGTH : IP_V4_HEADER_LENGTH)
         - TCP_HEADER_LENGTH - TCP_OPTIONS_LENGTH - S2N_TLS_RECORD_HEADER_LENGTH;
     return s2n_record_rounded_write_payload_size(conn, min_outgoing_fragement_length);
 }
@@ -124,12 +124,54 @@ int s2n_record_write_protocol_version(struct s2n_connection *conn)
     return 0;
 }
 
+static inline int s2n_record_encrypt(
+    struct s2n_connection *conn,
+    const struct s2n_cipher_suite *cipher_suite,
+    struct s2n_session_key *session_key,
+    struct s2n_blob *iv,
+    struct s2n_blob *aad,
+    struct s2n_blob *en,
+    uint8_t *implicit_iv, uint16_t block_size)
+{
+    notnull_check(en->data);
+
+    switch (cipher_suite->record_alg->cipher->type) {
+        case S2N_STREAM:
+            GUARD(cipher_suite->record_alg->cipher->io.stream.encrypt(session_key, en, en));
+            break;
+        case S2N_CBC:
+            GUARD(cipher_suite->record_alg->cipher->io.cbc.encrypt(session_key, iv, en, en));
+
+            /* Copy the last encrypted block to be the next IV */
+            if (conn->actual_protocol_version < S2N_TLS11) {
+                gte_check(en->size, block_size);
+                memcpy_check(implicit_iv, en->data + en->size - block_size, block_size);
+            }
+            break;
+        case S2N_AEAD:
+            GUARD(cipher_suite->record_alg->cipher->io.aead.encrypt(session_key, iv, aad, en, en));
+            break;
+        case S2N_COMPOSITE:
+            /* This will: compute mac, append padding, append padding length, and encrypt */
+            GUARD(cipher_suite->record_alg->cipher->io.comp.encrypt(session_key, iv, en, en));
+
+            /* Copy the last encrypted block to be the next IV */
+            gte_check(en->size, block_size);
+            memcpy_check(implicit_iv, en->data + en->size - block_size, block_size);
+            break;
+        default:
+            S2N_ERROR(S2N_ERR_CIPHER_TYPE);
+            break;
+    }
+
+    return 0;
+}
+
 int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const struct iovec *in, int in_count, size_t offs, size_t to_write)
 {
-    struct s2n_blob iv, aad;
+    struct s2n_blob iv;
     uint8_t padding = 0;
     uint16_t block_size = 0;
-    uint8_t aad_gen[S2N_TLS_MAX_AAD_LEN] = { 0 };
     uint8_t aad_iv[S2N_TLS_MAX_IV_LEN] = { 0 };
 
     uint8_t *sequence_number = conn->server->server_sequence_number;
@@ -147,6 +189,7 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
     }
 
     const int is_tls13_record = cipher_suite->record_alg->flags & S2N_TLS13_RECORD_AEAD_NONCE;
+    s2n_stack_blob(aad, is_tls13_record ? S2N_TLS13_AAD_LEN : S2N_TLS_MAX_AAD_LEN, S2N_TLS_MAX_AAD_LEN);
 
     S2N_ERROR_IF(s2n_stuffer_data_available(&conn->out), S2N_ERR_BAD_MESSAGE);
 
@@ -215,8 +258,7 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
     /* If we're AEAD, write the sequence number as an IV, and generate the AAD */
     if (cipher_suite->record_alg->cipher->type == S2N_AEAD) {
         struct s2n_stuffer iv_stuffer = {0};
-        iv.data = aad_iv;
-        iv.size = sizeof(aad_iv);
+        s2n_blob_init(&iv, aad_iv, sizeof(aad_iv));
         GUARD(s2n_stuffer_init(&iv_stuffer, &iv));
 
         if (cipher_suite->record_alg->flags & S2N_TLS12_AES_GCM_AEAD_NONCE) {
@@ -239,9 +281,6 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
         /* Set the IV size to the amount of data written */
         iv.size = s2n_stuffer_data_available(&iv_stuffer);
 
-        aad.data = aad_gen;
-        aad.size = is_tls13_record ? S2N_TLS13_AAD_LEN : sizeof(aad_gen);
-
         struct s2n_stuffer ad_stuffer = {0};
         GUARD(s2n_stuffer_init(&ad_stuffer, &aad));
         if (is_tls13_record) {
@@ -250,8 +289,7 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
             GUARD(s2n_aead_aad_init(conn, sequence_number, content_type, data_bytes_to_take, &ad_stuffer));
         }
     } else if (cipher_suite->record_alg->cipher->type == S2N_CBC || cipher_suite->record_alg->cipher->type == S2N_COMPOSITE) {
-        iv.size = block_size;
-        iv.data = implicit_iv;
+        s2n_blob_init(&iv, implicit_iv, block_size);
 
         /* For TLS1.1/1.2; write the IV with random data */
         if (conn->actual_protocol_version > S2N_TLS10) {
@@ -325,39 +363,8 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
     }
 
     /* Do the encryption */
-    struct s2n_blob en = {0};
-    en.size = encrypted_length;
-    en.data = s2n_stuffer_raw_write(&conn->out, en.size);
-    notnull_check(en.data);
-
-    switch (cipher_suite->record_alg->cipher->type) {
-        case S2N_STREAM:
-            GUARD(cipher_suite->record_alg->cipher->io.stream.encrypt(session_key, &en, &en));
-            break;
-        case S2N_CBC:
-            GUARD(cipher_suite->record_alg->cipher->io.cbc.encrypt(session_key, &iv, &en, &en));
-
-            /* Copy the last encrypted block to be the next IV */
-            if (conn->actual_protocol_version < S2N_TLS11) {
-                gte_check(en.size, block_size);
-                memcpy_check(implicit_iv, en.data + en.size - block_size, block_size);
-            }
-            break;
-        case S2N_AEAD:
-            GUARD(cipher_suite->record_alg->cipher->io.aead.encrypt(session_key, &iv, &aad, &en, &en));
-            break;
-        case S2N_COMPOSITE:
-            /* This will: compute mac, append padding, append padding length, and encrypt */
-            GUARD(cipher_suite->record_alg->cipher->io.comp.encrypt(session_key, &iv, &en, &en));
-
-            /* Copy the last encrypted block to be the next IV */
-            gte_check(en.size, block_size);
-            memcpy_check(implicit_iv, en.data + en.size - block_size, block_size);
-            break;
-        default:
-            S2N_ERROR(S2N_ERR_CIPHER_TYPE);
-            break;
-    }
+    struct s2n_blob en = { .size = encrypted_length, .data = s2n_stuffer_raw_write(&conn->out, encrypted_length) };
+    GUARD(s2n_record_encrypt(conn, cipher_suite, session_key, &iv, &aad, &en, implicit_iv, block_size));
 
     conn->wire_bytes_out += actual_fragment_length + S2N_TLS_RECORD_HEADER_LENGTH;
     return data_bytes_to_take;


### PR DESCRIPTION
**Issue # (if available):** 
#1169, continuation of #1195

**Description of changes:** 
Support TLS 1.3 AEAD Encryption mode with no record (implicit) IV and 5 byte AAD in S2N_TLS13_RECORD_AEAD_NONCE mode.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
