### PR TITLE
Add tls13 integration tests

### DIFF
--- a/tests/integration/Makefile
+++ b/tests/integration/Makefile
@@ -29,7 +29,15 @@ ifeq ($(S2N_CORKED_IO),true)
 endif
 
 .PHONY : all
-all: client_endpoints dynamic_record s_client s_server gnutls_cli gnutls_serv sslyze
+all: tls13 client_endpoints dynamic_record s_client s_server gnutls_cli gnutls_serv sslyze
+
+tls13:
+	( \
+	DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" \
+	LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
+	S2N_INTEG_TEST=1 \
+	python3 s2n_tls13_handshake_tests.py $(S2ND_HOST) $(S2ND_PORT); \
+	)
 
 client_endpoints:
 	# Run s2n client endpoint handshake tests

--- a/tests/integration/common/s2n_test_common.py
+++ b/tests/integration/common/s2n_test_common.py
@@ -1,0 +1,135 @@
+##
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+"""
+Common functions to run s2n integration tests.
+"""
+
+import subprocess
+
+from common.s2n_test_scenario import Mode, Version, run_scenarios
+from common.s2n_test_reporting import Result
+from s2n_test_constants import TEST_ECDSA_CERT, TEST_ECDSA_KEY
+
+
+def get_error(process):
+    return process.stderr.readline().decode("utf-8")
+
+
+def wait_for_output(process, marker, line_limit=10):
+    for count in range(line_limit):
+        line = process.stdout.readline().decode("utf-8")
+        if marker in line:
+            return True
+    return False
+
+
+def cleanup_processes(*processes):
+    for p in filter(None, processes):
+        p.kill()
+        p.wait()
+
+
+def get_process(cmd):
+    return subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def connect(get_peer, scenario):
+    """
+    Perform a handshake between s2n and another TLS process.
+
+    Args:
+        get_peer: a function that returns a TLS process
+        scenario: the handshake configuration
+
+    Returns:
+        A tuple of (client, server) processes which have completed a handshake.
+
+    """
+    server = get_s2n(scenario) if scenario.s2n_mode.is_server() else get_peer(scenario)
+    client = get_peer(scenario) if scenario.s2n_mode.is_server() else get_s2n(scenario)
+
+    return (server, client)
+
+
+def run_connection_test(get_peer, scenarios, test_func=None):
+    """
+    For each scenarios, s2n will attempt to perform a handshake with another TLS process
+    and then run the given test.
+
+    Args:
+        get_peer: a function that returns a TLS process for s2n to communicate with.
+            For an example of how to use this argument, see s2n_test_openssl.py.
+        scenarios: a list of handshake configurations
+        test_func: a function that takes a server and client process, performs some
+            additional testing, and then returns a Result
+
+    Returns:
+        A Result object indicating success or failure. If the given test returns
+        false or either the connection or the test throw an AssertionError, the Result
+        will indicate failure.
+
+    """
+    def __test(scenario):
+        client = None
+        server = None
+        try:
+            server, client = connect(get_peer, scenario)
+            if test_func:
+                return test_func(server, client)
+            else:
+                return Result()
+        except AssertionError as error:
+            return Result(error)
+        finally:
+            cleanup_processes(server, client)
+
+    return run_scenarios(__test, scenarios)
+
+
+def get_s2n_cmd(scenario):
+    mode_char = 'c' if scenario.s2n_mode.is_client() else 'd'
+
+    s2n_cmd = [ "../../bin/s2n%c" % mode_char,
+                "-c", "test_all",
+                "--insecure"]
+
+    if scenario.s2n_mode.is_server():
+        s2n_cmd.extend(["--key", TEST_ECDSA_KEY])
+        s2n_cmd.extend(["--cert", TEST_ECDSA_CERT])
+
+    if scenario.version is Version.TLS13:
+        s2n_cmd.append("--tls13")
+
+    s2n_cmd.extend(scenario.s2n_flags)
+    s2n_cmd.extend([str(scenario.host), str(scenario.port)])
+
+    return s2n_cmd
+
+
+S2N_SIGNALS = {
+    Mode.client: "Connected to",
+    Mode.server: "Listening on"
+}
+
+def get_s2n(scenario):
+    s2n_cmd = get_s2n_cmd(scenario)
+    s2n = get_process(s2n_cmd)
+
+    if not wait_for_output(s2n, S2N_SIGNALS[scenario.s2n_mode]):
+        raise AssertionError("s2n %s: %s" % (scenario.s2n_mode, get_error(s2n)))
+
+    return s2n
+

