### PR TITLE
Wipe exactly the bytes of the stuffer that need to be

### DIFF
--- a/docs/DEVELOPMENT-GUIDE.md
+++ b/docs/DEVELOPMENT-GUIDE.md
@@ -220,11 +220,11 @@ UNIT_TESTS=s2n_hash_test make
 
 ## A tour of s2n memory handling: blobs and stuffers
 
-C has a history of issues around memory and buffer handling. To avoid problems in this area, s2n does not use C string functions or standard buffer manipulation patterns. Instead memory regions are tracked explicitly, with s2n_blob structures, and buffers are re-oriented as streams with s2n_stuffer structures.
+C has a history of issues around memory and buffer handling. To avoid problems in this area, s2n does not use C string functions or standard buffer manipulation patterns. Instead memory regions are tracked explicitly, with `s2n_blob` structures, and buffers are re-oriented as streams with `s2n_stuffer` structures.
 
 ### s2n_blob : keeping track of memory ranges
 
-s2n_blob is a very simple data structure:
+`s2n_blob` is a very simple data structure:
 
 ```c
 struct s2n_blob {
@@ -292,21 +292,29 @@ void *s2n_stuffer_raw_write(struct s2n_stuffer *stuffer, uint32_t data_len);
 void *s2n_stuffer_raw_read(struct s2n_stuffer *stuffer, uint32_t data_len);
 ```
 
-the first function returns a pointer to the existing location of the write cursor, and then increments the write cursor by data_len, so an external function is free to write to the pointer, as long as it only writes data_len bytes. The second function does the same thing, except that it increments the read cursor. Use of these functions is discouraged and should only be done when necessary for compatibility. 
+the first function returns a pointer to the existing location of the write cursor, and then increments the write cursor by `data_len`, so an external function is free to write to the pointer, as long as it only writes `data_len` bytes.
+The second function does the same thing, except that it increments the read cursor.
+Use of these functions is discouraged and should only be done when necessary for compatibility.
 
 One problem with returning raw pointers is that a pointer can become stale if the stuffer is later resized. Growable stuffers are resized using realloc(), which is free to copy and re-address memory. This could leave the original pointer location dangling, potentially leading to an invalid access. To prevent this, stuffers have a life-cycle and can be tainted, which prevents them from being resized within their present life-cycle. 
 
-Internally stuffers track 4 bits of state:
+Internally stuffers track 4 pieces of state:
 
 ```c
+uint32_t     high_water_mark;
 unsigned int alloced:1;
 unsigned int growable:1;
-unsigned int wiped:1;
 unsigned int tainted:1;
 ```
 
