### PR TITLE
Fix processing of unexpected CCS messages

### DIFF
--- a/tests/unit/s2n_tls12_handshake_test.c
+++ b/tests/unit/s2n_tls12_handshake_test.c
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <s2n.h>
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+
+#include "tls/s2n_connection.h"
+#include "tls/s2n_handshake.h"
+#include "utils/s2n_safety.h"
+
+/* Just to get access to the static functions / variables we need to test */
+#include "tls/s2n_handshake_io.c"
+
+static message_type_t invalid_handshake[S2N_MAX_HANDSHAKE_LENGTH];
+
+static int expected_handler_called;
+static int unexpected_handler_called;
+
+static int s2n_test_handler(struct s2n_connection* conn)
+{
+    unexpected_handler_called = 1;
+    return 0;
+}
+
+static int s2n_test_expected_handler(struct s2n_connection* conn)
+{
+    expected_handler_called = 1;
+    return 0;
+}
+
+static int s2n_setup_handler_to_expect(message_type_t expected, uint8_t direction) {
+    for (int i = 0; i < sizeof(tls13_state_machine) / sizeof(struct s2n_handshake_action); i++) {
+        tls13_state_machine[i].handler[0] = s2n_test_handler;
+        tls13_state_machine[i].handler[1] = s2n_test_handler;
+    }
+
+    tls13_state_machine[expected].handler[direction] = s2n_test_expected_handler;
+
+    expected_handler_called = 0;
+    unexpected_handler_called = 0;
+
+    return 0;
+}
+
+int s2n_write_ccs_message(struct s2n_stuffer *output)
+{
+    GUARD(s2n_stuffer_write_uint8(output, TLS_CHANGE_CIPHER_SPEC));
+
+    /* TLS1.2 protocol version */
+    GUARD(s2n_stuffer_write_uint8(output, 3));
+    GUARD(s2n_stuffer_write_uint8(output, 3));
+
+    /* Total message size */
+    GUARD(s2n_stuffer_write_uint16(output, 1));
+
+    /* change spec is always just 0x01 */
+    GUARD(s2n_stuffer_write_uint8(output, 1));
+
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Construct an array of all valid tls1.2 handshake_types */
+    uint16_t valid_tls12_handshakes[S2N_HANDSHAKES_COUNT];
+    int valid_tls12_handshakes_size = 0;
+    for (int i = 0; i < S2N_HANDSHAKES_COUNT; i++) {
+        if( memcmp(handshakes, invalid_handshake, S2N_MAX_HANDSHAKE_LENGTH) != 0) {
+            valid_tls12_handshakes[valid_tls12_handshakes_size] = i;
+            valid_tls12_handshakes_size++;
+        }
+    }
+
+    /* Test: When using TLS 1.2, use the existing state machine and handshakes */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+        conn->actual_protocol_version = S2N_TLS12;
+        EXPECT_EQUAL(ACTIVE_STATE_MACHINE(conn), state_machine);
+        EXPECT_EQUAL(ACTIVE_HANDSHAKES(conn), handshakes);
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test: TLS1.2 server waits for expected CCS messages */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+        conn->actual_protocol_version = S2N_TLS12;
+
+        for (int i = 0; i < valid_tls12_handshakes_size; i++) {
+            int handshake = valid_tls12_handshakes[i];
+
+            conn->handshake.handshake_type = handshake;
+
+            for (int j = 0; j < S2N_MAX_HANDSHAKE_LENGTH; j++) {
+                if (handshakes[i][j] == CLIENT_CHANGE_CIPHER_SPEC) {
+                    conn->handshake.message_number = j - 1;
+
+                    EXPECT_SUCCESS(s2n_advance_message(conn));
+
+                    EXPECT_EQUAL(conn->handshake.message_number, j);
+                    EXPECT_EQUAL(ACTIVE_MESSAGE(conn), CLIENT_CHANGE_CIPHER_SPEC);
+
+                    break;
+                }
+            }
+        }
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test: TLS1.2 client waits for expected CCS messages */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+        conn->actual_protocol_version = S2N_TLS12;
+
+        for (int i = 0; i < valid_tls12_handshakes_size; i++) {
+            int handshake = valid_tls12_handshakes[i];
+
+            conn->handshake.handshake_type = handshake;
+
+            for (int j = 0; j < S2N_MAX_HANDSHAKE_LENGTH; j++) {
+                if (handshakes[i][j] == SERVER_CHANGE_CIPHER_SPEC) {
+                    conn->handshake.message_number = j - 1;
+
+                    EXPECT_SUCCESS(s2n_advance_message(conn));
+
+                    EXPECT_EQUAL(conn->handshake.message_number, j);
+                    EXPECT_EQUAL(ACTIVE_MESSAGE(conn), SERVER_CHANGE_CIPHER_SPEC);
+
+                    break;
+                }
+            }
+        }
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test: TLS1.2 client handles expected server CCS messages
+     *       but errors on unexpected CCS messages */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+        conn->actual_protocol_version = S2N_TLS12;
+
+        struct s2n_stuffer input;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, NULL, conn));
+
+        EXPECT_SUCCESS(s2n_setup_handler_to_expect(SERVER_CHANGE_CIPHER_SPEC, S2N_CLIENT));
+
+        for (int i = 0; i < valid_tls12_handshakes_size; i++) {
+            int handshake = valid_tls12_handshakes[i];
+
+            conn->handshake.handshake_type = handshake;
+            conn->in_status = ENCRYPTED;
+
+            for (int j = 1; j < S2N_MAX_HANDSHAKE_LENGTH; j++) {
+                conn->handshake.message_number = j;
+                EXPECT_SUCCESS(s2n_write_ccs_message(&input));
+
+                if (handshakes[i][j] == SERVER_CHANGE_CIPHER_SPEC) {
+                    EXPECT_SUCCESS(handshake_read_io(conn));
+                    EXPECT_TRUE(expected_handler_called);
+                    EXPECT_FALSE(unexpected_handler_called);
+                } else {
+                    EXPECT_FAILURE_WITH_ERRNO(handshake_read_io(conn), S2N_ERR_BAD_MESSAGE);
+                    EXPECT_FALSE(expected_handler_called);
+                    EXPECT_FALSE(unexpected_handler_called);
+                }
+
+                EXPECT_SUCCESS(s2n_stuffer_wipe(&input));
+                break;
+            }
+        }
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&input));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test: TLS1.2 server handles expected client CCS messages
+     *       but errors on unexpected CCS messages */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+        conn->actual_protocol_version = S2N_TLS12;
+
+        struct s2n_stuffer input;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, NULL, conn));
+
+        EXPECT_SUCCESS(s2n_setup_handler_to_expect(CLIENT_CHANGE_CIPHER_SPEC, S2N_SERVER));
+
+        for (int i = 0; i < valid_tls12_handshakes_size; i++) {
+            int handshake = valid_tls12_handshakes[i];
+
+            conn->handshake.handshake_type = handshake;
+            conn->in_status = ENCRYPTED;
+
+            for (int j = 1; j < S2N_MAX_HANDSHAKE_LENGTH; j++) {
+                conn->handshake.message_number = j;
+                EXPECT_SUCCESS(s2n_write_ccs_message(&input));
+
+                if (handshakes[i][j] == CLIENT_CHANGE_CIPHER_SPEC) {
+                    EXPECT_SUCCESS(handshake_read_io(conn));
+                    EXPECT_TRUE(expected_handler_called);
+                    EXPECT_FALSE(unexpected_handler_called);
+                } else {
+                    EXPECT_FAILURE_WITH_ERRNO(handshake_read_io(conn), S2N_ERR_BAD_MESSAGE);
+                    EXPECT_FALSE(expected_handler_called);
+                    EXPECT_FALSE(unexpected_handler_called);
+                }
+
+                EXPECT_SUCCESS(s2n_stuffer_wipe(&input));
+                break;
+            }
+        }
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&input));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    END_TEST();
+    return 0;
+}

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -408,17 +408,20 @@ static const char* handshake_type_names[] = {
     "NO_CLIENT_CERT|"
 };
 
