### PR TITLE
Speed up OpenSSL and GnuTLS integration tests

### DIFF
--- a/tests/integration/s2n_handshake_test_gnutls-cli.py
+++ b/tests/integration/s2n_handshake_test_gnutls-cli.py
@@ -204,7 +204,7 @@ def main():
                 return -1
 
     # Produce permutations of every accepted signature algorithm in every possible order
-    for size in range(1, len(EXPECTED_RSA_SIGNATURE_ALGORITHM_PREFS) + 1):
+    for size in range(1, min(MAX_ITERATION_DEPTH, len(EXPECTED_RSA_SIGNATURE_ALGORITHM_PREFS)) + 1):
         print("\n\tTesting ciphers using RSA signature preferences of size: " + str(size))
         threadpool = create_thread_pool()
         port_offset = 0
@@ -226,7 +226,7 @@ def main():
                 return -1
 
     # Try ECDSA signature algorithm permutations. When we support multiple certificates, we can combine the RSA and ECDSA tests
-    for size in range(1, len(EXPECTED_ECDSA_SIGNATURE_ALGORITHM_PREFS) + 1):
+    for size in range(1, min(MAX_ITERATION_DEPTH, len(EXPECTED_ECDSA_SIGNATURE_ALGORITHM_PREFS)) + 1):
         print("\n\tTesting ciphers using ECDSA signature preferences of size: " + str(size))
         threadpool = create_thread_pool()
         port_offset = 0

--- a/tests/integration/s2n_handshake_test_s_client.py
+++ b/tests/integration/s2n_handshake_test_s_client.py
@@ -521,7 +521,7 @@ def sigalg_test(host, port, fips_mode, use_client_auth=None, no_ticket=False):
     print("\tExpected supported:   " + str(supported_sigs))
     print("\tExpected unsupported: " + str(unsupported_sigs))
 
-    for size in range(1, len(supported_sigs) + 1):
+    for size in range(1, min(MAX_ITERATION_DEPTH, len(supported_sigs)) + 1):
         print("\n\t\tTesting ciphers using signature preferences of size: " + str(size))
         threadpool = create_thread_pool()
         portOffset = 0
@@ -555,7 +555,7 @@ def elliptic_curve_test(host, port, fips_mode):
     print("\tExpected unsupported: " + str(unsupported_curves))
 
     failed = 0
-    for size in range(1, len(supported_curves) + 1):
+    for size in range(1, min(MAX_ITERATION_DEPTH, len(supported_curves)) + 1):
         print("\n\t\tTesting ciphers using curve list of size: " + str(size))
 
         # Produce permutations of every accepted curve in every possible order

--- a/tests/integration/s2n_handshake_test_s_server.py
+++ b/tests/integration/s2n_handshake_test_s_server.py
@@ -268,7 +268,7 @@ def sigalg_test(host, port):
     print("\tExpected supported:   " + str(supported_sigs))
     print("\tExpected unsupported: " + str(unsupported_sigs))
 
-    for size in range(1, len(supported_sigs) + 1):
+    for size in range(1, min(MAX_ITERATION_DEPTH, len(supported_sigs)) + 1):
         print("\n\t\tTesting ciphers using signature preferences of size: " + str(size))
         threadpool = create_thread_pool()
         portOffset = 0
@@ -303,7 +303,7 @@ def elliptic_curve_test(host, port):
     print("\tExpected unsupported: " + str(unsupported_curves))
 
     failed = 0
-    for size in range(1, len(supported_curves) + 1):
+    for size in range(1, min(MAX_ITERATION_DEPTH, len(supported_curves)) + 1):
         print("\n\t\tTesting ciphers using curve list of size: " + str(size))
 
         # Produce permutations of every accepted curve in every possible order

--- a/tests/integration/s2n_test_constants.py
+++ b/tests/integration/s2n_test_constants.py
@@ -65,6 +65,9 @@ ALL_TEST_CIPHERS = [
     S2N_CIPHER("DHE-RSA-CHACHA20-POLY1305", S2N_GNUTLS_PRIORITY_PREFIX + ":+DHE-RSA:+CHACHA20-POLY1305:+AEAD", S2N_TLS12, True, False),
 ]
 
+# Limit the depth of combinations with itertools permutations to reduce integration tests runtime
+MAX_ITERATION_DEPTH = 3
+
 # Expected preferences for SignatureAlgorithms in GnuTLS priority string format
 # See https://github.com/awslabs/s2n/blob/master/tls/s2n_tls_digest_preferences.h
 EXPECTED_RSA_SIGNATURE_ALGORITHM_PREFS = [


### PR DESCRIPTION
**Issue # (if available):** 
With added integration tests (with TLS 1.3), Travis builds are failing as it hits a 50 minute limit.

**Description of changes:** 
This PR attempts to speed up integration tests by limiting permutation depth to 3 for signature  and curve combinations. Based on estimations (calculating depth 4 and depth 5 combinations), this could shave about 12-15 minutes from integration tests.


```
(timestamps)
Oct 29 19:54:25 		Testing ciphers using signature preferences of size: 4
Oct 29 19:56:38 		Testing ciphers using signature preferences of size: 5
Oct 29 19:58:03 	Running signature algorithm tests:
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
