### PR TITLE
Adding X25519 as supported curve in the integration tests

### DIFF
--- a/tests/integration/data/test_buf
+++ b/tests/integration/data/test_buf
@@ -36,6 +36,13 @@ PROTO_VERS_TO_S_CLIENT_ARG = {
 
 S_CLIENT_SUCCESSFUL_OCSP="OCSP Response Status: successful"
 
+def get_supported_curves_list_by_version(libcrypto_version):
+   # Curve X25519 is supported for Openssl 1.1.0 and higher
+    if libcrypto_version == "openssl-1.1.1":
+        return  ["P-256", "P-384", "X25519"]
+    else:
+        return  ["P-256", "P-384"]
+
 def cleanup_processes(*processes):
     for p in processes:
         p.kill()
@@ -355,12 +362,12 @@ def sigalg_test(host, port, fips_mode, use_client_auth=None):
 
     return failed
 
-def elliptic_curve_test(host, port, fips_mode):
+def elliptic_curve_test(host, port, libcrypto_version,  fips_mode):
     """
     Acceptance test for supported elliptic curves. Tests all possible supported curves with unsupported curves mixed in
     for noise.
     """
-    supported_curves = ["P-256", "P-384"]
+    supported_curves = get_supported_curves_list_by_version(libcrypto_version)
     unsupported_curves = ["B-163", "K-409"]
     print("\n\tRunning elliptic curve tests:")
     print("\tExpected supported:   " + str(supported_curves))
@@ -455,6 +462,7 @@ def main():
     test_ciphers = S2N_LIBCRYPTO_TO_TEST_CIPHERS[args.libcrypto]
     host = args.host
     port = args.port
+    libcrypto_version = args.libcrypto
 
     fips_mode = False
     if environ.get("S2N_TEST_IN_FIPS_MODE") is not None:
@@ -469,7 +477,7 @@ def main():
     failed += client_auth_test(host, port, test_ciphers, fips_mode)
     failed += sigalg_test(host, port, fips_mode)
     failed += sigalg_test(host, port, fips_mode, use_client_auth=True)
-    failed += elliptic_curve_test(host, port, fips_mode)
+    failed += elliptic_curve_test(host, port, libcrypto_version, fips_mode)
     failed += elliptic_curve_fallback_test(host, port, fips_mode)
     failed += handshake_fragmentation_test(host, port, fips_mode)
     failed += ocsp_stapling_test(host, port, fips_mode)
@@ -836,12 +844,12 @@ def sigalg_test(host, port, fips_mode, use_client_auth=None):
 
     return failed
 
-def elliptic_curve_test(host, port, fips_mode):
+def elliptic_curve_test(host, port, libcrypto_version, fips_mode):
     """
     Acceptance test for supported elliptic curves. Tests all possible supported curves with unsupported curves mixed in
     for noise.
     """
-    supported_curves = ["P-256", "P-384"]
+    supported_curves = get_supported_curves_list_by_version(libcrypto_version)
     unsupported_curves = ["B-163", "K-409"]
     print("\n\tRunning elliptic curve tests:")
     print("\tExpected supported:   " + str(supported_curves))
@@ -950,7 +958,7 @@ def main():
     failed += client_auth_test(host, port, test_ciphers, fips_mode)
     failed += sigalg_test(host, port, fips_mode)
     failed += sigalg_test(host, port, fips_mode, use_client_auth=True)
-    failed += elliptic_curve_test(host, port, fips_mode)
+    failed += elliptic_curve_test(host, port, libcrypto_version, fips_mode)
     failed += elliptic_curve_fallback_test(host, port, fips_mode)
     failed += handshake_fragmentation_test(host, port, fips_mode)
     failed += ocsp_stapling_test(host, port, fips_mode)

--- a/tests/integration/s2n_handshake_test_s_server.py
+++ b/tests/integration/s2n_handshake_test_s_server.py
@@ -36,6 +36,14 @@ PROTO_VERS_TO_S_SERVER_ARG = {
 
 use_corked_io=False
 
+
+def get_supported_curves_list_by_version(libcrypto_version):
+   # Curve X25519 is supported for Openssl 1.1.0 and higher
+    if libcrypto_version == "openssl-1.1.1":
+        return ["P-256", "P-384", "X25519"]
+    else:
+        return ["P-256", "P-384"]
+
 def cleanup_processes(*processes):
     for p in processes:
         p.kill()
@@ -291,12 +299,12 @@ def sigalg_test(host, port):
     return failed
 
 
-def elliptic_curve_test(host, port):
+def elliptic_curve_test(host, port, libcrypto_version):
     """
     Acceptance test for supported elliptic curves. Tests all possible supported curves with unsupported curves mixed in
     for noise.
     """
-    supported_curves = ["P-256", "P-384"]
+    supported_curves = get_supported_curves_list_by_version(libcrypto_version)
     unsupported_curves = ["B-163", "K-409"]
     print("\n\tRunning s2n Client elliptic curve tests:")
     print("\tExpected supported:   " + str(supported_curves))
@@ -334,6 +342,7 @@ def main():
     test_ciphers = S2N_LIBCRYPTO_TO_TEST_CIPHERS[args.libcrypto]
     host = args.host
     port = args.port
+    libcrypto_version = args.libcrypto
 
     print("\nRunning s2n Client tests with: " + os.popen('openssl version').read())
     if use_corked_io == True:
@@ -344,7 +353,7 @@ def main():
     failed += handshake_resumption_test(host, port, no_ticket=True)
     failed += handshake_resumption_test(host, port)
     failed += sigalg_test(host, port)
-    failed += elliptic_curve_test(host, port)
+    failed += elliptic_curve_test(host, port, libcrypto_version)
     return failed
 
 


### PR DESCRIPTION
**Issue # (if available):** 

https://github.com/awslabs/s2n/issues/1424

**Description of changes:** 
s2n now supports the curve x25519 for ECDHE key exchange with the completion of this issue: #356. This PR updates the integration tests to reflect this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
