### PR TITLE
CBMC proof for s2n_stuffer_skip_read

### DIFF
--- a/error/s2n_errno.h
+++ b/error/s2n_errno.h
@@ -242,8 +242,13 @@ extern __thread const char *s2n_debug_str;
 #define S2N_ERROR_IF( cond , x ) do { if ( cond ) { S2N_ERROR( x ); }} while (0)
 #define S2N_ERROR_IF_PTR( cond , x ) do { if ( cond ) { S2N_ERROR_PTR( x ); }} while (0)
 
-#define S2N_PRECONDITION( cond ) S2N_ERROR_IF(!(cond), S2N_ERR_PRECONDITION_VIOLATION)
-#define S2N_PRECONDITION_PTR( cond ) S2N_ERROR_IF_PTR(!(cond), S2N_ERR_PRECONDITION_VIOLATION)
+#ifdef __TIMING_CONTRACTS__
+#    define S2N_PRECONDITION( cond ) (void) 0
+#    define S2N_PRECONDITION_PTR( cond ) (void) 0
+#else
+#    define S2N_PRECONDITION( cond ) S2N_ERROR_IF(!(cond), S2N_ERR_PRECONDITION_VIOLATION)
+#    define S2N_PRECONDITION_PTR( cond ) S2N_ERROR_IF_PTR(!(cond), S2N_ERR_PRECONDITION_VIOLATION)
+#endif /* __TIMING_CONTRACTS__ */
 
 /**
  * Define function contracts.

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -179,6 +179,7 @@ int s2n_stuffer_wipe(struct s2n_stuffer *stuffer)
 
 int s2n_stuffer_skip_read(struct s2n_stuffer *stuffer, uint32_t n)
 {
+    S2N_PRECONDITION(s2n_stuffer_is_valid(stuffer));
     S2N_ERROR_IF(s2n_stuffer_data_available(stuffer) < n, S2N_ERR_STUFFER_OUT_OF_DATA);
 
     stuffer->read_cursor += n;

--- a/tests/cbmc/include/cbmc_proof/cbmc_utils.h
+++ b/tests/cbmc/include/cbmc_proof/cbmc_utils.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cbmc_proof/nondet.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <utils/s2n_blob.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define IMPLIES(a, b) (!(a) || (b))
+
+struct store_byte_from_buffer {
+    size_t index;
+    uint8_t byte;
+};
+
+/**
+ * Asserts whether all bytes from two arrays of same length match.
+ */
+void assert_bytes_match(const uint8_t *const a, const uint8_t *const b, const size_t len);
+
+/**
+ * Asserts whether all bytes from an array are equal to c.
+ */
+void assert_all_bytes_are(const uint8_t *const a, const uint8_t c, const size_t len);
+
+/**
+ * Asserts whether all bytes from an array are equal to 0.
+ */
+void assert_all_zeroes(const uint8_t *const a, const size_t len);
+
+/**
+ * Asserts whether the byte in storage correspond to the byte in the same position in buffer.
+ */
+void assert_byte_from_buffer_matches(const uint8_t *const buffer, const struct store_byte_from_buffer *const b);
+
+/**
+ * Asserts whether the byte in storage correspond to the byte in the same position in buffer.
+ */
+void assert_byte_from_blob_matches(const struct s2n_blob *blob, const struct store_byte_from_buffer *const b);
+
+/**
+ * Nondeterministically selects a byte from array and stores it into a store_array_list_byte
+ * structure. Afterwards, one can prove using the assert_byte_from_buffer_matches function
+ * whether no byte in the array has changed.
+ */
+void save_byte_from_array(const uint8_t *const array, const size_t size, struct store_byte_from_buffer *const storage);
+
+/**
+ * Nondeterministically selects a byte from blob and stores it into a store_array_list_byte
+ * structure. Afterwards, one can prove using the assert_byte_from_blob_matches function
+ * whether no byte in the blob has changed.
+ */
+void save_byte_from_blob(const struct s2n_blob *blob, struct store_byte_from_buffer * storage);
+
+/**
+ * Standard stub function to compare two items.
+ */
+int nondet_compare(const void *const a, const void *const b);
+
+/**
+ * Standard stub function to compare two items.
+ */
+int uninterpreted_compare(const void *const a, const void *const b);
+
+/**
+ * Standard stub function to compare two items.
+ */
+bool nondet_equals(const void *const a, const void *const b);
+
+/**
+ * Standard stub function to compare two items.
+ * Also enforces uninterpreted_hasher() to be equal for equal values.
+ */
+bool uninterpreted_equals(const void *const a, const void *const b);
+
+/**
+ * uninterpreted_equals(), but with an extra assertion that a and b are both not null
+ */
+bool uninterpreted_equals_assert_inputs_nonnull(const void *const a, const void *const b);
+
+/**
+ * Standard stub function to hash one item.
+ */
+uint64_t nondet_hasher(const void *a);
+
+/**
+ * Standard stub function to hash one item.
+ */
+uint64_t uninterpreted_hasher(const void *a);
+
+/**
+ * Standard stub function of a predicate
+ */
+bool uninterpreted_predicate_fn(uint8_t value);

