### PR TITLE
Blobs should auto-wipe when freed.

### DIFF
--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -62,7 +62,6 @@ bool s2n_blob_is_growable(const struct s2n_blob* b)
 static int s2n_get_memory(struct s2n_blob *b, uint32_t size)
 {
     if(use_mlock) {
-      printf("\nusing mlock \n");
         /* Page aligned allocation required for mlock */
         uint32_t allocate = page_size * (((size - 1) / page_size) + 1);
 	*b = (struct s2n_blob) {.data = NULL, .size = size, .allocated = allocate, .mlocked = 1, .growable = 1};

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -59,6 +59,29 @@ bool s2n_blob_is_growable(const struct s2n_blob* b)
   return b && (b->growable || (b->data == NULL && b->size == 0 && b->allocated == 0));
 }
 
+static int s2n_get_memory(struct s2n_blob *b, uint32_t size)
+{
+    if(use_mlock) {
+      printf("\nusing mlock \n");
+        /* Page aligned allocation required for mlock */
+        uint32_t allocate = page_size * (((size - 1) / page_size) + 1);
+	*b = (struct s2n_blob) {.data = NULL, .size = size, .allocated = allocate, .mlocked = 1, .growable = 1};
+	S2N_ERROR_IF(posix_memalign((void**) &b->data, page_size, allocate), S2N_ERR_ALLOC);
+#ifdef MADV_DONTDUMP
+	S2N_ERROR_IF(madvise(b->data, b->size, MADV_DONTDUMP) < 0, S2N_ERR_MADVISE);
+#endif
+	S2N_ERROR_IF(mlock(b->data, b->size) < 0, S2N_ERR_MLOCK);
+    } else {
+        *b = (struct s2n_blob) {.data = calloc(size, 1), .size = size, .allocated = size, .mlocked = 0, .growable = 1};
+    }
+    S2N_ERROR_IF(b->data == NULL, S2N_ERR_ALLOC);
+    return S2N_SUCCESS;
+}
+
+/* Tries to realloc the requested bytes.
+ * If successful, updates *b.
+ * If failed, *b remains unchanged
+ */
 int s2n_realloc(struct s2n_blob *b, uint32_t size)
 {
     notnull_check(b);
@@ -70,69 +93,35 @@ int s2n_realloc(struct s2n_blob *b, uint32_t size)
     /* blob already has space for the request */
     if (size < b->allocated) {
         b->size = size;
-        return 0;
+        return S2N_SUCCESS;
     }
 
-    void *data;
-    if (!use_mlock) {
-        data = realloc(b->data, size);
-        S2N_ERROR_IF(!data, S2N_ERR_ALLOC);
-
-        b->data = data;
-        b->size = size;
-        b->allocated = size;
-        b->growable = 1;
-        b->mlocked = 0;
-        return 0;
+    struct s2n_blob new_memory = {0};
+    if (s2n_get_memory(&new_memory, size) < 0) {
+        GUARD(s2n_free(&new_memory));
+        S2N_ERROR_PRESERVE_ERRNO();
     }
-
-    /* Page aligned allocation required for mlock */
-    uint32_t allocate = page_size * (((size - 1) / page_size) + 1);
-    S2N_ERROR_IF(posix_memalign(&data, page_size, allocate), S2N_ERR_ALLOC);
 
     if (b->size) {
-        memcpy_check(data, b->data, b->size);
+        memcpy_check(new_memory.data, b->data, b->size);
         GUARD(s2n_free(b));
     }
 
-    b->data = data;
-    b->size = size;
-    b->allocated = allocate;
-    b->growable = 1;
-
-#ifdef MADV_DONTDUMP
-    if (madvise(b->data, size, MADV_DONTDUMP) < 0) {
-        GUARD(s2n_free(b));
-        S2N_ERROR(S2N_ERR_MADVISE);
-    }
-#endif
-
-    if (mlock(b->data, size) < 0) {
-        GUARD(s2n_free(b));
-        S2N_ERROR(S2N_ERR_MLOCK);
-    }
-    b->mlocked = 1;
-
-    return 0;
+    *b = new_memory;
+    return S2N_SUCCESS;
 }
 
 int s2n_free(struct s2n_blob *b)
 {
     S2N_ERROR_IF(!s2n_blob_is_growable(b), S2N_ERR_FREE_STATIC_BLOB);
-    int munlock_rc = 0;
-    if (b->mlocked) {
-        munlock_rc = munlock(b->data, b->size);
-    }
-
+    /* To avoid memory leaks, still free the data even if we can't unlock / wipe it */
+    int zero_rc = s2n_blob_zero(b);
+    int munlock_rc = b->mlocked ? munlock(b->data, b->size) : 0;
     free(b->data);
-    b->data = NULL;
-    b->size = 0;
-    b->allocated = 0;
-
+    *b = (struct s2n_blob) {0};
     S2N_ERROR_IF(munlock_rc < 0, S2N_ERR_MUNLOCK);
-    b->mlocked = 0;
-
-    return 0;
+    GUARD(zero_rc);
+    return S2N_SUCCESS;
 }
 
 int s2n_free_object(uint8_t **p_data, uint32_t size)


### PR DESCRIPTION
**Description of changes:** 
1. Make blobs autowipe when freed.  This helps limit data lifetime
1. `realloc` is problematic, because it can free memory with no chance to ever wipe it.  Implement it manually.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
