### PR TITLE
Adds functionality to specify minimum protocol version

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -78,7 +78,7 @@ extern int s2n_config_set_monotonic_clock(struct s2n_config *config, s2n_clock_t
 
 extern const char *s2n_strerror(int error, const char *lang);
 extern const char *s2n_strerror_debug(int error, const char *lang);
-extern const char *s2n_strerror_name(int error); 
+extern const char *s2n_strerror_name(int error);
 
 struct s2n_stacktrace;
 extern bool s2n_stack_traces_enabled(void);
@@ -142,6 +142,7 @@ extern int s2n_config_add_dhparams(struct s2n_config *config, const char *dhpara
 extern int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *version);
 extern int s2n_config_set_signature_preferences(struct s2n_config *config, const char *version);
 extern int s2n_config_set_ecc_preferences(struct s2n_config *config, const char *version);
+extern int s2n_config_set_min_protocol_version(struct s2n_config *config, int version);
 extern int s2n_config_set_protocol_preferences(struct s2n_config *config, const char * const *protocols, int protocol_count);
 typedef enum { S2N_STATUS_REQUEST_NONE = 0, S2N_STATUS_REQUEST_OCSP = 1 } s2n_status_request_type;
 extern int s2n_config_set_status_request_type(struct s2n_config *config, s2n_status_request_type type);

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -811,4 +811,3 @@ int main(int argc, char **argv)
     END_TEST();
     return 0;
 }
-

--- a/tls/extensions/s2n_supported_versions.c
+++ b/tls/extensions/s2n_supported_versions.c
@@ -21,11 +21,16 @@
 
 #include "utils/s2n_safety.h"
 