-#define IS_TLS13_HANDSHAKE( conn ) ((conn)->actual_protocol_version == S2N_TLS13)
+#define IS_TLS13_HANDSHAKE( conn )    ((conn)->actual_protocol_version == S2N_TLS13)
 
 #define ACTIVE_STATE_MACHINE( conn )  (IS_TLS13_HANDSHAKE(conn) ? tls13_state_machine : state_machine)
-#define ACTIVE_HANDSHAKES( conn )      (IS_TLS13_HANDSHAKE(conn) ? tls13_handshakes : handshakes)
+#define ACTIVE_HANDSHAKES( conn )     (IS_TLS13_HANDSHAKE(conn) ? tls13_handshakes : handshakes)
 
 #define ACTIVE_MESSAGE( conn )        ACTIVE_HANDSHAKES(conn)[ (conn)->handshake.handshake_type ][ (conn)->handshake.message_number ]
 #define PREVIOUS_MESSAGE( conn )      ACTIVE_HANDSHAKES(conn)[ (conn)->handshake.handshake_type ][ (conn)->handshake.message_number - 1 ]
 
 #define ACTIVE_STATE( conn )          ACTIVE_STATE_MACHINE(conn)[ ACTIVE_MESSAGE( (conn) ) ]
 #define PREVIOUS_STATE( conn )        ACTIVE_STATE_MACHINE(conn)[ PREVIOUS_MESSAGE( (conn) ) ]
