### PR TITLE
Fix memory leak of tls13 keys in FIPS mode

### DIFF
--- a/crypto/s2n_tls13_keys.c
+++ b/crypto/s2n_tls13_keys.c
@@ -108,16 +108,27 @@ static int s2n_tls13_transcript_message_hash(struct s2n_tls13_keys *keys, const 
 /*
  * Initalizes the tls13_keys struct
  */
-int s2n_tls13_keys_init(struct s2n_tls13_keys *handshake, s2n_hmac_algorithm alg)
+int s2n_tls13_keys_init(struct s2n_tls13_keys *keys, s2n_hmac_algorithm alg)
 {
-    notnull_check(handshake);
+    notnull_check(keys);
 
-    handshake->hmac_algorithm = alg;
-    GUARD(s2n_hmac_hash_alg(alg, &handshake->hash_algorithm));
-    GUARD(s2n_hash_digest_size(handshake->hash_algorithm, &handshake->size));
-    GUARD(s2n_blob_init(&handshake->extract_secret, handshake->extract_secret_bytes, handshake->size));
-    GUARD(s2n_blob_init(&handshake->derive_secret, handshake->derive_secret_bytes, handshake->size));
-    GUARD(s2n_hmac_new(&handshake->hmac));
+    keys->hmac_algorithm = alg;
+    GUARD(s2n_hmac_hash_alg(alg, &keys->hash_algorithm));
+    GUARD(s2n_hash_digest_size(keys->hash_algorithm, &keys->size));
+    GUARD(s2n_blob_init(&keys->extract_secret, keys->extract_secret_bytes, keys->size));
+    GUARD(s2n_blob_init(&keys->derive_secret, keys->derive_secret_bytes, keys->size));
+    GUARD(s2n_hmac_new(&keys->hmac));
+
+    return 0;
+}
+
+/*
+ * Frees any allocation
+ */
+int s2n_tls13_keys_free(struct s2n_tls13_keys *keys) {
+    notnull_check(keys);
+
+    GUARD(s2n_hmac_free(&keys->hmac));
 
     return 0;
 }

--- a/crypto/s2n_tls13_keys.h
+++ b/crypto/s2n_tls13_keys.h
@@ -72,6 +72,7 @@ extern const struct s2n_blob s2n_tls13_label_traffic_secret_iv;
     s2n_stack_blob(name, bytes, S2N_TLS13_SECRET_MAX_LEN)
 
 int s2n_tls13_keys_init(struct s2n_tls13_keys *handshake, s2n_hmac_algorithm alg);
+int s2n_tls13_keys_free(struct s2n_tls13_keys *keys);
 int s2n_tls13_derive_early_secrets(struct s2n_tls13_keys *handshake);
 int s2n_tls13_derive_handshake_secrets(struct s2n_tls13_keys *handshake,
                                         const struct s2n_blob *ecdhe,

--- a/tests/unit/s2n_tls13_keys_test.c
+++ b/tests/unit/s2n_tls13_keys_test.c
@@ -148,7 +148,7 @@ int main(int argc, char **argv)
 
     BEGIN_TEST();
 
-    struct s2n_tls13_keys secrets;
+    DEFER_CLEANUP(struct s2n_tls13_keys secrets = {0}, s2n_tls13_keys_free);
 
     EXPECT_SUCCESS(s2n_tls13_keys_init(&secrets, S2N_HMAC_SHA256));
 
@@ -158,7 +158,7 @@ int main(int argc, char **argv)
     S2N_BLOB_EXPECT_EQUAL(secrets.extract_secret, expected_early_secret);
     S2N_BLOB_EXPECT_EQUAL(secrets.derive_secret, expect_derived_handshake_secret);
 
-    struct s2n_hash_state hash_state;
+    DEFER_CLEANUP(struct s2n_hash_state hash_state, s2n_hash_free);
     EXPECT_SUCCESS(s2n_hash_new(&hash_state));
     EXPECT_SUCCESS(s2n_hash_init(&hash_state, secrets.hash_algorithm));
     EXPECT_SUCCESS(s2n_hash_update(&hash_state, client_hello.data, client_hello.size));
@@ -167,7 +167,7 @@ int main(int argc, char **argv)
     s2n_tls13_key_blob(client_handshake_secret, secrets.size);
     s2n_tls13_key_blob(server_handshake_secret, secrets.size);
 
-    struct s2n_hash_state hash_state_copy;
+    DEFER_CLEANUP(struct s2n_hash_state hash_state_copy, s2n_hash_free);
     EXPECT_SUCCESS(s2n_hash_new(&hash_state_copy));
     EXPECT_SUCCESS(s2n_hash_copy(&hash_state_copy, &hash_state));
 

--- a/tls/s2n_tls13_handshake.h
+++ b/tls/s2n_tls13_handshake.h
@@ -28,7 +28,7 @@ int s2n_tls13_mac_verify(struct s2n_tls13_keys *keys, struct s2n_blob *finished_
 
 /* Creates a reference to tls13_keys from connection */
 #define s2n_tls13_connection_keys(keys, conn) \
-    struct s2n_tls13_keys keys = {0};\
+    DEFER_CLEANUP(struct s2n_tls13_keys keys = {0}, s2n_tls13_keys_free);\
     GUARD(s2n_tls13_keys_from_conn(&keys, conn));
 
 int s2n_tls13_keys_from_conn(struct s2n_tls13_keys *keys, struct s2n_connection *conn);


### PR DESCRIPTION
**Issue # (if available):** 
in fips mode, creating a hash means creating allocs that needs to be freed. 

**Description of changes:** 
free any hashes that may have created allocations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
