### PR TITLE
Allow client endpoint handshake test to not error out for wikipedia

### DIFF
--- a/tests/integration/s2n_client_endpoint_handshake_test.py
+++ b/tests/integration/s2n_client_endpoint_handshake_test.py
@@ -39,6 +39,11 @@ well_known_endpoints = [
     {"endpoint": "kms.us-east-1.amazonaws.com", "cipher_preference_version": "PQ-SIKE-TEST-TLS-1-0-2019-11", "expected_cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384"}
 ]
 
+# Make an exception to allow failure (if CI is having issues)
+allowed_endpoints_failures = [
+    'wikipedia.org'
+]
+
 def print_result(result_prefix, return_code):
     print(result_prefix, end="")
     if return_code == 0:
@@ -102,7 +107,7 @@ def well_known_endpoints_test(use_corked_io):
                 time.sleep(i)
 
         print_result("Endpoint: %-35sExpected Cipher: %-40s... " % (endpoint, expected_cipher if expected_cipher else "Any"), ret)
-        if ret != 0:
+        if ret != 0 and endpoint not in allowed_endpoints_failures:
             failed += 1
 
     return failed


### PR DESCRIPTION
**Issue # (if available):** 
#1349 

**Description of changes:** 
Added a `allowed_endpoints_failures` to make an exception to allow failure, while allowing these tests to run

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
