### PR TITLE
Add an s2n_set module.

### DIFF
--- a/crypto/s2n_certificate.c
+++ b/crypto/s2n_certificate.c
@@ -213,7 +213,7 @@ int s2n_cert_chain_and_key_load_sans(struct s2n_cert_chain_and_key *chain_and_ke
             /* Decoding isn't necessary here since a DNS SAN name is ASCII(type V_ASN1_IA5STRING) */
             unsigned char *san_str = san_name->d.dNSName->data;
             const size_t san_str_len = san_name->d.dNSName->length;
-            struct s2n_blob *san_blob = s2n_array_insert(chain_and_key->san_names, s2n_array_num_elements(chain_and_key->san_names));
+            struct s2n_blob *san_blob = s2n_array_pushback(chain_and_key->san_names);
             if (!san_blob) {
                 GENERAL_NAMES_free(san_names);
                 S2N_ERROR(S2N_ERR_NULL_SANS);
@@ -277,7 +277,7 @@ int s2n_cert_chain_and_key_load_cns(struct s2n_cert_chain_and_key *chain_and_key
             /* We still need to free memory here see https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-7521 */
             OPENSSL_free(utf8_str);
         } else {
-            struct s2n_blob *cn_name = s2n_array_insert(chain_and_key->cn_names, s2n_array_num_elements(chain_and_key->cn_names));
+            struct s2n_blob *cn_name = s2n_array_pushback(chain_and_key->cn_names);
             if (cn_name == NULL) {
                 OPENSSL_free(utf8_str);
                 S2N_ERROR(S2N_ERR_NULL_CN_NAME);

--- a/tests/unit/s2n_array_test.c
+++ b/tests/unit/s2n_array_test.c
@@ -23,38 +23,23 @@ struct array_element {
     char second;
 };
 
-int s2n_binary_search_comparator(void *a, void *b)
-{
-    if (((struct array_element *) a)->first > ((struct array_element *) b)->first) {
-        return 1;
-    } else if ((((struct array_element *) a)->first < ((struct array_element *) b)->first)) {
-        return -1;
-    } else {
-        return 0;
-    }
-}
+#define NUM_OF_ELEMENTS 17
 
 int main(int argc, char **argv)
 {
     struct s2n_array *array;
-    int num_of_elements = 17;
     int element_size = sizeof(struct array_element);
 
     BEGIN_TEST();
+    struct array_element elements[NUM_OF_ELEMENTS] = {0};
 
-    struct s2n_blob mem;
-    GUARD(s2n_alloc(&mem, sizeof(struct array_element) * num_of_elements));
-    GUARD(s2n_blob_zero(&mem));
-
-    struct array_element *elements = (struct  array_element *) (void *) mem.data;
-
-    for (int i = 0; i < num_of_elements; i++) {
+    for (int i = 0; i < NUM_OF_ELEMENTS; i++) {
         elements[i].first = i;
         elements[i].second = 'a' + i;
     }
 
     /* Verify add and get elements with null array */
-    EXPECT_NULL(s2n_array_add(NULL));
+    EXPECT_NULL(s2n_array_pushback(NULL));
     EXPECT_NULL(s2n_array_get(NULL, 0));
 
     /* Verify freeing null array */
@@ -68,7 +53,7 @@ int main(int argc, char **argv)
     EXPECT_EQUAL(array->element_size, element_size);
 
     /* Add an element */
-    struct array_element *element = s2n_array_add(array);
+    struct array_element *element = s2n_array_pushback(array);
     element->first = elements[0].first;
     element->second = elements[0].second;
 
@@ -86,8 +71,8 @@ int main(int argc, char **argv)
     EXPECT_NULL(second_element);
 
     /* Add more than 16 elements */
-    for (int i = 1; i < num_of_elements; i++) {
-        struct array_element *elem = s2n_array_add(array);
+    for (int i = 1; i < NUM_OF_ELEMENTS; i++) {
+        struct array_element *elem = s2n_array_pushback(array);
         elem->first = elements[i].first;
         elem->second = elements[i].second;
     }
@@ -96,7 +81,7 @@ int main(int argc, char **argv)
     EXPECT_EQUAL(array->capacity, 32);
     EXPECT_EQUAL(array->num_of_elements, 17);
     EXPECT_EQUAL(array->element_size, element_size);
-    EXPECT_SUCCESS(memcmp(array->mem.data, mem.data, num_of_elements * element_size));
+    EXPECT_SUCCESS(memcmp(array->mem.data, elements, NUM_OF_ELEMENTS * element_size));
 
     /* Insert element at given index */
     struct array_element *insert_element = s2n_array_insert(array, 16);
@@ -129,26 +114,8 @@ int main(int argc, char **argv)
     EXPECT_EQUAL(after_removed_element->first, elements[1].first);
     EXPECT_EQUAL(after_removed_element->second, elements[1].second);
 
-    /* Validate struct with same member value already exists using binary search */
-    struct array_element find_element = { 10 , 'a' + 10};
-    uint32_t index;
-    EXPECT_FAILURE(s2n_array_binary_search(array,
-                                           &find_element,
-                                           s2n_binary_search_comparator,
-                                           &index));
-
-    /* Find insert index of a struct based on increasing order of one of it's members */
-    struct array_element add_largest_element = { 25 , 'a' + 25};
-    EXPECT_SUCCESS(s2n_array_binary_search(array,
-                                           &add_largest_element,
-                                           s2n_binary_search_comparator,
-                                           &index));
-    EXPECT_EQUAL(index, array->num_of_elements);
-
     /* Done with the array, make sure it can be freed */
     EXPECT_SUCCESS(s2n_array_free(array));
-
-    EXPECT_SUCCESS(s2n_free(&mem));
 
     /* Check what happens if there is an integer overflow */
     /* 0xF00000F0 * 16 = 3840 (in 32 bit arithmatic) */

--- a/tests/unit/s2n_session_ticket_test.c
+++ b/tests/unit/s2n_session_ticket_test.c
@@ -1,4 +1,4 @@
-/*
+ /*
  * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
@@ -490,8 +490,8 @@ int main(int argc, char **argv)
         EXPECT_TRUE(IS_ISSUING_NEW_SESSION_TICKET(server_conn->handshake.handshake_type));
 
         /* Verify that the server has only the unexpired key */
-        EXPECT_BYTEARRAY_EQUAL(s2n_array_get(server_config->ticket_keys, 0), ticket_key_name2, strlen((char *)ticket_key_name2));
-        EXPECT_EQUAL(server_config->ticket_keys->num_of_elements, 1);
+        EXPECT_BYTEARRAY_EQUAL(s2n_set_get(server_config->ticket_keys, 0), ticket_key_name2, strlen((char *)ticket_key_name2));
+        EXPECT_EQUAL(s2n_set_size(server_config->ticket_keys), 1);
 
         /* Verify that the client received NST */
         serialized_session_state_length = s2n_connection_get_session_length(client_conn);
@@ -678,11 +678,11 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(s2n_errno, S2N_ELEMENT_ALREADY_IN_ARRAY);
 
         /* Verify that the config has only one unexpired key */
-        EXPECT_BYTEARRAY_EQUAL(s2n_array_get(server_config->ticket_keys, 0), ticket_key_name3, strlen((char *)ticket_key_name3));
-        EXPECT_EQUAL(server_config->ticket_keys->num_of_elements, 1);
+        EXPECT_BYTEARRAY_EQUAL(s2n_set_get(server_config->ticket_keys, 0), ticket_key_name3, strlen((char *)ticket_key_name3));
+        EXPECT_EQUAL(s2n_set_size(server_config->ticket_keys), 1);
 
         /* Verify that the total number of key hashes is three */
-        EXPECT_EQUAL(server_config->ticket_key_hashes->num_of_elements, 3);
+        EXPECT_EQUAL(s2n_set_size(server_config->ticket_key_hashes), 3);
 
         EXPECT_SUCCESS(s2n_config_free(server_config));
     }
@@ -926,9 +926,9 @@ int main(int argc, char **argv)
         EXPECT_BYTEARRAY_EQUAL(serialized_session_state + S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES, ticket_key_name2, strlen((char *)ticket_key_name2));
 
         /* Verify that the keys are stored from oldest to newest */
-        EXPECT_BYTEARRAY_EQUAL(((struct s2n_ticket_key *)s2n_array_get(server_config->ticket_keys, 0))->key_name, ticket_key_name2, strlen((char *)ticket_key_name2));
-        EXPECT_BYTEARRAY_EQUAL(((struct s2n_ticket_key *)s2n_array_get(server_config->ticket_keys, 1))->key_name, ticket_key_name1, strlen((char *)ticket_key_name1));
-        EXPECT_BYTEARRAY_EQUAL(((struct s2n_ticket_key *)s2n_array_get(server_config->ticket_keys, 2))->key_name, ticket_key_name3, strlen((char *)ticket_key_name3));
+        EXPECT_BYTEARRAY_EQUAL(((struct s2n_ticket_key *)s2n_set_get(server_config->ticket_keys, 0))->key_name, ticket_key_name2, strlen((char *)ticket_key_name2));
+        EXPECT_BYTEARRAY_EQUAL(((struct s2n_ticket_key *)s2n_set_get(server_config->ticket_keys, 1))->key_name, ticket_key_name1, strlen((char *)ticket_key_name1));
+        EXPECT_BYTEARRAY_EQUAL(((struct s2n_ticket_key *)s2n_set_get(server_config->ticket_keys, 2))->key_name, ticket_key_name3, strlen((char *)ticket_key_name3));
 
         EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
 

--- a/tests/unit/s2n_set_test.c
+++ b/tests/unit/s2n_set_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ struct array_element {
     char second;
 };
 
-int s2n_binary_search_comparator(const void *pa, const void *pb)
+static int s2n_binary_search_comparator(const void *pa, const void *pb)
 {
     const struct array_element* a = (const struct array_element *) pa;
     const struct array_element* b = (const struct array_element *) pb;

--- a/tests/unit/s2n_set_test.c
+++ b/tests/unit/s2n_set_test.c
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#include "s2n_test.h"
+#include "utils/s2n_blob.h"
+#include "utils/s2n_mem.h"
+#include "utils/s2n_safety.h"
+#include "utils/s2n_array.h"
+#include "utils/s2n_set.h"
+
+struct array_element {
+    int first;
+    char second;
+};
+
+int s2n_binary_search_comparator(const void *pa, const void *pb)
+{
+    const struct array_element* a = (const struct array_element *) pa;
+    const struct array_element* b = (const struct array_element *) pb;
+  
+    if (a->first > b->first) {
+        return 1;
+    } else if (a->first < b->first) {
+        return -1;
+    } else {
+        return 0;
+    }
+}
+
+int main(int argc, char **argv)
+{
+    const int element_size = sizeof(struct array_element);
+
+    BEGIN_TEST();
+    EXPECT_NULL(s2n_set_new(element_size, NULL));
+
+    struct s2n_set* set = NULL;
+    EXPECT_NOT_NULL(set = s2n_set_new(element_size, s2n_binary_search_comparator));
+    EXPECT_EQUAL(s2n_set_size(set), 0);
+    EXPECT_FAILURE(s2n_set_remove(set, 0));
+
+    struct array_element e1 = {.first = 1, .second = 'a'};
+    EXPECT_SUCCESS(s2n_set_add(set, &e1));
+    EXPECT_EQUAL(s2n_set_size(set), 1);
+    struct array_element* ep = NULL;
+    EXPECT_NOT_NULL(ep = s2n_set_get(set, 0));
+    EXPECT_EQUAL(ep->first, 1);
+    EXPECT_EQUAL(ep->second, 'a');
+    EXPECT_NULL(s2n_set_get(set,1));
+
+    /* Insert an element that will go after */
+    struct array_element e2 = {.first = 10, .second = 'b'};
+    EXPECT_SUCCESS(s2n_set_add(set, &e2));
+    EXPECT_EQUAL(s2n_set_size(set), 2);
+    EXPECT_NOT_NULL(ep = s2n_set_get(set, 0));
+    EXPECT_EQUAL(ep->first, 1);
+    EXPECT_EQUAL(ep->second, 'a');
+    EXPECT_NOT_NULL(ep = s2n_set_get(set, 1));
+    EXPECT_EQUAL(ep->first, 10);
+    EXPECT_EQUAL(ep->second, 'b');
+    EXPECT_NULL(s2n_set_get(set,2));
+
+    /* insert an element to the middle */
+    struct array_element e3 = {.first = 5, .second = 'c'};
+    EXPECT_SUCCESS(s2n_set_add(set, &e3));
+    EXPECT_EQUAL(s2n_set_size(set), 3);
+    EXPECT_NOT_NULL(ep = s2n_set_get(set, 0));
+    EXPECT_EQUAL(ep->first, 1);
+    EXPECT_EQUAL(ep->second, 'a');
+    EXPECT_NOT_NULL(ep = s2n_set_get(set, 1));
+    EXPECT_EQUAL(ep->first, 5);
+    EXPECT_EQUAL(ep->second, 'c');
+    EXPECT_NOT_NULL(ep = s2n_set_get(set, 2));
+    EXPECT_EQUAL(ep->first, 10);
+    EXPECT_EQUAL(ep->second, 'b');
+    EXPECT_NULL(s2n_set_get(set,3));
+
+    /* insert an element at the front */
+    struct array_element e4 = {.first = 0, .second = 'd'};
+    EXPECT_SUCCESS(s2n_set_add(set, &e4));
+    EXPECT_EQUAL(s2n_set_size(set), 4);
+    EXPECT_NOT_NULL(ep = s2n_set_get(set, 0));
+    EXPECT_EQUAL(ep->first, 0);
+    EXPECT_EQUAL(ep->second, 'd');
+    EXPECT_NOT_NULL(ep = s2n_set_get(set, 1));
+    EXPECT_EQUAL(ep->first, 1);
+    EXPECT_EQUAL(ep->second, 'a');
+    EXPECT_NOT_NULL(ep = s2n_set_get(set, 2));
+    EXPECT_EQUAL(ep->first, 5);
+    EXPECT_EQUAL(ep->second, 'c');
+    EXPECT_NOT_NULL(ep = s2n_set_get(set, 3));
+    EXPECT_EQUAL(ep->first, 10);
+    EXPECT_EQUAL(ep->second, 'b');
+    EXPECT_NULL(s2n_set_get(set,4));
+
+    /* Try removing non-existant elements */
+    EXPECT_FAILURE(s2n_set_remove(set, 4));
+    EXPECT_EQUAL(s2n_set_size(set), 4);
+    EXPECT_NOT_NULL(ep = s2n_set_get(set, 0));
+    EXPECT_EQUAL(ep->first, 0);
+    EXPECT_EQUAL(ep->second, 'd');
+    EXPECT_NOT_NULL(ep = s2n_set_get(set, 1));
+    EXPECT_EQUAL(ep->first, 1);
+    EXPECT_EQUAL(ep->second, 'a');
+    EXPECT_NOT_NULL(ep = s2n_set_get(set, 2));
+    EXPECT_EQUAL(ep->first, 5);
+    EXPECT_EQUAL(ep->second, 'c');
+    EXPECT_NOT_NULL(ep = s2n_set_get(set, 3));
+    EXPECT_EQUAL(ep->first, 10);
+    EXPECT_EQUAL(ep->second, 'b');
+    EXPECT_NULL(s2n_set_get(set,4));
+
+    /* Successfully remove an element */
+    EXPECT_SUCCESS(s2n_set_remove(set, 1));
+    EXPECT_EQUAL(s2n_set_size(set), 3);
+    EXPECT_NOT_NULL(ep = s2n_set_get(set, 0));
+    EXPECT_EQUAL(ep->first, 0);
+    EXPECT_EQUAL(ep->second, 'd');
+    EXPECT_NOT_NULL(ep = s2n_set_get(set, 1));
+    EXPECT_EQUAL(ep->first, 5);
+    EXPECT_EQUAL(ep->second, 'c');
+    EXPECT_NOT_NULL(ep = s2n_set_get(set, 2));
+    EXPECT_EQUAL(ep->first, 10);
+    EXPECT_EQUAL(ep->second, 'b');
+    EXPECT_NULL(s2n_set_get(set,3));
+
+    /* insert an element that already exists */
+    struct array_element e5 = {.first = 5, .second = 'e'};
+    EXPECT_FAILURE(s2n_set_add(set, &e5));
+    EXPECT_EQUAL(s2n_set_size(set), 3);
+    EXPECT_NOT_NULL(ep = s2n_set_get(set, 0));
+    EXPECT_EQUAL(ep->first, 0);
+    EXPECT_EQUAL(ep->second, 'd');
+    EXPECT_NOT_NULL(ep = s2n_set_get(set, 1));
+    EXPECT_EQUAL(ep->first, 5);
+    EXPECT_EQUAL(ep->second, 'c');
+    EXPECT_NOT_NULL(ep = s2n_set_get(set, 2));
+    EXPECT_EQUAL(ep->first, 10);
+    EXPECT_EQUAL(ep->second, 'b');
+    EXPECT_NULL(s2n_set_get(set,3));
+
+    /* Free the set to avoid memory leak */
+    EXPECT_SUCCESS(s2n_set_free(set));
+
+    /* Check what happens if there is an integer overflow */
+    /* 0xF00000F0 * 16 = 3840 (in 32 bit arithmatic) */
+    EXPECT_NULL(s2n_set_new(0xF00000F0, s2n_binary_search_comparator));
+    EXPECT_NOT_NULL(set = s2n_set_new(240, s2n_binary_search_comparator));
+    EXPECT_SUCCESS(s2n_set_free(set));
+    END_TEST();
+}

--- a/tests/unit/s2n_tls13_support_test.c
+++ b/tests/unit/s2n_tls13_support_test.c
@@ -64,7 +64,7 @@ int main(int argc, char **argv)
         struct s2n_array *extensions = s2n_array_new(sizeof(struct s2n_client_hello_parsed_extension*));
         for (int i=0; i < sizeof(tls13_extensions) / sizeof(uint8_t); i++) {
             struct s2n_client_hello_parsed_extension *extension;
-            EXPECT_NOT_NULL(extension = s2n_array_add(extensions));
+            EXPECT_NOT_NULL(extension = s2n_array_pushback(extensions));
 
             extension->extension = extension_data.blob;
             extension->extension_type = tls13_extensions[i];
@@ -118,7 +118,7 @@ int main(int argc, char **argv)
 
         struct s2n_array *extensions = s2n_array_new(sizeof(struct s2n_client_hello_parsed_extension*));
         struct s2n_client_hello_parsed_extension *extension;
-        EXPECT_NOT_NULL(extension = s2n_array_add(extensions));
+        EXPECT_NOT_NULL(extension = s2n_array_pushback(extensions));
 
         for (int i=0; i < sizeof(new_extensions) / sizeof(uint8_t); i++) {
             EXPECT_SUCCESS(s2n_stuffer_wipe(&extension_data));

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -259,7 +259,7 @@ static int s2n_populate_client_hello_extensions(struct s2n_client_hello *ch)
             continue;
         }
 
-        struct s2n_client_hello_parsed_extension *parsed_extension = s2n_array_add(ch->parsed_extensions);
+        struct s2n_client_hello_parsed_extension *parsed_extension = s2n_array_pushback(ch->parsed_extensions);
         notnull_check(parsed_extension);
 
         parsed_extension->extension_type = ext_type;

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -316,14 +316,28 @@ struct s2n_config *s2n_config_new(void)
     return new_config;
 }
 
+static int s2n_config_store_ticket_key_comparator(const void *a, const void *b)
+{
+    if (((const struct s2n_ticket_key *) a)->intro_timestamp >= ((const struct s2n_ticket_key *) b)->intro_timestamp) {
+        return S2N_GREATER_OR_EQUAL;
+    } else {
+        return S2N_LESS_THAN;
+    }
+}
+
+static int s2n_verify_unique_ticket_key_comparator(const void *a, const void *b)
+{
+    return memcmp(a, b, SHA_DIGEST_LENGTH);
+}
+
 int s2n_config_init_session_ticket_keys(struct s2n_config *config)
 {
     if (config->ticket_keys == NULL) {
-        notnull_check(config->ticket_keys = s2n_array_new(sizeof(struct s2n_ticket_key)));
+      notnull_check(config->ticket_keys = s2n_set_new(sizeof(struct s2n_ticket_key), s2n_config_store_ticket_key_comparator));
     }
 
     if (config->ticket_key_hashes == NULL) {
-        notnull_check(config->ticket_key_hashes = s2n_array_new(SHA_DIGEST_LENGTH));
+      notnull_check(config->ticket_key_hashes = s2n_set_new(SHA_DIGEST_LENGTH, s2n_verify_unique_ticket_key_comparator));
     }
 
     return 0;
@@ -332,11 +346,11 @@ int s2n_config_init_session_ticket_keys(struct s2n_config *config)
 int s2n_config_free_session_ticket_keys(struct s2n_config *config)
 {
     if (config->ticket_keys != NULL) {
-        GUARD(s2n_array_free_p(&config->ticket_keys));
+        GUARD(s2n_set_free_p(&config->ticket_keys));
     }
 
     if (config->ticket_key_hashes != NULL) {
-        GUARD(s2n_array_free_p(&config->ticket_key_hashes));
+        GUARD(s2n_set_free_p(&config->ticket_key_hashes));
     }
 
     return 0;
@@ -722,11 +736,6 @@ int s2n_config_set_ticket_decrypt_key_lifetime(struct s2n_config *config,
     return 0;
 }
 
-int s2n_verify_unique_ticket_key_comparator(void *a, void *b)
-{
-    return memcmp((uint8_t *) a, (uint8_t *) b, SHA_DIGEST_LENGTH);
-}
-
 int s2n_config_add_ticket_crypto_key(struct s2n_config *config,
                                      const uint8_t *name, uint32_t name_len,
                                      uint8_t *key, uint32_t key_len,
@@ -744,7 +753,7 @@ int s2n_config_add_ticket_crypto_key(struct s2n_config *config,
 
     S2N_ERROR_IF(key_len == 0, S2N_ERR_INVALID_TICKET_KEY_LENGTH);
 
-    S2N_ERROR_IF(config->ticket_keys->num_of_elements >= S2N_MAX_TICKET_KEYS, S2N_ERR_TICKET_KEY_LIMIT);
+    S2N_ERROR_IF(config->ticket_keys->data->num_of_elements >= S2N_MAX_TICKET_KEYS, S2N_ERR_TICKET_KEY_LIMIT);
 
     S2N_ERROR_IF(name_len == 0 || name_len > S2N_TICKET_KEY_NAME_LEN || s2n_find_ticket_key(config, name), S2N_ERR_INVALID_TICKET_KEY_NAME_OR_NAME_LENGTH);
 
@@ -772,15 +781,13 @@ int s2n_config_add_ticket_crypto_key(struct s2n_config *config,
     GUARD(s2n_hash_update(&hash, out_key.data, out_key.size));
     GUARD(s2n_hash_digest(&hash, hash_output, SHA_DIGEST_LENGTH));
 
-    if (config->ticket_key_hashes->num_of_elements >= S2N_MAX_TICKET_KEY_HASHES) {
-        GUARD(s2n_array_free_p(&config->ticket_key_hashes));
-        notnull_check(config->ticket_key_hashes = s2n_array_new(SHA_DIGEST_LENGTH));
+    if (s2n_set_size(config->ticket_key_hashes) >= S2N_MAX_TICKET_KEY_HASHES) {
+        GUARD(s2n_set_free_p(&config->ticket_key_hashes));
+        notnull_check(config->ticket_key_hashes = s2n_set_new(SHA_DIGEST_LENGTH, s2n_verify_unique_ticket_key_comparator));
     }
 
     /* Insert hash key into a sorted array at known index */
-    struct uint8_t *hash_element = 0;
-    GUARD_NONNULL(hash_element = s2n_array_insert_sorted(config->ticket_key_hashes, hash_output, s2n_verify_unique_ticket_key_comparator));
-    memcpy_check(hash_element, hash_output, SHA_DIGEST_LENGTH);
+    GUARD(s2n_set_add(config->ticket_key_hashes, hash_output));
 
     memcpy_check(session_ticket_key->key_name, name, S2N_TICKET_KEY_NAME_LEN);
     memcpy_check(session_ticket_key->aes_key, out_key.data, S2N_AES256_KEY_LEN);

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -753,7 +753,7 @@ int s2n_config_add_ticket_crypto_key(struct s2n_config *config,
 
     S2N_ERROR_IF(key_len == 0, S2N_ERR_INVALID_TICKET_KEY_LENGTH);
 
-    S2N_ERROR_IF(config->ticket_keys->data->num_of_elements >= S2N_MAX_TICKET_KEYS, S2N_ERR_TICKET_KEY_LIMIT);
+    S2N_ERROR_IF(s2n_set_size(config->ticket_keys) >= S2N_MAX_TICKET_KEYS, S2N_ERR_TICKET_KEY_LIMIT);
 
     S2N_ERROR_IF(name_len == 0 || name_len > S2N_TICKET_KEY_NAME_LEN || s2n_find_ticket_key(config, name), S2N_ERR_INVALID_TICKET_KEY_NAME_OR_NAME_LENGTH);
 

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -19,6 +19,7 @@
 #include "crypto/s2n_dhe.h"
 
 #include "utils/s2n_blob.h"
+#include "utils/s2n_set.h"
 #include "api/s2n.h"
 
 #include "tls/s2n_x509_validator.h"
@@ -53,8 +54,8 @@ struct s2n_config {
     uint64_t session_state_lifetime_in_nanos;
 
     uint8_t use_tickets;
-    struct s2n_array *ticket_keys;
-    struct s2n_array *ticket_key_hashes;
+    struct s2n_set *ticket_keys;
+    struct s2n_set *ticket_key_hashes;
     uint64_t encrypt_decrypt_key_lifetime_in_nanos;
     uint64_t decrypt_key_lifetime_in_nanos;
 

--- a/utils/s2n_array.c
+++ b/utils/s2n_array.c
@@ -55,7 +55,7 @@ struct s2n_array *s2n_array_new(size_t element_size)
     return array;
 }
 
-void *s2n_array_add(struct s2n_array *array)
+void *s2n_array_pushback(struct s2n_array *array)
 {
     notnull_check_ptr(array);
     return s2n_array_insert(array, array->num_of_elements);
@@ -66,6 +66,14 @@ void *s2n_array_get(struct s2n_array *array, uint32_t index)
     notnull_check_ptr(array);
     S2N_ERROR_IF_PTR(index >= array->num_of_elements, S2N_ERR_ARRAY_INDEX_OOB);
     return array->mem.data + array->element_size * index;
+}
+
+int s2n_array_insert_and_copy(struct s2n_array *array, void* element, uint32_t index)
+{
+  void* insert_location = NULL;
+  GUARD_NONNULL(insert_location = s2n_array_insert(array, index));
+  memcpy_check(insert_location, element, array->element_size);
+  return S2N_SUCCESS;
 }
 
 void *s2n_array_insert(struct s2n_array *array, uint32_t index)
@@ -135,57 +143,4 @@ int s2n_array_free_p(struct s2n_array **parray)
 int s2n_array_free(struct s2n_array *array)
 {
     return s2n_array_free_p(&array);
-}
-
-/* Sets "out" to the index at which the element should be inserted.
- * Returns an error if the element already exists */
-int s2n_array_binary_search(struct s2n_array *array, void *element, int (*comparator)(void*, void*), uint32_t* out)
-{
-    notnull_check(array);
-    notnull_check(element);
-    notnull_check(out);
-    if (array->num_of_elements == 0) {
-        *out = 0;
-        return S2N_SUCCESS;
-    }
-
-    if (array->num_of_elements == 1) {
-        void* array_element = NULL;
-        GUARD_NONNULL(array_element = s2n_array_get(array, 0));
-        int m = comparator(array_element, element);
-        S2N_ERROR_IF(m == 0, S2N_ELEMENT_ALREADY_IN_ARRAY);
-        if (m > 0) {
-            *out = 0;
-        } else {
-            *out = 1;
-        }
-        return S2N_SUCCESS;
-    }
-
-    uint32_t low = 0;
-    uint32_t top = array->num_of_elements - 1;
-
-    while (low <= top) {
-        int mid = low + ((top - low) / 2);
-        void* array_element = NULL;
-        GUARD_NONNULL(array_element = s2n_array_get(array, mid));
-        int m = comparator(array_element, element);
-
-        S2N_ERROR_IF(m == 0, S2N_ELEMENT_ALREADY_IN_ARRAY);
-        if (m > 0) {
-            top = mid - 1;
-        } else {
-            low = mid + 1;
-        }
-    }
-
-    *out = low;
-    return S2N_SUCCESS;
-}
-
-void *s2n_array_insert_sorted(struct s2n_array *array, void *element, int (*comparator)(void*, void*))
-{
-    uint32_t index;
-    GUARD_PTR(s2n_array_binary_search(array, element, comparator, &index));
-    return s2n_array_insert(array, index);
 }

--- a/utils/s2n_array.c
+++ b/utils/s2n_array.c
@@ -70,10 +70,10 @@ void *s2n_array_get(struct s2n_array *array, uint32_t index)
 
 int s2n_array_insert_and_copy(struct s2n_array *array, void* element, uint32_t index)
 {
-  void* insert_location = NULL;
-  GUARD_NONNULL(insert_location = s2n_array_insert(array, index));
-  memcpy_check(insert_location, element, array->element_size);
-  return S2N_SUCCESS;
+    void* insert_location = NULL;
+    GUARD_NONNULL(insert_location = s2n_array_insert(array, index));
+    memcpy_check(insert_location, element, array->element_size);
+    return S2N_SUCCESS;
 }
 
 void *s2n_array_insert(struct s2n_array *array, uint32_t index)

--- a/utils/s2n_array.h
+++ b/utils/s2n_array.h
@@ -35,11 +35,10 @@ struct s2n_array {
 #define S2N_ELEMENT_ALREADY_IN_ARRAY -1
 
 extern struct s2n_array *s2n_array_new(size_t element_size);
-extern void *s2n_array_add(struct s2n_array *array);
+extern void *s2n_array_pushback(struct s2n_array *array);
 extern void *s2n_array_get(struct s2n_array *array, uint32_t index);
 extern void *s2n_array_insert(struct s2n_array *array, uint32_t index);
 extern int s2n_array_remove(struct s2n_array *array, uint32_t index);
 extern int s2n_array_free_p(struct s2n_array **parray);
 extern int s2n_array_free(struct s2n_array *array);
-extern int s2n_array_binary_search(struct s2n_array *array, void *element, int (*comparator)(void*, void*), uint32_t* out);
-extern void *s2n_array_insert_sorted(struct s2n_array *array, void *element, int (*comparator)(void*, void*));
+extern int s2n_array_insert_and_copy(struct s2n_array *array, void* element, uint32_t index);

--- a/utils/s2n_set.c
+++ b/utils/s2n_set.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#include "utils/s2n_array.h"
+#include "utils/s2n_blob.h"
+#include "utils/s2n_mem.h"
+#include "utils/s2n_safety.h"
+#include "utils/s2n_set.h"
+
+#define S2N_INITIAL_ARRAY_SIZE 16
+
+/* Sets "out" to the index at which the element should be inserted.
+ * Returns an error if the element already exists */
+int s2n_set_binary_search(struct s2n_set *set, void *element, uint32_t* out)
+{
+    notnull_check(set);
+    notnull_check(element);
+    notnull_check(out);
+    struct s2n_array *array = set->data;
+    int (*comparator)(const void*, const void*) = set->comparator;
+    
+    if (array->num_of_elements == 0) {
+        *out = 0;
+        return S2N_SUCCESS;
+    }
+
+    /* Use 64 bit ints to avoid possibility of overflow */
+    int64_t low = 0;
+    int64_t top = array->num_of_elements - 1;
+
+    while (low <= top) {
+        int64_t mid = low + ((top - low) / 2);
+        void* array_element = NULL;
+        GUARD_NONNULL(array_element = s2n_array_get(array, mid));
+        int m = comparator(array_element, element);
+
+        S2N_ERROR_IF(m == 0, S2N_ELEMENT_ALREADY_IN_ARRAY);
+        if (m > 0) {
+            top = mid - 1;
+        } else {
+            low = mid + 1;
+        }
+    }
+
+    *out = low;
+    return S2N_SUCCESS;
+}
+
+struct s2n_set *s2n_set_new(size_t element_size, int (*comparator)(const void*, const void*))
+{
+    notnull_check_ptr(comparator);
+    struct s2n_blob mem = {0};
+    GUARD_PTR(s2n_alloc(&mem, sizeof(struct s2n_set)));
+    struct s2n_set *set = (void *) mem.data;
+    *set = (struct s2n_set) {.data = s2n_array_new(element_size), .comparator = comparator};
+    if(set->data == NULL) {
+        s2n_free(&mem);
+        return NULL;
+    }
+    return set;
+}
+
+int s2n_set_add(struct s2n_set *set, void *element)
+{
+    uint32_t index;
+    GUARD(s2n_set_binary_search(set, element, &index));
+    GUARD(s2n_array_insert_and_copy(set->data, element, index));
+    return S2N_SUCCESS;
+}
+
+void *s2n_set_get(struct s2n_set *set, uint32_t index)
+{
+    return s2n_array_get(set->data, index);
+}
+
+int s2n_set_remove(struct s2n_set *set, uint32_t index)
+{
+    return s2n_array_remove(set->data, index);
+}
+    
+int s2n_set_free_p(struct s2n_set **pset)
+{
+    notnull_check(pset);
+    struct s2n_set *set = *pset;
+
+    notnull_check(set);
+    GUARD(s2n_array_free(set->data));
+    GUARD(s2n_free_object((uint8_t **)pset, sizeof(struct s2n_set)));
+
+    return S2N_SUCCESS;
+
+}
+
+int s2n_set_free(struct s2n_set *set)
+{
+    return s2n_set_free_p(&set);
+}
+
+
+int s2n_set_size(struct s2n_set *set)
+{
+    return set->data->num_of_elements;
+}

--- a/utils/s2n_set.c
+++ b/utils/s2n_set.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 
 /* Sets "out" to the index at which the element should be inserted.
  * Returns an error if the element already exists */
-int s2n_set_binary_search(struct s2n_set *set, void *element, uint32_t* out)
+static int s2n_set_binary_search(struct s2n_set *set, void *element, uint32_t* out)
 {
     notnull_check(set);
     notnull_check(element);

--- a/utils/s2n_set.h
+++ b/utils/s2n_set.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#pragma once
+
+#include <s2n.h>
+#include "utils/s2n_array.h"
+
+struct s2n_set {
+  struct s2n_array *data;
+  int (*comparator)(const void*, const void*);
+};
+
+extern struct s2n_set *s2n_set_new(size_t element_size, int (*comparator)(const void*, const void*));
+extern int s2n_set_add(struct s2n_set *set, void *element);
+extern void *s2n_set_get(struct s2n_set *set, uint32_t index);
+extern int s2n_set_remove(struct s2n_set *set, uint32_t index);
+extern int s2n_set_free_p(struct s2n_set **pset);
+extern int s2n_set_free(struct s2n_set *set);
+extern int s2n_set_size(struct s2n_set *set);


### PR DESCRIPTION
**Issue # (if available):** 

**Description of changes:** 
s2n_array has two orthogonal use-cases: as an array list, and as a sorted set.  Create separate s2n_set module to represent the sorted-set use case.

1. Create a new `struct s2n_set` class to represent a sorted set
2. Make the comparator a function of the set, not the `insert` operation.  This ensures that we always use the same comparator on a given set
3. Make the inputs to the comparator `const`.
4. Rename `s2n_array_add` to the more descriptive `s2n_array_pushback`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
