### PR TITLE
DO NOT MERGE. Testing travis fails even though test PASSED

### DIFF
--- a/tls/s2n_server_cert_verify.c
+++ b/tls/s2n_server_cert_verify.c
@@ -92,7 +92,8 @@ int s2n_server_write_cert_verify_signature(struct s2n_connection *conn, struct s
 
 int s2n_server_generate_unsigned_cert_verify_content(struct s2n_connection *conn, struct s2n_stuffer *unsigned_content, s2n_hash_algorithm chosen_hash_alg)
 {
-    struct s2n_hash_state hash_copy;
+    DEFER_CLEANUP(struct s2n_hash_state hash_copy = {0}, s2n_hash_free);
+    GUARD(s2n_hash_new(&hash_copy));
     uint8_t hash_digest_length;
     uint8_t digest_out[S2N_MAX_DIGEST_LEN];
 


### PR DESCRIPTION
**Issue # (if available):** https://github.com/awslabs/s2n/issues/1290

**Description of changes:** 
DO NOT MERGE. Reverted to a state where a test has PASSED despite memory leaks. Kicking off a travis build to see how it handles it. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
