### PR TITLE
Modified the Setting of client_protocol_version

### DIFF
--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -815,7 +815,7 @@ typedef int s2n_client_hello_fn(struct s2n_connection *conn, void *ctx);
 
 The callback function take as an input s2n connection, which received
 ClientHello and context provided in **s2n_config_set_client_hello_cb**. The
-callback can get any ClientHello infromation from the connection and use
+callback can get any ClientHello information from the connection and use
 **s2n_connection_set_config** call to change the config of the connection.
 
 If any of the properties of the connection were changed based on server_name

--- a/tests/unit/s2n_client_hello_recv_test.c
+++ b/tests/unit/s2n_client_hello_recv_test.c
@@ -38,20 +38,35 @@ int main(int argc, char **argv)
     struct s2n_connection *client_conn;
     struct s2n_stuffer *hello_stuffer;
     struct s2n_config *config;
+    struct s2n_config *tls13_config;
     struct s2n_cert_chain_and_key *chain_and_key;
+    struct s2n_cert_chain_and_key *tls13_chain_and_key;
     char *cert_chain;
+    char *tls13_cert_chain;
     char *private_key;
+    char *tls13_private_key;
 
     BEGIN_TEST();
 
     EXPECT_NOT_NULL(cert_chain = malloc(S2N_MAX_TEST_PEM_SIZE));
     EXPECT_NOT_NULL(private_key = malloc(S2N_MAX_TEST_PEM_SIZE));
     EXPECT_NOT_NULL(config = s2n_config_new());
+    EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
+   
+    EXPECT_NOT_NULL(tls13_cert_chain = malloc(S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_NOT_NULL(tls13_private_key = malloc(S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_NOT_NULL(tls13_config = s2n_config_new());
+    EXPECT_NOT_NULL(tls13_chain_and_key = s2n_cert_chain_and_key_new());
+
     EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
     EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key, S2N_MAX_TEST_PEM_SIZE));
-    EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
     EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain, private_key));
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+
+    EXPECT_SUCCESS(s2n_read_test_pem(S2N_ECDSA_P384_PKCS1_CERT_CHAIN, tls13_cert_chain, S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_SUCCESS(s2n_read_test_pem(S2N_ECDSA_P384_PKCS1_KEY, tls13_private_key, S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(tls13_chain_and_key, tls13_cert_chain, tls13_private_key));
+    EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(tls13_config, tls13_chain_and_key));
 
     /* These tests verify the logic behind the setting of these three connection fields: 
     server_protocol_version, client_protocol_version, and actual_protocol version. */ 
@@ -110,7 +125,7 @@ int main(int argc, char **argv)
         
         EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &client_conn->handshake.io.blob));
         EXPECT_SUCCESS(s2n_client_hello_recv(server_conn)); 
-        /* Check to make sure actual protocol version is set to tls13*/
+      
         EXPECT_SUCCESS(server_conn->server_protocol_version = S2N_TLS13);
         EXPECT_SUCCESS(server_conn->actual_protocol_version = S2N_TLS12);
         EXPECT_SUCCESS(server_conn->client_protocol_version = S2N_TLS12);
@@ -124,8 +139,11 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_enable_tls13());
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, tls13_config));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "default_tls13"));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
 
         hello_stuffer = &client_conn->handshake.io;
 
@@ -140,7 +158,7 @@ int main(int argc, char **argv)
         
         EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &hello_stuffer->blob));
         EXPECT_SUCCESS(s2n_client_hello_recv(server_conn)); 
-        /* Check to make sure actual protocol version is set to tls13 */
+
         EXPECT_SUCCESS(server_conn->server_protocol_version = S2N_TLS13);
         EXPECT_SUCCESS(server_conn->actual_protocol_version = S2N_TLS13);
         EXPECT_SUCCESS(server_conn->client_protocol_version = S2N_TLS13);
@@ -154,14 +172,17 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_enable_tls13());
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, tls13_config));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "default_tls13"));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
 
         EXPECT_SUCCESS(s2n_client_hello_send(client_conn)); 
         
         EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &client_conn->handshake.io.blob));
         EXPECT_SUCCESS(s2n_client_hello_recv(server_conn)); 
