### PR TITLE
Fix broken GCC 4 builds, improve cmake to support add_subdirectory fr…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ jobs:
     env: S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=6
 
   - os: linux
-    dist: trusty
-    env: S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true GCC_VERSION=4
+    dist: bionic
+    env: S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true GCC_VERSION=4.8
 
   - os: linux
     dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,10 @@ jobs:
     env: S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=6
 
   - os: linux
+    dist: trusty
+    env: S2N_LIBCRYPTO=openssl-1.1.1 BUILD_s2N=true GCC_VERSION=4
+
+  - os: linux
     dist: bionic
     env: S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=9
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
 
   - os: linux
     dist: trusty
-    env: S2N_LIBCRYPTO=openssl-1.1.1 BUILD_s2N=true GCC_VERSION=4
+    env: S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true GCC_VERSION=4
 
   - os: linux
     dist: bionic

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,37 +122,37 @@ file(GLOB S2N_SRC
     ${UTILS_SRC}
 )
 
-add_library(${CMAKE_PROJECT_NAME} ${S2N_HEADERS} ${S2N_SRC})
-set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES LINKER_LANGUAGE C)
+add_library(${PROJECT_NAME} ${S2N_HEADERS} ${S2N_SRC})
+set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE C)
 
 set(CMAKE_C_FLAGS_DEBUGOPT "")
 
-target_compile_options(${CMAKE_PROJECT_NAME} PRIVATE -pedantic -std=c99 -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-subscripts
+target_compile_options(${PROJECT_NAME} PRIVATE -pedantic -std=c99 -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-subscripts
         -Wuninitialized -Wshadow -Wcast-qual -Wcast-align -Wwrite-strings -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security
         -Wno-missing-braces)
-target_compile_options(${CMAKE_PROJECT_NAME} PUBLIC -fPIC)
+target_compile_options(${PROJECT_NAME} PUBLIC -fPIC)
 
-target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE -D_POSIX_C_SOURCE=200809L)
+target_compile_definitions(${PROJECT_NAME} PRIVATE -D_POSIX_C_SOURCE=200809L)
 if(CMAKE_BUILD_TYPE MATCHES Release)
-    target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE -D_FORTIFY_SOURCE=2)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE -D_FORTIFY_SOURCE=2)
 endif()
 
 if(NO_STACK_PROTECTOR)
-    target_compile_options(${CMAKE_PROJECT_NAME} PRIVATE -Wstack-protector -fstack-protector-all)
+    target_compile_options(${PROJECT_NAME} PRIVATE -Wstack-protector -fstack-protector-all)
 endif()
 
 if(S2N_UNSAFE_FUZZING_MODE)
-    target_compile_options(${CMAKE_PROJECT_NAME} PRIVATE -fsanitize-coverage=trace-pc-guard -fsanitize=address,undefined,leak)
+    target_compile_options(${PROJECT_NAME} PRIVATE -fsanitize-coverage=trace-pc-guard -fsanitize=address,undefined,leak)
 endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 
 find_package(LibCrypto REQUIRED)
-target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC LibCrypto::Crypto ${OS_LIBS} m)
+target_link_libraries(${PROJECT_NAME} PUBLIC LibCrypto::Crypto ${OS_LIBS} m)
 
-target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
-target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api> $<INSTALL_INTERFACE:include>)
-target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC $<TARGET_PROPERTY:LibCrypto::Crypto,INTERFACE_INCLUDE_DIRECTORIES>)
+target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api> $<INSTALL_INTERFACE:include>)
+target_include_directories(${PROJECT_NAME} PUBLIC $<TARGET_PROPERTY:LibCrypto::Crypto,INTERFACE_INCLUDE_DIRECTORIES>)
 
 include(CTest)
 if (BUILD_TESTING)
@@ -164,7 +164,7 @@ if (BUILD_TESTING)
     add_library(testss2n ${TESTLIB_HEADERS} ${TESTLIB_SRC})
     target_include_directories(testss2n PRIVATE tests)
     target_compile_options(testss2n PRIVATE -std=c99)
-    target_link_libraries(testss2n PUBLIC ${CMAKE_PROJECT_NAME})
+    target_link_libraries(testss2n PUBLIC ${PROJECT_NAME})
 
     #run unit tests
     file (GLOB TEST_LD_PRELOAD "tests/LD_PRELOAD/*.c")
@@ -190,12 +190,12 @@ if (BUILD_TESTING)
     endforeach(test_case)
 
     add_executable(s2nc "bin/s2nc.c" "bin/echo.c")
