### PR TITLE
Remove spurious gte_check

### DIFF
--- a/tls/s2n_aead.c
+++ b/tls/s2n_aead.c
@@ -37,7 +37,6 @@ int s2n_aead_aad_init(const struct s2n_connection *conn, uint8_t * sequence_numb
 /* Prepares an AAD (additional authentication data) for a TLS 1.3 AEAD record */
 int s2n_tls13_aead_aad_init(uint16_t record_length, uint8_t tag_length, struct s2n_stuffer *additional_data)
 {
-    gte_check(record_length, 0);
     gt_check(tag_length, 0);
     notnull_check(additional_data);
 


### PR DESCRIPTION
the datatype is unsigned, so this is always true

**Issue # (if available):** N/A

**Description of changes:** 

Some compilers will treat this as a warning and fail with `-Werror`:

```
tls/s2n_aead.c: In function 's2n_tls13_aead_aad_init':
tls/s2n_aead.c:40: warning: comparison is always false due to limited range of data type
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
