### PR TITLE
Add certificate extensions

### DIFF
--- a/crypto/s2n_certificate.h
+++ b/crypto/s2n_certificate.h
@@ -77,7 +77,7 @@ int s2n_cert_chain_and_key_matches_dns_name(const struct s2n_cert_chain_and_key 
 
 int s2n_cert_public_key_set_rsa_from_openssl(s2n_cert_public_key *cert_pub_key, RSA *rsa);
 int s2n_cert_set_cert_type(struct s2n_cert *cert, s2n_pkey_type pkey_type);
-int s2n_send_cert_chain(struct s2n_stuffer *out, struct s2n_cert_chain *chain);
+int s2n_send_cert_chain(struct s2n_stuffer *out, struct s2n_cert_chain *chain, uint8_t actual_protocol_version);
 int s2n_send_empty_cert_chain(struct s2n_stuffer *out);
 int s2n_create_cert_chain_from_stuffer(struct s2n_cert_chain *cert_chain_out, struct s2n_stuffer *chain_in_stuffer);
 int s2n_cert_chain_and_key_set_cert_chain(struct s2n_cert_chain_and_key *cert_and_key, const char *cert_chain_pem);

--- a/tests/unit/s2n_certificate_extensions_test.c
+++ b/tests/unit/s2n_certificate_extensions_test.c
@@ -1,0 +1,277 @@
+    /*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include <s2n.h>
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+
+#include "tls/s2n_tls.h"
+#include "tls/s2n_tls13.h"
+#include "tls/extensions/s2n_certificate_extensions.h"
+
+#include "error/s2n_errno.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+/* Modified test vectors from https://tools.ietf.org/html/rfc8448#section-3 */
+
+/* with invalid certificate extension (supported version) on the end */
+const char tls13_cert_invalid_ext_hex[] =
+    "000001bb0001b03082" /* without 0b0001b9 header */
+    "01ac30820115a003020102020102300d06092a8648"
+    "86f70d01010b0500300e310c300a06035504031303"
+    "727361301e170d3136303733303031323335395a17"
+    "0d3236303733303031323335395a300e310c300a06"
+    "03550403130372736130819f300d06092a864886f7"
+    "0d010101050003818d0030818902818100b4bb498f"
+    "8279303d980836399b36c6988c0c68de55e1bdb826"
+    "d3901a2461eafd2de49a91d015abbc9a95137ace6c"
+    "1af19eaa6af98c7ced43120998e187a80ee0ccb052"
+    "4b1b018c3e0b63264d449a6d38e22a5fda43084674"
+    "8030530ef0461c8ca9d9efbfae8ea6d1d03e2bd193"
+    "eff0ab9a8002c47428a6d35a8d88d79f7f1e3f0203"
+    "010001a31a301830090603551d1304023000300b06"
+    "03551d0f0404030205a0300d06092a864886f70d01"
+    "010b05000381810085aad2a0e5b9276b908c65f73a"
+    "7267170618a54c5f8a7b337d2df7a594365417f2ea"
+    "e8f8a58c8f8172f9319cf36b7fd6c55b80f21a0301"
+    "5156726096fd335e5e67f2dbf102702e608ccae6be"
+    "c1fc63a42a99be5c3eb7107c3c54e9b9eb2bd5203b"
+    "1c3b84e0a8b2f759409ba3eac9d91d402dcc0cc8f8"
+    "961229ac9187b42b4de10006002b00020103";
+
+/* with single extension sent */
+/* server can send empty status request extension from https://tools.ietf.org/html/rfc8446#section-4.4.2.1 */
+const char tls13_cert_single_ext_hex[] =
+    "000001b90001b03082" /* without 0b0001b9 header */
+    "01ac30820115a003020102020102300d06092a8648"
+    "86f70d01010b0500300e310c300a06035504031303"
+    "727361301e170d3136303733303031323335395a17"
+    "0d3236303733303031323335395a300e310c300a06"
+    "03550403130372736130819f300d06092a864886f7"
+    "0d010101050003818d0030818902818100b4bb498f"
+    "8279303d980836399b36c6988c0c68de55e1bdb826"
+    "d3901a2461eafd2de49a91d015abbc9a95137ace6c"
+    "1af19eaa6af98c7ced43120998e187a80ee0ccb052"
+    "4b1b018c3e0b63264d449a6d38e22a5fda43084674"
+    "8030530ef0461c8ca9d9efbfae8ea6d1d03e2bd193"
+    "eff0ab9a8002c47428a6d35a8d88d79f7f1e3f0203"
+    "010001a31a301830090603551d1304023000300b06"
+    "03551d0f0404030205a0300d06092a864886f70d01"
+    "010b05000381810085aad2a0e5b9276b908c65f73a"
+    "7267170618a54c5f8a7b337d2df7a594365417f2ea"
+    "e8f8a58c8f8172f9319cf36b7fd6c55b80f21a0301"
+    "5156726096fd335e5e67f2dbf102702e608ccae6be"
+    "c1fc63a42a99be5c3eb7107c3c54e9b9eb2bd5203b"
+    "1c3b84e0a8b2f759409ba3eac9d91d402dcc0cc8f8"
+    "961229ac9187b42b4de1000400050000";
+
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    EXPECT_SUCCESS(s2n_enable_tls13());
+
+    struct s2n_config *config;
+    EXPECT_NOT_NULL(config = s2n_config_new());
+
+    /* Server send/receive certificate with TLS 1.3 and no extensions */
+    {
+        /* Initialize connections */
+        struct s2n_connection *server_conn;
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        server_conn->actual_protocol_version = S2N_TLS13;
+
+        /* Initialize cert chain */
+        char *cert_chain_pem;
+        char *private_key_pem;
+        struct s2n_cert_chain_and_key *ecdsa_cert;
+
+        EXPECT_NOT_NULL(ecdsa_cert = s2n_cert_chain_and_key_new());
+        EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_ECDSA_P384_PKCS1_CERT_CHAIN, cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_ECDSA_P384_PKCS1_KEY, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(ecdsa_cert, cert_chain_pem, private_key_pem));
+        
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, ecdsa_cert));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        server_conn->handshake_params.our_chain_and_key = ecdsa_cert;
+
+        /* Send empty extensions */
+        EXPECT_SUCCESS(s2n_server_cert_send(server_conn));
+        EXPECT_TRUE(s2n_stuffer_data_available(&server_conn->handshake.io) > 0);
+
+        /* Receive empty extensions */
+        EXPECT_SUCCESS(s2n_server_cert_recv(server_conn));
+
+        /* Clean up */
+        free(cert_chain_pem);
+        free(private_key_pem);
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(ecdsa_cert));
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+    }
+
+    /* Client send/receive certificate with TLS 1.3 and no extensions */
+    {
+        /* Initialize connections */
+        struct s2n_connection *client_conn;
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        client_conn->actual_protocol_version = S2N_TLS13;
+
+        /* Initialize cert chain */
+        char *cert_chain_pem;
+        char *private_key_pem;
+        struct s2n_cert_chain_and_key *ecdsa_cert;
+
+        EXPECT_NOT_NULL(ecdsa_cert = s2n_cert_chain_and_key_new());
+        EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_ECDSA_P384_PKCS1_CERT_CHAIN, cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_ECDSA_P384_PKCS1_KEY, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(ecdsa_cert, cert_chain_pem, private_key_pem));
+        
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, ecdsa_cert));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+        client_conn->handshake_params.our_chain_and_key = ecdsa_cert;
+
+        /* Send empty extensions */
+        EXPECT_SUCCESS(s2n_client_cert_send(client_conn));
+        EXPECT_TRUE(s2n_stuffer_data_available(&client_conn->handshake.io) > 0);
+
+        /* Receive empty extensions */
+        client_conn->x509_validator.skip_cert_validation = 1;
+        EXPECT_SUCCESS(s2n_client_cert_recv(client_conn));
+
+        /* Clean up */
+        free(cert_chain_pem);
+        free(private_key_pem);
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(ecdsa_cert));
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+    }
+
+    /* Test this does not break happy path TLS 1.2 server send/recv */
+    { 
+        struct s2n_connection *server_conn;
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        server_conn->actual_protocol_version = S2N_TLS12;
+        server_conn->secure.cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
+
+        char *cert_chain_pem;
+        char *private_key_pem;
+        struct s2n_cert_chain_and_key *ecdsa_cert;
+
+        EXPECT_NOT_NULL(ecdsa_cert = s2n_cert_chain_and_key_new());
+        EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_ECDSA_P384_PKCS1_CERT_CHAIN, cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_ECDSA_P384_PKCS1_KEY, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(ecdsa_cert, cert_chain_pem, private_key_pem));
+        
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, ecdsa_cert));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        server_conn->handshake_params.our_chain_and_key = ecdsa_cert;
+
+        EXPECT_SUCCESS(s2n_server_cert_send(server_conn));
+        EXPECT_TRUE(s2n_stuffer_data_available(&server_conn->handshake.io) > 0);
+
+        server_conn->x509_validator.skip_cert_validation = 1;
+        EXPECT_SUCCESS(s2n_server_cert_recv(server_conn));
+
+        free(cert_chain_pem);
+        free(private_key_pem);
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(ecdsa_cert));
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+    }
+
+    /* Test TLS 1.2 client send/recv happy path does not break */
+    { 
+        struct s2n_connection *client_conn;
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        client_conn->actual_protocol_version = S2N_TLS12;
+
+        char *cert_chain_pem;
+        char *private_key_pem;
+        struct s2n_cert_chain_and_key *ecdsa_cert;
+
+        EXPECT_NOT_NULL(ecdsa_cert = s2n_cert_chain_and_key_new());
+        EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_ECDSA_P384_PKCS1_CERT_CHAIN, cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_ECDSA_P384_PKCS1_KEY, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(ecdsa_cert, cert_chain_pem, private_key_pem));
+        
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, ecdsa_cert));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+        client_conn->handshake_params.our_chain_and_key = ecdsa_cert;
+
+        EXPECT_SUCCESS(s2n_client_cert_send(client_conn));
+        EXPECT_TRUE(s2n_stuffer_data_available(&client_conn->handshake.io) > 0);
+
+        client_conn->x509_validator.skip_cert_validation = 1;
+        EXPECT_SUCCESS(s2n_client_cert_recv(client_conn));
+
+        free(cert_chain_pem);
+        free(private_key_pem);
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(ecdsa_cert));
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+    }
+
+    /* Test with TLS 1.3 and an extension sent */
+    {
+        struct s2n_connection *client_conn;
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        client_conn->actual_protocol_version = S2N_TLS13;
+
+        S2N_BLOB_FROM_HEX(tls13_cert, tls13_cert_single_ext_hex);
+        EXPECT_SUCCESS(s2n_stuffer_write(&client_conn->handshake.io, &tls13_cert));
+        EXPECT_EQUAL(s2n_stuffer_data_available(&client_conn->handshake.io), 445);
+
+        client_conn->x509_validator.skip_cert_validation = 1;
+        EXPECT_SUCCESS(s2n_server_cert_recv(client_conn));
+        EXPECT_EQUAL(s2n_stuffer_data_available(&client_conn->handshake.io), 0);
+
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+    }
+
+    /* Test with TLS 1.3 and invalid kind of extension sent */
+    {
+        struct s2n_connection *client_conn;
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        client_conn->actual_protocol_version = S2N_TLS13;
+
+        /* Fill io stuffer with data for incorrect extension */
+        S2N_BLOB_FROM_HEX(tls13_cert, tls13_cert_invalid_ext_hex);
+        EXPECT_SUCCESS(s2n_stuffer_write(&client_conn->handshake.io, &tls13_cert));
+        EXPECT_EQUAL(s2n_stuffer_data_available(&client_conn->handshake.io), 447);
+
+        client_conn->x509_validator.skip_cert_validation = 1;
+        /* Verified it fails inside of extension parsing, but the error is masked by cert_untrusted */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_server_cert_recv(client_conn), S2N_ERR_CERT_UNTRUSTED);
+        EXPECT_EQUAL(s2n_stuffer_data_available(&client_conn->handshake.io), 0);
+
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+    }
+
+    EXPECT_SUCCESS(s2n_config_free(config));
+
+    END_TEST();
+
+    return 0;
+}

