### PR TITLE
Fix codecov upload in travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -135,3 +135,4 @@ install:
 
 script:
   - .travis/s2n_travis_build.sh
+  - .travis/s2n_after_travis_build.sh

--- a/.travis/s2n_after_travis_build.sh
+++ b/.travis/s2n_after_travis_build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+set -ex
+
+# Upload Code Coverage Information to CodeCov.io
+if [[ -n "$CODECOV_IO_UPLOAD" ]]; then
+    bash <(curl -s https://codecov.io/bash) -F ${TESTS};
+fi

--- a/.travis/s2n_travis_build.sh
+++ b/.travis/s2n_travis_build.sh
@@ -83,12 +83,8 @@ if [[ "$TESTS" == "ALL" || "$TESTS" == "ctverif" ]]; then .travis/run_ctverif.sh
 if [[ "$TESTS" == "ALL" || "$TESTS" == "sawSIKE" ]]; then make -C tests/saw sike ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "sidetrail" ]]; then .travis/run_sidetrail.sh "$SIDETRAIL_INSTALL_DIR" "$PART" ; fi
 
-# Upload Code Coverage Information to CodeCov.io
+# Generate *.gcov files that can be picked up by the CodeCov.io Bash helper script. Don't run lcov or genhtml 
+# since those will delete .gcov files as they're processed.
 if [[ -n "$CODECOV_IO_UPLOAD" ]]; then
-    # Generate *.gcov files that can be picked up by the CodeCov.io Bash helper script. Don't run lcov or genhtml 
-    # since those will delete .gcov files as they're processed.
     make run-gcov;
-
-    # Upload coverage metrics to codecov.io site
-    bash <(curl -s https://codecov.io/bash) -F ${TESTS};
 fi


### PR DESCRIPTION
**Issue # (if available):** None

**Description of changes:** Our OpenSSL overrides interfere with curl, so we need to move the curl command that uploads code coverage reports to a separate script. I added it to the "script" step so that if it fails, the build will also fail. I left the "make gcov" command in the main build script to keep it with the rest of our make commands.

To verify this fix works, check the output of the [first build job](https://travis-ci.org/awslabs/s2n/jobs/608382669?utm_medium=notification&utm_source=github_status). You'll see a successful upload to codecov.io. In a broken build, you would see the message "curl: relocation error: /usr/lib/x86_64-linux-gnu/libcurl.so.4: symbol DSA_get0_key version OPENSSL_1_1_0 not defined in file libcrypto.so.1.1 with link time reference"

Successful codecov upload of unit, integration, and fuzz: https://codecov.io/gh/awslabs/s2n/commit/d6208dd0ad9a9d4534b9beaa26bc9b143e57ed5c/build

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
