### PR TITLE
Enable use of S2N_NO_PQ_ASM flag; disable PQ assembly code for Darwin/osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ jobs:
   - os: linux
     dist: bionic
     # Force S2N to use the generic C code for SIKE round 2 (instead of the optimized x86_64 assembly code)
-    env: S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=9 S2N_SIKE_R2_FORCE_GENERIC=true
+    env: S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=9 S2N_NO_PQ_ASM=true
 
 # Fuzz Tests
   - os: linux

--- a/.travis/s2n_setup_env.sh
+++ b/.travis/s2n_setup_env.sh
@@ -77,7 +77,7 @@ export FUZZ_TIMEOUT_SEC
 export TRAVIS_OS_NAME
 export UBUNTU_VERSION
 export S2N_CORKED_IO
-export S2N_SIKE_R2_FORCE_GENERIC
+export S2N_NO_PQ_ASM
 
 
 # Select the libcrypto to build s2n against. If this is unset, default to the latest stable version(Openssl 1.1.1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,16 +60,18 @@ file(GLOB PQ_SRC
         "pq-crypto/sike_r2/P434.c"
         )
 
-if($ENV{S2N_SIKE_R2_FORCE_GENERIC})
-    message(STATUS "Forcing usage of generic C code for SIKE p434 r2")
+if($ENV{S2N_NO_PQ_ASM})
+    message(STATUS "Forcing usage of generic C code for PQ crypto")
+elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "Darwin")
+    message(STATUS "Detected Darwin, using generic C code for PQ crypto")
 elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64" OR ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "amd64" OR (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "AMD64" AND CMAKE_CL_64))
-    message(STATUS "Using optimized x86_64 assembly for SIKE p434 r2")
+    message(STATUS "Using optimized x86_64 assembly for PQ crypto")
     enable_language(ASM)
     file(GLOB PQ_X86_64_ASM
             "pq-crypto/sike_r2/fp_x64_asm.S")
     list(APPEND PQ_SRC ${PQ_X86_64_ASM})
 else()