-        /* Check to make sure actual protocol version is set to tls13*/
+       
         EXPECT_SUCCESS(server_conn->server_protocol_version = S2N_TLS13);
         EXPECT_SUCCESS(server_conn->actual_protocol_version = S2N_TLS13);
         EXPECT_SUCCESS(server_conn->client_protocol_version = S2N_TLS13);
@@ -177,6 +198,8 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
         client_conn->client_protocol_version = S2N_TLS12;
         hello_stuffer = &client_conn->handshake.io;
 
@@ -191,7 +214,7 @@ int main(int argc, char **argv)
         
         EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &hello_stuffer->blob));
         EXPECT_SUCCESS(s2n_client_hello_recv(server_conn)); 
-        /* Check to make sure actual protocol version is set to tls13*/
+    
         EXPECT_SUCCESS(server_conn->server_protocol_version = S2N_TLS13);
         EXPECT_SUCCESS(server_conn->actual_protocol_version = S2N_TLS12);
         EXPECT_SUCCESS(server_conn->client_protocol_version = S2N_TLS12);
@@ -201,9 +224,13 @@ int main(int argc, char **argv)
     } 
 
     s2n_config_free(config);
+    s2n_config_free(tls13_config);
     s2n_cert_chain_and_key_free(chain_and_key);
     free(cert_chain);
     free(private_key);
+    s2n_cert_chain_and_key_free(tls13_chain_and_key);
+    free(tls13_cert_chain);
+    free(tls13_private_key);
     EXPECT_SUCCESS(s2n_disable_tls13());
     END_TEST();
     return 0;

--- a/tests/unit/s2n_client_hello_recv_test.c
+++ b/tests/unit/s2n_client_hello_recv_test.c
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "testlib/s2n_testlib.h"
+
+#include <sys/wait.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <fcntl.h>
+#include <errno.h>
+
+#include <s2n.h>
+
+#include "tls/s2n_tls.h"
+#include "tls/s2n_tls13.h"
+#include "tls/s2n_connection.h"
+#include "tls/s2n_client_hello.h"
+
+#include "utils/s2n_safety.h"
+
+int main(int argc, char **argv)
+{
+    struct s2n_connection *conn;
+    struct s2n_stuffer *hello_stuffer;
+    struct s2n_config *config;
+    struct s2n_cert_chain_and_key *chain_and_key;
+    char *cert_chain;
+    char *private_key;
+
+    BEGIN_TEST();
+
+    EXPECT_NOT_NULL(cert_chain = malloc(S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_NOT_NULL(private_key = malloc(S2N_MAX_TEST_PEM_SIZE));
+    
+    /* These tests verify the logic behind the setting of these three connection fields: 
+    server_protocol_version, client_protocol_version, and actual_protocol version. */ 
+    
+    /* Test that a tls12 client legacy version and tls12 server version 
+    will successfully set a tls12 connection, since tls13 is not enabled. */
+    {
+        EXPECT_NOT_NULL(config = s2n_config_new());
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain, private_key));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+        conn->client_protocol_version = S2N_TLS12;
+        
+        EXPECT_SUCCESS(s2n_client_hello_send(conn));
+
+        EXPECT_SUCCESS(s2n_client_hello_recv(conn));
+
+        EXPECT_SUCCESS(conn->server_protocol_version = S2N_TLS12);
+        EXPECT_SUCCESS(conn->actual_protocol_version = S2N_TLS12);
+        EXPECT_SUCCESS(conn->client_protocol_version = S2N_TLS12);
+
+        s2n_connection_free(conn);
+        s2n_config_free(config);
+        s2n_cert_chain_and_key_free(chain_and_key);
+    }
+    /* Test that a tls11 client legacy version and tls12 server version 
+    will successfully set a tls11 connection. */
+    {
+        EXPECT_NOT_NULL(config = s2n_config_new());
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain, private_key));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+        conn->client_protocol_version = S2N_TLS11;
+        
+        EXPECT_SUCCESS(s2n_client_hello_send(conn));
+
+        EXPECT_SUCCESS(s2n_client_hello_recv(conn));
+
+        EXPECT_SUCCESS(conn->server_protocol_version = S2N_TLS12);
+        EXPECT_SUCCESS(conn->actual_protocol_version = S2N_TLS11);
+        EXPECT_SUCCESS(conn->client_protocol_version = S2N_TLS11);
+
+        s2n_connection_free(conn);
+        s2n_config_free(config);
+        s2n_cert_chain_and_key_free(chain_and_key);
+    }
+    /* Test that an erroneous client legacy version and tls13 server version 
+    will still successfully set a tls13 connection, if possible. */
+    {
+        EXPECT_SUCCESS(s2n_enable_tls13());
+        EXPECT_NOT_NULL(config = s2n_config_new());
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+        conn->server_protocol_version = S2N_TLS13;
+        hello_stuffer = &conn->handshake.io;
+
+        EXPECT_SUCCESS(s2n_client_hello_send(conn));
+
+        /* Overwrite the client legacy version so that it reads tls13 (incorrectly) */
+        uint8_t incorrect_protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN];
+        incorrect_protocol_version[0] = S2N_TLS13 / 10;
+        incorrect_protocol_version[1] = S2N_TLS13 % 10;
+        EXPECT_SUCCESS(s2n_stuffer_rewrite(hello_stuffer));
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(hello_stuffer, incorrect_protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));
+        hello_stuffer->write_cursor = hello_stuffer->high_water_mark;
+
+        EXPECT_SUCCESS(s2n_client_hello_recv(conn));
+        /* Check to make sure actual protocol version is set to tls13*/
+        EXPECT_SUCCESS(conn->server_protocol_version = S2N_TLS13);
+        EXPECT_SUCCESS(conn->actual_protocol_version = S2N_TLS13);
+        EXPECT_SUCCESS(conn->client_protocol_version = S2N_TLS12);
+
+        s2n_connection_free(conn);
+        s2n_config_free(config);
+    }
+
+    free(cert_chain);
+    free(private_key);
+    EXPECT_SUCCESS(s2n_disable_tls13());
+    END_TEST();
+    return 0;
+}

