### PR TITLE
Detect process crash and fail respective TLS 1.3 integration test

### DIFF
--- a/tests/integration/Makefile
+++ b/tests/integration/Makefile
@@ -29,7 +29,7 @@ ifeq ($(S2N_CORKED_IO),true)
 endif
 
 .PHONY : all
-all: tls13 client_endpoints dynamic_record s_client s_server gnutls_cli gnutls_serv sslyze
+all: client_endpoints dynamic_record s_client s_server gnutls_cli gnutls_serv sslyze
 
 tls13:
 	( \

--- a/tests/integration/common/s2n_test_common.py
+++ b/tests/integration/common/s2n_test_common.py
@@ -87,10 +87,13 @@ def run_connection_test(get_peer, scenarios, test_func=None):
         server = None
         try:
             server, client = connect(get_peer, scenario)
-            if test_func:
-                return test_func(server, client)
-            else:
-                return Result()
+            result = test_func(server, client) if test_func else Result()
+            if client.poll():
+                raise AssertionError("Client process crashed")
+            if server.poll():
+                raise AssertionError("Server process crashed")
+
+            return result
         except AssertionError as error:
             return Result(error)
         finally:

--- a/tests/integration/common/s2n_test_scenario.py
+++ b/tests/integration/common/s2n_test_scenario.py
@@ -168,7 +168,7 @@ def run_scenarios(test_func, scenarios):
     sorted_results = sorted(results.items(), key=lambda x: not x[1].is_success())
     for scenario, result in sorted_results:
         print("%s %s" % (str(scenario), str(result).rstrip()))
-        if not result.is_success:
+        if not result.is_success():
             failed += 1
 
     return failed


### PR DESCRIPTION
**Issue # (if available):** 
Another fix for #1483

**Description of changes:** 
Fail respective TLS 1.3 integration test if process exits unexpectedly. Half of TLS 1.3 integration tests fail with this change. This is expected because #1481 needs to be merge first for tests to pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
