### PR TITLE
Set full handshake type in TLS 1.3 after receiving ClientHello

### DIFF
--- a/tests/unit/s2n_tls13_handshake_test.c
+++ b/tests/unit/s2n_tls13_handshake_test.c
@@ -387,12 +387,6 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&server_to_client, &client_to_server, client_conn));
         EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&client_to_server, &server_to_client, server_conn));
 
-        server_conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
-        server_conn->handshake.message_number = CLIENT_HELLO;
-
-        client_conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
-        client_conn->handshake.message_number = CLIENT_HELLO;
-
         struct s2n_blob server_seq = { .data = server_conn->secure.server_sequence_number,.size = sizeof(server_conn->secure.server_sequence_number) };
         S2N_BLOB_FROM_HEX(seq_0, "0000000000000000");
         S2N_BLOB_FROM_HEX(seq_1, "0000000000000001");
@@ -411,9 +405,11 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(server_secrets_0.size, 0);
 
         /* Server reads ClientHello */
+        EXPECT_EQUAL(server_conn->handshake.handshake_type, INITIAL);
         EXPECT_SUCCESS(handshake_read_io(server_conn));
         EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS13); /* Server is now on TLS13 */
         EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), SERVER_HELLO);
+        EXPECT_EQUAL(server_conn->handshake.handshake_type, NEGOTIATED | FULL_HANDSHAKE);
 
         s2n_tls13_connection_keys(server_secrets, server_conn);
         EXPECT_EQUAL(server_secrets.size, 48);

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -341,6 +341,16 @@ int s2n_client_hello_recv(struct s2n_connection *conn)
         }
     }
     GUARD(s2n_process_client_hello(conn));
+
+    /* s2n_conn_set_handshake_type() is called by SERVER_SESSION_LOOKUP in < TLS 1.3,
+     * which is something not present in the current s2n tls 1.3 state machine.
+     * we call this manually so the state machine can transition to the
+     * negotiated and handshake type for tls1.3
+     */
+    if (conn->actual_protocol_version == S2N_TLS13) {
+        GUARD(s2n_conn_set_handshake_type(conn));
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
**Issue # (if available):** 
Handshake type needs to be set for the state machine for TLS 1.3 handshake to transition.

**Description of changes:** 
As the title.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