-int s2n_connection_get_minimum_supported_version(struct s2n_connection *conn, uint8_t *min_version) 
+int s2n_connection_get_minimum_supported_version(struct s2n_connection *conn, uint8_t *min_version)
 {
-    const struct s2n_cipher_preferences *cipher_preferences;
-    GUARD(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
-    *min_version = cipher_preferences->minimum_protocol_version;
+    notnull_check(conn);
+    notnull_check(min_version);
+
+    if (conn->cipher_pref_override != NULL) {
+        *min_version = conn->cipher_pref_override->minimum_protocol_version;
+    } else {
+        *min_version = conn->config->minimum_protocol_version;
+    }
 
     return 0;
 }

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -648,7 +648,7 @@ struct s2n_cipher_suite *cipher_suites_elb_security_policy_fs_1_2_2019_08[] = {
 
 const struct s2n_cipher_preferences elb_security_policy_fs_1_2_2019_08 = {
     .count = s2n_array_len(cipher_suites_elb_security_policy_fs_1_2_2019_08),
-    .suites = cipher_suites_elb_security_policy_fs_1_2_2019_08, 
+    .suites = cipher_suites_elb_security_policy_fs_1_2_2019_08,
     .minimum_protocol_version = S2N_TLS12,
     .kem_count = 0,
     .kems = NULL,
@@ -671,7 +671,7 @@ struct s2n_cipher_suite *cipher_suites_elb_security_policy_fs_1_1_2019_08[] = {
 
 const struct s2n_cipher_preferences elb_security_policy_fs_1_1_2019_08 = {
     .count = s2n_array_len(cipher_suites_elb_security_policy_fs_1_1_2019_08),
-    .suites = cipher_suites_elb_security_policy_fs_1_1_2019_08, 
+    .suites = cipher_suites_elb_security_policy_fs_1_1_2019_08,
     .minimum_protocol_version = S2N_TLS11,
     .kem_count = 0,
     .kems = NULL,
@@ -690,7 +690,7 @@ struct s2n_cipher_suite *cipher_suites_elb_security_policy_fs_1_2_Res_2019_08[] 
 
 const struct s2n_cipher_preferences elb_security_policy_fs_1_2_Res_2019_08 = {
     .count = s2n_array_len(cipher_suites_elb_security_policy_fs_1_2_Res_2019_08),
-    .suites = cipher_suites_elb_security_policy_fs_1_2_Res_2019_08, 
+    .suites = cipher_suites_elb_security_policy_fs_1_2_Res_2019_08,
     .minimum_protocol_version = S2N_TLS12,
     .kem_count = 0,
     .kems = NULL,
@@ -1076,9 +1076,9 @@ struct {
     { .version="ELBSecurityPolicy-TLS-1-2-2017-01", .preferences=&elb_security_policy_tls_1_2_2017_01, .ecc_extension_required=0, .pq_kem_extension_required=0},
     { .version="ELBSecurityPolicy-TLS-1-2-Ext-2018-06", .preferences=&elb_security_policy_tls_1_2_ext_2018_06, .ecc_extension_required=0, .pq_kem_extension_required=0},
     { .version="ELBSecurityPolicy-FS-2018-06", .preferences=&elb_security_policy_fs_2018_06, .ecc_extension_required=0, .pq_kem_extension_required=0},
-    { .version="ELBSecurityPolicy-FS-1-2-2019-08", .preferences=&elb_security_policy_fs_1_2_2019_08, .ecc_extension_required=0, .pq_kem_extension_required=0}, 
-    { .version="ELBSecurityPolicy-FS-1-1-2019-08", .preferences=&elb_security_policy_fs_1_1_2019_08, .ecc_extension_required=0, .pq_kem_extension_required=0}, 
-    { .version="ELBSecurityPolicy-FS-1-2-Res-2019-08", .preferences=&elb_security_policy_fs_1_2_Res_2019_08, .ecc_extension_required=0, .pq_kem_extension_required=0}, 
+    { .version="ELBSecurityPolicy-FS-1-2-2019-08", .preferences=&elb_security_policy_fs_1_2_2019_08, .ecc_extension_required=0, .pq_kem_extension_required=0},
+    { .version="ELBSecurityPolicy-FS-1-1-2019-08", .preferences=&elb_security_policy_fs_1_1_2019_08, .ecc_extension_required=0, .pq_kem_extension_required=0},
+    { .version="ELBSecurityPolicy-FS-1-2-Res-2019-08", .preferences=&elb_security_policy_fs_1_2_Res_2019_08, .ecc_extension_required=0, .pq_kem_extension_required=0},
     { .version="CloudFront-Upstream", .preferences=&cipher_preferences_cloudfront_upstream, .ecc_extension_required=0, .pq_kem_extension_required=0},
     { .version="CloudFront-Upstream-TLS-1-0", .preferences=&cipher_preferences_cloudfront_upstream_tls10, .ecc_extension_required=0, .pq_kem_extension_required=0},
     { .version="CloudFront-Upstream-TLS-1-1", .preferences=&cipher_preferences_cloudfront_upstream_tls11, .ecc_extension_required=0, .pq_kem_extension_required=0},
@@ -1125,6 +1125,18 @@ struct {
     { .version=NULL, .preferences=NULL, .ecc_extension_required=0, .pq_kem_extension_required=0}
 };
 
+struct {
+    int version;
+} protocol_version_lookup [] = {
+    { .version=S2N_TLS13},
+    { .version=S2N_TLS12},
+    { .version=S2N_TLS11},
+    { .version=S2N_TLS10},
+    { .version=S2N_SSLv3},
+    { .version=S2N_SSLv2},
+    { .version=S2N_UNKNOWN_PROTOCOL_VERSION}
+};
+
 int s2n_find_cipher_pref_from_version(const char *version, const struct s2n_cipher_preferences **cipher_preferences)
 {
     notnull_check(version);
@@ -1143,7 +1155,26 @@ int s2n_find_cipher_pref_from_version(const char *version, const struct s2n_ciph
 int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *version)
 {
     GUARD(s2n_find_cipher_pref_from_version(version, &config->cipher_preferences));
+    config->minimum_protocol_version = config->cipher_preferences->minimum_protocol_version;
     return 0;
+}
+
+int s2n_config_set_min_protocol_version(struct s2n_config *config, int version)
+{
+    notnull_check(config);
+
+    for (int i = 0; protocol_version_lookup[i].version != S2N_UNKNOWN_PROTOCOL_VERSION; i++) {
+        if (version == protocol_version_lookup[i].version) {
+            if ((version > s2n_highest_protocol_version) || (version < config->cipher_preferences->minimum_protocol_version)) {
+                S2N_ERROR(S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
+            } else {
+                config->minimum_protocol_version = version;
+                return 0;
+            }
+        }
+    }
+
+    S2N_ERROR(S2N_ERR_UNKNOWN_PROTOCOL_VERSION);
 }
 
 int s2n_connection_set_cipher_preferences(struct s2n_connection *conn, const char *version)

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -37,6 +37,8 @@ extern const struct s2n_kem *pq_kems_sike_r2r1[2];
 
 #endif
 
+extern uint8_t s2n_highest_protocol_version;
+
 extern const struct s2n_cipher_preferences cipher_preferences_20140601;
 extern const struct s2n_cipher_preferences cipher_preferences_20141001;
 extern const struct s2n_cipher_preferences cipher_preferences_20150202;
@@ -74,6 +76,7 @@ extern const struct s2n_cipher_preferences elb_security_policy_fs_1_2_res_2019_0
 extern int s2n_cipher_preferences_init();
 extern int s2n_find_cipher_pref_from_version(const char *version, const struct s2n_cipher_preferences **cipher_preferences);
 extern int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *version);
+extern int s2n_config_set_min_protocol_version(struct s2n_config *config, int version);
 extern int s2n_ecc_extension_required(const struct s2n_cipher_preferences *preferences);
 extern int s2n_pq_kem_extension_required(const struct s2n_cipher_preferences *preferences);
 extern bool s2n_cipher_preference_supports_tls13(const struct s2n_cipher_preferences *preferences);

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -77,7 +77,7 @@ static int s2n_config_setup_tls13(struct s2n_config *config)
 {
     GUARD(s2n_config_set_cipher_preferences(config, "default_tls13"));
     GUARD(s2n_config_set_signature_preferences(config, "default_tls13"));
-    GUARD(s2n_config_set_ecc_preferences(config, "default_tls13"));      
+    GUARD(s2n_config_set_ecc_preferences(config, "default_tls13"));
     return S2N_SUCCESS;
 }
 
@@ -127,6 +127,8 @@ static int s2n_config_init(struct s2n_config *config)
     config->cert_tiebreak_cb = NULL;
 
     GUARD(s2n_config_setup_default(config));
+
+    config->minimum_protocol_version = config->cipher_preferences->minimum_protocol_version;
     if (s2n_is_tls13_enabled()) {
        GUARD(s2n_config_setup_tls13(config));
     } else if (s2n_is_in_fips_mode()) {

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -43,7 +43,7 @@ struct s2n_config {
 
     struct s2n_dh_params *dhparams;
     /* Needed until we can deprecate s2n_config_add_cert_chain_and_key. This is
-     * used to release memory allocated only in the deprecated API that the application 
+     * used to release memory allocated only in the deprecated API that the application
      * does not have a reference to. */
     struct s2n_map *domain_name_to_cert_map;
     struct certs_by_type default_certs_by_type;
@@ -97,6 +97,10 @@ struct s2n_config {
 
     struct s2n_x509_trust_store trust_store;
     uint16_t max_verify_cert_chain_depth;
+
+    /* Minimum supported TLS protocol version. This is initiated according to attached
+     * cipher_preferences but can be updated by s2n_config_set_min_protocol_version. */
+    uint8_t minimum_protocol_version;
 };
 
 extern int s2n_config_defaults_init(void);

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -92,14 +92,14 @@ static int s2n_connection_init_hashes(struct s2n_connection *conn)
     if (s2n_is_in_fips_mode()) {
         GUARD(s2n_hash_allow_md5_for_fips(&conn->handshake.md5));
         GUARD(s2n_hash_allow_md5_for_fips(&conn->handshake.prf_md5_hash_copy));
-        
-        /* Do not check s2n_hash_is_available before initialization. Allow MD5 and 
+
+        /* Do not check s2n_hash_is_available before initialization. Allow MD5 and
          * SHA-1 for both fips and non-fips mode. This is required to perform the
-         * signature checks in the CertificateVerify message in TLS 1.0 and TLS 1.1. 
+         * signature checks in the CertificateVerify message in TLS 1.0 and TLS 1.1.
          * This is approved per Nist SP 800-52r1.*/
         GUARD(s2n_hash_allow_md5_for_fips(&conn->handshake.md5_sha1));
     }
-    
+
     GUARD(s2n_hash_init(&conn->handshake.md5, S2N_HASH_MD5));
     GUARD(s2n_hash_init(&conn->handshake.prf_md5_hash_copy, S2N_HASH_MD5));
     GUARD(s2n_hash_init(&conn->handshake.md5_sha1, S2N_HASH_MD5_SHA1));
@@ -743,7 +743,7 @@ int s2n_connection_get_cipher_preferences(struct s2n_connection *conn, const str
     notnull_check(conn);
     notnull_check(cipher_preferences);
 
-    if(conn->cipher_pref_override != NULL) {
+    if (conn->cipher_pref_override != NULL) {
         *cipher_preferences = conn->cipher_pref_override;
     } else {
         *cipher_preferences = conn->config->cipher_preferences;
@@ -1203,4 +1203,3 @@ struct s2n_cert_chain_and_key *s2n_connection_get_selected_cert(struct s2n_conne
     notnull_check_ptr(conn);
     return conn->handshake_params.our_chain_and_key;
 }
-

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -209,8 +209,8 @@ struct s2n_connection {
      */
     uint16_t max_outgoing_fragment_length;
 
-    /* The number of bytes to send before changing the record size. 
-     * If this value > 0 then dynamic TLS record size is enabled. Otherwise, the feature is disabled (default). 
+    /* The number of bytes to send before changing the record size.
+     * If this value > 0 then dynamic TLS record size is enabled. Otherwise, the feature is disabled (default).
      */
     uint32_t dynamic_record_resize_threshold;
 

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -34,6 +34,8 @@
 #include "utils/s2n_safety.h"
 #include "utils/s2n_random.h"
 
+#include "tls/extensions/s2n_supported_versions.h"
+
 /* From RFC5246 7.4.1.2. */
 #define S2N_TLS_COMPRESSION_METHOD_NULL 0
 
@@ -139,10 +141,10 @@ int s2n_server_hello_recv(struct s2n_connection *conn)
 
         S2N_ERROR_IF(s2n_client_detect_downgrade_mechanism(conn), S2N_ERR_PROTOCOL_DOWNGRADE_DETECTED);
 
-        const struct s2n_cipher_preferences *cipher_preferences;
-        GUARD(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
+        uint8_t minimum_protocol_version;
+        GUARD(s2n_connection_get_minimum_supported_version(conn, &minimum_protocol_version));
 
-        if (conn->server_protocol_version < cipher_preferences->minimum_protocol_version
+        if (conn->server_protocol_version < minimum_protocol_version
                 || conn->server_protocol_version > conn->client_protocol_version) {
             GUARD(s2n_queue_reader_unsupported_protocol_version_alert(conn));
             S2N_ERROR(S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);


### PR DESCRIPTION
**Issue # (if available):** 
Add functionality to specify minimum protocol version.

The current plan is to give struct s2n_config a dedicated param to specify min version.

**So on config level, we have logic:**
When new function s2n_config_set_min_protocol_version() is called onto a config, and only when the input version is higher than the config's cipher preferences' default TLS version, the param will be overrode.

When s2n_config_set_cipher_preferences() is called onto a config, then its min version will be set back to the new cipher preferences' default TLS version.

**On connection level, we have logic:**
We don't specify another override version param for each single connection.
Each connection only reads min version according to:
Does it have connection-layer overrode cipher preference?
    If so, then use the cipher preference's default version
Else:
    Then use its config's min version, as mentioned above.

We don't add another override version param for each connection because it will add too much nested logic, add unnecessary complexity and we don't see any demands for it so far.

**Description of changes:** 
Add minimum_protocol_version param for struct s2n_config;
Add API int s2n_config_set_min_protocol_version(struct s2n_config *config, const char *version);
Change the way how we read a connection's current minimum TLS version

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
