### PR TITLE
Allow up to 0.5% reduction in code coverage per pull request

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,8 +9,16 @@ coverage:
   range: "70...100"
 
   status:
-    project: yes
-    patch: yes
+    project:
+      default:
+         target: auto
+         threshold: 0.5
+         base: auto
+    patch:
+      default:
+        target: auto
+        threshold: 0.5
+        base: auto
     changes: no
 
 parsers:


### PR DESCRIPTION
**Issue # (if available):** 
Lots of people are getting intermittent code coverage failures due to 0.01% reductions in code coverage caused by a 1-2 line difference in code coverage. 

**Description of changes:** 
Looked at CodeCov Docs: https://docs.codecov.io/docs/commit-status
Set our CodeCov config to allow up to a 0.5% reduction in code coverage and still allow a PR to pass the build. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