--- a/tests/unit/s2n_tls13_server_cert_test.c
+++ b/tests/unit/s2n_tls13_server_cert_test.c
@@ -25,8 +25,10 @@
 #include "utils/s2n_safety.h"
 
 /* Test vectors from https://tools.ietf.org/html/rfc8448#section-3 */
-const char tls13_cert_hex[] =
-    "3082" /* without certificate chain header */
+
+/* whole cert message without 0b0001b9 header */
+const char tls13_cert_message_hex[] =
+    "000001b50001b03082"
     "01ac30820115a003020102020102300d06092a8648"
     "86f70d01010b0500300e310c300a06035504031303"
     "727361301e170d3136303733303031323335395a17"
@@ -49,32 +51,47 @@ const char tls13_cert_hex[] =
     "1c3b84e0a8b2f759409ba3eac9d91d402dcc0cc8f8"
     "961229ac9187b42b4de10000";
 
+/* cert only */
+const char tls13_cert_hex[] =
+    "3082" /* without certificate chain header */
+    "01ac30820115a003020102020102300d06092a8648"
+    "86f70d01010b0500300e310c300a06035504031303"
+    "727361301e170d3136303733303031323335395a17"
+    "0d3236303733303031323335395a300e310c300a06"
+    "03550403130372736130819f300d06092a864886f7"
+    "0d010101050003818d0030818902818100b4bb498f"
+    "8279303d980836399b36c6988c0c68de55e1bdb826"
+    "d3901a2461eafd2de49a91d015abbc9a95137ace6c"
+    "1af19eaa6af98c7ced43120998e187a80ee0ccb052"
+    "4b1b018c3e0b63264d449a6d38e22a5fda43084674"
+    "8030530ef0461c8ca9d9efbfae8ea6d1d03e2bd193"
+    "eff0ab9a8002c47428a6d35a8d88d79f7f1e3f0203"
+    "010001a31a301830090603551d1304023000300b06"
+    "03551d0f0404030205a0300d06092a864886f70d01"
+    "010b05000381810085aad2a0e5b9276b908c65f73a"
+    "7267170618a54c5f8a7b337d2df7a594365417f2ea"
+    "e8f8a58c8f8172f9319cf36b7fd6c55b80f21a0301"
+    "5156726096fd335e5e67f2dbf102702e608ccae6be"
+    "c1fc63a42a99be5c3eb7107c3c54e9b9eb2bd5203b"
+    "1c3b84e0a8b2f759409ba3eac9d91d402dcc0cc8f8"
+    "961229ac9187b42b4de1";
+
 /* certificate chain header. It contains
    1. Request Context length (00)
-   2. Cert chain length (00001b5)
+   2. Cert chain length (0001b5)
    3. Cert length (0001b0)
  */
 const char tls13_cert_chain_header_hex[] =
      "000001b50001b0";
 