--- a/tests/unit/s2n_client_hello_recv_test.c
+++ b/tests/unit/s2n_client_hello_recv_test.c
@@ -34,7 +34,8 @@
 
 int main(int argc, char **argv)
 {
-    struct s2n_connection *conn;
+    struct s2n_connection *server_conn;
+    struct s2n_connection *client_conn;
     struct s2n_stuffer *hello_stuffer;
     struct s2n_config *config;
     struct s2n_cert_chain_and_key *chain_and_key;
@@ -45,90 +46,162 @@ int main(int argc, char **argv)
 
     EXPECT_NOT_NULL(cert_chain = malloc(S2N_MAX_TEST_PEM_SIZE));
     EXPECT_NOT_NULL(private_key = malloc(S2N_MAX_TEST_PEM_SIZE));
-    
+    EXPECT_NOT_NULL(config = s2n_config_new());
+    EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key, S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
+    EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain, private_key));
+    EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+
     /* These tests verify the logic behind the setting of these three connection fields: 
     server_protocol_version, client_protocol_version, and actual_protocol version. */ 
     
     /* Test that a tls12 client legacy version and tls12 server version 
     will successfully set a tls12 connection, since tls13 is not enabled. */
     {
-        EXPECT_NOT_NULL(config = s2n_config_new());
-        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key, S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
-        EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain, private_key));
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
-        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
-        conn->client_protocol_version = S2N_TLS12;
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
         
-        EXPECT_SUCCESS(s2n_client_hello_send(conn));
+        EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
+        EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &client_conn->handshake.io.blob));
+        EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
 
-        EXPECT_SUCCESS(s2n_client_hello_recv(conn));
+        EXPECT_SUCCESS(server_conn->server_protocol_version = S2N_TLS12);
+        EXPECT_SUCCESS(server_conn->actual_protocol_version = S2N_TLS12);
+        EXPECT_SUCCESS(server_conn->client_protocol_version = S2N_TLS12);
 
