### PR TITLE
Update s2n_handshake_io.saw to prove TLS1.3

### DIFF
--- a/.travis/s2n_travis_build.sh
+++ b/.travis/s2n_travis_build.sh
@@ -78,7 +78,12 @@ if [[ "$TESTS" == "ALL" || "$TESTS" == "integration" ]]; then make clean; make i
 if [[ "$TESTS" == "ALL" || "$TESTS" == "fuzz" ]]; then (make clean && make fuzz) ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "sawHMAC" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make -C tests/saw/ tmp/"verify_s2n_hmac_$SAW_HMAC_TEST".log ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "sawDRBG" ]]; then make -C tests/saw tmp/verify_drbg.log ; fi
-if [[ "$TESTS" == "ALL" || "$TESTS" == "tls" ]]; then make -C tests/saw tmp/verify_handshake.log ; fi
+if [[ "$TESTS" == "ALL" || "$TESTS" == "tls" ]]; then
+    # We have to output something every 9 minutes, as some proofs may run longer than 10 minutes
+    while sleep 9m; do echo "=====[ $SECONDS seconds still running ]====="; done &
+    make -C tests/saw tmp/verify_handshake.log
+    kill %1
+fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "sawHMACFailure" ]]; then make -C tests/saw failure-tests ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "ctverif" ]]; then .travis/run_ctverif.sh "$CTVERIF_INSTALL_DIR" ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "sawSIKE" ]]; then make -C tests/saw sike ; fi

--- a/tests/saw/spec/handshake/handshake_io_lowlevel.saw
+++ b/tests/saw/spec/handshake/handshake_io_lowlevel.saw
@@ -97,9 +97,8 @@ let setup_connection = do {
    let corked_io = {{1 : [8]}};
    crucible_points_to (conn_corked_io pconn) (crucible_term corked_io); 
    
-   // this proof is only valid for the tls1.2 version of the handshake
-   let tls12_version = {{33 : [8]}};
-   crucible_points_to (crucible_field pconn "actual_protocol_version") (crucible_term tls12_version);
+   version <- crucible_fresh_var "version" (llvm_int 8);
+   crucible_points_to (crucible_field pconn "actual_protocol_version") (crucible_term version);
    
    mode <- crucible_fresh_var "mode" (llvm_int 32);
    crucible_points_to (conn_mode pconn) (crucible_term mode);
@@ -158,8 +157,8 @@ let setup_connection = do {
    return (pconn, {{ {corked_io = corked_io
                      ,mode      = mode
                      ,handshake = {message_number = message_number
-		                  ,handshake_type = handshake_type}
-         	     ,corked    = cork_val
+                                  ,handshake_type = handshake_type}
+                     ,corked    = cork_val
                      ,is_caching_enabled = False
                      ,key_exchange_eph = eph_flag != zero
                      ,server_can_send_ocsp =
@@ -167,8 +166,9 @@ let setup_connection = do {
                             ((mode == 1) && (ocsp_flag == 1))
                      ,resume_from_cache = False
                      ,client_auth_flag = if mode == S2N_CLIENT then client_cert_auth_type == 1 else 
-                                            if mode == S2N_SERVER then client_cert_auth_type != 0 else False
-                     }                  
+                                         if mode == S2N_SERVER then client_cert_auth_type != 0 else False
+                     ,actual_protocol_version = version
+                     }
                   }}); 
 };
 