--- a/tests/integration/common/s2n_test_openssl.py
+++ b/tests/integration/common/s2n_test_openssl.py
@@ -1,0 +1,82 @@
+#
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+"""
+Common functions used to create test openssl servers and clients.
+"""
+
+import common.s2n_test_common as util
+from common.s2n_test_scenario import Mode, Version
+from s2n_test_constants import TEST_ECDSA_CERT, TEST_ECDSA_KEY
+from time import sleep
+
+
+OPENSSL_SIGNALS = {
+    Mode.client: "CONNECTED",
+    Mode.server: "ACCEPT",
+}
+
+
+VERSION_ARGS = {
+    Version.TLS10: "-tls1",
+    Version.TLS11: "-tls1_1",
+    Version.TLS12: "-tls1_2",
+    Version.TLS13: "-tls1_3",
+}
+
+
+def get_openssl_cmd(scenario):
+    openssl_cmd = [ "openssl"]
+
+    if scenario.s2n_mode.is_client():
+        openssl_cmd.extend(["s_server", "-accept", str(scenario.port)])
+    else:
+        openssl_cmd.extend(["s_client", "-connect", str(scenario.host) + ":" + str(scenario.port)])
+
+    openssl_cmd.extend(["-cert", TEST_ECDSA_CERT,
+                        "-key", TEST_ECDSA_KEY,
+                        "-tlsextdebug"])
+
+    if scenario.version:
+        openssl_cmd.append(VERSION_ARGS[scenario.version])
+
+    if scenario.cipher:
+        if scenario.version is Version.TLS13:
+            openssl_cmd.extend(["-ciphersuites", str(scenario.cipher)])
+            openssl_cmd.extend(["-curves", scenario.curve])
+        else:
+            openssl_cmd.extend(["cipher", str(scenario.cipher)])
+
+    openssl_cmd.extend(scenario.peer_flags)
+
+    return openssl_cmd
+
+
+def get_openssl(scenario):
+    openssl_cmd = get_openssl_cmd(scenario)
+    openssl = util.get_process(openssl_cmd)
+    
+    if not util.wait_for_output(openssl, OPENSSL_SIGNALS[scenario.s2n_mode.other()]):
+        raise AssertionError("openssl %s: %s" % (scenario.s2n_mode.other(), util.get_error(openssl)))
+
+    # Openssl outputs the success signal BEFORE binding the socket, so wait a little
+    sleep(0.1)
+
+    return openssl
+
+
+def run_openssl_connection_test(scenarios, test_func=None):
+    return util.run_connection_test(get_openssl, scenarios, test_func)
+

--- a/tests/integration/common/s2n_test_reporting.py
+++ b/tests/integration/common/s2n_test_reporting.py
@@ -1,0 +1,62 @@
+##
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+"""
+Common functions used to report the results of tests.
+"""
+
+import sys
+from enum import Enum
+
+
+class Status(Enum):
+    """
+    Enum to represent success/failure. The values are the
+    color codes used to print the status.
+    """
+    PASSED = 32
+    FAILED = 31
+
+    def __str__(self):
+        return with_color(self.name, self.value)
+
+
+class Result:
+
+    """
+    A class to standardize how test results are reported.
+
+    """
+
+    def __init__(self, error=None):
+        self.error = error
+        self.status = Status.PASSED if error == None else Status.FAILED
+
+    def is_success(self):
+        return self.status is not Status.FAILED
+
+    def __str__(self):
+        result = str(self.status)
+        if self.error:
+            result += "\n\t%s" % self.error
+        return result
+
+
+def with_color(msg, color):
+    if sys.stdout.isatty():
+        return "\033[%d;1m%s\033[0m" % (color, msg)
+    else:
+        return msg
+

