### PR TITLE
Add precondition macros, and use them on s2n_stuffer_init

### DIFF
--- a/error/s2n_errno.c
+++ b/error/s2n_errno.c
@@ -150,6 +150,7 @@ const char *s2n_strerror(int error, const char *lang)
         case S2N_ERR_POLLING_FROM_SOCKET: return "Error polling from socket";
         case S2N_ERR_RECV_STUFFER_FROM_CONN: return "Error receiving stuffer from connection";
         case S2N_ERR_SEND_STUFFER_TO_CONN: return "Error sending stuffer to connection";
+        case S2N_ERR_PRECONDITION_VIOLATION: return "Precondition violation";
         case S2N_ERR_NO_ALERT: return "No Alert present";
         case S2N_ERR_CLIENT_MODE: return "operation not allowed in client mode";
         case S2N_ERR_CLIENT_MODE_DISABLED: return "client connections not allowed";
@@ -327,6 +328,7 @@ const char *s2n_strerror_name(int error)
         CASE_ERROR_NAME(S2N_ERR_POLLING_FROM_SOCKET);
         CASE_ERROR_NAME(S2N_ERR_RECV_STUFFER_FROM_CONN);
         CASE_ERROR_NAME(S2N_ERR_SEND_STUFFER_TO_CONN);
+	CASE_ERROR_NAME(S2N_ERR_PRECONDITION_VIOLATION);
         CASE_ERROR_NAME(S2N_ERR_NO_ALERT);
         CASE_ERROR_NAME(S2N_ERR_CLIENT_MODE);
         CASE_ERROR_NAME(S2N_ERR_CLIENT_MODE_DISABLED);

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -23,10 +23,22 @@
 #include "utils/s2n_blob.h"
 #include "utils/s2n_mem.h"
 
