### PR TITLE
Clean up viz Makefile

### DIFF
--- a/tests/viz/Makefile
+++ b/tests/viz/Makefile
@@ -19,16 +19,19 @@ all: build_viz
 
 include ../../s2n.mk
 
-CFLAGS += -I../
-LDFLAGS += -L../../lib/ -ls2n
+LDFLAGS += -L../../lib ${LIBS} -ls2n -L$(LIBCRYPTO_ROOT)/lib ${CRYPTO_LIBS}
 
 # Run state machine graph generation
 # with `make STATE_MACHINE_GRAPHS=1`.
 # graphviz is required.
 
 build_viz::
-	${CC} ${CFLAGS} ${LDFLAGS} -o s2n_state_machine_viz s2n_state_machine_viz.c
+	${CC} ${CFLAGS} -fno-omit-frame-pointer -fno-optimize-sibling-calls -o s2n_state_machine_viz s2n_state_machine_viz.c ${LDFLAGS}
 	@[ "${STATE_MACHINE_GRAPHS}" ] && \
-	DYLD_LIBRARY_PATH="../../lib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" \
-	LD_LIBRARY_PATH="../../lib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
+	DYLD_LIBRARY_PATH="../../lib:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" \
+	LD_LIBRARY_PATH="../../lib:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
 	./s2n_state_machine_viz || true
+
+.PHONY : clean
+clean: decruft
+	rm s2n_state_machine_viz


### PR DESCRIPTION
**Issue # (if available):** 
Found out the order of LD flags before output flags on some systems causes linker errors.

```
/tmp/ccsjuc9p.o:(.data.rel+0x238): undefined reference to `s2n_server_cert_recv'
/tmp/ccsjuc9p.o:(.data.rel+0x248): undefined reference to `s2n_server_nst_send'
/tmp/ccsjuc9p.o:(.data.rel+0x250): undefined reference to `s2n_server_nst_recv'
```

**Description of changes:** 
Switch the order of LD flags, clean up viz Makefile. This should fix travis builds too.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
