### PR TITLE
Add stacktrace support to s2n

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -20,7 +20,9 @@ extern "C" {
 #endif
 
 #include <sys/types.h>
+#include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <openssl/ossl_typ.h>
 #include <sys/uio.h>
 
@@ -75,6 +77,15 @@ extern int s2n_config_set_monotonic_clock(struct s2n_config *config, s2n_clock_t
 extern const char *s2n_strerror(int error, const char *lang);
 extern const char *s2n_strerror_debug(int error, const char *lang);
 extern const char *s2n_strerror_name(int error); 
+
+extern bool s2n_stack_traces_enabled();
+extern int s2n_stack_traces_enabled_set(bool newval);
+
+extern int s2n_calculate_stacktrace(void);
+extern int s2n_print_stacktrace(FILE *fptr);
+extern int s2n_free_stacktrace(void);
+extern int s2n_get_stacktrace(char*** trace, int* trace_size);
+
 
 extern int s2n_config_set_cache_store_callback(struct s2n_config *config, s2n_cache_store_callback cache_store_callback, void *data);
 extern int s2n_config_set_cache_retrieve_callback(struct s2n_config *config, s2n_cache_retrieve_callback cache_retrieve_callback, void *data);

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -78,14 +78,14 @@ extern const char *s2n_strerror(int error, const char *lang);
 extern const char *s2n_strerror_debug(int error, const char *lang);
 extern const char *s2n_strerror_name(int error); 
 
+
+struct s2n_stacktrace;
 extern bool s2n_stack_traces_enabled();
 extern int s2n_stack_traces_enabled_set(bool newval);
-
 extern int s2n_calculate_stacktrace(void);
 extern int s2n_print_stacktrace(FILE *fptr);
 extern int s2n_free_stacktrace(void);
-extern int s2n_get_stacktrace(char*** trace, int* trace_size);
-
+extern int s2n_get_stacktrace(struct s2n_stacktrace *trace);
 
 extern int s2n_config_set_cache_store_callback(struct s2n_config *config, s2n_cache_store_callback cache_store_callback, void *data);
 extern int s2n_config_set_cache_retrieve_callback(struct s2n_config *config, s2n_cache_retrieve_callback cache_retrieve_callback, void *data);

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -398,6 +398,22 @@ if (s2n_config_set_cipher_preferences(config, prefs) < 0) {
 
 **NOTE**: To avoid possible confusion, s2n_errno should be cleared after processing an error: `s2n_errno = S2N_ERR_T_OK`
 
+### Stacktraces
+s2n has an mechanism to capture stacktraces when errors occur.
+This mechanism is off by default, but can be enabled in code by calling `s2n_stack_traces_enabled_set()`.
+It can be enabled globally by setting the environment variable `S2N_PRINT_STACKTRACE=1`.
+Note that enabling stacktraces this can significantly slow down unit tests, and can cause failures on unit-tests (such as `s2n_cbc_verify`) that measure the timing of events.
+
+```
+bool s2n_stack_traces_enabled();
+int s2n_stack_traces_enabled_set(bool newval);
+
+int s2n_calculate_stacktrace(void);
+int s2n_print_stacktrace(FILE *fptr);
+int s2n_free_stacktrace(void);
+int s2n_get_stacktrace(char*** trace, int* trace_size);
+```
+
 ### Error categories
 
 s2n organizes errors into different "types" to allow applications to do logic on error values without catching all possibilities. 

--- a/error/s2n_errno.c
+++ b/error/s2n_errno.c
@@ -302,14 +302,16 @@ int s2n_free_stacktrace(void)
 
 int s2n_calculate_stacktrace(void)
 {
-    if (s_s2n_stack_traces_enabled) {
-        int old_errno = errno;
-        GUARD(s2n_free_stacktrace());
-        void *array[MAX_BACKTRACE_DEPTH];
-        s2n_stacktrace_size = backtrace(array, MAX_BACKTRACE_DEPTH);
-        s2n_stacktrace = backtrace_symbols(array, s2n_stacktrace_size);
-        errno = old_errno;
+    if (!s_s2n_stack_traces_enabled) {
+        return S2N_SUCCESS;
     }
+
+    int old_errno = errno;
+    GUARD(s2n_free_stacktrace());
+    void *array[MAX_BACKTRACE_DEPTH];
+    s2n_stacktrace_size = backtrace(array, MAX_BACKTRACE_DEPTH);
+    s2n_stacktrace = backtrace_symbols(array, s2n_stacktrace_size);
+    errno = old_errno;
     return S2N_SUCCESS;
 }
 
@@ -321,11 +323,13 @@ int s2n_get_stacktrace(char*** trace, int* trace_size) {
 
 int s2n_print_stacktrace(FILE *fptr)
 {
-    if (s_s2n_stack_traces_enabled) {
-        fprintf(fptr, "\nStacktrace is:\n");
-        for (int i = 0; i < s2n_stacktrace_size; ++i){
-            fprintf(fptr, "%s\n", s2n_stacktrace[i]);
-        }
+    if (!s_s2n_stack_traces_enabled) {
+        return S2N_SUCCESS;
+    }
+
+    fprintf(fptr, "\nStacktrace is:\n");
+    for (int i = 0; i < s2n_stacktrace_size; ++i){
+        fprintf(fptr, "%s\n", s2n_stacktrace[i]);
     }
     return S2N_SUCCESS;
 }

--- a/error/s2n_errno.c
+++ b/error/s2n_errno.c
@@ -293,7 +293,7 @@ __thread int s2n_stacktrace_size = 0;
 
 int s2n_free_stacktrace(void)
 {
-    if(s2n_stacktrace != NULL) {
+    if (s2n_stacktrace != NULL) {
         free(s2n_stacktrace);
         s2n_stacktrace_size = 0;
     }
@@ -302,13 +302,13 @@ int s2n_free_stacktrace(void)
 
 int s2n_calculate_stacktrace(void)
 {
-    if(s_s2n_stack_traces_enabled) {
+    if (s_s2n_stack_traces_enabled) {
         int old_errno = errno;
         GUARD(s2n_free_stacktrace());
         void *array[MAX_BACKTRACE_DEPTH];
         s2n_stacktrace_size = backtrace(array, MAX_BACKTRACE_DEPTH);
         s2n_stacktrace = backtrace_symbols(array, s2n_stacktrace_size);
-	errno = old_errno;
+        errno = old_errno;
     }
     return S2N_SUCCESS;
 }
@@ -321,10 +321,11 @@ int s2n_get_stacktrace(char*** trace, int* trace_size) {
 
 int s2n_print_stacktrace(FILE *fptr)
 {
-    fprintf(fptr, "\nStacktrace is:\n");
-    for(int i = 0; i < s2n_stacktrace_size; ++i){
-        fprintf(fptr, "%s\n", s2n_stacktrace[i]);
+    if (s_s2n_stack_traces_enabled) {
+        fprintf(fptr, "\nStacktrace is:\n");
+        for (int i = 0; i < s2n_stacktrace_size; ++i){
+            fprintf(fptr, "%s\n", s2n_stacktrace[i]);
+        }
     }
     return S2N_SUCCESS;
 }
-

--- a/error/s2n_errno.c
+++ b/error/s2n_errno.c
@@ -323,7 +323,9 @@ int s2n_get_stacktrace(struct s2n_stacktrace *trace) {
 int s2n_print_stacktrace(FILE *fptr)
 {
     if (!s_s2n_stack_traces_enabled) {
-        fprintf(fptr, "NOTE: Some details are omitted, run with S2N_PRINT_STACKTRACE=1 for a verbose backtrace.  See https://github.com/awslabs/s2n/blob/master/docs/USAGE-GUIDE.md\n");
+      fprintf(fptr, "%s\n%s\n",
+	      "NOTE: Some details are omitted, run with S2N_PRINT_STACKTRACE=1 for a verbose backtrace.",
+	      "See https://github.com/awslabs/s2n/blob/master/docs/USAGE-GUIDE.md");
         return S2N_SUCCESS;
     }
 

--- a/error/s2n_errno.h
+++ b/error/s2n_errno.h
@@ -16,7 +16,8 @@
 #pragma once
 
 #include <s2n.h>
-
+#include <stdio.h>
+#include <stdbool.h>
 /*
  * To easily retrieve error types, we split error values into two parts.
  * The upper 6 bits describe the error type and the lower bits describe the value within the category.
@@ -227,7 +228,7 @@ extern __thread const char *s2n_debug_str;
 #define STRING__LINE__ STRING_(__LINE__)
 
 #define _S2N_DEBUG_LINE     "Error encountered in " __FILE__ " line " STRING__LINE__
-#define _S2N_ERROR( x )     do { s2n_debug_str = _S2N_DEBUG_LINE; s2n_errno = ( x ); } while (0)
+#define _S2N_ERROR( x )     do { s2n_debug_str = _S2N_DEBUG_LINE; s2n_errno = ( x ); s2n_calculate_stacktrace(); } while (0)
 #define S2N_ERROR( x )      do { _S2N_ERROR( ( x ) ); return -1; } while (0)
 #define S2N_ERROR_PRESERVE_ERRNO() do { return -1; } while (0)
 #define S2N_ERROR_PTR( x )  do { _S2N_ERROR( ( x ) ); return NULL; } while (0)
@@ -256,3 +257,11 @@ extern __thread const char *s2n_debug_str;
 
 #define S2N_OBJECT_PTR_IS_READABLE(ptr) S2N_MEM_IS_READABLE((ptr), sizeof(*(ptr)))
 #define S2N_OBJECT_PTR_IS_WRITABLE(ptr) S2N_MEM_IS_WRITABLE((ptr), sizeof(*(ptr)))
+
+/** Calculate and print stacktraces */
+extern bool s2n_stack_traces_enabled();
+extern int s2n_stack_traces_enabled_set(bool newval);
+
+extern int s2n_calculate_stacktrace(void);
+extern int s2n_print_stacktrace(FILE *fptr);
+extern int s2n_free_stacktrace(void);

--- a/error/s2n_errno.h
+++ b/error/s2n_errno.h
@@ -265,3 +265,4 @@ extern int s2n_stack_traces_enabled_set(bool newval);
 extern int s2n_calculate_stacktrace(void);
 extern int s2n_print_stacktrace(FILE *fptr);
 extern int s2n_free_stacktrace(void);
+extern int s2n_get_stacktrace(char*** trace, int* trace_size);

--- a/error/s2n_errno.h
+++ b/error/s2n_errno.h
@@ -259,10 +259,15 @@ extern __thread const char *s2n_debug_str;
 #define S2N_OBJECT_PTR_IS_WRITABLE(ptr) S2N_MEM_IS_WRITABLE((ptr), sizeof(*(ptr)))
 
 /** Calculate and print stacktraces */
+struct s2n_stacktrace {
+  char **trace;
+  int trace_size;
+};
+
 extern bool s2n_stack_traces_enabled();
 extern int s2n_stack_traces_enabled_set(bool newval);
 
 extern int s2n_calculate_stacktrace(void);
 extern int s2n_print_stacktrace(FILE *fptr);
 extern int s2n_free_stacktrace(void);
-extern int s2n_get_stacktrace(char*** trace, int* trace_size);
+extern int s2n_get_stacktrace(struct s2n_stacktrace *trace);

--- a/tests/s2n_test.h
+++ b/tests/s2n_test.h
@@ -15,10 +15,10 @@
 
 #pragma once
 #include <errno.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
 
 #include <openssl/crypto.h>
 
@@ -80,6 +80,7 @@
 #define FAIL()      FAIL_MSG("")
 
 #define FAIL_MSG( msg ) do { \
+                          s2n_print_stacktrace(stdout); \
                           /* isatty will overwrite errno on failure */ \
                           int real_errno = errno; \
                           if (isatty(fileno(stdout))) { \

--- a/tests/sidetrail/working/s2n-cbc/Makefile
+++ b/tests/sidetrail/working/s2n-cbc/Makefile
@@ -8,7 +8,11 @@ cflags += -I$(CURDIR)/../../../../
 #/api .h that haven't fixed that
 cflags += -I$(CURDIR)/../../../../api/
 cflags += -fPIC -std=c99 -fgnu89-inline
-extras += crypto/s2n_hmac.c  crypto/s2n_hash.c utils/s2n_safety.c tls/s2n_cbc.c
+extras += crypto/s2n_hash.c
+extras += crypto/s2n_hmac.c
+extras += error/s2n_errno.c
+extras += tls/s2n_cbc.c
+extras += utils/s2n_safety.c
 goals  += simple_cbc_wrapper@cbc.c
 full_self_comp += true
 smtlog += p.smt2

--- a/tests/sidetrail/working/s2n-cbc/clean.sh
+++ b/tests/sidetrail/working/s2n-cbc/clean.sh
@@ -15,5 +15,7 @@
 
 make clean
 rm -r crypto
+rm -r error
+rm -r stuffer
 rm -r tls
 rm -r utils

--- a/tests/sidetrail/working/s2n-cbc/copy_as_needed.sh
+++ b/tests/sidetrail/working/s2n-cbc/copy_as_needed.sh
@@ -14,6 +14,8 @@
 #
 
 set -x 
+set -e
+
 BASEDIR=$(pwd)
 echo $BASEDIR
 S2N_BASE="$BASEDIR/../../../.."
@@ -30,6 +32,9 @@ patch -p5 < patches/hmac.patch
 cp stubs/s2n_hash.c crypto/
 cp stubs/s2n_hash.h crypto/
 
+mkdir -p error
+cp ../stubs/s2n_errno.c error/
+
 mkdir -p tls
 #add invariants etc needed for the proof to the s2n_cbc code
 cp $S2N_BASE/tls/s2n_cbc.c tls/
@@ -38,7 +43,8 @@ patch -p5 < patches/cbc.patch
 mkdir -p utils
 cp $S2N_BASE/utils/s2n_safety.c utils/
 cp $S2N_BASE/utils/s2n_safety.h utils/
-patch -p5 < patches/safety.patch
+patch -p5 < ../patches/safety1.patch
+patch -p5 < ../patches/safety2.patch
 
 cp stubs/s2n_annotations.h utils/
 

--- a/tests/sidetrail/working/s2n-record-read-aead/Makefile
+++ b/tests/sidetrail/working/s2n-record-read-aead/Makefile
@@ -1,4 +1,3 @@
-
 include ../../lib/ct-verif.mk
 
 cflags +=-D__TIMING_CONTRACTS__
@@ -9,7 +8,16 @@ cflags += -I$(CURDIR)/../../../../
 #/api .h that haven't fixed that
 cflags += -I$(CURDIR)/../../../../api/
 cflags += -fPIC -std=c99 -fgnu89-inline
-extras +=  crypto/s2n_hash.c crypto/s2n_hmac.c   stuffer/s2n_stuffer.c tls/s2n_cbc.c  tls/s2n_aead.c tls/s2n_record_read_aead.c  utils/s2n_blob.c utils/s2n_safety.c utils/s2n_mem.c
+extras += crypto/s2n_hash.c
+extras += crypto/s2n_hmac.c
+extras += error/s2n_errno.c
+extras += stuffer/s2n_stuffer.c
+extras += tls/s2n_aead.c
+extras += tls/s2n_cbc.c
+extras += tls/s2n_record_read_aead.c
+extras += utils/s2n_blob.c
+extras += utils/s2n_mem.c
+extras += utils/s2n_safety.c
 goals  += s2n_record_parse_wrapper@s2n_record_read_wrapper.c
 #goals += test_leakage@s2n_record_read_wrapper.c
 full_self_comp += true

--- a/tests/sidetrail/working/s2n-record-read-aead/clean.sh
+++ b/tests/sidetrail/working/s2n-record-read-aead/clean.sh
@@ -15,6 +15,7 @@
 
 make clean
 rm -r crypto
+rm -r error
 rm -r tls
 rm -r stuffer
 rm -r utils

--- a/tests/sidetrail/working/s2n-record-read-aead/copy_as_needed.sh
+++ b/tests/sidetrail/working/s2n-record-read-aead/copy_as_needed.sh
@@ -14,6 +14,7 @@
 #
 
 set -x 
+set -e
 BASEDIR=$(pwd)
 echo $BASEDIR
 S2N_BASE="$BASEDIR/../../../.."
@@ -29,6 +30,9 @@ patch -p5 < ../patches/hmac.patch
 #the hash uses my stubs for now, so replace the file
 cp ../stubs/s2n_hash.c crypto/
 cp ../stubs/s2n_hash.h crypto/
+
+mkdir -p error
+cp ../stubs/s2n_errno.c error/
 
 mkdir -p stuffer
 cp $S2N_BASE/stuffer/s2n_stuffer.c stuffer/

--- a/tests/sidetrail/working/s2n-record-read-cbc/Makefile
+++ b/tests/sidetrail/working/s2n-record-read-cbc/Makefile
@@ -8,7 +8,14 @@ cflags += -I$(CURDIR)/../../../../
 #/api .h that haven't fixed that
 cflags += -I$(CURDIR)/../../../../api/
 cflags += -fPIC -std=c99 -fgnu89-inline
-extras += crypto/s2n_hash.c crypto/s2n_hmac.c tls/s2n_cbc.c tls/s2n_record_read_cbc.c stuffer/s2n_stuffer.c utils/s2n_mem.c utils/s2n_safety.c
+extras += crypto/s2n_hash.c
+extras += crypto/s2n_hmac.c
+extras += error/s2n_errno.c
+extras += stuffer/s2n_stuffer.c
+extras += tls/s2n_cbc.c
+extras += tls/s2n_record_read_cbc.c
+extras += utils/s2n_mem.c
+extras += utils/s2n_safety.c
 goals  += s2n_record_parse_wrapper@s2n_record_read_wrapper.c
 #goals += test_leakage@s2n_record_read_wrapper.c
 full_self_comp += true

--- a/tests/sidetrail/working/s2n-record-read-cbc/clean.sh
+++ b/tests/sidetrail/working/s2n-record-read-cbc/clean.sh
@@ -15,6 +15,7 @@
 
 make clean
 rm -r crypto
+rm -r error
 rm -r tls
 rm -r stuffer
 rm -r utils

--- a/tests/sidetrail/working/s2n-record-read-cbc/copy_as_needed.sh
+++ b/tests/sidetrail/working/s2n-record-read-cbc/copy_as_needed.sh
@@ -14,6 +14,8 @@
 #
 
 set -x 
+set -e
+
 BASEDIR=$(pwd)
 echo $BASEDIR
 S2N_BASE="$BASEDIR/../../../.."
@@ -29,6 +31,9 @@ patch -p5 < ../patches/hmac.patch
 #the hash uses my stubs for now, so replace the file
 cp ../stubs/s2n_hash.c crypto/
 cp ../stubs/s2n_hash.h crypto/
+
+mkdir -p error
+cp ../stubs/s2n_errno.c error/
 
 mkdir -p stuffer
 cp $S2N_BASE/stuffer/s2n_stuffer.c stuffer/

--- a/tests/sidetrail/working/s2n-record-read-composite/Makefile
+++ b/tests/sidetrail/working/s2n-record-read-composite/Makefile
@@ -8,7 +8,13 @@ cflags += -I$(CURDIR)/../../../../
 #/api .h that haven't fixed that
 cflags += -I$(CURDIR)/../../../../api/
 cflags += -fPIC -std=c99 -fgnu89-inline
-extras += crypto/s2n_hash.c crypto/s2n_hmac.c stuffer/s2n_stuffer.c  tls/s2n_record_read_composite.c  utils/s2n_mem.c utils/s2n_safety.c
+extras += crypto/s2n_hash.c
+extras += crypto/s2n_hmac.c
+extras += error/s2n_errno.c
+extras += stuffer/s2n_stuffer.c
+extras += tls/s2n_record_read_composite.c
+extras += utils/s2n_mem.c
+extras += utils/s2n_safety.c
 goals  += s2n_record_parse_wrapper@s2n_record_read_wrapper.c
 #goals += test_leakage@s2n_record_read_wrapper.c
 full_self_comp += true

--- a/tests/sidetrail/working/s2n-record-read-composite/clean.sh
+++ b/tests/sidetrail/working/s2n-record-read-composite/clean.sh
@@ -15,6 +15,7 @@
 
 make clean
 rm -r crypto
+rm -r error
 rm -r tls
 rm -r stuffer
 rm -r utils

--- a/tests/sidetrail/working/s2n-record-read-composite/copy_as_needed.sh
+++ b/tests/sidetrail/working/s2n-record-read-composite/copy_as_needed.sh
@@ -14,6 +14,8 @@
 #
 
 set -x 
+set -e
+
 BASEDIR=$(pwd)
 echo $BASEDIR
 S2N_BASE="$BASEDIR/../../../.."
@@ -29,6 +31,9 @@ patch -p5 < ../patches/hmac.patch
 #the hash uses my stubs for now, so replace the file
 cp ../stubs/s2n_hash.c crypto/
 cp ../stubs/s2n_hash.h crypto/
+
+mkdir -p error
+cp ../stubs/s2n_errno.c error/
 
 mkdir -p stuffer
 cp $S2N_BASE/stuffer/s2n_stuffer.c stuffer/

--- a/tests/sidetrail/working/s2n-record-read-stream/Makefile
+++ b/tests/sidetrail/working/s2n-record-read-stream/Makefile
@@ -8,7 +8,14 @@ cflags += -I$(CURDIR)/../../../../
 #/api .h that haven't fixed that
 cflags += -I$(CURDIR)/../../../../api/
 cflags += -fPIC -std=c99 -fgnu89-inline
-extras += crypto/s2n_hmac.c  crypto/s2n_hash.c stuffer/s2n_stuffer.c tls/s2n_cbc.c  tls/s2n_record_read_stream.c  utils/s2n_mem.c utils/s2n_safety.c 
+extras += crypto/s2n_hash.c
+extras += crypto/s2n_hmac.c
+extras += error/s2n_errno.c
+extras += stuffer/s2n_stuffer.c
+extras += tls/s2n_cbc.c
+extras += tls/s2n_record_read_stream.c
+extras += utils/s2n_mem.c
+extras += utils/s2n_safety.c
 goals  += s2n_record_parse_wrapper@s2n_record_read_wrapper.c
 full_self_comp += true
 smtlog += p.smt2

--- a/tests/sidetrail/working/s2n-record-read-stream/clean.sh
+++ b/tests/sidetrail/working/s2n-record-read-stream/clean.sh
@@ -15,6 +15,7 @@
 
 make clean
 rm -r crypto
+rm -r error
 rm -r tls
 rm -r stuffer
 rm -r utils

--- a/tests/sidetrail/working/s2n-record-read-stream/copy_as_needed.sh
+++ b/tests/sidetrail/working/s2n-record-read-stream/copy_as_needed.sh
@@ -14,6 +14,8 @@
 #
 
 set -x 
+set -e
+
 BASEDIR=$(pwd)
 echo $BASEDIR
 S2N_BASE="$BASEDIR/../../../.."
@@ -29,6 +31,9 @@ patch -p5 < ../patches/hmac.patch
 #the hash uses my stubs for now, so replace the file
 cp ../stubs/s2n_hash.c crypto/
 cp ../stubs/s2n_hash.h crypto/
+
+mkdir -p error
+cp ../stubs/s2n_errno.c error/
 
 mkdir -p stuffer
 cp $S2N_BASE/stuffer/s2n_stuffer.c stuffer/

--- a/tests/sidetrail/working/stubs/s2n_errno.c
+++ b/tests/sidetrail/working/stubs/s2n_errno.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <errno.h>
+
+int s2n_calculate_stacktrace(void)
+{
+    return 0;
+}

--- a/tests/unit/s2n_stacktrace_test.c
+++ b/tests/unit/s2n_stacktrace_test.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "utils/s2n_blob.h"
+
+#include <s2n.h>
+
+int raises_error()
+{
+  S2N_ERROR(S2N_ERR_INVALID_ARGUMENT);
+}
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+    EXPECT_SUCCESS(s2n_stack_traces_enabled_set(true));
+    char** trace = NULL;
+    int trace_size = 0;
+
+    /* If nothing has errored yet, we have no stacktrace */
+    EXPECT_SUCCESS(s2n_get_stacktrace(&trace, &trace_size));
+    EXPECT_NULL(trace);
+    EXPECT_EQUAL(trace_size, 0);
+
+    /* Raise an error, and see that it generates a stacktrace */
+    EXPECT_FAILURE(raises_error());
+    EXPECT_SUCCESS(s2n_get_stacktrace(&trace, &trace_size));
+    EXPECT_NOT_NULL(trace);
+    EXPECT_NOT_EQUAL(trace_size, 0);
+
+    /* Test printing the stacktrace. */
+    FILE *stream = fopen("/dev/null","w");
+    EXPECT_SUCCESS(s2n_print_stacktrace(stream));
+    fclose(stream);
+
+    /* Free the stacktrace to avoid memory leaks */
+    EXPECT_SUCCESS(s2n_free_stacktrace());
+    END_TEST();
+}

--- a/tests/unit/s2n_stacktrace_test.c
+++ b/tests/unit/s2n_stacktrace_test.c
@@ -28,19 +28,17 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_stack_traces_enabled_set(true));
-    char** trace = NULL;
-    int trace_size = 0;
-
+    struct s2n_stacktrace trace;
     /* If nothing has errored yet, we have no stacktrace */
-    EXPECT_SUCCESS(s2n_get_stacktrace(&trace, &trace_size));
-    EXPECT_NULL(trace);
-    EXPECT_EQUAL(trace_size, 0);
+    EXPECT_SUCCESS(s2n_get_stacktrace(&trace));
+    EXPECT_NULL(trace.trace);
+    EXPECT_EQUAL(trace.trace_size, 0);
 
     /* Raise an error, and see that it generates a stacktrace */
     EXPECT_FAILURE(raises_error());
-    EXPECT_SUCCESS(s2n_get_stacktrace(&trace, &trace_size));
-    EXPECT_NOT_NULL(trace);
-    EXPECT_NOT_EQUAL(trace_size, 0);
+    EXPECT_SUCCESS(s2n_get_stacktrace(&trace));
+    EXPECT_NOT_NULL(trace.trace);
+    EXPECT_NOT_EQUAL(trace.trace_size, 0);
 
     /* Test printing the stacktrace. */
     FILE *stream = fopen("/dev/null","w");

--- a/utils/s2n_init.c
+++ b/utils/s2n_init.c
@@ -74,6 +74,10 @@ int s2n_init(void)
         s2n_register_extension(extensions[i]);
     }
 
+    if (getenv("S2N_PRINT_STACKTRACE")) {
+      s2n_stack_traces_enabled_set(true);
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
**Description of changes:** 
1. Add stacktrace support to s2n.  
1. This slows down the error path, and makes unit tests slower, so turn it off by default and add a mechanism to turn it on
1. Add documentation
1. Add a unit test
1. Fix sidetrail makefiles to account for the new functions



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
