### PR TITLE
Added proof for s2n_stuffer_rewind_read

### DIFF
--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -33,7 +33,10 @@ bool s2n_stuffer_is_valid(const struct s2n_stuffer* stuffer)
 {
     /* Note that we do not assert any properties on the alloced, growable, and tainted fields,
      * as all possible combinations of boolean values in those fields are valid */
-    return S2N_OBJECT_PTR_IS_READABLE(stuffer) && 
+    if (stuffer == NULL) {
+        return false;
+    }
+    return S2N_OBJECT_PTR_IS_READABLE(stuffer) &&
         s2n_blob_is_valid(&stuffer->blob) &&
         /* <= is valid because we can have a fully written/read stuffer */
         stuffer->high_water_mark <= stuffer->blob.size &&

--- a/tests/cbmc/proofs/s2n_stuffer_rewind_read/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_rewind_read/Makefile
@@ -1,0 +1,30 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+
+
+ENTRY = s2n_stuffer_rewind_read_harness
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_rewind_read/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_rewind_read/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;6"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_rewind_read_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_rewind_read/s2n_stuffer_rewind_read_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_rewind_read/s2n_stuffer_rewind_read_harness.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_blob.h"
+
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_calculate_stacktrace() {
+}
+
+void s2n_stuffer_rewind_read_harness() {
+	struct s2n_stuffer *stuffer = can_fail_malloc(sizeof(struct s2n_stuffer));
+	__CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+	uint32_t size;
+	int ret = s2n_stuffer_rewind_read(stuffer, size);
+	if (ret != 0) {
+		assert(stuffer->read_cursor < size);
+	}
+	assert(s2n_stuffer_is_valid(stuffer));
+}


### PR DESCRIPTION
Added a CBMC proof for s2n_stuffer_skip_read_harness

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
