### PR TITLE
verify if server_hello is actually a hello_retry request or

### DIFF
--- a/tls/s2n_client_hello_retry.c
+++ b/tls/s2n_client_hello_retry.c
@@ -12,8 +12,24 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+#include <stdbool.h>
 
 #include "error/s2n_errno.h"
+#include "utils/s2n_blob.h"
+#include "tls/s2n_tls.h"
+#include "utils/s2n_safety.h"
+
+/* from RFC: https://tools.ietf.org/html/rfc8446#section-4.1.3*/
+const uint8_t hello_retry_req_random[] = {
+    0xCF ,0x21 ,0xAD ,0x74 ,0xE5 ,0x9A ,0x61 ,0x11 ,0xBE ,0x1D ,0x8C ,0x02 ,0x1E ,0x65 ,0xB8 ,0x91,
+    0xC2 ,0xA2 ,0x11 ,0x16 ,0x7A ,0xBB ,0x8C ,0x5E ,0x07 ,0x9E ,0x09 ,0xE2 ,0xC8 ,0xA8 ,0x33 ,0x9C
+};
+
+inline bool s2n_is_hello_retry_req(struct s2n_connection *conn)
+{
+    return s2n_constant_time_equals(hello_retry_req_random, conn->secure.server_random, S2N_TLS_RANDOM_DATA_LEN);
+}
+
 
 int s2n_client_hello_retry_send(struct s2n_connection *conn)
 {

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -72,6 +72,10 @@ int s2n_server_hello_recv(struct s2n_connection *conn)
     }
 
     if (conn->server_protocol_version >= S2N_TLS13) {
+        /* verify if it is a hello retry request*/
+        if (s2n_is_hello_retry_req(conn)) {
+            GUARD(s2n_client_hello_retry_recv(conn));
+        }
         /* Check echoed session ID matches */
         S2N_ERROR_IF(session_id_len != conn->session_id_len || memcmp(session_id, conn->session_id, session_id_len), S2N_ERR_BAD_MESSAGE);
         conn->actual_protocol_version = conn->server_protocol_version;

--- a/tls/s2n_tls.h
+++ b/tls/s2n_tls.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <stdbool.h> 
 
 #include "tls/s2n_connection.h"
 
@@ -29,6 +30,7 @@ extern int s2n_handshake_status_handler(struct s2n_connection *conn);
 extern int s2n_sslv2_client_hello_recv(struct s2n_connection *conn);
 extern int s2n_client_hello_retry_send(struct s2n_connection *conn);
 extern int s2n_client_hello_retry_recv(struct s2n_connection *conn);
+extern bool s2n_is_hello_retry_req(struct s2n_connection *conn);
 extern int s2n_server_hello_send(struct s2n_connection *conn);
 extern int s2n_server_hello_recv(struct s2n_connection *conn);
 extern int s2n_encrypted_extensions_send(struct s2n_connection *conn);


### PR DESCRIPTION
**Issue # (if available):**  #975

**Description of changes:**  if the secure_random in server_hello msg matches the specific value[1] of hello_retry abort the connection with S2N_ERR_UNIMPLEMENTED. 

[1] https://tools.ietf.org/html/rfc8446#section-4.1.3

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
