### PR TITLE
Create CodeBuild Saw projects

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,5 @@
 codecov:
+  token: e460b7c1-6019-4a50-b65d-555c4a8fbc22
   notify:
     require_ci_to_pass: no
     after_n_builds: 3
@@ -11,9 +12,9 @@ coverage:
   status:
     project:
       default:
-         target: auto
-         threshold: 0.5
-         base: auto
+        target: auto
+        threshold: 0.5
+        base: auto
     patch:
       default:
         target: auto
@@ -35,11 +36,13 @@ comment:
   require_changes: no
   require_head: no
   require_base: no
-  
+
 
 ignore:
   - ".travis/**/*"
   - "test-deps/**/*"
   - "libcrypto-build/**/*"
   - "libcrypto-root/**/*"
-  
+  - "tests/**/*"
+  - "codebuild/**/*"
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,8 +97,8 @@ jobs:
     addons: &sawaddons
       apt:
         packages:
-          - clang-3.8
-          - llvm-3.8
+          - clang-3.9
+          - llvm-3.9
   - os : linux
     dist: trusty
     env: TESTS=sawHMAC SAW_HMAC_TEST=sha1   SAW=true GCC_VERSION=NONE

--- a/codebuild/bin/install_saw.sh
+++ b/codebuild/bin/install_saw.sh
@@ -32,10 +32,9 @@ mkdir -p "$DOWNLOAD_DIR"
 cd "$DOWNLOAD_DIR"
 
 #download saw binaries
