### PR TITLE
Add ubuntu 19.04 gcc6/9 and clang8 Docker images and codebuild config

### DIFF
--- a/.ci/README.md
+++ b/.ci/README.md
@@ -1,0 +1,11 @@
+# CI for s2n
+We use prebuilt docker images for all of our AWS CodeBuild builds for speed and
+consistency.
+
+## Setup
+ To setup the images for local testing or testing in your own AWS account see
+the platform specific `README` in docker_images/*.
+
+Once you have the docker images uploaded to AWS Elastic Container Registry you
+can setup the AWS CodeBuild projects that use the custom image with the
+appropriate buildspec files in codebuild/spec/*.

--- a/.ci/codebuild/scripts/common_setup.sh
+++ b/.ci/codebuild/scripts/common_setup.sh
@@ -1,0 +1,19 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+sudo prlimit --pid "$$" --memlock=unlimited:unlimited
+ln -s /test-deps/ .
+export LIBCRYPTO_ROOT=$(pwd)/test-deps/${S2N_LIBCRYPTO}
+export NUM_CORES=$(nproc --all)
+rm -rf libcrypto-root && ln -s "$LIBCRYPTO_ROOT" libcrypto-root
+source .travis/s2n_override_paths.sh

--- a/.ci/codebuild/scripts/run_fuzz_tests.sh
+++ b/.ci/codebuild/scripts/run_fuzz_tests.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -ex
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+source .ci/codebuild/scripts/common_setup.sh
+export LIBFUZZER_ROOT=$LIBFUZZER_INSTALL_DIR
+
+make fuzz

--- a/.ci/codebuild/scripts/run_static_analysis.sh
+++ b/.ci/codebuild/scripts/run_static_analysis.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+source .ci/codebuild/scripts/common_setup.sh
+
+.travis/run_cppcheck.sh "$CPPCHECK_INSTALL_DIR"
+.travis/copyright_mistake_scanner.sh
+.travis/grep_simple_mistakes.sh
+.travis/run_kwstyle.sh
+.travis/cpp_style_comment_linter.sh

--- a/.ci/codebuild/scripts/run_unit_and_integ_tests.sh
+++ b/.ci/codebuild/scripts/run_unit_and_integ_tests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -ex
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+source .ci/codebuild/scripts/common_setup.sh
+
+# make defaults to all which will build everything then run the unit tests, -j runs the build with NUM_CORES parallel jobs
+make -j $NUM_CORES
+
+make integration

--- a/.ci/codebuild/scripts/run_valgrind.sh
+++ b/.ci/codebuild/scripts/run_valgrind.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -ex
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+source .ci/codebuild/scripts/common_setup.sh
+
+S2N_DEBUG=true make -j $NUM_CORES valgrind

--- a/.ci/codebuild/specs/ubuntu-19-04_clang-8x_fuzz_openssl-1-1-1.yml
+++ b/.ci/codebuild/specs/ubuntu-19-04_clang-8x_fuzz_openssl-1-1-1.yml
@@ -1,0 +1,24 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - export CC=clang-8
+      - export CXX=clang++-8
+      - export S2N_LIBCRYPTO=openssl-1.1.1
+  build:
+    commands:
+      - .ci/codebuild/scripts/run_fuzz_tests.sh

--- a/.ci/codebuild/specs/ubuntu-19-04_clang-8x_unit-and-integ-tests_openssl-1-1-1.yml
+++ b/.ci/codebuild/specs/ubuntu-19-04_clang-8x_unit-and-integ-tests_openssl-1-1-1.yml
@@ -1,0 +1,24 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - export CC=clang-8
+      - export CXX=clang++-8
+      - export S2N_LIBCRYPTO=openssl-1.1.1
+  build:
+    commands:
+      - .ci/codebuild/scripts/run_unit_and_integ_tests.sh

--- a/.ci/codebuild/specs/ubuntu-19-04_gcc-6x_unit-and-integ-tests_openssl-1-0-2.yml
+++ b/.ci/codebuild/specs/ubuntu-19-04_gcc-6x_unit-and-integ-tests_openssl-1-0-2.yml
@@ -1,0 +1,25 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - export CC=gcc-6
+      - export CXX=g++-6
+      - export GCC_VERSION=6
+      - export S2N_LIBCRYPTO=openssl-1.0.2
+  build:
+    commands:
+      - .ci/codebuild/scripts/run_unit_and_integ_tests.sh

--- a/.ci/codebuild/specs/ubuntu-19-04_gcc-9x_asan_unit-and-integ-tests_openssl-1-1-1.yml
+++ b/.ci/codebuild/specs/ubuntu-19-04_gcc-9x_asan_unit-and-integ-tests_openssl-1-1-1.yml
@@ -1,0 +1,26 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - export CC=gcc-9
+      - export CXX=g++-9
+      - export GCC_VERSION=9
+      - export S2N_LIBCRYPTO=openssl-1.1.1
+      - S2N_ADDRESS_SANITIZER=1
+  build:
+    commands:
+      - .ci/codebuild/scripts/run_unit_and_integ_tests.sh

--- a/.ci/codebuild/specs/ubuntu-19-04_gcc-9x_corked-unit-and-integ-tests_openssl-1-1-1.yml
+++ b/.ci/codebuild/specs/ubuntu-19-04_gcc-9x_corked-unit-and-integ-tests_openssl-1-1-1.yml
@@ -1,0 +1,26 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - export CC=gcc-9
+      - export CXX=g++-9
+      - export GCC_VERSION=9
+      - export S2N_LIBCRYPTO=openssl-1.1.1
+      - export S2N_CORKED_IO=true
+  build:
+    commands:
+      - .ci/codebuild/scripts/run_unit_and_integ_tests.sh

--- a/.ci/codebuild/specs/ubuntu-19-04_gcc-9x_unit-and-integ-tests_openssl-1-1-1.yml
+++ b/.ci/codebuild/specs/ubuntu-19-04_gcc-9x_unit-and-integ-tests_openssl-1-1-1.yml
@@ -1,0 +1,25 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - export CC=gcc-9
+      - export CXX=g++-9
+      - export GCC_VERSION=9
+      - export S2N_LIBCRYPTO=openssl-1.1.1
+  build:
+    commands:
+      - .ci/codebuild/scripts/run_unit_and_integ_tests.sh

--- a/.ci/codebuild/specs/ubuntu-19-04_gcc-9x_valgrind_unit-and-integ-tests_openssl-1-1-1.yml
+++ b/.ci/codebuild/specs/ubuntu-19-04_gcc-9x_valgrind_unit-and-integ-tests_openssl-1-1-1.yml
@@ -1,0 +1,25 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - export CC=gcc-9
+      - export CXX=g++-9
+      - export GCC_VERSION=9
+      - export S2N_LIBCRYPTO=openssl-1.1.1
+  build:
+    commands:
+      - .ci/codebuild/scripts/run_valgrind.sh

--- a/.ci/codebuild/specs/ubuntu-19-04_static_analysis.yml
+++ b/.ci/codebuild/specs/ubuntu-19-04_static_analysis.yml
@@ -1,0 +1,19 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 0.2
+
+phases:
+  build:
+    commands:
+      - .ci/codebuild/scripts/run_static_analysis.sh

--- a/.ci/docker/linux/README.md
+++ b/.ci/docker/linux/README.md
@@ -1,0 +1,29 @@
+# Prerequistes
+EC2 Ubuntu 18.04 host:
+```
+$ sudo apt-get update
+$ sudo apt-get install -y awscli apt-transport-https ca-certificates curl gnupg-agent software-properties-common
+$ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+$ sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+$ sudo apt-get update
+$ sudo apt-get install -y docker-ce
+$ sudo usermod -aG docker ${USER}
+# Log in and out
+```
+
+Build images locally with `build_images.sh` which will take ~15 minutes to build
+all the images. To push to the main repository run `push_images.sh`. To push to
+a custom repository pass in a complete ECS url such as `push_images.sh
+${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/${REPOSITORY}`.
+
+To simulate the GCC-9 with OpenSSL 1.1.1 build, unit, and integ tests locally:
+```
+$ docker run -it ubuntu-19.04:gcc-9x_openssl-1.1.1
+$ git clone git@github.com:awslabs/aws-lc.git
+$ cd aws-lc
+$ export CC=gcc-9
+$ export CXX=g++-9
+$ export GCC_VERSION=9
+$ export LIBCRYPTO_ROOT=$OPENSSL_$OPENSSL_1_1_1_INSTALL_DIR
+$ .ci/codebuild/scripts/run_unit_and_integ_tests.sh
+```

--- a/.ci/docker/linux/build_images.sh
+++ b/.ci/docker/linux/build_images.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+docker build -m6g -t s2n_ubuntu:19.04_base -f docker_images/ubuntu-19.04_base .
+docker build -m6g -t s2n_ubuntu:19.04_openssl-1.1.1 -f docker_images/ubuntu-19.04_openssl-1.1.1_base .
+docker build -m6g -t ubuntu-19.04:gcc-9x_openssl-1.1.1 -f docker_images/ubuntu-19.04_gcc-9x_openssl-1.1.1 .
+docker build -m6g -t ubuntu-19.04:clang-8x_openssl-1.1.1 -f docker_images/ubuntu-19.04_clang-8x_openssl-1.1.1 .
+
+docker build -m6g -t s2n_ubuntu:19.04_openssl-1.0.2 -f docker_images/ubuntu-19.04_openssl-1.0.2_base .
+docker build -m6g -t ubuntu-19.04:gcc-6x_openssl-1.0.2 -f docker_images/ubuntu-19.04_gcc-6x_openssl-1.0.2 .

--- a/.ci/docker/linux/docker_images/ubuntu-19.04_base
+++ b/.ci/docker/linux/docker_images/ubuntu-19.04_base
@@ -1,0 +1,62 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Disco is the code name for the 19.04 release. The official 19.04 tag appears to act like a latest which we don't want.
+# Disco gets specific versions and disco-20191030 is the latest. https://hub.docker.com/_/ubuntu/
+FROM ubuntu:disco-20191030
+
+SHELL ["/bin/bash", "-c"]
+
+# ENV variables are available when the image (and thus the CodeBuild build) are running and during image build time
+ENV CPPCHECK_INSTALL_DIR=/test-deps/cppcheck \
+    GNUTLS_INSTALL_DIR=/test-deps/gnutls \
+    PYTHON_INSTALL_DIR=/test-deps/python
+
+# ARG variables are only available while building the image
+ARG GNU_TEMP=/tmp/gnutls
+ARG PYTHON_TEMP=/tmp/python
+
+RUN set -ex && \
+    apt-get update && apt-get -y --no-install-recommends install  \
+    curl=7.64.0-2ubuntu1.2 \
+    git=1:2.20.1-2ubuntu1 \
+    kwstyle=1.0.1+git3224cf2-1 \
+    m4=1.4.18-2 \
+    make=4.2.1-1.2 \
+    net-tools=1.60+git20180626.aebd88e-1ubuntu1 \
+    nettle-bin=3.4.1-1 \
+    nettle-dev=3.4.1-1 \
+    perl=5.28.1-6 \
+    pkg-config=0.29.1-0ubuntu2 \
+    psmisc=23.2-1 \
+    python3-pip=18.1-5 \
+    sudo=1.8.27-1ubuntu1.1 \
+    tcpdump=4.9.2-3 \
+    unzip=6.0-22ubuntu1 \
+    valgrind=1:3.14.0-2ubuntu6 \
+    zlib1g-dev=1:1.2.11.dfsg-1ubuntu2 \
+    zlibc=0.9k-4.3 \
+    && \
+    apt-get autoremove --purge -y && \
+    apt-get clean && \
+    apt-get autoclean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /tmp/* && \
+    mkdir -p $PYTHON_INSTALL_DIR $PYTHON_TEMP \
+        $GNUTLS_INSTALL_DIR $GNU_TEMP \
+        $CPPCHECK_INSTALL_DIR
+
+COPY setup_scripts/install_cppcheck.sh /tmp/install_cppcheck.sh
+COPY setup_scripts/install_gnutls.sh /tmp/install_gnutls.sh
+COPY setup_scripts/install_python.sh /tmp/install_python.sh
+COPY setup_scripts/install_sslyze.sh /tmp/install_sslyze.sh

--- a/.ci/docker/linux/docker_images/ubuntu-19.04_clang-8x_openssl-1.1.1
+++ b/.ci/docker/linux/docker_images/ubuntu-19.04_clang-8x_openssl-1.1.1
@@ -1,0 +1,40 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+FROM s2n_ubuntu:19.04_openssl-1.1.1
+
+SHELL ["/bin/bash", "-c"]
+ENV LIBFUZZER_INSTALL_DIR=/test-deps/libfuzzer
+ARG LIBFUZZER_TEMP=/tmp/libfuzzer
+ARG GNU_TEMP=/tmp/gnutls
+ARG OPENSSL_TEMP=/tmp/openssl
+ARG PYTHON_TEMP=/tmp/python
+
+RUN set -ex && \
+    apt-get update && apt-get -y --no-install-recommends install  \
+    clang=1:8.0-48~exp1ubuntu1
+
+COPY setup_scripts/install_libFuzzer.sh /tmp/install_libFuzzer.sh
+
+RUN set -ex && \
+    export CXX=clang++-8 CC=clang-8 && \
+    /tmp/install_openssl_1_1_1.sh $OPENSSL_TEMP $OPENSSL_1_1_1_INSTALL_DIR && \
+    /tmp/install_python.sh $OPENSSL_1_1_1_INSTALL_DIR $PYTHON_TEMP $PYTHON_INSTALL_DIR && \
+    /tmp/install_gnutls.sh $GNU_TEMP $GNUTLS_INSTALL_DIR && \
+    /tmp/install_cppcheck.sh $CPPCHECK_INSTALL_DIR && \
+    /tmp/install_sslyze.sh && \
+    /tmp/install_libFuzzer.sh $LIBFUZZER_TEMP $LIBFUZZER_INSTALL_DIR && \
+    apt-get autoremove --purge -y && \
+    apt-get clean && \
+    apt-get autoclean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /tmp/*

--- a/.ci/docker/linux/docker_images/ubuntu-19.04_gcc-6x_openssl-1.0.2
+++ b/.ci/docker/linux/docker_images/ubuntu-19.04_gcc-6x_openssl-1.0.2
@@ -1,0 +1,37 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+FROM s2n_ubuntu:19.04_openssl-1.0.2
+
+SHELL ["/bin/bash", "-c"]
+
+ARG PYTHON_TEMP=/tmp/python
+ARG OPENSSL_TEMP=/tmp/openssl
+ARG GNU_TEMP=/tmp/gnutls
+
+RUN set -ex && \
+    apt-get update && apt-get -y --no-install-recommends install  \
+    gcc-6=6.5.0-2ubuntu1 \
+    g++-6=6.5.0-2ubuntu1
+
+RUN set -ex && \
+    export CXX=g++-6 CC=gcc-6 && \
+    /tmp/install_openssl_1_0_2.sh $OPENSSL_TEMP $OPENSSL_1_0_2_INSTALL_DIR && \
+    /tmp/install_python.sh $OPENSSL_1_0_2_INSTALL_DIR $PYTHON_TEMP $PYTHON_INSTALL_DIR && \
+    /tmp/install_gnutls.sh $GNU_TEMP $GNUTLS_INSTALL_DIR && \
+    /tmp/install_cppcheck.sh $CPPCHECK_INSTALL_DIR && \
+    /tmp/install_sslyze.sh && \
+    apt-get autoremove --purge -y && \
+    apt-get clean && \
+    apt-get autoclean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /tmp/*

--- a/.ci/docker/linux/docker_images/ubuntu-19.04_gcc-9x_openssl-1.1.1
+++ b/.ci/docker/linux/docker_images/ubuntu-19.04_gcc-9x_openssl-1.1.1
@@ -1,0 +1,37 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+FROM s2n_ubuntu:19.04_openssl-1.1.1
+
+SHELL ["/bin/bash", "-c"]
+
+ARG PYTHON_TEMP=/tmp/python
+ARG OPENSSL_TEMP=/tmp/openssl
+ARG GNU_TEMP=/tmp/gnutls
+
+RUN set -ex && \
+    apt-get update && apt-get -y --no-install-recommends install  \
+    gcc-9=9.1.0-2ubuntu2~19.04 \
+    g++-9=9.1.0-2ubuntu2~19.04
+
+RUN set -ex && \
+    export CXX=g++-9 CC=gcc-9 && \
+    /tmp/install_openssl_1_1_1.sh $OPENSSL_TEMP $OPENSSL_1_1_1_INSTALL_DIR && \
+    /tmp/install_python.sh $OPENSSL_1_1_1_INSTALL_DIR $PYTHON_TEMP $PYTHON_INSTALL_DIR && \
+    /tmp/install_gnutls.sh $GNU_TEMP $GNUTLS_INSTALL_DIR && \
+    /tmp/install_cppcheck.sh $CPPCHECK_INSTALL_DIR && \
+    /tmp/install_sslyze.sh && \
+    apt-get autoremove --purge -y && \
+    apt-get clean && \
+    apt-get autoclean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /tmp/*

--- a/.ci/docker/linux/docker_images/ubuntu-19.04_openssl-1.0.2_base
+++ b/.ci/docker/linux/docker_images/ubuntu-19.04_openssl-1.0.2_base
@@ -1,0 +1,28 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Disco is the code name for the 19.04 release. The official 19.04 tag appears to act like a latest which we don't want.
+# Disco gets specific versions and disco-20191030 is the latest. https://hub.docker.com/_/ubuntu/
+FROM s2n_ubuntu:19.04_base
+
+SHELL ["/bin/bash", "-c"]
+
+# ENV variables are available when the image (and thus the CodeBuild build) are running and during image build time
+ENV OPENSSL_1_0_2_INSTALL_DIR=/test-deps/openssl-1.0.2
+
+# ARG variables are only available while building the image
+ARG OPENSSL_TEMP=/tmp/openssl
+
+COPY setup_scripts/install_openssl_1_0_2.sh /tmp/install_openssl_1_0_2.sh
+RUN set -ex && \
+    mkdir -p $OPENSSL_1_0_2_INSTALL_DIR $OPENSSL_TEMP

--- a/.ci/docker/linux/docker_images/ubuntu-19.04_openssl-1.1.1_base
+++ b/.ci/docker/linux/docker_images/ubuntu-19.04_openssl-1.1.1_base
@@ -1,0 +1,28 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Disco is the code name for the 19.04 release. The official 19.04 tag appears to act like a latest which we don't want.
+# Disco gets specific versions and disco-20191030 is the latest. https://hub.docker.com/_/ubuntu/
+FROM s2n_ubuntu:19.04_base
+
+SHELL ["/bin/bash", "-c"]
+
+# ENV variables are available when the image (and thus the CodeBuild build) are running and during image build time
+ENV OPENSSL_1_1_1_INSTALL_DIR=/test-deps/openssl-1.1.1
+
+# ARG variables are only available while building the image
+ARG OPENSSL_TEMP=/tmp/openssl
+
+COPY setup_scripts/install_openssl_1_1_1.sh /tmp/install_openssl_1_1_1.sh
+RUN set -ex && \
+    mkdir -p $OPENSSL_1_1_1_INSTALL_DIR $OPENSSL_TEMP

--- a/.ci/docker/linux/push_images.sh
+++ b/.ci/docker/linux/push_images.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -e
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ -z ${1+x} ]; then
+  ECS_REPO="024603541914.dkr.ecr.us-west-2.amazonaws.com/linux-docker-images"
+else
+  ECS_REPO=$1
+fi
+
+echo "Uploading docker images to ${ECS_REPO}."
+
+$(aws ecr get-login --no-include-email --region us-west-2)
+
+docker tag ubuntu-19.04:gcc-9x_openssl-1.1.1 ${ECS_REPO}:ubuntu-19.04_gcc-9x_openssl-1.1.1_`date +%Y-%m-%d`
+docker push ${ECS_REPO}:ubuntu-19.04_gcc-9x_openssl-1.1.1_`date +%Y-%m-%d`
+
+docker tag ubuntu-19.04:clang-8x_openssl-1.1.1 ${ECS_REPO}:ubuntu-19.04_clang-8x_openssl-1.1.1_`date +%Y-%m-%d`
+docker push ${ECS_REPO}:ubuntu-19.04_clang-8x_openssl-1.1.1_`date +%Y-%m-%d`
+
+docker tag ubuntu-19.04:gcc-6x_openssl-1.0.2 ${ECS_REPO}:ubuntu-19.04_gcc-6x_openssl-1.0.2_`date +%Y-%m-%d`
+docker push ${ECS_REPO}:ubuntu-19.04_gcc-6x_openssl-1.0.2_`date +%Y-%m-%d`

--- a/.ci/docker/linux/setup_scripts/install_cppcheck.sh
+++ b/.ci/docker/linux/setup_scripts/install_cppcheck.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+set -e
+
+usage() {
+    echo "install_cppcheck.sh install_dir"
+    exit 1
+}
+
+if [ "$#" -ne "1" ]; then
+    usage
+fi
+
+INSTALL_DIR=$1
+
+cd "$INSTALL_DIR"
+git clone https://github.com/danmar/cppcheck.git
+cd cppcheck
+git checkout 1.88
+
+make

--- a/.ci/docker/linux/setup_scripts/install_gnutls.sh
+++ b/.ci/docker/linux/setup_scripts/install_gnutls.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+set -e
+
+usage() {
+    echo "install_gnutls.sh build_dir install_dir"
+    exit 1
+}
+
+if [ "$#" -ne "2" ]; then
+    usage
+fi
+
+GNUTLS_BUILD_DIR=$1
+GNUTLS_INSTALL_DIR=$2
+
+cd "$GNUTLS_BUILD_DIR"
+
+# libnettle is a dependency of GnuTLS
+# Originally from: https://ftp.gnu.org/gnu/nettle/nettle-3.3.tar.gz
+curl --retry 3 https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/2017-08-29_nettle-3.3.tar.gz --output nettle-3.3.tar.gz
+tar -xzf nettle-3.3.tar.gz
+cd nettle-3.3
+./configure --prefix="$GNUTLS_INSTALL_DIR"/nettle
+make
+make install
+cd ..
+
+# Install GnuTLS
+# Originally from: ftp://ftp.gnutls.org/gcrypt/gnutls/v3.5/gnutls-3.5.5.tar.xz
+curl --retry 3 https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/2017-08-29_gnutls-3.5.5.tar.xz --output gnutls-3.5.5.tar.xz
+tar -xJf gnutls-3.5.5.tar.xz
+cd gnutls-3.5.5
+./configure LD_FLAGS="-R$GNUTLS_INSTALL_DIR/nettle/lib -L$GNUTLS_INSTALL_DIR/nettle/lib -lnettle -lhogweed" \
+            NETTLE_LIBS="-R$GNUTLS_INSTALL_DIR/nettle/lib -L$GNUTLS_INSTALL_DIR/nettle/lib -lnettle" \
+            NETTLE_CFLAGS="-I$GNUTLS_INSTALL_DIR/nettle/include" \
+            HOGWEED_LIBS="-R$GNUTLS_INSTALL_DIR/nettle/lib -L$GNUTLS_INSTALL_DIR/nettle/lib -lhogweed" \
+            HOGWEED_CFLAGS="-I$GNUTLS_INSTALL_DIR/nettle/include" \
+            --without-p11-kit \
+            --with-included-libtasn1 \
+            --prefix="$GNUTLS_INSTALL_DIR"
+make
+make install

--- a/.ci/docker/linux/setup_scripts/install_libFuzzer.sh
+++ b/.ci/docker/linux/setup_scripts/install_libFuzzer.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+set -e
+
+usage() {
+	echo "install_libFuzzer.sh download_dir install_dir"
+	exit 1
+}
+
+if [ "$#" -ne "2" ]; then
+	usage
+fi
+
+LIBFUZZER_DOWNLOAD_DIR=$1
+LIBFUZZER_INSTALL_DIR=$2
+
+mkdir -p "$LIBFUZZER_DOWNLOAD_DIR"
+cd "$LIBFUZZER_DOWNLOAD_DIR"
+
+git clone https://chromium.googlesource.com/chromium/llvm-project/llvm/lib/Fuzzer
+cd Fuzzer
+git checkout 651ead
+cd ..
+
+echo "Compiling LibFuzzer..."
+clang++ -c -g -v -O2 -lstdc++ -std=c++11 Fuzzer/*.cpp -IFuzzer
+ar ruv libFuzzer.a Fuzzer*.o
+
+echo "Copying libFuzzer.a to $LIBFUZZER_INSTALL_DIR"
+mkdir -p "$LIBFUZZER_INSTALL_DIR"/lib && cp libFuzzer.a "$LIBFUZZER_INSTALL_DIR"/lib
+

--- a/.ci/docker/linux/setup_scripts/install_openssl_1_0_2.sh
+++ b/.ci/docker/linux/setup_scripts/install_openssl_1_0_2.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+set -ex
+pushd "$(pwd)"
+
+usage() {
+    echo "install_openssl_1_0_2.sh build_dir install_dir"
+    exit 1
+}
+
+if [ "$#" -ne "2" ]; then
+    usage
+fi
+
+BUILD_DIR=$1
+INSTALL_DIR=$2
+
+cd "$BUILD_DIR"
+curl --retry 3 -L https://github.com/openssl/openssl/archive/OpenSSL_1_0_2-stable.zip --output openssl-OpenSSL_1_0_2-stable.zip
+unzip openssl-OpenSSL_1_0_2-stable.zip
+cd openssl-OpenSSL_1_0_2-stable
+
+./config -d -g3 -fPIC no-libunbound no-gmp no-jpake no-krb5 no-md2 no-rc5 no-rfc3779 no-sctp no-ssl-trace \
+         no-store no-zlib no-hw no-mdc2 no-seed no-idea enable-ec_nistp_64_gcc_128 no-camellia no-bf no-ripemd \
+         no-dsa no-ssl2 no-capieng -DSSL_FORBID_ENULL -DOPENSSL_NO_DTLS1 -DOPENSSL_NO_HEARTBEATS \
+         --prefix="$INSTALL_DIR"
+
+make depend
+make
+make install_sw
+
+popd
+
+exit 0
+

--- a/.ci/docker/linux/setup_scripts/install_openssl_1_1_1.sh
+++ b/.ci/docker/linux/setup_scripts/install_openssl_1_1_1.sh
@@ -1,0 +1,49 @@
+#!/bin/bash -ex
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+pushd "$(pwd)"
+
+usage() {
+    echo "install_openssl_1_1_1.sh build_dir install_dir"
+    exit 1
+}
+
+if [ "$#" -ne "2" ]; then
+    usage
+fi
+
+BUILD_DIR=$1
+INSTALL_DIR=$2
+PLATFORM=$3
+
+cd "$BUILD_DIR"
+curl --retry 3 -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1-stable.zip --output OpenSSL_1_1_1-stable.zip
+unzip OpenSSL_1_1_1-stable.zip
+cd openssl-OpenSSL_1_1_1-stable
+
+# Use g3 to get debug symbols in libcrypto to chase memory leaks
+./config -d -g3 -fPIC              \
+         no-md2 no-rc5 no-rfc3779 no-sctp no-ssl-trace no-zlib     \
+         no-hw no-mdc2 no-seed no-idea enable-ec_nistp_64_gcc_128 no-camellia\
+         no-bf no-ripemd no-dsa no-ssl2 no-ssl3 no-capieng                  \
+         -DSSL_FORBID_ENULL -DOPENSSL_NO_DTLS1 -DOPENSSL_NO_HEARTBEATS      \
+         --prefix="$INSTALL_DIR"
+
+make depend
+make
+make install_sw
+
+popd
+
+exit 0

--- a/.ci/docker/linux/setup_scripts/install_python.sh
+++ b/.ci/docker/linux/setup_scripts/install_python.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -ex
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+if [ "$#" -ne 3 ]; then
+    echo "install_python.sh libcrypto_root build_dir install_dir"
+    exit 1
+fi
+
+LIBCRYPTO_ROOT=$1
+BUILD_DIR=$2
+INSTALL_DIR=$3
+
+cd "$BUILD_DIR"
+# Originally from: https://www.python.org/ftp/python/3.6.0/Python-3.6.0.tgz
+curl --retry 3 https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/2017-08-29_Python-3.6.0.tgz --output Python-3.6.0.tgz
+tar xzf Python-3.6.0.tgz
+cd Python-3.6.0
+ CPPFLAGS="-I$LIBCRYPTO_ROOT/include" LDFLAGS="-Wl,-rpath,$LIBCRYPTO_ROOT/lib -L$LIBCRYPTO_ROOT/lib" ./configure --prefix="$INSTALL_DIR"
+make
+make install

--- a/.ci/docker/linux/setup_scripts/install_sslyze.sh
+++ b/.ci/docker/linux/setup_scripts/install_sslyze.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+set -ex
+
+python3 -m pip install --user --upgrade pip setuptools
+python3 -m pip install --user sslyze
+
+ln -s /root/.local/bin/sslyze /usr/bin/sslyze
+
+which sslyze
+sslyze --version

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 s2n is a C99 implementation of the TLS/SSL protocols that is designed to be simple, small, fast, and with security as a priority. It is released and licensed under the Apache License 2.0. 
 
 [![Build Status](https://img.shields.io/travis/awslabs/s2n.svg)](https://travis-ci.org/awslabs/s2n)
+![Build Status](https://codebuild.us-west-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiUlF5Yk9mcFAzeThEM1M0b1FwVUlRb1VFZXRDRVkyL1lWa2VxaWtDTlpIL0dBZ0V1TW84bjN5VVZLQ0hIaDVPOXVVYnFtbnhhaUtONExsTUE1cy9rUzlZPSIsIml2UGFyYW1ldGVyU3BlYyI6IkJ6YUp5Vm00NVB5UmIzOHIiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 [![Apache 2 License](https://img.shields.io/github/license/awslabs/s2n.svg)](http://aws.amazon.com/apache-2-0/)
 [![C99](https://img.shields.io/badge/language-C99-blue.svg)](http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf)
 [![Language grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/awslabs/s2n.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/awslabs/s2n/context:cpp)

--- a/tests/fuzz/runFuzzTest.sh
+++ b/tests/fuzz/runFuzzTest.sh
@@ -63,7 +63,7 @@ mkdir -p "./corpus/${TEST_NAME}"
 
 ACTUAL_TEST_FAILURE=0
 
-# Copy existing Corpus to a temp directory so that new inputs from fuzz tests runs will add new inputs to the temp directory. 
+# Copy existing Corpus to a temp directory so that new inputs from fuzz tests runs will add new inputs to the temp directory.
 # This allows us to minimize new inputs before merging to the original corpus directory.
 TEMP_CORPUS_DIR="$(mktemp -d)"
 cp -r ./corpus/${TEST_NAME}/. "${TEMP_CORPUS_DIR}"


### PR DESCRIPTION
**Issue # (if available):** 
https://github.com/awslabs/s2n/issues/469

**Description of changes:** 
This adds codebuild support with custom docker images for maximum build reproducibility. The docker images cover the GCC6, GCC8, and Clang builds with OpenSSL 1.1.1 and 1.0.2. It also covers the address sanitizer, valgrind, and static analysis builds. This change leaves the travis builds for now while we evaluate the reliability of CodeBuild builds. 

This change includes copying some scripts with minor modifications to get them to work with docker and be in the correct directory so Docker can use them. 

* Static analysis takes ~50 seconds
* Unit and integ builds take ~4 minutes
* Address sanitizer ~6 minutes
* Corked IO ~5 minutes
* Fuzz 28 minutes, this is due to the number of fuzz tests (13) and how long each runs (2 minutes)
* Valgrind ~16 minutes

I am by no means a Docker expert and am open to suggestions to improve the Docker image hierarchy and style overall. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
