### PR TITLE
Make clean should clean up /tests/viz directory

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -55,4 +55,6 @@ clean: decruft
 	${MAKE} -C LD_PRELOAD decruft
 	${MAKE} -C unit clean
 	${MAKE} -C fuzz clean
+	${MAKE} -C viz clean
 	${MAKE} -C saw decruft
+

--- a/tests/viz/Makefile
+++ b/tests/viz/Makefile
@@ -38,4 +38,4 @@ build_viz::
 
 .PHONY : clean
 clean: decruft
-	rm s2n_state_machine_viz
+	rm -f s2n_state_machine_viz


### PR DESCRIPTION
**Issue # (if available):** N/A

**Description of changes:** 
Running `make clean` didn't clean up `tests/viz/` directory since `tests/Makefile` didn't invoke `tests/viz/Makefile` on clean target. This PR fixes that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
