### PR TITLE
Only resize stuffers to the amount of bytes needed

### DIFF
--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -231,7 +231,7 @@ int s2n_stuffer_skip_write(struct s2n_stuffer *stuffer, const uint32_t n)
     if (s2n_stuffer_space_remaining(stuffer) < n) {
         if (stuffer->growable) {
             /* Always grow a stuffer by at least 1k */
-            uint32_t growth = MAX(n, 1024);
+            uint32_t growth = MAX(n - s2n_stuffer_space_remaining(stuffer), 1024);
 
             GUARD(s2n_stuffer_resize(stuffer, stuffer->blob.size + growth));
         } else {


### PR DESCRIPTION
**Description of changes:** 
In s2n_stuffer_skip_write, growth is incorrectly initialized to n. This can result in overallocation of memory; for example, if you need 1500 bytes and have 1000 bytes remaining, it will allocate two 1024 blocks rather than one. This problem can be fixed by initializing growth to n - space_remaining.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
