### PR TITLE
Adding GUARD_STRICT for functions that return non-zero on error

### DIFF
--- a/docs/DEVELOPMENT-GUIDE.md
+++ b/docs/DEVELOPMENT-GUIDE.md
@@ -113,11 +113,12 @@ if (s2n_do_something(with_something_else) < 0) {
 }
 ```
 
-is so common that utils/s2n_safety.h provides two macros:
+is so common that utils/s2n_safety.h provides three macros:
 
 ```c
-#define GUARD( x )      if ( (x) < 0 ) return -1
-#define GUARD_PTR( x )  if ( (x) < 0 ) return NULL
+#define GUARD( x )         if ( (x) < 0 ) return -1
+#define GUARD_STRICT( x )  if ( (x) != 0 ) return -1
+#define GUARD_PTR( x )     if ( (x) < 0 ) return NULL
 ```
 
 These macros should be used when calling functions you expect to succeed. Primarily these macros help save two lines that repeatedly clutter files, and secondarily they are very useful when developing and debugging code as it is easy to redefine the macro to implement a simple backtrace (even a simple printf will suffice, but a breakpoint is more usual). 

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -91,6 +91,7 @@ static inline void* trace_memcpy_check(void *restrict to, const void *restrict f
   } while (0)
 
 #define GUARD( x )              do {if ( (x) < 0 ) return S2N_FAILURE;} while (0)
+#define GUARD_STRICT( x )       do {if ( (x) != 0 ) return S2N_FAILURE;} while (0)
 #define GUARD_GOTO( x , label ) do {if ( (x) < 0 ) goto label;} while (0)
 #define GUARD_PTR( x )          do {if ( (x) < 0 ) return NULL;} while (0)
 


### PR DESCRIPTION
**Description of changes:** Added a new GUARD macro (GUARD_STRICT) for functions that return non-zero values on error that are not necessarily negative. This should likely not be used for guarding S2N functions since our standard is returning negative values on error, but is useful for calling some external functions that return non-zero on error like atexit(), and fits in with the code style that we have been using. A documentation update for the development guide is also included.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