+bool s2n_stuffer_is_valid(const struct s2n_stuffer* stuffer)
+{
+  return S2N_OBJECT_PTR_IS_READABLE(stuffer) && 
+    s2n_blob_is_valid(&stuffer->blob) &&
+    /* <= is valid because we can have a fully written/read stuffer */
+    stuffer->read_cursor <= stuffer->blob.size &&
+    stuffer->write_cursor <= stuffer->blob.size &&
+    stuffer->read_cursor <= stuffer->write_cursor;
+    /*any combination of wiped, alloced, growable, and tainted are valid */
+}
+
 int s2n_stuffer_init(struct s2n_stuffer *stuffer, struct s2n_blob *in)
 {
-    stuffer->blob.data = in->data;
-    stuffer->blob.size = in->size;
+    S2N_PRECONDITION(S2N_OBJECT_PTR_IS_WRITABLE(stuffer));
+    S2N_PRECONDITION(s2n_blob_is_valid(in));
+    stuffer->blob = *in;
     stuffer->wiped = 1;
     stuffer->alloced = 0;
     stuffer->growable = 0;

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -25,13 +25,14 @@
 
 bool s2n_stuffer_is_valid(const struct s2n_stuffer* stuffer)
 {
-  return S2N_OBJECT_PTR_IS_READABLE(stuffer) && 
+    /* Note that we do not assert any properties on the  wiped, alloced, growable, and tainted fields,
+     * as all possible combinations of boolean values in those fields are valid */
+    return S2N_OBJECT_PTR_IS_READABLE(stuffer) && 
     s2n_blob_is_valid(&stuffer->blob) &&
     /* <= is valid because we can have a fully written/read stuffer */
     stuffer->read_cursor <= stuffer->blob.size &&
     stuffer->write_cursor <= stuffer->blob.size &&
     stuffer->read_cursor <= stuffer->write_cursor;
-    /*any combination of wiped, alloced, growable, and tainted are valid */
 }
 
 int s2n_stuffer_init(struct s2n_stuffer *stuffer, struct s2n_blob *in)

--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -46,6 +46,9 @@ struct s2n_stuffer {
 #define s2n_stuffer_data_available( s )   ((s)->write_cursor - (s)->read_cursor)
 #define s2n_stuffer_space_remaining( s )  ((s)->blob.size - (s)->write_cursor)
 
+/* Check basic validity constraints on the stuffer: e.g. that cursors point within the blob */
+extern bool s2n_stuffer_is_valid(const struct s2n_stuffer* stuffer);
+
 /* Initialize and destroying stuffers */
 extern int s2n_stuffer_init(struct s2n_stuffer *stuffer, struct s2n_blob *in);
 extern int s2n_stuffer_alloc(struct s2n_stuffer *stuffer, const uint32_t size);

--- a/tests/cbmc/include/cbmc_proof/make_common_datastructures.h
+++ b/tests/cbmc/include/cbmc_proof/make_common_datastructures.h
@@ -13,17 +13,11 @@
  * permissions and limitations under the License.
  */
 
+#pragma once
+
+#include <cbmc_proof/proof_allocators.h>
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
-#include <cbmc_proof/make_common_datastructures.h>
 
-void s2n_stuffer_init_harness() {
-  struct s2n_stuffer *stuffer = can_fail_malloc(sizeof(*stuffer));
-  struct s2n_blob* in = cbmc_allocate_s2n_blob();
-  if (s2n_stuffer_init(stuffer, in) == S2N_SUCCESS){
-    assert(s2n_stuffer_is_valid(stuffer));
-    assert(s2n_blob_is_valid(in));
-  };
-}
+void ensure_s2n_blob_has_allocated_fields(struct s2n_blob* blob);
+struct s2n_blob* cbmc_allocate_s2n_blob();

--- a/tests/cbmc/proofs/Makefile.common
+++ b/tests/cbmc/proofs/Makefile.common
@@ -60,8 +60,13 @@ LOGDIR = $(PROOFDIR)/logs
 
 ################################################################
 # Useful macros for running commands
+
 #1: command, 2: flags, 3: log file
 DO_AND_LOG_COMMAND = $(1) $(2) 2>&1 | tee $(3); exit $${PIPESTATUS[0]}
+
+#1: command, 2: flags, 3: log file
+DO_AND_LOG_COMMAND_EAT_ERRORS = $(1) $(2) 2>&1 | tee $(3)
+
 
 #1: flags, 2: source, 3: target
 DO_GOTO_ANALYZER = $(call DO_AND_LOG_COMMAND,$(GOTO_ANALYZER),$(CBMC_VERBOSITY) $(1) $(2) $(3), $(call LOG_FROM_ENTRY,$(3)))
@@ -73,7 +78,7 @@ DO_GOTO_CC =  $(call DO_AND_LOG_COMMAND,$(GOTO_CC),$(CBMC_VERBOSITY) $(1) $(2) -
 DO_GOTO_INSTRUMENT = $(call DO_AND_LOG_COMMAND,$(GOTO_INSTRUMENT),$(CBMC_VERBOSITY) $(1) $(2) $(3), $(call LOG_FROM_ENTRY,$(3)))
 
 #1: flags, 2: source, 3: logfile
-DO_CBMC =  $(call DO_AND_LOG_COMMAND,$(CBMC),$(CBMC_VERBOSITY) $(1) $(2), $(3))
+DO_CBMC =  $(call DO_AND_LOG_COMMAND_EAT_ERRORS,$(CBMC),$(CBMC_VERBOSITY) $(1) $(2), $(3))
 
 #1: message 2: source 3: dest 
 DO_NOOP_COPY = cp $(2) $(3); echo $(1) | tee $(call LOG_FROM_ENTRY,$(3))
@@ -262,8 +267,7 @@ report: logs/cbmc.log logs/property.xml logs/coverage.xml
 	--htmldir html \
 	--property logs/property.xml \
 	--result logs/cbmc.log \
-	--srcdir $(SRCDIR) \
-	--srcexclude "(./verification|./tests|./tools|./lib/third_party)"
+	--srcdir $(SRCDIR)
 
 ################################################################
 # Targets to clean up after ourselves

--- a/tests/cbmc/proofs/Makefile.common
+++ b/tests/cbmc/proofs/Makefile.common
@@ -65,8 +65,8 @@ LOGDIR = $(PROOFDIR)/logs
 DO_AND_LOG_COMMAND = $(1) $(2) 2>&1 | tee $(3); exit $${PIPESTATUS[0]}
 
 #1: command, 2: flags, 3: log file
-DO_AND_LOG_COMMAND_EAT_ERRORS = $(1) $(2) 2>&1 | tee $(3)
-
+# CBMC uses the special error-code 10 to signify that it detected an assertion violation.  Continue the build so we can output the trace.
+DO_AND_LOG_IGNORING_ERROR_10 =  $(1) $(2) 2>&1 | tee $(3); if [ $${PIPESTATUS[0]} -ne 10 ]; then exit $${PIPESTATUS[0]}; fi
 
 #1: flags, 2: source, 3: target
 DO_GOTO_ANALYZER = $(call DO_AND_LOG_COMMAND,$(GOTO_ANALYZER),$(CBMC_VERBOSITY) $(1) $(2) $(3), $(call LOG_FROM_ENTRY,$(3)))
@@ -78,7 +78,7 @@ DO_GOTO_CC =  $(call DO_AND_LOG_COMMAND,$(GOTO_CC),$(CBMC_VERBOSITY) $(1) $(2) -
 DO_GOTO_INSTRUMENT = $(call DO_AND_LOG_COMMAND,$(GOTO_INSTRUMENT),$(CBMC_VERBOSITY) $(1) $(2) $(3), $(call LOG_FROM_ENTRY,$(3)))
 
 #1: flags, 2: source, 3: logfile
-DO_CBMC =  $(call DO_AND_LOG_COMMAND_EAT_ERRORS,$(CBMC),$(CBMC_VERBOSITY) $(1) $(2), $(3))
+DO_CBMC =  $(call DO_AND_LOG_IGNORING_ERROR_10,$(CBMC),$(CBMC_VERBOSITY) $(1) $(2), $(3))
 
 #1: message 2: source 3: dest 
 DO_NOOP_COPY = cp $(2) $(3); echo $(1) | tee $(call LOG_FROM_ENTRY,$(3))

--- a/tests/cbmc/proofs/s2n_stuffer_init/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_init/Makefile
@@ -15,8 +15,10 @@
 #Use the default set of CBMC flags
 CBMCFLAGS +=
 
-DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
 
 ENTRY = s2n_stuffer_init_harness
 

--- a/tests/cbmc/source/make_common_datastructures.c
+++ b/tests/cbmc/source/make_common_datastructures.c
@@ -13,17 +13,15 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "stuffer/s2n_stuffer.h"
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/make_common_datastructures.h>
+void ensure_s2n_blob_has_allocated_fields(struct s2n_blob* blob) {
+  blob->data = bounded_malloc(blob->size);  
+}
 
-void s2n_stuffer_init_harness() {
-  struct s2n_stuffer *stuffer = can_fail_malloc(sizeof(*stuffer));
-  struct s2n_blob* in = cbmc_allocate_s2n_blob();
-  if (s2n_stuffer_init(stuffer, in) == S2N_SUCCESS){
-    assert(s2n_stuffer_is_valid(stuffer));
-    assert(s2n_blob_is_valid(in));
-  };
+struct s2n_blob* cbmc_allocate_s2n_blob() {
+  struct s2n_blob* blob = can_fail_malloc(sizeof(*blob));
+  if(blob) {
+    ensure_s2n_blob_has_allocated_fields(blob);
+  }
+  return blob;
 }

--- a/tests/sidetrail/working/s2n-record-read-aead/Makefile
+++ b/tests/sidetrail/working/s2n-record-read-aead/Makefile
@@ -1,3 +1,4 @@
+
 include ../../lib/ct-verif.mk
 
 cflags +=-D__TIMING_CONTRACTS__
@@ -8,7 +9,7 @@ cflags += -I$(CURDIR)/../../../../
 #/api .h that haven't fixed that
 cflags += -I$(CURDIR)/../../../../api/
 cflags += -fPIC -std=c99 -fgnu89-inline
-extras +=  crypto/s2n_hash.c crypto/s2n_hmac.c   stuffer/s2n_stuffer.c tls/s2n_cbc.c  tls/s2n_aead.c tls/s2n_record_read_aead.c  utils/s2n_safety.c utils/s2n_mem.c 
+extras +=  crypto/s2n_hash.c crypto/s2n_hmac.c   stuffer/s2n_stuffer.c tls/s2n_cbc.c  tls/s2n_aead.c tls/s2n_record_read_aead.c  utils/s2n_blob.c utils/s2n_safety.c utils/s2n_mem.c
 goals  += s2n_record_parse_wrapper@s2n_record_read_wrapper.c
 #goals += test_leakage@s2n_record_read_wrapper.c
 full_self_comp += true

--- a/tests/sidetrail/working/s2n-record-read-aead/copy_as_needed.sh
+++ b/tests/sidetrail/working/s2n-record-read-aead/copy_as_needed.sh
@@ -42,6 +42,7 @@ patch -p5 < ../patches/cbc.patch
 
 mkdir -p utils
 cp s2n_annotations.h utils/
+cp $S2N_BASE/utils/s2n_blob.c utils/
 cp $S2N_BASE/utils/s2n_safety.c utils/
 cp $S2N_BASE/utils/s2n_safety.h utils/
 cp ../stubs/s2n_mem.c utils/

--- a/tests/unit/s2n_blob_test.c
+++ b/tests/unit/s2n_blob_test.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "utils/s2n_blob.h"
+
+#include <s2n.h>
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Null blob is not valid */
+    EXPECT_FALSE(s2n_blob_is_valid(NULL));
+
+    /* Invalid blob is not valid */
+    struct s2n_blob b1 = {.data = 0, .size = 101 };
+    EXPECT_FALSE(s2n_blob_is_valid(&b1));
+
+    /* Size of 0 is OK if data is null */
+    struct s2n_blob b2 = {.data = 0, .size = 0 };
+    EXPECT_TRUE(s2n_blob_is_valid(&b2));
+
+    /* Valid blob is valid */
+    uint8_t array[12];
+    struct s2n_blob b3 = {.data = array, .size = sizeof(array)};
+    EXPECT_TRUE(s2n_blob_is_valid(&b3));
+
+    END_TEST();
+}

--- a/tests/unit/s2n_stuffer_test.c
+++ b/tests/unit/s2n_stuffer_test.c
@@ -118,5 +118,51 @@ int main(int argc, char **argv)
 
     EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
 
+    /* Invalid blob should fail init */
+    struct s2n_stuffer s1;
+    struct s2n_blob b1 = {.data = 0,.size = 101 };
+    EXPECT_FAILURE(s2n_stuffer_init(&s1, &b1));
+
+    /* Valid empty blob should succeed init */
+    struct s2n_stuffer s2;
+    struct s2n_blob b2 = {.data = 0,.size = 0 };
+    EXPECT_SUCCESS(s2n_stuffer_init(&s2, &b2));
+
+    /* Valid blob should succeed init */
+    struct s2n_stuffer s3;
+    uint8_t a3[12];
+    struct s2n_blob b3 = {.data = a3,.size = sizeof(a3)};
+    EXPECT_SUCCESS(s2n_stuffer_init(&s3, &b3));
+
+    /* Null blob should fail init */
+    struct s2n_stuffer s4;
+    EXPECT_FAILURE(s2n_stuffer_init(&s4, NULL));
+
+    /* Null stuffer should fail init */
+    struct s2n_blob b5 = {.data = 0,.size = 0 };
+    EXPECT_FAILURE(s2n_stuffer_init(NULL, &b5));
+
+    /* Check s2n_stuffer_is_valid() function */
+    EXPECT_FALSE(s2n_stuffer_is_valid(NULL));
+    uint8_t valid_blob_array[12];
+    struct s2n_blob blob_valid = {.data = valid_blob_array,.size = sizeof(valid_blob_array)};
+    struct s2n_blob blob_invalid = {.data = 0,.size = sizeof(valid_blob_array)};
+
+    struct s2n_stuffer stuffer_valid;
+    EXPECT_SUCCESS(s2n_stuffer_init(&stuffer_valid, &blob_valid));
+    EXPECT_TRUE(s2n_stuffer_is_valid(&stuffer));
+
+    struct s2n_stuffer stuffer_invalid1 = {.blob = blob_invalid};
+    EXPECT_FALSE(s2n_stuffer_is_valid(&stuffer_invalid1));
+
+    struct s2n_stuffer stuffer_invalid2 = {.blob = blob_valid, .write_cursor = 13};
+    EXPECT_FALSE(s2n_stuffer_is_valid(&stuffer_invalid2));
+
+    struct s2n_stuffer stuffer_invalid3 = {.blob = blob_valid, .read_cursor = 13};
+    EXPECT_FALSE(s2n_stuffer_is_valid(&stuffer_invalid3));
+
+    struct s2n_stuffer stuffer_invalid4 = {.blob = blob_valid, .read_cursor = 12, .write_cursor = 1};
+    EXPECT_FALSE(s2n_stuffer_is_valid(&stuffer_invalid4));
+
     END_TEST();
 }

--- a/utils/s2n_blob.c
+++ b/utils/s2n_blob.c
@@ -23,6 +23,12 @@
 
 #include <s2n.h>
 
+bool s2n_blob_is_valid(const struct s2n_blob* b)
+{
+  bool blob_was_valid = S2N_OBJECT_PTR_IS_READABLE(b) && S2N_MEM_IS_READABLE(b->data,b->size);
+  return blob_was_valid;
+}
+
 int s2n_blob_init(struct s2n_blob *b, uint8_t * data, uint32_t size)
 {
     b->data = data;

--- a/utils/s2n_blob.h
+++ b/utils/s2n_blob.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <stdint.h>
 
 struct s2n_blob {
@@ -24,6 +25,7 @@ struct s2n_blob {
     uint8_t mlocked;
 };
 
+extern bool s2n_blob_is_valid(const struct s2n_blob* b);
 extern int s2n_blob_init(struct s2n_blob *b, uint8_t * data, uint32_t size);
 extern int s2n_blob_zero(struct s2n_blob *b);
 extern int s2n_blob_char_to_lower(struct s2n_blob *b);


### PR DESCRIPTION
**Description of changes:** 
1. Add macros to capture the idea of a function precondition
1. Add macros to express the idea of a valid memory region.  In CBMC mode, these check that the memory was actually allocated; in non CBMC mode, these become non-null checks
1. Create `*is_valid()` functions to describe when a `s2n_stuffer` and a `s2n_blob` are validly allocated
1. Use these functions to define a function contract for `s2n_stuffer_init`, and prove it using CBMC
1. Additional helper functions for CBMC proofs
1. Small bug fix: the `blob` in the stuffer had its `data` and `size` fields set, but not `allocated` or `mlocked`.  Make sure to set all fields.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
