### PR TITLE
Safer memset

### DIFF
--- a/.travis/grep_simple_mistakes.sh
+++ b/.travis/grep_simple_mistakes.sh
@@ -37,6 +37,17 @@ for file in $S2N_FILES_ASSERT_RETURN; do
   fi
 done
 
+# Detect raw usage of memset
+S2N_FILES_RAW_MEMSET=$(find "$PWD" -type f -name "s2n*.c" ! -path "*tests*")
+for file in $S2N_FILES_RAW_MEMSET; do
+  RESULT_RAW_MEMSET=`grep -Ern 'memset\((.*)\)' $file`
+
+  if [ "${#RESULT_RAW_MEMSET}" != "0" ]; then
+    FAILED=1
+    printf "\e[1;34mGrep for 'memset\((.*)\)' check failed in $file:\e[0m\n$RESULT_ARR_DIV\n\n"
+  fi
+done
+
 # Detect any array size calculations that are not using the s2n_array_len() function.
 S2N_FILES_ARRAY_SIZING_RETURN=$(find "$PWD" -type f -name "s2n*.c" -path "*")
 for file in $S2N_FILES_ARRAY_SIZING_RETURN; do

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -214,7 +214,7 @@ static void setup_s2n_config(struct s2n_config *config, const char *cipher_prefs
 
 int main(int argc, char *const *argv)
 {
-    struct addrinfo hints, *ai_list, *ai;
+    struct addrinfo *ai_list, *ai;
     int r, sockfd = 0;
     ssize_t session_state_length = 0;
     uint8_t *session_state = NULL;
@@ -341,10 +341,7 @@ int main(int argc, char *const *argv)
         server_name = host;
     }
 
-    memset(&hints, 0, sizeof(hints));
-
-    hints.ai_family = AF_UNSPEC;
-    hints.ai_socktype = SOCK_STREAM;
+    struct addrinfo hints = {.ai_family = AF_UNSPEC, .ai_socktype = SOCK_STREAM};
 
     if (signal(SIGPIPE, SIG_IGN) == SIG_ERR) {
         fprintf(stderr, "Error disabling SIGPIPE\n");

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -421,7 +421,7 @@ int handle_connection(int fd, struct s2n_config *config, struct conn_settings se
 
 int main(int argc, char *const *argv)
 {
-    struct addrinfo hints, *ai;
+    struct addrinfo *ai;
     int r, sockfd = 0;
 
     /* required args */
@@ -586,10 +586,7 @@ int main(int argc, char *const *argv)
         exit(1);
     }
 
-    memset(&hints, 0, sizeof(hints));
-
-    hints.ai_family = AF_UNSPEC;
-    hints.ai_socktype = SOCK_STREAM;
+    struct addrinfo hints = {.ai_family = AF_UNSPEC, .ai_socktype = SOCK_STREAM};
 
     if (signal(SIGPIPE, SIG_IGN) == SIG_ERR) {
         fprintf(stderr, "Error disabling SIGPIPE\n");

--- a/crypto/s2n_certificate.c
+++ b/crypto/s2n_certificate.c
@@ -181,8 +181,8 @@ struct s2n_cert_chain_and_key *s2n_cert_chain_and_key_new(void)
 
     chain_and_key->cert_chain->head = NULL;
     GUARD_PTR(s2n_pkey_zero_init(chain_and_key->private_key));
-    memset(&chain_and_key->ocsp_status, 0, sizeof(chain_and_key->ocsp_status));
-    memset(&chain_and_key->sct_list, 0, sizeof(chain_and_key->sct_list));
+    memset_check_ptr(&chain_and_key->ocsp_status, 0, sizeof(chain_and_key->ocsp_status));
+    memset_check_ptr(&chain_and_key->sct_list, 0, sizeof(chain_and_key->sct_list));
     chain_and_key->cn_names = s2n_array_new(sizeof(struct s2n_blob));
     if (!chain_and_key->cn_names) {
         return NULL;

--- a/crypto/s2n_certificate.c
+++ b/crypto/s2n_certificate.c
@@ -181,8 +181,8 @@ struct s2n_cert_chain_and_key *s2n_cert_chain_and_key_new(void)
 
     chain_and_key->cert_chain->head = NULL;
     GUARD_PTR(s2n_pkey_zero_init(chain_and_key->private_key));
-    memset_check_ptr(&chain_and_key->ocsp_status, 0, sizeof(chain_and_key->ocsp_status));
-    memset_check_ptr(&chain_and_key->sct_list, 0, sizeof(chain_and_key->sct_list));
+    S2N_ZERO_STRUCT(chain_and_key->ocsp_status);
+    S2N_ZERO_STRUCT(chain_and_key->sct_list);
     chain_and_key->cn_names = s2n_array_new(sizeof(struct s2n_blob));
     if (!chain_and_key->cn_names) {
         return NULL;

--- a/crypto/s2n_drbg.c
+++ b/crypto/s2n_drbg.c
@@ -164,7 +164,7 @@ int s2n_drbg_instantiate(struct s2n_drbg *drbg, struct s2n_blob *personalization
     static const uint8_t zero_key[S2N_DRBG_MAX_KEY_SIZE] = {0};
 
     /* Start off with zeroed data, per 10.2.1.3.1 item 4 and 5 */
-    memset(drbg->v, 0, sizeof(drbg->v));
+    S2N_ZERO_ARRAY(drbg->v);
     GUARD_OSSL(EVP_EncryptInit_ex(drbg->ctx, NULL, NULL, zero_key, NULL), S2N_ERR_DRBG);
 
     /* Copy the personalization string */

--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -102,7 +102,7 @@ static int s2n_sslv3_mac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm a
 
 static int s2n_tls_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm alg, const void *key, uint32_t klen)
 {
-    memset(&state->xor_pad, 0, sizeof(state->xor_pad));
+    memset_check(&state->xor_pad, 0, sizeof(state->xor_pad));
     
     if (klen > state->xor_pad_size) {
         GUARD(s2n_hash_update(&state->outer, key, klen));
@@ -209,7 +209,7 @@ int s2n_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm alg, const vo
      * Since xor_pad is used as a source of bytes in s2n_hmac_digest_two_compression_rounds,
      * this also prevents uninitilized bytes being used.
      */
-    memset(&state->xor_pad, 0, sizeof(state->xor_pad));
+    memset_check(&state->xor_pad, 0, sizeof(state->xor_pad));
     GUARD(s2n_hmac_reset(state));
 
     return 0;

--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -102,7 +102,7 @@ static int s2n_sslv3_mac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm a
 
 static int s2n_tls_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm alg, const void *key, uint32_t klen)
 {
-    memset_check(&state->xor_pad, 0, sizeof(state->xor_pad));
+    S2N_ZERO_ARRAY(state->xor_pad);
     
     if (klen > state->xor_pad_size) {
         GUARD(s2n_hash_update(&state->outer, key, klen));
@@ -209,7 +209,7 @@ int s2n_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm alg, const vo
      * Since xor_pad is used as a source of bytes in s2n_hmac_digest_two_compression_rounds,
      * this also prevents uninitilized bytes being used.
      */
-    memset_check(&state->xor_pad, 0, sizeof(state->xor_pad));
+    S2N_ZERO_ARRAY(state->xor_pad);
     GUARD(s2n_hmac_reset(state));
 
     return 0;

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -209,7 +209,7 @@ int s2n_stuffer_erase_and_read(struct s2n_stuffer *stuffer, struct s2n_blob *out
     notnull_check(ptr);
 
     memcpy_check(out->data, ptr, out->size);
-    memset(ptr, 0, out->size);
+    memset_check(ptr, 0, out->size);
 
     return 0;
 }
@@ -235,7 +235,7 @@ int s2n_stuffer_erase_and_read_bytes(struct s2n_stuffer *stuffer, uint8_t * data
     notnull_check(ptr);
 
     memcpy_check(data, ptr, size);
-    memset(ptr, 0, size);
+    memset_check(ptr, 0, size);
 
     return 0;
 }

--- a/tests/unit/s2n_random_test.c
+++ b/tests/unit/s2n_random_test.c
@@ -130,7 +130,7 @@ int main(int argc, char **argv)
      */
     int trailing_zeros[8];
 
-    memset(trailing_zeros, 0, sizeof(trailing_zeros));
+    S2N_ZERO_ARRAY(trailing_zeros);
     for (int i = 0; i < 5120; i++) {
         blob.size = i;
         EXPECT_SUCCESS(s2n_get_public_random_data(&blob));
@@ -174,7 +174,7 @@ int main(int argc, char **argv)
         EXPECT_TRUE(trailing_zeros[t] < 5120 / 16);
     }
 
-    memset(trailing_zeros, 0, sizeof(trailing_zeros));
+    S2N_ZERO_ARRAY(trailing_zeros);
     for (int i = 0; i < 5120; i++) {
         blob.size = i;
         EXPECT_SUCCESS(s2n_get_private_random_data(&blob));
@@ -218,7 +218,7 @@ int main(int argc, char **argv)
         EXPECT_TRUE(trailing_zeros[t] < 5120 / 16);
     }
 
-    memset(trailing_zeros, 0, sizeof(trailing_zeros));
+    S2N_ZERO_ARRAY(trailing_zeros);
     for (int i = 0; i < 5120; i++) {
         blob.size = i;
         EXPECT_SUCCESS(s2n_get_urandom_data(&blob));
@@ -263,7 +263,7 @@ int main(int argc, char **argv)
     }
 
     if (s2n_cpu_supports_rdrand()) {
-        memset(trailing_zeros, 0, sizeof(trailing_zeros));
+        S2N_ZERO_ARRAY(trailing_zeros);
         for (int i = 0; i < 5120; i++) {
             blob.size = i;
             EXPECT_SUCCESS(s2n_get_urandom_data(&blob));

--- a/tests/unit/s2n_self_talk_session_id_test.c
+++ b/tests/unit/s2n_self_talk_session_id_test.c
@@ -141,8 +141,6 @@ static void initialize_cache()
 
 void mock_client(struct s2n_test_piped_io *piped_io)
 {
-    size_t serialized_session_state_length = 0;
-    uint8_t serialized_session_state[256] = { 0 };
 
     struct s2n_connection *conn;
     struct s2n_config *config;
@@ -174,8 +172,8 @@ void mock_client(struct s2n_test_piped_io *piped_io)
     }
 
     /* Save session state from the connection */
-    memset(serialized_session_state, 0, sizeof(serialized_session_state));
-    serialized_session_state_length = s2n_connection_get_session_length(conn);
+    uint8_t serialized_session_state[256] = { 0 };
+    size_t serialized_session_state_length = s2n_connection_get_session_length(conn);
     if (serialized_session_state_length > sizeof(serialized_session_state)) {
         result = 3;
     }
@@ -421,7 +419,7 @@ int main(int argc, char **argv)
         EXPECT_TRUE(IS_RESUMPTION_HANDSHAKE(conn->handshake.handshake_type));
 
         /* Ensure the message was delivered */
-        memset(buffer, 0, sizeof(buffer));
+	S2N_ZERO_ARRAY(buffer);
         EXPECT_SUCCESS(bytes_read = s2n_recv(conn, buffer, sizeof(buffer), &blocked));
         EXPECT_EQUAL(bytes_read, sizeof(MSG));
         EXPECT_EQUAL(memcmp(buffer, MSG, sizeof(MSG)), 0);

--- a/tests/unit/s2n_self_talk_session_id_test.c
+++ b/tests/unit/s2n_self_talk_session_id_test.c
@@ -141,7 +141,6 @@ static void initialize_cache()
 
 void mock_client(struct s2n_test_piped_io *piped_io)
 {
-
     struct s2n_connection *conn;
     struct s2n_config *config;
     s2n_blocked_status blocked;

--- a/tests/unit/s2n_stuffer_text_test.c
+++ b/tests/unit/s2n_stuffer_text_test.c
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_blob_init(&line_blob, (uint8_t *) lf_line, sizeof(lf_line)));
         EXPECT_SUCCESS(s2n_stuffer_init(&lstuffer, &line_blob));
         EXPECT_SUCCESS(s2n_stuffer_write(&lstuffer, &line_blob));
-        memset(pad, 0, sizeof(pad));
+        S2N_ZERO_ARRAY(pad);
         EXPECT_SUCCESS(s2n_blob_init(&pad_blob, pad, sizeof(pad)));
         EXPECT_SUCCESS(s2n_stuffer_init(&token, &pad_blob));
         EXPECT_SUCCESS(s2n_stuffer_read_line(&lstuffer, &token));
@@ -130,7 +130,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_blob_init(&line_blob, (uint8_t *) crlf_line, sizeof(crlf_line)));
         EXPECT_SUCCESS(s2n_stuffer_init(&lstuffer, &line_blob));
         EXPECT_SUCCESS(s2n_stuffer_write(&lstuffer, &line_blob));
-        memset(pad, 0, sizeof(pad));
+        S2N_ZERO_ARRAY(pad);
         EXPECT_SUCCESS(s2n_blob_init(&pad_blob, pad, sizeof(pad)));
         EXPECT_SUCCESS(s2n_stuffer_init(&token, &pad_blob));
         EXPECT_SUCCESS(s2n_stuffer_read_line(&lstuffer, &token));
@@ -140,7 +140,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_blob_init(&line_blob, (uint8_t *) lf_line_trailing_cr, sizeof(lf_line_trailing_cr)));
         EXPECT_SUCCESS(s2n_stuffer_init(&lstuffer, &line_blob));
         EXPECT_SUCCESS(s2n_stuffer_write(&lstuffer, &line_blob));
-        memset(pad, 0, sizeof(pad));
+        S2N_ZERO_ARRAY(pad);
         EXPECT_SUCCESS(s2n_blob_init(&pad_blob, pad, sizeof(pad)));
         EXPECT_SUCCESS(s2n_stuffer_init(&token, &pad_blob));
         EXPECT_SUCCESS(s2n_stuffer_read_line(&lstuffer, &token));
@@ -150,7 +150,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_blob_init(&line_blob, (uint8_t *) not_a_line, sizeof(not_a_line)));
         EXPECT_SUCCESS(s2n_stuffer_init(&lstuffer, &line_blob));
         EXPECT_SUCCESS(s2n_stuffer_write(&lstuffer, &line_blob));
-        memset(pad, 0, sizeof(pad));
+        S2N_ZERO_ARRAY(pad);
         EXPECT_SUCCESS(s2n_blob_init(&pad_blob, pad, sizeof(pad)));
         EXPECT_SUCCESS(s2n_stuffer_init(&token, &pad_blob));
         EXPECT_SUCCESS(s2n_stuffer_read_line(&lstuffer, &token));

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -238,7 +238,7 @@ static int s2n_populate_client_hello_extensions(struct s2n_client_hello *ch)
     GUARD(s2n_stuffer_write(&in, &ch->extensions));
 
     static __thread s2n_tls_extension_mask parsed_extensions_mask;
-    memset(&parsed_extensions_mask, 0, sizeof(s2n_tls_extension_mask));
+    memset_check(&parsed_extensions_mask, 0, sizeof(s2n_tls_extension_mask));
 
     while (s2n_stuffer_data_available(&in)) {
         uint16_t ext_size, ext_type;

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -81,7 +81,7 @@ static int s2n_config_init(struct s2n_config *config)
 {
     config->cert_allocated = 0;
     config->dhparams = NULL;
-    memset(&config->application_protocols, 0, sizeof(config->application_protocols));
+    memset_check(&config->application_protocols, 0, sizeof(config->application_protocols));
     config->status_request_type = S2N_STATUS_REQUEST_NONE;
     config->wall_clock = wall_clock;
     config->monotonic_clock = monotonic_clock;
@@ -128,7 +128,7 @@ static int s2n_config_init(struct s2n_config *config)
 
     notnull_check(config->domain_name_to_cert_map = s2n_map_new_with_initial_capacity(1));
     GUARD(s2n_map_complete(config->domain_name_to_cert_map));
-    memset(&config->default_cert_per_auth_method, 0, sizeof(struct auth_method_to_cert_value));
+    memset_check(&config->default_cert_per_auth_method, 0, sizeof(struct auth_method_to_cert_value));
     config->default_certs_are_explicit = 0;
 
     s2n_x509_trust_store_init_empty(&config->trust_store);

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -81,7 +81,7 @@ static int s2n_config_init(struct s2n_config *config)
 {
     config->cert_allocated = 0;
     config->dhparams = NULL;
-    memset_check(&config->application_protocols, 0, sizeof(config->application_protocols));
+    S2N_ZERO_STRUCT(config->application_protocols);
     config->status_request_type = S2N_STATUS_REQUEST_NONE;
     config->wall_clock = wall_clock;
     config->monotonic_clock = monotonic_clock;
@@ -128,7 +128,7 @@ static int s2n_config_init(struct s2n_config *config)
 
     notnull_check(config->domain_name_to_cert_map = s2n_map_new_with_initial_capacity(1));
     GUARD(s2n_map_complete(config->domain_name_to_cert_map));
-    memset_check(&config->default_cert_per_auth_method, 0, sizeof(struct auth_method_to_cert_value));
+    S2N_ZERO_STRUCT(config->default_cert_per_auth_method);
     config->default_certs_are_explicit = 0;
 
     s2n_x509_trust_store_init_empty(&config->trust_store);

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -254,7 +254,7 @@ static int s2n_connection_free_keys(struct s2n_connection *conn)
 static int s2n_connection_zero(struct s2n_connection *conn, int mode, struct s2n_config *config)
 {
     /* Zero the whole connection structure */
-    memset_check(conn, 0, sizeof(struct s2n_connection));
+    S2N_ZERO_STRUCT(conn);
 
     conn->send = NULL;
     conn->recv = NULL;

--- a/tls/s2n_handshake.c
+++ b/tls/s2n_handshake.c
@@ -100,7 +100,7 @@ int s2n_handshake_get_hash_state(struct s2n_connection *conn, s2n_hash_algorithm
 
 int s2n_handshake_require_all_hashes(struct s2n_handshake *handshake)
 {
-    memset(handshake->required_hash_algs, 1, sizeof(handshake->required_hash_algs));
+    S2N_MEMSET_ARRAY(handshake->required_hash_algs, 1);
     return 0;
 }
 
@@ -123,7 +123,7 @@ uint8_t s2n_handshake_is_hash_required(struct s2n_handshake *handshake, s2n_hash
 int s2n_conn_update_required_handshake_hashes(struct s2n_connection *conn)
 {
     /* Clear all of the required hashes */
-    memset(conn->handshake.required_hash_algs, 0, sizeof(conn->handshake.required_hash_algs));
+    S2N_ZERO_ARRAY(conn->handshake.required_hash_algs);
 
     message_type_t handshake_message = s2n_conn_get_current_message_type(conn);
     const uint8_t client_cert_verify_done = (handshake_message >= CLIENT_CERT_VERIFY) ? 1 : 0;

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -68,6 +68,23 @@ static inline void* trace_memcpy_check(void *restrict to, const void *restrict f
     }                                                                       \
   } while(0)
 
+#define memset_check_ptr( d, c, n )                                         \
+  do {                                                                      \
+    __typeof( n ) __tmp_n = ( n );                                          \
+    if ( __tmp_n ) {                                                        \
+      __typeof( d ) __tmp_d = ( d );                                        \
+      notnull_check_ptr( __tmp_d );                                         \
+      memset( __tmp_d, (c), __tmp_n);                                       \
+    }                                                                       \
+  } while(0)
+
+/* Use the __builtin_types_compatible_p to prevent this ever being called on a pointer */
+#define S2N_ZERO_ARRAY( a )                                                            \
+    do {                                                                               \
+        S2N_ERROR_IF(__builtin_types_compatible_p(typeof (p), void*), S2N_ERR_SAFETY); \
+        memset((a), 0, sizeof(a));                                                     \
+    } while (0)
+
 #define char_to_digit(c, d)  do { if(!isdigit(c)) { S2N_ERROR(S2N_ERR_SAFETY); } d = c - '0'; } while(0)
 
 /* Range check a number */

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -78,12 +78,9 @@ static inline void* trace_memcpy_check(void *restrict to, const void *restrict f
     }                                                                       \
   } while(0)
 
-/* Use the __builtin_types_compatible_p to prevent this ever being called on a pointer */
-#define S2N_ZERO_ARRAY( a )                                                            \
-    do {                                                                               \
-        S2N_ERROR_IF(__builtin_types_compatible_p(typeof (p), void*), S2N_ERR_SAFETY); \
-        memset((a), 0, sizeof(a));                                                     \
-    } while (0)
+#define S2N_MEMSET_ARRAY( a, c ) memset((a), (c), sizeof(a)) 
+#define S2N_ZERO_ARRAY( a ) memset((a), 0, sizeof(a))
+#define S2N_ZERO_STRUCT( s ) (s) = (typeof(s)) {0}
 
 #define char_to_digit(c, d)  do { if(!isdigit(c)) { S2N_ERROR(S2N_ERR_SAFETY); } d = c - '0'; } while(0)
 


### PR DESCRIPTION
**Issue # (if available):** 

**Description of changes:** 
1. Replace `memset` with `memset_check()`
1. Add a `grep_simple_mistakes` check for this
1.  There are a bunch of places in the code where memset is used in the same pattern.  Code reuse suggests a macro. These macros are actually better than the old ones, in that they do the right thing between structs (where you want `memset(&s, 0, sizeof(s))`) and arrays, where you want `memset(s, 0, sizeof(s))`.  The compiler will error if you try to use the wrong macro.
1. adds an `S2N_STATIC_ASSERT()` macro, which is useful here and may be useful elsewhere as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
