### PR TITLE
Move client extension send logic into their own functions

### DIFF
--- a/tls/extensions/s2n_client_alpn.c
+++ b/tls/extensions/s2n_client_alpn.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <sys/param.h>
+#include <stdint.h>
+
+#include "tls/extensions/s2n_client_alpn.h"
+#include "tls/s2n_tls.h"
+#include "tls/s2n_tls_parameters.h"
+
+#include "utils/s2n_safety.h"
+
+int s2n_extensions_client_alpn_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    struct s2n_blob *client_app_protocols;
+    GUARD(s2n_connection_get_protocol_preferences(conn, &client_app_protocols));
+    uint16_t application_protocols_len = client_app_protocols->size;
+
+    GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_ALPN));
+    GUARD(s2n_stuffer_write_uint16(out, application_protocols_len + 2));
+    GUARD(s2n_stuffer_write_uint16(out, application_protocols_len));
+    GUARD(s2n_stuffer_write(out, client_app_protocols));
+
+    return 0;
+}

--- a/tls/extensions/s2n_client_alpn.h
+++ b/tls/extensions/s2n_client_alpn.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include "tls/s2n_connection.h"
+#include "stuffer/s2n_stuffer.h"
+
+extern int s2n_extensions_client_alpn_send(struct s2n_connection *conn, struct s2n_stuffer *out);

--- a/tls/extensions/s2n_client_max_frag_len.c
+++ b/tls/extensions/s2n_client_max_frag_len.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <sys/param.h>
+#include <stdint.h>
+
+#include "tls/extensions/s2n_client_max_frag_len.h"
+#include "tls/s2n_tls.h"
+#include "tls/s2n_tls_parameters.h"
+
+#include "utils/s2n_safety.h"
+
+int s2n_extensions_client_max_frag_len_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    uint16_t mfl_code_len = sizeof(conn->config->mfl_code);
+
+    GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_MAX_FRAG_LEN));
+    GUARD(s2n_stuffer_write_uint16(out, mfl_code_len));
+    GUARD(s2n_stuffer_write_uint8(out, conn->config->mfl_code));
+
+    return 0;
+}

--- a/tls/extensions/s2n_client_max_frag_len.h
+++ b/tls/extensions/s2n_client_max_frag_len.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include "tls/s2n_connection.h"
+#include "stuffer/s2n_stuffer.h"
+
+extern int s2n_extensions_client_max_frag_len_send(struct s2n_connection *conn, struct s2n_stuffer *out);

--- a/tls/extensions/s2n_client_pq_kem.c
+++ b/tls/extensions/s2n_client_pq_kem.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <sys/param.h>
+#include <stdint.h>
+
+#include "tls/extensions/s2n_client_pq_kem.h"
+#include "tls/s2n_tls.h"
+#include "tls/s2n_tls_parameters.h"
+#include "tls/s2n_kem.h"
+#include "tls/s2n_cipher_preferences.h"
+
+#include "utils/s2n_safety.h"
+
+int s2n_extensions_client_pq_kem_send(struct s2n_connection *conn, struct s2n_stuffer *out, uint16_t pq_kem_list_size)
+{
+    const struct s2n_cipher_preferences *cipher_preferences;
+    GUARD(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
+
+    GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_PQ_KEM_PARAMETERS));
+    /* Overall extension length */
+    GUARD(s2n_stuffer_write_uint16(out, 2 + pq_kem_list_size));
+    /* Length of parameters in bytes */
+    GUARD(s2n_stuffer_write_uint16(out, pq_kem_list_size));
+
+    for (int i = 0; i < cipher_preferences->count; i++) {
+        const struct s2n_iana_to_kem *supported_params = NULL;
+        if(s2n_cipher_suite_to_kem(cipher_preferences->suites[i]->iana_value, &supported_params) == 0) {
+            /* Each supported kem id is 2 bytes */
+            for (int j = 0; j < supported_params->kem_count; j++) {
+                GUARD(s2n_stuffer_write_uint16(out, supported_params->kems[j]->kem_extension_id));
+            }
+        }
+    }
+
+    return 0;
+}

--- a/tls/extensions/s2n_client_pq_kem.h
+++ b/tls/extensions/s2n_client_pq_kem.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include "tls/s2n_connection.h"
+#include "stuffer/s2n_stuffer.h"
+
+extern int s2n_extensions_client_pq_kem_send(struct s2n_connection *conn, struct s2n_stuffer *out, uint16_t pq_kem_list_size);

--- a/tls/extensions/s2n_client_sct_list.c
+++ b/tls/extensions/s2n_client_sct_list.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <sys/param.h>
+#include <stdint.h>
+
+#include "tls/extensions/s2n_client_sct_list.h"
+#include "tls/s2n_tls.h"
+#include "tls/s2n_tls_parameters.h"
+
+#include "utils/s2n_safety.h"
+
+int s2n_extensions_client_sct_list_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_SCT_LIST));
+    GUARD(s2n_stuffer_write_uint16(out, 0));
+
+    return 0;
+}

--- a/tls/extensions/s2n_client_sct_list.h
+++ b/tls/extensions/s2n_client_sct_list.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include "tls/s2n_connection.h"
+#include "stuffer/s2n_stuffer.h"
+
+extern int s2n_extensions_client_sct_list_send(struct s2n_connection *conn, struct s2n_stuffer *out);