-        EXPECT_SUCCESS(conn->server_protocol_version = S2N_TLS12);
-        EXPECT_SUCCESS(conn->actual_protocol_version = S2N_TLS12);
-        EXPECT_SUCCESS(conn->client_protocol_version = S2N_TLS12);
-
-        s2n_connection_free(conn);
-        s2n_config_free(config);
-        s2n_cert_chain_and_key_free(chain_and_key);
+        s2n_connection_free(server_conn);
+        s2n_connection_free(client_conn);
     }
     /* Test that a tls11 client legacy version and tls12 server version 
     will successfully set a tls11 connection. */
     {
-        EXPECT_NOT_NULL(config = s2n_config_new());
-        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key, S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
-        EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain, private_key));
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
-        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
-        conn->client_protocol_version = S2N_TLS11;
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
+        client_conn->client_protocol_version = S2N_TLS11;
         
-        EXPECT_SUCCESS(s2n_client_hello_send(conn));
+        EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
+        EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &client_conn->handshake.io.blob));
+        EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
 
-        EXPECT_SUCCESS(s2n_client_hello_recv(conn));
+        EXPECT_SUCCESS(server_conn->server_protocol_version = S2N_TLS12);
+        EXPECT_SUCCESS(server_conn->actual_protocol_version = S2N_TLS11);
+        EXPECT_SUCCESS(server_conn->client_protocol_version = S2N_TLS11);
 
-        EXPECT_SUCCESS(conn->server_protocol_version = S2N_TLS12);
-        EXPECT_SUCCESS(conn->actual_protocol_version = S2N_TLS11);
-        EXPECT_SUCCESS(conn->client_protocol_version = S2N_TLS11);
-
-        s2n_connection_free(conn);
-        s2n_config_free(config);
-        s2n_cert_chain_and_key_free(chain_and_key);
+        s2n_connection_free(server_conn);
+        s2n_connection_free(client_conn);
     }
+    /* Test that a tls12 client and tls13 server will successfully 
+    set a tls12 connection. */ 
+    {
+        EXPECT_SUCCESS(s2n_enable_tls13());
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+        client_conn->client_protocol_version = S2N_TLS12;
+
+        EXPECT_SUCCESS(s2n_client_hello_send(client_conn)); 
+        
+        EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &client_conn->handshake.io.blob));
+        EXPECT_SUCCESS(s2n_client_hello_recv(server_conn)); 
+        /* Check to make sure actual protocol version is set to tls13*/
+        EXPECT_SUCCESS(server_conn->server_protocol_version = S2N_TLS13);
+        EXPECT_SUCCESS(server_conn->actual_protocol_version = S2N_TLS12);
+        EXPECT_SUCCESS(server_conn->client_protocol_version = S2N_TLS12);
+
+        s2n_connection_free(server_conn);
+        s2n_connection_free(client_conn);
+    } 
     /* Test that an erroneous client legacy version and tls13 server version 
     will still successfully set a tls13 connection, if possible. */
     {
         EXPECT_SUCCESS(s2n_enable_tls13());
-        EXPECT_NOT_NULL(config = s2n_config_new());
-        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
-        conn->server_protocol_version = S2N_TLS13;
-        hello_stuffer = &conn->handshake.io;
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
-        EXPECT_SUCCESS(s2n_client_hello_send(conn));
+        hello_stuffer = &client_conn->handshake.io;
 
-        /* Overwrite the client legacy version so that it reads tls13 (incorrectly) */
+        EXPECT_SUCCESS(s2n_client_hello_send(client_conn)); 
+
+        /* Overwrite the client legacy version so that it reads tls13 (incorrectly) */ 
         uint8_t incorrect_protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN];
         incorrect_protocol_version[0] = S2N_TLS13 / 10;
         incorrect_protocol_version[1] = S2N_TLS13 % 10;
         EXPECT_SUCCESS(s2n_stuffer_rewrite(hello_stuffer));
         EXPECT_SUCCESS(s2n_stuffer_write_bytes(hello_stuffer, incorrect_protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));
