### PR TITLE
try_compile PQ ASM code before including it in build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,22 +64,6 @@ file(GLOB PQ_SRC
         "pq-crypto/sike_r2/P434.c"
         )
 
-if(S2N_NO_PQ_ASM)
-    message(STATUS "Forcing usage of generic C code for PQ crypto")
-elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "Darwin")
-    set(S2N_NO_PQ_ASM ON)	
-    message(STATUS "Detected Darwin, using generic C code for PQ crypto")
-elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64" OR ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "amd64" OR (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "AMD64" AND CMAKE_CL_64))
-    message(STATUS "Using optimized x86_64 assembly for PQ crypto")
-    enable_language(ASM)
-    file(GLOB PQ_X86_64_ASM
-            "pq-crypto/sike_r2/fp_x64_asm.S")
-    list(APPEND PQ_SRC ${PQ_X86_64_ASM})
-else()
-    set(S2N_NO_PQ_ASM ON)
-    message(STATUS "Architecture is not x86_64 compatible - using generic C code for PQ crypto")
-endif()
-
 file(GLOB STUFFER_SRC
     "stuffer/*.c"
 )
@@ -111,6 +95,27 @@ if(MSVC)
 else()
     set(THREADS_PREFER_PTHREAD_FLAG ON)
     find_package(Threads REQUIRED)
+endif()
+
+# The PQ ASM try_compile has to come after we turn on pthread
+if(S2N_NO_PQ_ASM)
+    message(STATUS "S2N_NO_PQ_ASM flag was detected - forcing usage of generic C code for PQ crypto")
+else()
+    message(STATUS "Attempting to try_compile PQ ASM")
+    set(PQ_ASM_COMPILES false)
+    enable_language(ASM)
+    try_compile(PQ_ASM_COMPILES ${CMAKE_BINARY_DIR}
+            SOURCES
+            "${CMAKE_SOURCE_DIR}/tests/unit/s2n_pq_asm_noop_test.c"
+            "${CMAKE_SOURCE_DIR}/pq-crypto/sike_r2/fp_x64_asm.S")
+    if(PQ_ASM_COMPILES)
+        message(STATUS "PQ ASM try_compile succeeded - using optimized x86_64 assembly for PQ crypto")
+        file(GLOB PQ_X86_64_ASM "pq-crypto/sike_r2/fp_x64_asm.S")
+        list(APPEND PQ_SRC ${PQ_X86_64_ASM})
+    else()
+        message(STATUS "PQ ASM try_compile failed - using generic C code for PQ crypto")
+        set(S2N_NO_PQ_ASM ON)
+    endif()
 endif()
 
 if(APPLE)

--- a/pq-crypto/README.md
+++ b/pq-crypto/README.md
@@ -41,6 +41,12 @@ review. The known answer tests are [here](https://github.com/awslabs/s2n/blob/ma
 and use the BIKE1_L1.const.kat from the above Additional_Implementation.2019.03.30.zip. This implementation uses constant
 time primitives on x86 and aarch64 platforms.
 
+## How to disable optimized assembly code for PQ Crypto
+Certain post-quantum KEM algorithms included in s2n use optimized assembly code for efficient computation. When compiling s2n on compatible toolchains,
+the optimized assembly code will significantly improve performance of the post-quantum cryptographic operations. s2n attempts to detect whether or not
+the architecture is compatible with the assembly code, and falls back to the portable C implementation if it detects incompatibility. However, some users
+may wish to manually force s2n to use the portable C implementation. To do so, simply `export S2N_NO_PQ_ASM=1` as an environment variable before compiling.
+
 ## How to add a new PQ KEM family
 1. Add the code to `pq-crypto/KEM_NAME/`
     1. Update `pq-crypto/Makefile` to build that directory

--- a/pq-crypto/sike_r2/Makefile
+++ b/pq-crypto/sike_r2/Makefile
@@ -16,17 +16,6 @@
 SRCS=fips202.c P434.c
 OBJS=$(SRCS:.c=.o)
 
-ARCH := $(shell uname -p)
-KERNEL := $(shell uname -s)
-ifeq ($(KERNEL), Linux)
-ifeq ($(ARCH), x86_64)
-ifndef S2N_NO_PQ_ASM
-ASRC=fp_x64_asm.S
-OBJS+=$(ASRC:.S=.o)
-endif
-endif
-endif
-
 # TODO add when ready for SIKE R2 SAW proofs
 #BCS_1=fips202.bc P434.bc
 #BCS=$(addprefix $(BITCODE_DIR), $(BCS_1))
@@ -39,3 +28,21 @@ all: $(OBJS)
 #bc: $(BCS)
 
 include ../../s2n.mk
+
+# Verify that the ASM code compiles before actually including it in the build.
+# Output is directed to /dev/null so it doesn't pollute the console on compilation
+# failures that may be expected.
+# Note that if compilation is successful, you probably will not see Make re-compile
+# fp_x64_asm.S in the logs when it compiles the rest of the sike_r2 code, since the
+# object file is up to date. If you're looking to sanity check that the ASM was
+# included in the build, you will be able to see fp_x64_asm.o linked at the end
+# of the build.
+ifndef S2N_NO_PQ_ASM
+	TRY_COMPILE_PQ_ASM := $(shell $(CC) -c -o ./fp_x64_asm.o ./fp_x64_asm.S > /dev/null 2>&1; echo $$?)
+	ifeq ($(TRY_COMPILE_PQ_ASM), 0)
+		ASRC=fp_x64_asm.S
+		OBJS+=$(ASRC:.S=.o)
+	else
+		CFLAGS += -DS2N_NO_PQ_ASM
+	endif
+endif

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -31,6 +31,18 @@ all: $(UNIT_TESTS)
 
 include ../../s2n.mk
 
+# Verify that the ASM code compiles before actually including it in the build.
+# (At least) One unit test verifies if we are using the PQ ASM code, so we need to
+# include the flag here as appropriate.
+# Output is directed to /dev/null so it doesn't pollute the console on compilation
+# failures that may be expected.
+ifndef S2N_NO_PQ_ASM
+	TRY_COMPILE_PQ_ASM := $(shell $(CC) -c -o ../../pq-crypto/sike_r2/fp_x64_asm.o ../../pq-crypto/sike_r2/fp_x64_asm.S > /dev/null 2>&1; echo $$?)
+	ifneq ($(TRY_COMPILE_PQ_ASM), 0)
+		CFLAGS += -DS2N_NO_PQ_ASM
+	endif
+endif
+
 CRUFT += $(wildcard *_test)
 LIBS += -lm -ltests2n -ls2n -ldl
 

--- a/tests/unit/s2n_pq_asm_noop_test.c
+++ b/tests/unit/s2n_pq_asm_noop_test.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+int main(int argc, char **argv)
+{
+    /* In CMakeLists.txt, we try_compile the PQ ASM code to determine if the
+     * toolchain is compatible with the assembly instructions. Older versions
+     * of CMake require that we supply a main() function in the sources that
+     * we are passing to try_compile. So, in the try_compile, we use this main()
+     * function as a noop. IMPORTANT NOTE: This file is referenced by name
+     * in CMakeLists.txt (which is unusual for a unit tst). If this file is
+     * renamed, then CMakeLists.txt must be updated as well.*/
+    return 0;
+}


### PR DESCRIPTION
**Issue # (if available):** N/A

**Description of changes:** ~~Disables PQ assembly unless all of the following are true: on Linux, x86_64 platform, using GCC >= version 4.9.0.~~ Attempts a dry-run compile of the PQ ASM code as a more robust solution to verify that the host toolchain is compatible.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
