### PR TITLE
Add s2n_ prefix to functions in s2n_handshake_io.c

### DIFF
--- a/tests/unit/s2n_tls12_handshake_test.c
+++ b/tests/unit/s2n_tls12_handshake_test.c
@@ -173,11 +173,11 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_write_ccs_message(&input));
 
                 if (handshakes[i][j] == SERVER_CHANGE_CIPHER_SPEC) {
-                    EXPECT_SUCCESS(handshake_read_io(conn));
+                    EXPECT_SUCCESS(s2n_handshake_read_io(conn));
                     EXPECT_TRUE(expected_handler_called);
                     EXPECT_FALSE(unexpected_handler_called);
                 } else {
-                    EXPECT_FAILURE_WITH_ERRNO(handshake_read_io(conn), S2N_ERR_BAD_MESSAGE);
+                    EXPECT_FAILURE_WITH_ERRNO(s2n_handshake_read_io(conn), S2N_ERR_BAD_MESSAGE);
                     EXPECT_FALSE(expected_handler_called);
                     EXPECT_FALSE(unexpected_handler_called);
                 }
@@ -214,11 +214,11 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_write_ccs_message(&input));
 
                 if (handshakes[i][j] == CLIENT_CHANGE_CIPHER_SPEC) {
-                    EXPECT_SUCCESS(handshake_read_io(conn));
+                    EXPECT_SUCCESS(s2n_handshake_read_io(conn));
                     EXPECT_TRUE(expected_handler_called);
                     EXPECT_FALSE(unexpected_handler_called);
                 } else {
-                    EXPECT_FAILURE_WITH_ERRNO(handshake_read_io(conn), S2N_ERR_BAD_MESSAGE);
+                    EXPECT_FAILURE_WITH_ERRNO(s2n_handshake_read_io(conn), S2N_ERR_BAD_MESSAGE);
                     EXPECT_FALSE(expected_handler_called);
                     EXPECT_FALSE(unexpected_handler_called);
                 }

--- a/tests/unit/s2n_tls13_handshake_test.c
+++ b/tests/unit/s2n_tls13_handshake_test.c
@@ -368,7 +368,7 @@ int main(int argc, char **argv)
         }
     }
 
-    /* Test: Handshake self-talks using handshake_write_io and handshake_read_io */
+    /* Test: Handshake self-talks using s2n_handshake_write_io and s2n_handshake_read_io */
     {
         EXPECT_SUCCESS(s2n_enable_tls13());
 
@@ -395,7 +395,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
 
         /* Client sends ClientHello */
-        EXPECT_SUCCESS(handshake_write_io(client_conn));
+        EXPECT_SUCCESS(s2n_handshake_write_io(client_conn));
         EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), SERVER_HELLO);
 
         EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS13);
@@ -406,7 +406,7 @@ int main(int argc, char **argv)
 
         /* Server reads ClientHello */
         EXPECT_EQUAL(server_conn->handshake.handshake_type, INITIAL);
-        EXPECT_SUCCESS(handshake_read_io(server_conn));
+        EXPECT_SUCCESS(s2n_handshake_read_io(server_conn));
         EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS13); /* Server is now on TLS13 */
         EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), SERVER_HELLO);
         EXPECT_EQUAL(server_conn->handshake.handshake_type, NEGOTIATED | FULL_HANDSHAKE);
@@ -417,21 +417,21 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_conn_set_handshake_type(server_conn));
 
         /* Server sends ServerHello */
-        EXPECT_SUCCESS(handshake_write_io(server_conn));
+        EXPECT_SUCCESS(s2n_handshake_write_io(server_conn));
         EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), SERVER_CHANGE_CIPHER_SPEC);
 
         /* Server sends CCS */
-        EXPECT_SUCCESS(handshake_write_io(server_conn));
+        EXPECT_SUCCESS(s2n_handshake_write_io(server_conn));
         EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), ENCRYPTED_EXTENSIONS);
         S2N_BLOB_EXPECT_EQUAL(server_seq, seq_0);
 
         /* Server sends EncryptedExtensions */