+
 int main(int argc, char **argv)
 {
-    char *tls13_cert_chain_hex;
     BEGIN_TEST();
-    /* creating a certificate chain by concatenating
-       1. chain header
-       2. certificate
-    */
-    EXPECT_NOT_NULL(tls13_cert_chain_hex = malloc(S2N_MAX_TEST_PEM_SIZE));
-    strcpy(tls13_cert_chain_hex, tls13_cert_chain_header_hex);
-    strcat(tls13_cert_chain_hex, tls13_cert_hex);
-    /* convert certificate chain hex to bytes*/
-    struct s2n_blob tls13_cert = {0};
-    EXPECT_SUCCESS(s2n_alloc(&tls13_cert, strlen(tls13_cert_chain_hex) / 2 ));
-    GUARD(s2n_hex_string_to_bytes(tls13_cert_chain_hex, &tls13_cert));
 
     /* Test s2n_server_cert_recv() parses tls13 certificate */
     {
+        S2N_BLOB_FROM_HEX(tls13_cert, tls13_cert_message_hex);
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
@@ -98,13 +115,27 @@ int main(int argc, char **argv)
 
     /* Test s2n_server_cert_send() verify server's certificate */
     {
+        char *tls13_cert_chain_hex;
+        /* creating a certificate chain by concatenating
+           1. chain header
+           2. certificate
+        */
+        EXPECT_NOT_NULL(tls13_cert_chain_hex = malloc(S2N_MAX_TEST_PEM_SIZE));
+        strcpy(tls13_cert_chain_hex, tls13_cert_chain_header_hex);
+        strcat(tls13_cert_chain_hex, tls13_cert_hex);
+        /* convert certificate chain hex to bytes*/
+        struct s2n_blob tls13_cert = {0};
+        EXPECT_SUCCESS(s2n_alloc(&tls13_cert, strlen(tls13_cert_chain_hex) / 2 ));
+        GUARD(s2n_hex_string_to_bytes(tls13_cert_chain_hex, &tls13_cert));
+
         S2N_BLOB_FROM_HEX(tls13_cert_chain, tls13_cert_hex);
 
         struct s2n_connection *conn;
         uint8_t certificate_request_context_len;
 
         struct s2n_cert cert = {.raw = tls13_cert_chain,.next = NULL};
-        struct s2n_cert_chain cert_chain = {.head = &cert};
+        /* .chain_size is size of cert + 3 for the 3 bytes to express the length */
+        struct s2n_cert_chain cert_chain = {.head = &cert, .chain_size = tls13_cert_chain.size + 3};
         struct s2n_cert_chain_and_key cert_chain_and_key = {.cert_chain = &cert_chain};
 
         /* tls13 mode */
@@ -113,8 +144,10 @@ int main(int argc, char **argv)
         conn->handshake_params.our_chain_and_key = &cert_chain_and_key;
         EXPECT_EQUAL(conn->actual_protocol_version, S2N_TLS13);
         EXPECT_SUCCESS(s2n_server_cert_send(conn));
-        EXPECT_EQUAL(s2n_stuffer_data_available(&conn->handshake.io), tls13_cert.size);
-        GUARD(s2n_stuffer_read_uint8(&conn->handshake.io, &certificate_request_context_len));
+
+        EXPECT_EQUAL(s2n_stuffer_data_available(&conn->handshake.io), tls13_cert.size + 2);
+        EXPECT_SUCCESS(s2n_stuffer_read_uint8(&conn->handshake.io, &certificate_request_context_len));
+
         /* server's certificate request context should always be of zero length */
         EXPECT_EQUAL(certificate_request_context_len, 0);
         EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -129,10 +162,11 @@ int main(int argc, char **argv)
            TLS1.2 Cert length = TLS1.3 Cert length -1 (server's request context)*/
         EXPECT_EQUAL(s2n_stuffer_data_available(&conn->handshake.io), tls13_cert.size - 1);
         EXPECT_SUCCESS(s2n_connection_free(conn));
-    }
 
-    free(tls13_cert_chain_hex);
-    /* free memory allocated in s2n_alloc*/
-    free(tls13_cert.data);
+        free(tls13_cert_chain_hex);
+        /* free memory allocated in s2n_alloc*/
+        free(tls13_cert.data);
+    }
+    
     END_TEST();
 }

--- a/tls/extensions/s2n_certificate_extensions.c
+++ b/tls/extensions/s2n_certificate_extensions.c
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "error/s2n_errno.h"
+#include "utils/s2n_safety.h"
+#include "stuffer/s2n_stuffer.h"
+
+#include "tls/s2n_tls.h"
+#include "tls/s2n_tls13.h"
+#include "tls/extensions/s2n_server_sct_list.h"
+#include "tls/extensions/s2n_server_certificate_status.h"
+
+static int s2n_get_number_certs_in_chain(struct s2n_cert *head, uint8_t *chain_length);
+
+int s2n_certificate_extensions_parse(struct s2n_connection *conn, struct s2n_blob *extensions)
+{
+    struct s2n_stuffer extensions_in = {0};
+    GUARD(s2n_stuffer_init(&extensions_in, extensions));
+    GUARD(s2n_stuffer_write(&extensions_in, extensions));
+
+    while (s2n_stuffer_data_available(&extensions_in)) {
+        struct s2n_blob ext = {0};
+        uint16_t extension_type, extension_size;
+        struct s2n_stuffer extension = {0};
+
+        S2N_ERROR_IF(s2n_stuffer_data_available(&extensions_in) < 4, S2N_ERR_BAD_MESSAGE);
+        GUARD(s2n_stuffer_read_uint16(&extensions_in, &extension_type));
+        GUARD(s2n_stuffer_read_uint16(&extensions_in, &extension_size));
+
+        S2N_ERROR_IF(extension_size > s2n_stuffer_data_available(&extensions_in), S2N_ERR_BAD_MESSAGE);
+        ext.size = extension_size;
+        ext.data = s2n_stuffer_raw_read(&extensions_in, ext.size);
+        notnull_check(ext.data);
+
+        switch (extension_type) {
+        case TLS_EXTENSION_SCT_LIST:
+            /* only servers should be sending this extension here therefore
+             * only clients should be parsing the extension
+             */
+            if (conn->mode == S2N_CLIENT) {
+                GUARD(s2n_stuffer_init(&extension, &ext));
+                GUARD(s2n_stuffer_write(&extension, &ext));
+                GUARD(s2n_recv_server_sct_list(conn, &extension));
+            }
+            break;
+        case TLS_EXTENSION_STATUS_REQUEST:
+            GUARD(s2n_server_certificate_status_parse(conn, &ext));
+            break;
+        /* Error on known extensions that are not supposed to appear in EE
+         * https://tools.ietf.org/html/rfc8446#page-37
+         */
+        case TLS_EXTENSION_SERVER_NAME:
+        case TLS_EXTENSION_ALPN:
+        case TLS_EXTENSION_MAX_FRAG_LEN:
+        case TLS_EXTENSION_RENEGOTIATION_INFO:
+        case TLS_EXTENSION_SESSION_TICKET:
+        case TLS_EXTENSION_SUPPORTED_VERSIONS:
+        case TLS_EXTENSION_KEY_SHARE:
+            S2N_ERROR(S2N_ERR_BAD_MESSAGE);
+            break;
+        }
+    }
+
+    return 0;
+}
+
+int s2n_certificate_extensions_send(struct s2n_stuffer *out)
+{
+    /* For minimal TLS 1.3 implementation, we are sending no certificate extensions. 
+     * We only send the length field with a value of 0. 
+     */
+    GUARD(s2n_stuffer_write_uint16(out, 0));
+    return 0;
+}
+
+int s2n_certificate_extensions_size(struct s2n_cert *head)
+{
+    /* For minimal TLS 1.3 implementation, we are sending no certificate extensions. For now, size is
+     * hardcoded to 2 * num_certs in order to send extensions_length field with value 0 for each cert.
+     */
+    uint8_t num_certs;
+    GUARD(s2n_get_number_certs_in_chain(head, &num_certs));
+
+    return 2 * num_certs;
+}
+
+int s2n_get_number_certs_in_chain(struct s2n_cert *head, uint8_t *chain_length)
+{
+    notnull_check(head);
+
+    int length = 1;
+
+    while (head->next != NULL) {
+        length += 1;
+        head = head->next;
+    }
+
+    *chain_length = length;
+    
+    return 0;
+}

--- a/tls/extensions/s2n_certificate_extensions.h
+++ b/tls/extensions/s2n_certificate_extensions.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+
+#pragma once
+
+#include "tls/s2n_connection.h"
+#include "stuffer/s2n_stuffer.h"
+
+extern int s2n_certificate_extensions_parse(struct s2n_connection *conn, struct s2n_blob *extensions);
+extern int s2n_certificate_extensions_send(struct s2n_stuffer *out);
+extern int s2n_certificate_extensions_size(struct s2n_cert *head);

--- a/tls/extensions/s2n_server_certificate_status.c
+++ b/tls/extensions/s2n_server_certificate_status.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "tls/s2n_cipher_suites.h"
+#include "tls/s2n_config.h"
+#include "tls/s2n_connection.h"
+#include "tls/s2n_tls.h"
+#include "tls/s2n_x509_validator.h"
+#include "tls/extensions/s2n_server_certificate_status.h"
+#include "utils/s2n_safety.h"
+
+int s2n_server_certificate_status_parse(struct s2n_connection *conn, struct s2n_blob *status)
+{
+    GUARD(s2n_alloc(&conn->status_response, status->size));
+    memcpy_check(conn->status_response.data, status->data, status->size);
+    conn->status_response.size = status->size;
+
+    return s2n_x509_validator_validate_cert_stapled_ocsp_response(&conn->x509_validator, conn,
+                                                                      conn->status_response.data, conn->status_response.size);
+}

--- a/tls/extensions/s2n_server_certificate_status.h
+++ b/tls/extensions/s2n_server_certificate_status.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+extern int s2n_server_certificate_status_parse(struct s2n_connection *conn, struct s2n_blob *status);

--- a/tls/s2n_client_cert.c
+++ b/tls/s2n_client_cert.c
@@ -86,6 +86,6 @@ int s2n_client_cert_send(struct s2n_connection *conn)
         return 0;
     }
 
