### PR TITLE
Don't invoke blinding on some SSL Handshake errors

### DIFF
--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -300,8 +300,8 @@ typedef enum { S2N_BUILT_IN_BLINDING, S2N_SELF_SERVICE_BLINDING } s2n_blinding;
 
 **s2n_blinding** is used to opt-out of s2n's built-in blinding. Blinding is a
 mitigation against timing side-channels which in some cases can leak information
-about encrypted data. By default s2n will cause a thread to sleep between 1ms and 
-10 seconds whenever tampering is detected. 
+about encrypted data. By default s2n will cause a thread to sleep between 10 and 
+30 seconds whenever tampering is detected. 
 
 Setting the **S2N_SELF_SERVICE_BLINDING** option with **s2n_connection_set_blinding**
 turns off this behavior. This is useful for applications that are handling many connections

--- a/tests/unit/s2n_self_talk_min_protocol_version.c
+++ b/tests/unit/s2n_self_talk_min_protocol_version.c
@@ -119,6 +119,9 @@ int main(int argc, char **argv)
     /* Negotiate the handshake. */
     EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate(conn, &blocked), S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
 
+    /* Check that blinding was not invoked */
+    EXPECT_EQUAL(s2n_connection_get_delay(conn), 0);
+
     /* Free connection */
     EXPECT_SUCCESS(s2n_connection_free(conn));
 


### PR DESCRIPTION
**Issue # (if available):** 

**Description of changes:** 

Some of the errors are safe to report right away without keeping end user waiting for up to 30 seconds. For this change the following errors are included:
* S2N_ERR_CANCELLED - when client hello callback requested handshake cancellation, which is used when no SNI match was found.
* S2N_ERR_CIPHER_NOT_SUPPORTED - when no cipher overlap was found.
* S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED - when protocol version didn't meet cipher preference criteria.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
