### PR TITLE
Add Eclipse IDE files to gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@
 *.info
 *.profraw
 *.tmp
+build/*
+.cproject
+.project
+.settings/*
 coverage/html/*
 libcrypto-build/*
 libcrypto-root


### PR DESCRIPTION
**Issue # (if available):** 

**Description of changes:** 
Adds Eclipse IDE project files to `.gitignore` file

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