-    GUARD(s2n_send_cert_chain(&conn->handshake.io, chain_and_key->cert_chain));
+    GUARD(s2n_send_cert_chain(&conn->handshake.io, chain_and_key->cert_chain, conn->actual_protocol_version));
     return 0;
 }

--- a/tls/s2n_ocsp_stapling.c
+++ b/tls/s2n_ocsp_stapling.c
@@ -22,6 +22,7 @@
 #include "tls/s2n_connection.h"
 #include "tls/s2n_tls.h"
 #include "tls/s2n_x509_validator.h"
+#include "tls/extensions/s2n_server_certificate_status.h"
 #include "utils/s2n_safety.h"
 
 int s2n_server_status_send(struct s2n_connection *conn)
@@ -44,14 +45,8 @@ int s2n_server_status_recv(struct s2n_connection *conn)
     notnull_check(status.data);
 
     if (type == S2N_STATUS_REQUEST_OCSP) {
-        GUARD(s2n_alloc(&conn->status_response, status.size));
-        memcpy_check(conn->status_response.data, status.data, status.size);
-        conn->status_response.size = status.size;
-
-        return s2n_x509_validator_validate_cert_stapled_ocsp_response(&conn->x509_validator, conn,
-                                                                      conn->status_response.data, conn->status_response.size);
+        GUARD(s2n_server_certificate_status_parse(conn, &status));
     }
 
     return 0;
 }
