### PR TITLE
Fix KEM pointer bug

### DIFF
--- a/tests/unit/s2n_kem_test.c
+++ b/tests/unit/s2n_kem_test.c
@@ -119,16 +119,16 @@ int main(int argc, char **argv)
         struct s2n_blob  clientKemBlob = {0};
         EXPECT_SUCCESS(s2n_blob_init(&clientKemBlob, clientKems, 8));
 
-        struct s2n_kem only02[] = {kem02};
+        const struct s2n_kem *only02[] = {&kem02};
         EXPECT_SUCCESS(s2n_kem_find_supported_kem(&clientKemBlob, only02, 1, &negotiated_kem));
         EXPECT_EQUAL(negotiated_kem->kem_extension_id, kem02.kem_extension_id);
 
-        struct s2n_kem onlyff[] = {kemff};
+        const struct s2n_kem *onlyff[] = {&kemff};
         negotiated_kem = NULL;
         EXPECT_FAILURE(s2n_kem_find_supported_kem(&clientKemBlob, onlyff, 1, &negotiated_kem));
         EXPECT_NULL(negotiated_kem);
 
-        struct s2n_kem server_order_test[] = {kemff, kembc, kem03};
+        const struct s2n_kem *server_order_test[] = {&kemff, &kembc, &kem03};
         EXPECT_SUCCESS(s2n_kem_find_supported_kem(&clientKemBlob, server_order_test, 3, &negotiated_kem));
         EXPECT_EQUAL(negotiated_kem->kem_extension_id, kembc.kem_extension_id);
     }

--- a/tls/s2n_kem.c
+++ b/tls/s2n_kem.c
@@ -124,7 +124,7 @@ int s2n_kem_decapsulate(const struct s2n_kem_keypair *kem_keys, struct s2n_blob 
     return 0;
 }
 
-int s2n_kem_find_supported_kem(struct s2n_blob *client_kem_ids, const struct s2n_kem *server_kem_pref_list,
+int s2n_kem_find_supported_kem(struct s2n_blob *client_kem_ids, const struct s2n_kem *server_kem_pref_list[],
                                const int num_server_supported_kems, const struct s2n_kem **matching_kem)
 {
     struct s2n_stuffer client_kems_in = {0};
@@ -133,13 +133,13 @@ int s2n_kem_find_supported_kem(struct s2n_blob *client_kem_ids, const struct s2n
     GUARD(s2n_stuffer_write(&client_kems_in, client_kem_ids));
 
     for (int i = 0; i < num_server_supported_kems; i++) {
-        const struct s2n_kem candidate_server_kem_name = server_kem_pref_list[i];
+        const struct s2n_kem candidate_server_kem_name = *server_kem_pref_list[i];
         for (int j = 0; j < client_kem_ids->size / 2; j++) {
             kem_extension_size candidate_client_kem_id;
             GUARD(s2n_stuffer_read_uint16(&client_kems_in, &candidate_client_kem_id));
 
             if (candidate_server_kem_name.kem_extension_id == candidate_client_kem_id) {
-                *matching_kem = &server_kem_pref_list[i];
+                *matching_kem = server_kem_pref_list[i];
                 return 0;
             }
         }

--- a/tls/s2n_kem.h
+++ b/tls/s2n_kem.h
@@ -55,7 +55,7 @@ extern int s2n_kem_encapsulate(const struct s2n_kem_keypair *kem_keys, struct s2
 extern int s2n_kem_decapsulate(const struct s2n_kem_keypair *kem_params, struct s2n_blob *shared_secret,
                                const struct s2n_blob *ciphertext);
 
-extern int s2n_kem_find_supported_kem(struct s2n_blob *client_kem_names, const struct s2n_kem *server_kem_pref_list,
+extern int s2n_kem_find_supported_kem(struct s2n_blob *client_kem_names, const struct s2n_kem *server_kem_pref_list[],
                                       const int num_server_supported_kems, const struct s2n_kem **matching_kem);
 
 extern int s2n_kem_free(struct s2n_kem_keypair *kem_keys);

--- a/tls/s2n_kex.c
+++ b/tls/s2n_kex.c
@@ -91,7 +91,7 @@ static int s2n_check_kem(const struct s2n_cipher_suite *cipher_suite, struct s2n
 
     /* If the client did send a PQ KEM extension the server must find a mutually supported parameter */
     const struct s2n_kem *matching_kem = NULL;
-    if(s2n_kem_find_supported_kem(proposed_kems, *supported_params->kems, supported_params->kem_count, &matching_kem) != 0) { return 0; }
+    if(s2n_kem_find_supported_kem(proposed_kems, supported_params->kems, supported_params->kem_count, &matching_kem) != 0) { return 0; }
     return matching_kem != NULL;
 }
 
@@ -108,7 +108,7 @@ static int s2n_configure_kem(const struct s2n_cipher_suite *cipher_suite, struct
     }
 
     const struct s2n_kem *matching_kem = NULL;
-    GUARD(s2n_kem_find_supported_kem(proposed_kems, *supported_params->kems, supported_params->kem_count, &matching_kem));
+    GUARD(s2n_kem_find_supported_kem(proposed_kems, supported_params->kems, supported_params->kem_count, &matching_kem));
     conn->secure.s2n_kem_keys.negotiated_kem = matching_kem;
     return 0;
 }

--- a/tls/s2n_server_key_exchange.c
+++ b/tls/s2n_server_key_exchange.c
@@ -169,7 +169,7 @@ int s2n_kem_server_key_recv_parse_data(struct s2n_connection *conn, struct s2n_k
     const struct s2n_iana_to_kem *supported_params = NULL;
     GUARD(s2n_cipher_suite_to_kem(conn->secure.cipher_suite->iana_value, &supported_params));
 
-    S2N_ERROR_IF(s2n_kem_find_supported_kem(&kem_data->kem_name, *supported_params->kems, supported_params->kem_count, &match) != 0, S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+    S2N_ERROR_IF(s2n_kem_find_supported_kem(&kem_data->kem_name, supported_params->kems, supported_params->kem_count, &match) != 0, S2N_ERR_KEM_UNSUPPORTED_PARAMS);
     conn->secure.s2n_kem_keys.negotiated_kem = match;
 
     S2N_ERROR_IF(kem_data->raw_public_key.size != conn->secure.s2n_kem_keys.negotiated_kem->public_key_length, S2N_ERR_BAD_MESSAGE);


### PR DESCRIPTION
**Issue # (if available):** N/A

**Description of changes:** Fixes a bug in the handling of KEM arrays while matching server & client preferences. This was discovered when attempting to add SIKE R2 P434 to the list of KEMs - once a second entry existed in the server preferences list, `s2n_kem_find_supported_kem` would trigger a buffer overflow because the pointer indirection was not handled correctly. There was no impact up to this point because the loop in `s2n_kem_find_supported_kem` never iterated more than once.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
