### PR TITLE
Add CodeBuild job for Sidetrail tests.

### DIFF
--- a/codebuild/README.md
+++ b/codebuild/README.md
@@ -13,29 +13,30 @@
 General flow of the CodeBuild Test Projects
 
 - buildspec_{OS}.yml
-    - codebuild/install_default_dependencies.sh
-        - codebuild/install_clang.sh
-        - codebuild/install_libFuzzer.sh
-        - codebuild/install_openssl_1_1_1.sh
-        - codebuild/install_openssl_1_0_2.sh
-        - codebuild/install_openssl_1_0_2_fips.sh
-        - codebuild/install_cppcheck.sh
-        - codebuild/install_libressl.sh
-        - codebuild/install_python.sh
-        - codebuild/install_gnutls.sh
-        - codebuild/install_saw.sh
-        - codebuild/install_z3_yices.sh
-        - codebuild/install_sslyze.sh
-    - codebuild/s2n_codebuild.sh
-        - codebuild/s2n_override_paths.sh
-        - codebuild/run_cppcheck.sh
-        - codebuild/copyright_mistake_scanner.sh
-        - codebuild/run_kwstyle.sh
-        - codebuild/cpp_style_comment_linter.sh
-        - codebuild/run_ctverif.sh
-        - codebuild/run_sidetrail.sh
-        - codebuild/grep_simple_mistakes.sh
-    - codebuild/s2n_after_codebuild.sh
+    - codebuild/bin/install_default_dependencies.sh
+        - codebuild/bin/install_clang.sh
+        - codebuild/bin/install_libFuzzer.sh
+        - codebuild/bin/install_openssl_1_1_1.sh
+        - codebuild/bin/install_openssl_1_0_2.sh
+        - codebuild/bin/install_openssl_1_0_2_fips.sh
+        - codebuild/bin/install_cppcheck.sh
+        - codebuild/bin/install_libressl.sh
+        - codebuild/bin/install_python.sh
+        - codebuild/bin/install_gnutls.sh
+        - codebuild/bin/install_saw.sh
+        - codebuild/bin/install_z3_yices.sh
+        - codebuild/bin/install_sslyze.sh
+        - codebuild/bin/install_sidetrail_dependencies.sh
+    - codebuild/bin/s2n_codebuild.sh
+        - codebuild/bin/s2n_override_paths.sh
+        - codebuild/bin/run_cppcheck.sh
+        - codebuild/bin/copyright_mistake_scanner.sh
+        - codebuild/bin/run_kwstyle.sh
+        - codebuild/bin/cpp_style_comment_linter.sh
+        - codebuild/bin/run_ctverif.sh
+        - codebuild/bin/run_sidetrail.sh
+        - codebuild/bin/grep_simple_mistakes.sh
+    - codebuild/bin/s2n_after_codebuild.sh
         - curl -s https://codecov.io/bash
 
 

--- a/codebuild/bin/install_default_dependencies.sh
+++ b/codebuild/bin/install_default_dependencies.sh
@@ -83,3 +83,15 @@ fi
 if [[ "$TESTS" == "integration" || "$TESTS" == "ALL" ]] ; then
     codebuild/bin/install_sslyze.sh
 fi
+
+if [[ "${TESTS}" == "sidetrail" || "${TESTS}" == "ALL" ]]; then
+    mkdir -p "${SIDETRAIL_INSTALL_DIR}" ||true
+    # Don't run install on the smack docker image.
+    if [[ $(test -x /usr/local/bin/smack) -eq 1 ]] ; then
+        codebuild/bin/install_sidetrail_dependencies.sh ; 
+        codebuild/bin/install_sidetrail.sh "${SIDETRAIL_INSTALL_DIR}" > /dev/null ;
+    else
+        echo "Symlinking to the pre-built smack env."
+        ln -s /home/user/smack.environment ${SIDETRAIL_INSTALL_DIR}/
+    fi
+fi

--- a/codebuild/bin/install_default_dependencies.sh
+++ b/codebuild/bin/install_default_dependencies.sh
@@ -16,6 +16,9 @@
 set -ex
 source codebuild/bin/s2n_setup_env.sh
 
+# TODO: Make the build directory deterministic.
+#BUILD_DIR=/tmp/tmp.$(hostname|sha256sum |cut -c 1-10)
+
  # Install latest version of clang, clang++, and llvm-symbolizer. Needed for fuzzing.
 if [[ "$TESTS" == "fuzz" || "$TESTS" == "ALL" || "$LATEST_CLANG" == "true" ]]; then
     mkdir -p "$LATEST_CLANG_INSTALL_DIR"||true
