### PR TITLE
Update openssl integ tests to try tls1.3

### DIFF
--- a/tests/integration/s2n_test_constants.py
+++ b/tests/integration/s2n_test_constants.py
@@ -112,6 +112,7 @@ S2N_PROTO_VERS_TO_STR = {
     S2N_TLS11 : "TLSv1.1",
     S2N_TLS12 : "TLSv1.2",
     S2N_TLS13 : "TLSv1.3",
+    None      : "Default",
 }
 
 S2N_PROTO_VERS_TO_GNUTLS = {


### PR DESCRIPTION
**Issue # (if available):** [1175](https://github.com/awslabs/s2n/issues/1175)

**Description of changes:**
The openssl s_server/s_client commands offer optional "-tls1_x" arguments that can be used to force the protocol to use a specific version. At the moment, many of our tests specifically run against all the versions we support. For those tests, I add an extra run that doesn't provide any version argument, causing s_server/s_client to use the current default behavior of attempting to use tls1.3 but negotiating down to tls1.2. For the tests that previously only ran against a single specific version (using -tls1_2), I removed the version argument so that we just use the default behavior. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
