### PR TITLE
Reduce fuzz timeout from 120 seconds to 90 seconds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ jobs:
   - os: linux
     # coverage + fuzz flags don't work simultaneously on bionic
     dist: trusty
-    env: S2N_LIBCRYPTO=openssl-1.1.1 LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=120 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true
+    env: S2N_LIBCRYPTO=openssl-1.1.1 LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=90 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true
 
 # Normal Build Targets
   - os: linux
@@ -66,11 +66,11 @@ jobs:
 # Fuzz Tests
   - os: linux
     dist: bionic
-    env: S2N_LIBCRYPTO=openssl-1.1.1 LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=120
+    env: S2N_LIBCRYPTO=openssl-1.1.1 LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=90
 
   - os: linux
     dist: bionic
-    env: S2N_LIBCRYPTO=openssl-1.0.2-fips LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=120
+    env: S2N_LIBCRYPTO=openssl-1.0.2-fips LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=90
   
 # ASAN and Valgrind Tests
   - os: linux


### PR DESCRIPTION
**Issue # (if available):** 

**Description of changes:** There are so many s2n fuzz tests, that having a 2 minute timeout on each of them causes the Travis builds to hit the 50 minute hard limit consistently. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