-        EXPECT_SUCCESS(handshake_write_io(server_conn));
+        EXPECT_SUCCESS(s2n_handshake_write_io(server_conn));
         EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), SERVER_CERT);
         S2N_BLOB_EXPECT_EQUAL(server_seq, seq_1);
 
         /* Client reads CCS */
-        EXPECT_SUCCESS(handshake_read_io(client_conn));
+        EXPECT_SUCCESS(s2n_handshake_read_io(client_conn));
         EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), ENCRYPTED_EXTENSIONS);
 
         s2n_tls13_connection_keys(client_secrets, client_conn);
@@ -442,7 +442,7 @@ int main(int argc, char **argv)
         S2N_BLOB_EXPECT_EQUAL(server_secrets.extract_secret, client_secrets.extract_secret);
 
         /* Client reads Encrypted extensions */
-        EXPECT_SUCCESS(handshake_read_io(client_conn));
+        EXPECT_SUCCESS(s2n_handshake_read_io(client_conn));
         EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), ENCRYPTED_EXTENSIONS);
 
         /* TODO add the rest of the handshakes tests
@@ -451,19 +451,19 @@ int main(int argc, char **argv)
 
         /*
          * // Server sends ServerCert
-         * EXPECT_SUCCESS(handshake_write_io(server_conn));
+         * EXPECT_SUCCESS(s2n_handshake_write_io(server_conn));
          * EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), SERVER_CERT_VERIFY);
          *
          * // Server sends CertVerify
-         * EXPECT_SUCCESS(handshake_write_io(server_conn));
+         * EXPECT_SUCCESS(s2n_handshake_write_io(server_conn));
          * EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), SERVER_FINISHED);
          *
          * // Server sends ServerFinished
-         * EXPECT_SUCCESS(handshake_write_io(server_conn));
+         * EXPECT_SUCCESS(s2n_handshake_write_io(server_conn));
          * EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), SERVER_FINISHED);
          *
          * // Client sends ClientFinished
-         * EXPECT_SUCCESS(handshake_write_io(client_conn));
+         * EXPECT_SUCCESS(s2n_handshake_write_io(client_conn));
          * EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), APPLICATION_DATA);
          *
          * // Verify that sequence numbers reset

--- a/tests/unit/s2n_tls13_state_machine_handshake_test.c
+++ b/tests/unit/s2n_tls13_state_machine_handshake_test.c
@@ -253,7 +253,7 @@ int main(int argc, char **argv)
 
                 EXPECT_SUCCESS(s2n_test_write_header(&input, TLS_CHANGE_CIPHER_SPEC, 0));
 
-                EXPECT_SUCCESS(handshake_read_io(conn));
+                EXPECT_SUCCESS(s2n_handshake_read_io(conn));
 
                 EXPECT_EQUAL(conn->handshake.message_number, j);
                 EXPECT_FALSE(unexpected_handler_called);
@@ -290,7 +290,7 @@ int main(int argc, char **argv)
 
                 EXPECT_SUCCESS(s2n_test_write_header(&input, TLS_CHANGE_CIPHER_SPEC, 0));
 
-                EXPECT_SUCCESS(handshake_read_io(conn));
+                EXPECT_SUCCESS(s2n_handshake_read_io(conn));
 
                 EXPECT_EQUAL(conn->handshake.message_number, j);
                 EXPECT_FALSE(unexpected_handler_called);

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -708,14 +708,14 @@ static int s2n_conn_post_handshake_hashes_update(struct s2n_connection *conn)
  * messages into single records. 
  * Precondition: secure outbound I/O has already been flushed
  */
