### PR TITLE
Verify server certificate only after negotiating signature scheme

### DIFF
--- a/tests/unit/s2n_server_cert_verify_test.c
+++ b/tests/unit/s2n_server_cert_verify_test.c
@@ -45,8 +45,9 @@ int main(int argc, char **argv)
         char *private_key_pem;
         s2n_pkey_type pkey_type;
 
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn, *server_conn;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
 
         EXPECT_SUCCESS(s2n_stuffer_alloc(&certificate_in, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_stuffer_alloc(&certificate_out, S2N_MAX_TEST_PEM_SIZE));
@@ -58,39 +59,42 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(ecdsa_cert, cert_chain_pem, private_key_pem));
 
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, ecdsa_cert));
-        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
-        client_conn->handshake_params.our_chain_and_key = ecdsa_cert;
-        client_conn->secure.conn_sig_scheme = s2n_ecdsa_secp256r1_sha256;
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        server_conn->handshake_params.our_chain_and_key = ecdsa_cert;
+        server_conn->secure.conn_sig_scheme = s2n_ecdsa_secp256r1_sha256;
 
         b.data = (uint8_t *) cert_chain_pem;
         b.size = strlen(cert_chain_pem) + 1;
         EXPECT_SUCCESS(s2n_stuffer_write(&certificate_in, &b));
         EXPECT_SUCCESS(s2n_stuffer_certificate_from_pem(&certificate_in, &certificate_out));
 
-        /* Extract public key from certificate */
+        /* Extract public key from certificate and set it for client */
         b.size = s2n_stuffer_data_available(&certificate_out);
         b.data = s2n_stuffer_raw_read(&certificate_out, b.size);
         EXPECT_SUCCESS(s2n_asn1der_to_public_key_and_type(&client_conn->secure.server_public_key, &pkey_type, &b));
-
-        EXPECT_SUCCESS(s2n_pkey_match(&client_conn->secure.server_public_key, client_conn->handshake_params.our_chain_and_key->private_key));
+        EXPECT_SUCCESS(s2n_pkey_match(&client_conn->secure.server_public_key, server_conn->handshake_params.our_chain_and_key->private_key));
 
         /* Hash initialization */
+        EXPECT_SUCCESS(s2n_hash_init(&server_conn->handshake.sha256, S2N_HASH_SHA256));
+        EXPECT_SUCCESS(s2n_hash_update(&server_conn->handshake.sha256, hello, strlen((char *)hello)));
         EXPECT_SUCCESS(s2n_hash_init(&client_conn->handshake.sha256, S2N_HASH_SHA256));
         EXPECT_SUCCESS(s2n_hash_update(&client_conn->handshake.sha256, hello, strlen((char *)hello)));
 
-        /* Send and receive cert verify */
-        EXPECT_SUCCESS(s2n_server_cert_verify_send(client_conn));
+        /* Send cert verify */
+        EXPECT_SUCCESS(s2n_server_cert_verify_send(server_conn));
+        EXPECT_SUCCESS(s2n_stuffer_copy(&server_conn->handshake.io, &client_conn->handshake.io, s2n_stuffer_data_available(&server_conn->handshake.io)));
 
+        /* Receive and verify cert */
         EXPECT_SUCCESS(s2n_server_cert_verify_recv(client_conn));
-        EXPECT_EQUAL(client_conn->secure.conn_sig_scheme.iana_value, 0x403);
+        EXPECT_EQUAL(client_conn->secure.conn_sig_scheme.iana_value, TLS_SIGNATURE_SCHEME_ECDSA_SHA256);
 
         /* Clean up */
         free(cert_chain_pem);
         free(private_key_pem);
-        EXPECT_SUCCESS(s2n_pkey_free(&client_conn->secure.server_public_key));
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(ecdsa_cert));
         EXPECT_SUCCESS(s2n_stuffer_free(&certificate_in));
         EXPECT_SUCCESS(s2n_stuffer_free(&certificate_out));
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
     }
 

--- a/tls/s2n_server_cert_verify.c
+++ b/tls/s2n_server_cert_verify.c
@@ -38,31 +38,43 @@ int s2n_server_cert_verify_send(struct s2n_connection *conn)
     return 0;
 }
 
