### PR TITLE
Do Not Merge. Verifying codebuild/travis fail

### DIFF
--- a/crypto/s2n_tls13_keys.c
+++ b/crypto/s2n_tls13_keys.c
@@ -123,17 +123,6 @@ int s2n_tls13_keys_init(struct s2n_tls13_keys *keys, s2n_hmac_algorithm alg)
 }
 
 /*
- * Frees any allocation
- */
-int s2n_tls13_keys_free(struct s2n_tls13_keys *keys) {
-    notnull_check(keys);
-
-    GUARD(s2n_hmac_free(&keys->hmac));
-
-    return 0;
-}
-
-/*
  * Derives early secrets
  */
 int s2n_tls13_derive_early_secrets(struct s2n_tls13_keys *keys)

--- a/crypto/s2n_tls13_keys.h
+++ b/crypto/s2n_tls13_keys.h
@@ -72,7 +72,6 @@ extern const struct s2n_blob s2n_tls13_label_traffic_secret_iv;
     s2n_stack_blob(name, bytes, S2N_TLS13_SECRET_MAX_LEN)
 
 int s2n_tls13_keys_init(struct s2n_tls13_keys *handshake, s2n_hmac_algorithm alg);
-int s2n_tls13_keys_free(struct s2n_tls13_keys *keys);
 int s2n_tls13_derive_early_secrets(struct s2n_tls13_keys *handshake);
 int s2n_tls13_derive_handshake_secrets(struct s2n_tls13_keys *handshake,
                                         const struct s2n_blob *ecdhe,

--- a/tests/unit/s2n_tls13_keys_test.c
+++ b/tests/unit/s2n_tls13_keys_test.c
@@ -148,7 +148,7 @@ int main(int argc, char **argv)
 
     BEGIN_TEST();
 
-    DEFER_CLEANUP(struct s2n_tls13_keys secrets = {0}, s2n_tls13_keys_free);
+    struct s2n_tls13_keys secrets;
 
     EXPECT_SUCCESS(s2n_tls13_keys_init(&secrets, S2N_HMAC_SHA256));
 
@@ -158,7 +158,7 @@ int main(int argc, char **argv)
     S2N_BLOB_EXPECT_EQUAL(secrets.extract_secret, expected_early_secret);
     S2N_BLOB_EXPECT_EQUAL(secrets.derive_secret, expect_derived_handshake_secret);
 
-    DEFER_CLEANUP(struct s2n_hash_state hash_state, s2n_hash_free);
+    struct s2n_hash_state hash_state;
     EXPECT_SUCCESS(s2n_hash_new(&hash_state));
     EXPECT_SUCCESS(s2n_hash_init(&hash_state, secrets.hash_algorithm));
     EXPECT_SUCCESS(s2n_hash_update(&hash_state, client_hello.data, client_hello.size));
@@ -167,7 +167,7 @@ int main(int argc, char **argv)
     s2n_tls13_key_blob(client_handshake_secret, secrets.size);
     s2n_tls13_key_blob(server_handshake_secret, secrets.size);
 
-    DEFER_CLEANUP(struct s2n_hash_state hash_state_copy, s2n_hash_free);
+    struct s2n_hash_state hash_state_copy;
     EXPECT_SUCCESS(s2n_hash_new(&hash_state_copy));
     EXPECT_SUCCESS(s2n_hash_copy(&hash_state_copy, &hash_state));
 

--- a/tls/s2n_tls13_handshake.h
+++ b/tls/s2n_tls13_handshake.h
@@ -28,7 +28,7 @@ int s2n_tls13_mac_verify(struct s2n_tls13_keys *keys, struct s2n_blob *finished_
 
 /* Creates a reference to tls13_keys from connection */
 #define s2n_tls13_connection_keys(keys, conn) \
-    DEFER_CLEANUP(struct s2n_tls13_keys keys = {0}, s2n_tls13_keys_free);\
+    struct s2n_tls13_keys keys = {0};\
     GUARD(s2n_tls13_keys_from_conn(&keys, conn));
 
 int s2n_tls13_keys_from_conn(struct s2n_tls13_keys *keys, struct s2n_connection *conn);


### PR DESCRIPTION
**Issue # (if available):** https://github.com/awslabs/s2n/issues/1290

**Description of changes:** 
Do Not Merge! Reverted to a previous state that had been passing travis with memory leaks in valgrind/FIPS mode. Verifying that travis/codebuild will now fail appropriately or not

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
