### PR TITLE
fix: Missing notnull check and macOS dep.

### DIFF
--- a/.travis/install_osx_dependencies.sh
+++ b/.travis/install_osx_dependencies.sh
@@ -26,6 +26,7 @@ brew_install_if_not_installed gnu-indent
 brew_install_if_not_installed cppcheck
 brew_install_if_not_installed pkg-config # for gnutls compilation
 brew_install_if_not_installed openssl # for python compilation with ssl
+brew_install_if_not_installed zlib
 
 # Download and Install Clang Scan-build for static analysis
 if [[ ! -d "$SCAN_BUILD_INSTALL_DIR" ]] && [[ "$TRAVIS_OS_NAME" == "osx" ]]; then .travis/install_scan-build.sh "$SCAN_BUILD_INSTALL_DIR"; fi

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -319,7 +319,7 @@ s2n_cert_validation_code s2n_x509_validator_validate_cert_chain(struct s2n_x509_
 
         struct s2n_blob asn1cert = {0};
         asn1cert.size = certificate_size;
-        asn1cert.data = s2n_stuffer_raw_read(&cert_chain_in_stuffer, certificate_size);
+        notnull_check(asn1cert.data = s2n_stuffer_raw_read(&cert_chain_in_stuffer, certificate_size));
         if (asn1cert.data == NULL) {
             return S2N_CERT_ERR_INVALID;
         }


### PR DESCRIPTION
**Issue #670 :** 

**Description of changes:** 
Address failure on macOS from recent grep_simple_mistakes (on sha 4c4cd04139c9365934e69):

```
.travis/s2n_travis_build.sh
...snip...

Cppcheck 1.88
cppcheck: unusedFunction check can't be used with '-j' option. Disabling unusedFunction check.
PASSED cppcheck
+ .travis/copyright_mistake_scanner.sh
PASSED Copyright Check
+ .travis/grep_simple_mistakes.sh
Found a call to s2n_stuffer_raw_read without a notnull_check in /Volumes/workspaces/gitrepos/github.com/s2n/tls/s2n_x509_validator.c:
/Volumes/workspaces/gitrepos/github.com/s2n/tls/s2n_x509_validator.c:322:        asn1cert.data = s2n_stuffer_raw_read(&cert_chain_in_stuffer, certificate_size);

FAILED Grep For Simple Mistakes check
```

zlib is required but was not called out in `install_osx_dependencies.sh`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