-int s2n_server_cert_verify_recv(struct s2n_connection *conn)
+int s2n_server_cert_read_and_verify_signature(struct s2n_connection *conn)
 {
     struct s2n_stuffer *in = &conn->handshake.io;
     DEFER_CLEANUP(struct s2n_blob signed_content = {0}, s2n_free);
     DEFER_CLEANUP(struct s2n_stuffer unsigned_content = {0}, s2n_stuffer_free);
     DEFER_CLEANUP(struct s2n_hash_state message_hash = {0}, s2n_hash_free);
     GUARD(s2n_hash_new(&message_hash));
-    GUARD(s2n_hash_init(&message_hash, conn->secure.conn_sig_scheme.hash_alg));
+
+    struct s2n_signature_scheme chosen_sig_scheme = conn->secure.conn_sig_scheme;
+
+    /* Get signature size */
     uint16_t signature_size;
-
-    /* Read the algorithm */
-    struct s2n_signature_scheme chosen_sig_scheme = {0};
-    GUARD(s2n_get_and_validate_negotiated_signature_scheme(conn, in, &chosen_sig_scheme));
-
-    /* Verify signature */
     GUARD(s2n_stuffer_read_uint16(in, &signature_size));
     S2N_ERROR_IF(signature_size > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);
 
+    /* Get wire signature */
     GUARD(s2n_alloc(&signed_content, signature_size));
     signed_content.size = signature_size;
     GUARD(s2n_stuffer_read_bytes(in, signed_content.data, signature_size));
 
+    /* Verify signature */
     GUARD(s2n_server_generate_unsigned_cert_verify_content(conn, &unsigned_content, chosen_sig_scheme.hash_alg));
+
+    GUARD(s2n_hash_init(&message_hash, chosen_sig_scheme.hash_alg));
     GUARD(s2n_hash_update(&message_hash, unsigned_content.blob.data, s2n_stuffer_data_available(&unsigned_content)));
     GUARD(s2n_pkey_verify(&conn->secure.server_public_key, &message_hash, &signed_content));
+
+    return 0;
+}
+
+
+int s2n_server_cert_verify_recv(struct s2n_connection *conn)
+{
+    /* Read the algorithm and update conn->secure.conn_sig_scheme */
+    GUARD(s2n_get_and_validate_negotiated_signature_scheme(conn, &conn->handshake.io, &conn->secure.conn_sig_scheme));
+    /* Read the rest of the signature and verify */
+    GUARD(s2n_server_cert_read_and_verify_signature(conn));
 
     return 0;
 }
@@ -83,7 +95,7 @@ int s2n_server_write_cert_verify_signature(struct s2n_connection *conn, struct s
 
     GUARD(s2n_hash_update(&message_hash, unsigned_content.blob.data, s2n_stuffer_data_available(&unsigned_content)));
     GUARD(s2n_pkey_sign(conn->handshake_params.our_chain_and_key->private_key, &message_hash, &signed_content));
-    
+
     GUARD(s2n_stuffer_write_uint16(out, signed_content.size));
     GUARD(s2n_stuffer_write_bytes(out, signed_content.data, signed_content.size));
 
@@ -92,14 +104,20 @@ int s2n_server_write_cert_verify_signature(struct s2n_connection *conn, struct s
 
 int s2n_server_generate_unsigned_cert_verify_content(struct s2n_connection *conn, struct s2n_stuffer *unsigned_content, s2n_hash_algorithm chosen_hash_alg)
 {
-    struct s2n_hash_state hash_copy;
+    struct s2n_hash_state selected_hash, hash_copy;
     uint8_t hash_digest_length;
     uint8_t digest_out[S2N_MAX_DIGEST_LEN];
 
+    /* Get current hash content */
+    GUARD(s2n_handshake_get_hash_state(conn, chosen_hash_alg, &selected_hash));
+
     /* Copy current hash content */
-    GUARD(s2n_handshake_get_hash_state(conn, chosen_hash_alg, &hash_copy));
+    GUARD(s2n_hash_new(&hash_copy));
+    GUARD(s2n_hash_copy(&hash_copy, &selected_hash));
+
     GUARD(s2n_hash_digest_size(chosen_hash_alg, &hash_digest_length));
     GUARD(s2n_hash_digest(&hash_copy, digest_out, hash_digest_length));
+    GUARD(s2n_hash_free(&hash_copy));
 
     /* Concatenate the content to be signed/verified */
     GUARD(s2n_stuffer_alloc(unsigned_content, hash_digest_length + s2n_server_cert_verify_header_length()));


### PR DESCRIPTION
**Issue # (if available):** 
previously chosen signature scheme was not respected, causing a TLS 1.3 handshake to fail.

**Description of changes:** 
Reorder signature checking after client has set it's chosen signature scheme. Also ensure handshake hashes are copied, not modified.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