--- a/tests/integration/common/s2n_test_scenario.py
+++ b/tests/integration/common/s2n_test_scenario.py
@@ -1,0 +1,199 @@
+##
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+"""
+Most s2n integration tests are run against a variety of arguments.
+A "scenario" represents a specific set of inputs, such as address,
+cipher, version, etc.
+"""
+
+import itertools
+import multiprocessing
+import os
+from enum import Enum as BaseEnum
+from multiprocessing.pool import ThreadPool
+
+class Enum(BaseEnum):
+
+    def __str__(self):
+        return self.name
+
+    @classmethod
+    def all(cls):
+        return cls
+
+
+class Version(Enum):
+    SSLv3 = 30
+    TLS10 = 31
+    TLS11 = 32
+    TLS12 = 33
+    TLS13 = 34
+
+
+class Mode(Enum):
+    client = 0
+    server = 1
+
+    def is_client(self):
+        return self is Mode.client
+
+    def is_server(self):
+        return self is Mode.server
+
+    def other(self):
+        return Mode.server if self.is_client() else Mode.client
+
+
+class Cipher():
+    def __init__(self, name, min_version):
+        self.name = name
+        self.min_version = min_version
+
+    def valid_for(self, version):
+        if not version:
+            version = Version.default()
+
+        if version.value < self.min_version.value:
+            return False
+        if self.min_version is Version.TLS13:
+            return version.value >= Version.TLS13.value
+        return True
+
+    def __str__(self):
+        return self.name
+
+    @classmethod
+    def all(cls):
+        return ALL_CIPHERS_PER_LIBCRYPTO_VERSION[get_libcrypto()]
+
+
+def get_libcrypto():
+    return str(os.getenv("S2N_LIBCRYPTO")).strip('"')
+
+
+ALL_CIPHERS = [
+    Cipher("TLS_AES_256_GCM_SHA384", Version.TLS13),
+    Cipher("TLS_CHACHA20_POLY1305_SHA256", Version.TLS13),
+    Cipher("TLS_AES_128_GCM_SHA256", Version.TLS13)
+]
+
+# Older Openssl and libressl do not support CHACHA20
+LEGACY_COMPATIBLE_CIPHERS = list(filter(lambda x: "CHACHA20" not in x.name, ALL_CIPHERS))
+
+ALL_CIPHERS_PER_LIBCRYPTO_VERSION = {
+    "openssl-1.1.1"         : ALL_CIPHERS,
+    "openssl-1.0.2"         : LEGACY_COMPATIBLE_CIPHERS,
+    "openssl-1.0.2-fips"    : LEGACY_COMPATIBLE_CIPHERS,
+    "libressl"              : LEGACY_COMPATIBLE_CIPHERS,
+}
+
+
+ALL_CURVES = ["P-256", "P-384"]
+
+
+class Scenario:
+
+    """
+    Describes the configuration for a specific TLS connection.
+
+    """
+
+    def __init__(self, s2n_mode, host, port, version=None, cipher=None, curve=None, s2n_flags=[], peer_flags=[]):
+        """
+        Args:
+            s2n_mode: whether s2n should act as a client or server.
+            host: host to connect or listen to.
+            port: port to connect or listen to.
+            version: which TLS protocol version to use. If None, the implementation will
+                use its default.
+            cipher: which cipher to use. If None, the implementation will use its default.
+            s2n_flags: any extra flags that should be passed to s2n.
+            peer_flags: any extra flags that should be passed to the TLS implementation
+                that s2n connects to.
+
+        """
+        self.s2n_mode = s2n_mode
+        self.host = host
+        self.port = port
+        self.version = version
+        self.cipher = cipher
+        self.curve = curve
+        self.s2n_flags = s2n_flags
+        self.peer_flags = peer_flags
+
+    def __str__(self):
+        version = self.version if self.version else "DEFAULT"
+        cipher = self.cipher if self.cipher else "ANY"
+        result = "Mode:%s %s Version:%s Curve:%s Cipher:%s" % \
+            (self.s2n_mode, " ".join(self.s2n_flags), str(version).ljust(7), self.curve, str(cipher).ljust(30))
+
+        return result.ljust(100)
+
+
+def __create_thread_pool():
+    threadpool_size = multiprocessing.cpu_count() * 2  # Multiply by 2 since performance improves slightly if CPU has hyperthreading
+    threadpool = ThreadPool(processes=threadpool_size)
+    return threadpool
+
+
+def run_scenarios(test_func, scenarios):
+    failed = 0
+    threadpool = __create_thread_pool()
+    results = {}
+
+    print("\tRunning scenarios: " + str(len(scenarios)))
+
+    for scenario in scenarios:
+        async_result = threadpool.apply_async(test_func, (scenario,))
+        results.update({scenario: async_result})
+
+    threadpool.close()
+    threadpool.join()
+
+    results.update((k, v.get()) for k,v in results.items())
+    # Sort the results so that failures appear at the end
+    sorted_results = sorted(results.items(), key=lambda x: not x[1].is_success())
+    for scenario, result in sorted_results:
+        print("%s %s" % (str(scenario), str(result).rstrip()))
+        if not result.is_success:
+            failed += 1
+
+    return failed
+
+
+def get_scenarios(host, start_port, s2n_modes=Mode.all(), versions=[None], ciphers=[None], curves=ALL_CURVES, s2n_flags=[], peer_flags=[]):
+    port = start_port
+    scenarios = []
+
+    combos = itertools.product(versions, s2n_modes, ciphers, curves)
+    for (version, s2n_mode, cipher, curve) in combos:
+        if cipher and not cipher.valid_for(version):
+            continue
+
+        for s2n_mode in s2n_modes:
+            scenarios.append(Scenario(
+                s2n_mode=s2n_mode,
+                host=host,
+                port=port,
+                version=version,
+                cipher=cipher,
+                curve=curve,
+                s2n_flags=s2n_flags,
+                peer_flags=peer_flags))
+            port += 1
+        
+    return scenarios
+

