### PR TITLE
Fix bug KEM tests that used incorrect key lengths for comparison

### DIFF
--- a/tests/testlib/s2n_kem_tests.c
+++ b/tests/testlib/s2n_kem_tests.c
@@ -87,9 +87,9 @@ int s2n_test_kem_with_kat(const struct s2n_kem *kem, const char *kat_file_name)
         eq_check(memcmp(client_shared_secret, server_shared_secret, kem->shared_secret_key_length), 0);
 
         /* Compare the KAT values */
-        eq_check(memcmp(pk_answer, pk, kem->shared_secret_key_length), 0);
-        eq_check(memcmp(sk_answer, sk, kem->shared_secret_key_length), 0);
-        eq_check(memcmp(ct_answer, ct, kem->shared_secret_key_length), 0);
+        eq_check(memcmp(pk_answer, pk, kem->public_key_length), 0);
+        eq_check(memcmp(sk_answer, sk, kem->private_key_length), 0);
+        eq_check(memcmp(ct_answer, ct, kem->ciphertext_length), 0);
         eq_check(memcmp(ss_answer, server_shared_secret, kem->shared_secret_key_length ), 0);
     }
     fclose(kat_file);


### PR DESCRIPTION
**Issue # (if available):** N/A

**Description of changes:** While making changes for SIKE round 2, we discovered that the KAT tests had been using incorrect key lengths for comparison. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
