### PR TITLE
Move client extension receive functions to their respective files

### DIFF
--- a/tls/extensions/s2n_client_alpn.c
+++ b/tls/extensions/s2n_client_alpn.c
@@ -35,3 +35,62 @@ int s2n_extensions_client_alpn_send(struct s2n_connection *conn, struct s2n_stuf
 
     return 0;
 }
+
+int s2n_recv_client_alpn(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    uint16_t size_of_all;
+    struct s2n_stuffer client_protos = {0};
+    struct s2n_stuffer server_protos = {0};
+
+    struct s2n_blob *server_app_protocols;
+    GUARD(s2n_connection_get_protocol_preferences(conn, &server_app_protocols));
+
+    if (!server_app_protocols->size) {
+        /* No protocols configured, nothing to do */
+        return 0;
+    }
+
+    GUARD(s2n_stuffer_read_uint16(extension, &size_of_all));
+    if (size_of_all > s2n_stuffer_data_available(extension) || size_of_all < 3) {
+        /* Malformed length, ignore the extension */
+        return 0;
+    }
+
+    struct s2n_blob client_app_protocols = { 0 };
+    client_app_protocols.size = size_of_all;
+    client_app_protocols.data = s2n_stuffer_raw_read(extension, size_of_all);
+    notnull_check(client_app_protocols.data);
+
+    /* Find a matching protocol */
+    GUARD(s2n_stuffer_init(&client_protos, &client_app_protocols));
+    GUARD(s2n_stuffer_write(&client_protos, &client_app_protocols));
+    GUARD(s2n_stuffer_init(&server_protos, server_app_protocols));
+    GUARD(s2n_stuffer_write(&server_protos, server_app_protocols));
+
+    while (s2n_stuffer_data_available(&server_protos)) {
+        uint8_t length;
+        uint8_t server_protocol[255];
+        GUARD(s2n_stuffer_read_uint8(&server_protos, &length));
+        GUARD(s2n_stuffer_read_bytes(&server_protos, server_protocol, length));
+
+        while (s2n_stuffer_data_available(&client_protos)) {
+            uint8_t client_length;
+            GUARD(s2n_stuffer_read_uint8(&client_protos, &client_length));
+            S2N_ERROR_IF(client_length > s2n_stuffer_data_available(&client_protos), S2N_ERR_BAD_MESSAGE);
+            if (client_length != length) {
+                GUARD(s2n_stuffer_skip_read(&client_protos, client_length));
+            } else {
+                uint8_t client_protocol[255];
+                GUARD(s2n_stuffer_read_bytes(&client_protos, client_protocol, client_length));
+                if (memcmp(client_protocol, server_protocol, client_length) == 0) {
+                    memcpy_check(conn->application_protocol, client_protocol, client_length);
+                    conn->application_protocol[client_length] = '\0';
+                    return 0;
+                }
+            }
+        }
+
+        GUARD(s2n_stuffer_reread(&client_protos));
+    }
+    return 0;
+}

