### PR TITLE
Turning off support for Curve X25519 until TLS1.3 is enabled

### DIFF
--- a/crypto/s2n_ecc_evp.c
+++ b/crypto/s2n_ecc_evp.c
@@ -65,9 +65,6 @@ const struct s2n_ecc_named_curve s2n_ecc_curve_x25519 = {
 const struct s2n_ecc_named_curve *const s2n_ecc_evp_supported_curves_list[] = {
     &s2n_ecc_curve_secp256r1,
     &s2n_ecc_curve_secp384r1,
-#if MODERN_EC_SUPPORTED
-    &s2n_ecc_curve_x25519,
-#endif
 };
 
 const size_t s2n_ecc_evp_supported_curves_list_len = s2n_array_len(s2n_ecc_evp_supported_curves_list);

--- a/crypto/s2n_ecc_evp.h
+++ b/crypto/s2n_ecc_evp.h
@@ -35,13 +35,12 @@ struct s2n_ecc_named_curve {
 extern const struct s2n_ecc_named_curve s2n_ecc_curve_secp256r1;
 extern const struct s2n_ecc_named_curve s2n_ecc_curve_secp384r1;
 
+#define S2N_ECC_EVP_SUPPORTED_CURVES_COUNT 2
 #if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0) && !defined(LIBRESSL_VERSION_NUMBER)
 #define MODERN_EC_SUPPORTED 1
-#define S2N_ECC_EVP_SUPPORTED_CURVES_COUNT 3
 extern const struct s2n_ecc_named_curve s2n_ecc_curve_x25519;
 #else
 #define MODERN_EC_SUPPORTED 0
-#define S2N_ECC_EVP_SUPPORTED_CURVES_COUNT 2
 #endif
 
 extern const struct s2n_ecc_named_curve *const s2n_ecc_evp_supported_curves_list[];

--- a/tests/integration/s2n_handshake_test_s_client.py
+++ b/tests/integration/s2n_handshake_test_s_client.py
@@ -60,16 +60,14 @@ class TlsExtensionServerName:
 use_corked_io=False
 
 def get_supported_curves_list_by_version(libcrypto_version):
-   # Curve X25519 is supported for Openssl 1.1.0 and higher
     if libcrypto_version == "openssl-1.1.1":
-        return  ["P-256", "P-384", "X25519"]
+        return  ["P-256", "P-384"]
     else:
         return  ["P-256", "P-384"]
 
 def get_supported_curves_str_by_version(libcrypto_version):
-   # Curve X25519 is supported for Openssl 1.1.0 and higher
     if libcrypto_version == "openssl-1.1.1":
-        return "P-256:P-384:X25519"
+        return "P-256:P-384"
     else:
         return "P-256:P-384"
 

--- a/tests/integration/s2n_handshake_test_s_server.py
+++ b/tests/integration/s2n_handshake_test_s_server.py
@@ -38,9 +38,8 @@ use_corked_io=False
 
 
 def get_supported_curves_list_by_version(libcrypto_version):
-   # Curve X25519 is supported for Openssl 1.1.0 and higher
     if libcrypto_version == "openssl-1.1.1":
-        return ["P-256", "P-384", "X25519"]
+        return ["P-256", "P-384"]
     else:
         return ["P-256", "P-384"]
 


### PR DESCRIPTION
**Issue # (if available):** 

https://github.com/awslabs/s2n/pull/1239

**Description of changes:** 
- Removed  `s2n_ecc_curve_x25519` from `s2n_ecc_evp_supported_curves_list`.
- Removed `curve x25519` from the integration tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
