### PR TITLE
Added cbmc proof for s2n_stuffer_raw_read()

### DIFF
--- a/tests/cbmc/proofs/s2n_stuffer_raw_read/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_raw_read/Makefile
@@ -1,0 +1,30 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+
+ENTRY = s2n_stuffer_raw_read_harness
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_raw_read/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_raw_read/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_init_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_raw_read/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_raw_read/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
 expected: "SUCCESSFUL"
-goto: gotos/s2n_stuffer_init_harness.goto
+goto: gotos/s2n_stuffer_raw_read_harness.goto
 jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_raw_read/s2n_stuffer_raw_read_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_raw_read/s2n_stuffer_raw_read_harness.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_stuffer_raw_read_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_blob(&stuffer->blob, &old_byte);
+    uint32_t size;
+
+    void *result = s2n_stuffer_raw_read(stuffer, size);
+    if (result) {
+        assert(stuffer->tainted == 1);
+        assert(__CPROVER_r_ok(result, size));
+        assert(stuffer->read_cursor == old_stuffer.read_cursor + size);
+    } else {
+        assert(stuffer->read_cursor == old_stuffer.read_cursor);
+    }
+
+    /* These assertions should always hold, regardless of whether the test succeeded */
+    assert(stuffer->blob.data == old_stuffer.blob.data);
+    assert(stuffer->blob.size == old_stuffer.blob.size);
+    assert(stuffer->write_cursor == old_stuffer.write_cursor);
+    assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+    assert(stuffer->alloced == old_stuffer.alloced);
+    assert(stuffer->growable == old_stuffer.growable);
+    assert_byte_from_blob_matches(&stuffer->blob, &old_byte);
+    assert(s2n_stuffer_is_valid(stuffer));
+}


### PR DESCRIPTION
**Issue # (if available):** 
N/A
**Description of changes:** 
Added cbmc proof for the function s2n_stuffer_raw_read().

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
