### PR TITLE
Fix s2n_tls13_support_test and add more validaiton into version extension

### DIFF
--- a/tls/extensions/s2n_client_supported_versions.c
+++ b/tls/extensions/s2n_client_supported_versions.c
@@ -61,6 +61,8 @@ int s2n_extensions_client_supported_versions_process(struct s2n_connection *conn
 
     uint8_t size_of_version_list;
     GUARD(s2n_stuffer_read_uint8(extension, &size_of_version_list));
+    S2N_ERROR_IF(size_of_version_list != s2n_stuffer_data_available(extension), S2N_ERR_BAD_MESSAGE);
+    S2N_ERROR_IF(size_of_version_list % 2 == 1, S2N_ERR_BAD_MESSAGE);
 
     conn->client_protocol_version = s2n_unknown_protocol_version;
     conn->actual_protocol_version = s2n_unknown_protocol_version;


### PR DESCRIPTION
**Issue # (if available):** 

**Description of changes:** 
Stuffer blob size is the amount of memory allocated for stuffer, not the amount of written data. Passing it as is causes extension parsing to go through uninitialized memory, which sometimes causes extension parsing to succeed, which fails the test.

While in there, changed s2n_extensions_client_supported_versions_process to validate the size of versions list before parsing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