--- a/tests/cbmc/include/cbmc_proof/make_common_datastructures.h
+++ b/tests/cbmc/include/cbmc_proof/make_common_datastructures.h
@@ -21,3 +21,5 @@
 
 void ensure_s2n_blob_has_allocated_fields(struct s2n_blob* blob);
 struct s2n_blob* cbmc_allocate_s2n_blob();
+void ensure_s2n_stuffer_has_allocated_fields(struct s2n_stuffer* stuffer);
+struct s2n_stuffer* cbmc_allocate_s2n_stuffer();

--- a/tests/cbmc/proofs/s2n_stuffer_skip_read/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_read/Makefile
@@ -1,0 +1,30 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+
+ENTRY = s2n_stuffer_skip_read_harness
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_skip_read/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_read/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;6"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_skip_read_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_skip_read/s2n_stuffer_skip_read_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_read/s2n_stuffer_skip_read_harness.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_stuffer_skip_read_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_blob(&stuffer->blob, &old_byte);
+    uint32_t n;
+   
+    if (s2n_stuffer_skip_read(stuffer, n) == S2N_SUCCESS) {
+	assert(stuffer->read_cursor == old_stuffer.read_cursor + n);
+    } else {
+	assert(stuffer->read_cursor == old_stuffer.read_cursor);
+    }
+
+    /* These assertions should always hold, regardless of whether the test succeeded */
+    assert(stuffer->blob.data == old_stuffer.blob.data);
+    assert(stuffer->blob.size == old_stuffer.blob.size);
+    assert(stuffer->write_cursor == old_stuffer.write_cursor);
+    assert(stuffer->wiped == old_stuffer.wiped);
+    assert(stuffer->alloced == old_stuffer.alloced);
+    assert(stuffer->growable == old_stuffer.growable);
+    assert(stuffer->tainted == old_stuffer.tainted);
+    assert_byte_from_blob_matches(&stuffer->blob, &old_byte);
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/source/cbmc_utils.c
+++ b/tests/cbmc/source/cbmc_utils.c
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cbmc_proof/cbmc_utils.h>
+
+void assert_bytes_match(const uint8_t *const a, const uint8_t *const b, const size_t len) {
+    assert(!a == !b);
+    if (len > 0 && a != NULL && b != NULL) {
+        size_t i;
+        __CPROVER_assume(i < len && len < MAX_MALLOC); /* prevent spurious pointer overflows */
+        assert(a[i] == b[i]);
+    }
+}
+
+void assert_all_bytes_are(const uint8_t *const a, const uint8_t c, const size_t len) {
+    if (len > 0 && a != NULL) {
+        size_t i;
+        __CPROVER_assume(i < len);
+        assert(a[i] == c);
+    }
+}
+
+void assert_all_zeroes(const uint8_t *const a, const size_t len) {
+    assert_all_bytes_are(a, 0, len);
+}
+
+void assert_byte_from_buffer_matches(const uint8_t *const buffer, const struct store_byte_from_buffer *const b) {
+    if (buffer && b) {
+        assert(*(buffer + b->index) == b->byte);
+    }
+}
+
+void assert_byte_from_blob_matches(const struct s2n_blob *blob, const struct store_byte_from_buffer *const b) {
+    if(blob && blob->size) {
+	assert_byte_from_buffer_matches(blob->data, b);
+    }
+}
+
+void save_byte_from_array(const uint8_t *const array, const size_t size, struct store_byte_from_buffer *const storage) {
+    if (size > 0 && array && storage) {
+        storage->index = nondet_size_t();
+        __CPROVER_assume(storage->index < size);
+        storage->byte = array[storage->index];
+    }
+}
+
+void save_byte_from_blob(const struct s2n_blob *blob, struct store_byte_from_buffer * storage) {
+    save_byte_from_array(blob->data, blob->size, storage);
+}
+
+int nondet_compare(const void *const a, const void *const b) {
+    assert(a != NULL);
+    assert(b != NULL);
+    return nondet_int();
+}
+
+int __CPROVER_uninterpreted_compare(const void *const a, const void *const b);
+int uninterpreted_compare(const void *const a, const void *const b) {
+    assert(a != NULL);
+    assert(b != NULL);
+    int rval = __CPROVER_uninterpreted_compare(a, b);
+    /* Compare is reflexive */
+    __CPROVER_assume(IMPLIES(a == b, rval == 0));
+    /* Compare is anti-symmetric*/
+    __CPROVER_assume(__CPROVER_uninterpreted_compare(b, a) == -rval);
+    /* If two things are equal, their hashes are also equal */
+    if (rval == 0) {
+        __CPROVER_assume(__CPROVER_uninterpreted_hasher(a) == __CPROVER_uninterpreted_hasher(b));
+    }
+    return rval;
+}
+
+bool nondet_equals(const void *const a, const void *const b) {
+    assert(a != NULL);
+    assert(b != NULL);
+    return nondet_bool();
+}
+
+bool __CPROVER_uninterpreted_equals(const void *const a, const void *const b);
+uint64_t __CPROVER_uninterpreted_hasher(const void *const a);
+/**
+ * Add assumptions that equality is reflexive and symmetric. Don't bother with
+ * transitivity because it doesn't cause any spurious proof failures on hash-table
+ */
+bool uninterpreted_equals(const void *const a, const void *const b) {
+    bool rval = __CPROVER_uninterpreted_equals(a, b);
+    /* Equals is reflexive */
+    __CPROVER_assume(IMPLIES(a == b, rval));
+    /* Equals is symmetric */
+    __CPROVER_assume(__CPROVER_uninterpreted_equals(b, a) == rval);
+    /* If two things are equal, their hashes are also equal */
+    if (rval) {
+        __CPROVER_assume(__CPROVER_uninterpreted_hasher(a) == __CPROVER_uninterpreted_hasher(b));
+    }
+    return rval;
+}
+
+bool uninterpreted_equals_assert_inputs_nonnull(const void *const a, const void *const b) {
+    assert(a != NULL);
+    assert(b != NULL);
+    return uninterpreted_equals(a, b);
+}
+
+uint64_t nondet_hasher(const void *a) {
+    assert(a != NULL);
+    return nondet_uint64_t();
+}
+
+/**
+ * Standard stub function to hash one item.
+ */
+uint64_t uninterpreted_hasher(const void *a) {
+    assert(a != NULL);
+    return __CPROVER_uninterpreted_hasher(a);
+}
+
+bool uninterpreted_predicate_fn(uint8_t value);