-        hello_stuffer->write_cursor = hello_stuffer->high_water_mark;
+        
+        EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &hello_stuffer->blob));
+        EXPECT_SUCCESS(s2n_client_hello_recv(server_conn)); 
+        /* Check to make sure actual protocol version is set to tls13 */
+        EXPECT_SUCCESS(server_conn->server_protocol_version = S2N_TLS13);
+        EXPECT_SUCCESS(server_conn->actual_protocol_version = S2N_TLS13);
+        EXPECT_SUCCESS(server_conn->client_protocol_version = S2N_TLS13);
 
-        EXPECT_SUCCESS(s2n_client_hello_recv(conn));
+        s2n_connection_free(server_conn);
+        s2n_connection_free(client_conn);
+    } 
+    /* Test that a tls12 client legacy version and tls13 server version 
+    will still successfully set a tls13 connection, if possible. */
+    {
+        EXPECT_SUCCESS(s2n_enable_tls13());
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
+        EXPECT_SUCCESS(s2n_client_hello_send(client_conn)); 
+        
+        EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &client_conn->handshake.io.blob));
+        EXPECT_SUCCESS(s2n_client_hello_recv(server_conn)); 
         /* Check to make sure actual protocol version is set to tls13*/
-        EXPECT_SUCCESS(conn->server_protocol_version = S2N_TLS13);
-        EXPECT_SUCCESS(conn->actual_protocol_version = S2N_TLS13);
-        EXPECT_SUCCESS(conn->client_protocol_version = S2N_TLS12);
+        EXPECT_SUCCESS(server_conn->server_protocol_version = S2N_TLS13);
+        EXPECT_SUCCESS(server_conn->actual_protocol_version = S2N_TLS13);
+        EXPECT_SUCCESS(server_conn->client_protocol_version = S2N_TLS13);
 
-        s2n_connection_free(conn);
-        s2n_config_free(config);
-    }
+        s2n_connection_free(server_conn);
+        s2n_connection_free(client_conn);
+    } 
+     /* Test that an erroneous(tls13) client legacy version and tls13 server version 
+    will still successfully set a tls12 connection, if tls13 is not possible. */
+    {
+        EXPECT_SUCCESS(s2n_enable_tls13());
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+        client_conn->client_protocol_version = S2N_TLS12;
+        hello_stuffer = &client_conn->handshake.io;
 
+        EXPECT_SUCCESS(s2n_client_hello_send(client_conn)); 
+
+        /* Overwrite the client legacy version so that it reads tls13 (incorrectly) */ 
+        uint8_t incorrect_protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN];
+        incorrect_protocol_version[0] = S2N_TLS13 / 10;
+        incorrect_protocol_version[1] = S2N_TLS13 % 10;
+        EXPECT_SUCCESS(s2n_stuffer_rewrite(hello_stuffer));
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(hello_stuffer, incorrect_protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));
+        
+        EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &hello_stuffer->blob));
+        EXPECT_SUCCESS(s2n_client_hello_recv(server_conn)); 
+        /* Check to make sure actual protocol version is set to tls13*/
+        EXPECT_SUCCESS(server_conn->server_protocol_version = S2N_TLS13);
+        EXPECT_SUCCESS(server_conn->actual_protocol_version = S2N_TLS12);
+        EXPECT_SUCCESS(server_conn->client_protocol_version = S2N_TLS12);
+
+        s2n_connection_free(server_conn);
+        s2n_connection_free(client_conn);
+    } 
+
+    s2n_config_free(config);
+    s2n_cert_chain_and_key_free(chain_and_key);
     free(cert_chain);
     free(private_key);
     EXPECT_SUCCESS(s2n_disable_tls13());

--- a/tests/unit/s2n_self_talk_min_protocol_version.c
+++ b/tests/unit/s2n_self_talk_min_protocol_version.c
@@ -41,7 +41,7 @@ int mock_client(struct s2n_test_piped_io *piped_io)
     s2n_connection_set_config(client_conn, client_config);
     s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING);
 
