### PR TITLE
Make s2n_array use a s2n_blob for its underlying memory store

### DIFF
--- a/tests/unit/s2n_array_test.c
+++ b/tests/unit/s2n_array_test.c
@@ -96,7 +96,7 @@ int main(int argc, char **argv)
     EXPECT_EQUAL(array->capacity, 32);
     EXPECT_EQUAL(array->num_of_elements, 17);
     EXPECT_EQUAL(array->element_size, element_size);
-    EXPECT_SUCCESS(memcmp(array->elements, mem.data, num_of_elements * element_size));
+    EXPECT_SUCCESS(memcmp(array->mem.data, mem.data, num_of_elements * element_size));
 
     /* Insert element at given index */
     struct array_element *insert_element = s2n_array_insert(array, 16);

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -270,7 +270,7 @@ static int s2n_populate_client_hello_extensions(struct s2n_client_hello *ch)
     }
 
     /* Sort extensions by extension type */
-    qsort(ch->parsed_extensions->elements, ch->parsed_extensions->num_of_elements, ch->parsed_extensions->element_size, s2n_parsed_extensions_compare);
+    qsort(ch->parsed_extensions->mem.data, ch->parsed_extensions->num_of_elements, ch->parsed_extensions->element_size, s2n_parsed_extensions_compare);
 
     return 0;
 }
@@ -488,7 +488,7 @@ int s2n_client_hello_get_parsed_extension(struct s2n_array *parsed_extensions, s
     struct s2n_client_hello_parsed_extension search = {0};
     search.extension_type = extension_type;
 
-    struct s2n_client_hello_parsed_extension *result_extension = bsearch(&search, parsed_extensions->elements, parsed_extensions->num_of_elements,
+    struct s2n_client_hello_parsed_extension *result_extension = bsearch(&search, parsed_extensions->mem.data, parsed_extensions->num_of_elements,
             parsed_extensions->element_size, s2n_parsed_extensions_compare);
 
     notnull_check(result_extension);

--- a/utils/s2n_array.c
+++ b/utils/s2n_array.c
@@ -40,12 +40,9 @@ struct s2n_array *s2n_array_new(size_t element_size)
     struct s2n_blob mem = {0};
     GUARD_PTR(s2n_alloc(&mem, sizeof(struct s2n_array)));
 
+    struct s2n_array initilizer = {.mem = {0}, .num_of_elements = 0, .capacity = 0, .element_size = element_size};
     struct s2n_array *array = (void *) mem.data;
-    array->mem = (struct s2n_blob) {0};	
-    array->num_of_elements = 0;
-    array->capacity = 0;
-    array->element_size = element_size;
-
+    *array = initilizer;
     GUARD_PTR(s2n_array_enlarge(array, S2N_INITIAL_ARRAY_SIZE));
 
     return array;

--- a/utils/s2n_array.c
+++ b/utils/s2n_array.c
@@ -24,16 +24,13 @@ static int s2n_array_enlarge(struct s2n_array *array, uint32_t capacity)
     notnull_check(array);
     size_t array_elements_size = array->element_size * array->num_of_elements;
 
-    struct s2n_blob mem = {.data = array->elements, .size = array_elements_size, .allocated = array_elements_size};
-
-    GUARD(s2n_realloc(&mem, array->element_size * capacity));
+    GUARD(s2n_realloc(&array->mem, array->element_size * capacity));
 
     /* Zero the extened part */
-    memset_check(mem.data + array_elements_size, 0, mem.size - array_elements_size);
+    memset_check(array->mem.data + array_elements_size, 0, array->mem.size - array_elements_size);
 
     /* Update array capacity and elements */
     array->capacity = capacity;
-    array->elements = (void *) mem.data;
 
     return 0;
 }
@@ -41,15 +38,13 @@ static int s2n_array_enlarge(struct s2n_array *array, uint32_t capacity)
 struct s2n_array *s2n_array_new(size_t element_size)
 {
     struct s2n_blob mem = {0};
-    struct s2n_array *array;
-
     GUARD_PTR(s2n_alloc(&mem, sizeof(struct s2n_array)));
 
-    array = (void *) mem.data;
-    array->capacity = 0;
+    struct s2n_array *array = (void *) mem.data;
+    array->mem = (struct s2n_blob) {0};	
     array->num_of_elements = 0;
+    array->capacity = 0;
     array->element_size = element_size;
-    array->elements = NULL;
 
     GUARD_PTR(s2n_array_enlarge(array, S2N_INITIAL_ARRAY_SIZE));
 
@@ -67,7 +62,7 @@ void *s2n_array_add(struct s2n_array *array)
         GUARD_PTR(s2n_array_enlarge(array, array->capacity * 2));
     }
 
-    void *element = (uint8_t *) array->elements + array->element_size * array->num_of_elements;
+    void *element = array->mem.data + array->element_size * array->num_of_elements;
     array->num_of_elements++;
 
     return element;
@@ -82,7 +77,7 @@ void *s2n_array_get(struct s2n_array *array, uint32_t index)
     void *element = NULL;
 
     if (index < array->num_of_elements) {
-        element = (uint8_t *) array->elements + array->element_size * index;
+        element = array->mem.data + array->element_size * index;
     }
 
     return element;
@@ -99,11 +94,11 @@ void *s2n_array_insert(struct s2n_array *array, uint32_t index)
         GUARD_PTR(s2n_array_enlarge(array, array->capacity * 2));
     }
 