-curl --retry 3 https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/saw-0.3-2019-10-12-Ubuntu14.04-64.tar.gz --output saw.tar.gz
+curl --retry 3 https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/saw-0.4.0.99-2019-12-10-Ubuntu14.04-64.tar.gz --output saw.tar.gz
 
 mkdir -p saw && tar -xzf saw.tar.gz --strip-components=1 -C saw
 mkdir -p "$INSTALL_DIR" && mv saw/* "$INSTALL_DIR"
 
-clang --version
 "$INSTALL_DIR"/bin/saw --version

--- a/codebuild/bin/s2n_codebuild.sh
+++ b/codebuild/bin/s2n_codebuild.sh
@@ -77,9 +77,9 @@ fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "asan" ]]; then make clean; S2N_ADDRESS_SANITIZER=1 make -j $JOBS ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "integration" ]]; then make clean; make integration ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "fuzz" ]]; then (make clean && make fuzz) ; fi
-if [[ "$TESTS" == "ALL" || "$TESTS" == "sawHMAC" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make -C tests/saw/ tmp/"verify_s2n_hmac_$SAW_HMAC_TEST".log ; fi
+if [[ "$TESTS" == "ALL" || "$TESTS" == "sawHMAC" ]] && [[ "$OS_NAME" == "linux" ]]; then make -C tests/saw/ tmp/"verify_s2n_hmac_$SAW_HMAC_TEST".log ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "sawDRBG" ]]; then make -C tests/saw tmp/verify_drbg.log ; fi
-if [[ "$TESTS" == "ALL" || "$TESTS" == "tls" ]]; then (make -C tests/saw tmp/handshake.log && make -C tests/saw tmp/cork-uncork.log) ; fi
+if [[ "$TESTS" == "ALL" || "$TESTS" == "tls" ]]; then make -C tests/saw tmp/verify_handshake.log ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "sawHMACFailure" ]]; then make -C tests/saw failure-tests ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "ctverif" ]]; then .travis/run_ctverif.sh "$CTVERIF_INSTALL_DIR" ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "sawSIKE_r1" ]]; then make -C tests/saw sike_r1 ; fi

--- a/codebuild/bin/s2n_codebuild.sh
+++ b/codebuild/bin/s2n_codebuild.sh
@@ -77,13 +77,14 @@ fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "asan" ]]; then make clean; S2N_ADDRESS_SANITIZER=1 make -j $JOBS ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "integration" ]]; then make clean; make integration ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "fuzz" ]]; then (make clean && make fuzz) ; fi
-if [[ "$TESTS" == "ALL" || "$TESTS" == "sawHMAC" ]] && [[ "$OS_NAME" == "linux" ]]; then make -C tests/saw/ tmp/"verify_s2n_hmac_$SAW_HMAC_TEST".log ; fi
+if [[ "$TESTS" == "ALL" || "$TESTS" == "sawHMAC" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make -C tests/saw/ tmp/"verify_s2n_hmac_$SAW_HMAC_TEST".log ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "sawDRBG" ]]; then make -C tests/saw tmp/verify_drbg.log ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "tls" ]]; then (make -C tests/saw tmp/handshake.log && make -C tests/saw tmp/cork-uncork.log) ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "sawHMACFailure" ]]; then make -C tests/saw failure-tests ; fi
-if [[ "$TESTS" == "ALL" || "$TESTS" == "ctverif" ]]; then codebuild/bin/run_ctverif.sh "$CTVERIF_INSTALL_DIR" ; fi
-if [[ "$TESTS" == "ALL" || "$TESTS" == "sawSIKE" ]]; then make -C tests/saw sike ; fi
-if [[ "$TESTS" == "ALL" || "$TESTS" == "sidetrail" ]]; then codebuild/bin/run_sidetrail.sh "$SIDETRAIL_INSTALL_DIR" "$PART" ; fi
+if [[ "$TESTS" == "ALL" || "$TESTS" == "ctverif" ]]; then .travis/run_ctverif.sh "$CTVERIF_INSTALL_DIR" ; fi
+if [[ "$TESTS" == "ALL" || "$TESTS" == "sawSIKE_r1" ]]; then make -C tests/saw sike_r1 ; fi
+if [[ "$TESTS" == "ALL" || "$TESTS" == "sawBIKE_r1" ]]; then make -C tests/saw bike_r1 ; fi
+if [[ "$TESTS" == "ALL" || "$TESTS" == "sidetrail" ]]; then .travis/run_sidetrail.sh "$SIDETRAIL_INSTALL_DIR" "$PART" ; fi
 
 # Generate *.gcov files that can be picked up by the CodeCov.io Bash helper script. Don't run lcov or genhtml 
 # since those will delete .gcov files as they're processed.

--- a/codebuild/codebuild.config
+++ b/codebuild/codebuild.config
@@ -78,7 +78,49 @@ env: S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=valgrind GCC_VERSION=9
 snippet: UbuntuBoilerplate2XL
 env: S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=valgrind GCC_VERSION=6
 
-
 # SAW tests
+[CodeBuild:s2nSawHmacMd5]
+snippet: UbuntuBoilerplate2XL
+env: TESTS=sawHMAC SAW_HMAC_TEST=md5 SAW=true GCC_VERSION=NONE
+
+[CodeBuild:s2nSawHmacSha1]
+snippet: UbuntuBoilerplate2XL
+env: TESTS=sawHMAC SAW_HMAC_TEST=sha1 SAW=true GCC_VERSION=NONE
+
+[CodeBuild:s2nSawHmacSha224]
+snippet: UbuntuBoilerplate2XL
+env: TESTS=sawHMAC SAW_HMAC_TEST=sha224 SAW=true GCC_VERSION=NONE
+
+[CodeBuild:s2nSawHmacSha256]
+snippet: UbuntuBoilerplate2XL
+env: TESTS=sawHMAC SAW_HMAC_TEST=sha256 SAW=true GCC_VERSION=NONE
+
+[CodeBuild:s2nSawHmacsha384]
+snippet: UbuntuBoilerplate2XL
+env: TESTS=sawHMAC SAW_HMAC_TEST=sha384 SAW=true GCC_VERSION=NONE
+
+[CodeBuild:s2nSawHmacSha512]
+snippet: UbuntuBoilerplate2XL
+env: TESTS=sawHMAC SAW_HMAC_TEST=sha512 SAW=true GCC_VERSION=NONE
+
+[CodeBuild:s2nSawDrbg]
+snippet: UbuntuBoilerplate2XL
+env: TESTS=sawDRBG SAW=true GCC_VERSION=NONE
+
+[CodeBuild:s2nSawSike]
+snippet: UbuntuBoilerplate2XL
+env: TESTS=sawSIKE_r1 SAW=true GCC_VERSION=NONE
+
+[CodeBuild:s2nSawBike]
+snippet: UbuntuBoilerplate2XL
+env: TESTS=sawBIKE_r1 SAW=true GCC_VERSION=NONE S2N_LIBCRYPTO=openssl-1.0.2
+
+[CodeBuild:s2nSawTls]
+snippet: UbuntuBoilerplate2XL
+env: TESTS=tls SAW=true GCC_VERSION=NONE
+
+[CodeBuild:s2nSawHmacFailure]
+snippet: UbuntuBoilerplate2XL
+env: TESTS=sawHMACFailure SAW=true
 
 # Sidetrail

--- a/codebuild/create_project.py
+++ b/codebuild/create_project.py
@@ -123,7 +123,7 @@ def main(**kwargs):
             else:
                 build_project(template=codebuild, project_name=job_title, section=job, service_role=service_role['Ref'])
 
-    with(open("cfn/codebuild_test_projects.yml", 'w')) as fh:
+    with(open(args.output_dir + "/codebuild_test_projects.yml", 'w')) as fh:
         fh.write(codebuild.to_yaml())
 
     if args.dry_run:
@@ -139,6 +139,7 @@ if __name__ == '__main__':
     parser.add_argument('--config', type=str, default="codebuild.config", help='The config filename to create the '
                                                                                'CodeBuild projects')
     parser.add_argument('--dry-run', dest='dry_run', action='store_true', help='Output CFN to stdout; Do not call AWS')
+    parser.add_argument('--output-dir', dest='output_dir', default='cfn', help="Directory to write CFN files")
     args = parser.parse_args()
 
     config = configparser.RawConfigParser()

--- a/codebuild/spec/buildspec_ubuntu.yml
+++ b/codebuild/spec/buildspec_ubuntu.yml
@@ -32,8 +32,7 @@ phases:
         if expr "${GCC_VERSION}" : "6" >/dev/null; then
           apt-get install -y --no-install-recommends g++ g++-6 gcc gcc-6;
         fi
-      - apt-get install -y --no-install-recommends indent kwstyle lcov libssl-dev llvm m4 make net-tools nettle-bin nettle-dev pkg-config psmisc python3-pip shellcheck sudo tcpdump unzip valgrind zlib1g-dev zlibc
-      #Note: shellcheck isn't available by default in Ubuntu < 18.04
+      - apt-get install -y --no-install-recommends indent kwstyle lcov libssl-dev clang-3.9 llvm-3.9 m4 make net-tools nettle-bin nettle-dev pkg-config psmisc python3-pip shellcheck sudo tcpdump unzip valgrind zlib1g-dev zlibc
   pre_build:
     commands:
       - codebuild/bin/install_default_dependencies.sh

--- a/s2n.mk
+++ b/s2n.mk
@@ -28,8 +28,8 @@ CRYPTO_LIBS = -lcrypto
 CC	:= $(CROSS_COMPILE)$(CC)
 AR	= $(CROSS_COMPILE)ar
 RANLIB	= $(CROSS_COMPILE)ranlib
-CLANG    ?= clang-3.8
-LLVMLINK ?= llvm-link-3.8
+CLANG    ?= clang-3.9
+LLVMLINK ?= llvm-link-3.9
 
 SOURCES = $(wildcard *.c *.h)
 CRUFT   = $(wildcard *.c~ *.h~ *.c.BAK *.h.BAK *.o *.a *.so *.dylib *.bc *.gcov *.gcda *.gcno *.info *.profraw *.tmp)


### PR DESCRIPTION
**Issue #469:** 

**Description of changes:** 
Configs to create CodeBuild Projects for saw tests.
Sync any travis scripts that have diverged.

The clang version bump is needed for Ubuntu18 on CodeBuild.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
