### PR TITLE
Tls13 record type

### DIFF
--- a/tests/unit/s2n_tls13_parse_record_type_test.c
+++ b/tests/unit/s2n_tls13_parse_record_type_test.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+#include "stuffer/s2n_stuffer.h"
+#include "tls/s2n_record.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <s2n.h>
+
+int main(int argc, char **argv)
+{
+    uint16_t plaintext = 0xdaf3;
+    struct s2n_stuffer plaintext_stuffer = {0};
+    uint8_t record_type;
+    BEGIN_TEST();
+
+   /* In tls13 the true record type is inserted in the last byte of the encrypted payload. This
+    * test creates a fake unencrypted payload and checks that the helper function
+    * s2n_parse_record_type() correctly parses the type.
+    */
+    {
+        EXPECT_SUCCESS(s2n_stuffer_alloc(&plaintext_stuffer, sizeof(plaintext)));
+        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&plaintext_stuffer, plaintext));
+        EXPECT_SUCCESS(s2n_parse_record_type(&plaintext_stuffer, &record_type));
+        EXPECT_EQUAL(record_type, 0xf3);
+        EXPECT_EQUAL(s2n_stuffer_data_available(&plaintext_stuffer), 1);
+
+        /* Clean up */
+        EXPECT_SUCCESS(s2n_stuffer_free(&plaintext_stuffer));
+    }
+
+    END_TEST();
+
+}

--- a/tests/unit/s2n_tls13_parse_record_type_test.c
+++ b/tests/unit/s2n_tls13_parse_record_type_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -25,16 +25,18 @@
 
 int main(int argc, char **argv)
 {
-    uint16_t plaintext = 0xdaf3;
-    struct s2n_stuffer plaintext_stuffer = {0};
-    uint8_t record_type;
     BEGIN_TEST();
+
+    uint8_t record_type;
 
    /* In tls13 the true record type is inserted in the last byte of the encrypted payload. This
     * test creates a fake unencrypted payload and checks that the helper function
     * s2n_parse_record_type() correctly parses the type.
     */
     {
+        uint16_t plaintext = 0xdaf3;
+        struct s2n_stuffer plaintext_stuffer = {0};
+
         EXPECT_SUCCESS(s2n_stuffer_alloc(&plaintext_stuffer, sizeof(plaintext)));
         EXPECT_SUCCESS(s2n_stuffer_write_uint16(&plaintext_stuffer, plaintext));
         EXPECT_SUCCESS(s2n_parse_record_type(&plaintext_stuffer, &record_type));
@@ -45,7 +47,29 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_free(&plaintext_stuffer));
     }
 
-    END_TEST();
+    /* Test for failure when stuffer is completely empty */
+    {
+        struct s2n_stuffer empty_stuffer = {0};
 
+        EXPECT_SUCCESS(s2n_stuffer_alloc(&empty_stuffer, 0));
+        EXPECT_FAILURE(s2n_parse_record_type(&empty_stuffer, &record_type));
+    }
+
+    /* Test for case where there is a record type in the stuffer but no content */
+    {
+        uint16_t plaintext = 0xf3;
+        struct s2n_stuffer plaintext_stuffer = {0};
+
+        EXPECT_SUCCESS(s2n_stuffer_alloc(&plaintext_stuffer, sizeof(plaintext)));
+        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&plaintext_stuffer, plaintext));
+        EXPECT_SUCCESS(s2n_parse_record_type(&plaintext_stuffer, &record_type));
+        EXPECT_EQUAL(record_type, 0xf3);
+        EXPECT_EQUAL(s2n_stuffer_data_available(&plaintext_stuffer), 1);
+
+        /* Clean up */
+        EXPECT_SUCCESS(s2n_stuffer_free(&plaintext_stuffer));
+    }
+    
+    END_TEST();
 }
 

--- a/tests/unit/s2n_tls13_parse_record_type_test.c
+++ b/tests/unit/s2n_tls13_parse_record_type_test.c
@@ -48,3 +48,4 @@ int main(int argc, char **argv)
     END_TEST();
 
 }
+

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -907,23 +907,6 @@ static int handshake_read_io(struct s2n_connection *conn)
         GUARD(s2n_handshake_handle_sslv2(conn));
     }
 
-    /* In TLS 1.3, encrypted handshake records would appear to be of record type
-     * TLS_APPLICATION_DATA. The actual record content type is found after the encryped
-     * is decrypted.
-     */
-    if (conn->actual_protocol_version == S2N_TLS13 && record_type == TLS_APPLICATION_DATA) {
-        GUARD(s2n_stuffer_skip_read(&conn->in, s2n_stuffer_data_available(&conn->in) - 1));
-
-        /* set the true record type */
-        GUARD(s2n_stuffer_read_uint8(&conn->in, &record_type));
-
-        /* wipe this last byte so the rest handshake works like < TLS 1.3 */
-        GUARD(s2n_stuffer_wipe_n(&conn->in, 1));
-
-        /* set the read cursor at where it should be */
-        GUARD(s2n_stuffer_reread(&conn->in));
-    }
-
     /* Now we have a record, but it could be a partial fragment of a message, or it might
      * contain several messages.
      */