@@ -92,6 +95,6 @@ if [[ "${TESTS}" == "sidetrail" || "${TESTS}" == "ALL" ]]; then
         codebuild/bin/install_sidetrail.sh "${SIDETRAIL_INSTALL_DIR}" > /dev/null ;
     else
         echo "Symlinking to the pre-built smack env."
-        ln -s /home/user/smack.environment ${SIDETRAIL_INSTALL_DIR}/
+        ln -s /home/user/smack.environment ${SIDETRAIL_INSTALL_DIR}/ ||true
     fi
 fi

--- a/codebuild/bin/install_openssl_1_1_1.sh
+++ b/codebuild/bin/install_openssl_1_1_1.sh
@@ -30,6 +30,11 @@ INSTALL_DIR=$2
 OS_NAME=$3
 
 cd "$BUILD_DIR"
+
+#if [ -f "${INSTALL_DIR}/bin/openssl" ]; then
+#  echo "OpenSSL already installed, returning"
+#  exit 0
+#fi
 curl --retry 3 -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1-stable.zip --output OpenSSL_1_1_1-stable.zip
 unzip OpenSSL_1_1_1-stable.zip
 cd openssl-OpenSSL_1_1_1-stable

--- a/codebuild/bin/install_sidetrail.sh
+++ b/codebuild/bin/install_sidetrail.sh
@@ -14,9 +14,10 @@
 #
 
 set -e
+set -x
 
 usage() {
-    echo "install_ctverif.sh install_dir"
+    echo "install_sidetrail.sh install_dir"
     exit 1
 }
 
@@ -29,10 +30,11 @@ INSTALL_DIR=$1
 cd "$INSTALL_DIR"
 
 #install smack
-git clone https://github.com/smackers/smack.git -b develop
+git clone https://github.com/smackers/smack.git -b v2.4.0
 cd smack/bin
-git checkout 45e1fc5
-./build.sh
+
+# CodeBuild is missing build step output
+./build.sh | tee /dev/stderr
 
 # Disabling ShellCheck using https://github.com/koalaman/shellcheck/wiki/Directive
 # Turn of Warning in one line as https://github.com/koalaman/shellcheck/wiki/SC1090

