### PR TITLE
Using OpenSSL EVP_PKEY APIs for ECDHE key exchange  [Part 1] 

### DIFF
--- a/crypto/s2n_ecc_evp.c
+++ b/crypto/s2n_ecc_evp.c
@@ -26,12 +26,7 @@
 DEFINE_POINTER_CLEANUP_FUNC(EVP_PKEY *, EVP_PKEY_free);
 DEFINE_POINTER_CLEANUP_FUNC(EVP_PKEY_CTX *, EVP_PKEY_CTX_free);
 
-/* IANA values can be found here:
- * https://tools.ietf.org/html/rfc8446#appendix-B.3.1.4 */
-/* Share sizes are described here:
- * https://tools.ietf.org/html/rfc8446#section-4.2.8.2 and include the extra
- * "legacy_form" byte */
-#if S2N_IS_X25519_SUPPORTED
+#if MODERN_EC_SUPPORTED
 const struct s2n_ecc_named_curve s2n_ecc_curve_x25519 = {
     .iana_id = TLS_EC_CURVE_ECDH_X25519, 
     .libcrypto_nid = NID_X25519, 
@@ -40,20 +35,15 @@ const struct s2n_ecc_named_curve s2n_ecc_curve_x25519 = {
 };
 #endif
 
-/* IANA values can be found here:
- * https://tools.ietf.org/html/rfc8446#appendix-B.3.1.4 */
-/* Share sizes are described here:
- * https://tools.ietf.org/html/rfc8446#section-4.2.8.2 and include the extra
- * "legacy_form" byte */
 const struct s2n_ecc_named_curve *const s2n_ecc_evp_supported_curves[] = {
     &s2n_ecc_curve_secp256r1,
     &s2n_ecc_curve_secp384r1,
-#if S2N_IS_X25519_SUPPORTED
+#if MODERN_EC_SUPPORTED
     &s2n_ecc_curve_x25519,
 #endif
 };
 
-#if S2N_IS_X25519_SUPPORTED
+#if MODERN_EC_SUPPORTED
 static int s2n_ecc_evp_generate_key_x25519(const struct s2n_ecc_named_curve *named_curve, EVP_PKEY **evp_pkey);
 #endif
 
@@ -61,7 +51,7 @@ static int s2n_ecc_evp_generate_key_nist_curves(const struct s2n_ecc_named_curve
 static int s2n_ecc_evp_generate_own_key(const struct s2n_ecc_named_curve *named_curve, EVP_PKEY **evp_pkey);
 static int s2n_ecc_evp_compute_shared_secret(EVP_PKEY *own_key, EVP_PKEY *peer_public, struct s2n_blob *shared_secret);
 
-#if S2N_IS_X25519_SUPPORTED
+#if MODERN_EC_SUPPORTED
 static int s2n_ecc_evp_generate_key_x25519(const struct s2n_ecc_named_curve *named_curve, EVP_PKEY **evp_pkey) {
 
     DEFER_CLEANUP(EVP_PKEY_CTX *pctx = EVP_PKEY_CTX_new_id(named_curve->libcrypto_nid, NULL),
@@ -99,7 +89,7 @@ static int s2n_ecc_evp_generate_key_nist_curves(const struct s2n_ecc_named_curve
 }
 
 static int s2n_ecc_evp_generate_own_key(const struct s2n_ecc_named_curve *named_curve, EVP_PKEY **evp_pkey) {
-#if S2N_IS_X25519_SUPPORTED
+#if MODERN_EC_SUPPORTED
     if (named_curve->libcrypto_nid == NID_X25519) {
         return s2n_ecc_evp_generate_key_x25519(named_curve, evp_pkey);
     }

--- a/crypto/s2n_ecc_evp.c
+++ b/crypto/s2n_ecc_evp.c
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "crypto/s2n_ecc_evp.h"
+
+#include <openssl/bn.h>
+#include <openssl/ecdh.h>
+#include <openssl/evp.h>
+#include <openssl/obj_mac.h>
+#include <stdint.h>
+
+#include "tls/s2n_kex.h"
+#include "tls/s2n_tls_parameters.h"
+#include "utils/s2n_mem.h"
+#include "utils/s2n_safety.h"
+
+#define TLS_EC_EVP_CURVE_TYPE_NAMED S2N_ECC_EVP_SUPPORTED_CURVES_COUNT
+
+/* IANA values can be found here:
+ * https://tools.ietf.org/html/rfc8446#appendix-B.3.1.4 */
+/* Share sizes are described here:
+ * https://tools.ietf.org/html/rfc8446#section-4.2.8.2 and include the extra
+ * "legacy_form" byte */
+#if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0) && !defined(LIBRESSL_VERSION_NUMBER)
+const struct s2n_ecc_named_curve s2n_ecc_curve_x25519 = {
+    .iana_id = TLS_EC_CURVE_ECDH_X25519, 
+    .libcrypto_nid = NID_X25519, 
+    .name = "x25519", 
+    .share_size = 32
+};
+#endif
+
+/* IANA values can be found here:
+ * https://tools.ietf.org/html/rfc8446#appendix-B.3.1.4 */
+/* Share sizes are described here:
+ * https://tools.ietf.org/html/rfc8446#section-4.2.8.2 and include the extra
+ * "legacy_form" byte */
+const struct s2n_ecc_named_curve *const s2n_ecc_evp_supported_curves[] = {
+    &s2n_ecc_curve_secp256r1,
+    &s2n_ecc_curve_secp384r1,
+#if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0) && !defined(LIBRESSL_VERSION_NUMBER)
+    &s2n_ecc_curve_x25519,
+#endif
+};
+
+#if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0) && !defined(LIBRESSL_VERSION_NUMBER)
+static EVP_PKEY *s2n_ecc_evp_generate_key_x25519(const struct s2n_ecc_named_curve *named_curve);
+#endif
+
+static EVP_PKEY *s2n_ecc_evp_generate_key_nist_curves(const struct s2n_ecc_named_curve *named_curve);
+static EVP_PKEY *s2n_ecc_evp_generate_own_key(const struct s2n_ecc_named_curve *named_curve);
+static int s2n_ecc_evp_compute_shared_secret(EVP_PKEY *own_key, EVP_PKEY *peer_public, struct s2n_blob *shared_secret);
+
+#if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0) && !defined(LIBRESSL_VERSION_NUMBER)
+static EVP_PKEY *s2n_ecc_evp_generate_key_x25519(const struct s2n_ecc_named_curve *named_curve) {
+    EVP_PKEY *evp_pkey = NULL;
+    EVP_PKEY_CTX *pctx = NULL;
+
+    pctx = EVP_PKEY_CTX_new_id(named_curve->libcrypto_nid, NULL);
+    if (pctx == NULL) {
+        S2N_ERROR_PTR(S2N_ERR_ECDHE_GEN_KEY);
+    }
+    if (EVP_PKEY_keygen_init(pctx) != 1) {
+        EVP_PKEY_CTX_free(pctx);
+        S2N_ERROR_PTR(S2N_ERR_ECDHE_GEN_KEY);
+    }
+    if (EVP_PKEY_keygen(pctx, &evp_pkey) != 1) {
+        EVP_PKEY_CTX_free(pctx);
+        S2N_ERROR_PTR(S2N_ERR_ECDHE_GEN_KEY);
+    }
+
+    EVP_PKEY_CTX_free(pctx);
+    return evp_pkey;
+}
+#endif
+
+static EVP_PKEY *s2n_ecc_evp_generate_key_nist_curves(const struct s2n_ecc_named_curve *named_curve) {
+    EVP_PKEY *evp_pkey = NULL;
+    EVP_PKEY_CTX *pctx = NULL;
+    EVP_PKEY_CTX *kctx = NULL;
+    EVP_PKEY *params = NULL;
+
+    pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL);
+    if (pctx == NULL) {
+        S2N_ERROR_PTR(S2N_ERR_ECDHE_GEN_KEY);
+    }
+    if (EVP_PKEY_paramgen_init(pctx) != 1) {
+        EVP_PKEY_CTX_free(pctx);
+        S2N_ERROR_PTR(S2N_ERR_ECDHE_GEN_KEY);
+    }
+    if (EVP_PKEY_CTX_set_ec_paramgen_curve_nid(pctx, named_curve->libcrypto_nid) != 1) {
+        EVP_PKEY_CTX_free(pctx);
+        S2N_ERROR_PTR(S2N_ERR_ECDHE_GEN_KEY);
+    }
+    if (!EVP_PKEY_paramgen(pctx, &params)) {
+        EVP_PKEY_CTX_free(pctx);
+        EVP_PKEY_free(params);
+        S2N_ERROR_PTR(S2N_ERR_ECDHE_GEN_KEY);
+    }
+    kctx = EVP_PKEY_CTX_new(params, NULL);
+    if (kctx == NULL) {
+        EVP_PKEY_CTX_free(pctx);
+        EVP_PKEY_free(params);
+        S2N_ERROR_PTR(S2N_ERR_ECDHE_GEN_KEY);
+    }
+    if (EVP_PKEY_keygen_init(kctx) != 1) {
+        EVP_PKEY_CTX_free(pctx);
+        EVP_PKEY_free(params);
+        EVP_PKEY_CTX_free(kctx);
+        S2N_ERROR_PTR(S2N_ERR_ECDHE_GEN_KEY);
+    }
+    if (EVP_PKEY_keygen(kctx, &evp_pkey) != 1) {
+        EVP_PKEY_CTX_free(pctx);
+        EVP_PKEY_free(params);
+        EVP_PKEY_CTX_free(kctx);
+        S2N_ERROR_PTR(S2N_ERR_ECDHE_GEN_KEY);
+    }
+    EVP_PKEY_CTX_free(pctx);
+    EVP_PKEY_CTX_free(kctx);
+    EVP_PKEY_free(params);
+    return evp_pkey;
+}
+
+static EVP_PKEY *s2n_ecc_evp_generate_own_key(const struct s2n_ecc_named_curve *named_curve) {
+#if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0) && !defined(LIBRESSL_VERSION_NUMBER)
+    if (named_curve->libcrypto_nid == NID_X25519) {
+        return s2n_ecc_evp_generate_key_x25519(named_curve);
+    }
+#endif
+    if (named_curve->libcrypto_nid == NID_X9_62_prime256v1 || named_curve->libcrypto_nid == NID_secp384r1) {
+        return s2n_ecc_evp_generate_key_nist_curves(named_curve);
+    }
+    S2N_ERROR_PTR(S2N_ERR_ECDHE_GEN_KEY);
+}
+
+static int s2n_ecc_evp_compute_shared_secret(EVP_PKEY *own_key, EVP_PKEY *peer_public, struct s2n_blob *shared_secret) {
+    EVP_PKEY_CTX *ctx = NULL;
+    size_t shared_secret_size;
+
+    ctx = EVP_PKEY_CTX_new(own_key, NULL);
+    if (ctx == NULL) {
+        S2N_ERROR(S2N_ERR_ECDHE_SHARED_SECRET);
+    }
+
+    if (EVP_PKEY_derive_init(ctx) != 1) {
+        EVP_PKEY_CTX_free(ctx);
+        S2N_ERROR(S2N_ERR_ECDHE_SHARED_SECRET);
+    }
+    if (EVP_PKEY_derive_set_peer(ctx, peer_public) != 1) {
+        EVP_PKEY_CTX_free(ctx);
+        S2N_ERROR(S2N_ERR_ECDHE_SHARED_SECRET);
+    }
+    if (EVP_PKEY_derive(ctx, NULL, &shared_secret_size) != 1) {
+        EVP_PKEY_CTX_free(ctx);
+        S2N_ERROR(S2N_ERR_ECDHE_SHARED_SECRET);
+    }
+    GUARD(s2n_alloc(shared_secret, shared_secret_size));
+    if (EVP_PKEY_derive(ctx, shared_secret->data, &shared_secret_size) != 1) {
+        EVP_PKEY_CTX_free(ctx);
+        GUARD(s2n_free(shared_secret));
+        S2N_ERROR(S2N_ERR_ECDHE_SHARED_SECRET);
+    }
+    EVP_PKEY_CTX_free(ctx);
+    return 0;
+}
+
+int s2n_ecc_evp_generate_ephemeral_key(struct s2n_ecc_evp_params *ecc_evp_params) {
+    notnull_check(ecc_evp_params->negotiated_curve);
+    ecc_evp_params->evp_pkey = s2n_ecc_evp_generate_own_key(ecc_evp_params->negotiated_curve);
+    S2N_ERROR_IF(ecc_evp_params->evp_pkey == NULL, S2N_ERR_ECDHE_GEN_KEY);
+    return 0;
+}
+
+int s2n_ecc_evp_compute_shared_secret_from_params(struct s2n_ecc_evp_params *private_ecc_evp_params,
+                                                  struct s2n_ecc_evp_params *public_ecc_evp_params,
+                                                  struct s2n_blob *shared_key) {
+    notnull_check(private_ecc_evp_params->negotiated_curve);
+    notnull_check(private_ecc_evp_params->evp_pkey);
+    notnull_check(public_ecc_evp_params->negotiated_curve);
+    notnull_check(public_ecc_evp_params->evp_pkey);
+    S2N_ERROR_IF(private_ecc_evp_params->negotiated_curve->iana_id != public_ecc_evp_params->negotiated_curve->iana_id,
+                 S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
+    GUARD(s2n_ecc_evp_compute_shared_secret(private_ecc_evp_params->evp_pkey, public_ecc_evp_params->evp_pkey,
+                                            shared_key));
+    return 0;
+}
+
+int s2n_ecc_evp_params_free(struct s2n_ecc_evp_params *ecc_evp_params) {
+    if (ecc_evp_params->evp_pkey != NULL) {
+        EVP_PKEY_free(ecc_evp_params->evp_pkey);
+        ecc_evp_params->evp_pkey = NULL;
+    }
+    return 0;
+}

--- a/crypto/s2n_ecc_evp.c
+++ b/crypto/s2n_ecc_evp.c
@@ -35,13 +35,15 @@ const struct s2n_ecc_named_curve s2n_ecc_curve_x25519 = {
 };
 #endif
 
-const struct s2n_ecc_named_curve *const s2n_ecc_evp_supported_curves[] = {
+const struct s2n_ecc_named_curve *const s2n_ecc_evp_supported_curves_list[] = {
     &s2n_ecc_curve_secp256r1,
     &s2n_ecc_curve_secp384r1,
 #if MODERN_EC_SUPPORTED
     &s2n_ecc_curve_x25519,
 #endif
 };
+
+const size_t s2n_ecc_evp_supported_curves_list_len = s2n_array_len(s2n_ecc_evp_supported_curves_list);
 
 #if MODERN_EC_SUPPORTED
 static int s2n_ecc_evp_generate_key_x25519(const struct s2n_ecc_named_curve *named_curve, EVP_PKEY **evp_pkey);

--- a/crypto/s2n_ecc_evp.h
+++ b/crypto/s2n_ecc_evp.h
@@ -24,7 +24,8 @@
 #include "tls/s2n_tls_parameters.h"
 #include "utils/s2n_safety.h"
 
-#if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0) && !defined(LIBRESSL_VERSION_NUMBER)
+#define S2N_IS_X25519_SUPPORTED S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0) && !defined(LIBRESSL_VERSION_NUMBER)
+#if S2N_IS_X25519_SUPPORTED
 #define S2N_ECC_EVP_SUPPORTED_CURVES_COUNT 3
 extern const struct s2n_ecc_named_curve s2n_ecc_curve_x25519;
 #else

--- a/crypto/s2n_ecc_evp.h
+++ b/crypto/s2n_ecc_evp.h
@@ -16,11 +16,13 @@
 #pragma once
 
 #include "crypto/s2n_ecc.h"
+
+#include <openssl/evp.h>
+
 #include "crypto/s2n_hash.h"
 #include "stuffer/s2n_stuffer.h"
-#include "tls/s2n_kex_data.h"
 #include "tls/s2n_tls_parameters.h"
-#include <openssl/evp.h>
+#include "utils/s2n_safety.h"
 
 #if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0) && !defined(LIBRESSL_VERSION_NUMBER)
 #define S2N_ECC_EVP_SUPPORTED_CURVES_COUNT 3

--- a/crypto/s2n_ecc_evp.h
+++ b/crypto/s2n_ecc_evp.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include "crypto/s2n_ecc.h"
+#include "crypto/s2n_hash.h"
+#include "stuffer/s2n_stuffer.h"
+#include "tls/s2n_kex_data.h"
+#include "tls/s2n_tls_parameters.h"
+#include <openssl/evp.h>
+
+#if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0) && !defined(LIBRESSL_VERSION_NUMBER)
+#define S2N_ECC_EVP_SUPPORTED_CURVES_COUNT 3
+extern const struct s2n_ecc_named_curve s2n_ecc_curve_x25519;
+#else
+#define S2N_ECC_EVP_SUPPORTED_CURVES_COUNT 2
+#endif
+
+extern const struct s2n_ecc_named_curve *const s2n_ecc_evp_supported_curves[S2N_ECC_EVP_SUPPORTED_CURVES_COUNT];
+
+struct s2n_ecc_evp_params {
+    const struct s2n_ecc_named_curve *negotiated_curve;
+    EVP_PKEY *evp_pkey;
+};
+
+int s2n_ecc_evp_generate_ephemeral_key(struct s2n_ecc_evp_params *ecc_evp_params);
+int s2n_ecc_evp_compute_shared_secret_from_params(struct s2n_ecc_evp_params *private_ecc_evp_params,
+                                                  struct s2n_ecc_evp_params *public_ecc_evp_params,
+                                                  struct s2n_blob *shared_key);
+int s2n_ecc_evp_params_free(struct s2n_ecc_evp_params *ecc_evp_params);

--- a/crypto/s2n_ecc_evp.h
+++ b/crypto/s2n_ecc_evp.h
@@ -24,8 +24,8 @@
 #include "tls/s2n_tls_parameters.h"
 #include "utils/s2n_safety.h"
 
-#define S2N_IS_X25519_SUPPORTED S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0) && !defined(LIBRESSL_VERSION_NUMBER)
-#if S2N_IS_X25519_SUPPORTED
+#if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0) && !defined(LIBRESSL_VERSION_NUMBER)
+#define S2N_IS_X25519_SUPPORTED 1
 #define S2N_ECC_EVP_SUPPORTED_CURVES_COUNT 3
 extern const struct s2n_ecc_named_curve s2n_ecc_curve_x25519;
 #else

--- a/crypto/s2n_ecc_evp.h
+++ b/crypto/s2n_ecc_evp.h
@@ -26,15 +26,11 @@
 
 #if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0) && !defined(LIBRESSL_VERSION_NUMBER)
 #define MODERN_EC_SUPPORTED 1
-/* S2N_ECC_EVP_SUPPORTED_CURVES_COUNT determines the number of ecc_curves 
-supported, the supported curves are listed in the s2n_ecc_evp_supported_curves array. */ 
-#define S2N_ECC_EVP_SUPPORTED_CURVES_COUNT 3
 extern const struct s2n_ecc_named_curve s2n_ecc_curve_x25519;
-#else
-#define S2N_ECC_EVP_SUPPORTED_CURVES_COUNT 2
 #endif
 
-extern const struct s2n_ecc_named_curve *const s2n_ecc_evp_supported_curves[S2N_ECC_EVP_SUPPORTED_CURVES_COUNT];
+extern const struct s2n_ecc_named_curve* const s2n_ecc_evp_supported_curves_list[];
+extern const size_t s2n_ecc_evp_supported_curves_list_len;
 
 struct s2n_ecc_evp_params {
     const struct s2n_ecc_named_curve *negotiated_curve;

--- a/crypto/s2n_ecc_evp.h
+++ b/crypto/s2n_ecc_evp.h
@@ -25,7 +25,9 @@
 #include "utils/s2n_safety.h"
 
 #if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0) && !defined(LIBRESSL_VERSION_NUMBER)
-#define S2N_IS_X25519_SUPPORTED 1
+#define MODERN_EC_SUPPORTED 1
+/* S2N_ECC_EVP_SUPPORTED_CURVES_COUNT determines the number of ecc_curves 
+supported, the supported curves are listed in the s2n_ecc_evp_supported_curves array. */ 
 #define S2N_ECC_EVP_SUPPORTED_CURVES_COUNT 3
 extern const struct s2n_ecc_named_curve s2n_ecc_curve_x25519;
 #else

--- a/tests/unit/s2n_ecc_evp_test.c
+++ b/tests/unit/s2n_ecc_evp_test.c
@@ -26,10 +26,9 @@ int main(int argc, char **argv) {
     BEGIN_TEST();
     {
         /* Test generate ephemeral keys for all supported curves */
-        for (int i = 1; i < S2N_ECC_EVP_SUPPORTED_CURVES_COUNT; i++) {
-            struct s2n_ecc_evp_params evp_params;
+        for (int i = 0; i < S2N_ECC_EVP_SUPPORTED_CURVES_COUNT; i++) {
+            struct s2n_ecc_evp_params evp_params = {0};
             /* Server generates a key */
-            EXPECT_FAILURE(s2n_ecc_evp_generate_ephemeral_key(&evp_params));
             evp_params.negotiated_curve = s2n_ecc_evp_supported_curves[i];
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&evp_params));
             EXPECT_SUCCESS(s2n_ecc_evp_params_free(&evp_params));
@@ -38,7 +37,8 @@ int main(int argc, char **argv) {
     {
         /* Test generate ephemeral key and compute shared key for all supported curves */
         for (int i = 0; i < S2N_ECC_EVP_SUPPORTED_CURVES_COUNT; i++) {
-            struct s2n_ecc_evp_params server_params, client_params;
+            struct s2n_ecc_evp_params server_params = {0};
+            struct s2n_ecc_evp_params client_params = {0};
             struct s2n_blob server_shared, client_shared;
             struct s2n_stuffer wire;
             server_params.negotiated_curve = s2n_ecc_evp_supported_curves[i];
@@ -72,7 +72,8 @@ int main(int argc, char **argv) {
     {
         /* Test failure case for computing shared key for all supported curves */
         for (int i = 1; i < S2N_ECC_EVP_SUPPORTED_CURVES_COUNT; i++) {
-            struct s2n_ecc_evp_params server_params, client_params;
+            struct s2n_ecc_evp_params server_params = {0};
+            struct s2n_ecc_evp_params client_params = {0};
             struct s2n_blob server_shared, client_shared;
             struct s2n_stuffer wire;
             server_params.negotiated_curve = s2n_ecc_evp_supported_curves[i];

--- a/tests/unit/s2n_ecc_evp_test.c
+++ b/tests/unit/s2n_ecc_evp_test.c
@@ -26,7 +26,7 @@ int main(int argc, char **argv) {
     BEGIN_TEST();
     {
         /* Test generate ephemeral keys for all supported curves */
-        for (int i = 0; i < S2N_ECC_EVP_SUPPORTED_CURVES_COUNT; i++) {
+        for (int i = 0; i < s2n_array_len(s2n_ecc_evp_supported_curves); i++) {
             struct s2n_ecc_evp_params evp_params = {0};
             /* Server generates a key */
             evp_params.negotiated_curve = s2n_ecc_evp_supported_curves[i];
@@ -36,23 +36,25 @@ int main(int argc, char **argv) {
     }
     {
         /* Test generate ephemeral key and compute shared key for all supported curves */
-        for (int i = 0; i < S2N_ECC_EVP_SUPPORTED_CURVES_COUNT; i++) {
+        for (int i = 0; i < s2n_array_len(s2n_ecc_evp_supported_curves); i++) {
             struct s2n_ecc_evp_params server_params = {0};
             struct s2n_ecc_evp_params client_params = {0};
             struct s2n_blob server_shared = {0};
             struct s2n_blob client_shared = {0};
-            server_params.negotiated_curve = s2n_ecc_evp_supported_curves[i];
 
             /* Server generates a key */
+            server_params.negotiated_curve = s2n_ecc_evp_supported_curves[i];
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_params));
+
+            /* Client generates a key */
             client_params.negotiated_curve = s2n_ecc_evp_supported_curves[i];
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_params));
 
-            /* Compute shared secret for server*/
+            /* Compute shared secret for server */
             EXPECT_SUCCESS(
                 s2n_ecc_evp_compute_shared_secret_from_params(&server_params, &client_params, &server_shared));
 
-            /* Compute shared secret for client*/
+            /* Compute shared secret for client */
             EXPECT_SUCCESS(
                 s2n_ecc_evp_compute_shared_secret_from_params(&client_params, &server_params, &client_shared));
 
@@ -70,26 +72,29 @@ int main(int argc, char **argv) {
     }
     {
         /* Test failure case for computing shared key for all supported curves */
-        for (int i = 1; i < S2N_ECC_EVP_SUPPORTED_CURVES_COUNT; i++) {
+        for (int i = 1; i < s2n_array_len(s2n_ecc_evp_supported_curves); i++) {
             struct s2n_ecc_evp_params server_params = {0};
             struct s2n_ecc_evp_params client_params = {0};
             struct s2n_blob server_shared = {0};
             struct s2n_blob client_shared = {0};
-            server_params.negotiated_curve = s2n_ecc_evp_supported_curves[i];
 
             /* Server generates a key */
+            server_params.negotiated_curve = s2n_ecc_evp_supported_curves[i];
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_params));
+
+            /* Client generates a key */
             client_params.negotiated_curve = s2n_ecc_evp_supported_curves[0];
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_params));
 
-            /* Compute shared secret for server*/
+            /* Compute shared secret for server */
             EXPECT_FAILURE(
                 s2n_ecc_evp_compute_shared_secret_from_params(&server_params, &client_params, &server_shared));
 
-            /* Compute shared secret for client*/
+            /* Compute shared secret for client */
             EXPECT_FAILURE(
                 s2n_ecc_evp_compute_shared_secret_from_params(&client_params, &server_params, &client_shared));
 
+            /* Clean up */
             EXPECT_SUCCESS(s2n_ecc_evp_params_free(&server_params));
             EXPECT_SUCCESS(s2n_ecc_evp_params_free(&client_params));
         }

--- a/tests/unit/s2n_ecc_evp_test.c
+++ b/tests/unit/s2n_ecc_evp_test.c
@@ -26,28 +26,38 @@ int main(int argc, char **argv) {
     BEGIN_TEST();
     {
         /* Test generate ephemeral keys for all supported curves */
-        for (int i = 0; i < s2n_array_len(s2n_ecc_evp_supported_curves); i++) {
+        for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
             struct s2n_ecc_evp_params evp_params = {0};
             /* Server generates a key */
-            evp_params.negotiated_curve = s2n_ecc_evp_supported_curves[i];
+            evp_params.negotiated_curve = s2n_ecc_evp_supported_curves_list[i];
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&evp_params));
             EXPECT_SUCCESS(s2n_ecc_evp_params_free(&evp_params));
         }
     }
     {
+        /* Test failure case for generate ephemeral key when the negotiated curve is not set */
+        for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
+            struct s2n_ecc_evp_params evp_params = {0};
+            /* Server generates a key */
+            evp_params.negotiated_curve = NULL;
+            EXPECT_FAILURE(s2n_ecc_evp_generate_ephemeral_key(&evp_params));
+            EXPECT_SUCCESS(s2n_ecc_evp_params_free(&evp_params));
+        }
+    }
+    {
         /* Test generate ephemeral key and compute shared key for all supported curves */
-        for (int i = 0; i < s2n_array_len(s2n_ecc_evp_supported_curves); i++) {
+        for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
             struct s2n_ecc_evp_params server_params = {0};
             struct s2n_ecc_evp_params client_params = {0};
             struct s2n_blob server_shared = {0};
             struct s2n_blob client_shared = {0};
 
             /* Server generates a key */
-            server_params.negotiated_curve = s2n_ecc_evp_supported_curves[i];
+            server_params.negotiated_curve = s2n_ecc_evp_supported_curves_list[i];
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_params));
 
             /* Client generates a key */
-            client_params.negotiated_curve = s2n_ecc_evp_supported_curves[i];
+            client_params.negotiated_curve = s2n_ecc_evp_supported_curves_list[i];
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_params));
 
             /* Compute shared secret for server */
@@ -71,32 +81,39 @@ int main(int argc, char **argv) {
         }
     }
     {
-        /* Test failure case for computing shared key for all supported curves */
-        for (int i = 1; i < s2n_array_len(s2n_ecc_evp_supported_curves); i++) {
-            struct s2n_ecc_evp_params server_params = {0};
-            struct s2n_ecc_evp_params client_params = {0};
-            struct s2n_blob server_shared = {0};
-            struct s2n_blob client_shared = {0};
+        /* Test failure case for computing shared key for all supported curves when the server
+        and client curves donot match */
+        for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
+            for (int j = 0; j < s2n_ecc_evp_supported_curves_list_len; j++) {
+                    struct s2n_ecc_evp_params server_params = {0};
+                    struct s2n_ecc_evp_params client_params = {0};
+                    struct s2n_blob server_shared = {0};
+                    struct s2n_blob client_shared = {0};
+                    if (i == j) {
+                        continue;
+                    }
 
-            /* Server generates a key */
-            server_params.negotiated_curve = s2n_ecc_evp_supported_curves[i];
-            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_params));
+                    /* Server generates a key */
+                    server_params.negotiated_curve = s2n_ecc_evp_supported_curves_list[j];
 
-            /* Client generates a key */
-            client_params.negotiated_curve = s2n_ecc_evp_supported_curves[0];
-            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_params));
+                    EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_params));
 
-            /* Compute shared secret for server */
-            EXPECT_FAILURE(
-                s2n_ecc_evp_compute_shared_secret_from_params(&server_params, &client_params, &server_shared));
+                    /* Client generates a key */
+                    client_params.negotiated_curve = s2n_ecc_evp_supported_curves_list[i];
+                    EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_params));
 
-            /* Compute shared secret for client */
-            EXPECT_FAILURE(
-                s2n_ecc_evp_compute_shared_secret_from_params(&client_params, &server_params, &client_shared));
+                    /* Compute shared secret for server */
+                    EXPECT_FAILURE(
+                        s2n_ecc_evp_compute_shared_secret_from_params(&server_params, &client_params, &server_shared));
 
-            /* Clean up */
-            EXPECT_SUCCESS(s2n_ecc_evp_params_free(&server_params));
-            EXPECT_SUCCESS(s2n_ecc_evp_params_free(&client_params));
+                    /* Compute shared secret for client */
+                    EXPECT_FAILURE(
+                        s2n_ecc_evp_compute_shared_secret_from_params(&client_params, &server_params, &client_shared));
+
+                    /* Clean up */
+                    EXPECT_SUCCESS(s2n_ecc_evp_params_free(&server_params));
+                    EXPECT_SUCCESS(s2n_ecc_evp_params_free(&client_params));
+            }
         }
     }
 

--- a/tests/unit/s2n_ecc_evp_test.c
+++ b/tests/unit/s2n_ecc_evp_test.c
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include <s2n.h>
+
+#include "crypto/s2n_ecc_evp.h"
+#include "stuffer/s2n_stuffer.h"
+#include "testlib/s2n_testlib.h"
+#include "utils/s2n_mem.h"
+
+int main(int argc, char **argv) {
+    BEGIN_TEST();
+    {
+        /* Test generate ephemeral keys for all supported curves */
+        for (int i = 1; i < S2N_ECC_EVP_SUPPORTED_CURVES_COUNT; i++) {
+            struct s2n_ecc_evp_params evp_params;
+            /* Server generates a key */
+            EXPECT_FAILURE(s2n_ecc_evp_generate_ephemeral_key(&evp_params));
+            evp_params.negotiated_curve = s2n_ecc_evp_supported_curves[i];
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&evp_params));
+            EXPECT_SUCCESS(s2n_ecc_evp_params_free(&evp_params));
+        }
+    }
+    {
+        /* Test generate ephemeral key and compute shared key for all supported curves */
+        for (int i = 0; i < S2N_ECC_EVP_SUPPORTED_CURVES_COUNT; i++) {
+            struct s2n_ecc_evp_params server_params, client_params;
+            struct s2n_blob server_shared, client_shared;
+            struct s2n_stuffer wire;
+            server_params.negotiated_curve = s2n_ecc_evp_supported_curves[i];
+
+            /* Server generates a key */
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_params));
+            client_params.negotiated_curve = s2n_ecc_evp_supported_curves[i];
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_params));
+
+            /* Compute shared secret for server*/
+            EXPECT_SUCCESS(
+                s2n_ecc_evp_compute_shared_secret_from_params(&server_params, &client_params, &server_shared));
+
+            /* Compute shared secret for client*/
+            EXPECT_SUCCESS(
+                s2n_ecc_evp_compute_shared_secret_from_params(&client_params, &server_params, &client_shared));
+
+            /* Check if the shared secret computed is the same for the client
+             * and the server */
+            EXPECT_EQUAL(client_shared.size, server_shared.size);
+            EXPECT_BYTEARRAY_EQUAL(client_shared.data, server_shared.data, client_shared.size);
+
+            /* Clean up */
+            EXPECT_SUCCESS(s2n_stuffer_free(&wire));
+            EXPECT_SUCCESS(s2n_free(&server_shared));
+            EXPECT_SUCCESS(s2n_free(&client_shared));
+            EXPECT_SUCCESS(s2n_ecc_evp_params_free(&server_params));
+            EXPECT_SUCCESS(s2n_ecc_evp_params_free(&client_params));
+        }
+    }
+    {
+        /* Test failure case for computing shared key for all supported curves */
+        for (int i = 1; i < S2N_ECC_EVP_SUPPORTED_CURVES_COUNT; i++) {
+            struct s2n_ecc_evp_params server_params, client_params;
+            struct s2n_blob server_shared, client_shared;
+            struct s2n_stuffer wire;
+            server_params.negotiated_curve = s2n_ecc_evp_supported_curves[i];
+
+            /* Server generates a key */
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_params));
+            client_params.negotiated_curve = s2n_ecc_evp_supported_curves[0];
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_params));
+
+            /* Compute shared secret for server*/
+            EXPECT_FAILURE(
+                s2n_ecc_evp_compute_shared_secret_from_params(&server_params, &client_params, &server_shared));
+
+            /* Compute shared secret for client*/
+            EXPECT_FAILURE(
+                s2n_ecc_evp_compute_shared_secret_from_params(&client_params, &server_params, &client_shared));
+
+            /* Clean up */
+            EXPECT_SUCCESS(s2n_stuffer_free(&wire));
+            EXPECT_SUCCESS(s2n_free(&server_shared));
+            EXPECT_SUCCESS(s2n_free(&client_shared));
+            EXPECT_SUCCESS(s2n_ecc_evp_params_free(&server_params));
+            EXPECT_SUCCESS(s2n_ecc_evp_params_free(&client_params));
+        }
+    }
+
+    END_TEST();
+}