--- a/tls/s2n_record.h
+++ b/tls/s2n_record.h
@@ -26,6 +26,7 @@ extern int s2n_record_write(struct s2n_connection *conn, uint8_t content_type, s
 extern int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const struct iovec *in, int in_count, size_t offs, size_t to_write);
 extern int s2n_record_parse(struct s2n_connection *conn);
 extern int s2n_record_header_parse(struct s2n_connection *conn, uint8_t * content_type, uint16_t * fragment_length);
+extern int s2n_parse_record_type(struct s2n_stuffer *stuffer, uint8_t * record_type);
 extern int s2n_sslv2_record_header_parse(struct s2n_connection *conn, uint8_t * record_type, uint8_t * client_protocol_version, uint16_t * fragment_length);
 extern int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, struct s2n_blob *decrypted);
 extern int s2n_aead_aad_init(const struct s2n_connection *conn, uint8_t * sequence_number, uint8_t content_type, uint16_t record_length, struct s2n_stuffer *ad);

--- a/tls/s2n_record_read.c
+++ b/tls/s2n_record_read.c
@@ -162,3 +162,4 @@ int s2n_parse_record_type(struct s2n_stuffer *stuffer, uint8_t * record_type) {
 
     return 0;
 }
+

--- a/tls/s2n_record_read.c
+++ b/tls/s2n_record_read.c
@@ -73,7 +73,7 @@ int s2n_record_header_parse(
     const uint8_t version = (protocol_version[0] * 10) + protocol_version[1];
     /* https://tools.ietf.org/html/rfc5246#appendix-E.1 states that servers must accept any value {03,XX} as the record
      * layer version number for the first TLS record. There is some ambiguity here because the client does not know
-     * what version to use in the record header prior to receiving the ServerHello. Some client implmentations may use
+     * what version to use in the record header prior to receiving the ServerHello. Some client implementations may use
      * a garbage value(not {03,XX}) in the ClientHello.
      * Choose to be lenient to these clients. After protocol negotiation, we will enforce that all record versions
      * match the negotiated version.
@@ -143,6 +143,22 @@ int s2n_record_parse(struct s2n_connection *conn)
         S2N_ERROR(S2N_ERR_CIPHER_TYPE);
         break;
     }
+
+    return 0;
+}
+
+int s2n_parse_record_type(struct s2n_stuffer *stuffer, uint8_t * record_type) {
+
+    GUARD(s2n_stuffer_skip_read(stuffer, s2n_stuffer_data_available(stuffer) - 1));
+
+    /* set the true record type */
+    GUARD(s2n_stuffer_read_uint8(stuffer, record_type));
+
+    /* wipe this last byte so the rest handshake works like < TLS 1.3 */
+    GUARD(s2n_stuffer_wipe_n(stuffer, 1));
+
+    /* set the read cursor at where it should be */
+    GUARD(s2n_stuffer_reread(stuffer));
 
     return 0;
 }

--- a/tls/s2n_record_read.c
+++ b/tls/s2n_record_read.c
@@ -147,8 +147,8 @@ int s2n_record_parse(struct s2n_connection *conn)
     return 0;
 }
 
-int s2n_parse_record_type(struct s2n_stuffer *stuffer, uint8_t * record_type) {
-
+int s2n_parse_record_type(struct s2n_stuffer *stuffer, uint8_t * record_type) 
+{
     GUARD(s2n_stuffer_skip_read(stuffer, s2n_stuffer_data_available(stuffer) - 1));
 
     /* set the true record type */

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -49,7 +49,6 @@ int s2n_read_full_record(struct s2n_connection *conn, uint8_t * record_type, int
         *record_type = TLS_APPLICATION_DATA;
         return 0;
     }
-
     GUARD(s2n_stuffer_resize_if_empty(&conn->in, S2N_LARGE_FRAGMENT_LENGTH));
 
     /* Read the record until we at least have a header */
@@ -120,6 +119,14 @@ int s2n_read_full_record(struct s2n_connection *conn, uint8_t * record_type, int
     if (s2n_record_parse(conn) < 0) {
         GUARD(s2n_connection_kill(conn));
         S2N_ERROR_PRESERVE_ERRNO();
+    }
+
+    /* In TLS 1.3, encrypted handshake records would appear to be of record type
+    * TLS_APPLICATION_DATA. The actual record content type is found after the encrypted
+    * is decrypted.
+    */
+    if (conn->actual_protocol_version == S2N_TLS13 && *record_type == TLS_APPLICATION_DATA) {
+        GUARD(s2n_parse_record_type(&conn->in, record_type));
     }
 
     return 0;

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -235,3 +235,4 @@ int s2n_recv_close_notify(struct s2n_connection *conn, s2n_blocked_status * bloc
     *blocked = S2N_NOT_BLOCKED;
     return 0;
 }
+


### PR DESCRIPTION
*Issue # (if available):** 
https://github.com/awslabs/s2n/issues/1326
**Description of changes:** 
- Moved code that parsed true record type (that has been encrypted along with the payload in tls13) from handshake_io.c to recv.c and put it into a small helper function called parse_record_type().
- Wrote a unit test to for this new helper function which creates a stuffer with fake data and checks to make sure s2n_parse_record_type() correctly gets the last byte.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
