### PR TITLE
Enforce use of s2n_array_len to calculate array lengths. 

### DIFF
--- a/.travis/grep_simple_mistakes.sh
+++ b/.travis/grep_simple_mistakes.sh
@@ -37,6 +37,17 @@ for file in $S2N_FILES_ASSERT_RETURN; do
   fi
 done
 
+# Detect any array size calculations that are not using the s2n_array_len() function.
+S2N_FILES_ARRAY_SIZING_RETURN=$(find "$PWD" -type f -name "s2n*.c" -path "*")
+for file in $S2N_FILES_ARRAY_SIZING_RETURN; do
+  RESULT_ARR_DIV=`grep -Ern 'sizeof\((.*)\) \/ sizeof\(\1\[0\]\)' $file`
+
+  if [ "${#RESULT_ARR_DIV}" != "0" ]; then
+    FAILED=1
+    printf "\e[1;34mGrep for 'sizeof\((.*)\) \/ sizeof\(\1\[0\]\)' check failed in $file:\e[0m\n$RESULT_ARR_DIV\n\n"
+  fi
+done
+
 # Assert that all assignments from s2n_stuffer_raw_read() have a
 # notnull_check (or similar manual null check) on the same, or next, line.
 # The assertion is shallow; this doesn't guarantee that we're doing the