-the first two bits of state track whether a stuffer was dynamically allocated (and so should be free'd later) and whether or not it is growable. The "wiped" piece of state tracks whether a stuffer has been wiped clean and the data erased. If a stuffer has been fully read then it should be in a wiped state, but a stuffer is also explicitly wiped at the end of its lifecycle and this bit of state helps avoids needless zeroing of memory. tainted is set to 1 whenever the raw access functions are called. If a stuffer is currently tainted then it can not be resized and it becomes ungrowable. This is reset when a stuffer is explicitly wiped, which begins the life-cycle anew. So any pointers returned by the raw access functions are legal only until s2n_stuffer_wipe is called. 
-
+The `high_water_mark` tracks the furthermost byte which has been written but not yet wiped.
+Note that this may be past the `write_cursor` if `s2n_stuffer_rewrite()` has been called.
+Explicitly tracking the `high_water_mark` allows us to track the bytes which need to be wiped, and helps avoids needless zeroing of memory.
+The next two bits of state track whether a stuffer was dynamically allocated (and so should be free'd later) and whether or not it is growable.
+`tainted` is set to 1 whenever the raw access functions are called.
+If a stuffer is currently tainted then it can not be resized and it becomes ungrowable.
+This is reset when a stuffer is explicitly wiped, which begins the life-cycle anew.
+So any pointers returned by the raw access functions are legal only until `s2n_stuffer_wipe()` is called.
 The end result is that this kind of pattern is legal:
 
 ```c

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -25,14 +25,16 @@
 
 bool s2n_stuffer_is_valid(const struct s2n_stuffer* stuffer)
 {
-    /* Note that we do not assert any properties on the  wiped, alloced, growable, and tainted fields,
+    /* Note that we do not assert any properties on the alloced, growable, and tainted fields,
      * as all possible combinations of boolean values in those fields are valid */
     return S2N_OBJECT_PTR_IS_READABLE(stuffer) && 
-    s2n_blob_is_valid(&stuffer->blob) &&
-    /* <= is valid because we can have a fully written/read stuffer */
-    stuffer->read_cursor <= stuffer->blob.size &&
-    stuffer->write_cursor <= stuffer->blob.size &&
-    stuffer->read_cursor <= stuffer->write_cursor;
+      s2n_blob_is_valid(&stuffer->blob) &&
+      /* <= is valid because we can have a fully written/read stuffer */
+      stuffer->read_cursor <= stuffer->blob.size &&
+      stuffer->write_cursor <= stuffer->blob.size &&
+      stuffer->read_cursor <= stuffer->write_cursor &&
+      stuffer->high_water_mark <= stuffer->blob.size &&
+      stuffer->write_cursor <= stuffer->high_water_mark;
 }
 
 int s2n_stuffer_init(struct s2n_stuffer *stuffer, struct s2n_blob *in)
@@ -40,19 +42,16 @@ int s2n_stuffer_init(struct s2n_stuffer *stuffer, struct s2n_blob *in)
     S2N_PRECONDITION(S2N_OBJECT_PTR_IS_WRITABLE(stuffer));
     S2N_PRECONDITION(s2n_blob_is_valid(in));
     stuffer->blob = *in;
-    stuffer->wiped = 1;
+    stuffer->read_cursor = 0;
+    stuffer->write_cursor = 0;
+    stuffer->high_water_mark = 0;
     stuffer->alloced = 0;
     stuffer->growable = 0;
     stuffer->tainted = 0;
-    stuffer->read_cursor = 0;
-    stuffer->write_cursor = 0;
-
     return 0;
 }
-
 int s2n_stuffer_alloc(struct s2n_stuffer *stuffer, const uint32_t size)
 {
-
     GUARD(s2n_alloc(&stuffer->blob, size));
     GUARD(s2n_stuffer_init(stuffer, &stuffer->blob));
 
@@ -72,17 +71,10 @@ int s2n_stuffer_growable_alloc(struct s2n_stuffer *stuffer, const uint32_t size)
 
 int s2n_stuffer_free(struct s2n_stuffer *stuffer)
 {
-    if (stuffer->alloced == 0) {
-        return 0;
+    if (stuffer->alloced) {
+        GUARD(s2n_free(&stuffer->blob));
     }
-    if (stuffer->wiped == 0) {
-        GUARD(s2n_stuffer_wipe(stuffer));
-    }
-
-    GUARD(s2n_free(&stuffer->blob));
-
-    stuffer->blob.data = NULL;
-    stuffer->blob.size = 0;
+    *stuffer = (struct s2n_stuffer) {0};
 
     return 0;
 }
@@ -101,8 +93,6 @@ int s2n_stuffer_resize(struct s2n_stuffer *stuffer, const uint32_t size)
     }
 
     GUARD(s2n_realloc(&stuffer->blob, size));
-
-    stuffer->blob.size = size;
 
     return 0;
 }
@@ -141,16 +131,13 @@ int s2n_stuffer_reread(struct s2n_stuffer *stuffer)
 
 int s2n_stuffer_wipe_n(struct s2n_stuffer *stuffer, const uint32_t size)
 {
-    uint32_t n = MIN(size, stuffer->write_cursor);
-
-    /* Use '0' instead of 0 precisely to prevent C string compatibility */
-    memset_check(stuffer->blob.data + stuffer->write_cursor - n, '0', n);
-    stuffer->write_cursor -= n;
-
-    if (stuffer->write_cursor == 0) {
-        stuffer->wiped = 1;
+    if (size >= stuffer->write_cursor) {
+        return s2n_stuffer_wipe(stuffer);
     }
 
+    /* We know that size is now less than write_cursor */
+    stuffer->write_cursor -= size;
+    memset_check(stuffer->blob.data + stuffer->write_cursor, '0', size);
     stuffer->read_cursor = MIN(stuffer->read_cursor, stuffer->write_cursor);
 
     return 0;
@@ -173,8 +160,15 @@ int s2n_stuffer_release_if_empty(struct s2n_stuffer *stuffer)
 
 int s2n_stuffer_wipe(struct s2n_stuffer *stuffer)
 {
+    if (!s2n_stuffer_is_wiped(stuffer)) {
+        memset_check(stuffer->blob.data, 0, stuffer->high_water_mark);
+    }
+
     stuffer->tainted = 0;
-    return s2n_stuffer_wipe_n(stuffer, stuffer->write_cursor);
+    stuffer->write_cursor = 0;
+    stuffer->read_cursor = 0;
+    stuffer->high_water_mark = 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_stuffer_skip_read(struct s2n_stuffer *stuffer, uint32_t n)
@@ -253,7 +247,7 @@ int s2n_stuffer_skip_write(struct s2n_stuffer *stuffer, const uint32_t n)
     }
 
     stuffer->write_cursor += n;
-    stuffer->wiped = 0;
+    stuffer->high_water_mark = MAX(stuffer->write_cursor, stuffer->high_water_mark);
     return 0;
 }
 

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -23,6 +23,12 @@
 #include "utils/s2n_blob.h"
 #include "utils/s2n_mem.h"
 
+/* Using a non-zero value 
+ * (a) makes wiped data easy to see in the debugger
+ * (b) makes use of wiped data obvious since this is unlikely to be a valid bit pattern
+ */
+#define S2N_WIPE_PATTERN 'w'
+
 bool s2n_stuffer_is_valid(const struct s2n_stuffer* stuffer)
 {
     /* Note that we do not assert any properties on the alloced, growable, and tainted fields,
@@ -135,9 +141,9 @@ int s2n_stuffer_wipe_n(struct s2n_stuffer *stuffer, const uint32_t size)
 
     /* We know that size is now less than write_cursor */
     stuffer->write_cursor -= size;
-    memset_check(stuffer->blob.data + stuffer->write_cursor, '0', size);
+    memset_check(stuffer->blob.data + stuffer->write_cursor, S2N_WIPE_PATTERN, size);
     stuffer->read_cursor = MIN(stuffer->read_cursor, stuffer->write_cursor);
-
+    
     return 0;
 }
 
@@ -159,7 +165,7 @@ int s2n_stuffer_release_if_empty(struct s2n_stuffer *stuffer)
 int s2n_stuffer_wipe(struct s2n_stuffer *stuffer)
 {
     if (!s2n_stuffer_is_wiped(stuffer)) {
-        memset_check(stuffer->blob.data, 0, stuffer->high_water_mark);
+        memset_check(stuffer->blob.data, S2N_WIPE_PATTERN, stuffer->high_water_mark);
     }
 
     stuffer->tainted = 0;

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -28,13 +28,11 @@ bool s2n_stuffer_is_valid(const struct s2n_stuffer* stuffer)
     /* Note that we do not assert any properties on the alloced, growable, and tainted fields,
      * as all possible combinations of boolean values in those fields are valid */
     return S2N_OBJECT_PTR_IS_READABLE(stuffer) && 
-      s2n_blob_is_valid(&stuffer->blob) &&
-      /* <= is valid because we can have a fully written/read stuffer */
-      stuffer->read_cursor <= stuffer->blob.size &&
-      stuffer->write_cursor <= stuffer->blob.size &&
-      stuffer->read_cursor <= stuffer->write_cursor &&
-      stuffer->high_water_mark <= stuffer->blob.size &&
-      stuffer->write_cursor <= stuffer->high_water_mark;
+        s2n_blob_is_valid(&stuffer->blob) &&
+        /* <= is valid because we can have a fully written/read stuffer */
+        stuffer->high_water_mark <= stuffer->blob.size &&
+        stuffer->write_cursor <= stuffer->high_water_mark &&
+        stuffer->read_cursor <= stuffer->write_cursor;
 }
 
 int s2n_stuffer_init(struct s2n_stuffer *stuffer, struct s2n_blob *in)

--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -28,10 +28,7 @@ struct s2n_stuffer {
     /* Cursors to the current read/write position in the s2n_stuffer */
     uint32_t read_cursor;
     uint32_t write_cursor;
-
-    /* The total size of the data segment */
-    /* Has the stuffer been wiped? */
-    unsigned int wiped:1;
+    uint32_t high_water_mark;
 
     /* Was this stuffer alloc()'d ? */
     unsigned int alloced:1;
@@ -45,7 +42,7 @@ struct s2n_stuffer {
 
 #define s2n_stuffer_data_available( s )   ((s)->write_cursor - (s)->read_cursor)
 #define s2n_stuffer_space_remaining( s )  ((s)->blob.size - (s)->write_cursor)
-
+#define s2n_stuffer_is_wiped( s )         ((s)->high_water_mark == 0)
 /* Check basic validity constraints on the stuffer: e.g. that cursors point within the blob */
 extern bool s2n_stuffer_is_valid(const struct s2n_stuffer* stuffer);
 

--- a/stuffer/s2n_stuffer_file.c
+++ b/stuffer/s2n_stuffer_file.c
@@ -42,10 +42,8 @@ int s2n_stuffer_recv_from_fd(struct s2n_stuffer *stuffer, int rfd, uint32_t len)
         S2N_ERROR_IF(r < 0 && errno != EINTR, S2N_ERR_READ);
     } while (r < 0);
 
-      /* Record just how many bytes we have written */
-    stuffer->write_cursor += r;
-    stuffer->wiped = 0;
-
+    /* Record just how many bytes we have written */
+    GUARD(s2n_stuffer_skip_write(stuffer, r));
     return r;
 }
 

--- a/tests/sidetrail/working/s2n-record-read-cbc/s2n_record_read_wrapper.c
+++ b/tests/sidetrail/working/s2n-record-read-cbc/s2n_record_read_wrapper.c
@@ -121,6 +121,7 @@ int s2n_record_parse_wrapper(int *xor_pad,
     .in = {
       .read_cursor = 0,
       .write_cursor = MAX_SIZE,
+      .high_water_mark = MAX_SIZE,
       .blob = {
 	.data = data1,
 	.size = MAX_SIZE,
@@ -129,6 +130,7 @@ int s2n_record_parse_wrapper(int *xor_pad,
     .header_in = {
       .read_cursor = 0,
       .write_cursor = S2N_TLS_RECORD_HEADER_LENGTH,
+      .high_water_mark = S2N_TLS_RECORD_HEADER_LENGTH,
       .blob = {
 	.data = data2,
 	.size = MAX_SIZE,

--- a/tests/sidetrail/working/s2n-record-read-composite/s2n_record_read_wrapper.c
+++ b/tests/sidetrail/working/s2n-record-read-composite/s2n_record_read_wrapper.c
@@ -131,6 +131,7 @@ int s2n_record_parse_wrapper(int *xor_pad,
     .in = {
       .read_cursor = 0,
       .write_cursor = MAX_SIZE,
+      .high_water_mark = MAX_SIZE,
       .blob = {
 	.data = data1,
 	.size = MAX_SIZE,
@@ -139,6 +140,7 @@ int s2n_record_parse_wrapper(int *xor_pad,
     .header_in = {
       .read_cursor = 0,
       .write_cursor = S2N_TLS_RECORD_HEADER_LENGTH,
+      .high_water_mark = S2N_TLS_RECORD_HEADER_LENGTH,
       .blob = {
 	.data = data2,
 	.size = MAX_SIZE,

--- a/tests/sidetrail/working/s2n-record-read-stream/s2n_record_read_wrapper.c
+++ b/tests/sidetrail/working/s2n-record-read-stream/s2n_record_read_wrapper.c
@@ -120,6 +120,7 @@ int s2n_record_parse_wrapper(int *xor_pad,
     .in = {
       .read_cursor = 0,
       .write_cursor = MAX_SIZE,
+      .high_water_mark = MAX_SIZE,
       .blob = {
 	.data = data1,
 	.size = MAX_SIZE,
@@ -128,6 +129,7 @@ int s2n_record_parse_wrapper(int *xor_pad,
     .header_in = {
       .read_cursor = 0,
       .write_cursor = S2N_TLS_RECORD_HEADER_LENGTH,
+      .high_water_mark = S2N_TLS_RECORD_HEADER_LENGTH,
       .blob = {
 	.data = data2,
 	.size = MAX_SIZE,

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1153,9 +1153,7 @@ int s2n_connection_recv_stuffer(struct s2n_stuffer *stuffer, struct s2n_connecti
     }
 
     /* Record just how many bytes we have written */
-    stuffer->write_cursor += r;
-    stuffer->wiped = 0;
-
+    GUARD(s2n_stuffer_skip_write(stuffer, r));
     return r;
 }
 

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -717,7 +717,7 @@ static int handshake_write_io(struct s2n_connection *conn)
      * Check wiped instead of s2n_stuffer_data_available to differentiate between the initial call
      * to handshake_write_io and a repeated call after an EWOULDBLOCK.
      */
-    if (conn->handshake.io.wiped == 1) {
+    if (s2n_stuffer_is_wiped(&conn->handshake.io)) {
         if (record_type == TLS_HANDSHAKE) {
             GUARD(s2n_handshake_write_header(conn, ACTIVE_STATE(conn).message_type));
         }


### PR DESCRIPTION
**Description of changes:** 
Same as https://github.com/awslabs/s2n/pull/1322 but implementing the high-water-mark optimization.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
