### PR TITLE
Update pq-crypto/README.md for SIKE round 2

### DIFF
--- a/pq-crypto/README.md
+++ b/pq-crypto/README.md
@@ -23,10 +23,15 @@ of newly proposed key exchanges. s2n implements the hybrid specification from [t
 See [this s2n issue](https://github.com/awslabs/s2n/issues/904) for more up-to-date information.
 
 ## SIKE (Supersingular Isogeny Key Encapsulation)
-The code in the pq-crypto/sike_r1 directory was taken from the [round 1 nist submission](https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-1/submissions/SIKE.zip).
+The code in the pq-crypto/sike_r1 directory was taken from the [round 1 NIST submission](https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-1/submissions/SIKE.zip).
 s2n uses the optimized portable implementation to ensure maximum comparability and ease of review. The known answer tests
 are [here](https://github.com/awslabs/s2n/blob/master/tests/unit/s2n_sike_p503_kat_test.c) and use the known answer file
 from the SIKEp503 round 1 submission.
+
+The code in the pq-crypto/sike_r2 directory was imported from [liboqs](https://github.com/open-quantum-safe/liboqs/tree/386372ba7dbef781f0b939f1cf73d33019958d6a/src/kem/sike), and
+implements the [round 2 NIST submission](https://csrc.nist.gov/projects/post-quantum-cryptography/round-2-submissions). s2n is configured to use the optimized
+assembly implementation on x86_64 processors, and the optimized portable implementation elsewhere. The known answer tests
+are [here](https://github.com/awslabs/s2n/blob/master/tests/unit/kats/sike_p434.kat) and use the known answer file from the SIKEP434 round 2 submission.
 
 ## BIKE (Bit Flipping Key Encapsulation)
 The code in the pq-crypto/bike directory was taken from the [additional implementation](https://bikesuite.org/files/round2/add-impl/Additional_Implementation.2019.03.30.zip).
@@ -36,20 +41,36 @@ review. The known answer tests are [here](https://github.com/awslabs/s2n/blob/ma
 and use the BIKE1_L1.const.kat from the above Additional_Implementation.2019.03.30.zip. This implementation uses constant
 time primitives on x86 and aarch64 platforms.
 
-## How to add another PQ KEM
+## How to add a new PQ KEM family
 1. Add the code to `pq-crypto/KEM_NAME/`
     1. Update `pq-crypto/Makefile` to build that directory
     1. Update `lib/Makefile` to also include that directory
     1. Update the KEM code to include `pq-crypto/pq_random.h` and use the function `get_random_bytes` for any random data the KEM needs
     1. Create a `pq-crypto/KEM_NAME/KEM_NAME.h` with the size of objects and method definitions
-1. Define the new cipher suite and KEM extension value in `tls/s2n_tls_parameters.h`
+1. Define the new cipher suite value and KEM extension value in `tls/s2n_tls_parameters.h`
 1. Create the `KEM_NAME` `s2n_kem` struct in `tls/s2n_kem.c`
+    1. Create the `supported_KEM_NAME_params` array in `tls/s2n_kem.c`
     1. Add the new kem to the `kem_mapping` with the correct cipher suite value
 1. Add known answer tests using `s2n_test_kem_with_kat()` in `tests/unit/s2n_KEM_NAME_kat_test.c`
 1. Add fuzz testing in `tests/fuzz/s2n_KEM_NAME_fuzz_test.c`
 1. Add formal verification in `tests/saw/KEM_NAME/verify.saw`
 1. Create a new `s2n_cipher_suite` in `tls/s2n_cipher_suites.c`
 1. Create a new `s2n_cipher_preferences` in `tls/s2n_cipher_prefrences.c` that uses the new cipher suite
+    1. Once this change is made, the KEM will be available for use in TLS handshakes; ensure that all testing/verification has been completed
+    
+## How to add a new variant to an existing PQ KEM family
+1. Add the code to `pq-crypto/KEM_NAME/`
+    1. Update `pq-crypto/Makefile` to build that directory
+    1. Update `lib/Makefile` to also include that directory
+    1. Update the KEM code to include `pq-crypto/pq_random.h` and use the function `get_random_bytes` for any random data the KEM needs
+    1. Create a `pq-crypto/KEM_NAME/KEM_NAME.h` with the size of objects and method definitions
+1. Define the KEM extension value in `tls/s2n_tls_parameters.h`
+1. Create the `KEM_NAME` `s2n_kem` struct in `tls/s2n_kem.c`
+1. Add known answer tests using `s2n_test_kem_with_kat()` in `tests/unit/s2n_KEM_NAME_kat_test.c`
+1. Add fuzz testing in `tests/fuzz/s2n_KEM_NAME_fuzz_test.c`
+1. Add formal verification in `tests/saw/KEM_NAME/verify.saw`
+1. Update the appropriate `supported_KEM_NAME_params` array in `tls/s2n_kem.c`
+    1. Once this change is made, the KEM extension will be available for use in TLS handshakes; ensure that all testing/verification has been completed 
 
 ## How to use PQ cipher suites
 1. Checkout s2n `git clone https://github.com/awslabs/s2n.git`


### PR DESCRIPTION
**Issue # (if available):** https://github.com/awslabs/s2n/projects/7

**Description of changes:** 

* Updates the PQ crypto README with information about SIKE round 2
* Adds instructions for adding an extension to an existing KEM


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
