### PR TITLE
Update client handshake integ test to connect to KMS using PQ-hybrid ciphers

### DIFF
--- a/tests/integration/s2n_client_endpoint_handshake_test.py
+++ b/tests/integration/s2n_client_endpoint_handshake_test.py
@@ -21,16 +21,23 @@ import subprocess
 import itertools
 from s2n_test_constants import *
 
+
+# If a cipher_preference_version is specified, we will use it while attempting the handshake;
+# otherwise, s2n will use the default. If an expected_cipher is specified, the test will pass
+# if and only if the handshake is negotiated with that cipher; otherwise, the test will pass
+# if the handshake is negotiated with any cipher.
 well_known_endpoints = [
-    "amazon.com",
-    "facebook.com",
-    "google.com",
-    "netflix.com",
-    "s3.amazonaws.com",
-    "twitter.com",
-    "wikipedia.org",
-    "yahoo.com",
-    ]
+    {"endpoint": "amazon.com"},
+    {"endpoint": "facebook.com"},
+    {"endpoint": "google.com"},
+    {"endpoint": "netflix.com"},
+    {"endpoint": "s3.amazonaws.com"},
+    {"endpoint": "twitter.com"},
+    {"endpoint": "wikipedia.org"},
+    {"endpoint": "yahoo.com"},
+    {"endpoint": "kms.us-east-1.amazonaws.com", "cipher_preference_version": "KMS-PQ-TLS-1-0-2019-06", "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384"},
+    {"endpoint": "kms.us-east-1.amazonaws.com", "cipher_preference_version": "PQ-SIKE-TEST-TLS-1-0-2019-11", "expected_cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384"}
+]
 
 def print_result(result_prefix, return_code):
     print(result_prefix, end="")
@@ -45,18 +52,19 @@ def print_result(result_prefix, return_code):
         else:
             print("FAILED")
 
-def try_client_handshake(endpoint, use_corked_io):
-    s2nc_cmd = ["../../bin/s2nc", "-f",  "./trust-store/ca-bundle.crt", "-a", "http/1.1", str(endpoint)]
-    if use_corked_io:
-        s2nc_cmd.append("-C")
-
+def try_client_handshake(endpoint, arguments, expected_cipher):
+    s2nc_cmd = ["../../bin/s2nc", "-f", "./trust-store/ca-bundle.crt", "-a", "http/1.1"] + arguments + [str(endpoint)]
     currentDir = os.path.dirname(os.path.realpath(__file__))
     s2nc = subprocess.Popen(s2nc_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, cwd=currentDir)
 
     found = 0
+    expected_output = "Cipher negotiated: "
+    if expected_cipher:
+        expected_output += expected_cipher
+
     for line in range(0, 10):
-        output = s2nc.stdout.readline().decode("utf-8")
-        if "Cipher negotiated" in str(output):
+        output = str(s2nc.stdout.readline().decode("utf-8"))
+        if expected_output in output:
             found = 1
             break
 
@@ -69,23 +77,31 @@ def try_client_handshake(endpoint, use_corked_io):
     return 0
 
 def well_known_endpoints_test(use_corked_io):
+    arguments = []
     msg = "\n\tTesting s2n Client with Well Known Endpoints:"
     if use_corked_io:
         msg = "\n\tTesting s2n Client with Well Known Endpoints using Corked IO:"
+        arguments += ["-C"]
     print(msg)
 
     maxRetries = 5
     failed = 0
-    for endpoint in well_known_endpoints:
+    for endpoint_config in well_known_endpoints:
+        endpoint = endpoint_config["endpoint"]
+        expected_cipher = endpoint_config.get("expected_cipher")
+
+        if "cipher_preference_version" in endpoint_config:
+            arguments += ["-c", endpoint_config["cipher_preference_version"]]
+
         # Retry handshake in case there are any problems going over the internet
         for i in range(1, maxRetries):
-            ret = try_client_handshake(endpoint, use_corked_io)
+            ret = try_client_handshake(endpoint, arguments, expected_cipher)
             if ret is 0:
                 break
             else:
                 time.sleep(i)