--- a/codebuild/bin/install_sidetrail_dependencies.sh
+++ b/codebuild/bin/install_sidetrail_dependencies.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+set -e
+set -x
+
+#Install boogieman
+gem install bam-bam-boogieman
+which bam
+
+#Install the apt-get dependencies from the smack build script: this way they will still be there
+#when we get things from cache
+
+# For python- either use pip or apt, don't do both.
+DEPENDENCIES="git cmake python-yaml python-psutil unzip wget python-pip"
+DEPENDENCIES+=" mono-complete libz-dev libedit-dev"
+# Smack needs a clang that can do -Xclang -disable-O0-optnone
+DEPENDENCIES+=" figlet clang-8.0 llvm-8.0 llvm-8.0-dev"
+
+
+# Adding MONO repository
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+echo "deb http://download.mono-project.com/repo/ubuntu trusty main" | sudo tee /etc/apt/sources.list.d/mono-official.list
+
+apt-get update -o Acquire::CompressionTypes::Order::=gz
+apt-get install -y ${DEPENDENCIES}
+
+LLVM_SHORT_VERSION=8.0
+
+# TODO: This should be done at a higher level.
+update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${LLVM_SHORT_VERSION} 1000
+update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${LLVM_SHORT_VERSION} 1000
+update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-${LLVM_SHORT_VERSION} 1000
+update-alternatives --install /usr/bin/llvm-link llvm-link /usr/bin/llvm-link-${LLVM_SHORT_VERSION} 1000
+update-alternatives --install /usr/bin/llvm-dis llvm-dis /usr/bin/llvm-dis-${LLVM_SHORT_VERSION} 1000
+
+#TODO: Why do two layers of symlink?
+mkdir -p ~/override_clang
+ln -s /usr/bin/clang          ~/override_clang/clang
+ln -s /usr/bin/clang++        ~/override_clang/clang++
+ln -s /usr/bin/llvm-config   ~/override_clang/llvm-config
+ln -s /usr/bin/llvm-link      ~/override_clang/llvm-link
+ln -s /usr/bin/llvm-dis       ~/override_clang/llvm-dis
+chmod +x ~/override_clang/*
+
+export PATH="$HOME/override_clang/:${PATH}"
+
+which python
+python --version

--- a/codebuild/bin/install_ubuntu_dependencies.sh
+++ b/codebuild/bin/install_ubuntu_dependencies.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Historical artifact; remove in future PR.
 # Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").

--- a/codebuild/bin/run_sidetrail.sh
+++ b/codebuild/bin/run_sidetrail.sh
@@ -50,7 +50,7 @@ SMACK_DIR="${1}/smack"
 #Put the dependencies on the path
 
 # Disabling ShellCheck using https://github.com/koalaman/shellcheck/wiki/Directive
-# Turn of Warning in one line as https://github.com/koalaman/shellcheck/wiki/SC1090
+# Turn off Warning in one line as https://github.com/koalaman/shellcheck/wiki/SC1090
 # shellcheck disable=SC1090
 source "${INSTALL_DIR}/smack.environment"
 export PATH="${SMACK_DIR}/bin:${SMACK_DIR}/build:${PATH}"
@@ -58,8 +58,6 @@ export PATH="${SMACK_DIR}/bin:${SMACK_DIR}/build:${PATH}"
 which smack || echo "can't find smack"
 which boogie || echo "can't find z3"
 which llvm2bpl || echo "can't find llvm2bpl"
-which clang
-clang --version
 
 if [[ "$2" == "" || "$2" == "1" ]]; then
     runSingleTest "s2n-cbc"

--- a/codebuild/bin/s2n_codebuild.sh
+++ b/codebuild/bin/s2n_codebuild.sh
@@ -81,10 +81,10 @@ if [[ "$TESTS" == "ALL" || "$TESTS" == "sawHMAC" ]] && [[ "$OS_NAME" == "linux" 
 if [[ "$TESTS" == "ALL" || "$TESTS" == "sawDRBG" ]]; then make -C tests/saw tmp/verify_drbg.log ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "tls" ]]; then make -C tests/saw tmp/verify_handshake.log ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "sawHMACFailure" ]]; then make -C tests/saw failure-tests ; fi
-if [[ "$TESTS" == "ALL" || "$TESTS" == "ctverif" ]]; then .travis/run_ctverif.sh "$CTVERIF_INSTALL_DIR" ; fi
+if [[ "$TESTS" == "ALL" || "$TESTS" == "ctverif" ]]; then codebuild/bin/run_ctverif.sh "$CTVERIF_INSTALL_DIR" ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "sawSIKE_r1" ]]; then make -C tests/saw sike_r1 ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "sawBIKE_r1" ]]; then make -C tests/saw bike_r1 ; fi
-if [[ "$TESTS" == "ALL" || "$TESTS" == "sidetrail" ]]; then .travis/run_sidetrail.sh "$SIDETRAIL_INSTALL_DIR" "$PART" ; fi
+if [[ "$TESTS" == "ALL" || "$TESTS" == "sidetrail" ]]; then codebuild/bin/run_sidetrail.sh "$SIDETRAIL_INSTALL_DIR" "$PART" ; fi
 
 # Generate *.gcov files that can be picked up by the CodeCov.io Bash helper script. Don't run lcov or genhtml 
 # since those will delete .gcov files as they're processed.

--- a/codebuild/codebuild.config
+++ b/codebuild/codebuild.config
@@ -127,4 +127,8 @@ env: TESTS=tls SAW=true GCC_VERSION=NONE
 snippet: UbuntuBoilerplate2XL
 env: TESTS=sawHMACFailure SAW=true
 
-# Sidetrail
+# Sidetrail - Run both tests in one job
+[CodeBuild:s2nSidetrail]
+snippet: UbuntuBoilerplate2XL
+env: TESTS=sidetrail
+

--- a/codebuild/spec/buildspec_ubuntu.yml
+++ b/codebuild/spec/buildspec_ubuntu.yml
@@ -32,7 +32,8 @@ phases:
         if expr "${GCC_VERSION}" : "6" >/dev/null; then
           apt-get install -y --no-install-recommends g++ g++-6 gcc gcc-6;
         fi
-      - apt-get install -y --no-install-recommends indent kwstyle lcov libssl-dev clang-3.9 llvm-3.9 m4 make net-tools nettle-bin nettle-dev pkg-config psmisc python3-pip shellcheck sudo tcpdump unzip valgrind zlib1g-dev zlibc
+      - apt-get install -y --no-install-recommends lsb wget ruby figlet curl indent kwstyle lcov libssl-dev clang-3.9 llvm-3.9 m4 make net-tools nettle-bin nettle-dev pkg-config psmisc python3-pip python-dev shellcheck sudo tcpdump unzip valgrind zlib1g-dev zlibc unzip
+      - update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10
   pre_build:
     commands:
       - codebuild/bin/install_default_dependencies.sh


### PR DESCRIPTION
**Issue #469 ** 

**Description of changes:** 
Add Configs to create CodeBuild jobs for SideTrail.

Reworked some scripts so a pre-built [smack Docker image](https://github.com/smackers/smack/blob/master/Dockerfile) can be used in CodeBuild to significantly speed-up run times.

HOLD on this... between github actions and building a smack docker image- this work might not be needed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
