### PR TITLE
Use optimized SIKE round 2 assembly code for x86_64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,11 @@ jobs:
     # unoptimized routines. See https://www.openssl.org/docs/man1.1.0/crypto/OPENSSL_ia32cap.html
     env: S2N_LIBCRYPTO=openssl-1.1.1 OPENSSL_ia32cap="~0x200000200000000" BUILD_S2N=true TESTS=integration GCC_VERSION=6
 
+  - os: linux
+    dist: bionic
+    # Force S2N to use the generic C code for SIKE round 2 (instead of the optimized x86_64 assembly code)
+    env: S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=9 S2N_SIKE_R2_FORCE_GENERIC=true
+
 # Fuzz Tests
   - os: linux
     dist: bionic

--- a/.travis/s2n_setup_env.sh
+++ b/.travis/s2n_setup_env.sh
@@ -77,6 +77,7 @@ export FUZZ_TIMEOUT_SEC
 export TRAVIS_OS_NAME
 export UBUNTU_VERSION
 export S2N_CORKED_IO
+export S2N_SIKE_R2_FORCE_GENERIC
 
 
 # Select the libcrypto to build s2n against. If this is unset, default to the latest stable version(Openssl 1.1.1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,15 +50,27 @@ file(GLOB ERROR_SRC
 
 # The SIKE code #includes .c files directly, including all sike_r*/*.c breaks the build due to duplicates
 file(GLOB PQ_SRC
-    "pq-crypto/*.c"
-    "pq-crypto/bike/*.c"
-    "pq-crypto/sike_r1/fp_generic_r1.c"
-    "pq-crypto/sike_r1/P503_r1.c"
-    "pq-crypto/sike_r1/sike_p503_r1_kem.c"
-    "pq-crypto/sike_r1/fips202_r1.c"
-    "pq-crypto/sike_r2/fips202.c"
-    "pq-crypto/sike_r2/P434.c"
-)
+        "pq-crypto/*.c"
+        "pq-crypto/bike/*.c"
+        "pq-crypto/sike_r1/fp_generic_r1.c"
+        "pq-crypto/sike_r1/P503_r1.c"
+        "pq-crypto/sike_r1/sike_p503_r1_kem.c"
+        "pq-crypto/sike_r1/fips202_r1.c"
+        "pq-crypto/sike_r2/fips202.c"
+        "pq-crypto/sike_r2/P434.c"
+        )
+
+if($ENV{S2N_SIKE_R2_FORCE_GENERIC})
+    message(STATUS "Forcing usage of generic C code for SIKE p434 r2")
+elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64" OR ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "amd64" OR (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "AMD64" AND CMAKE_CL_64))
+    message(STATUS "Using optimized x86_64 assembly for SIKE p434 r2")
+    enable_language(ASM)
+    file(GLOB PQ_X86_64_ASM
+            "pq-crypto/sike_r2/fp_x64_asm.S")
+    list(APPEND PQ_SRC ${PQ_X86_64_ASM})
+else()
+    message(STATUS "Architecture is not x86_64 compatible - using generic C code for SIKE p434 r2")
+endif()
 
 file(GLOB STUFFER_SRC
     "stuffer/*.c"

--- a/pq-crypto/sike_r2/Makefile
+++ b/pq-crypto/sike_r2/Makefile
@@ -16,6 +16,14 @@
 SRCS=fips202.c P434.c
 OBJS=$(SRCS:.c=.o)
 
+ARCH := $(shell uname -p)
+ifeq ($(ARCH), x86_64)
+ifndef S2N_SIKE_R2_FORCE_GENERIC
+ASRC=fp_x64_asm.S
+OBJS+=$(ASRC:.S=.o)
+endif
+endif
+
 # TODO add when ready for SIKE R2 SAW proofs
 #BCS_1=fips202.bc P434.bc
 #BCS=$(addprefix $(BITCODE_DIR), $(BCS_1))

--- a/pq-crypto/sike_r2/P434.c
+++ b/pq-crypto/sike_r2/P434.c
@@ -19,6 +19,10 @@
 // Curve isogeny system "SIDHp434". Base curve: Montgomery curve By^2 = Cx^3 + Ax^2 + Cx defined over GF(p434^2), where A=6, B=1, C=1 and p434 = 2^216*3^137-1
 //
 
+
+// The constants p434, p434p1, and p434x2 have been duplicated in
+// fp_x64_asm.S. If, for any reason, the constants are changed in
+// one file, they should be updated in the other file as well.
 const uint64_t p434[NWORDS64_FIELD] = {0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0xFDC1767AE2FFFFFF,
                                               0x7BC65C783158AEA3, 0x6CFC5FD681C52056, 0x0002341F27177344};
 const uint64_t p434p1[NWORDS64_FIELD] = {0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0xFDC1767AE3000000,
@@ -105,17 +109,13 @@ const unsigned int strat_Bob[MAX_Bob - 1] = {
 #define EphemeralSecretAgreement_A oqs_kem_sidh_p434_EphemeralSecretAgreement_A
 #define EphemeralSecretAgreement_B oqs_kem_sidh_p434_EphemeralSecretAgreement_B
 
-/*
- * TODO Get x86_64 assembly code working; for now, we just import the generic portable C
- * #if defined(X86_64)
- * #include "AMD64/fp_x64.c"
- * #include "AMD64/fp_x64_asm.S"
- * #else
- * #include "fp_generic.c"
- * #endif
-*/
-
+#if defined(OPTIMIZED_ASM_IMPLEMENTATION)
+#include "fp_x64.c"
+#elif defined(GENERIC_IMPLEMENTATION)
 #include "fp_generic.c"
+#else
+#error "Neither OPTIMIZED_ASM_IMPLEMENTATION nor GENERIC_IMPLEMENTATION was defined. One of those must be defined."
+#endif
 
 #include "fpx.c"
 #include "ec_isogeny.c"

--- a/pq-crypto/sike_r2/config.h
+++ b/pq-crypto/sike_r2/config.h
@@ -10,6 +10,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include "sike_r2_code_identifier.h"
 
 // Definition of operating system
 
@@ -35,39 +36,34 @@
 #error -- "Unsupported COMPILER"
 #endif
 
-
-// TODO - Hardcoding these #defines for now to get the build working with the generic C code.
-//  Need to enable builds for multiple architectures, and enable/include optimized x64 assembly
-//  code
-#define _AMD64_
-#define _GENERIC_
-
 // Definition of the targeted architecture and basic data types
+// NOTE - we determine whether to use the generic C code optimized assembly
+//     code in sike_r2_code_identifier.h.
 
 #define TARGET_AMD64 1
 #define TARGET_x86 2
 #define TARGET_ARM 3
 #define TARGET_ARM64 4
 
-#if defined(_AMD64_)
+#if defined(__x86_64__)
 #define TARGET TARGET_AMD64
 #define RADIX 64
 #define LOG2RADIX 6
 typedef uint64_t digit_t;  // Unsigned 64-bit digit
 typedef uint32_t hdigit_t; // Unsigned 32-bit digit
-#elif defined(_X86_)
+#elif defined(__i386__)
 #define TARGET TARGET_x86
 #define RADIX 32
 #define LOG2RADIX 5
 typedef uint32_t digit_t;  // Unsigned 32-bit digit
 typedef uint16_t hdigit_t; // Unsigned 16-bit digit
-#elif defined(_ARM_)
+#elif defined(__arm__)
 #define TARGET TARGET_ARM
 #define RADIX 32
 #define LOG2RADIX 5
 typedef uint32_t digit_t;  // Unsigned 32-bit digit
 typedef uint16_t hdigit_t; // Unsigned 16-bit digit
-#elif defined(_ARM64_)
+#elif defined(__aarch64__)
 #define TARGET TARGET_ARM64
 #define RADIX 64
 #define LOG2RADIX 6
@@ -78,12 +74,6 @@ typedef uint32_t hdigit_t; // Unsigned 32-bit digit
 #endif
 
 #define RADIX64 64
-
-// Selection of generic, portable implementation
-
-#if defined(_GENERIC_)
-#define GENERIC_IMPLEMENTATION
-#endif
 
 // Extended datatype support
 #if defined(GENERIC_IMPLEMENTATION)

--- a/pq-crypto/sike_r2/fp_generic.c
+++ b/pq-crypto/sike_r2/fp_generic.c
@@ -5,6 +5,7 @@
 *********************************************************************************************/
 
 #include "P434_internal.h"
+#include "sike_r2_code_identifier.h"
 
 void fpadd434(const digit_t *a, const digit_t *b, digit_t *c) { // Modular addition, c = a+b mod p434.
 	                                                                     // Inputs: a, b in [0, 2*p434-1]
@@ -199,4 +200,8 @@ void rdc_mont(const digit_t *ma, digit_t *mc) { // Efficient Montgomery reductio
 	}
 	ADDC(0, v, ma[2 * NWORDS_FIELD - 1], carry, v);
 	mc[NWORDS_FIELD - 1] = v;
+}
+
+int sike_r2_fp_code_identifier() {
+    return GENERIC_C_CODE_IDENTIFIER;
 }

--- a/pq-crypto/sike_r2/fp_x64.c
+++ b/pq-crypto/sike_r2/fp_x64.c
@@ -4,7 +4,9 @@
 * Abstract: modular arithmetic optimized for x64 platforms for P434
 *********************************************************************************************/
 
-#include "../P434_internal.h"
+#include "config.h"
+#include "P434_internal.h"
+#include "sike_r2_code_identifier.h"
 
 __inline void fpadd434(const digit_t *a, const digit_t *b, digit_t *c) { // Modular addition, c = a+b mod p434.
                                                                          // Inputs: a, b in [0, 2*p434-1]
@@ -66,7 +68,7 @@ __inline void fpneg434(digit_t *a) { // Modular negation, a = -a mod p434.
 	unsigned int i, borrow = 0;
 
 	for (i = 0; i < NWORDS_FIELD; i++) {
-		SUBC(borrow, ((digit_t *) p434x2)[i], a[i], borrow, a[i]);
+		SUBC(borrow, ((const digit_t *) p434x2)[i], a[i], borrow, a[i]);
 	}
 }
 
@@ -78,7 +80,7 @@ void fpdiv2_434(const digit_t *a, digit_t *c) { // Modular division by two, c = 
 
 	mask = 0 - (digit_t)(a[0] & 1); // If a is odd compute a+p434
 	for (i = 0; i < NWORDS_FIELD; i++) {
-		ADDC(carry, a[i], ((digit_t *) p434)[i] & mask, carry, c[i]);
+		ADDC(carry, a[i], ((const digit_t *) p434)[i] & mask, carry, c[i]);
 	}
 
 	mp_shiftr1(c, NWORDS_FIELD);
@@ -89,13 +91,13 @@ void fpcorrection434(digit_t *a) { // Modular correction to reduce field element
 	digit_t mask;
 
 	for (i = 0; i < NWORDS_FIELD; i++) {
-		SUBC(borrow, a[i], ((digit_t *) p434)[i], borrow, a[i]);
+		SUBC(borrow, a[i], ((const digit_t *) p434)[i], borrow, a[i]);
 	}
 	mask = 0 - (digit_t) borrow;
 
 	borrow = 0;
 	for (i = 0; i < NWORDS_FIELD; i++) {
-		ADDC(borrow, a[i], ((digit_t *) p434)[i] & mask, borrow, a[i]);
+		ADDC(borrow, a[i], ((const digit_t *) p434)[i] & mask, borrow, a[i]);
 	}
 }
 
@@ -419,4 +421,8 @@ void rdc_mont(const digit_t *ma, digit_t *mc) { // Montgomery reduction exploiti
 	rdc434_asm(ma, mc);
 
 #endif
+}
+
+int sike_r2_fp_code_identifier() {
+    return ASM_CODE_IDENTIFIER;
 }

--- a/pq-crypto/sike_r2/fp_x64_asm.S
+++ b/pq-crypto/sike_r2/fp_x64_asm.S
@@ -4,7 +4,9 @@
 // Abstract: field arithmetic in x64 assembly for P434 on Linux
 //*******************************************************************************************  
 
-.intel_syntax noprefix 
+.intel_syntax noprefix
+
+#define _MULX_
 
 // Registers that are used for parameter passing:
 #define reg_p1  rdi
@@ -30,8 +32,47 @@
 #endif    
 #endif
 
+// The constants below (asm_p434, asm_p434p1, and asm_p434x2) are duplicated from
+// P434.c, and correspond to the arrays p434, p434p1, and p434x2. The values are
+// idenctical; they are just represented here as standard (base 10) ints, instead
+// of hex. If, for any reason, the constants are changed in one file, they should be
+// updated in the other file as well.
 
 .text
+.align 32
+.type   asm_p434, @object
+.size   asm_p434, 56
+asm_p434:
+  .quad   -1
+  .quad   -1
+  .quad   -1
+  .quad   -161717841442111489
+  .quad   8918917783347572387
+  .quad   7853257225132122198
+  .quad   620258357900100
+.align 32
+.type   asm_p434p1, @object
+.size   asm_p434p1, 56
+asm_p434p1:
+  .quad   0
+  .quad   0
+  .quad   0
+  .quad   -161717841442111488
+  .quad   8918917783347572387
+  .quad   7853257225132122198
+  .quad   620258357900100
+.align 32
+.type   asm_p434x2, @object
+.size   asm_p434x2, 56
+asm_p434x2:
+  .quad   -2
+  .quad   -1
+  .quad   -1
+  .quad   -323435682884222977
+  .quad   -608908507014406841
+  .quad   -2740229623445307220
+  .quad   1240516715800200
+
 //***********************************************************************
 //  Field addition
 //  Operation: c [reg_p3] = a [reg_p1] + b [reg_p2]
@@ -61,18 +102,18 @@ fpadd434_asm:
   adc    r13, [reg_p2+40] 
   adc    r14, [reg_p2+48]
 
-  mov    rbx, [rip+p434x2]
+  mov    rbx, [rip+asm_p434x2]
   sub    r8, rbx
-  mov    rcx, [rip+p434x2+8]
+  mov    rcx, [rip+asm_p434x2+8]
   sbb    r9, rcx
   sbb    r10, rcx
-  mov    rdi, [rip+p434x2+24]
+  mov    rdi, [rip+asm_p434x2+24]
   sbb    r11, rdi
-  mov    rsi, [rip+p434x2+32]
+  mov    rsi, [rip+asm_p434x2+32]
   sbb    r12, rsi
-  mov    rbp, [rip+p434x2+40]
+  mov    rbp, [rip+asm_p434x2+40]
   sbb    r13, rbp
-  mov    r15, [rip+p434x2+48]
+  mov    r15, [rip+asm_p434x2+48]
   sbb    r14, r15
   sbb    rax, 0
   
@@ -134,9 +175,9 @@ fpsub434_asm:
   sbb    r14, [reg_p2+48]
   sbb    rax, 0
   
-  mov    rcx, [rip+p434x2]
-  mov    rdi, [rip+p434x2+8]
-  mov    rsi, [rip+p434x2+24]
+  mov    rcx, [rip+asm_p434x2]
+  mov    rdi, [rip+asm_p434x2+8]
+  mov    rsi, [rip+asm_p434x2+24]
   and    rcx, rax
   and    rdi, rax
   and    rsi, rax  
@@ -150,9 +191,9 @@ fpsub434_asm:
   mov    [reg_p3+24], r11 
   setc   cl  
 
-  mov    r8, [rip+p434x2+32]
-  mov    rdi, [rip+p434x2+40]
-  mov    rsi, [rip+p434x2+48]
+  mov    r8, [rip+asm_p434x2+32]
+  mov    rdi, [rip+asm_p434x2+40]
+  mov    rsi, [rip+asm_p434x2+48]
   and    r8, rax
   and    rdi, rax
   and    rsi, rax  
@@ -666,7 +707,7 @@ rdc434_asm:
     push   r13 
 
     // a[0-1] x p434p1_nz --> result: r8:r13 
-    MUL128x256_SCHOOL [reg_p1], [rip+p434p1+24], r8, r9, r10, r11, r12, r13, rcx     
+    MUL128x256_SCHOOL [reg_p1], [rip+asm_p434p1+24], r8, r9, r10, r11, r12, r13, rcx
 
     xor    rcx, rcx
     add    r8, [reg_p1+24]  
@@ -697,7 +738,7 @@ rdc434_asm:
     mov    [reg_p1+104], r11
 
     // a[2-3] x p434p1_nz --> result: r8:r13
-    MUL128x256_SCHOOL [reg_p1+16], [rip+p434p1+24], r8, r9, r10, r11, r12, r13, rcx 
+    MUL128x256_SCHOOL [reg_p1+16], [rip+asm_p434p1+24], r8, r9, r10, r11, r12, r13, rcx
 
     xor    rcx, rcx
     add    r8, [reg_p1+40]  
@@ -722,7 +763,7 @@ rdc434_asm:
     mov    [reg_p1+104], r9
 
     // a[4-5] x p434p1_nz --> result: r8:r13
-    MUL128x256_SCHOOL [reg_p1+32], [rip+p434p1+24], r8, r9, r10, r11, r12, r13, rcx  
+    MUL128x256_SCHOOL [reg_p1+32], [rip+asm_p434p1+24], r8, r9, r10, r11, r12, r13, rcx
 
     xor    rcx, rcx
     add    r8, [reg_p1+56]  
@@ -741,7 +782,7 @@ rdc434_asm:
     mov    [reg_p1+104], rcx
 
     // a[6-7] x p434p1_nz --> result: r8:r12
-    MUL64x256_SCHOOL [reg_p1+48], [rip+p434p1+24], r8, r9, r10, r11, r12, r13  
+    MUL64x256_SCHOOL [reg_p1+48], [rip+asm_p434p1+24], r8, r9, r10, r11, r12, r13
     
     // Final result c2:c6
     add    r8, [reg_p1+72]  
@@ -759,7 +800,7 @@ rdc434_asm:
     pop    r12
     ret
 
-  #else
+#else
   
 //***********************************************************************
 //  Montgomery reduction
@@ -774,7 +815,7 @@ rdc434_asm:
 
 # error "CONFIGURATION NOT SUPPORTED. TRY USE_MULX=TRUE"
 
-  #endif
+#endif
 
 
 //***********************************************************************
@@ -860,11 +901,11 @@ mp_subadd434x2_asm:
   sbb    rax, 0
   
   // Add p434 anded with the mask in rax 
-  mov    r8, [rip+p434]
-  mov    r9, [rip+p434+24]
-  mov    r10, [rip+p434+32]
-  mov    rdi, [rip+p434+40]
-  mov    rsi, [rip+p434+48]
+  mov    r8, [rip+asm_p434]
+  mov    r9, [rip+asm_p434+24]
+  mov    r10, [rip+asm_p434+32]
+  mov    rdi, [rip+asm_p434+40]
+  mov    rsi, [rip+asm_p434+48]
   and    r8, rax
   and    r9, rax
   and    r10, rax

--- a/pq-crypto/sike_r2/sike_r2_code_identifier.h
+++ b/pq-crypto/sike_r2/sike_r2_code_identifier.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#ifndef S2N_SIKE_R2_CODE_IDENTIFIER_H
+#define S2N_SIKE_R2_CODE_IDENTIFIER_H
+
+#if defined(__x86_64__)
+// Allow the forced usage of the generic implementation if desired.
+#if defined(S2N_SIKE_R2_FORCE_GENERIC)
+#define GENERIC_IMPLEMENTATION
+#else
+#define OPTIMIZED_ASM_IMPLEMENTATION
+#endif
+#else
+#define GENERIC_IMPLEMENTATION
+#endif
+
+#define ASM_CODE_IDENTIFIER 1
+#define GENERIC_C_CODE_IDENTIFIER 2
+
+// Simply returns either ASM_CODE_IDENTIFIER or GENERIC_C_CODE_IDENTIFIER depending on
+// which file the function is defined in. See also tests/unit/s2n_sike_r2_verify_included_code_test.c
+int sike_r2_fp_code_identifier();
+
+#endif //S2N_SIKE_R2_CODE_IDENTIFIER_H

--- a/s2n.mk
+++ b/s2n.mk
@@ -60,6 +60,11 @@ ifdef S2N_TEST_IN_FIPS_MODE
     DEFAULT_CFLAGS += -DS2N_TEST_IN_FIPS_MODE
 endif
 
+# Force the usage of generic C code for round 2 SIKE, even if the optimized assembly could be used
+ifdef S2N_SIKE_R2_FORCE_GENERIC
+	DEFAULT_CFLAGS += -DS2N_SIKE_R2_FORCE_GENERIC
+endif
+
 CFLAGS += ${DEFAULT_CFLAGS}
 
 ifdef GCC_VERSION

--- a/tests/unit/s2n_sike_r2_verify_included_code_test.c
+++ b/tests/unit/s2n_sike_r2_verify_included_code_test.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "pq-crypto/sike_r2/sike_r2_code_identifier.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /*
+     * A little extra defense in depth to ensure that we are running the code
+     * that we think we are. In particular, this helps prevent the scenario
+     * where we accidentally include/run the generic C code when we actually
+     * wanted to use the optimized assembly.
+     */
+#if defined(OPTIMIZED_ASM_IMPLEMENTATION)
+    EXPECT_EQUAL(sike_r2_fp_code_identifier(), ASM_CODE_IDENTIFIER);
+#elif defined(GENERIC_IMPLEMENTATION)
+    EXPECT_EQUAL(sike_r2_fp_code_identifier(), GENERIC_C_CODE_IDENTIFIER);
+#else
+    FAIL_MSG("Neither OPTIMIZED_ASM_IMPLEMENTATION nor GENERIC_IMPLEMENTATION was defined. One of those must be defined.");
+#endif
+
+    END_TEST();
+}


### PR DESCRIPTION
**Issue # (if available):** https://github.com/awslabs/s2n/projects/7

**Description of changes:** 

* Enables the use of optimized assembly code for SIKE round 2 p434 on x86_64 processors. The code will default to using the assembly code if it detects compatible architecture.
* Enables the usage of environment variable `S2N_SIKE_R2_FORCE_GENERIC` to force S2N to use the generic C code, even if the processor is x86_64 compatible; adds one Travis build with that flag enabled so that we test the generic code path. (By default, Travis builds will test the assembly code, since they are all amd64.)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