--- a/tests/unit/s2n_ecc_evp_test.c
+++ b/tests/unit/s2n_ecc_evp_test.c
@@ -39,8 +39,8 @@ int main(int argc, char **argv) {
         for (int i = 0; i < S2N_ECC_EVP_SUPPORTED_CURVES_COUNT; i++) {
             struct s2n_ecc_evp_params server_params = {0};
             struct s2n_ecc_evp_params client_params = {0};
-            struct s2n_blob server_shared, client_shared;
-            struct s2n_stuffer wire;
+            struct s2n_blob server_shared = {0};
+            struct s2n_blob client_shared = {0};
             server_params.negotiated_curve = s2n_ecc_evp_supported_curves[i];
 
             /* Server generates a key */
@@ -62,7 +62,6 @@ int main(int argc, char **argv) {
             EXPECT_BYTEARRAY_EQUAL(client_shared.data, server_shared.data, client_shared.size);
 
             /* Clean up */
-            EXPECT_SUCCESS(s2n_stuffer_free(&wire));
             EXPECT_SUCCESS(s2n_free(&server_shared));
             EXPECT_SUCCESS(s2n_free(&client_shared));
             EXPECT_SUCCESS(s2n_ecc_evp_params_free(&server_params));
@@ -74,8 +73,8 @@ int main(int argc, char **argv) {
         for (int i = 1; i < S2N_ECC_EVP_SUPPORTED_CURVES_COUNT; i++) {
             struct s2n_ecc_evp_params server_params = {0};
             struct s2n_ecc_evp_params client_params = {0};
-            struct s2n_blob server_shared, client_shared;
-            struct s2n_stuffer wire;
+            struct s2n_blob server_shared = {0};
+            struct s2n_blob client_shared = {0};
             server_params.negotiated_curve = s2n_ecc_evp_supported_curves[i];
 
             /* Server generates a key */
@@ -91,10 +90,6 @@ int main(int argc, char **argv) {
             EXPECT_FAILURE(
                 s2n_ecc_evp_compute_shared_secret_from_params(&client_params, &server_params, &client_shared));
 
-            /* Clean up */
-            EXPECT_SUCCESS(s2n_stuffer_free(&wire));
-            EXPECT_SUCCESS(s2n_free(&server_shared));
-            EXPECT_SUCCESS(s2n_free(&client_shared));
             EXPECT_SUCCESS(s2n_ecc_evp_params_free(&server_params));
             EXPECT_SUCCESS(s2n_ecc_evp_params_free(&client_params));
         }

--- a/tls/s2n_tls_parameters.h
+++ b/tls/s2n_tls_parameters.h
@@ -167,6 +167,7 @@
 /* Elliptic curves from https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8 */
 #define TLS_EC_CURVE_SECP_256_R1           23
 #define TLS_EC_CURVE_SECP_384_R1           24
+#define TLS_EC_CURVE_ECDH_X25519           29
 
 /* Ethernet maximum transmission unit (MTU)
  * MTU is usually associated with the Ethernet protocol,


### PR DESCRIPTION
**Issue # (if available):** 
https://github.com/awslabs/s2n/issues/356
**Description of changes:** 
This PR adds support for the  elliptical curves `secp256r1`, `secp384r1` and `x25519` to s2n. It uses the more general EVP_PKEY_* api. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
