### PR TITLE
Modify grep_simple_mistakes regex to detect manual null checks on Lin…

### DIFF
--- a/.travis/grep_simple_mistakes.sh
+++ b/.travis/grep_simple_mistakes.sh
@@ -65,7 +65,7 @@ for file in $S2N_FILES_ASSERT_NOTNULL_CHECK; do
     # $line_one definitely contains an assignment from s2n_stuffer_raw_read(),
     # because that's what we grepped for. So verify that either $line_one or
     # $line_two contains a null check.
-    manual_null_check_regex=".*if.*==\sNULL"
+    manual_null_check_regex=".*if.*==\ NULL"
     if [[ $line_one == *"notnull_check("* ]] || [[ $line_one =~ $manual_null_check_regex ]] ||\
     [[ $line_two == *"notnull_check("* ]] || [[ $line_two =~ $manual_null_check_regex ]]; then
       # Found a notnull_check


### PR DESCRIPTION
Modify grep_simple_mistakes regex to detect manual null checks on Linux and OSX.

**Issue # (if available):** #1362 

**Description of changes:** 
Update a regex to work across multiple platforms.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