-    /* Force TLSv1 on a client so that server fail handshake */
+    /* Force TLSv1 on a client so that server will fail handshake */
     client_conn->client_protocol_version = S2N_TLS10;
 
     s2n_connection_set_piped_io(client_conn, piped_io);

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -172,13 +172,16 @@ static int s2n_parse_client_hello(struct s2n_connection *conn)
     GUARD(s2n_stuffer_erase_and_read_bytes(in, conn->secure.client_random, S2N_TLS_RANDOM_DATA_LEN));
     GUARD(s2n_stuffer_read_uint8(in, &conn->session_id_len));
 
-    conn->client_protocol_version = (client_protocol_version[0] * 10) + client_protocol_version[1];
+    conn->client_protocol_version = MIN((client_protocol_version[0] * 10) + client_protocol_version[1], S2N_TLS12);
     conn->client_hello_version = conn->client_protocol_version;
     /* Protocol version in the ClientHello is fixed at 0x0303(TLS 1.2) for
      * future versions of TLS. Still, we will negotiate down if a client sends
      * an unexpected value above 0x0303.
      */
-    conn->actual_protocol_version = MIN(conn->client_protocol_version, conn->server_protocol_version);
+    if (conn->server_protocol_version < S2N_TLS13)
+    {
+        conn->actual_protocol_version = MIN(conn->client_protocol_version, conn->server_protocol_version);
+    } 
 
     S2N_ERROR_IF(conn->session_id_len > S2N_TLS_SESSION_ID_MAX_LEN || conn->session_id_len > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);
 

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -172,17 +172,13 @@ static int s2n_parse_client_hello(struct s2n_connection *conn)
     GUARD(s2n_stuffer_erase_and_read_bytes(in, conn->secure.client_random, S2N_TLS_RANDOM_DATA_LEN));
     GUARD(s2n_stuffer_read_uint8(in, &conn->session_id_len));
 
-    conn->client_protocol_version = MIN((client_protocol_version[0] * 10) + client_protocol_version[1], S2N_TLS12);
-    conn->client_hello_version = conn->client_protocol_version;
     /* Protocol version in the ClientHello is fixed at 0x0303(TLS 1.2) for
-     * future versions of TLS. Still, we will negotiate down if a client sends
+     * future versions of TLS. Therefore, we will negotiate down if a client sends
      * an unexpected value above 0x0303.
      */
-    if (conn->server_protocol_version < S2N_TLS13)
-    {
-        conn->actual_protocol_version = MIN(conn->client_protocol_version, conn->server_protocol_version);
-    } 
-
+    conn->client_protocol_version = MIN((client_protocol_version[0] * 10) + client_protocol_version[1], S2N_TLS12);
+    conn->client_hello_version = conn->client_protocol_version;
+    
     S2N_ERROR_IF(conn->session_id_len > S2N_TLS_SESSION_ID_MAX_LEN || conn->session_id_len > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);
 
     GUARD(s2n_stuffer_read_bytes(in, conn->session_id, conn->session_id_len));
@@ -300,7 +296,10 @@ int s2n_process_client_hello(struct s2n_connection *conn)
     if (client_hello->parsed_extensions != NULL && client_hello->parsed_extensions->num_of_elements > 0) {
         GUARD(s2n_client_extensions_recv(conn, client_hello->parsed_extensions));
     }
-
+    
+    if (conn->actual_protocol_version != S2N_TLS13) {
+        conn->actual_protocol_version = MIN(conn->server_protocol_version, conn->client_protocol_version);
+    }
     const struct s2n_cipher_preferences *cipher_preferences;
     GUARD(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
 


### PR DESCRIPTION
**Issue # (if available):** 
#1415
**Description of changes:** 
- In tls13 the client protocol version is sent in the extensions. Thus if the client sends a legacy protocol version that is greater than tls12 NOT in extensions, the client protocol version will be set to tls12 because its probably a bug. 
- Additionally, now actual_protocol_version is set to the minimum version between server and client after extensions have been parsed, which is where we actually determine which protocol to use.
- Also fixed spelling mistake and grammar mistake.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