-    message(STATUS "Architecture is not x86_64 compatible - using generic C code for SIKE p434 r2")
+    message(STATUS "Architecture is not x86_64 compatible - using generic C code for PQ crypto")
 endif()
 
 file(GLOB STUFFER_SRC

--- a/pq-crypto/sike_r2/Makefile
+++ b/pq-crypto/sike_r2/Makefile
@@ -17,10 +17,13 @@ SRCS=fips202.c P434.c
 OBJS=$(SRCS:.c=.o)
 
 ARCH := $(shell uname -p)
+KERNEL := $(shell uname -s)
+ifeq ($(KERNEL), Linux)
 ifeq ($(ARCH), x86_64)
-ifndef S2N_SIKE_R2_FORCE_GENERIC
+ifndef S2N_NO_PQ_ASM
 ASRC=fp_x64_asm.S
 OBJS+=$(ASRC:.S=.o)
+endif
 endif
 endif
 

--- a/pq-crypto/sike_r2/P434.c
+++ b/pq-crypto/sike_r2/P434.c
@@ -109,12 +109,10 @@ const unsigned int strat_Bob[MAX_Bob - 1] = {
 #define EphemeralSecretAgreement_A oqs_kem_sidh_p434_EphemeralSecretAgreement_A
 #define EphemeralSecretAgreement_B oqs_kem_sidh_p434_EphemeralSecretAgreement_B
 
-#if defined(OPTIMIZED_ASM_IMPLEMENTATION)
+#if defined(S2N_PQ_ASM)
 #include "fp_x64.c"
-#elif defined(GENERIC_IMPLEMENTATION)
-#include "fp_generic.c"
 #else
-#error "Neither OPTIMIZED_ASM_IMPLEMENTATION nor GENERIC_IMPLEMENTATION was defined. One of those must be defined."
+#include "fp_generic.c"
 #endif
 
 #include "fpx.c"

--- a/pq-crypto/sike_r2/config.h
+++ b/pq-crypto/sike_r2/config.h
@@ -76,7 +76,7 @@ typedef uint32_t hdigit_t; // Unsigned 32-bit digit
 #define RADIX64 64
 
 // Extended datatype support
-#if defined(GENERIC_IMPLEMENTATION)
+#if defined(S2N_PQ_GENERIC)
 typedef uint64_t uint128_t[2];
 #elif (TARGET == TARGET_AMD64 && OS_TARGET == OS_LINUX)
 typedef unsigned uint128_t __attribute__((mode(TI)));
@@ -113,7 +113,7 @@ unsigned int is_digit_lessthan_ct(digit_t x, digit_t y) { // Is x < y?
 
 /********************** Macros for platform-dependent operations **********************/
 
-#if defined(GENERIC_IMPLEMENTATION) || (TARGET == TARGET_ARM)
+#if defined(S2N_PQ_GENERIC) || (TARGET == TARGET_ARM)
 
 // Digit multiplication
 #define MUL(multiplier, multiplicand, hi, lo) \

--- a/pq-crypto/sike_r2/fpx.c
+++ b/pq-crypto/sike_r2/fpx.c
@@ -124,7 +124,7 @@ void fp2correction(f2elm_t *a) { // Modular correction, a = a in GF(p^2).
 }
 
 __inline static void mp_addfast(const digit_t *a, const digit_t *b, digit_t *c) { // Multiprecision addition, c = a+b.
-#if (OS_TARGET == OS_WIN) || defined(GENERIC_IMPLEMENTATION) || (TARGET == TARGET_ARM) || (TARGET == TARGET_ARM64 && (NBITS_FIELD == 434 || NBITS_FIELD == 610))
+#if (OS_TARGET == OS_WIN) || defined(S2N_PQ_GENERIC) || (TARGET == TARGET_ARM) || (TARGET == TARGET_ARM64 && (NBITS_FIELD == 434 || NBITS_FIELD == 610))
 
 	mp_add(a, b, c, NWORDS_FIELD);
 
@@ -157,7 +157,7 @@ unsigned int mp_sub(const digit_t *a, const digit_t *b, digit_t *c, const unsign
 }
 
 __inline static void mp_subaddfast(const digit_t *a, const digit_t *b, digit_t *c) { // Multiprecision subtraction followed by addition with p*2^MAXBITS_FIELD, c = a-b+(p*2^MAXBITS_FIELD) if a-b < 0, otherwise c=a-b.
-#if (OS_TARGET == OS_WIN) || defined(GENERIC_IMPLEMENTATION) || (TARGET == TARGET_ARM) || (TARGET == TARGET_ARM64 && (NBITS_FIELD == 434 || NBITS_FIELD == 610))
+#if (OS_TARGET == OS_WIN) || defined(S2N_PQ_GENERIC) || (TARGET == TARGET_ARM) || (TARGET == TARGET_ARM64 && (NBITS_FIELD == 434 || NBITS_FIELD == 610))
 	felm_t t1;
 
 	digit_t mask = 0 - (digit_t) mp_sub(a, b, c, 2 * NWORDS_FIELD);
@@ -173,7 +173,7 @@ __inline static void mp_subaddfast(const digit_t *a, const digit_t *b, digit_t *
 }
 
 __inline static void mp_dblsubfast(const digit_t *a, const digit_t *b, digit_t *c) { // Multiprecision subtraction, c = c-a-b, where lng(a) = lng(b) = 2*NWORDS_FIELD.
-#if (OS_TARGET == OS_WIN) || defined(GENERIC_IMPLEMENTATION) || (TARGET == TARGET_ARM) || (TARGET == TARGET_ARM64 && (NBITS_FIELD == 434 || NBITS_FIELD == 610))
+#if (OS_TARGET == OS_WIN) || defined(S2N_PQ_GENERIC) || (TARGET == TARGET_ARM) || (TARGET == TARGET_ARM64 && (NBITS_FIELD == 434 || NBITS_FIELD == 610))
 
 	mp_sub(c, a, c, 2 * NWORDS_FIELD);
 	mp_sub(c, b, c, 2 * NWORDS_FIELD);

--- a/pq-crypto/sike_r2/sike_r2_code_identifier.h
+++ b/pq-crypto/sike_r2/sike_r2_code_identifier.h
@@ -16,15 +16,16 @@
 #ifndef S2N_SIKE_R2_CODE_IDENTIFIER_H
 #define S2N_SIKE_R2_CODE_IDENTIFIER_H
 
-#if defined(__x86_64__)
-// Allow the forced usage of the generic implementation if desired.
-#if defined(S2N_SIKE_R2_FORCE_GENERIC)
-#define GENERIC_IMPLEMENTATION
-#else
-#define OPTIMIZED_ASM_IMPLEMENTATION
+#ifndef S2N_NO_PQ_ASM
+#ifndef __APPLE__
+#ifdef __x86_64__
+#define S2N_PQ_ASM
 #endif
-#else
-#define GENERIC_IMPLEMENTATION
+#endif
+#endif
+
+#ifndef S2N_PQ_ASM
+#define S2N_PQ_GENERIC
 #endif
 
 #define ASM_CODE_IDENTIFIER 1

--- a/s2n.mk
+++ b/s2n.mk
@@ -60,9 +60,9 @@ ifdef S2N_TEST_IN_FIPS_MODE
     DEFAULT_CFLAGS += -DS2N_TEST_IN_FIPS_MODE
 endif
 
-# Force the usage of generic C code for round 2 SIKE, even if the optimized assembly could be used
-ifdef S2N_SIKE_R2_FORCE_GENERIC
-	DEFAULT_CFLAGS += -DS2N_SIKE_R2_FORCE_GENERIC
+# Force the usage of generic C code for PQ crypto, even if the optimized assembly could be used
+ifdef S2N_NO_PQ_ASM
+	DEFAULT_CFLAGS += -DS2N_NO_PQ_ASM
 endif
 
 CFLAGS += ${DEFAULT_CFLAGS}

--- a/tests/unit/s2n_sike_r2_verify_included_code_test.c
+++ b/tests/unit/s2n_sike_r2_verify_included_code_test.c
@@ -26,12 +26,12 @@ int main(int argc, char **argv)
      * where we accidentally include/run the generic C code when we actually
      * wanted to use the optimized assembly.
      */
-#if defined(OPTIMIZED_ASM_IMPLEMENTATION)
+#if defined(S2N_PQ_ASM)
     EXPECT_EQUAL(sike_r2_fp_code_identifier(), ASM_CODE_IDENTIFIER);
-#elif defined(GENERIC_IMPLEMENTATION)
+#elif defined(S2N_PQ_GENERIC)
     EXPECT_EQUAL(sike_r2_fp_code_identifier(), GENERIC_C_CODE_IDENTIFIER);
 #else
-    FAIL_MSG("Neither OPTIMIZED_ASM_IMPLEMENTATION nor GENERIC_IMPLEMENTATION was defined. One of those must be defined.");
+    FAIL_MSG("Neither S2N_PQ_ASM nor S2N_PQ_GENERIC was defined. One of those must be defined.");
 #endif
 
     END_TEST();


### PR DESCRIPTION
**Issue # (if available):** N/A

**Description of changes:** 
* Enables the use of a `S2N_NO_PQ_ASM` compile flag to force the PQ code to use the generic C version
* Detects Darwin/Apple/osx and forces the use of the generic C code because the ASM code was not written for it


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
