### PR TITLE
CBMC proofs for s2n_stuffer_wipe() and s2n_stuffer_wipe_n()

### DIFF
--- a/tests/cbmc/proofs/s2n_stuffer_wipe/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_wipe/Makefile
@@ -1,0 +1,29 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+
+ENTRY = s2n_stuffer_wipe_harness
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_wipe/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_wipe/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_wipe_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_wipe/s2n_stuffer_wipe_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_wipe/s2n_stuffer_wipe_harness.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_stuffer_wipe_harness() {
+  struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+
+  __CPROVER_assume( s2n_stuffer_is_valid(stuffer) );
+  __CPROVER_assume( stuffer->high_water_mark );
+
+  if ( s2n_stuffer_wipe(stuffer) == S2N_SUCCESS ){
+    assert( s2n_stuffer_is_valid(stuffer) );
+    assert( stuffer->high_water_mark == 0 );
+    assert( stuffer->tainted == 0 );
+    assert( stuffer->write_cursor == 0 );
+    assert( stuffer->read_cursor == 0);
+  };
+}

--- a/tests/cbmc/proofs/s2n_stuffer_wipe_n/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_wipe_n/Makefile
@@ -1,0 +1,29 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+
+ENTRY = s2n_stuffer_wipe_n_harness
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_wipe_n/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_wipe_n/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_wipe_n_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_wipe_n/s2n_stuffer_wipe_n_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_wipe_n/s2n_stuffer_wipe_n_harness.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_stuffer_wipe_n_harness() {
+  struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+  int n;
+
+  __CPROVER_assume( s2n_stuffer_is_valid(stuffer) );
+
+  if (s2n_stuffer_wipe_n(stuffer, n) == S2N_SUCCESS){
+    assert(s2n_stuffer_is_valid(stuffer));
+  };
+}


### PR DESCRIPTION
**Issue # (if available):** 
N/A

**Description of changes:** 
CBMC memory-safety proofs for s2n_stuffer_wipe and s2n_stuffer_wipe_n, with basic correctness checks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