-static int handshake_write_io(struct s2n_connection *conn)
+static int s2n_handshake_write_io(struct s2n_connection *conn)
 {
     uint8_t record_type = EXPECTED_RECORD_TYPE(conn);
     s2n_blocked_status blocked = S2N_NOT_BLOCKED;
 
     /* Populate handshake.io with header/payload for the current state, once.
      * Check wiped instead of s2n_stuffer_data_available to differentiate between the initial call
-     * to handshake_write_io and a repeated call after an EWOULDBLOCK.
+     * to s2n_handshake_write_io and a repeated call after an EWOULDBLOCK.
      */
     if (s2n_stuffer_is_wiped(&conn->handshake.io)) {
         if (record_type == TLS_HANDSHAKE) {
@@ -767,7 +767,7 @@ static int handshake_write_io(struct s2n_connection *conn)
  *  0  - we read the whole handshake message.
  * -1  - error processing the handshake message.
  */
-static int read_full_handshake_message(struct s2n_connection *conn, uint8_t * message_type)
+static int s2n_read_full_handshake_message(struct s2n_connection *conn, uint8_t * message_type)
 {
     uint32_t current_handshake_data = s2n_stuffer_data_available(&conn->handshake.io);
     if (current_handshake_data < TLS_HANDSHAKE_HEADER_LENGTH) {
@@ -895,7 +895,7 @@ done:
  * data messages that need to be handled by the application. The latter is punted
  * for now (s2n does not support renegotiations).
  */
-static int handshake_read_io(struct s2n_connection *conn)
+static int s2n_handshake_read_io(struct s2n_connection *conn)
 {
     uint8_t record_type;
     int isSSLv2;
@@ -952,7 +952,7 @@ static int handshake_read_io(struct s2n_connection *conn)
     while (s2n_stuffer_data_available(&conn->in)) {
         int r;
         uint8_t actual_handshake_message_type;
-        GUARD((r = read_full_handshake_message(conn, &actual_handshake_message_type)));
+        GUARD((r = s2n_read_full_handshake_message(conn, &actual_handshake_message_type)));
 
         /* Do we need more data? This happens for message fragmentation */
         if (r == 1) {
@@ -1053,8 +1053,8 @@ int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status * blocked)
                 s2n_try_delete_session_cache(conn);
                 /* The peer might have sent an alert. Try and read it. */
                 if (s2n_errno == S2N_ERR_BLOCKED && s2n_stuffer_data_available(&conn->in)) {
-                    if (handshake_read_io(conn) < 0 && s2n_errno == S2N_ERR_ALERT) {
-                        /* handshake_read_io has set s2n_errno */
+                    if (s2n_handshake_read_io(conn) < 0 && s2n_errno == S2N_ERR_ALERT) {
+                        /* s2n_handshake_read_io has set s2n_errno */
                         S2N_ERROR_PRESERVE_ERRNO();
                     }
                 }
@@ -1062,14 +1062,14 @@ int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status * blocked)
             }
         } else if (ACTIVE_STATE(conn).writer == this) {
             *blocked = S2N_BLOCKED_ON_WRITE;
-            if (handshake_write_io(conn) < 0 && s2n_errno != S2N_ERR_BLOCKED) {
+            if (s2n_handshake_write_io(conn) < 0 && s2n_errno != S2N_ERR_BLOCKED) {
                 /* Non-retryable write error. The peer might have sent an alert. Try and read it. */
                 const int write_errno = errno;
                 const int write_s2n_errno = s2n_errno;
                 const char *write_s2n_debug_str = s2n_debug_str;
 
-                if (handshake_read_io(conn) < 0 && s2n_errno == S2N_ERR_ALERT) {
-                    /* handshake_read_io has set s2n_errno */
+                if (s2n_handshake_read_io(conn) < 0 && s2n_errno == S2N_ERR_ALERT) {
+                    /* s2n_handshake_read_io has set s2n_errno */
                     S2N_ERROR_PRESERVE_ERRNO();
                 } else {
                     /* Let the write error take precedence if we didn't read an alert. */
@@ -1081,7 +1081,7 @@ int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status * blocked)
             }
         } else {
             *blocked = S2N_BLOCKED_ON_READ;
-            int r = handshake_read_io(conn);
+            int r = s2n_handshake_read_io(conn);
 
             if (r < 0) {
                 s2n_try_delete_session_cache(conn);


### PR DESCRIPTION
**Issue # (if available):** https://github.com/awslabs/s2n/issues/1509

**Description of changes:** 

read_full_handshake_message() -> s2n_read_full_handshake_message()
handshake_write_io() -> s2n_handshake_write_io()
handshake_read_io() -> s2n_handshake_read_io()

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