--- a/tls/extensions/s2n_client_server_name.c
+++ b/tls/extensions/s2n_client_server_name.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <sys/param.h>
+#include <stdint.h>
+
+#include "tls/extensions/s2n_client_server_name.h"
+#include "tls/s2n_tls.h"
+#include "tls/s2n_tls_parameters.h"
+
+#include "utils/s2n_safety.h"
+
+int s2n_extensions_client_server_name_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    uint16_t server_name_len = strlen(conn->server_name);
+
+    /* Write the server name */
+    GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_SERVER_NAME));
+    GUARD(s2n_stuffer_write_uint16(out, server_name_len + 5));
+
+    /* Size of all of the server names */
+    GUARD(s2n_stuffer_write_uint16(out, server_name_len + 3));
+
+    /* Name type - host name, RFC3546 */
+    GUARD(s2n_stuffer_write_uint8(out, 0));
+
+    struct s2n_blob server_name = {0};
+    server_name.data = (uint8_t *) conn->server_name;
+    server_name.size = server_name_len;
+    GUARD(s2n_stuffer_write_uint16(out, server_name_len));
+    GUARD(s2n_stuffer_write(out, &server_name));
+
+    return 0;
+}

--- a/tls/extensions/s2n_client_server_name.h
+++ b/tls/extensions/s2n_client_server_name.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include "tls/s2n_connection.h"
+#include "stuffer/s2n_stuffer.h"
+
+extern int s2n_extensions_client_server_name_send(struct s2n_connection *conn, struct s2n_stuffer *out);

--- a/tls/extensions/s2n_client_session_ticket.c
+++ b/tls/extensions/s2n_client_session_ticket.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <sys/param.h>
+#include <stdint.h>
+
+#include "tls/extensions/s2n_client_session_ticket.h"
+#include "tls/s2n_tls.h"
+#include "tls/s2n_tls_parameters.h"
+
+#include "utils/s2n_safety.h"
+
+int s2n_extensions_client_session_ticket_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    uint16_t client_ticket_len = conn->client_ticket.size;
+    
+    GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_SESSION_TICKET));
+    GUARD(s2n_stuffer_write_uint16(out, client_ticket_len));
+    GUARD(s2n_stuffer_write(out, &conn->client_ticket));
+
+    return 0;
+}

--- a/tls/extensions/s2n_client_session_ticket.h
+++ b/tls/extensions/s2n_client_session_ticket.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include "tls/s2n_connection.h"
+#include "stuffer/s2n_stuffer.h"
+
+extern int s2n_extensions_client_session_ticket_send(struct s2n_connection *conn, struct s2n_stuffer *out);

--- a/tls/extensions/s2n_client_status_request.c
+++ b/tls/extensions/s2n_client_status_request.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <sys/param.h>
+#include <stdint.h>
+
+#include "tls/extensions/s2n_client_status_request.h"
+#include "tls/s2n_tls.h"
+#include "tls/s2n_tls_parameters.h"
+
+#include "utils/s2n_safety.h"
+
+int s2n_extensions_client_status_request_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_STATUS_REQUEST));
+    GUARD(s2n_stuffer_write_uint16(out, 5));
+    GUARD(s2n_stuffer_write_uint8(out, (uint8_t) conn->config->status_request_type));
+    GUARD(s2n_stuffer_write_uint16(out, 0));
+    GUARD(s2n_stuffer_write_uint16(out, 0));
+
+    return 0;
+}

--- a/tls/extensions/s2n_client_status_request.h
+++ b/tls/extensions/s2n_client_status_request.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include "tls/s2n_connection.h"
+#include "stuffer/s2n_stuffer.h"
+
+extern int s2n_extensions_client_status_request_send(struct s2n_connection *conn, struct s2n_stuffer *out);

--- a/tls/extensions/s2n_client_supported_groups.c
+++ b/tls/extensions/s2n_client_supported_groups.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <sys/param.h>
+#include <stdint.h>
+
+#include "tls/extensions/s2n_client_supported_groups.h"
+#include "tls/s2n_tls.h"
+#include "tls/s2n_tls_parameters.h"
+
+#include "utils/s2n_safety.h"
+
+int s2n_extensions_client_supported_groups_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    int ec_curves_count = s2n_array_len(s2n_ecc_supported_curves);
+    GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_SUPPORTED_GROUPS));
+    GUARD(s2n_stuffer_write_uint16(out, 2 + ec_curves_count * 2));
+    /* Curve list len */
+    GUARD(s2n_stuffer_write_uint16(out, ec_curves_count * 2));
+    /* Curve list */
+    for (int i = 0; i < ec_curves_count; i++) {
+        GUARD(s2n_stuffer_write_uint16(out, s2n_ecc_supported_curves[i]->iana_id));
+    }
+
+    GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_EC_POINT_FORMATS));
+    GUARD(s2n_stuffer_write_uint16(out, 2));
+    /* Point format list len */
+    GUARD(s2n_stuffer_write_uint8(out, 1));
+    /* Only allow uncompressed format */
+    GUARD(s2n_stuffer_write_uint8(out, 0));
+    
+    return 0;
+}

--- a/tls/extensions/s2n_client_supported_groups.h
+++ b/tls/extensions/s2n_client_supported_groups.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include "tls/s2n_connection.h"
+#include "stuffer/s2n_stuffer.h"
+
+extern int s2n_extensions_client_supported_groups_send(struct s2n_connection *conn, struct s2n_stuffer *out);


### PR DESCRIPTION
**Issue # (if available):** #1189 

**Description of changes:** 

This is phase one of beginning to clean up how we handle our extensions. I moved all the client extension send logic into their own files/functions. No logic changes. No additional tests added. Doing this in pieces to minimize merge conflicts and make it more review-able. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