--- a/tests/cbmc/source/make_common_datastructures.c
+++ b/tests/cbmc/source/make_common_datastructures.c
@@ -15,13 +15,26 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 void ensure_s2n_blob_has_allocated_fields(struct s2n_blob* blob) {
-  blob->data = bounded_malloc(blob->size);  
+    blob->data = bounded_malloc(blob->size);
 }
 
 struct s2n_blob* cbmc_allocate_s2n_blob() {
-  struct s2n_blob* blob = can_fail_malloc(sizeof(*blob));
-  if(blob) {
-    ensure_s2n_blob_has_allocated_fields(blob);
-  }
-  return blob;
+    struct s2n_blob* blob = can_fail_malloc(sizeof(*blob));
+    if (blob) {
+	ensure_s2n_blob_has_allocated_fields(blob);
+    }
+    return blob;
+}
+
+void ensure_s2n_stuffer_has_allocated_fields(struct s2n_stuffer* stuffer)
+{
+    ensure_s2n_blob_has_allocated_fields(&stuffer->blob);
+}
+
+struct s2n_stuffer* cbmc_allocate_s2n_stuffer() {
+    struct s2n_stuffer* stuffer = can_fail_malloc(sizeof(*stuffer));
+    if (stuffer) {
+	ensure_s2n_stuffer_has_allocated_fields(stuffer);
+    }
+    return stuffer;
 }


### PR DESCRIPTION
**Description of changes:** 
Adds a CBMC proof for the s2n_stuffer_skip_read function

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