-    target_link_libraries(s2nc ${CMAKE_PROJECT_NAME})
+    target_link_libraries(s2nc ${PROJECT_NAME})
     target_include_directories(s2nc PRIVATE api)
     target_compile_options(s2nc PRIVATE -std=c99 -D_POSIX_C_SOURCE=200112L)
 
     add_executable(s2nd "bin/s2nd.c" "bin/echo.c")
-    target_link_libraries(s2nd ${CMAKE_PROJECT_NAME})
+    target_link_libraries(s2nd ${PROJECT_NAME})
     target_include_directories(s2nd PRIVATE api)
     target_compile_options(s2nd PRIVATE -std=c99 -D_POSIX_C_SOURCE=200112L)
 endif()
@@ -210,15 +210,15 @@ elseif(NOT DEFINED CMAKE_INSTALL_LIBDIR)
 endif()
 
 install(
-        TARGETS ${CMAKE_PROJECT_NAME}
-        EXPORT ${CMAKE_PROJECT_NAME}-targets
+        TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}-targets
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Development
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Runtime
         RUNTIME DESTINATION bin COMPONENT Runtime
 )
 
-configure_file("cmake/${CMAKE_PROJECT_NAME}-config.cmake"
-        "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_PROJECT_NAME}-config.cmake"
+configure_file("cmake/${PROJECT_NAME}-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
         @ONLY)
 
 if (BUILD_SHARED_LIBS)
@@ -227,13 +227,13 @@ else()
    set (TARGET_DIR "static")
 endif()
 
-install(EXPORT "${CMAKE_PROJECT_NAME}-targets"
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/cmake/${TARGET_DIR}"
+install(EXPORT "${PROJECT_NAME}-targets"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/cmake/${TARGET_DIR}"
         NAMESPACE AWS::
         COMPONENT Development)
 
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_PROJECT_NAME}-config.cmake"
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/cmake/"
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/cmake/"
         COMPONENT Development)
 
 install(FILES "cmake/modules/FindLibCrypto.cmake"

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -80,7 +80,7 @@ extern const char *s2n_strerror_name(int error);
 
 
 struct s2n_stacktrace;
-extern bool s2n_stack_traces_enabled();
+extern bool s2n_stack_traces_enabled(void);
 extern int s2n_stack_traces_enabled_set(bool newval);
 extern int s2n_calculate_stacktrace(void);
 extern int s2n_print_stacktrace(FILE *fptr);

--- a/cmake/s2n-config.cmake
+++ b/cmake/s2n-config.cmake
@@ -8,8 +8,8 @@ endif()
 find_dependency(LibCrypto)
 
 if (BUILD_SHARED_LIBS)
-    include(${CMAKE_CURRENT_LIST_DIR}/shared/@CMAKE_PROJECT_NAME@-targets.cmake)
+    include(${CMAKE_CURRENT_LIST_DIR}/shared/@PROJECT_NAME@-targets.cmake)
 else()
-    include(${CMAKE_CURRENT_LIST_DIR}/static/@CMAKE_PROJECT_NAME@-targets.cmake)
+    include(${CMAKE_CURRENT_LIST_DIR}/static/@PROJECT_NAME@-targets.cmake)
 endif()
 

--- a/utils/s2n_blob.h
+++ b/utils/s2n_blob.h
@@ -25,8 +25,8 @@ struct s2n_blob {
     uint8_t *data;
     uint32_t size;
     uint32_t allocated;
-    unsigned int mlocked :1;
-    unsigned int growable :1;
+    unsigned mlocked :1;
+    unsigned growable :1;
 };
 
 

--- a/utils/s2n_blob.h
+++ b/utils/s2n_blob.h
@@ -19,13 +19,16 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+
+
 struct s2n_blob {
     uint8_t *data;
     uint32_t size;
     uint32_t allocated;
-    uint8_t mlocked :1;
-    uint8_t growable :1;
+    unsigned int mlocked :1;
+    unsigned int growable :1;
 };
+
 
 extern bool s2n_blob_is_growable(const struct s2n_blob* b);
 extern bool s2n_blob_is_valid(const struct s2n_blob* b);


### PR DESCRIPTION
…om parent projects.

Fixes this broken rule in GCC 4.x

 "A bit-field shall have a type that is a qualified or unqualified version of _Bool, signed int, unsigned int, or some other implementation-defined type."

uint8_t is considered implementation-defined and thus pedantic pops an error. This seems to be the most portable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