-

--- a/tls/s2n_server_cert.c
+++ b/tls/s2n_server_cert.c
@@ -95,6 +95,8 @@ int s2n_server_cert_send(struct s2n_connection *conn)
         uint8_t certificate_request_context_len = 0;
         GUARD(s2n_stuffer_write_uint8(&conn->handshake.io, certificate_request_context_len));
     }
-    GUARD(s2n_send_cert_chain(&conn->handshake.io, conn->handshake_params.our_chain_and_key->cert_chain));
+
+    GUARD(s2n_send_cert_chain(&conn->handshake.io, conn->handshake_params.our_chain_and_key->cert_chain, conn->actual_protocol_version));
+
     return 0;
 }

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -20,6 +20,7 @@
 #include "utils/s2n_rfc5952.h"
 #include "tls/s2n_config.h"
 #include "tls/s2n_connection.h"
+#include "extensions/s2n_certificate_extensions.h"
 
 #include <arpa/inet.h>
 #include <sys/socket.h>
@@ -350,9 +351,21 @@ s2n_cert_validation_code s2n_x509_validator_validate_cert_chain(struct s2n_x509_
         /* certificate extensions is a field in TLS 1.3 - https://tools.ietf.org/html/rfc8446#section-4.4.2 */
         if (conn->actual_protocol_version == S2N_TLS13) {
             uint16_t certificate_extensions_length = 0;
+            S2N_ERROR_IF(2 > s2n_stuffer_data_available(&cert_chain_in_stuffer), S2N_ERR_BAD_MESSAGE);
             GUARD(s2n_stuffer_read_uint16(&cert_chain_in_stuffer, &certificate_extensions_length));
-            /* we currently do not process certificate extensions, but we can skip pass it */
-            GUARD(s2n_stuffer_skip_read(&cert_chain_in_stuffer, certificate_extensions_length));
+            S2N_ERROR_IF(certificate_extensions_length > s2n_stuffer_data_available(&cert_chain_in_stuffer), S2N_ERR_BAD_MESSAGE);
+
+            if (certificate_extensions_length > 0) {
+                struct s2n_blob extensions = {0};
+                extensions.size = certificate_extensions_length;
+                extensions.data = s2n_stuffer_raw_read(&cert_chain_in_stuffer, extensions.size);
+                notnull_check(extensions.data);
+                
+                /* RFC 8446: if an extension applies to the entire chain, it SHOULD be included in the first CertificateEntry */
+                if (certificate_count == 0) {
+                    GUARD(s2n_certificate_extensions_parse(conn, &extensions));
+                }
+            }
         }
 
         certificate_count++;


### PR DESCRIPTION
**Issue # (if available):**  https://github.com/awslabs/s2n/issues/1207

**Description of changes:** 

Add certificate extensions for minimal TLS 1.3 implementation. Server sends no extensions, but can parse received ones.

Fix tests/unit/s2n_tls13_server_cert_test.c

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
