### PR TITLE
Initial CBMC proof for s2n_stuffer_init

### DIFF
--- a/tests/cbmc/.gitignore
+++ b/tests/cbmc/.gitignore
@@ -1,0 +1,7 @@
+TAGS
+cbmc.log
+coverage.xml
+gotos
+html
+logs
+property.xml

--- a/tests/cbmc/README.md
+++ b/tests/cbmc/README.md
@@ -10,14 +10,14 @@ The proofs are checked using the
 [C Bounded Model Checker](http://www.cprover.org/cbmc/), an open-source static
 analysis tool
 ([GitHub repository](https://github.com/diffblue/cbmc)). This README describes
-how to run the proofs on your local clone s2n.
+how to run the proofs on your local clone of s2n.
 
 
 Prerequisites
 -------------
 
 You will need Python 3.
-On macOS and Linux, you will need Make.
+On macOS and Linux, you will need Make, plus the CBMC build tools.
 
 
 Installing CBMC
@@ -27,37 +27,21 @@ Installing CBMC
 
 - The canonical compilation and installation instructions are in the
   [COMPILING.md](https://github.com/diffblue/cbmc/blob/develop/COMPILING.md)
-  file in the CBMC repository; we reproduce the most important steps for
-  Windows users here, but refer to that document if in doubt.
-  - Download and install CMake from the [CMake website](https://cmake.org/download).
-  - Download and install the "git for Windows" package, which also
-    provides the `patch` command, from [here](https://git-scm.com/download/win).
-  - Download the flex and bison for Windows package from
-    [this sourceforge site](https://sourceforge.net/projects/winflexbison).
-    "Install" it by dropping the contents of the entire unzipped
-    package into the top-level CBMC source directory.
-  - Change into the top-level CBMC source directory and run
-    ```
-    cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release -DWITH_JBMC=OFF
-    cmake --build build
-    ```
+  file in the CBMC repository
 
-- Ensure that you can run the programs `cbmc`, `goto-cc` (or `goto-cl`
-  on Windows), and `goto-instrument` from the command line. If you build
-  CBMC with CMake, the programs will have been installed under the
-  `build/bin/Debug` directory under the top-level `cbmc` directory; you
-  should add that directory to your `$PATH`. If you built CBMC using
-  Make, then those programs will have been installed in the `src/cbmc`,
-  `src/goto-cc`, and `src/goto-instrument` directories respectively.
+- Ensure that you can run the programs `cbmc`, `goto-cc`, and `goto-instrument` from the command line.
+  If you build CBMC with CMake, the programs will have been installed under the
+  `build/bin/Debug` or `build/bin/Release` directories under the top-level `cbmc` directory; you
+  should add that directory to your `$PATH`.
+  If you built CBMC using Make, then those programs will have been installed in the `src/cbmc`, `src/goto-cc`, and `src/goto-instrument` directories respectively.
 
 
 Running the proofs
 ------------------
 
-Each of the leaf directories under `proofs` is a proof of the memory
-safety of a single entry point. The scripts that you ran in the
-previous step will have left a Makefile in each of those directories. To
-run a proof, change into the directory for that proof and run `make` on Linux or macOS. The proofs may take some time to run; they eventually write their output to `cbmc.txt`, which should have the text `VERIFICATION SUCCESSFUL` at the end.
+Each of the leaf directories under `proofs` is a proof of the memory safety of a single entry point.
+To run a proof, change into the directory for that proof and run `make` on Linux or macOS.
+The proofs may take some time to run; they eventually write their output to `cbmc.txt`, which should have the text `VERIFICATION SUCCESSFUL` at the end.
 
 
 Proof directory structure

--- a/tests/cbmc/README.md
+++ b/tests/cbmc/README.md
@@ -2,7 +2,7 @@ CBMC Proof Infrastructure
 =========================
 
 This directory contains automated proofs of the memory safety of various parts
-of the amazon:FreeRTOS codebase. A continuous integration system validates every
+of the s2n codebase. A continuous integration system validates every
 pull request posted to the repository against these proofs, and developers can
 also run the proofs on their local machines.
 

--- a/tests/cbmc/README.md
+++ b/tests/cbmc/README.md
@@ -10,15 +10,14 @@ The proofs are checked using the
 [C Bounded Model Checker](http://www.cprover.org/cbmc/), an open-source static
 analysis tool
 ([GitHub repository](https://github.com/diffblue/cbmc)). This README describes
-how to run the proofs on your local clone of a:FR.
+how to run the proofs on your local clone s2n.
 
 
 Prerequisites
 -------------
 
-You will need Python 3. On Windows, you will need Visual Studio 2015 or later
-(in particular, you will need the Developer Command Prompt and NMake). On macOS
-and Linux, you will need Make.
+You will need Python 3.
+On macOS and Linux, you will need Make.
 
 
 Installing CBMC

--- a/tests/cbmc/README.md
+++ b/tests/cbmc/README.md
@@ -1,0 +1,72 @@
+CBMC Proof Infrastructure
+=========================
+
+This directory contains automated proofs of the memory safety of various parts
+of the amazon:FreeRTOS codebase. A continuous integration system validates every
+pull request posted to the repository against these proofs, and developers can
+also run the proofs on their local machines.
+
+The proofs are checked using the
+[C Bounded Model Checker](http://www.cprover.org/cbmc/), an open-source static
+analysis tool
+([GitHub repository](https://github.com/diffblue/cbmc)). This README describes
+how to run the proofs on your local clone of a:FR.
+
+
+Prerequisites
+-------------
+
+You will need Python 3. On Windows, you will need Visual Studio 2015 or later
+(in particular, you will need the Developer Command Prompt and NMake). On macOS
+and Linux, you will need Make.
+
+
+Installing CBMC
+---------------
+
+- Clone the [CBMC repository](https://github.com/diffblue/cbmc).
+
+- The canonical compilation and installation instructions are in the
+  [COMPILING.md](https://github.com/diffblue/cbmc/blob/develop/COMPILING.md)
+  file in the CBMC repository; we reproduce the most important steps for
+  Windows users here, but refer to that document if in doubt.
+  - Download and install CMake from the [CMake website](https://cmake.org/download).
+  - Download and install the "git for Windows" package, which also
+    provides the `patch` command, from [here](https://git-scm.com/download/win).
+  - Download the flex and bison for Windows package from
+    [this sourceforge site](https://sourceforge.net/projects/winflexbison).
+    "Install" it by dropping the contents of the entire unzipped
+    package into the top-level CBMC source directory.
+  - Change into the top-level CBMC source directory and run
+    ```
+    cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release -DWITH_JBMC=OFF
+    cmake --build build
+    ```
+
+- Ensure that you can run the programs `cbmc`, `goto-cc` (or `goto-cl`
+  on Windows), and `goto-instrument` from the command line. If you build
+  CBMC with CMake, the programs will have been installed under the
+  `build/bin/Debug` directory under the top-level `cbmc` directory; you
+  should add that directory to your `$PATH`. If you built CBMC using
+  Make, then those programs will have been installed in the `src/cbmc`,
+  `src/goto-cc`, and `src/goto-instrument` directories respectively.
+
+
+Running the proofs
+------------------
+
+Each of the leaf directories under `proofs` is a proof of the memory
+safety of a single entry point. The scripts that you ran in the
+previous step will have left a Makefile in each of those directories. To
+run a proof, change into the directory for that proof and run `make` on Linux or macOS. The proofs may take some time to run; they eventually write their output to `cbmc.txt`, which should have the text `VERIFICATION SUCCESSFUL` at the end.
+
+
+Proof directory structure
+-------------------------
+
+This directory contains the following subdirectories:
+
+- `proofs` contains the proofs run against each pull request
+- `include` contains the `.h` files needed by proofs
+- `source` contains functions useful in multiple CBMC proofs
+- `stubs` contains stubs for functions which are modelled by CBMC

--- a/tests/cbmc/include/cbmc_proof/nondet.h
+++ b/tests/cbmc/include/cbmc_proof/nondet.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * Non-determinstic functions used in CBMC proofs
+ */
+bool nondet_bool();
+int nondet_int();
+size_t nondet_size_t();
+uint16_t nondet_uint16_t();
+uint32_t nondet_uint32_t();
+uint64_t nondet_uint64_t();
+uint8_t nondet_uint8_t();
+void *nondet_voidp();

--- a/tests/cbmc/include/cbmc_proof/nondet.h
+++ b/tests/cbmc/include/cbmc_proof/nondet.h
@@ -22,7 +22,7 @@
 /**
  * These functions provide a way to get unconstrained values of the correct types for use in CBMC proofs
  * CBMC treats any function which does not have a body as returning an unconstrained value.
- * For exampkle, each call to nondet_uint8_t() will return a different unconstrained value which can be used
+ * For example, each call to nondet_uint8_t() will return a different unconstrained value which can be used
  * in CBMC proofs.
  */
 bool nondet_bool();

--- a/tests/cbmc/include/cbmc_proof/nondet.h
+++ b/tests/cbmc/include/cbmc_proof/nondet.h
@@ -20,7 +20,10 @@
 #include <stdint.h>
 
 /**
- * Non-determinstic functions used in CBMC proofs
+ * These functions provide a way to get unconstrained values of the correct types for use in CBMC proofs
+ * CBMC treats any function which does not have a body as returning an unconstrained value.
+ * For exampkle, each call to nondet_uint8_t() will return a different unconstrained value which can be used
+ * in CBMC proofs.
  */
 bool nondet_bool();
 int nondet_int();

--- a/tests/cbmc/include/cbmc_proof/proof_allocators.h
+++ b/tests/cbmc/include/cbmc_proof/proof_allocators.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include <cbmc_proof/nondet.h>
+#include <stdlib.h>
+
+/**
+ * CBMC has an internal representation in which each object has an index and a (signed) offset
+ * A buffer cannot be larger than the max size of the offset
+ * The Makefile is expected to set CBMC_OBJECT_BITS to the value of --object-bits
+ */
+#define MAX_MALLOC (SIZE_MAX >> (CBMC_OBJECT_BITS + 1))
+
+/**
+ * CBMC model of calloc always succeeds, even if the requested size is larger
+ * than CBMC can internally represent.  This function does a
+ *     __CPROVER_assume(size <= MAX_MALLOC);
+ * before calling calloc, and hence will never return an invalid pointer.
+ */
+void *bounded_calloc(size_t num, size_t size);
+
+/**
+ * CBMC model of malloc always succeeds, even if the requested size is larger
+ * than CBMC can internally represent.  This function does a
+ *     __CPROVER_assume(size <= MAX_MALLOC);
+ * before calling malloc, and hence will never return an invalid pointer.
+ */
+void *bounded_malloc(size_t size);
+
+/**
+ * CBMC model of calloc never returns NULL, which can mask bugs in C programs. Thus function:
+ * 1) Deterministically returns NULL if more memory is requested than CBMC can represent
+ * 2) Nondeterminstically returns either valid memory or NULL otherwise
+ */
+void *can_fail_calloc(size_t num, size_t size);
+
+/**
+ * CBMC model of malloc never returns NULL, which can mask bugs in C programs. Thus function:
+ * 1) Deterministically returns NULL if more memory is requested than CBMC can represent
+ * 2) Nondeterminstically returns either valid memory or NULL otherwise
+ */
+void *can_fail_malloc(size_t size);
+
+/**
+ * CBMC model of realloc never returns NULL, which can mask bugs in C programs. Thus function:
+ * 1) Deterministically returns NULL if more memory is requested than CBMC can represent
+ * 2) Does the full range of valid behaviours if (newsize == 0)
+ * 3) Nondeterminstically returns either valid memory or NULL otherwise
+ */
+void *can_fail_realloc(void *ptr, size_t newsize);

--- a/tests/cbmc/proofs/Makefile.cbmc_batch
+++ b/tests/cbmc/proofs/Makefile.cbmc_batch
@@ -1,0 +1,93 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+.PHONY: batch-yaml ci-yaml
+
+################################################################
+# Launching cbmc on cbmc-batch
+BATCH ?= cbmc-batch
+
+BATCHFLAGS ?= \
+	--batchpkg $(BATCHPKG) \
+	--blddir $(SRCDIR) \
+	--bucket $(BUCKET) \
+	--cbmcflags $(call encode_options,$(CBMCFLAGS)) \
+	--cbmcpkg $(CBMCPKG) \
+	--coverage-memory $(COVMEM) \
+	--goto $(ENTRY).goto \
+	--jobprefix $(ENTRY) \
+	--no-build \
+	--no-copysrc \
+	--property-memory $(PROPMEM) \
+	--srcdir $(SRCDIR) \
+	--viewerpkg $(VIEWERPKG) \
+	--wsdir $(WS)
+
+BATCHPKG ?= cbmc-batch.tar.gz
+BUCKET ?= cbmc
+CBMCPKG ?= cbmc.tar.gz
+COVMEM ?= 64000
+
+define encode_options
+       '=$(shell echo $(1) | sed 's/ ,/ /g' | sed 's/ /;/g')='
+endef
+
+PROPMEM ?= 64000
+VIEWERPKG ?= cbmc-viewer.tar.gz
+WS ?= ws
+
+define yaml_encode_options
+       "$(shell echo $(1) | sed 's/ ,/ /g' | sed 's/ /;/g')"
+endef
+
+$(ENTRY).yaml: $(ENTRY).goto Makefile
+	echo 'batchpkg: $(BATCHPKG)' > $@
+	echo 'build: true' >> $@
+	echo 'cbmcflags: $(call yaml_encode_options,$(CBMCFLAGS))' >> $@
+	echo 'cbmcpkg: $(CBMCPKG)' >> $@
+	echo 'coverage_memory: $(COVMEM)' >> $@
+	echo 'expected: "SUCCESSFUL"' >> $@
+	echo 'goto: $(ENTRY).goto' >> $@
+	echo 'jobos: ubuntu16' >> $@
+	echo 'property_memory: $(PROPMEM)' >> $@
+	echo 'viewerpkg: $(VIEWERPKG)' >> $@
+
+batch-yaml: $(ENTRY).yaml
+
+cbmc-batch.yaml: $(ENTRY).goto Makefile
+	echo 'cbmcflags: $(strip $(call yaml_encode_options,$(CBMCFLAGS)))' > $@
+	echo 'expected: "SUCCESSFUL"' >> $@
+	echo 'goto: $(ENTRY).goto' >> $@
+	echo 'jobos: ubuntu16' >> $@
+
+ci-yaml: cbmc-batch.yaml
+
+launch: $(ENTRY).goto Makefile
+	mkdir -p $(WS)
+	cp $(ENTRY).goto $(WS)
+	$(BATCH) $(BATCHFLAGS)
+
+launch-clean:
+	for d in $(ENTRY)*; do \
+	  if [ -d $$d ]; then \
+	    for f in $$d.json $$d.yaml Makefile-$$d; do \
+	      if [ -f $$f ]; then mv $$f $$d; fi \
+	    done\
+	  fi \
+	done
+	$(RM) Makefile-$(ENTRY)-[0-7]*-[0-7]*
+	$(RM) $(ENTRY)-[0-7]*-[0-7]*.json $(ENTRY)-[0-7]*-[0-7]*.yaml
+	$(RM) -r $(WS)
+
+launch-veryclean: launch-clean
+	$(RM) -r $(ENTRY)-[0-7]*-[0-7]*

--- a/tests/cbmc/proofs/Makefile.cbmc_batch
+++ b/tests/cbmc/proofs/Makefile.cbmc_batch
@@ -24,7 +24,7 @@ BATCHFLAGS ?= \
 	--cbmcflags $(call encode_options,$(CBMCFLAGS)) \
 	--cbmcpkg $(CBMCPKG) \
 	--coverage-memory $(COVMEM) \
-	--goto $(ENTRY).goto \
+	--goto gotos/$(ENTRY).goto \
 	--jobprefix $(ENTRY) \
 	--no-build \
 	--no-copysrc \
@@ -50,44 +50,26 @@ define yaml_encode_options
        "$(shell echo $(1) | sed 's/ ,/ /g' | sed 's/ /;/g')"
 endef
 
-$(ENTRY).yaml: $(ENTRY).goto Makefile
+$(ENTRY).yaml: 
 	echo 'batchpkg: $(BATCHPKG)' > $@
 	echo 'build: true' >> $@
 	echo 'cbmcflags: $(call yaml_encode_options,$(CBMCFLAGS))' >> $@
 	echo 'cbmcpkg: $(CBMCPKG)' >> $@
 	echo 'coverage_memory: $(COVMEM)' >> $@
 	echo 'expected: "SUCCESSFUL"' >> $@
-	echo 'goto: $(ENTRY).goto' >> $@
+	echo 'goto: gotos/$(GOTO).goto' >> $@
 	echo 'jobos: ubuntu16' >> $@
 	echo 'property_memory: $(PROPMEM)' >> $@
 	echo 'viewerpkg: $(VIEWERPKG)' >> $@
 
-batch-yaml: $(ENTRY).yaml
+batch-yaml: $(ENTRY).yaml Makefile
 
-cbmc-batch.yaml: $(ENTRY).goto Makefile
+cbmc-batch.yaml: 
 	echo 'cbmcflags: $(strip $(call yaml_encode_options,$(CBMCFLAGS)))' > $@
 	echo 'expected: "SUCCESSFUL"' >> $@
-	echo 'goto: $(ENTRY).goto' >> $@
+	echo 'goto: gotos/$(ENTRY).goto' >> $@
 	echo 'jobos: ubuntu16' >> $@
 
-ci-yaml: cbmc-batch.yaml
+ci-yaml: cbmc-batch.yaml Makefile
 
-launch: $(ENTRY).goto Makefile
-	mkdir -p $(WS)
-	cp $(ENTRY).goto $(WS)
-	$(BATCH) $(BATCHFLAGS)
-
-launch-clean:
-	for d in $(ENTRY)*; do \
-	  if [ -d $$d ]; then \
-	    for f in $$d.json $$d.yaml Makefile-$$d; do \
-	      if [ -f $$f ]; then mv $$f $$d; fi \
-	    done\
-	  fi \
-	done
-	$(RM) Makefile-$(ENTRY)-[0-7]*-[0-7]*
-	$(RM) $(ENTRY)-[0-7]*-[0-7]*.json $(ENTRY)-[0-7]*-[0-7]*.yaml
-	$(RM) -r $(WS)
-
-launch-veryclean: launch-clean
-	$(RM) -r $(ENTRY)-[0-7]*-[0-7]*
+.PHONY: ci-yaml batch-yaml

--- a/tests/cbmc/proofs/Makefile.common
+++ b/tests/cbmc/proofs/Makefile.common
@@ -1,4 +1,4 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is
@@ -76,10 +76,10 @@ DO_NOOP_COPY = cp $(2) $(3); echo $(1) | tee $(call LOG_FROM_ENTRY,$(3))
 
 ################################################################
 # Useful macros translating filenames
-#C_FROM_GOTO = $(patsubst $(GOTODIR)%,$(SRCDIR)%,$(1:.goto=.c))
-#GOTO_FROM_C = $(patsubst $(SRCDIR)%,$(GOTODIR)%,$(1:.c=.goto))
+C_FROM_GOTO = $(patsubst $(GOTODIR)%,$(SRCDIR)%,$(1:.goto=.c))
+GOTO_FROM_C = $(patsubst $(SRCDIR)%,$(GOTODIR)%,$(1:.c=.goto))
 LOG_FROM_ENTRY = $(LOGDIR)/$(notdir $(1:.goto=.log))
-#LOG_FROM_GOTO = $(patsubst $(GOTODIR)%,$(LOGDIR)%,$(1:.goto=.log))
+LOG_FROM_GOTO = $(patsubst $(GOTODIR)%,$(LOGDIR)%,$(1:.goto=.log))
 
 ################################################################
 # Default CBMC flags
@@ -99,7 +99,8 @@ CBMCFLAGS += --unwinding-assertions
 ################################################################
 # Setup the unwindset
 # TODO: CBMC should accept multiple unwindset flags, making the substutions here
-# unnecessary
+# unnecessary.
+# Tracked in https://github.com/diffblue/cbmc/issues/5185
 ifneq ($(UNWINDSET),)
 CBMC_UNWINDSET := --unwindset $(subst $(SPACE),$(COMMA),$(strip $(UNWINDSET)))
 endif
@@ -227,18 +228,6 @@ $(ENTRY_GOTO)7.goto: $(ENTRY_GOTO)6.goto
 
 $(ENTRY_GOTO).goto: $(ENTRY_GOTO)7.goto
 	cp $< $@
-
-# # Catch-all used for building goto-binaries of the individual
-# # dependencies, which are then linked in the $(ENTRY_GOTO)0.goto rule above
-# # DSN TODO This should be able to go away once we have static removal working
-# # properly.
-# %.goto:
-# 	mkdir -p $(dir $@)
-# 	mkdir -p $(dir $(call LOG_FROM_GOTO,$@))
-# 	echo $(call C_FROM_GOTO,$@)
-# 	$(GOTO_CC) -c $(call C_FROM_GOTO,$@) --export-function-local-symbols $(CBMC_VERBOSITY) \
-# 	  $(INC) $(DEFINES) -o $@ \
-# 	  2>&1 | tee $(call LOG_FROM_GOTO,$@) ; exit $${PIPESTATUS[0]}
 
 goto: $(ENTRY_GOTO).goto
 	echo $(DEPENDENT_GOTOS)

--- a/tests/cbmc/proofs/Makefile.common
+++ b/tests/cbmc/proofs/Makefile.common
@@ -44,6 +44,7 @@ COMMA :=,
 # Paths to binaries
 # By default, use the version on your path; this can be overriden to select particular
 # versions of the tools. /usr/bin/goto-analyzer or ${HOME}/sw/goto-analyzer etc
+CBMC ?= cbmc
 GOTO_ANALYZER ?= goto-analyzer
 GOTO_CC ?= goto-cc
 GOTO_INSTRUMENT ?= goto-instrument
@@ -63,16 +64,20 @@ LOGDIR = $(PROOFDIR)/logs
 DO_AND_LOG_COMMAND = $(1) $(2) 2>&1 | tee $(3); exit $${PIPESTATUS[0]}
 
 #1: flags, 2: source, 3: target
-DO_GOTO_ANALYZER = $(call DO_AND_LOG_COMMAND,$(GOTO_ANALYZER),$(1) $(2) $(3), $(call LOG_FROM_ENTRY,$(3)))
+DO_GOTO_ANALYZER = $(call DO_AND_LOG_COMMAND,$(GOTO_ANALYZER),$(CBMC_VERBOSITY) $(1) $(2) $(3), $(call LOG_FROM_ENTRY,$(3)))
 
 #1: flags, 2: source, 3: target
-DO_GOTO_CC =  $(call DO_AND_LOG_COMMAND,$(GOTO_CC),$(1) $(2) -o $(3), $(call LOG_FROM_ENTRY,$(3)))
+DO_GOTO_CC =  $(call DO_AND_LOG_COMMAND,$(GOTO_CC),$(CBMC_VERBOSITY) $(1) $(2) -o $(3), $(call LOG_FROM_ENTRY,$(3)))
 
 #1: flags, 2: source, 3: target
-DO_GOTO_INSTRUMENT = $(call DO_AND_LOG_COMMAND,$(GOTO_INSTRUMENT),$(1) $(2) $(3), $(call LOG_FROM_ENTRY,$(3)))
+DO_GOTO_INSTRUMENT = $(call DO_AND_LOG_COMMAND,$(GOTO_INSTRUMENT),$(CBMC_VERBOSITY) $(1) $(2) $(3), $(call LOG_FROM_ENTRY,$(3)))
+
+#1: flags, 2: source, 3: logfile
+DO_CBMC =  $(call DO_AND_LOG_COMMAND,$(CBMC),$(CBMC_VERBOSITY) $(1) $(2), $(3))
 
 #1: message 2: source 3: dest 
 DO_NOOP_COPY = cp $(2) $(3); echo $(1) | tee $(call LOG_FROM_ENTRY,$(3))
+
 
 ################################################################
 # Useful macros translating filenames
@@ -83,7 +88,6 @@ LOG_FROM_GOTO = $(patsubst $(GOTODIR)%,$(LOGDIR)%,$(1:.goto=.log))
 
 ################################################################
 # Default CBMC flags
-CBMC_VERBOSITY ?= ""
 CBMCFLAGS += --bounds-check
 CBMCFLAGS += --div-by-zero-check
 CBMCFLAGS += --float-overflow-check
@@ -97,6 +101,18 @@ CBMCFLAGS += --unwind 1
 CBMCFLAGS += --unwinding-assertions
 
 ################################################################
+# Verbosity
+# 0 none
+# 1 only errors
+# 2 + warnings
+# 4 + results
+# 6 + status/phase information
+# 8 + statistical information
+# 9 + progress information
+# 10 + debug info
+CBMC_VERBOSITY ?= --verbosity 4
+
+################################################################
 # Setup the unwindset
 # TODO: CBMC should accept multiple unwindset flags, making the substutions here
 # unnecessary.
@@ -108,7 +124,7 @@ CBMCFLAGS += $(CBMC_UNWINDSET)
 
 ################################################################
 # Set C compiler defines
-CBMC_OBJECT_BITS ?= 8
+CBMC_OBJECT_BITS ?= 6
 CBMCFLAGS +=  --object-bits $(CBMC_OBJECT_BITS)
 DEFINES += -DCBMC_OBJECT_BITS=$(CBMC_OBJECT_BITS)
 DEFINES += -DCBMC=1
@@ -123,7 +139,8 @@ INC += -I$(SRCDIR)/api
 
 ################################################################
 # Enables costly checks (e.g. ones that contain loops)
-# Don't execute deep checks by default
+# Whether a proof needs these checks should be decided on a proof by proof basis.  
+# Checks can be enabled by setting AWS_DEEP_CHECKS to 1 in the makefile of the proof that requires them
 AWS_DEEP_CHECKS ?= 0
 DEFINES += -DAWS_DEEP_CHECKS=$(AWS_DEEP_CHECKS)
 
@@ -141,7 +158,6 @@ REMOVE_FUNCTION_BODY += $(ADDITIONAL_REMOVE_FUNCTION_BODY)
 
 ################################################################
 # Determine the names of the goto files to build
-#DEPENDENT_GOTOS = $(call GOTO_FROM_C,$(DEPENDENCIES))
 ENTRY_GOTO = $(GOTODIR)/$(ENTRY)
 
 ################################################################
@@ -153,26 +169,14 @@ SIMPLIFY ?= 0
 ################################################################
 # Build targets that make the relevant .goto files
 
-# Other libraries that use this Makefile template may wish to do
-# actual work here
-setup_dependencies:
-	echo "Setting up dependencies"
-
 # Here, whenever there is a change in any of ANSI-C source
 # dependency files, make will take action. However, to make
 # sure changes in the headers files will also trigger make,
 # the user must run make clean first.
-$(ENTRY_GOTO)0.goto: setup_dependencies $(ENTRY).c $(DEPENDENCIES)
+$(ENTRY_GOTO)0.goto: $(ENTRY).c $(DEPENDENCIES)
 	mkdir -p $(dir $@)
 	mkdir -p $(dir $(call LOG_FROM_ENTRY,$@))
-	$(call DO_GOTO_CC,\
-		--export-function-local-symbols \
-			$(CBMC_VERBOSITY) \
-			--function $(ENTRY) \
-			$(INC) \
-			$(DEFINES), \
-		$(ENTRY).c $(DEPENDENCIES),\
-		$@)
+	$(call DO_GOTO_CC,--export-function-local-symbols --function $(ENTRY) $(INC) $(DEFINES),$^,$@)
 
 # Removes specified function bodies. This allows us to replace
 # function definitions with ABSTRACTIONS.
@@ -202,6 +206,8 @@ else
 endif
 
 # Skip simplify (and hence generate-function-body) until missing source locations debugged
+# --generate-function-body requires a regular expression specifying the names of functions
+# that a body is to be generated for: ".*" is all functions
 $(ENTRY_GOTO)4.goto: $(ENTRY_GOTO)3.goto
 ifeq ($(SIMPLIFY),1)
 	$(call DO_GOTO_INSTRUMENT,--generate-function-body '.*',$<,$@)
@@ -235,13 +241,13 @@ goto: $(ENTRY_GOTO).goto
 ################################################################
 # Targets to run the analysis commands
 logs/cbmc.log: $(ENTRY_GOTO).goto
-	cbmc $(CBMCFLAGS) --trace $< 2>&1 | tee $@
+	$(call DO_CBMC,$(CBMCFLAGS) --trace,$<,$@)
 
 logs/property.xml: $(ENTRY_GOTO).goto
-	cbmc $(CBMCFLAGS) --show-properties --xml-ui $< 2>&1 > $@
+	$(call DO_CBMC,$(CBMCFLAGS) --show-properties --xml-ui,$<,$@)
 
 logs/coverage.xml: $(ENTRY_GOTO).goto
-	cbmc $(filter-out --unwinding-assertions,$(CBMCFLAGS)) --cover location --xml-ui $< 2>&1 > $@
+	$(call DO_CBMC,$(filter-out --unwinding-assertions,$(CBMCFLAGS)) --cover location --xml-ui,$<,$@)
 
 cbmc: logs/cbmc.log
 

--- a/tests/cbmc/proofs/Makefile.common
+++ b/tests/cbmc/proofs/Makefile.common
@@ -1,0 +1,299 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+################################################################
+# This Makefile is the base makefile for CBMC proofs in this repository
+# Consumers of this makefile are expected to set the relevant variables
+# e.g. ENTRY, CBMCFLAGS, UNWINDSET etc
+# and then include this makefile.  To see how to use this makefile, take a look
+# at any of the existing proofs in this repository.
+#
+# This makefile is designed so that all files created during a proof are
+# placed in the proof directory, or subdirectories of it.
+# In particular, all gotos are built into the "gotos" folder, and logs go into
+# the "logs" folder. This means that the main source directories are untouched by
+# doing a build, and should make it safe to simultaniously build multiple proofs,
+# including proofs with different configurations and -D defines.
+#
+# Dependency handling in this file may not be perfect.  It is recommended that
+# you "make clean" or "make veryclean" before rerunning a proof.
+
+SHELL=/bin/bash
+
+default: report
+
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude Makefile.local
+
+################################################################
+# Define some constants that are hard to reference otherwise
+SPACE :=$() $()
+COMMA :=,
+
+################################################################
+# Paths to binaries
+# By default, use the version on your path; this can be overriden to select particular
+# versions of the tools. /usr/bin/goto-analyzer or ${HOME}/sw/goto-analyzer etc
+GOTO_ANALYZER ?= goto-analyzer
+GOTO_CC ?= goto-cc
+GOTO_INSTRUMENT ?= goto-instrument
+VIEWER ?= cbmc-viewer
+
+################################################################
+# Setup directory aliases
+SRCDIR ?= $(abspath ../../../..)
+HELPERDIR ?= $(SRCDIR)/tests/cbmc
+PROOFDIR = $(abspath .)
+GOTODIR = $(PROOFDIR)/gotos
+LOGDIR = $(PROOFDIR)/logs
+
+################################################################
+# Useful macros for running commands
+#1: command, 2: flags, 3: log file
+DO_AND_LOG_COMMAND = $(1) $(2) 2>&1 | tee $(3); exit $${PIPESTATUS[0]}
+
+#1: flags, 2: source, 3: target
+DO_GOTO_ANALYZER = $(call DO_AND_LOG_COMMAND,$(GOTO_ANALYZER),$(1) $(2) $(3), $(call LOG_FROM_ENTRY,$(3)))
+
+#1: flags, 2: source, 3: target
+DO_GOTO_CC =  $(call DO_AND_LOG_COMMAND,$(GOTO_CC),$(1) $(2) -o $(3), $(call LOG_FROM_ENTRY,$(3)))
+
+#1: flags, 2: source, 3: target
+DO_GOTO_INSTRUMENT = $(call DO_AND_LOG_COMMAND,$(GOTO_INSTRUMENT),$(1) $(2) $(3), $(call LOG_FROM_ENTRY,$(3)))
+
+#1: message 2: source 3: dest 
+DO_NOOP_COPY = cp $(2) $(3); echo $(1) | tee $(call LOG_FROM_ENTRY,$(3))
+
+################################################################
+# Useful macros translating filenames
+#C_FROM_GOTO = $(patsubst $(GOTODIR)%,$(SRCDIR)%,$(1:.goto=.c))
+#GOTO_FROM_C = $(patsubst $(SRCDIR)%,$(GOTODIR)%,$(1:.c=.goto))
+LOG_FROM_ENTRY = $(LOGDIR)/$(notdir $(1:.goto=.log))
+#LOG_FROM_GOTO = $(patsubst $(GOTODIR)%,$(LOGDIR)%,$(1:.goto=.log))
+
+################################################################
+# Default CBMC flags
+CBMC_VERBOSITY ?= ""
+CBMCFLAGS += --bounds-check
+CBMCFLAGS += --div-by-zero-check
+CBMCFLAGS += --float-overflow-check
+CBMCFLAGS += --nan-check
+CBMCFLAGS += --pointer-check
+CBMCFLAGS += --pointer-overflow-check
+CBMCFLAGS += --signed-overflow-check
+CBMCFLAGS += --undefined-shift-check
+CBMCFLAGS += --unsigned-overflow-check
+CBMCFLAGS += --unwind 1
+CBMCFLAGS += --unwinding-assertions
+
+################################################################
+# Setup the unwindset
+# TODO: CBMC should accept multiple unwindset flags, making the substutions here
+# unnecessary
+ifneq ($(UNWINDSET),)
+CBMC_UNWINDSET := --unwindset $(subst $(SPACE),$(COMMA),$(strip $(UNWINDSET)))
+endif
+CBMCFLAGS += $(CBMC_UNWINDSET)
+
+################################################################
+# Set C compiler defines
+CBMC_OBJECT_BITS ?= 8
+CBMCFLAGS +=  --object-bits $(CBMC_OBJECT_BITS)
+DEFINES += -DCBMC_OBJECT_BITS=$(CBMC_OBJECT_BITS)
+DEFINES += -DCBMC=1
+
+################################################################
+# Setup include directory order
+# HELPERDIR must go before any other includes to override default
+# implementations by stubs
+INC += -I$(HELPERDIR)/include/
+INC += -I$(SRCDIR)
+INC += -I$(SRCDIR)/api
+
+################################################################
+# Enables costly checks (e.g. ones that contain loops)
+# Don't execute deep checks by default
+AWS_DEEP_CHECKS ?= 0
+DEFINES += -DAWS_DEEP_CHECKS=$(AWS_DEEP_CHECKS)
+
+################################################################
+# Remove function bodies that are not used in the proofs. 
+# Removing the function from the goto program helps CBMC's
+# function pointer analysis
+
+# We override abort() to be assert(0)
+ABSTRACTIONS += $(HELPERDIR)/stubs/abort_override_assert_false.c
+REMOVE_FUNCTION_BODY += --remove-function-body abort
+
+# Users can remove additonal functions using this paramater
+REMOVE_FUNCTION_BODY += $(ADDITIONAL_REMOVE_FUNCTION_BODY)
+
+################################################################
+# Determine the names of the goto files to build
+#DEPENDENT_GOTOS = $(call GOTO_FROM_C,$(DEPENDENCIES))
+ENTRY_GOTO = $(GOTODIR)/$(ENTRY)
+
+################################################################
+# Temporarily disable UNWIND_GOTO, SIMPLIFY until the feature is
+# stable
+UNWIND_GOTO ?= 0
+SIMPLIFY ?= 0
+
+################################################################
+# Build targets that make the relevant .goto files
+
+# Other libraries that use this Makefile template may wish to do
+# actual work here
+setup_dependencies:
+	echo "Setting up dependencies"
+
+# Here, whenever there is a change in any of ANSI-C source
+# dependency files, make will take action. However, to make
+# sure changes in the headers files will also trigger make,
+# the user must run make clean first.
+$(ENTRY_GOTO)0.goto: setup_dependencies $(ENTRY).c $(DEPENDENCIES)
+	mkdir -p $(dir $@)
+	mkdir -p $(dir $(call LOG_FROM_ENTRY,$@))
+	$(call DO_GOTO_CC,\
+		--export-function-local-symbols \
+			$(CBMC_VERBOSITY) \
+			--function $(ENTRY) \
+			$(INC) \
+			$(DEFINES), \
+		$(ENTRY).c $(DEPENDENCIES),\
+		$@)
+
+# Removes specified function bodies. This allows us to replace
+# function definitions with ABSTRACTIONS.
+$(ENTRY_GOTO)1.goto: $(ENTRY_GOTO)0.goto
+ifeq ($(REMOVE_FUNCTION_BODY),"")
+	$(call DO_NOOP_COPY,"Not removing function bodies",$<,$@)
+else
+	$(call DO_GOTO_INSTRUMENT,$(REMOVE_FUNCTION_BODY),$<,$@)
+endif
+
+# ABSTRACTIONS is a list of function stubs to use. If a function body
+# is missing and is not abstracted, then it returnes a non
+# deterministic value.
+$(ENTRY_GOTO)2.goto: $(ENTRY_GOTO)1.goto
+ifeq ($(ABSTRACTIONS),"")
+	$(call DO_NOOP_COPY,"Not implementing abstractions",$<,$@)
+else
+	$(call DO_GOTO_CC,--function $(ENTRY) $(ABSTRACTIONS) $(INC) $(DEFINES),$<,$@)
+endif
+
+# Simplify and constant propagation may benefit from unwinding first
+$(ENTRY_GOTO)3.goto: $(ENTRY_GOTO)2.goto
+ifeq ($(UNWIND_GOTO),1)
+	$(call DO_GOTO_INSTRUMENT,$(UNWINDING),$<,$@)
+else
+	$(call DO_NOOP_COPY,"Not unwinding goto program",$<,$@)
+endif
+
+# Skip simplify (and hence generate-function-body) until missing source locations debugged
+$(ENTRY_GOTO)4.goto: $(ENTRY_GOTO)3.goto
+ifeq ($(SIMPLIFY),1)
+	$(call DO_GOTO_INSTRUMENT,--generate-function-body '.*',$<,$@)
+else
+	$(call DO_NOOP_COPY,"Not generating-function-bodies in goto program",$<,$@)
+endif
+
+# Skip simplify (and hence generate-function-body) until missing source locations debugged
+$(ENTRY_GOTO)5.goto: $(ENTRY_GOTO)4.goto
+ifeq ($(SIMPLIFY),1)
+	$(call DO_GOTO_ANALYZER,--simplify,$@,$<)
+else
+	$(call DO_NOOP_COPY,"Not simplfying goto program",$<,$@)
+endif
+
+# Simplify the goto program by removing any unused function bodies
+$(ENTRY_GOTO)6.goto: $(ENTRY_GOTO)5.goto
+	$(call DO_GOTO_INSTRUMENT,--drop-unused-functions,$<,$@)
+
+# Simplify the goto program by slicing away initializations of unused
+# global variables
+$(ENTRY_GOTO)7.goto: $(ENTRY_GOTO)6.goto
+	$(call DO_GOTO_INSTRUMENT,--slice-global-inits,$<,$@)
+
+$(ENTRY_GOTO).goto: $(ENTRY_GOTO)7.goto
+	cp $< $@
+
+# For now, CBMC batch expects the goto in the same folder as the proof itself,
+# instead of the proof/gotos folder all other gotos go in.  This isn't a problem
+# for out-of-tree or parallel builds, it just clutters the proof directory.
+# I could update the .yaml file for all 160 proofs, or I could copy it, and
+# have one goto file in the proof directory.  Doing the second option for now.
+# TODO: cleanup which files go in which directories.
+$(ENTRY).goto: $(ENTRY_GOTO).goto
+	cp $< $@
+
+# # Catch-all used for building goto-binaries of the individual
+# # dependencies, which are then linked in the $(ENTRY_GOTO)0.goto rule above
+# # DSN TODO This should be able to go away once we have static removal working
+# # properly.
+# %.goto:
+# 	mkdir -p $(dir $@)
+# 	mkdir -p $(dir $(call LOG_FROM_GOTO,$@))
+# 	echo $(call C_FROM_GOTO,$@)
+# 	$(GOTO_CC) -c $(call C_FROM_GOTO,$@) --export-function-local-symbols $(CBMC_VERBOSITY) \
+# 	  $(INC) $(DEFINES) -o $@ \
+# 	  2>&1 | tee $(call LOG_FROM_GOTO,$@) ; exit $${PIPESTATUS[0]}
+
+goto: $(ENTRY).goto
+	echo $(DEPENDENT_GOTOS)
+
+################################################################
+# Targets to run the analysis commands
+cbmc.log: $(ENTRY).goto
+	cbmc $(CBMCFLAGS) --trace $< 2>&1 | tee $@
+
+property.xml: $(ENTRY).goto
+	cbmc $(CBMCFLAGS) --show-properties --xml-ui $< 2>&1 > $@
+
+coverage.xml: $(ENTRY).goto
+	cbmc $(filter-out --unwinding-assertions,$(CBMCFLAGS)) --cover location --xml-ui $< 2>&1 > $@
+
+cbmc: cbmc.log
+
+property: property.xml
+
+coverage: coverage.xml
+
+report: cbmc.log property.xml coverage.xml
+	$(VIEWER) \
+	--block coverage.xml \
+	--goto $(ENTRY).goto \
+	--htmldir html \
+	--property property.xml \
+	--result cbmc.log \
+	--srcdir $(SRCDIR) \
+	--srcexclude "(./verification|./tests|./tools|./lib/third_party)"
+
+################################################################
+# Targets to clean up after ourselves
+clean:
+	$(RM) *.goto
+	$(RM) $(DEPENDENT_GOTOS)
+	$(RM) *.log
+	$(RM) cbmc.log property.xml coverage.xml TAGS
+	$(RM) *~ \#*
+	$(RM) -r gotos
+
+
+veryclean: clean
+	$(RM) -r html
+	$(RM) -r logs
+
+.PHONY: setup_dependencies cbmc property coverage report clean veryclean testdeps
+
+include $(HELPERDIR)/proofs/Makefile.cbmc_batch

--- a/tests/cbmc/proofs/Makefile.common
+++ b/tests/cbmc/proofs/Makefile.common
@@ -228,15 +228,6 @@ $(ENTRY_GOTO)7.goto: $(ENTRY_GOTO)6.goto
 $(ENTRY_GOTO).goto: $(ENTRY_GOTO)7.goto
 	cp $< $@
 
-# For now, CBMC batch expects the goto in the same folder as the proof itself,
-# instead of the proof/gotos folder all other gotos go in.  This isn't a problem
-# for out-of-tree or parallel builds, it just clutters the proof directory.
-# I could update the .yaml file for all 160 proofs, or I could copy it, and
-# have one goto file in the proof directory.  Doing the second option for now.
-# TODO: cleanup which files go in which directories.
-$(ENTRY).goto: $(ENTRY_GOTO).goto
-	cp $< $@
-
 # # Catch-all used for building goto-binaries of the individual
 # # dependencies, which are then linked in the $(ENTRY_GOTO)0.goto rule above
 # # DSN TODO This should be able to go away once we have static removal working
@@ -254,28 +245,28 @@ goto: $(ENTRY).goto
 
 ################################################################
 # Targets to run the analysis commands
-cbmc.log: $(ENTRY).goto
+logs/cbmc.log: $(ENTRY_GOTO).goto
 	cbmc $(CBMCFLAGS) --trace $< 2>&1 | tee $@
 
-property.xml: $(ENTRY).goto
+logs/property.xml: $(ENTRY_GOTO).goto
 	cbmc $(CBMCFLAGS) --show-properties --xml-ui $< 2>&1 > $@
 
-coverage.xml: $(ENTRY).goto
+logs/coverage.xml: $(ENTRY_GOTO).goto
 	cbmc $(filter-out --unwinding-assertions,$(CBMCFLAGS)) --cover location --xml-ui $< 2>&1 > $@
 
-cbmc: cbmc.log
+cbmc: logs/cbmc.log
 
-property: property.xml
+property: logs/property.xml
 
-coverage: coverage.xml
+coverage: logs/coverage.xml
 
-report: cbmc.log property.xml coverage.xml
+report: logs/cbmc.log logs/property.xml logs/coverage.xml
 	$(VIEWER) \
-	--block coverage.xml \
-	--goto $(ENTRY).goto \
+	--block logs/coverage.xml \
+	--goto $(ENTRY_GOTO).goto \
 	--htmldir html \
-	--property property.xml \
-	--result cbmc.log \
+	--property logs/property.xml \
+	--result logs/cbmc.log \
 	--srcdir $(SRCDIR) \
 	--srcexclude "(./verification|./tests|./tools|./lib/third_party)"
 

--- a/tests/cbmc/proofs/Makefile.common
+++ b/tests/cbmc/proofs/Makefile.common
@@ -32,7 +32,7 @@ SHELL=/bin/bash
 
 default: report
 
-# if Makefile.local exists, use it. This provides a way to override the defaults
+# Use `sinclude` to include Makefile.local if it exists. This provides a way to override the defaults
 sinclude Makefile.local
 
 ################################################################

--- a/tests/cbmc/proofs/Makefile.common
+++ b/tests/cbmc/proofs/Makefile.common
@@ -240,7 +240,7 @@ $(ENTRY_GOTO).goto: $(ENTRY_GOTO)7.goto
 # 	  $(INC) $(DEFINES) -o $@ \
 # 	  2>&1 | tee $(call LOG_FROM_GOTO,$@) ; exit $${PIPESTATUS[0]}
 
-goto: $(ENTRY).goto
+goto: $(ENTRY_GOTO).goto
 	echo $(DEPENDENT_GOTOS)
 
 ################################################################

--- a/tests/cbmc/proofs/s2n_stuffer_init/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_init/Makefile
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 ###########
+#Use the default set of CBMC flags
 CBMCFLAGS +=
 
 DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
@@ -19,6 +20,7 @@ DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
 
 ENTRY = s2n_stuffer_init_harness
 
+#No loops to unwind
 UNWINDSET +=
 ###########
 

--- a/tests/cbmc/proofs/s2n_stuffer_init/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_init/Makefile
@@ -1,0 +1,25 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+CBMCFLAGS +=
+
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+
+ENTRY = s2n_stuffer_init_harness
+
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_init/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_init/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
 expected: "SUCCESSFUL"
-goto: s2n_stuffer_init_harness.goto
+goto: gotos/s2n_stuffer_init_harness.goto
 jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_init/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_init/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+expected: "SUCCESSFUL"
+goto: s2n_stuffer_init_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_init/s2n_stuffer_init_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_init/s2n_stuffer_init_harness.c
@@ -20,7 +20,5 @@
 void s2n_stuffer_init_harness() {
   struct s2n_stuffer *stuffer = malloc(sizeof(*stuffer));
   struct s2n_blob *in = malloc(sizeof(*stuffer));
-  if(s2n_stuffer_init(stuffer,in) == S2N_SUCCESS){
-  } else {
-  }
+  int result = s2n_stuffer_init(stuffer,in);
 }

--- a/tests/cbmc/proofs/s2n_stuffer_init/s2n_stuffer_init_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_init/s2n_stuffer_init_harness.c
@@ -19,6 +19,6 @@
 
 void s2n_stuffer_init_harness() {
   struct s2n_stuffer *stuffer = malloc(sizeof(*stuffer));
-  struct s2n_blob *in = malloc(sizeof(*stuffer));
-  int result = s2n_stuffer_init(stuffer,in);
+  struct s2n_blob *in = malloc(sizeof(*in));
+  int result = s2n_stuffer_init(stuffer, in);
 }

--- a/tests/cbmc/proofs/s2n_stuffer_init/s2n_stuffer_init_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_init/s2n_stuffer_init_harness.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_init_harness() {
+  struct s2n_stuffer *stuffer = malloc(sizeof(*stuffer));
+  struct s2n_blob *in = malloc(sizeof(*stuffer));
+  if(s2n_stuffer_init(stuffer,in) == S2N_SUCCESS){
+  } else {
+  }
+}

--- a/tests/cbmc/source/proof_allocators.c
+++ b/tests/cbmc/source/proof_allocators.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <cbmc_proof/proof_allocators.h>
+#include <stdarg.h>
+#include <stdlib.h>
+
+void *bounded_calloc(size_t num, size_t size) {
+    size_t required_bytes;
+    __CPROVER_assume(!__builtin_mul_overflow(num, size, &required_bytes));
+    __CPROVER_assume(required_bytes <= MAX_MALLOC);
+    return calloc(num, size);
+}
+
+void *bounded_malloc(size_t size) {
+    __CPROVER_assume(size <= MAX_MALLOC);
+    return malloc(size);
+}
+
+
+void *can_fail_calloc(size_t num, size_t size) {
+    return nondet_bool() ? NULL : bounded_calloc(num, size);
+}
+
+void *can_fail_malloc(size_t size) {
+    return nondet_bool() ? NULL : bounded_malloc(size);
+}
+
+/**
+ * https://en.cppreference.com/w/c/memory/realloc
+ * If there is not enough memory, the old memory block is not freed and null pointer is returned.
+ *
+ * If ptr is NULL, the behavior is the same as calling malloc(new_size).
+ *
+ * If new_size is zero, the behavior is implementation defined (null pointer may be returned (in which case the old
+ * memory block may or may not be freed), or some non-null pointer may be returned that may not be used to access
+ * storage).
+ */
+void *can_fail_realloc(void *ptr, size_t newsize) {
+    if (newsize > MAX_MALLOC) {
+        return NULL;
+    }
+    if (newsize == 0) {
+        if (nondet_bool()) {
+            free(ptr);
+        }
+        return nondet_voidp();
+    }
+    return nondet_bool() ? NULL : realloc(ptr, newsize);
+}

--- a/tests/cbmc/stubs/abort_override_assert_false.c
+++ b/tests/cbmc/stubs/abort_override_assert_false.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * FUNCTION: abort
+ *
+ * We override abort to be an assert(0) so that it is caught by CBMC
+ */
+
+#include <stdint.h>
+
+void abort() {
+    assert(0);
+}

--- a/tests/cbmc/stubs/abort_override_assert_false.c
+++ b/tests/cbmc/stubs/abort_override_assert_false.c
@@ -19,7 +19,7 @@
  * We override abort to be an assert(0) so that it is caught by CBMC
  */
 
-#include <stdint.h>
+#include <assert.h>
 
 void abort() {
     assert(0);


### PR DESCRIPTION
**Description of changes:** 
Adds the infrastructure for CBMC proofs, and an initial memory safety proof for `s2n_stuffer_init`.  Future PRs will add support for more interesting pre/postconditions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
