### PR TITLE
Remove duplicated signature algorithm values sent from client

### DIFF
--- a/tls/s2n_signature_scheme.c
+++ b/tls/s2n_signature_scheme.c
@@ -183,13 +183,9 @@ const struct s2n_signature_scheme* const s2n_supported_sig_scheme_pref_list[] = 
         &s2n_rsa_pkcs1_sha512,
         &s2n_rsa_pkcs1_sha224,
 
-        /* ECDSA - TLS 1.3 */
-        &s2n_ecdsa_secp256r1_sha256,
-        &s2n_ecdsa_secp384r1_sha384,
-
-        /* ECDSA - TLS 1.2*/
-        &s2n_ecdsa_sha256,
-        &s2n_ecdsa_sha384,
+        /* ECDSA - TLS 1.2 */
+        &s2n_ecdsa_sha256, /* same iana value as TLS 1.3 s2n_ecdsa_secp256r1_sha256 */
+        &s2n_ecdsa_sha384, /* same iana value as TLS 1.3 s2n_ecdsa_secp384r1_sha384 */
         &s2n_ecdsa_sha512,
         &s2n_ecdsa_sha224,
 


### PR DESCRIPTION
**Issue # (if available):** 
The current client hello sends duplicated signature algorithm (0x0403, 0x0503).

**Description of changes:** 
This change removes the duplicate.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