-        
-        print_result("Endpoint:  %-40s... " % endpoint, ret)
+
+        print_result("Endpoint: %-35sExpected Cipher: %-40s... " % (endpoint, expected_cipher if expected_cipher else "Any"), ret)
         if ret != 0:
             failed += 1
 

--- a/tests/unit/s2n_cipher_preference_test.c
+++ b/tests/unit/s2n_cipher_preference_test.c
@@ -50,6 +50,11 @@ int main(int argc, char **argv)
         EXPECT_TRUE(s2n_pq_kem_extension_required(preferences));
 
         preferences = NULL;
+        EXPECT_SUCCESS(s2n_find_cipher_pref_from_version("PQ-SIKE-TEST-TLS-1-0-2019-11", &preferences));
+        EXPECT_TRUE(s2n_ecc_extension_required(preferences));
+        EXPECT_TRUE(s2n_pq_kem_extension_required(preferences));
+
+        preferences = NULL;
         EXPECT_SUCCESS(s2n_find_cipher_pref_from_version("20141001", &preferences));
         EXPECT_FALSE(s2n_ecc_extension_required(preferences));
         EXPECT_FALSE(s2n_pq_kem_extension_required(preferences));

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -791,6 +791,26 @@ const struct s2n_cipher_preferences cipher_preferences_kms_pq_tls_1_0_2019_06 = 
         .minimum_protocol_version = S2N_TLS10,
 };
 
+struct s2n_cipher_suite *cipher_suites_pq_sike_test_tls_1_0_2019_11[] = {
+        &s2n_ecdhe_sike_rsa_with_aes_256_gcm_sha384,
+        &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+        &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+        &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+        &s2n_ecdhe_rsa_with_aes_256_cbc_sha,
+        &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
+        &s2n_ecdhe_rsa_with_3des_ede_cbc_sha,
+        &s2n_dhe_rsa_with_aes_256_cbc_sha256,
+        &s2n_dhe_rsa_with_aes_128_cbc_sha256,
+        &s2n_dhe_rsa_with_aes_256_cbc_sha,
+        &s2n_dhe_rsa_with_aes_128_cbc_sha,
+};
+
+const struct s2n_cipher_preferences cipher_preferences_pq_sike_test_tls_1_0_2019_11 = {
+        .count = sizeof(cipher_suites_pq_sike_test_tls_1_0_2019_11) / sizeof(cipher_suites_pq_sike_test_tls_1_0_2019_11[0]),
+        .suites = cipher_suites_pq_sike_test_tls_1_0_2019_11,
+        .minimum_protocol_version = S2N_TLS10,
+};
+
 struct s2n_cipher_suite *cipher_suites_kms_fips_tls_1_2_2018_10[] = {
         &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
         &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
@@ -837,6 +857,7 @@ struct {
     { .version="CloudFront-TLS-1-2-2019", .preferences=&cipher_preferences_cloudfront_tls_1_2_2019, .ecc_extension_required=0, .pq_kem_extension_required=0},
     { .version="KMS-TLS-1-0-2018-10", .preferences=&cipher_preferences_kms_tls_1_0_2018_10, .ecc_extension_required=0, .pq_kem_extension_required=0},
     { .version="KMS-PQ-TLS-1-0-2019-06", .preferences=&cipher_preferences_kms_pq_tls_1_0_2019_06, .ecc_extension_required=0, .pq_kem_extension_required=0},
+    { .version="PQ-SIKE-TEST-TLS-1-0-2019-11", .preferences=&cipher_preferences_pq_sike_test_tls_1_0_2019_11, .ecc_extension_required=0, .pq_kem_extension_required=0},
     { .version="KMS-FIPS-TLS-1-2-2018-10", .preferences=&cipher_preferences_kms_fips_tls_1_2_2018_10, .ecc_extension_required=0, .pq_kem_extension_required=0},
     { .version="20140601", .preferences=&cipher_preferences_20140601, .ecc_extension_required=0, .pq_kem_extension_required=0},
     { .version="20141001", .preferences=&cipher_preferences_20141001, .ecc_extension_required=0, .pq_kem_extension_required=0},


### PR DESCRIPTION
**Issue # (if available):** https://github.com/awslabs/s2n/projects/7

**Description of changes:** Updates integration tests to ensure that s2n can negotiate TLS handshake with KMS using SIKE/BIKE hybrids.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