-    memmove((uint8_t *) array->elements + array->element_size * (index + 1),
-            (uint8_t *) array->elements + array->element_size * index,
+    memmove(array->mem.data + array->element_size * (index + 1),
+            array->mem.data + array->element_size * index,
             (array->num_of_elements - index) * array->element_size);
 
-    void *element = (uint8_t *) array->elements + array->element_size * index;
+    void *element = array->mem.data + array->element_size * index;
     array->num_of_elements++;
 
     return element;
@@ -113,14 +108,14 @@ int s2n_array_remove(struct s2n_array *array, uint32_t index)
 {
     notnull_check(array);
 
-    memmove((uint8_t *) array->elements + array->element_size * index,
-            (uint8_t *) array->elements + array->element_size * (index + 1),
+    memmove(array->mem.data + array->element_size * index,
+            array->mem.data + array->element_size * (index + 1),
             (array->num_of_elements - index - 1) * array->element_size);
 
     array->num_of_elements--;
 
     /* After shifting, zero the last element */
-    memset_check((uint8_t *) array->elements + array->element_size * array->num_of_elements,
+    memset_check(array->mem.data + array->element_size * array->num_of_elements,
                   0,
                   array->element_size);
 
@@ -134,7 +129,7 @@ int s2n_array_free_p(struct s2n_array **parray)
 
     notnull_check(array);
     /* Free the elements */
-    GUARD(s2n_free_object((uint8_t **)&array->elements, array->capacity * array->element_size));
+    GUARD(s2n_free(&array->mem));
 
     /* And finally the array */
     GUARD(s2n_free_object((uint8_t **)parray, sizeof(struct s2n_array)));

--- a/utils/s2n_array.h
+++ b/utils/s2n_array.h
@@ -15,10 +15,11 @@
 #pragma once
 
 #include <s2n.h>
+#include "utils/s2n_blob.h"
 
 struct s2n_array {
     /* Pointer to elements in array */
-    void *elements;
+    struct s2n_blob mem;
 
     /* The total number of elements currently in the array. */
     uint32_t num_of_elements;


### PR DESCRIPTION
**Description of changes:** 
`s2n_array` allocates memory using a `s2n_blob`, which it then forgets about until it needs to realloc or free the memory, at which point it creates a new temporary blob (which may not have the same flags as the first one did).  Simplify matters by keeping the original `s2n_blob` around.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
