### PR TITLE
Clean up errno handling

### DIFF
--- a/bin/echo.c
+++ b/bin/echo.c
@@ -111,6 +111,9 @@ int echo(struct s2n_connection *conn, int sockfd)
     readers[1].fd = STDIN_FILENO;
     readers[1].events = POLLIN;
 
+    /* Reset errno so that we can't inherit the errno == EINTR exit condition. */
+    errno = 0;
+
     /* Act as a simple proxy between stdin and the SSL connection */
     int p;
     s2n_blocked_status blocked;
@@ -147,12 +150,11 @@ int echo(struct s2n_connection *conn, int sockfd)
     
                 /* Read as many bytes as we think we can */
     	    do {
-    	        errno = 0;
-    		bytes_read = read(STDIN_FILENO, buffer, bytes_available);
-    		if(bytes_read < 0 && errno != EINTR){
-    		  fprintf(stderr, "Error reading from stdin\n");
-    		  exit(1);
-    		}
+    	        bytes_read = read(STDIN_FILENO, buffer, bytes_available);
+    	        if(bytes_read < 0 && errno != EINTR){
+    	            fprintf(stderr, "Error reading from stdin\n");
+    	            exit(1);
+    	        }
     	    } while (bytes_read < 0);
     
                 if (bytes_read == 0) {

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -308,6 +308,7 @@ int main(int argc, char *const *argv)
             dyn_rec_timeout = (uint8_t) MIN(255, atoi(optarg));
             break;
         case 'D':
+            errno = 0;
             dyn_rec_threshold = strtoul(optarg, 0, 10);
             if (errno == ERANGE) {
                 dyn_rec_threshold = 0;

--- a/stuffer/s2n_stuffer_file.c
+++ b/stuffer/s2n_stuffer_file.c
@@ -37,7 +37,6 @@ int s2n_stuffer_recv_from_fd(struct s2n_stuffer *stuffer, int rfd, uint32_t len)
 
     int r = 0;
     do {
-        errno = 0;
         r = read(rfd, stuffer->blob.data + stuffer->write_cursor, len);
         S2N_ERROR_IF(r < 0 && errno != EINTR, S2N_ERR_READ);
     } while (r < 0);
@@ -57,7 +56,6 @@ int s2n_stuffer_send_to_fd(struct s2n_stuffer *stuffer, int wfd, uint32_t len)
 
     int w = 0;
     do {
-        errno = 0;
         w = write(wfd, stuffer->blob.data + stuffer->read_cursor, len);
         S2N_ERROR_IF (w < 0 && errno != EINTR, S2N_ERR_WRITE);
     } while (w < 0);
@@ -86,7 +84,6 @@ int s2n_stuffer_alloc_ro_from_file(struct s2n_stuffer *stuffer, const char *file
     int fd;
 
     do {
-        errno = 0;
         fd = open(file, O_RDONLY);
         S2N_ERROR_IF(fd < 0 && errno != EINTR, S2N_ERR_OPEN);
     } while (fd < 0);

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1033,6 +1033,8 @@ static int s2n_try_delete_session_cache(struct s2n_connection *conn)
 
 int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status * blocked)
 {
+    /* Just in case we mishandle errno in this function, we have the minimal
+     * guarantee that outside errors aren't influencing s2n. */
     errno = 0;
 
     char this = 'S';

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -58,8 +58,9 @@ int s2n_read_full_record(struct s2n_connection *conn, uint8_t * record_type, int
         if (s2n_connection_is_managed_corked(conn)) {
             GUARD(s2n_socket_set_read_size(conn, remaining));
         }
-        r = s2n_connection_recv_stuffer(&conn->header_in, conn, remaining);
 
+        errno = 0;
+        r = s2n_connection_recv_stuffer(&conn->header_in, conn, remaining);
         if (r == 0) {
             conn->closed = 1;
             S2N_ERROR(S2N_ERR_CLOSED);
@@ -97,8 +98,8 @@ int s2n_read_full_record(struct s2n_connection *conn, uint8_t * record_type, int
             GUARD(s2n_socket_set_read_size(conn, remaining));
         }
 
+        errno = 0;
         r = s2n_connection_recv_stuffer(&conn->in, conn, remaining);
-
         if (r == 0) {
             conn->closed = 1;
             S2N_ERROR(S2N_ERR_CLOSED);

--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -40,6 +40,7 @@ int s2n_flush(struct s2n_connection *conn, s2n_blocked_status * blocked)
     /* Write any data that's already pending */
   WRITE:
     while (s2n_stuffer_data_available(&conn->out)) {
+        errno = 0;
         w = s2n_connection_send_stuffer(&conn->out, conn, s2n_stuffer_data_available(&conn->out));
         if (w < 0) {
             if (errno == EWOULDBLOCK || errno == EAGAIN) {

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -127,6 +127,7 @@ int s2n_get_urandom_data(struct s2n_blob *blob)
     long backoff = 1;
 
     while (n) {
+        errno = 0;
         int r = read(entropy_fd, data, n);
         if (r <= 0) {
             /*

--- a/utils/s2n_socket.c
+++ b/utils/s2n_socket.c
@@ -192,7 +192,6 @@ int s2n_socket_read(void *io_context, uint8_t *buf, uint32_t len)
 
     /* On success, the number of bytes read is returned. On failure, -1 is
      * returned and errno is set appropriately. */
-    errno = 0;
     return read(rfd, buf, len);
 }
 
@@ -206,7 +205,6 @@ int s2n_socket_write(void *io_context, const uint8_t *buf, uint32_t len)
 
     /* On success, the number of bytes written is returned. On failure, -1 is
      * returned and errno is set appropriately. */
-    errno = 0;
     return write(wfd, buf, len);
 }
 


### PR DESCRIPTION
In #1494 I added a errno=0 to s2n_negotitate to alleviate errors
handling errno. In this PR I want to actually fix those errno mistakes.

We DO NOT need to reset errno if we check the return value of a
system call, and only use errno if the call failed.

We DO need to reset errno if we use errno without a guarantee
that a specific system call failed. We should not assume any
internal s2n_* function sets errno on failure, just in case the
definition changes underneath us.

I left the errno=0 at the beginning of s2n_negotiate as a
defense against future mistakes.

**Issue # (if available):** #1489 

**Description of changes:** 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
