### PR TITLE
Added proof for s2n_stuffer_copy

### DIFF
--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -244,8 +244,9 @@ int s2n_stuffer_skip_write(struct s2n_stuffer *stuffer, const uint32_t n)
         if (stuffer->growable) {
             /* Always grow a stuffer by at least 1k */
             uint32_t growth = MAX(n - s2n_stuffer_space_remaining(stuffer), 1024);
-
-            GUARD(s2n_stuffer_resize(stuffer, stuffer->blob.size + growth));
+            uint32_t new_size = 0;
+            GUARD(s2n_add_overflow(stuffer->blob.size, growth, &new_size));
+            GUARD(s2n_stuffer_resize(stuffer, new_size));
         } else {
             S2N_ERROR(S2N_ERR_STUFFER_IS_FULL);
         }

--- a/tests/cbmc/proofs/s2n_stuffer_copy/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_copy/Makefile
@@ -1,0 +1,32 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+
+ENTRY = s2n_stuffer_copy_harness
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_copy/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_copy/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_copy_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_copy/s2n_stuffer_copy_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_copy/s2n_stuffer_copy_harness.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <error/s2n_errno.h>
+
+int s2n_get_memory(struct s2n_blob *b, uint32_t size)
+{
+    *b = (struct s2n_blob) {.data = nondet_bool() ? malloc(size) : 0, .size = size, .allocated = size, .mlocked = 0, .growable = 1};
+    S2N_ERROR_IF(b->data == NULL, S2N_ERR_ALLOC);
+    return S2N_SUCCESS;
+}
+
+void s2n_stuffer_copy_harness() {
+    struct s2n_stuffer *from = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(from));
+    struct s2n_stuffer old_stuffer = *from;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_blob(&from->blob, &old_byte);
+    struct s2n_stuffer *to = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(to));
+    struct s2n_stuffer to_stuffer_was = *to;
+    uint32_t length;
+
+    s2n_stuffer_copy(from, to, length);
+
+    /* These assertions should always hold, regardless of whether the test succeeded */
+    assert(from->blob.data == old_stuffer.blob.data);
+    assert(from->blob.size == old_stuffer.blob.size);
+    assert(from->write_cursor == old_stuffer.write_cursor);
+    assert(from->high_water_mark == old_stuffer.high_water_mark);
+    assert(from->alloced == old_stuffer.alloced);
+    assert(from->growable == old_stuffer.growable);
+    assert(from->tainted == old_stuffer.tainted);
+    assert_byte_from_blob_matches(&from->blob, &old_byte);
+    assert(s2n_stuffer_is_valid(from));
+}

--- a/tests/cbmc/source/make_common_datastructures.c
+++ b/tests/cbmc/source/make_common_datastructures.c
@@ -15,7 +15,7 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 void ensure_s2n_blob_has_allocated_fields(struct s2n_blob* blob) {
-    blob->data = bounded_malloc(blob->size);
+    blob->data = bounded_malloc(blob->allocated);
 }
 
 struct s2n_blob* cbmc_allocate_s2n_blob() {

--- a/utils/s2n_blob.c
+++ b/utils/s2n_blob.c
@@ -25,14 +25,15 @@
 
 bool s2n_blob_is_valid(const struct s2n_blob* b)
 {
-  bool blob_was_valid = S2N_OBJECT_PTR_IS_READABLE(b) && S2N_MEM_IS_READABLE(b->data,b->size);
-  return blob_was_valid;
+  return S2N_OBJECT_PTR_IS_READABLE(b)
+  && b->size <= b->allocated
+  && S2N_MEM_IS_READABLE(b->data,b->size);
 }
 
 int s2n_blob_init(struct s2n_blob *b, uint8_t * data, uint32_t size)
 {
     notnull_check(b);
-    *b = (struct s2n_blob) {.data = data, .size = size, .growable = 0, .mlocked = 0};
+    *b = (struct s2n_blob) {.data = data, .size = size, .allocated = size, .growable = 0, .mlocked = 0};
     return 0;
 }
 

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -59,7 +59,7 @@ bool s2n_blob_is_growable(const struct s2n_blob* b)
   return b && (b->growable || (b->data == NULL && b->size == 0 && b->allocated == 0));
 }
 
-static int s2n_get_memory(struct s2n_blob *b, uint32_t size)
+int s2n_get_memory(struct s2n_blob *b, uint32_t size)
 {
     if(use_mlock) {
         /* Page aligned allocation required for mlock */

--- a/utils/s2n_safety.c
+++ b/utils/s2n_safety.c
@@ -171,3 +171,11 @@ int s2n_mul_overflow(uint32_t a, uint32_t b, uint32_t* out)
     *out = (uint32_t) result;
     return S2N_SUCCESS;
 }
+
+int s2n_add_overflow(uint32_t a, uint32_t b, uint32_t* out)
+{
+    uint64_t result = ((uint64_t) a) + ((uint64_t) b);
+    S2N_ERROR_IF(result > UINT32_MAX, S2N_ERR_INTEGER_OVERFLOW);
+    *out = (uint32_t) result;
+    return S2N_SUCCESS;
+}

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -154,3 +154,4 @@ extern int s2n_constant_time_pkcs1_unpad_or_dont(uint8_t * dst, const uint8_t * 
 #define s2n_array_len(array) (sizeof(array) / sizeof(array[0]))
 
 extern int s2n_mul_overflow(uint32_t a, uint32_t b, uint32_t* out);
+extern int s2n_add_overflow(uint32_t a, uint32_t b, uint32_t* out);


### PR DESCRIPTION
**Issue # (if available):** 
N/A
**Description of changes:** 
- Added cbmc proof for s2n_stuffer_copy(). This proof caused multiple issues to show up within the stuffer code and tests/cbmc/source code. Some of those issues were fixed, but another s2n function, s2n_get_memory(), now needs a proof (in order to get around this issue, had to stub s2n_get_memory() as a hack, this will be removed when test harness for s2n_get_memory is written)
- Changed some cbmc test setup functions


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
