### PR TITLE
Unit tests should declare themselves as such

### DIFF
--- a/crypto/s2n_drbg.c
+++ b/crypto/s2n_drbg.c
@@ -133,8 +133,8 @@ static int s2n_drbg_seed(struct s2n_drbg *drbg, struct s2n_blob *ps)
 int s2n_drbg_instantiate(struct s2n_drbg *drbg, struct s2n_blob *personalization_string, const s2n_drbg_mode mode)
 {
     notnull_check(drbg);
-    S2N_ERROR_IF(mode == S2N_DANGEROUS_AES_256_CTR_NO_DF_NO_PR && !S2N_IN_UNIT_TEST, S2N_ERR_NOT_IN_UNIT_TEST);
-    S2N_ERROR_IF(drbg->entropy_generator != NULL && !S2N_IN_UNIT_TEST, S2N_ERR_NOT_IN_UNIT_TEST);
+    S2N_ERROR_IF(mode == S2N_DANGEROUS_AES_256_CTR_NO_DF_NO_PR && !s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
+    S2N_ERROR_IF(drbg->entropy_generator != NULL && !s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
 
     if (mode == S2N_AES_128_CTR_NO_DF_PR || mode == S2N_AES_256_CTR_NO_DF_PR) {
         drbg->use_prediction_resistance = 1;
@@ -195,7 +195,7 @@ int s2n_drbg_generate(struct s2n_drbg *drbg, struct s2n_blob *blob)
     /* If either use_prediction_resistance is set, or if we reach the definitely-need-to-reseed limit, then reseed */
     if (drbg->use_prediction_resistance || drbg->bytes_used + blob->size + S2N_DRBG_BLOCK_SIZE >= S2N_DRBG_RESEED_LIMIT) {
         GUARD(s2n_drbg_seed(drbg, &zeros));
-    } else if (!drbg->use_prediction_resistance && !S2N_IN_UNIT_TEST) {
+    } else if (!drbg->use_prediction_resistance && !s2n_in_unit_test()) {
         S2N_ERROR(S2N_ERR_NOT_IN_UNIT_TEST);
     }
 

--- a/tests/s2n_test.h
+++ b/tests/s2n_test.h
@@ -23,6 +23,7 @@
 #include <openssl/crypto.h>
 
 #include "error/s2n_errno.h"
+#include "utils/s2n_safety.h"
 
 /* Macro definitions for calls that occur within BEGIN_TEST() and END_TEST() to preserve the SKIPPED test behavior
  * by ignoring the test_count, keeping it as 0 to indicate that a test was skipped. */
@@ -38,13 +39,15 @@
  * happen in main() and start with a BEGIN_TEST() and end with an END_TEST();
  */
 #ifdef S2N_TEST_IN_FIPS_MODE
-#define BEGIN_TEST() int test_count = 0; do { EXPECT_NOT_EQUAL_WITHOUT_COUNT(FIPS_mode_set(1), 0); \
+#define BEGIN_TEST() int test_count = 0; do {  s2n_in_unit_test_set(true); \
+                            EXPECT_NOT_EQUAL_WITHOUT_COUNT(FIPS_mode_set(1), 0);		\
                             EXPECT_SUCCESS_WITHOUT_COUNT(s2n_init()); \
                             fprintf(stdout, "Running FIPS test %-50s ... ", __FILE__); } while(0)
 #else
-#define BEGIN_TEST() int test_count = 0; do { EXPECT_SUCCESS_WITHOUT_COUNT(s2n_init());  fprintf(stdout, "Running %-50s ... ", __FILE__); } while(0)
+#define BEGIN_TEST() int test_count = 0; do {s2n_in_unit_test_set(true); EXPECT_SUCCESS_WITHOUT_COUNT(s2n_init());  fprintf(stdout, "Running %-50s ... ", __FILE__); } while(0)
 #endif
-#define END_TEST()   do { EXPECT_SUCCESS_WITHOUT_COUNT(s2n_cleanup()); \
+#define END_TEST()   do { s2n_in_unit_test_set(false); \
+                        EXPECT_SUCCESS_WITHOUT_COUNT(s2n_cleanup());       \
                         if (isatty(fileno(stdout))) { \
                             if (test_count) { \
                                 fprintf(stdout, "\033[32;1mPASSED\033[0m %10d tests\n", test_count ); \

--- a/tests/s2n_test.h
+++ b/tests/s2n_test.h
@@ -39,14 +39,24 @@
  * happen in main() and start with a BEGIN_TEST() and end with an END_TEST();
  */
 #ifdef S2N_TEST_IN_FIPS_MODE
-#define BEGIN_TEST() int test_count = 0; do {  s2n_in_unit_test_set(true); \
-                            EXPECT_NOT_EQUAL_WITHOUT_COUNT(FIPS_mode_set(1), 0);		\
-                            EXPECT_SUCCESS_WITHOUT_COUNT(s2n_init()); \
-                            fprintf(stdout, "Running FIPS test %-50s ... ", __FILE__); } while(0)
+#define BEGIN_TEST()						\
+  int test_count = 0;						\
+  do {								\
+    EXPECT_SUCCESS_WITHOUT_COUNT(s2n_in_unit_test_set(true));	\
+    EXPECT_NOT_EQUAL_WITHOUT_COUNT(FIPS_mode_set(1), 0);	\
+    EXPECT_SUCCESS_WITHOUT_COUNT(s2n_init());			\
+    fprintf(stdout, "Running FIPS test %-50s ... ", __FILE__);	\
+  } while(0)
 #else
-#define BEGIN_TEST() int test_count = 0; do {s2n_in_unit_test_set(true); EXPECT_SUCCESS_WITHOUT_COUNT(s2n_init());  fprintf(stdout, "Running %-50s ... ", __FILE__); } while(0)
+#define BEGIN_TEST()						\
+  int test_count = 0; do {					\
+    EXPECT_SUCCESS_WITHOUT_COUNT(s2n_in_unit_test_set(true));	\
+    EXPECT_SUCCESS_WITHOUT_COUNT(s2n_init());			\
+    fprintf(stdout, "Running %-50s ... ", __FILE__);		\
+  } while(0)
 #endif
-#define END_TEST()   do { s2n_in_unit_test_set(false); \
+#define END_TEST()   do { \
+                        EXPECT_SUCCESS_WITHOUT_COUNT(s2n_in_unit_test_set(false));		\
                         EXPECT_SUCCESS_WITHOUT_COUNT(s2n_cleanup());       \
                         if (isatty(fileno(stdout))) { \
                             if (test_count) { \

--- a/tests/sidetrail/working/patches/safety1.patch
+++ b/tests/sidetrail/working/patches/safety1.patch
@@ -1,27 +1,16 @@
---- ../../../../../utils/s2n_safety.h	2019-03-27 14:17:01.000000000 -0400
-+++ s2n_safety.h	2019-03-27 15:11:07.000000000 -0400
-@@ -15,25 +15,27 @@
- 
- #pragma once
- 
--#include <string.h>
-+//#include <string.h>
- #include <sys/types.h>
- #include <stdint.h>
- #include <stdlib.h>
- 
+diff --git a/utils/s2n_safety.h b/utils/s2n_safety.h
+index eb9185e7..44b70221 100644
+--- ../../../../../utils/s2n_safety.h
++++ s2n_safety.h
+@@ -24,17 +24,15 @@
  #include "error/s2n_errno.h"
-+#include "s2n_annotations.h"
-+#include "sidetrail.h"
-+
-+void __VERIFIER_assume(int);
-+void *memcpy(void *str1, const void *str2, size_t n);
  
  /* NULL check a pointer */
 -#define notnull_check( ptr )           do { if ( (ptr) == NULL ) { S2N_ERROR(S2N_ERR_NULL); } } while(0)
 -#define notnull_check_ptr( ptr )       do { if ( (ptr) == NULL ) { S2N_ERROR_PTR(S2N_ERR_NULL); } } while(0)
 +#define notnull_check( ptr )           __VERIFIER_assume(ptr != NULL)
 +#define notnull_check_ptr( ptr )       __VERIFIER_assume(ptr != NULL)
++
 +
 +#define MEMCOPY_COST 2
 +void * my_memset ( void * ptr, int value, size_t num );
@@ -37,7 +26,7 @@
      return memcpy(to, from, size);
  }
  
-@@ -41,20 +43,12 @@
+@@ -42,20 +40,12 @@ static inline void* trace_memcpy_check(void *restrict to, const void *restrict f
   */
  #define memcpy_check( d, s, n )                                             \
    do {                                                                      \
@@ -60,7 +49,7 @@
    } while(0)
  
  #define memset_check( d, c, n )                                             \
-@@ -63,19 +57,19 @@
+@@ -64,19 +54,19 @@ static inline void* trace_memcpy_check(void *restrict to, const void *restrict f
      if ( __tmp_n ) {                                                        \
        __typeof( d ) __tmp_d = ( d );                                        \
        notnull_check( __tmp_d );                                             \
@@ -87,17 +76,21 @@
  #define inclusive_range_check( low, n, high )   \
    do  {                                         \
      __typeof( n ) __tmp_n = ( n );              \
-@@ -89,18 +83,13 @@
+@@ -90,9 +80,9 @@ static inline void* trace_memcpy_check(void *restrict to, const void *restrict f
      lt_check(__tmp_n, high);                    \
    } while (0)
  
--#define GUARD( x )              if ( (x) < 0 ) return -1
--#define GUARD_GOTO( x , label ) if ( (x) < 0 ) goto label
--#define GUARD_PTR( x )          if ( (x) < 0 ) return NULL
-+#define GUARD( x )              __VERIFIER_assume( (x) >= 0 )
-+#define GUARD_GOTO( x , label ) __VERIFIER_assume( (x) >= 0 )
-+#define GUARD_PTR( x )          __VERIFIER_assume( (x) >= 0 )
- #define S2N_IN_UNIT_TEST ( getenv("S2N_UNIT_TEST") != NULL )
+-#define GUARD( x )              do {if ( (x) < 0 ) return S2N_FAILURE;} while (0)
+-#define GUARD_GOTO( x , label ) do {if ( (x) < 0 ) goto label;} while (0)
+-#define GUARD_PTR( x )          do {if ( (x) < 0 ) return NULL;} while (0)
++#define GUARD( x )              __VERIFIER_assume((x) == 0)
++#define GUARD_GOTO( x , label ) __VERIFIER_assume((x) == 0)
++#define GUARD_PTR( x )          __VERIFIER_assume((x) == 0)
+ 
+ /* Check the return value from caller. If this value is -2, S2N_ERR_BLOCKED is marked*/
+ #define GUARD_AGAIN( x )  do {if ( (x) == -2 ) { S2N_ERROR(S2N_ERR_BLOCKED); } GUARD( x );} while(0)
+@@ -107,12 +97,7 @@ int s2n_in_unit_test_set(bool newval);
+ #define S2N_IN_TEST ( s2n_in_unit_test() || S2N_IN_INTEG_TEST )
  
  /* TODO: use the OSSL error code in error reporting https://github.com/awslabs/s2n/issues/705 */
 -#define GUARD_OSSL( x , errcode )               \

--- a/tests/sidetrail/working/patches/safety1.patch
+++ b/tests/sidetrail/working/patches/safety1.patch
@@ -1,9 +1,14 @@
-diff --git a/utils/s2n_safety.h b/utils/s2n_safety.h
-index eb9185e7..44b70221 100644
---- ../../../../../utils/s2n_safety.h
-+++ s2n_safety.h
-@@ -24,17 +24,15 @@
+--- ../../../../../utils/s2n_safety.h	2019-11-15 14:47:04.000000000 -0500
++++ s2n_safety.h	2019-11-15 14:57:20.000000000 -0500
+@@ -22,19 +22,22 @@
+ #include <stdlib.h>
+ 
  #include "error/s2n_errno.h"
++#include "s2n_annotations.h"
++#include "sidetrail.h"
++
++void __VERIFIER_assume(int);
++void *memcpy(void *str1, const void *str2, size_t n);
  
  /* NULL check a pointer */
 -#define notnull_check( ptr )           do { if ( (ptr) == NULL ) { S2N_ERROR(S2N_ERR_NULL); } } while(0)
@@ -26,7 +31,7 @@ index eb9185e7..44b70221 100644
      return memcpy(to, from, size);
  }
  
-@@ -42,20 +40,12 @@ static inline void* trace_memcpy_check(void *restrict to, const void *restrict f
+@@ -42,20 +45,12 @@
   */
  #define memcpy_check( d, s, n )                                             \
    do {                                                                      \
@@ -49,7 +54,7 @@ index eb9185e7..44b70221 100644
    } while(0)
  
  #define memset_check( d, c, n )                                             \
-@@ -64,19 +54,19 @@ static inline void* trace_memcpy_check(void *restrict to, const void *restrict f
+@@ -64,19 +59,19 @@
      if ( __tmp_n ) {                                                        \
        __typeof( d ) __tmp_d = ( d );                                        \
        notnull_check( __tmp_d );                                             \
@@ -76,7 +81,7 @@ index eb9185e7..44b70221 100644
  #define inclusive_range_check( low, n, high )   \
    do  {                                         \
      __typeof( n ) __tmp_n = ( n );              \
-@@ -90,9 +80,9 @@ static inline void* trace_memcpy_check(void *restrict to, const void *restrict f
+@@ -90,9 +85,9 @@
      lt_check(__tmp_n, high);                    \
    } while (0)
  
@@ -89,7 +94,7 @@ index eb9185e7..44b70221 100644
  
  /* Check the return value from caller. If this value is -2, S2N_ERR_BLOCKED is marked*/
  #define GUARD_AGAIN( x )  do {if ( (x) == -2 ) { S2N_ERROR(S2N_ERR_BLOCKED); } GUARD( x );} while(0)
-@@ -107,12 +97,7 @@ int s2n_in_unit_test_set(bool newval);
+@@ -107,12 +102,7 @@
  #define S2N_IN_TEST ( s2n_in_unit_test() || S2N_IN_INTEG_TEST )
  
  /* TODO: use the OSSL error code in error reporting https://github.com/awslabs/s2n/issues/705 */

--- a/tests/unit/s2n_drbg_test.c
+++ b/tests/unit/s2n_drbg_test.c
@@ -503,7 +503,7 @@ int main(int argc, char **argv)
     EXPECT_EQUAL(aes256_no_pr_drbg.generation, 1);
 
     /* Test that the drbg wont let you use dangerous configurations outside unit tests */
-    s2n_in_unit_test_set(false);
+    EXPECT_SUCCESS(s2n_in_unit_test_set(false));
     struct s2n_drbg failing_drbg_mode = {0};
     EXPECT_FAILURE(s2n_drbg_instantiate(&failing_drbg_mode, &blob, S2N_DANGEROUS_AES_256_CTR_NO_DF_NO_PR));
 
@@ -511,7 +511,7 @@ int main(int argc, char **argv)
     EXPECT_FAILURE(s2n_drbg_instantiate(&failing_drbg_entropy, &blob, S2N_AES_128_CTR_NO_DF_PR));
 
     /* Return to "unit test mode" and verify it would actually work and that was the reason for the failure */
-    s2n_in_unit_test_set(true);
+    EXPECT_SUCCESS(s2n_in_unit_test_set(true));
 
     EXPECT_SUCCESS(s2n_drbg_instantiate(&failing_drbg_mode, &blob, S2N_DANGEROUS_AES_256_CTR_NO_DF_NO_PR));
     EXPECT_SUCCESS(s2n_drbg_instantiate(&failing_drbg_entropy, &blob, S2N_AES_128_CTR_NO_DF_PR));

--- a/tests/unit/s2n_drbg_test.c
+++ b/tests/unit/s2n_drbg_test.c
@@ -512,7 +512,7 @@ int main(int argc, char **argv)
 
     /* Return to "unit test mode" and verify it would actually work and that was the reason for the failure */
     s2n_in_unit_test_set(true);
-    
+
     EXPECT_SUCCESS(s2n_drbg_instantiate(&failing_drbg_mode, &blob, S2N_DANGEROUS_AES_256_CTR_NO_DF_NO_PR));
     EXPECT_SUCCESS(s2n_drbg_instantiate(&failing_drbg_entropy, &blob, S2N_AES_128_CTR_NO_DF_PR));
 

--- a/tests/unit/s2n_drbg_test.c
+++ b/tests/unit/s2n_drbg_test.c
@@ -503,7 +503,7 @@ int main(int argc, char **argv)
     EXPECT_EQUAL(aes256_no_pr_drbg.generation, 1);
 
     /* Test that the drbg wont let you use dangerous configurations outside unit tests */
-    EXPECT_EQUAL(0, unsetenv("S2N_UNIT_TEST"));
+    s2n_in_unit_test_set(false);
     struct s2n_drbg failing_drbg_mode = {0};
     EXPECT_FAILURE(s2n_drbg_instantiate(&failing_drbg_mode, &blob, S2N_DANGEROUS_AES_256_CTR_NO_DF_NO_PR));
 
@@ -511,8 +511,8 @@ int main(int argc, char **argv)
     EXPECT_FAILURE(s2n_drbg_instantiate(&failing_drbg_entropy, &blob, S2N_AES_128_CTR_NO_DF_PR));
 
     /* Return to "unit test mode" and verify it would actually work and that was the reason for the failure */
-    EXPECT_EQUAL(0, setenv("S2N_UNIT_TEST", "1", 1));
-
+    s2n_in_unit_test_set(true);
+    
     EXPECT_SUCCESS(s2n_drbg_instantiate(&failing_drbg_mode, &blob, S2N_DANGEROUS_AES_256_CTR_NO_DF_NO_PR));
     EXPECT_SUCCESS(s2n_drbg_instantiate(&failing_drbg_entropy, &blob, S2N_AES_128_CTR_NO_DF_PR));
 

--- a/tests/unit/s2n_tls13_support_test.c
+++ b/tests/unit/s2n_tls13_support_test.c
@@ -144,7 +144,7 @@ int main(int argc, char **argv)
     EXPECT_FALSE(s2n_is_tls13_enabled());
 
     /* TLS 1.3 can't be enabled outside of unit tests */
-    EXPECT_SUCCESS(unsetenv("S2N_UNIT_TEST"));
+    EXPECT_SUCCESS(s2n_in_unit_test_set(false));
     EXPECT_FAILURE_WITH_ERRNO(s2n_enable_tls13(), S2N_ERR_NOT_IN_UNIT_TEST);
 
     END_TEST();

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -305,7 +305,7 @@ int s2n_rand_cleanup_thread(void)
  */
 int s2n_set_private_drbg_for_test(struct s2n_drbg drbg)
 {
-    S2N_ERROR_IF(!S2N_IN_UNIT_TEST, S2N_ERR_NOT_IN_UNIT_TEST);
+    S2N_ERROR_IF(!s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
     GUARD(s2n_drbg_wipe(&per_thread_private_drbg));
 
     per_thread_private_drbg = drbg;

--- a/utils/s2n_safety.c
+++ b/utils/s2n_safety.c
@@ -20,8 +20,10 @@
 #include <sys/syscall.h>
 #include <sys/types.h>
 #include <stdint.h>
+#include <stdio.h>
 
 #include "s2n_annotations.h"
+#include "s2n_safety.h"
 
 /**
  * Get the process id
@@ -147,4 +149,18 @@ int s2n_constant_time_pkcs1_unpad_or_dont(uint8_t * dst, const uint8_t * src, ui
     s2n_constant_time_copy_or_dont(dst, start_of_data, expectlen, dont_copy);
 
     return 0;
+}
+
+static bool s_s2n_in_unit_test = false;
+
+bool s2n_in_unit_test()
+{
+    return s_s2n_in_unit_test;
+}
+
+bool s2n_in_unit_test_set(bool newval)
+{
+    bool oldval = s_s2n_in_unit_test;
+    s_s2n_in_unit_test = newval;
+    return oldval;
 }

--- a/utils/s2n_safety.c
+++ b/utils/s2n_safety.c
@@ -158,9 +158,8 @@ bool s2n_in_unit_test()
     return s_s2n_in_unit_test;
 }
 
-bool s2n_in_unit_test_set(bool newval)
+int s2n_in_unit_test_set(bool newval)
 {
-    bool oldval = s_s2n_in_unit_test;
     s_s2n_in_unit_test = newval;
-    return oldval;
+    return S2N_SUCCESS;
 }

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -100,8 +100,8 @@ static inline void* trace_memcpy_check(void *restrict to, const void *restrict f
 /* Returns true if s2n is in unit test mode, false otherwise */
 bool s2n_in_unit_test();
 
-/* Sets whether s2n is in unit test mode. Returns the previous value for the flag */
-bool s2n_in_unit_test_set(bool newval);
+/* Sets whether s2n is in unit test mode */
+int s2n_in_unit_test_set(bool newval);
 
 #define S2N_IN_INTEG_TEST ( getenv("S2N_INTEG_TEST") != NULL )
 #define S2N_IN_TEST ( s2n_in_unit_test() || S2N_IN_INTEG_TEST )

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -18,6 +18,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <stdlib.h>
 
 #include "error/s2n_errno.h"
@@ -96,8 +97,13 @@ static inline void* trace_memcpy_check(void *restrict to, const void *restrict f
 /* Check the return value from caller. If this value is -2, S2N_ERR_BLOCKED is marked*/
 #define GUARD_AGAIN( x )  do {if ( (x) == -2 ) { S2N_ERROR(S2N_ERR_BLOCKED); } GUARD( x );} while(0)
 
+/* Returns true if s2n is in unit test mode, false otherwise */
+bool s2n_in_unit_test();
 
-#define S2N_IN_UNIT_TEST ( getenv("S2N_UNIT_TEST") != NULL )
+/* Sets whether s2n is in unit test mode. Returns the previous value for the flag */
+bool s2n_in_unit_test_set(bool newval);
+
+#define S2N_IN_UNIT_TEST ( s2n_in_unit_test() )
 #define S2N_IN_INTEG_TEST ( getenv("S2N_INTEG_TEST") != NULL )
 #define S2N_IN_TEST ( S2N_IN_UNIT_TEST || S2N_IN_INTEG_TEST )
 
@@ -121,7 +127,7 @@ extern pid_t s2n_actual_getpid();
 extern int s2n_constant_time_equals(const uint8_t * a, const uint8_t * b, uint32_t len);
 
 /* Copy src to dst, or don't copy it, in constant time */
-extern int s2n_constant_time_copy_or_dont(const uint8_t * dst, const uint8_t * src, uint32_t len, uint8_t dont);
+extern int s2n_constant_time_copy_or_dont(uint8_t * dst, const uint8_t * src, uint32_t len, uint8_t dont);
 
 /* If src contains valid PKCS#1 v1.5 padding of exactly expectlen bytes, decode
  * it into dst, otherwise leave dst alone, in constant time.

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -103,9 +103,8 @@ bool s2n_in_unit_test();
 /* Sets whether s2n is in unit test mode. Returns the previous value for the flag */
 bool s2n_in_unit_test_set(bool newval);
 
-#define S2N_IN_UNIT_TEST ( s2n_in_unit_test() )
 #define S2N_IN_INTEG_TEST ( getenv("S2N_INTEG_TEST") != NULL )
-#define S2N_IN_TEST ( S2N_IN_UNIT_TEST || S2N_IN_INTEG_TEST )
+#define S2N_IN_TEST ( s2n_in_unit_test() || S2N_IN_INTEG_TEST )
 
 /* TODO: use the OSSL error code in error reporting https://github.com/awslabs/s2n/issues/705 */
 #define GUARD_OSSL( x , errcode )               \


### PR DESCRIPTION
**Description of changes:** 
Rather than using an environment variable to track whether we are in unit test mode, use a local variable. This is cleaner and faster.

Also, fix an error in the declaration of `s2n_constant_time_copy_or_dont()` that was preventing this from compiling.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
