### PR TITLE
Add script to grep for simple mistakes

### DIFF
--- a/.travis/grep_simple_mistakes.sh
+++ b/.travis/grep_simple_mistakes.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+FAILED=0
+
+# Assert that functions do not return -1 or S2N_ERR* codes directly.
+# To indicate failure, functions should use the S2N_ERROR* macros defined
+# in s2n_errno.h.
+S2N_FILES_ASSERT_RETURN=$(find "$PWD" -type f -name "s2n*.c" -not -path "*/tests/*")
+for file in $S2N_FILES_ASSERT_RETURN; do
+  RESULT_NEGATIVE_ONE=`grep -rn 'return -1;' $file`
+  RESULT_S2N_ERR=`grep -rn 'return S2N_ERR*' $file`
+  RESULT_S2N_FAIL=`grep -rn 'return S2N_FAIL*' $file`
+
+  if [ "${#RESULT_NEGATIVE_ONE}" != "0" ]; then
+    FAILED=1
+    printf "\e[1;34mGrep for 'return -1;' check failed in $file:\e[0m\n$RESULT_NEGATIVE_ONE\n\n"
+  fi
+  if [ "${#RESULT_S2N_ERR}" != "0" ]; then
+    FAILED=1
+    printf "\e[1;34mGrep for 'return S2N_ERR*' check failed in $file:\e[0m\n$RESULT_S2N_ERR\n\n"
+  fi
+  if [ "${#RESULT_S2N_FAIL}" != "0" ]; then
+    FAILED=1
+    printf "\e[1;34mGrep for 'return S2N_FAIL*' check failed in $file:\e[0m\n$RESULT_S2N_FAIL\n\n"
+  fi
+done
+
+# Assert that all assignments from s2n_stuffer_raw_read() have a
+# notnull_check (or similar manual null check) on the same, or next, line.
+# The assertion is shallow; this doesn't guarantee that we're doing the
+# *correct* null check, just that we are doing *some* null check.
+S2N_FILES_ASSERT_NOTNULL_CHECK=$(find "$PWD" -type f -name "s2n*.[ch]" -not -path "*/tests/*")
+for file in $S2N_FILES_ASSERT_NOTNULL_CHECK; do
+  while read -r line_one; do
+    # When called with the -A option, grep uses lines of "--" as delimiters. We ignore them.
+    if [[ $line_one == "--" ]]; then
+      continue
+    fi
+
+    read -r line_two
+
+    # $line_one definitely contains an assignment from s2n_stuffer_raw_read(),
+    # because that's what we grepped for. So verify that either $line_one or
+    # $line_two contains a null check.
+    manual_null_check_regex=".*if.*==\sNULL"
+    if [[ $line_one == *"notnull_check("* ]] || [[ $line_one =~ $manual_null_check_regex ]] ||\
+    [[ $line_two == *"notnull_check("* ]] || [[ $line_two =~ $manual_null_check_regex ]]; then
+      # Found a notnull_check
+      continue
+    else
+      FAILED=1
+      printf "\e[1;34mFound a call to s2n_stuffer_raw_read without a notnull_check in $file:\e[0m\n$line_one\n\n"
+    fi
+  done < <(grep -rnE -A 1 "=\ss2n_stuffer_raw_read\(.*\)" $file)
+done
+
+if [ $FAILED == 1 ]; then
+  printf "\\033[31;1mFAILED Grep For Simple Mistakes check\\033[0m\\n"
+  exit -1
+else
+  printf "\\033[32;1mPASSED Grep For Simple Mistakes check\\033[0m\\n"
+fi

--- a/.travis/s2n_travis_build.sh
+++ b/.travis/s2n_travis_build.sh
@@ -22,6 +22,7 @@ source .travis/s2n_override_paths.sh
 if [[ "$BUILD_S2N" == "true" ]]; then
     .travis/run_cppcheck.sh "$CPPCHECK_INSTALL_DIR";
     .travis/copyright_mistake_scanner.sh;