--- a/tests/integration/s2n_tls13_handshake_tests.py
+++ b/tests/integration/s2n_tls13_handshake_tests.py
@@ -1,0 +1,48 @@
+#
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+"""
+Handshake tests against openssl using TLS13.
+At the moment these tests are expected fail, as TLS13 is incomplete.
+"""
+
+import argparse
+import os
+import sys
+
+from common.s2n_test_openssl import run_openssl_connection_test
+from common.s2n_test_scenario import get_scenarios, Mode, Cipher, Version
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Runs TLS1.3 minimal handshake integration tests against Openssl')
+    parser.add_argument('host', help='The host to connect to')
+    parser.add_argument('port', type=int, help='The port to bind to')
+
+    args = parser.parse_args()
+    host = args.host
+    port = args.port
+
+    failed = 0
+
+    print("\n\tRunning TLS1.3 handshake tests with openssl: %s" % os.popen('openssl version').read())
+    failed += run_openssl_connection_test(get_scenarios(host, port, versions=[Version.TLS13], s2n_modes=Mode.all(), ciphers=Cipher.all()))
+
+    return failed
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+


### PR DESCRIPTION
**Issue # (if available):** 
[1118](https://github.com/awslabs/s2n/issues/1118)
[1119](https://github.com/awslabs/s2n/issues/1119)

**Description of changes:** 
Also included common files to make future tests easier.

Output:
```text
> make -C tests/integration tls13
make: Entering directory '/home/ubuntu/s2n/tests/integration'
( \
DYLD_LIBRARY_PATH="../../lib/:../testlib/:/lib:$DYLD_LIBRARY_PATH" \
LD_LIBRARY_PATH="../../lib/:../testlib/:/lib:$LD_LIBRARY_PATH" \
S2N_INTEG_TEST=1 \
python3 s2n_tls13_handshake_tests.py 127.0.0.1 8888; \
)

	Running TLS1.3 handshake tests with openssl: OpenSSL 1.1.1d  10 Sep 2019

	Running scenarios: 24
Mode:Client  Version:TLS13   Curve:P-256 Cipher:TLS_AES_128_GCM_SHA256                               PASSED
Mode:Server  Version:TLS13   Curve:P-384 Cipher:TLS_AES_256_GCM_SHA384                               PASSED
Mode:Server  Version:TLS13   Curve:P-256 Cipher:TLS_AES_128_GCM_SHA256                               PASSED
Mode:Client  Version:TLS13   Curve:P-384 Cipher:TLS_AES_128_GCM_SHA256                               PASSED
Mode:Server  Version:TLS13   Curve:P-384 Cipher:TLS_AES_128_GCM_SHA256                               PASSED
Mode:Client  Version:TLS13   Curve:P-256 Cipher:TLS_CHACHA20_POLY1305_SHA256                         PASSED
Mode:Client  Version:TLS13   Curve:P-384 Cipher:TLS_CHACHA20_POLY1305_SHA256                         PASSED
Mode:Server  Version:TLS13   Curve:P-384 Cipher:TLS_CHACHA20_POLY1305_SHA256                         PASSED
Mode:Client  Version:TLS13   Curve:P-256 Cipher:TLS_AES_128_GCM_SHA256                               PASSED
Mode:Server  Version:TLS13   Curve:P-256 Cipher:TLS_AES_128_GCM_SHA256                               PASSED
Mode:Client  Version:TLS13   Curve:P-384 Cipher:TLS_AES_128_GCM_SHA256                               PASSED
Mode:Server  Version:TLS13   Curve:P-384 Cipher:TLS_AES_128_GCM_SHA256                               PASSED
Mode:Client  Version:TLS13   Curve:P-256 Cipher:TLS_AES_256_GCM_SHA384                               PASSED
Mode:Server  Version:TLS13   Curve:P-256 Cipher:TLS_AES_256_GCM_SHA384                               PASSED
Mode:Client  Version:TLS13   Curve:P-384 Cipher:TLS_AES_256_GCM_SHA384                               PASSED
Mode:Client  Version:TLS13   Curve:P-384 Cipher:TLS_AES_256_GCM_SHA384                               PASSED
Mode:Server  Version:TLS13   Curve:P-384 Cipher:TLS_AES_256_GCM_SHA384                               PASSED
Mode:Server  Version:TLS13   Curve:P-256 Cipher:TLS_CHACHA20_POLY1305_SHA256                         PASSED
Mode:Client  Version:TLS13   Curve:P-256 Cipher:TLS_CHACHA20_POLY1305_SHA256                         PASSED
Mode:Client  Version:TLS13   Curve:P-256 Cipher:TLS_AES_256_GCM_SHA384                               PASSED
Mode:Server  Version:TLS13   Curve:P-256 Cipher:TLS_CHACHA20_POLY1305_SHA256                         PASSED
Mode:Server  Version:TLS13   Curve:P-256 Cipher:TLS_AES_256_GCM_SHA384                               PASSED
Mode:Client  Version:TLS13   Curve:P-384 Cipher:TLS_CHACHA20_POLY1305_SHA256                         PASSED
Mode:Server  Version:TLS13   Curve:P-384 Cipher:TLS_CHACHA20_POLY1305_SHA256                         PASSED
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
