### PR TITLE
Fix memory leak when calling s2n_connection_set_fd multiple times

### DIFF
--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -707,12 +707,18 @@ int s2n_connection_wipe(struct s2n_connection *conn)
 
 int s2n_connection_set_recv_ctx(struct s2n_connection *conn, void *ctx)
 {
+    if (conn->managed_io) {
+        GUARD(s2n_free_object((uint8_t **)&conn->recv_io_context, sizeof(struct s2n_socket_read_io_context)));
+    }
     conn->recv_io_context = ctx;
     return 0;
 }
 
 int s2n_connection_set_send_ctx(struct s2n_connection *conn, void *ctx)
 {
+    if (conn->managed_io) {
+        GUARD(s2n_free_object((uint8_t **)&conn->send_io_context, sizeof(struct s2n_socket_write_io_context)));
+    }
     conn->send_io_context = ctx;
     return 0;
 }


### PR DESCRIPTION
**Issue # (if available):** 

#1266 

**Description of changes:** 

The set_fd functions (s2n_connection_set_fd, set_read_fd,
set_write_fd) allocate blobs to put into the connection IO contexts.
If these routines are called multiple times, they lose pointers to
past allocations, resulting in a memory leak.

Fix is to free a previous context when setting a new one.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