+    .travis/grep_simple_mistakes.sh;
 fi
 
 if [[ "$BUILD_S2N" == "true" && "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/tls/s2n_client_extensions.c
+++ b/tls/s2n_client_extensions.c
@@ -372,10 +372,9 @@ static int s2n_recv_client_alpn(struct s2n_connection *conn, struct s2n_stuffer 
         return 0;
     }
 
-    struct s2n_blob client_app_protocols = {
-        .data = s2n_stuffer_raw_read(extension, size_of_all),
-        .size = size_of_all
-    };
+    struct s2n_blob client_app_protocols = { 0 };
+    client_app_protocols.size = size_of_all;
+    client_app_protocols.data = s2n_stuffer_raw_read(extension, size_of_all);
     notnull_check(client_app_protocols.data);
 
     /* Find a matching protocol */

--- a/tls/s2n_connection_evp_digests.c
+++ b/tls/s2n_connection_evp_digests.c
@@ -1,7 +1,7 @@
 /*
- * Copyright 2017 Amazon.com = Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- * Licensed under the Apache License = Version 2.0 (the "License").
+ * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
  *

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -996,10 +996,10 @@ int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status * blocked)
                 if (s2n_errno == S2N_ERR_BLOCKED && s2n_stuffer_data_available(&conn->in)) {
                     if (handshake_read_io(conn) < 0 && s2n_errno == S2N_ERR_ALERT) {
                         /* handshake_read_io has set s2n_errno */
-                        return S2N_FAILURE;
+                        S2N_ERROR_PRESERVE_ERRNO();
                     }
                 }
-                return S2N_FAILURE;
+                S2N_ERROR_PRESERVE_ERRNO();
             }
         } else if (ACTIVE_STATE(conn).writer == this) {
             *blocked = S2N_BLOCKED_ON_WRITE;

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -585,8 +585,8 @@ static int s2n_prf_make_server_key(struct s2n_connection *conn, struct s2n_stuff
     struct s2n_blob server_key = {0};
     server_key.size = conn->secure.cipher_suite->record_alg->cipher->key_material_size;
     server_key.data = s2n_stuffer_raw_read(key_material, server_key.size);
-
     notnull_check(server_key.data);
+
     if (conn->mode == S2N_SERVER) {
         GUARD(conn->secure.cipher_suite->record_alg->cipher->set_encryption_key(&conn->secure.server_key, &server_key));
     } else {

--- a/tls/s2n_server_cert.c
+++ b/tls/s2n_server_cert.c
@@ -69,8 +69,9 @@ int s2n_server_cert_recv(struct s2n_connection *conn)
 
     s2n_cert_type actual_cert_type;
     struct s2n_blob cert_chain = {0};
-    cert_chain.data = s2n_stuffer_raw_read(&conn->handshake.io, size_of_all_certificates);
     cert_chain.size = size_of_all_certificates;
+    cert_chain.data = s2n_stuffer_raw_read(&conn->handshake.io, size_of_all_certificates);
+    notnull_check(cert_chain.data);
 
     S2N_ERROR_IF(s2n_x509_validator_validate_cert_chain(&conn->x509_validator, conn, cert_chain.data,
                          cert_chain.size, &actual_cert_type, &public_key) != S2N_CERT_OK, S2N_ERR_CERT_UNTRUSTED);

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -318,8 +318,8 @@ s2n_cert_validation_code s2n_x509_validator_validate_cert_chain(struct s2n_x509_
         }
 
         struct s2n_blob asn1cert = {0};
-        asn1cert.data = s2n_stuffer_raw_read(&cert_chain_in_stuffer, certificate_size);
         asn1cert.size = certificate_size;
+        asn1cert.data = s2n_stuffer_raw_read(&cert_chain_in_stuffer, certificate_size);
         if (asn1cert.data == NULL) {
             return S2N_CERT_ERR_INVALID;
         }


### PR DESCRIPTION
**Issue # (if available):** #391 

**Description of changes:** Addresses #391 by adding a script to grep for simple mistakes at build time. The script ensures that we are not directly returning -1 (outside of test or header files), and that we are null-checking immediately after doing any s2n_stuffer_raw_reads. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