--- a/tls/extensions/s2n_client_alpn.h
+++ b/tls/extensions/s2n_client_alpn.h
@@ -19,3 +19,4 @@
 #include "stuffer/s2n_stuffer.h"
 
 extern int s2n_extensions_client_alpn_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+extern int s2n_recv_client_alpn(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_client_ec_point_format.c
+++ b/tls/extensions/s2n_client_ec_point_format.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -13,18 +13,20 @@
  * permissions and limitations under the License.
  */
 
-#pragma once
-
+#include <sys/param.h>
 #include <stdint.h>
-#include <string.h>
 
-#include "utils/s2n_blob.h"
+#include "tls/extensions/s2n_client_ec_point_format.h"
+#include "tls/s2n_tls.h"
 
-struct s2n_client_hello_parsed_extension {
-	uint16_t extension_type;
-	struct s2n_blob extension;
-};
+#include "utils/s2n_safety.h"
 
-extern int s2n_client_hello_get_parsed_extension(struct s2n_array *parsed_extensions, s2n_tls_extension_type extension_type,
-        struct s2n_client_hello_parsed_extension *parsed_extension);
-extern void s2n_register_extension(uint16_t ext_type);
+int s2n_recv_client_ec_point_formats(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    /**
+     * Only uncompressed points are supported by the server and the client must include it in
+     * the extension. Just skip the extension.
+     */
+    conn->ec_point_formats = 1;
+    return 0;
+}

--- a/tls/extensions/s2n_client_ec_point_format.h
+++ b/tls/extensions/s2n_client_ec_point_format.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -15,16 +15,7 @@
 
 #pragma once
 
-#include <stdint.h>
-#include <string.h>
+#include "tls/s2n_connection.h"
+#include "stuffer/s2n_stuffer.h"
 
-#include "utils/s2n_blob.h"
-
-struct s2n_client_hello_parsed_extension {
-	uint16_t extension_type;
-	struct s2n_blob extension;
-};
-
-extern int s2n_client_hello_get_parsed_extension(struct s2n_array *parsed_extensions, s2n_tls_extension_type extension_type,
-        struct s2n_client_hello_parsed_extension *parsed_extension);
-extern void s2n_register_extension(uint16_t ext_type);
+extern int s2n_recv_client_ec_point_formats(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_client_max_frag_len.c
+++ b/tls/extensions/s2n_client_max_frag_len.c
@@ -32,3 +32,20 @@ int s2n_extensions_client_max_frag_len_send(struct s2n_connection *conn, struct 
 
     return 0;
 }
+
+int s2n_recv_client_max_frag_len(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    if (!conn->config->accept_mfl) {
+        return 0;
+    }
+
+    uint8_t mfl_code;
+    GUARD(s2n_stuffer_read_uint8(extension, &mfl_code));
+    if (mfl_code > S2N_TLS_MAX_FRAG_LEN_4096 || mfl_code_to_length[mfl_code] > S2N_TLS_MAXIMUM_FRAGMENT_LENGTH) {
+        return 0;
+    }
+
+    conn->mfl_code = mfl_code;
+    conn->max_outgoing_fragment_length = mfl_code_to_length[mfl_code];
+    return 0;
+}

--- a/tls/extensions/s2n_client_max_frag_len.h
+++ b/tls/extensions/s2n_client_max_frag_len.h
@@ -19,3 +19,4 @@
 #include "stuffer/s2n_stuffer.h"
 
 extern int s2n_extensions_client_max_frag_len_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+extern int s2n_recv_client_max_frag_len(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_client_pq_kem.c
+++ b/tls/extensions/s2n_client_pq_kem.c
@@ -47,3 +47,21 @@ int s2n_extensions_client_pq_kem_send(struct s2n_connection *conn, struct s2n_st
 
     return 0;
 }
+
+int s2n_recv_pq_kem_extension(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    uint16_t size_of_all;
+    struct s2n_blob *proposed_kems = &conn->secure.client_pq_kem_extension;
+
+    GUARD(s2n_stuffer_read_uint16(extension, &size_of_all));
+    if (size_of_all > s2n_stuffer_data_available(extension) || size_of_all % 2) {
+        /* Malformed length, ignore the extension */
+        return 0;
+    }
+
+    proposed_kems->size = size_of_all;
+    proposed_kems->data = s2n_stuffer_raw_read(extension, proposed_kems->size);
+    notnull_check(proposed_kems->data);
+
+    return 0;
+}

--- a/tls/extensions/s2n_client_pq_kem.h
+++ b/tls/extensions/s2n_client_pq_kem.h
@@ -19,3 +19,4 @@
 #include "stuffer/s2n_stuffer.h"
 
 extern int s2n_extensions_client_pq_kem_send(struct s2n_connection *conn, struct s2n_stuffer *out, uint16_t pq_kem_list_size);
+extern int s2n_recv_pq_kem_extension(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_client_renegotiation_info.h
+++ b/tls/extensions/s2n_client_renegotiation_info.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -15,16 +15,7 @@
 
 #pragma once
 
-#include <stdint.h>
-#include <string.h>
+#include "tls/s2n_connection.h"
+#include "stuffer/s2n_stuffer.h"
 
-#include "utils/s2n_blob.h"
-
-struct s2n_client_hello_parsed_extension {
-	uint16_t extension_type;
-	struct s2n_blob extension;
-};
-
-extern int s2n_client_hello_get_parsed_extension(struct s2n_array *parsed_extensions, s2n_tls_extension_type extension_type,
-        struct s2n_client_hello_parsed_extension *parsed_extension);
-extern void s2n_register_extension(uint16_t ext_type);
+extern int s2n_recv_client_renegotiation_info(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_client_sct_list.h
+++ b/tls/extensions/s2n_client_sct_list.h
@@ -19,3 +19,4 @@
 #include "stuffer/s2n_stuffer.h"
 
 extern int s2n_extensions_client_sct_list_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+extern int s2n_recv_client_sct_list(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_client_server_name.c
+++ b/tls/extensions/s2n_client_server_name.c
@@ -44,3 +44,45 @@ int s2n_extensions_client_server_name_send(struct s2n_connection *conn, struct s
 
     return 0;
 }
+
+int s2n_parse_client_hello_server_name(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    if (conn->server_name[0]) {
+        /* already parsed server name extension, exit early */
+        return 0;
+    }
+
+    uint16_t size_of_all;
+    uint8_t server_name_type;
+    uint16_t server_name_len;
+    uint8_t *server_name;
+
+    GUARD(s2n_stuffer_read_uint16(extension, &size_of_all));
+    if (size_of_all > s2n_stuffer_data_available(extension) || size_of_all < 3) {
+        /* the size of all server names is incorrect, ignore the extension */
+        return 0;
+    }
+
+    GUARD(s2n_stuffer_read_uint8(extension, &server_name_type));
+    if (server_name_type != 0) {
+        /* unknown server name type, ignore the extension */
+        return 0;
+    }
+
+    GUARD(s2n_stuffer_read_uint16(extension, &server_name_len));
+    if (server_name_len + 3 > size_of_all) {
+        /* the server name length is incorrect, ignore the extension */
+        return 0;
+    }
+
+    if (server_name_len > sizeof(conn->server_name) - 1) {
+        /* the server name is too long, ignore the extension */
+        return 0;
+    }
+
+    notnull_check(server_name = s2n_stuffer_raw_read(extension, server_name_len));
+
+    /* copy the first server name */
+    memcpy_check(conn->server_name, server_name, server_name_len);
+    return 0;
+}

--- a/tls/extensions/s2n_client_server_name.h
+++ b/tls/extensions/s2n_client_server_name.h
@@ -19,3 +19,4 @@
 #include "stuffer/s2n_stuffer.h"
 
 extern int s2n_extensions_client_server_name_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+extern int s2n_parse_client_hello_server_name(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_client_session_ticket.h
+++ b/tls/extensions/s2n_client_session_ticket.h
@@ -19,3 +19,4 @@
 #include "stuffer/s2n_stuffer.h"
 
 extern int s2n_extensions_client_session_ticket_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+extern int s2n_recv_client_session_ticket_ext(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_client_signature_algorithms.c
+++ b/tls/extensions/s2n_client_signature_algorithms.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <sys/param.h>
+#include <stdint.h>
+
+#include "tls/extensions/s2n_client_signature_algorithms.h"
+#include "tls/s2n_tls.h"
+#include "tls/s2n_tls_parameters.h"
+#include "tls/s2n_signature_algorithms.h"
+
+#include "utils/s2n_safety.h"
+
+int s2n_send_client_signature_algorithms_extension(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    /* The extension header */
+    GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_SIGNATURE_ALGORITHMS));
+
+    /* Each SignatureScheme is two bytes, and there's another two bytes for
+     * the extension length field.
+     */
+    uint16_t num_signature_schemes = s2n_supported_sig_scheme_pref_list_len;
+    uint16_t signature_schemes_size = num_signature_schemes * TLS_SIGNATURE_SCHEME_LEN;
+    uint16_t extension_len_field_size = 2;
+
+    GUARD(s2n_stuffer_write_uint16(out, extension_len_field_size + signature_schemes_size));
+    GUARD(s2n_send_supported_signature_algorithms(out));
+
+    return 0;
+}
+
+int s2n_recv_client_signature_algorithms(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    return s2n_recv_supported_sig_scheme_list(extension, &conn->handshake_params.client_sig_hash_algs);
+}

--- a/tls/extensions/s2n_client_signature_algorithms.h
+++ b/tls/extensions/s2n_client_signature_algorithms.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -15,16 +15,8 @@
 
 #pragma once
 
-#include <stdint.h>
-#include <string.h>
+#include "tls/s2n_connection.h"
+#include "stuffer/s2n_stuffer.h"
 
-#include "utils/s2n_blob.h"
-
-struct s2n_client_hello_parsed_extension {
-	uint16_t extension_type;
-	struct s2n_blob extension;
-};
-
-extern int s2n_client_hello_get_parsed_extension(struct s2n_array *parsed_extensions, s2n_tls_extension_type extension_type,
-        struct s2n_client_hello_parsed_extension *parsed_extension);
-extern void s2n_register_extension(uint16_t ext_type);
+extern int s2n_send_client_signature_algorithms_extension(struct s2n_connection *conn, struct s2n_stuffer *out);
+extern int s2n_recv_client_signature_algorithms(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_client_status_request.c
+++ b/tls/extensions/s2n_client_status_request.c
@@ -32,3 +32,19 @@ int s2n_extensions_client_status_request_send(struct s2n_connection *conn, struc
 
     return 0;
 }
+
+int s2n_recv_client_status_request(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    if (s2n_stuffer_data_available(extension) < 5) {
+        /* Malformed length, ignore the extension */
+        return 0;
+    }
+    uint8_t type;
+    GUARD(s2n_stuffer_read_uint8(extension, &type));
+    if (type != (uint8_t) S2N_STATUS_REQUEST_OCSP) {
+        /* We only support OCSP (type 1), ignore the extension */
+        return 0;
+    }
+    conn->status_type = (s2n_status_request_type) type;
+    return 0;
+}

--- a/tls/extensions/s2n_client_status_request.h
+++ b/tls/extensions/s2n_client_status_request.h
@@ -19,3 +19,4 @@
 #include "stuffer/s2n_stuffer.h"
 
 extern int s2n_extensions_client_status_request_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+extern int s2n_recv_client_status_request(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_client_supported_groups.h
+++ b/tls/extensions/s2n_client_supported_groups.h
@@ -19,3 +19,4 @@
 #include "stuffer/s2n_stuffer.h"
 
 extern int s2n_extensions_client_supported_groups_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+extern int s2n_recv_client_supported_groups(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -30,6 +30,7 @@
 #include "tls/s2n_tls_parameters.h"
 #include "tls/s2n_cipher_suites.h"
 #include "tls/s2n_client_extensions.h"
+#include "tls/extensions/s2n_client_server_name.h"
 #include "tls/s2n_connection.h"
 #include "tls/s2n_connection_evp_digests.h"
 #include "tls/s2n_handshake.h"


### PR DESCRIPTION
**Issue # (if available):** 

#1189

**Description of changes:** 

This is phase two of cleaning up how we handle our extensions. I moved all the client extension recv functions into their own files. No logic changes. No additional tests added. Doing this in pieces to minimize merge conflicts and make it more review-able.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
