### PR TITLE
s2n_stuffer_copy cbmc proof

### DIFF
--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -428,7 +428,9 @@ int s2n_stuffer_reserve_space(struct s2n_stuffer *stuffer, uint32_t n)
 	S2N_ERROR_IF(!stuffer->growable, S2N_ERR_STUFFER_IS_FULL);
 	/* Always grow a stuffer by at least 1k */
 	const uint32_t growth = MAX(n - s2n_stuffer_space_remaining(stuffer), 1024);
-	GUARD(s2n_stuffer_resize(stuffer, stuffer->blob.size + growth));
+    uint32_t new_size = 0;
+    GUARD(s2n_add_overflow(stuffer->blob.size, growth, &new_size));
+	GUARD(s2n_stuffer_resize(stuffer, new_size));
     }
     return S2N_SUCCESS;
 }

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -425,12 +425,12 @@ static int s2n_stuffer_copy_impl(struct s2n_stuffer *from, struct s2n_stuffer *t
 int s2n_stuffer_reserve_space(struct s2n_stuffer *stuffer, uint32_t n)
 {
     if (s2n_stuffer_space_remaining(stuffer) < n) {
-	S2N_ERROR_IF(!stuffer->growable, S2N_ERR_STUFFER_IS_FULL);
-	/* Always grow a stuffer by at least 1k */
-	const uint32_t growth = MAX(n - s2n_stuffer_space_remaining(stuffer), 1024);
-    uint32_t new_size = 0;
-    GUARD(s2n_add_overflow(stuffer->blob.size, growth, &new_size));
-	GUARD(s2n_stuffer_resize(stuffer, new_size));
+        S2N_ERROR_IF(!stuffer->growable, S2N_ERR_STUFFER_IS_FULL);
+        /* Always grow a stuffer by at least 1k */
+        const uint32_t growth = MAX(n - s2n_stuffer_space_remaining(stuffer), 1024);
+        uint32_t new_size = 0;
+        GUARD(s2n_add_overflow(stuffer->blob.size, growth, &new_size));
+        GUARD(s2n_stuffer_resize(stuffer, new_size));
     }
     return S2N_SUCCESS;
 }

--- a/tests/cbmc/proofs/s2n_stuffer_copy/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_copy/Makefile
@@ -1,0 +1,32 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+
+ENTRY = s2n_stuffer_copy_harness
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_copy/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_copy/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;6"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_copy_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_copy/s2n_stuffer_copy_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_copy/s2n_stuffer_copy_harness.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <error/s2n_errno.h>
+
+int s2n_get_memory(struct s2n_blob *b, uint32_t size)
+{
+    *b = (struct s2n_blob) {.data = nondet_bool() ? malloc(size) : 0,
+            .size = size, .allocated = size, .mlocked = 0, .growable = 1};
+    S2N_ERROR_IF(b->data == NULL, S2N_ERR_ALLOC);
+    return S2N_SUCCESS;
+}
+
+void s2n_stuffer_copy_harness() {
+    struct s2n_stuffer *from = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(from));
+    struct s2n_stuffer old_stuffer = *from;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_blob(&from->blob, &old_byte);
+    struct s2n_stuffer *to = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(to));
+    uint32_t length;
+
+    s2n_stuffer_copy(from, to, length);
+
+    /* These assertions should always hold, regardless of whether the test succeeded */
+    assert(from->blob.data == old_stuffer.blob.data);
+    assert(from->blob.size == old_stuffer.blob.size);
+    assert(from->write_cursor == old_stuffer.write_cursor);
+    assert(from->high_water_mark == old_stuffer.high_water_mark);
+    assert(from->alloced == old_stuffer.alloced);
+    assert(from->growable == old_stuffer.growable);
+    assert(from->tainted == old_stuffer.tainted);
+    assert_byte_from_blob_matches(&from->blob, &old_byte);
+    assert(s2n_stuffer_is_valid(from));
+
+}

--- a/tests/cbmc/proofs/s2n_stuffer_copy/s2n_stuffer_copy_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_copy/s2n_stuffer_copy_harness.c
@@ -22,6 +22,8 @@
 #include <cbmc_proof/make_common_datastructures.h>
 #include <error/s2n_errno.h>
 