@@ -177,15 +177,15 @@ let setup_connection = do {
 // This function checks that the values of the state_machine array are what we
 // expect. 'sm' is the pointer to the beginning of the array, 'ixt' is the term
 // representing the index in the array.
-let verify_state_machine_elem sm ixt = do {
-    let ix = eval_int ixt;
-    let abstract = {{ state_machine @ ixt }};
+let verify_state_machine_elem state_machine state_machine_model index_term = do {
+    let index = eval_int index_term;
+    let abstract = {{ state_machine_model @ index_term }};
 
-    crucible_points_to (crucible_elem (crucible_elem sm ix) 0) (crucible_term {{ abstract.record_type }});
+    crucible_points_to (crucible_elem (crucible_elem state_machine index) 0) (crucible_term {{ abstract.record_type }});
 
-    crucible_points_to (crucible_elem (crucible_elem sm ix) 1) (crucible_term {{ abstract.message_type }});
+    crucible_points_to (crucible_elem (crucible_elem state_machine index) 1) (crucible_term {{ abstract.message_type }});
 
-    crucible_points_to (crucible_elem (crucible_elem sm ix) 2) (crucible_term {{ abstract.writer }});
+    crucible_points_to (crucible_elem (crucible_elem state_machine index) 2) (crucible_term {{ abstract.writer }});
 
 };
 
@@ -232,12 +232,12 @@ let s2n_conn_set_handshake_type_spec = do {
     // "handshakes")
     crucible_precond {{ valid_handshake conn.handshake }};
 
-    // symbolically execute s2n_advance_message
+    // symbolically execute s2n_conn_set_handshake_type
     crucible_execute_func [pconn];
 
     // Next we check that the changes to s2n_connection fields are
     // simulated by the low-level specification of the function. We do
-    // this by running the model function advance_message on the
+    // this by running the model function conn_set_handshake_type on the
     // deserealized pre-state of the s2n_connection struct and checking
     // that values of the fields of the resulting struct match the fields
     // of the post-state of the s2n_connection struct. In this case only handshake
@@ -246,7 +246,7 @@ let s2n_conn_set_handshake_type_spec = do {
     crucible_ghost_value corked {{ conn'.corked }};
     crucible_points_to (conn_handshake_handshake_type pconn) (crucible_term {{ conn'.handshake.handshake_type }});
 
-    // assert that s2n_advance_message returns 0 (true if the 4
+    // assert that s2n_conn_set_handshake_type returns 0 (true if the 4
     // functions it calls don't fail)
     crucible_return (crucible_term {{ 0 : [32] }});
 };
@@ -272,19 +272,23 @@ let s2n_advance_message_spec = do {
     let conn' = {{ advance_message conn }};
     crucible_ghost_value corked {{ conn'.corked }};
     crucible_points_to (conn_corked_io pconn) (crucible_term {{ conn'.corked_io }});
-    crucible_points_to (conn_mode pconn) (crucible_term {{ (advance_message conn).mode }});
-    crucible_points_to (conn_handshake_handshake_type pconn) (crucible_term {{ (advance_message conn).handshake.handshake_type }});
-    crucible_points_to (conn_handshake_message_number pconn) (crucible_term {{ (advance_message conn).handshake.message_number }});
+    crucible_points_to (conn_mode pconn) (crucible_term {{ conn'.mode }});
+    crucible_points_to (conn_handshake_handshake_type pconn) (crucible_term {{ conn'.handshake.handshake_type }});
+    crucible_points_to (conn_handshake_message_number pconn) (crucible_term {{ conn'.handshake.message_number }});
 
     // make sure the low-level spec representation of the declarative
     // handshake/cork-uncork state machine is equivalent to the one in
     // s2n
     crucible_points_to (crucible_global "handshakes") (crucible_term {{ handshakes }});
+    crucible_points_to (crucible_global "tls13_handshakes") (crucible_term {{ tls13_handshakes }});
+    
     let messages = [ {{CLIENT_HELLO : [5]}}, {{SERVER_SESSION_LOOKUP : [5]}}, {{SERVER_HELLO : [5]}}, {{SERVER_CERT : [5]}}, {{SERVER_NEW_SESSION_TICKET : [5]}}, {{SERVER_CERT_STATUS : [5]}}, 
       {{SERVER_KEY : [5]}}, {{SERVER_CERT : [5]}}, {{SERVER_CERT_REQ : [5]}}, {{SERVER_HELLO_DONE : [5]}}, {{CLIENT_CERT : [5]}}, {{CLIENT_KEY : [5]}}, {{CLIENT_CERT_VERIFY : [5]}}, 
-      {{CLIENT_CHANGE_CIPHER_SPEC : [5]}}, {{SERVER_FINISHED : [5]}}, {{APPLICATION_DATA : [5]}}];
+      {{CLIENT_CHANGE_CIPHER_SPEC : [5]}}, {{SERVER_FINISHED : [5]}}, {{ENCRYPTED_EXTENSIONS : [5]}}, {{SERVER_CERT_VERIFY : [5]}}, {{APPLICATION_DATA : [5]}} ];
 
-    for messages (verify_state_machine_elem (crucible_global "state_machine"));
+    for messages (verify_state_machine_elem (crucible_global "state_machine") {{ state_machine }} );
+    for messages (verify_state_machine_elem (crucible_global "tls13_state_machine") {{ tls13_state_machine }} );
+
     // assert that s2n_advance_message returns 0 (true if the 4
     // functions it calls don't fail)
     crucible_return (crucible_term {{ 0 : [32] }});

--- a/tests/saw/spec/handshake/rfc-handshake.cry
+++ b/tests/saw/spec/handshake/rfc-handshake.cry
@@ -132,6 +132,7 @@ connectionParameters conn params =
  /\ (~params.includeSessionTicket) // s2n server does not issue tickets at this time
  /\ (~params.renewSessionTicket) // s2n server does not issue tickets at this time
  /\ conn.client_auth_flag == params.requestClientCert
+ /\ conn.actual_protocol_version != S2N_TLS13
 
 // A predicate that tells whether key-exchange is non-ephemeral and uses server certificate
 // data for exchanging a premaster secret (RFC 5246 7.4.3). In this case the key exchange
@@ -245,8 +246,6 @@ message = lookupDefault messages (mkMessage noSender data error)
             ,(clientFinishedWithTicketSent, mkMessage client handshake finished)
             ,(serverCertificateStatusSent, mkMessage server handshake certificateStatus)
             ]
-
-
 
 // a mapping from RFC messages to s2n handshake_action's
 rfc2S2N : Message -> handshake_action

--- a/tests/saw/spec/handshake/s2n_handshake_io.cry
+++ b/tests/saw/spec/handshake/s2n_handshake_io.cry
@@ -16,14 +16,17 @@ conn_set_handshake_type conn = conn'
                 ,resume_from_cache = conn.resume_from_cache
                 ,server_can_send_ocsp = conn.server_can_send_ocsp
                 ,key_exchange_eph = conn.key_exchange_eph
-                ,client_auth_flag = conn.client_auth_flag}
+                ,client_auth_flag = conn.client_auth_flag
+                ,actual_protocol_version = conn.actual_protocol_version
+                }
         (handshake' : handshake) = {handshake_type = handshake_type'
                                    ,message_number = conn.handshake.message_number
                                    }
-        handshake_type' = NEGOTIATED || full_handshake ||
-                          (if (full_handshake != 0) then
-                            perfect_forward_secrecy || ocsp_status || client_auth
-                            else zero)
+        handshake_type' = if (IS_TLS13_HANDSHAKE conn) then NEGOTIATED || FULL_HANDSHAKE
+                          else NEGOTIATED || full_handshake ||
+                            (if (full_handshake != 0) then
+                              perfect_forward_secrecy || ocsp_status || client_auth
+                              else zero)
         full_handshake  = if (conn.is_caching_enabled && ~conn.resume_from_cache)
                           then zero
                           else FULL_HANDSHAKE
@@ -36,7 +39,7 @@ conn_set_handshake_type conn = conn'
         client_auth = if conn.client_auth_flag
                       then CLIENT_AUTH
                       else zero
-                                                     
+
 // This function models the update of the s2n_connection struct by the
 // s2n_advance_message function in s2n.
 advance_message : connection -> connection
@@ -50,15 +53,18 @@ advance_message conn = conn2
                 ,server_can_send_ocsp = conn.server_can_send_ocsp
                 ,key_exchange_eph = conn.key_exchange_eph
                 ,client_auth_flag = conn.client_auth_flag
+                ,actual_protocol_version = conn.actual_protocol_version
                 }
-        (handshake2 : handshake) = {handshake_type = conn.handshake.handshake_type
-                                   ,message_number = conn.handshake.message_number + 1
-                                   }
-        cork2 = if (ACTIVE_STATE conn2).writer != (PREVIOUS_STATE conn2).writer /\
+        (handshake2 : handshake) = { handshake_type = conn.handshake.handshake_type,
+                                     message_number = message_number2 }
+        cork2 = if (ACTIVE_STATE conn2).writer != (ACTIVE_STATE conn).writer /\
                    (ACTIVE_STATE conn2).writer != 'A'
                 then if (ACTIVE_STATE conn2).writer == mode_writer conn2.mode
                      then s2n_cork conn else s2n_uncork conn
                 else conn.corked
+        message_number2 = conn.handshake.message_number + ( if skip_message then 2 else 1)
+        skip_message = (IS_TLS13_HANDSHAKE conn2) /\ ((mode_writer conn2.mode) != (next_state conn).writer)
+                           /\ ((next_state conn).record_type == TLS_CHANGE_CIPHER_SPEC)
 
 // for a given initial connection struct generate the
 // sequence of handshake_action's
@@ -136,29 +142,40 @@ type connection = {handshake : handshake
                   ,server_can_send_ocsp : Bit
                   ,key_exchange_eph : Bit
                   ,client_auth_flag : Bit //whether the server will request client cert
+                  ,actual_protocol_version : [8]
                   }
 
 type handshake = {handshake_type : [32]
                  ,message_number : [32]
                  }
 
-// {ACTIVE,PREVIOUS}_{STATE,MESSAGE} functions model the corresponding macros in C
-ACTIVE_MESSAGE : connection -> [32]
-ACTIVE_MESSAGE conn = (handshakes @ (conn.handshake.handshake_type))
-                                  @ (conn.handshake.message_number)
+// functions model the corresponding macros in C
 
-PREVIOUS_MESSAGE : connection -> [32]
-PREVIOUS_MESSAGE conn = (handshakes @ (conn.handshake.handshake_type))
-                                    @ (conn.handshake.message_number - 1)
+IS_TLS13_HANDSHAKE : connection -> Bit
+IS_TLS13_HANDSHAKE conn = conn.actual_protocol_version == S2N_TLS13
+
+ACTIVE_STATE_MACHINE : connection -> [19]handshake_action
+ACTIVE_STATE_MACHINE conn = if IS_TLS13_HANDSHAKE conn then tls13_state_machine else state_machine # zero
+
+ACTIVE_HANDSHAKES : connection -> [128][32][32]
+ACTIVE_HANDSHAKES conn = if IS_TLS13_HANDSHAKE conn then tls13_handshakes else handshakes
+
+ACTIVE_MESSAGE : connection -> [32]
+ACTIVE_MESSAGE conn = ((ACTIVE_HANDSHAKES conn) @ (conn.handshake.handshake_type))
+                                                @ (conn.handshake.message_number)
 
 ACTIVE_STATE : connection -> handshake_action
-ACTIVE_STATE conn = state_machine @ (ACTIVE_MESSAGE conn)
+ACTIVE_STATE conn = (ACTIVE_STATE_MACHINE conn) @ (ACTIVE_MESSAGE conn)
 
-PREVIOUS_STATE : connection -> handshake_action
-PREVIOUS_STATE conn = state_machine @ (PREVIOUS_MESSAGE conn)
+next_message : connection -> [32]
+next_message conn = ((ACTIVE_HANDSHAKES conn) @ (conn.handshake.handshake_type))
+                                              @ (conn.handshake.message_number + 1)
+                                              
+next_state : connection -> handshake_action
+next_state conn = (ACTIVE_STATE_MACHINE conn) @ (next_message conn)
 
 // Helper function that gives the value of the 'writer' field of the
-// current hanshake state (handshake action) that would correspond to
+// current handshake state (handshake action) that would correspond to
 // the connection mode  (S2N_SERVER or S2N_CLIENT)
 mode_writer : [32] -> [8]
 mode_writer m = if m == S2N_CLIENT then 'C' else 'S'
@@ -168,8 +185,6 @@ s2n_cork c = c.corked + 1
 
 s2n_uncork : connection -> [2]
 s2n_uncork c = c.corked - 1
-
-
 
 // this models the handshake_action struct (part of the handshake
 // state), but without the handler functions
@@ -181,9 +196,31 @@ type handshake_action = {record_type : [8]
 mkAct : [8] -> [8] -> [8] -> handshake_action
 mkAct r m w = {record_type = r, message_type = m, writer = w}
 
+// A model of the tls1.3 handshake states (array state_machine in C)
+tls13_state_machine : [19]handshake_action
+tls13_state_machine = [tls13_state_machine_fn m | m <- [0..18]]
+
+// Function that tells a handshake_action for a given tls1.3 state
+tls13_state_machine_fn : [5] -> handshake_action
+tls13_state_machine_fn m =
+  if      m == CLIENT_HELLO then mkAct TLS_HANDSHAKE TLS_CLIENT_HELLO 'C'
+  else if m == SERVER_HELLO then mkAct TLS_HANDSHAKE TLS_SERVER_HELLO 'S'
+  else if m == ENCRYPTED_EXTENSIONS then mkAct TLS_HANDSHAKE TLS_ENCRYPTED_EXTENSIONS 'S'
+  else if m == SERVER_CERT then mkAct TLS_HANDSHAKE TLS_SERVER_CERT 'S'
+  else if m == SERVER_CERT_REQ then mkAct TLS_HANDSHAKE TLS_SERVER_CERT_REQ 'S'
+  else if m == SERVER_CERT_VERIFY then mkAct TLS_HANDSHAKE TLS_SERVER_CERT_VERIFY 'S'
+  else if m == SERVER_FINISHED then mkAct TLS_HANDSHAKE TLS_SERVER_FINISHED 'S'
+  else if m == CLIENT_CERT then mkAct TLS_HANDSHAKE TLS_CLIENT_CERT 'C'
+  else if m == CLIENT_CERT_VERIFY then mkAct TLS_HANDSHAKE TLS_CLIENT_CERT_VERIFY 'C'
+  else if m == CLIENT_FINISHED then mkAct TLS_HANDSHAKE TLS_CLIENT_FINISHED 'C'
+  else if m == CLIENT_CHANGE_CIPHER_SPEC then mkAct TLS_CHANGE_CIPHER_SPEC 0 'C'
+  else if m == SERVER_CHANGE_CIPHER_SPEC then mkAct TLS_CHANGE_CIPHER_SPEC 0 'S'
+  else if m == APPLICATION_DATA then mkAct TLS_APPLICATION_DATA 0 'B'
+  else zero
+
 // A model of the handshake states (array state_machine in C)
-state_machine : [17]handshake_action
-state_machine = [state_machine_fn m | m <- [0..16]]
+state_machine : [19]handshake_action
+state_machine = [state_machine_fn m | m <- [0..18]]
 
 // Function that tells a handshake_action for a given state
 state_machine_fn : [5] -> handshake_action
@@ -205,6 +242,22 @@ state_machine_fn m =
   else if m == SERVER_CHANGE_CIPHER_SPEC then mkAct TLS_CHANGE_CIPHER_SPEC 0 'S'
   else if m == SERVER_FINISHED then mkAct TLS_HANDSHAKE TLS_SERVER_FINISHED 'S'
   else if m == APPLICATION_DATA then mkAct TLS_APPLICATION_DATA 0 'B'
+  else zero
+
+// A model of the tls1.3 handshake state machine (array handshakes in C)
+tls13_handshakes : [128][32][32]
+tls13_handshakes = [tls13_handshakes_fn h | h <- [0..127]]
+
+// A function that gives the tls1.3 handshake sequence for each valid handshake_type.
+tls13_handshakes_fn: [32] -> [32][32]
+tls13_handshakes_fn handshk =
+  if handshk == INITIAL then [CLIENT_HELLO, SERVER_HELLO] # zero
+  else if handshk == (NEGOTIATED || FULL_HANDSHAKE) then
+    [ CLIENT_HELLO,
+      SERVER_HELLO, SERVER_CHANGE_CIPHER_SPEC, ENCRYPTED_EXTENSIONS, SERVER_CERT, SERVER_CERT_VERIFY, SERVER_FINISHED,
+      CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
+      APPLICATION_DATA
+    ] # zero
   else zero
 
 // A model of the handshake state machine (array handshakes in C)
@@ -378,11 +431,10 @@ handshakes_fn handshk =
 // (i.e. the fields are indexing into a valid state of the handshake
 // state machine)
 valid_handshake : handshake -> Bit
-valid_handshake hs = (handshakes_fn hs.handshake_type) != zero /\
+valid_handshake hs = handshakefn != zero /\
                      (hs.message_number < length handshakefn - 1) /\
                      ((hs.message_number > 0) ==> (handshakefn@(hs.message_number + 1) != 0)) where
                      handshakefn = (handshakes_fn hs.handshake_type)
-
 
 valid_connection : connection -> Bit
 valid_connection conn = valid_handshake (conn.handshake)
@@ -416,6 +468,8 @@ CLIENT_AUTH = zero # 0x10
 NO_CLIENT_CERT : [32]
 NO_CLIENT_CERT = zero # 0x40
 
+S2N_TLS13 : [8]
+S2N_TLS13 = 34
 
 CLIENT_HELLO = 0
 SERVER_SESSION_LOOKUP = 1
@@ -433,7 +487,9 @@ CLIENT_CHANGE_CIPHER_SPEC = 12
 CLIENT_FINISHED = 13
 SERVER_CHANGE_CIPHER_SPEC = 14
 SERVER_FINISHED = 15
-APPLICATION_DATA = 16
+ENCRYPTED_EXTENSIONS = 16
+SERVER_CERT_VERIFY = 17
+APPLICATION_DATA = 18
 
 //TLS record type
 TLS_CHANGE_CIPHER_SPEC = 20
@@ -446,11 +502,13 @@ TLS_HELLO_REQUEST = 0
 TLS_CLIENT_HELLO  = 1
 TLS_SERVER_HELLO  = 2
 TLS_SERVER_NEW_SESSION_TICKET = 4
+TLS_ENCRYPTED_EXTENSIONS      = 8
 TLS_SERVER_CERT               = 11
 TLS_SERVER_KEY                = 12
 TLS_SERVER_CERT_REQ           = 13
 TLS_SERVER_HELLO_DONE         = 14
 TLS_CLIENT_CERT               = 11
+TLS_SERVER_CERT_VERIFY        = 15
 TLS_CLIENT_CERT_VERIFY        = 15
 TLS_CLIENT_KEY                = 16
 TLS_CLIENT_FINISHED           = 20

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -45,11 +45,12 @@ typedef enum {
     CLIENT_FINISHED,
     SERVER_CHANGE_CIPHER_SPEC,
     SERVER_FINISHED,
-    APPLICATION_DATA,
 
     /* TLS1.3 message types. Defined: https://tools.ietf.org/html/rfc8446#appendix-B.3 */
     ENCRYPTED_EXTENSIONS,
     SERVER_CERT_VERIFY,
+
+    APPLICATION_DATA,
 } message_type_t;
 
 struct s2n_handshake_parameters {

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -72,15 +72,15 @@ static int s2n_handshake_dummy_handler(struct s2n_connection *conn) {
  */
 static struct s2n_handshake_action state_machine[] = {
     /* message_type_t           = {Record type   Message type     Writer S2N_SERVER                S2N_CLIENT }  */
-    [CLIENT_HELLO]              = {TLS_HANDSHAKE, TLS_CLIENT_HELLO, 'C', {s2n_client_hello_recv, s2n_client_hello_send}}, 
-    [SERVER_SESSION_LOOKUP]     = {TLS_HANDSHAKE, TLS_SERVER_SESSION_LOOKUP, 'A', {s2n_handshake_status_handler, s2n_handshake_dummy_handler}}, 
+    [CLIENT_HELLO]              = {TLS_HANDSHAKE, TLS_CLIENT_HELLO, 'C', {s2n_client_hello_recv, s2n_client_hello_send}},
+    [SERVER_SESSION_LOOKUP]     = {TLS_HANDSHAKE, TLS_SERVER_SESSION_LOOKUP, 'A', {s2n_handshake_status_handler, s2n_handshake_dummy_handler}},
     [SERVER_HELLO]              = {TLS_HANDSHAKE, TLS_SERVER_HELLO, 'S', {s2n_server_hello_send, s2n_server_hello_recv}},
     [SERVER_NEW_SESSION_TICKET] = {TLS_HANDSHAKE, TLS_SERVER_NEW_SESSION_TICKET,'S', {s2n_server_nst_send, s2n_server_nst_recv}},
     [SERVER_CERT]               = {TLS_HANDSHAKE, TLS_CERTIFICATE, 'S', {s2n_server_cert_send, s2n_server_cert_recv}},
     [SERVER_CERT_STATUS]        = {TLS_HANDSHAKE, TLS_SERVER_CERT_STATUS, 'S', {s2n_server_status_send, s2n_server_status_recv}},
     [SERVER_KEY]                = {TLS_HANDSHAKE, TLS_SERVER_KEY, 'S', {s2n_server_key_send, s2n_server_key_recv}},
     [SERVER_CERT_REQ]           = {TLS_HANDSHAKE, TLS_CERT_REQ, 'S', {s2n_client_cert_req_send, s2n_client_cert_req_recv}},
-    [SERVER_HELLO_DONE]         = {TLS_HANDSHAKE, TLS_SERVER_HELLO_DONE, 'S', {s2n_server_done_send, s2n_server_done_recv}}, 
+    [SERVER_HELLO_DONE]         = {TLS_HANDSHAKE, TLS_SERVER_HELLO_DONE, 'S', {s2n_server_done_send, s2n_server_done_recv}},
     [CLIENT_CERT]               = {TLS_HANDSHAKE, TLS_CERTIFICATE, 'C', {s2n_client_cert_recv, s2n_client_cert_send}},
     [CLIENT_KEY]                = {TLS_HANDSHAKE, TLS_CLIENT_KEY, 'C', {s2n_client_key_recv, s2n_client_key_send}},
     [CLIENT_CERT_VERIFY]        = {TLS_HANDSHAKE, TLS_CERT_VERIFY, 'C', {s2n_client_cert_verify_recv, s2n_client_cert_verify_send}},
@@ -404,10 +404,8 @@ static const char* handshake_type_names[] = {
 #define ACTIVE_HANDSHAKES( conn )     (IS_TLS13_HANDSHAKE(conn) ? tls13_handshakes : handshakes)
 
 #define ACTIVE_MESSAGE( conn )        ACTIVE_HANDSHAKES(conn)[ (conn)->handshake.handshake_type ][ (conn)->handshake.message_number ]
-#define PREVIOUS_MESSAGE( conn )      ACTIVE_HANDSHAKES(conn)[ (conn)->handshake.handshake_type ][ (conn)->handshake.message_number - 1 ]
 
 #define ACTIVE_STATE( conn )          ACTIVE_STATE_MACHINE(conn)[ ACTIVE_MESSAGE( (conn) ) ]
-#define PREVIOUS_STATE( conn )        ACTIVE_STATE_MACHINE(conn)[ PREVIOUS_MESSAGE( (conn) ) ]
 #define CCS_STATE( conn )             (((conn)->mode == S2N_CLIENT) ? ACTIVE_STATE_MACHINE(conn)[SERVER_CHANGE_CIPHER_SPEC] \
                                                                     : ACTIVE_STATE_MACHINE(conn)[CLIENT_CHANGE_CIPHER_SPEC] )
 
@@ -422,23 +420,25 @@ message_type_t s2n_conn_get_current_message_type(struct s2n_connection *conn)
 
 static int s2n_advance_message(struct s2n_connection *conn)
 {
-    char this = 'S';
+    /* Get the mode: 'C'lient or 'S'erver */
+    char previous_writer = ACTIVE_STATE(conn).writer;
+    char this_mode = 'S';
     if (conn->mode == S2N_CLIENT) {
-        this = 'C';
+        this_mode = 'C';
     }
 
     /* Actually advance the message number */
     conn->handshake.message_number++;
 
-    /* Set TCP_QUICKACK to avoid artificial delay during the handshake */
-    GUARD(s2n_socket_quickack(conn));
-
     /* When reading and using TLS1.3, skip optional change_cipher_spec states. */
-    if (ACTIVE_STATE(conn).writer != this &&
+    if (ACTIVE_STATE(conn).writer != this_mode &&
             EXPECTED_RECORD_TYPE(conn) == TLS_CHANGE_CIPHER_SPEC &&
             IS_TLS13_HANDSHAKE(conn)) {
-        return s2n_advance_message(conn);
+        conn->handshake.message_number++;
     }
+
+    /* Set TCP_QUICKACK to avoid artificial delay during the handshake */
+    GUARD(s2n_socket_quickack(conn));
 
     /* If optimized io hasn't been enabled or if the caller started out with a corked socket,
      * we don't mess with it
@@ -448,12 +448,12 @@ static int s2n_advance_message(struct s2n_connection *conn)
     }
 
     /* Are we changing I/O directions */
-    if (ACTIVE_STATE(conn).writer == PREVIOUS_STATE(conn).writer || ACTIVE_STATE(conn).writer == 'A') {
+    if (ACTIVE_STATE(conn).writer == previous_writer || ACTIVE_STATE(conn).writer == 'A') {
         return 0;
     }
 
     /* We're the new writer */
-    if (ACTIVE_STATE(conn).writer == this) {
+    if (ACTIVE_STATE(conn).writer == this_mode) {
         if (s2n_connection_is_managed_corked(conn)) {
             /* Set TCP_CORK/NOPUSH */
             GUARD(s2n_socket_write_cork(conn));


### PR DESCRIPTION
**Issue # (if available):** 

**Description of changes:** 
* Expanded the s2n_handshake_io.saw proofs to prove TLS1.3.
* Modified s2n_advance_message to make the proof easier to write and to fix a TLS1.3-only corking issue that the proof surfaced.
* Wrapped the TLS saw tests in a script that prints a message every 9min, because some of the proofs now take more than 10 minutes, leading travis to decide that they've hung.
* Updated the rfc_handshake.cry proof to ignore TLS1.3. The RFC-based proof still does NOT support TLS1.3. That will be a separate change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
