### PR TITLE
Issue NST if incoming ST is of unexpected size

### DIFF
--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -716,7 +716,7 @@ int main(int argc, char *const *argv)
             close(fd);
         } else {
             st_key = default_ticket_key;
-            st_key_length = strlen((char *)default_ticket_key);
+            st_key_length = sizeof(default_ticket_key);
         }
 
         if (s2n_config_add_ticket_crypto_key(config, ticket_key_name, strlen((char *) ticket_key_name), st_key, st_key_length, 0) != 0) {

--- a/tls/s2n_client_extensions.c
+++ b/tls/s2n_client_extensions.c
@@ -508,14 +508,11 @@ static int s2n_recv_client_session_ticket_ext(struct s2n_connection *conn, struc
         return 0;
     }
 
-    if (s2n_stuffer_data_available(extension) == 0 && s2n_config_is_encrypt_decrypt_key_available(conn->config) == 1) {
-        conn->session_ticket_status = S2N_NEW_TICKET;
-        return 0;
-    }
-
     if (s2n_stuffer_data_available(extension) == S2N_TICKET_SIZE_IN_BYTES) {
         conn->session_ticket_status = S2N_DECRYPT_TICKET;
         GUARD(s2n_stuffer_copy(extension, &conn->client_ticket_to_decrypt, S2N_TICKET_SIZE_IN_BYTES));
+    } else if (s2n_config_is_encrypt_decrypt_key_available(conn->config) == 1) {
+        conn->session_ticket_status = S2N_NEW_TICKET;
     }
 
     return 0;


### PR DESCRIPTION
**Issue # (if available):** 

**Description of changes:** 

Previously if s2n couldn't recognize ticket size, it would ignore it and not issue a new session ticket, causing client to hold to the bad ticket without ability to recover.

With this change we would issue a new session ticket in such cases.

Also fixed buffer overrun in s2nd.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