+/* The stuffer function s2n_get_memory fails the cbmc proof. This stub is needed
+until that proof has been written. */
 int s2n_get_memory(struct s2n_blob *b, uint32_t size)
 {
     *b = (struct s2n_blob) {.data = nondet_bool() ? malloc(size) : 0,

--- a/tests/cbmc/source/make_common_datastructures.c
+++ b/tests/cbmc/source/make_common_datastructures.c
@@ -15,7 +15,7 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 void ensure_s2n_blob_has_allocated_fields(struct s2n_blob* blob) {
-    blob->data = bounded_malloc(blob->allocated);
+    blob->data = blob->growable ? bounded_malloc(blob->allocated) : bounded_malloc(blob->size);
 }
 
 struct s2n_blob* cbmc_allocate_s2n_blob() {

--- a/tests/cbmc/source/make_common_datastructures.c
+++ b/tests/cbmc/source/make_common_datastructures.c
@@ -15,7 +15,7 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 void ensure_s2n_blob_has_allocated_fields(struct s2n_blob* blob) {
-    blob->data = bounded_malloc(blob->size);
+    blob->data = bounded_malloc(blob->allocated);
 }
 
 struct s2n_blob* cbmc_allocate_s2n_blob() {

--- a/tests/unit/s2n_cbc_verify_test.c
+++ b/tests/unit/s2n_cbc_verify_test.c
@@ -159,7 +159,9 @@ int main(int argc, char **argv)
 
         /* Start out with zero byte padding */
         fragment[i - 1] = 0;
-        struct s2n_blob decrypted = { .data = fragment, .size = i};
+        
+        struct s2n_blob decrypted = {0};
+        s2n_blob_init(&decrypted, fragment, i);
 
         uint64_t timings[10001];
         for (int t = 0; t < 10001; t++) {

--- a/tests/unit/s2n_safety_test.c
+++ b/tests/unit/s2n_safety_test.c
@@ -360,6 +360,26 @@ int main(int argc, char **argv)
 
     EXPECT_FAILURE(s2n_align_to(UINT32_MAX - 4000, 4096, &result));
     EXPECT_FAILURE(s2n_align_to(UINT32_MAX, 4096, &result));
+    const uint32_t HALF_MAX = UINT32_MAX / 2;
+    const uint32_t ACTUAL_MAX = UINT32_MAX;
+
+    CHECK_NO_OVF(s2n_add_overflow, uint32_t, 0, 0, 0);
+    CHECK_NO_OVF(s2n_add_overflow, uint32_t, 0, 1, 1);
+    CHECK_NO_OVF(s2n_add_overflow, uint32_t, 4, 5, 9);
+    CHECK_NO_OVF(s2n_add_overflow, uint32_t, 1234, 4321, 5555);
+    CHECK_NO_OVF(s2n_add_overflow, uint32_t, 0, ACTUAL_MAX, ACTUAL_MAX);
+    CHECK_NO_OVF(s2n_add_overflow, uint32_t, HALF_MAX, HALF_MAX, ACTUAL_MAX - 1);
+    CHECK_NO_OVF(s2n_add_overflow, uint32_t, HALF_MAX + 1, HALF_MAX, ACTUAL_MAX);
+    CHECK_NO_OVF(s2n_add_overflow, uint32_t, 100, ACTUAL_MAX - 102, ACTUAL_MAX - 2);
+    CHECK_NO_OVF(s2n_add_overflow, uint32_t, 100, ACTUAL_MAX - 100, ACTUAL_MAX);
+    CHECK_OVF(s2n_add_overflow, uint32_t, 1, ACTUAL_MAX);
+    CHECK_OVF(s2n_add_overflow, uint32_t, 100, ACTUAL_MAX);
+    CHECK_OVF(s2n_add_overflow, uint32_t, HALF_MAX, ACTUAL_MAX);
+    CHECK_OVF(s2n_add_overflow, uint32_t, ACTUAL_MAX, ACTUAL_MAX);
+    CHECK_OVF(s2n_add_overflow, uint32_t, HALF_MAX + 1, HALF_MAX + 1);
+    CHECK_OVF(s2n_add_overflow, uint32_t, 100, ACTUAL_MAX - 99);
+    CHECK_OVF(s2n_add_overflow, uint32_t, 100, ACTUAL_MAX - 1);
+
     END_TEST();
     return 0;
 }

--- a/tests/unit/s2n_tls13_support_test.c
+++ b/tests/unit/s2n_tls13_support_test.c
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
 
         uint8_t original_data_size = s2n_stuffer_data_available(&extension_data);
 
-        struct s2n_array *extensions = s2n_array_new(sizeof(struct s2n_client_hello_parsed_extension*));
+        struct s2n_array *extensions = s2n_array_new(sizeof(struct s2n_client_hello_parsed_extension));
         for (int i=0; i < sizeof(tls13_extensions) / sizeof(uint8_t); i++) {
             struct s2n_client_hello_parsed_extension *extension;
             EXPECT_NOT_NULL(extension = s2n_array_pushback(extensions));
@@ -116,7 +116,7 @@ int main(int argc, char **argv)
         struct s2n_stuffer extension_data;
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&extension_data, 0));
 
-        struct s2n_array *extensions = s2n_array_new(sizeof(struct s2n_client_hello_parsed_extension*));
+        struct s2n_array *extensions = s2n_array_new(sizeof(struct s2n_client_hello_parsed_extension));
         struct s2n_client_hello_parsed_extension *extension;
         EXPECT_NOT_NULL(extension = s2n_array_pushback(extensions));
 

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -353,9 +353,7 @@ int s2n_client_hello_send(struct s2n_connection *conn)
     struct s2n_blob b, r;
     uint8_t client_protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN];
 
-    b.data = conn->secure.client_random;
-    b.size = S2N_TLS_RANDOM_DATA_LEN;
-
+    GUARD(s2n_blob_init(&b, conn->secure.client_random, S2N_TLS_RANDOM_DATA_LEN));
     /* Create the client random data */
     GUARD(s2n_stuffer_init(&client_random, &b));
 

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -350,7 +350,7 @@ int s2n_client_hello_send(struct s2n_connection *conn)
 {
     struct s2n_stuffer *out = &conn->handshake.io;
     struct s2n_stuffer client_random = {0};
-    struct s2n_blob b, r;
+    struct s2n_blob b, r = {0};
     uint8_t client_protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN];
 
     GUARD(s2n_blob_init(&b, conn->secure.client_random, S2N_TLS_RANDOM_DATA_LEN));

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -607,8 +607,7 @@ int s2n_prf_key_expansion(struct s2n_connection *conn)
 
     label.data = key_expansion_label;
     label.size = sizeof(key_expansion_label) - 1;
-    out.data = key_block;
-    out.size = sizeof(key_block);
+    GUARD(s2n_blob_init(&out, key_block, sizeof(key_block)));
 
     struct s2n_stuffer key_material = {0};
     GUARD(s2n_prf(conn, &master_secret, &label, &server_random, &client_random, NULL, &out));

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -194,11 +194,10 @@ int s2n_server_hello_send(struct s2n_connection *conn)
 {
     struct s2n_stuffer *out = &conn->handshake.io;
     struct s2n_stuffer server_random = {0};
-    struct s2n_blob b, rand_data;
+    struct s2n_blob b, rand_data = {0};
     uint8_t protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN];
 
-    b.data = conn->secure.server_random;
-    b.size = S2N_TLS_RANDOM_DATA_LEN;
+    s2n_blob_init(&b, conn->secure.server_random, S2N_TLS_RANDOM_DATA_LEN);
 
     /* Create the server random data */
     GUARD(s2n_stuffer_init(&server_random, &b));

--- a/utils/s2n_blob.c
+++ b/utils/s2n_blob.c
@@ -25,14 +25,20 @@
 
 bool s2n_blob_is_valid(const struct s2n_blob* b)
 {
-  bool blob_was_valid = S2N_OBJECT_PTR_IS_READABLE(b) && S2N_MEM_IS_READABLE(b->data,b->size);
-  return blob_was_valid;
+    if (!S2N_OBJECT_PTR_IS_READABLE(b)) {
+        return 0;
+    }
+    if(b->growable) {
+        return S2N_MEM_IS_READABLE(b->data,b->allocated) && b->size <= b->allocated;
+    } else {
+        return S2N_MEM_IS_READABLE(b->data,b->size) && b->allocated == 0;
+    }
 }
 
 int s2n_blob_init(struct s2n_blob *b, uint8_t * data, uint32_t size)
 {
     notnull_check(b);
-    *b = (struct s2n_blob) {.data = data, .size = size, .growable = 0, .mlocked = 0};
+    *b = (struct s2n_blob) {.data = data, .size = size, .allocated = 0, .growable = 0, .mlocked = 0};
     return 0;
 }
 

--- a/utils/s2n_blob.h
+++ b/utils/s2n_blob.h
@@ -22,10 +22,21 @@
 
 
 struct s2n_blob {
+    /* The data for the s2n_blob */
     uint8_t *data;
+
+    /* The size of the data */
     uint32_t size;
+
+    /* The amount of memory allocated for this blob. If this blob was 
+    created with s2n_blob_init(), this value is 0. If s2n_alloc() was called,
+    this value will be greater than 0. */
     uint32_t allocated;
+
+    /* Is the data mlocked */
     unsigned mlocked :1;
+
+    /* Can this blob be resized */
     unsigned growable :1;
 };
 

--- a/utils/s2n_blob.h
+++ b/utils/s2n_blob.h
@@ -28,9 +28,11 @@ struct s2n_blob {
     /* The size of the data */
     uint32_t size;
 
-    /* The amount of memory allocated for this blob. If this blob was 
-    created with s2n_blob_init(), this value is 0. If s2n_alloc() was called,
-    this value will be greater than 0. */
+    /* The amount of memory allocated for this blob (i.e. the amount of memory
+     * which needs to be freed when the blob is cleaned up). If this blob was 
+     * created with s2n_blob_init(), this value is 0. If s2n_alloc() was called,
+     * this value will be greater than 0. 
+     */
     uint32_t allocated;
 
     /* Is the data mlocked */

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -59,7 +59,7 @@ bool s2n_blob_is_growable(const struct s2n_blob* b)
   return b && (b->growable || (b->data == NULL && b->size == 0 && b->allocated == 0));
 }
 
-static int s2n_get_memory(struct s2n_blob *b, uint32_t size)
+int s2n_get_memory(struct s2n_blob *b, uint32_t size)
 {
     if(use_mlock) {
         /* Page aligned allocation required for mlock */

--- a/utils/s2n_safety.c
+++ b/utils/s2n_safety.c
@@ -186,3 +186,12 @@ int s2n_align_to(uint32_t initial, uint32_t alignment, uint32_t* out)
     *out = (uint32_t) result;
     return S2N_SUCCESS;
 }
+
+int s2n_add_overflow(uint32_t a, uint32_t b, uint32_t* out)
+{
+    uint64_t result = ((uint64_t) a) + ((uint64_t) b);
+    S2N_ERROR_IF(result > UINT32_MAX, S2N_ERR_INTEGER_OVERFLOW);
+    *out = (uint32_t) result;
+    return S2N_SUCCESS;
+}
+

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -172,3 +172,4 @@ extern int s2n_mul_overflow(uint32_t a, uint32_t b, uint32_t* out);
  * NOT CONSTANT TIME.
  */
 extern int s2n_align_to(uint32_t initial, uint32_t alignment, uint32_t* out);
+extern int s2n_add_overflow(uint32_t a, uint32_t b, uint32_t* out);


### PR DESCRIPTION
**Issue # (if available):** 
N/A
**Description of changes:** 

Added cbmc proof for s2n_stuffer_copy(). This proof caused multiple issues to show up within the stuffer code.
1. There was a potential add overflow problem. This was fixed by creating a safe add function and using it in the stuffer.c file. Also added a unit test for this add function.
2. What defined a valid blob was not especially strict. This was fixed by adding comments to the definition of a blob, namely, the function of each element inside of a blob. Additionally, added stricter checks to the blob_is_valid function. Creating a stricter blob_is_valid function caused two blob initializations to fail in s2n_prf.c and s2n_client_hello.c, so I had to fix that too.
- There are also cbmc issues in s2n_get_memory, which s2n_stuffer_copy calls, so stubbed the function in this proof until s2n_get_memory is proved.
- Fixed a small issue in s2n_tls13_support_test that was causing memory corruption.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