+#define CCS_STATE( conn )             (((conn)->mode == S2N_CLIENT) ? ACTIVE_STATE_MACHINE(conn)[SERVER_CHANGE_CIPHER_SPEC] \
+                                                                    : ACTIVE_STATE_MACHINE(conn)[CLIENT_CHANGE_CIPHER_SPEC] )
 
+#define EXPECTED_RECORD_TYPE( conn )  ACTIVE_STATE( conn ).record_type
 #define EXPECTED_MESSAGE_TYPE( conn ) ACTIVE_STATE( conn ).message_type
 
 /* Used in our test cases */
@@ -442,7 +445,7 @@ static int s2n_advance_message(struct s2n_connection *conn)
 
     /* When reading and using TLS1.3, skip optional change_cipher_spec states. */
     if (ACTIVE_STATE(conn).writer != this &&
-            ACTIVE_STATE(conn).record_type == TLS_CHANGE_CIPHER_SPEC &&
+            EXPECTED_RECORD_TYPE(conn) == TLS_CHANGE_CIPHER_SPEC &&
             IS_TLS13_HANDSHAKE(conn)) {
         return s2n_advance_message(conn);
     }
@@ -660,7 +663,7 @@ static int s2n_conn_update_handshake_hashes(struct s2n_connection *conn, struct 
  */
 static int handshake_write_io(struct s2n_connection *conn)
 {
-    uint8_t record_type = ACTIVE_STATE(conn).record_type;
+    uint8_t record_type = EXPECTED_RECORD_TYPE(conn);
     s2n_blocked_status blocked = S2N_NOT_BLOCKED;
 
     /* Populate handshake.io with header/payload for the current state, once.
@@ -823,10 +826,15 @@ static int handshake_read_io(struct s2n_connection *conn)
      */
     S2N_ERROR_IF(record_type == TLS_APPLICATION_DATA, S2N_ERR_BAD_MESSAGE);
     if (record_type == TLS_CHANGE_CIPHER_SPEC) {
+        /* TLS1.2 should not receive unexpected change cipher spec messages, but TLS1.3 might. */
+        if (!IS_TLS13_HANDSHAKE(conn)) {
+            S2N_ERROR_IF(EXPECTED_RECORD_TYPE(conn) != TLS_CHANGE_CIPHER_SPEC, S2N_ERR_BAD_MESSAGE);
+        }
+
         S2N_ERROR_IF(s2n_stuffer_data_available(&conn->in) != 1, S2N_ERR_BAD_MESSAGE);
 
         GUARD(s2n_stuffer_copy(&conn->in, &conn->handshake.io, s2n_stuffer_data_available(&conn->in)));
-        GUARD(ACTIVE_STATE(conn).handler[conn->mode] (conn));
+        GUARD(CCS_STATE(conn).handler[conn->mode] (conn));
         GUARD(s2n_stuffer_wipe(&conn->handshake.io));
 
         /* We're done with the record, wipe it */
@@ -834,8 +842,8 @@ static int handshake_read_io(struct s2n_connection *conn)
         GUARD(s2n_stuffer_wipe(&conn->in));
         conn->in_status = ENCRYPTED;
 
-        /* Advance the state machine */
-        if (ACTIVE_STATE(conn).record_type == TLS_CHANGE_CIPHER_SPEC) {
+        /* Advance the state machine if this was an expected message */
+        if (EXPECTED_RECORD_TYPE(conn) == TLS_CHANGE_CIPHER_SPEC) {
             GUARD(s2n_advance_message(conn));
         }
 


### PR DESCRIPTION
**Issue # (if available):** [1203](https://github.com/awslabs/s2n/issues/1203)

**Description of changes:** 
In TLS1.2, we assumed that if we got a CCS message, then we were in the CCS state. We would process the message with the active handler and then advance the state machine.

In TLS1.3, we can receive a CCS message at any time. I previously updated the code to not advance the state machine if the CCS message wasn't expected, but didn't update which handler we were using. So we would use the handler of whatever the active state was. This commit corrects that, explicitly using the CCS handler.

For added safety, I also added an new explicit "Bad Message" error if we get unexpected CCS messages pre-TLS1.3.

This was missed in the unit tests because I didn't check which handler was called, so I updated the unit tests to explicitly verify that we call the right handler.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
