### PR TITLE
fix hash availability return value

### DIFF
--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -76,29 +76,25 @@ int s2n_hash_block_size(s2n_hash_algorithm alg, uint64_t *block_size)
     return 0;
 }
 
-/* Return 1 if hash algorithm is available, 0 otherwise. */
-int s2n_hash_is_available(s2n_hash_algorithm alg)
+/* Return true if hash algorithm is available, false otherwise. */
+bool s2n_hash_is_available(s2n_hash_algorithm alg)
 {
-    int is_available = 0;
     switch (alg) {
     case S2N_HASH_MD5:
     case S2N_HASH_MD5_SHA1:
-        /* Set is_available to 0 if in FIPS mode, as MD5 algs are not available in FIPS mode. */
-        is_available = !s2n_is_in_fips_mode();
-        break;
+        /* return false if in FIPS mode, as MD5 algs are not available in FIPS mode. */
+        return !s2n_is_in_fips_mode();
     case S2N_HASH_NONE:
     case S2N_HASH_SHA1:
     case S2N_HASH_SHA224:
     case S2N_HASH_SHA256:
     case S2N_HASH_SHA384:
     case S2N_HASH_SHA512:
-        is_available = 1;
-        break;
-    default:
-        S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
+        return true;
+    case S2N_HASH_SENTINEL:
+        return false;
     }
-
-    return is_available;
+    return false;
 }
 
 int s2n_hash_is_ready_for_input(struct s2n_hash_state *state)

--- a/crypto/s2n_hash.h
+++ b/crypto/s2n_hash.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #include <openssl/md5.h>
 #include <openssl/sha.h>
@@ -88,7 +89,7 @@ struct s2n_hash {
 
 extern int s2n_hash_digest_size(s2n_hash_algorithm alg, uint8_t *out);
 extern int s2n_hash_block_size(s2n_hash_algorithm alg, uint64_t *block_size);
-extern int s2n_hash_is_available(s2n_hash_algorithm alg);
+extern bool s2n_hash_is_available(s2n_hash_algorithm alg);
 extern int s2n_hash_is_ready_for_input(struct s2n_hash_state *state);
 extern int s2n_hash_new(struct s2n_hash_state *state);
 extern int s2n_hash_allow_md5_for_fips(struct s2n_hash_state *state);


### PR DESCRIPTION
**Issue # (if available):**  #715

**Description of changes:**  In s2n_hash_is_available, instead of logging error and returning -1, return 0 if requested hash algo is not supported.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
