### PR TITLE
Fix record write payload length and ensure opaque type in TLS 1.3

### DIFF
--- a/tests/unit/s2n_tls13_record_aead_test.c
+++ b/tests/unit/s2n_tls13_record_aead_test.c
@@ -266,6 +266,14 @@ int main(int argc, char **argv)
         /* Takes an input blob and writes to out stuffer then encrypt the payload */
         EXPECT_SUCCESS(s2n_record_write(conn, TLS_HANDSHAKE, &in));
 
+        /* Verify opaque content type in tls 1.3 */
+        EXPECT_EQUAL(conn->out.blob.data[0], TLS_APPLICATION_DATA);
+        /* Verify TLS legacy record version */
+        EXPECT_EQUAL(conn->out.blob.data[1], 3);
+        EXPECT_EQUAL(conn->out.blob.data[2], 3);
+        /* Verify payload length */
+        EXPECT_EQUAL((conn->out.blob.data[3] << 8) + conn->out.blob.data[4], protected_record.size);
+
         /* Make a slice of output bytes to verify */
         struct s2n_blob out = {
             .data = &conn->out.blob.data[S2N_TLS13_AAD_LEN],


### PR DESCRIPTION
**Issue # (if available):** 
Fix a off-by-one record length error for TLS 1.3 record in 

**Description of changes:** 
Record write payload length now include additional 1 byte content type correctly.
s2n_record_writev() will also ensure Application Data opaque type in TLS 1.3 record mode

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
