### PR TITLE
Update grep_simple_mistakes.sh to enforce memcpy_check()

### DIFF
--- a/.travis/grep_simple_mistakes.sh
+++ b/.travis/grep_simple_mistakes.sh
@@ -77,6 +77,18 @@ for file in $S2N_FILES_ASSERT_NOTNULL_CHECK; do
   done < <(grep -rnE -A 1 "=\ss2n_stuffer_raw_read\(.*\)" $file)
 done
 
+# Enforce the use of memcpy_check(), which checks for null, instead of raw
+# memcpy(). This routine greps through all .[ch] files for the usage of raw
+# memcpy() and returns a failure in that case
+S2N_FILES_ASSERT_MEMCPY_CHECK=$(find "$PWD" -type f -name "s2n*.[ch]" -not -path "*/tests/*")
+for file in $S2N_FILES_ASSERT_MEMCPY_CHECK; do
+  RESULT_RAW_MEMCPY=`grep -Ern 'memcpy\(' $file`
+  if [ "${#RESULT_RAW_MEMCPY}" != "0" ]; then
+    FAILED=1
+    printf "\e[1;34mGrep for 'memcpy()' check failed in $file:\e[0m\n$RESULT_RAW_MEMCPY\n\n"
+  fi
+done
+
 if [ $FAILED == 1 ]; then
   printf "\\033[31;1mFAILED Grep For Simple Mistakes check\\033[0m\\n"
   exit -1

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -158,7 +158,7 @@ static void setup_s2n_config(struct s2n_config *config, const char *cipher_prefs
                     fprintf(stderr, "Error allocating memory\n");
                     exit(1);
                 }
-                memcpy(protocols[idx], next, length);
+                memcpy_check(protocols[idx], next, length);
                 protocols[idx][length] = '\0';
                 length = 0;
                 idx++;
@@ -175,7 +175,7 @@ static void setup_s2n_config(struct s2n_config *config, const char *cipher_prefs
                 fprintf(stderr, "Error allocating memory\n");
                 exit(1);
             }
-            memcpy(protocols[idx], next, length);
+            memcpy_check(protocols[idx], next, length);
             protocols[idx][length] = '\0';
         }
 

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -171,8 +171,8 @@ int cache_store_callback(struct s2n_connection *conn, void *ctx, uint64_t ttl, c
 
     uint8_t index = ((const uint8_t *)key)[0];
 
-    memcpy(cache[index].key, key, key_size);
-    memcpy(cache[index].value, value, value_size);
+    memcpy_check(cache[index].key, key, key_size);
+    memcpy_check(cache[index].value, value, value_size);
 
     cache[index].key_len = key_size;
     cache[index].value_len = value_size;
@@ -193,7 +193,7 @@ int cache_retrieve_callback(struct s2n_connection *conn, void *ctx, const void *
     S2N_ERROR_IF(*value_size < cache[index].value_len, S2N_ERR_INVALID_ARGUMENT);
 
     *value_size = cache[index].value_len;
-    memcpy(value, cache[index].value, cache[index].value_len);
+    memcpy_check(value, cache[index].value, cache[index].value_len);
 
     for (int i = 0; i < key_size; i++) {
         printf("%02x", ((const uint8_t *)key)[i]);

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -243,7 +243,7 @@ int s2n_connection_set_session(struct s2n_connection *conn, const uint8_t *sessi
 
     DEFER_CLEANUP(struct s2n_blob session_data = {0}, s2n_free);
     GUARD(s2n_alloc(&session_data, length));
-    memcpy(session_data.data, session, length);
+    memcpy_check(session_data.data, session, length);
 
     struct s2n_stuffer from = {0};
     GUARD(s2n_stuffer_init(&from, &session_data));

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -35,7 +35,7 @@ static inline void* trace_memcpy_check(void *restrict to, const void *restrict f
         return NULL;
     }
 
-    return memcpy(to, from, size);
+    return memcpy_check(to, from, size);
 }
 
 /* Check memcpy and memset's arguments, if these are not right, log an error

--- a/utils/s2n_str.c
+++ b/utils/s2n_str.c
@@ -33,7 +33,7 @@ char *s2n_strcpy(char *buf, char *last, const char *str) {
 
     char *p = buf;
     if (bytes_to_copy > 0) {
-        p = (char *)memcpy(buf, str, bytes_to_copy) + bytes_to_copy;
+        p = (char *)memcpy_check(buf, str, bytes_to_copy) + bytes_to_copy;
     }
     *p = '\0';
 


### PR DESCRIPTION
**Issue # (if available):** #1411 

**Description of changes:** 
Added routine in grep_simple_mistakes.sh to grep through all s2n code and detect calls of raw memcpy(). This will allow to enforce usage of correct memcpy_check() instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