--- a/tests/fuzz/s2n_client_cert_recv_test.c
+++ b/tests/fuzz/s2n_client_cert_recv_test.c
@@ -56,7 +56,7 @@ int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
 
 int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
 {
-    for(int version = 0; version < (s2n_array_len(TLS_VERSIONS)); version++){
+    for(int version = 0; version < s2n_array_len(TLS_VERSIONS); version++){
         /* Setup */
         struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
         notnull_check(server_conn);

--- a/tests/fuzz/s2n_client_cert_recv_test.c
+++ b/tests/fuzz/s2n_client_cert_recv_test.c
@@ -34,6 +34,7 @@
 #include "tls/s2n_tls_parameters.h"
 #include "utils/s2n_random.h"
 #include "utils/s2n_safety.h"
+
 #include "s2n_test.h"
 
 static const uint8_t TLS_VERSIONS[] = {S2N_TLS10, S2N_TLS11, S2N_TLS12};

--- a/tests/fuzz/s2n_client_cert_recv_test.c
+++ b/tests/fuzz/s2n_client_cert_recv_test.c
@@ -56,7 +56,7 @@ int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
 
 int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
 {
-    for(int version = 0; version < (sizeof(TLS_VERSIONS) / sizeof(TLS_VERSIONS[0])); version++){
+    for(int version = 0; version < (s2n_array_len(TLS_VERSIONS)); version++){
         /* Setup */
         struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
         notnull_check(server_conn);

--- a/tests/fuzz/s2n_client_hello_recv_fuzz_test.c
+++ b/tests/fuzz/s2n_client_hello_recv_fuzz_test.c
@@ -45,7 +45,7 @@ int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
 
 int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
 {
-    for(int version = 0; version < (sizeof(TLS_VERSIONS) / sizeof(TLS_VERSIONS[0])); version++){
+    for(int version = 0; version < (s2n_array_len(TLS_VERSIONS)); version++){
         /* Setup */
         struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
         notnull_check(server_conn);

--- a/tests/fuzz/s2n_client_hello_recv_fuzz_test.c
+++ b/tests/fuzz/s2n_client_hello_recv_fuzz_test.c
@@ -45,7 +45,7 @@ int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
 
 int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
 {
-    for(int version = 0; version < (s2n_array_len(TLS_VERSIONS)); version++){
+    for(int version = 0; version < s2n_array_len(TLS_VERSIONS); version++){
         /* Setup */
         struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
         notnull_check(server_conn);

--- a/tests/unit/s2n_ecdsa_test.c
+++ b/tests/unit/s2n_ecdsa_test.c
@@ -28,6 +28,9 @@
 #include "crypto/s2n_ecc.h"
 #include "crypto/s2n_fips.h"
 
+#include "utils/s2n_safety.h"
+
+
 static uint8_t unmatched_private_key[] =
     "-----BEGIN EC PRIVATE KEY-----\n"
     "MIIB+gIBAQQwuenHFMJsDm5tCQgthH8kGXQ1dHkKACmHH3ZqIGteoghhGow6vGmr\n"

--- a/tests/unit/s2n_ecdsa_test.c
+++ b/tests/unit/s2n_ecdsa_test.c
@@ -123,7 +123,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_hash_new(&hash_one));
     EXPECT_SUCCESS(s2n_hash_new(&hash_two));
 
-    for (int i = 0; i < sizeof(supported_hash_algorithms) / sizeof(supported_hash_algorithms[0]); i++) {
+    for (int i = 0; i < s2n_array_len(supported_hash_algorithms); i++) {
         int hash_alg = supported_hash_algorithms[i];
         
         if (!s2n_hash_is_available(hash_alg)) {

--- a/tests/unit/s2n_pem_test.c
+++ b/tests/unit/s2n_pem_test.c
@@ -65,7 +65,7 @@ int main(int argc, char **argv)
     EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
     EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
 
-    for (int i = 0; i < (sizeof(valid_pem_pairs) / sizeof(valid_pem_pairs[0])); i++) {
+    for (int i = 0; i < (s2n_array_len(valid_pem_pairs)); i++) {
         EXPECT_NOT_NULL(config = s2n_config_new());
         EXPECT_SUCCESS(s2n_read_test_pem(valid_pem_pairs[i][0], cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_read_test_pem(valid_pem_pairs[i][1], private_key_pem, S2N_MAX_TEST_PEM_SIZE));
@@ -76,7 +76,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_free(config));
     }
 
-    for (int i = 0; i < (sizeof(invalid_pem_pairs) / sizeof(invalid_pem_pairs[0])); i++) {
+    for (int i = 0; i < (s2n_array_len(invalid_pem_pairs)); i++) {
         EXPECT_SUCCESS(s2n_read_test_pem(invalid_pem_pairs[i][0], cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_read_test_pem(invalid_pem_pairs[i][1], private_key_pem, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());

--- a/tests/unit/s2n_pem_test.c
+++ b/tests/unit/s2n_pem_test.c
@@ -66,7 +66,7 @@ int main(int argc, char **argv)
     EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
     EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
 
-    for (int i = 0; i < (s2n_array_len(valid_pem_pairs)); i++) {
+    for (int i = 0; i < s2n_array_len(valid_pem_pairs); i++) {
         EXPECT_NOT_NULL(config = s2n_config_new());
         EXPECT_SUCCESS(s2n_read_test_pem(valid_pem_pairs[i][0], cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_read_test_pem(valid_pem_pairs[i][1], private_key_pem, S2N_MAX_TEST_PEM_SIZE));
@@ -77,7 +77,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_free(config));
     }
 
-    for (int i = 0; i < (s2n_array_len(invalid_pem_pairs)); i++) {
+    for (int i = 0; i < s2n_array_len(invalid_pem_pairs); i++) {
         EXPECT_SUCCESS(s2n_read_test_pem(invalid_pem_pairs[i][0], cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_read_test_pem(invalid_pem_pairs[i][1], private_key_pem, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());

--- a/tests/unit/s2n_pem_test.c
+++ b/tests/unit/s2n_pem_test.c
@@ -20,6 +20,7 @@
 
 #include <s2n.h>
 
+#include "utils/s2n_safety.h"
 #include "testlib/s2n_testlib.h"
 
 static const char *valid_pem_pairs[][2] = {

--- a/tests/unit/s2n_self_talk_alpn_test.c
+++ b/tests/unit/s2n_self_talk_alpn_test.c
@@ -24,6 +24,8 @@
 
 #include <s2n.h>
 
+
+#include "utils/s2n_safety.h"
 #include "tls/s2n_connection.h"
 #include "tls/s2n_handshake.h"
 

--- a/tests/unit/s2n_self_talk_alpn_test.c
+++ b/tests/unit/s2n_self_talk_alpn_test.c
@@ -122,7 +122,7 @@ int main(int argc, char **argv)
     struct s2n_cert_chain_and_key *chain_and_key;
 
     const char *protocols[] = { "http/1.1", "spdy/3.1", "h2" };
-    const int protocols_size = sizeof(protocols) / sizeof(protocols[0]);
+    const int protocols_size = s2n_array_len(protocols);
     const char *mismatch_protocols[] = { "spdy/2" };
 
     BEGIN_TEST();

--- a/tests/unit/s2n_wildcard_hostname_test.c
+++ b/tests/unit/s2n_wildcard_hostname_test.c
@@ -24,6 +24,8 @@
 
 #include "crypto/s2n_certificate.h"
 
+#include "utils/s2n_safety.h"
+
 struct wildcardify_test_case {
     const char *hostname;
     const char *output;

--- a/tests/unit/s2n_wildcard_hostname_test.c
+++ b/tests/unit/s2n_wildcard_hostname_test.c
@@ -44,7 +44,7 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
-    const int num_wildcardify_tests = sizeof(wildcardify_test_cases) / sizeof(wildcardify_test_cases[0]);
+    const int num_wildcardify_tests = s2n_array_len(wildcardify_test_cases);
     for (int i = 0; i < num_wildcardify_tests; i++) {
         const char *hostname = wildcardify_test_cases[i].hostname;
         struct s2n_blob hostname_blob = { .data = (uint8_t *) (uintptr_t) hostname , .size = strlen(hostname) };

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -46,7 +46,7 @@ struct s2n_cipher_suite *cipher_suites_20190801[] = {
 };
 
 const struct s2n_cipher_preferences cipher_preferences_20190801 = {
-    .count = sizeof(cipher_suites_20190801) / sizeof(cipher_suites_20190801[0]),
+    .count = s2n_array_len(cipher_suites_20190801),
     .suites = cipher_suites_20190801,
     .minimum_protocol_version = S2N_TLS10,
 };
@@ -64,14 +64,14 @@ struct s2n_cipher_suite *cipher_suites_20140601[] = {
 };
 
 const struct s2n_cipher_preferences cipher_preferences_20140601 = {
-    .count = sizeof(cipher_suites_20140601) / sizeof(cipher_suites_20140601[0]),
+    .count = s2n_array_len(cipher_suites_20140601),
     .suites = cipher_suites_20140601,
     .minimum_protocol_version = S2N_SSLv3,
 };
 
 /* Disable SSLv3 due to POODLE */
 const struct s2n_cipher_preferences cipher_preferences_20141001 = {
-    .count = sizeof(cipher_suites_20140601) / sizeof(cipher_suites_20140601[0]),
+    .count = s2n_array_len(cipher_suites_20140601),
     .suites = cipher_suites_20140601,
     .minimum_protocol_version = S2N_TLS10,
 };
@@ -87,7 +87,7 @@ struct s2n_cipher_suite *cipher_suites_20150202[] = {
 };
 
 const struct s2n_cipher_preferences cipher_preferences_20150202 = {
-    .count = sizeof(cipher_suites_20150202) / sizeof(cipher_suites_20150202[0]),
+    .count = s2n_array_len(cipher_suites_20150202),
     .suites = cipher_suites_20150202,
     .minimum_protocol_version = S2N_TLS10,
 };
@@ -105,7 +105,7 @@ struct s2n_cipher_suite *cipher_suites_20150214[] = {
 };
 
 const struct s2n_cipher_preferences cipher_preferences_20150214 = {
-    .count = sizeof(cipher_suites_20150214) / sizeof(cipher_suites_20150214[0]),
+    .count = s2n_array_len(cipher_suites_20150214),
     .suites = cipher_suites_20150214,
     .minimum_protocol_version = S2N_TLS10,
 };
@@ -128,7 +128,7 @@ struct s2n_cipher_suite *cipher_suites_20160411[] = {
 };
 
 const struct s2n_cipher_preferences cipher_preferences_20160411 = {
-    .count = sizeof(cipher_suites_20160411) / sizeof(cipher_suites_20160411[0]),
+    .count = s2n_array_len(cipher_suites_20160411),
     .suites = cipher_suites_20160411,
     .minimum_protocol_version = S2N_TLS10,
 };
@@ -148,7 +148,7 @@ struct s2n_cipher_suite *cipher_suites_20150306[] = {
 };
 
 const struct s2n_cipher_preferences cipher_preferences_20150306 = {
-    .count = sizeof(cipher_suites_20150306) / sizeof(cipher_suites_20150306[0]),
+    .count = s2n_array_len(cipher_suites_20150306),
     .suites = cipher_suites_20150306,
     .minimum_protocol_version = S2N_TLS10,
 };
@@ -170,7 +170,7 @@ struct s2n_cipher_suite *cipher_suites_20160804[] = {
 };
 
 const struct s2n_cipher_preferences cipher_preferences_20160804 = {
-    .count = sizeof(cipher_suites_20160804) / sizeof(cipher_suites_20160804[0]),
+    .count = s2n_array_len(cipher_suites_20160804),
     .suites = cipher_suites_20160804,
     .minimum_protocol_version = S2N_TLS10,
 };
@@ -187,7 +187,7 @@ struct s2n_cipher_suite *cipher_suites_20160824[] = {
 };
 
 const struct s2n_cipher_preferences cipher_preferences_20160824 = {
-    .count = sizeof(cipher_suites_20160824) / sizeof(cipher_suites_20160824[0]),
+    .count = s2n_array_len(cipher_suites_20160824),
     .suites = cipher_suites_20160824,
     .minimum_protocol_version = S2N_TLS10,
 };
@@ -206,7 +206,7 @@ struct s2n_cipher_suite *cipher_suites_20170210[] = {
 };
 
 const struct s2n_cipher_preferences cipher_preferences_20170210 = {
-    .count = sizeof(cipher_suites_20170210) / sizeof(cipher_suites_20170210[0]),
+    .count = s2n_array_len(cipher_suites_20170210),
     .suites = cipher_suites_20170210,
     .minimum_protocol_version = S2N_TLS10,
 };
@@ -230,7 +230,7 @@ struct s2n_cipher_suite *cipher_suites_20190122[] = {
 };
 
 const struct s2n_cipher_preferences cipher_preferences_20190122 = {
-    .count = sizeof(cipher_suites_20190122) / sizeof(cipher_suites_20190122[0]),
+    .count = s2n_array_len(cipher_suites_20190122),
     .suites = cipher_suites_20190122,
     .minimum_protocol_version = S2N_TLS10,
 };
@@ -254,7 +254,7 @@ struct s2n_cipher_suite *cipher_suites_20190121[] = {
 };
 
 const struct s2n_cipher_preferences cipher_preferences_20190121 = {
-    .count = sizeof(cipher_suites_20190121) / sizeof(cipher_suites_20190121[0]),
+    .count = s2n_array_len(cipher_suites_20190121),
     .suites = cipher_suites_20190121,
     .minimum_protocol_version = S2N_TLS10,
 };
@@ -278,7 +278,7 @@ struct s2n_cipher_suite *cipher_suites_20190120[] = {
 };
 
 const struct s2n_cipher_preferences cipher_preferences_20190120 = {
-    .count = sizeof(cipher_suites_20190120) / sizeof(cipher_suites_20190120[0]),
+    .count = s2n_array_len(cipher_suites_20190120),
     .suites = cipher_suites_20190120,
     .minimum_protocol_version = S2N_TLS10,
 };
@@ -313,7 +313,7 @@ struct s2n_cipher_suite *cipher_suites_20190214[] = {
 };
 
 const struct s2n_cipher_preferences cipher_preferences_20190214 = {
-    .count = sizeof(cipher_suites_20190214) / sizeof(cipher_suites_20190214[0]),
+    .count = s2n_array_len(cipher_suites_20190214),
     .suites = cipher_suites_20190214,
     .minimum_protocol_version = S2N_TLS10,
 };
@@ -323,7 +323,7 @@ struct s2n_cipher_suite *cipher_suites_null[] = {
 };
 
 const struct s2n_cipher_preferences cipher_preferences_null = {
-    .count = sizeof(cipher_suites_null) / sizeof(cipher_suites_null[0]),
+    .count = s2n_array_len(cipher_suites_null),
     .suites = cipher_suites_null,
     .minimum_protocol_version = S2N_TLS10,
 };
@@ -352,7 +352,7 @@ struct s2n_cipher_suite *cipher_suites_20170328[] = {
 };
 
 const struct s2n_cipher_preferences cipher_preferences_20170328 = {
-    .count = sizeof(cipher_suites_20170328) / sizeof(cipher_suites_20170328[0]),
+    .count = s2n_array_len(cipher_suites_20170328),
     .suites = cipher_suites_20170328,
     .minimum_protocol_version = S2N_TLS10,
 };
@@ -373,7 +373,7 @@ struct s2n_cipher_suite *cipher_suites_20170405[] = {
 };
 
 const struct s2n_cipher_preferences cipher_preferences_20170405 = {
-    .count = sizeof(cipher_suites_20170405) / sizeof(cipher_suites_20170405[0]),
+    .count = s2n_array_len(cipher_suites_20170405),
     .suites = cipher_suites_20170405,
     .minimum_protocol_version = S2N_TLS10,
 };
@@ -396,7 +396,7 @@ struct s2n_cipher_suite *cipher_suites_20170718[] = {
 };
 
 const struct s2n_cipher_preferences cipher_preferences_20170718 = {
-    .count = sizeof(cipher_suites_20170718) / sizeof(cipher_suites_20170718[0]),
+    .count = s2n_array_len(cipher_suites_20170718),
     .suites = cipher_suites_20170718,
     .minimum_protocol_version = S2N_TLS10,
 };
@@ -424,7 +424,7 @@ struct s2n_cipher_suite *cipher_suites_elb_security_policy_2015_04[] = {
 };
 
 const struct s2n_cipher_preferences elb_security_policy_2015_04 = {
-    .count = sizeof(cipher_suites_elb_security_policy_2015_04) / sizeof(cipher_suites_elb_security_policy_2015_04[0]),
+    .count = s2n_array_len(cipher_suites_elb_security_policy_2015_04),
     .suites = cipher_suites_elb_security_policy_2015_04,
     .minimum_protocol_version = S2N_TLS10,
 };
@@ -451,7 +451,7 @@ struct s2n_cipher_suite *cipher_suites_elb_security_policy_2016_08[] = {
 };
 
 const struct s2n_cipher_preferences elb_security_policy_2016_08 = {
-    .count = sizeof(cipher_suites_elb_security_policy_2016_08) / sizeof(cipher_suites_elb_security_policy_2016_08[0]),
+    .count = s2n_array_len(cipher_suites_elb_security_policy_2016_08),
     .suites = cipher_suites_elb_security_policy_2016_08,
     .minimum_protocol_version = S2N_TLS10,
 };
@@ -472,7 +472,7 @@ struct s2n_cipher_suite *cipher_suites_elb_security_policy_tls_1_2_2017_01[] = {
 };
 
 const struct s2n_cipher_preferences elb_security_policy_tls_1_2_2017_01 = {
-    .count = sizeof(cipher_suites_elb_security_policy_tls_1_2_2017_01) / sizeof(cipher_suites_elb_security_policy_tls_1_2_2017_01[0]),
+    .count = s2n_array_len(cipher_suites_elb_security_policy_tls_1_2_2017_01),
     .suites = cipher_suites_elb_security_policy_tls_1_2_2017_01,
     .minimum_protocol_version = S2N_TLS12,
 };
@@ -499,7 +499,7 @@ struct s2n_cipher_suite *cipher_suites_elb_security_policy_tls_1_1_2017_01[] = {
 };
 
 const struct s2n_cipher_preferences elb_security_policy_tls_1_1_2017_01 = {
-    .count = sizeof(cipher_suites_elb_security_policy_tls_1_1_2017_01) / sizeof(cipher_suites_elb_security_policy_tls_1_1_2017_01[0]),
+    .count = s2n_array_len(cipher_suites_elb_security_policy_tls_1_1_2017_01),
     .suites = cipher_suites_elb_security_policy_tls_1_1_2017_01,
     .minimum_protocol_version = S2N_TLS11,
 };
@@ -526,7 +526,7 @@ struct s2n_cipher_suite *cipher_suites_elb_security_policy_tls_1_2_ext_2018_06[]
 };
 
 const struct s2n_cipher_preferences elb_security_policy_tls_1_2_ext_2018_06 = {
-    .count = sizeof(cipher_suites_elb_security_policy_tls_1_2_ext_2018_06) / sizeof(cipher_suites_elb_security_policy_tls_1_2_ext_2018_06[0]),
+    .count = s2n_array_len(cipher_suites_elb_security_policy_tls_1_2_ext_2018_06),
     .suites = cipher_suites_elb_security_policy_tls_1_2_ext_2018_06,
     .minimum_protocol_version = S2N_TLS12,
 };
@@ -547,7 +547,7 @@ struct s2n_cipher_suite *cipher_suites_elb_security_policy_fs_2018_06[] = {
 };
 
 const struct s2n_cipher_preferences elb_security_policy_fs_2018_06 = {
-    .count = sizeof(cipher_suites_elb_security_policy_fs_2018_06) / sizeof(cipher_suites_elb_security_policy_fs_2018_06[0]),
+    .count = s2n_array_len(cipher_suites_elb_security_policy_fs_2018_06),
     .suites = cipher_suites_elb_security_policy_fs_2018_06,
     .minimum_protocol_version = S2N_TLS10,
 };
@@ -568,7 +568,7 @@ struct s2n_cipher_suite *cipher_suites_elb_security_policy_fs_1_2_2019_08[] = {
 };
 
 const struct s2n_cipher_preferences elb_security_policy_fs_1_2_2019_08 = {
-    .count = sizeof(cipher_suites_elb_security_policy_fs_1_2_2019_08) / sizeof(cipher_suites_elb_security_policy_fs_1_2_2019_08[0]), 
+    .count = s2n_array_len(cipher_suites_elb_security_policy_fs_1_2_2019_08),
     .suites = cipher_suites_elb_security_policy_fs_1_2_2019_08, 
     .minimum_protocol_version = S2N_TLS12,
 };
@@ -589,7 +589,7 @@ struct s2n_cipher_suite *cipher_suites_elb_security_policy_fs_1_1_2019_08[] = {
 };
 
 const struct s2n_cipher_preferences elb_security_policy_fs_1_1_2019_08 = {
-    .count = sizeof(cipher_suites_elb_security_policy_fs_1_1_2019_08) / sizeof(cipher_suites_elb_security_policy_fs_1_1_2019_08[0]), 
+    .count = s2n_array_len(cipher_suites_elb_security_policy_fs_1_1_2019_08),
     .suites = cipher_suites_elb_security_policy_fs_1_1_2019_08, 
     .minimum_protocol_version = S2N_TLS11,
 };
@@ -606,7 +606,7 @@ struct s2n_cipher_suite *cipher_suites_elb_security_policy_fs_1_2_Res_2019_08[] 
 };
 
 const struct s2n_cipher_preferences elb_security_policy_fs_1_2_Res_2019_08 = {
-    .count = sizeof(cipher_suites_elb_security_policy_fs_1_2_Res_2019_08) / sizeof(cipher_suites_elb_security_policy_fs_1_2_Res_2019_08[0]), 
+    .count = s2n_array_len(cipher_suites_elb_security_policy_fs_1_2_Res_2019_08),
     .suites = cipher_suites_elb_security_policy_fs_1_2_Res_2019_08, 
     .minimum_protocol_version = S2N_TLS12,
 };
@@ -634,7 +634,7 @@ struct s2n_cipher_suite *cipher_suites_cloudfront_upstream[] = {
 };
 
 const struct s2n_cipher_preferences cipher_preferences_cloudfront_upstream = {
-    .count = sizeof(cipher_suites_cloudfront_upstream) / sizeof(cipher_suites_cloudfront_upstream[0]),
+    .count = s2n_array_len(cipher_suites_cloudfront_upstream),
     .suites = cipher_suites_cloudfront_upstream,
     .minimum_protocol_version = S2N_SSLv3,
 };
@@ -656,7 +656,7 @@ struct s2n_cipher_suite *cipher_suites_cloudfront_ssl_v_3[] = {
 };
 
 const struct s2n_cipher_preferences cipher_preferences_cloudfront_ssl_v_3 = {
-    .count = sizeof(cipher_suites_cloudfront_ssl_v_3) / sizeof(cipher_suites_cloudfront_ssl_v_3[0]),
+    .count = s2n_array_len(cipher_suites_cloudfront_ssl_v_3),
     .suites = cipher_suites_cloudfront_ssl_v_3,
     .minimum_protocol_version = S2N_SSLv3,
 };
@@ -677,7 +677,7 @@ struct s2n_cipher_suite *cipher_suites_cloudfront_tls_1_0_2014[] = {
 };
 
 const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_0_2014 = {
-    .count = sizeof(cipher_suites_cloudfront_tls_1_0_2014) / sizeof(cipher_suites_cloudfront_tls_1_0_2014[0]),
+    .count = s2n_array_len(cipher_suites_cloudfront_tls_1_0_2014),
     .suites = cipher_suites_cloudfront_tls_1_0_2014,
     .minimum_protocol_version = S2N_TLS10,
 };
@@ -697,7 +697,7 @@ struct s2n_cipher_suite *cipher_suites_cloudfront_tls_1_0_2016[] = {
 };
 
 const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_0_2016 = {
-    .count = sizeof(cipher_suites_cloudfront_tls_1_0_2016) / sizeof(cipher_suites_cloudfront_tls_1_0_2016[0]),
+    .count = s2n_array_len(cipher_suites_cloudfront_tls_1_0_2016),
     .suites = cipher_suites_cloudfront_tls_1_0_2016,
     .minimum_protocol_version = S2N_TLS10,
 };
@@ -717,7 +717,7 @@ struct s2n_cipher_suite *cipher_suites_cloudfront_tls_1_1_2016[] = {
 };
 
 const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_1_2016 = {
-    .count = sizeof(cipher_suites_cloudfront_tls_1_1_2016) / sizeof(cipher_suites_cloudfront_tls_1_1_2016[0]),
+    .count = s2n_array_len(cipher_suites_cloudfront_tls_1_1_2016),
     .suites = cipher_suites_cloudfront_tls_1_1_2016,
     .minimum_protocol_version = S2N_TLS11,
 };
@@ -733,7 +733,7 @@ struct s2n_cipher_suite *cipher_suites_cloudfront_tls_1_2_2018[] = {
 };
 
 const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_2_2018 = {
-    .count = sizeof(cipher_suites_cloudfront_tls_1_2_2018) / sizeof(cipher_suites_cloudfront_tls_1_2_2018[0]),
+    .count = s2n_array_len(cipher_suites_cloudfront_tls_1_2_2018),
     .suites = cipher_suites_cloudfront_tls_1_2_2018,
     .minimum_protocol_version = S2N_TLS12,
 };
@@ -746,7 +746,7 @@ struct s2n_cipher_suite *cipher_suites_cloudfront_tls_1_2_2019[] = {
 };
 
 const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_2_2019 = {
-    .count = sizeof(cipher_suites_cloudfront_tls_1_2_2019) / sizeof(cipher_suites_cloudfront_tls_1_2_2019[0]),
+    .count = s2n_array_len(cipher_suites_cloudfront_tls_1_2_2019),
     .suites = cipher_suites_cloudfront_tls_1_2_2019,
     .minimum_protocol_version = S2N_TLS12,
 };
@@ -765,7 +765,7 @@ struct s2n_cipher_suite *cipher_suites_kms_tls_1_0_2018_10[] = {
 };
 
 const struct s2n_cipher_preferences cipher_preferences_kms_tls_1_0_2018_10 = {
-        .count = sizeof(cipher_suites_kms_tls_1_0_2018_10) / sizeof(cipher_suites_kms_tls_1_0_2018_10[0]),
+        .count = s2n_array_len(cipher_suites_kms_tls_1_0_2018_10),
         .suites = cipher_suites_kms_tls_1_0_2018_10,
         .minimum_protocol_version = S2N_TLS10,
 };
@@ -786,7 +786,7 @@ struct s2n_cipher_suite *cipher_suites_kms_pq_tls_1_0_2019_06[] = {
 };
 
 const struct s2n_cipher_preferences cipher_preferences_kms_pq_tls_1_0_2019_06 = {
-        .count = sizeof(cipher_suites_kms_pq_tls_1_0_2019_06) / sizeof(cipher_suites_kms_pq_tls_1_0_2019_06[0]),
+        .count = s2n_array_len(cipher_suites_kms_pq_tls_1_0_2019_06),
         .suites = cipher_suites_kms_pq_tls_1_0_2019_06,
         .minimum_protocol_version = S2N_TLS10,
 };
@@ -821,7 +821,7 @@ struct s2n_cipher_suite *cipher_suites_kms_fips_tls_1_2_2018_10[] = {
 };
 
 const struct s2n_cipher_preferences cipher_preferences_kms_fips_tls_1_2_2018_10 = {
-        .count = sizeof(cipher_suites_kms_fips_tls_1_2_2018_10) / sizeof(cipher_suites_kms_fips_tls_1_2_2018_10[0]),
+        .count = s2n_array_len(cipher_suites_kms_fips_tls_1_2_2018_10),
         .suites = cipher_suites_kms_fips_tls_1_2_2018_10,
         .minimum_protocol_version = S2N_TLS12,
 

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -806,7 +806,7 @@ struct s2n_cipher_suite *cipher_suites_pq_sike_test_tls_1_0_2019_11[] = {
 };
 
 const struct s2n_cipher_preferences cipher_preferences_pq_sike_test_tls_1_0_2019_11 = {
-        .count = sizeof(cipher_suites_pq_sike_test_tls_1_0_2019_11) / sizeof(cipher_suites_pq_sike_test_tls_1_0_2019_11[0]),
+        .count = s2n_array_len(cipher_suites_pq_sike_test_tls_1_0_2019_11),
         .suites = cipher_suites_pq_sike_test_tls_1_0_2019_11,
         .minimum_protocol_version = S2N_TLS10,
 };

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -771,7 +771,7 @@ static struct s2n_cipher_suite *s2n_all_cipher_suites[] = {
 
 /* All supported ciphers. Exposed for integration testing. */
 const struct s2n_cipher_preferences cipher_preferences_test_all = {
-    .count = sizeof(s2n_all_cipher_suites) / sizeof(s2n_all_cipher_suites[0]),
+    .count = s2n_array_len(s2n_all_cipher_suites),
     .suites = s2n_all_cipher_suites,
     .minimum_protocol_version = S2N_SSLv3,
 };
@@ -803,7 +803,7 @@ static struct s2n_cipher_suite *s2n_all_fips_cipher_suites[] = {
 
 /* All supported FIPS ciphers. Exposed for integration testing. */
 const struct s2n_cipher_preferences cipher_preferences_test_all_fips = {
-    .count = sizeof(s2n_all_fips_cipher_suites) / sizeof(s2n_all_fips_cipher_suites[0]),
+    .count = s2n_array_len(s2n_all_fips_cipher_suites),
     .suites = s2n_all_fips_cipher_suites,
     .minimum_protocol_version = S2N_TLS10,
 };
@@ -823,7 +823,7 @@ static struct s2n_cipher_suite *s2n_all_ecdsa_cipher_suites[] = {
 
 /* All supported ECDSA cipher suites. Exposed for integration testing. */
 const struct s2n_cipher_preferences cipher_preferences_test_all_ecdsa = {
-    .count = sizeof(s2n_all_ecdsa_cipher_suites) / sizeof(s2n_all_ecdsa_cipher_suites[0]),
+    .count = s2n_array_len(s2n_all_ecdsa_cipher_suites),
     .suites = s2n_all_ecdsa_cipher_suites,
     .minimum_protocol_version = S2N_TLS10,
 };
@@ -869,7 +869,7 @@ static struct s2n_cipher_suite *s2n_ecdsa_priority_cipher_suites[] = {
 
 /* All cipher suites, but with ECDSA priority. Exposed for integration testing. */
 const struct s2n_cipher_preferences cipher_preferences_test_ecdsa_priority = {
-    .count = sizeof(s2n_ecdsa_priority_cipher_suites) / sizeof(s2n_ecdsa_priority_cipher_suites[0]),
+    .count = s2n_array_len(s2n_ecdsa_priority_cipher_suites),
     .suites = s2n_ecdsa_priority_cipher_suites,
     .minimum_protocol_version = S2N_SSLv3,
 };
@@ -881,7 +881,7 @@ static struct s2n_cipher_suite *s2n_tls13_null_key_exchange_alg_cipher_suites[] 
 };
 
 const struct s2n_cipher_preferences cipher_preferences_test_tls13_null_key_exchange_alg = {
-    .count = sizeof(s2n_tls13_null_key_exchange_alg_cipher_suites) / sizeof(s2n_tls13_null_key_exchange_alg_cipher_suites[0]),
+    .count = s2n_array_len(s2n_tls13_null_key_exchange_alg_cipher_suites),
     .suites = s2n_tls13_null_key_exchange_alg_cipher_suites,
     .minimum_protocol_version = S2N_SSLv3,
 };
@@ -889,7 +889,7 @@ const struct s2n_cipher_preferences cipher_preferences_test_tls13_null_key_excha
 /* Determines cipher suite availability and selects record algorithms */
 int s2n_cipher_suites_init(void)
 {
-    const int num_cipher_suites = sizeof(s2n_all_cipher_suites) / sizeof(s2n_all_cipher_suites[0]);
+    const int num_cipher_suites = s2n_array_len(s2n_all_cipher_suites);
     for (int i = 0; i < num_cipher_suites; i++) {
         struct s2n_cipher_suite *cur_suite = s2n_all_cipher_suites[i];
         cur_suite->available = 0;

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -592,7 +592,7 @@ const char *s2n_connection_get_handshake_type_name(struct s2n_connection *conn)
     char *p = handshake_type_str[handshake_type];
     char *end = p + sizeof(handshake_type_str[0]);
 
-    for (int i = 0; i < sizeof(handshake_type_names) / sizeof(handshake_type_names[0]); ++i) {
+    for (int i = 0; i < s2n_array_len(handshake_type_names); ++i) {
         if (handshake_type & (1 << i)) {
             p = s2n_strcpy(p, end, handshake_type_names[i]);
         }


### PR DESCRIPTION
**Issue #1259** 

**Description of changes:** 
Fix up some merge conflicts that occurred between @bt3gl original commits and the current state of the repository.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
