### PR TITLE
Add the cookie extension per RFC8446 sect 4.2.2

### DIFF
--- a/tests/unit/s2n_tls13_cookie_test.c
+++ b/tests/unit/s2n_tls13_cookie_test.c
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "testlib/s2n_testlib.h"
+
+#include <s2n.h>
+
+#include "tls/s2n_tls.h"
+#include "tls/s2n_tls13.h"
+
+#include "tls/extensions/s2n_cookie.h"
+
+#include "utils/s2n_safety.h"
+
+#define EXTENSION_LEN       2
+#define COOKIE_SIZE_LEN     2
+#define COOKIE_TEST_SIZE    16
+
+int main(int argc, char *argv[])
+{
+    BEGIN_TEST();
+
+    {
+        EXPECT_SUCCESS(s2n_enable_tls13());
+
+        struct s2n_config *config;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+
+        uint8_t cookie_data_compare[COOKIE_TEST_SIZE] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5 };
+        struct s2n_blob compare_blob;
+        EXPECT_SUCCESS(s2n_blob_init(&compare_blob, cookie_data_compare, COOKIE_TEST_SIZE));
+
+        /* Test that cookies are not implemented until HelloRetryRequests are available */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_client_cookie_recv(NULL, NULL), S2N_ERR_UNIMPLEMENTED);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_client_cookie_send(NULL, NULL), S2N_ERR_UNIMPLEMENTED);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_server_cookie_recv(NULL, NULL), S2N_ERR_UNIMPLEMENTED);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_server_cookie_send(NULL, NULL), S2N_ERR_UNIMPLEMENTED);
+
+        /* Test that we can send and receive a cookie extension */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+            /* Initialize the connection's cookie data with a default value.
+             * The server will send this value in the cookie extension. */
+            EXPECT_SUCCESS(s2n_stuffer_resize(&conn->cookie_stuffer, COOKIE_TEST_SIZE));
+            EXPECT_SUCCESS(s2n_stuffer_write(&conn->cookie_stuffer, &compare_blob));
+
+            /* Initialize the extension stuff which will be written to */
+            struct s2n_blob out_blob;
+            struct s2n_stuffer out_stuffer;
+            uint8_t extension_out[COOKIE_SIZE_LEN + EXTENSION_LEN + COOKIE_TEST_SIZE] = { 0 };
+
+            /* Send the extension and verify the expected number of bytes were written */
+            EXPECT_SUCCESS(s2n_blob_init(&out_blob, extension_out, sizeof(extension_out)));
+            EXPECT_SUCCESS(s2n_stuffer_init(&out_stuffer, &out_blob));
+            EXPECT_SUCCESS(s2n_cookie_send(conn, &out_stuffer));
+            S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(&out_stuffer, EXTENSION_LEN + COOKIE_SIZE_LEN + COOKIE_TEST_SIZE);
+
+            /* Reset the extension stuffer and cookie data */
+            EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->cookie_stuffer));
+            EXPECT_SUCCESS(s2n_stuffer_reread(&out_stuffer));
+            EXPECT_SUCCESS(s2n_stuffer_skip_read(&out_stuffer, EXTENSION_LEN));
+
+            /* Verify we can receive the extension and the cookie_data is set correctly */
+            EXPECT_SUCCESS(s2n_cookie_recv(conn, &out_stuffer));
+            S2N_BLOB_EXPECT_EQUAL(conn->cookie_stuffer.blob, compare_blob);
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Test that cookies with incorrect size fields don't get processed */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+            /* Initialize the extension stuff which will be written to */
+            struct s2n_blob out_blob;
+            struct s2n_stuffer out_stuffer;
+            uint8_t extension_out[COOKIE_SIZE_LEN + EXTENSION_LEN + COOKIE_TEST_SIZE] = { 0 };
+
+            EXPECT_SUCCESS(s2n_blob_init(&out_blob, extension_out, sizeof(extension_out)));
+            EXPECT_SUCCESS(s2n_stuffer_init(&out_stuffer, &out_blob));
+
+            /* This cookie says it has 3 bytes, but only has 2 bytes */
+            uint8_t bad_size[5] = { TLS_EXTENSION_COOKIE, 0x00, 0x03, 0x00, 0x00 };
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&out_stuffer, bad_size, sizeof(bad_size)));
+
+            /* The receive should succeed, but since the extension was corrupted it 
+             * should not be saved to the connection. */
+            EXPECT_SUCCESS(s2n_cookie_recv(conn, &out_stuffer));
+            EXPECT_EQUAL(s2n_cookie_len(conn), 0);
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        EXPECT_SUCCESS(s2n_config_free(config));
+        EXPECT_SUCCESS(s2n_disable_tls13());
+    }
+
+    END_TEST();
+    return 0;
+}

--- a/tls/extensions/s2n_client_cookie.c
+++ b/tls/extensions/s2n_client_cookie.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "tls/s2n_tls.h"
+
+#include "tls/extensions/s2n_cookie.h"
+
+int s2n_extensions_client_cookie_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    /* Until HelloRetryRequests are supported, the client does not support cookies */
+    S2N_ERROR(S2N_ERR_UNIMPLEMENTED);
+
+    return 0;
+}
+
+int s2n_extensions_client_cookie_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    /* Until HelloRetryRequests are supported, the client does not support cookies */
+    S2N_ERROR(S2N_ERR_UNIMPLEMENTED);
+
+    return 0;
+}

--- a/tls/extensions/s2n_cookie.c
+++ b/tls/extensions/s2n_cookie.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "tls/extensions/s2n_cookie.h"
+
+int s2n_cookie_len(struct s2n_connection *conn)
+{
+    return s2n_stuffer_data_available(&conn->cookie_stuffer);
+}
+
+int s2n_cookie_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    uint16_t cookie_len;
+
+    GUARD(s2n_stuffer_read_uint16(extension, &cookie_len));
+
+    if (s2n_stuffer_data_available(extension) != cookie_len) {
+        return 0;
+    }
+
+    GUARD(s2n_stuffer_wipe(&conn->cookie_stuffer));
+    GUARD(s2n_stuffer_resize(&conn->cookie_stuffer, cookie_len));
+    GUARD(s2n_stuffer_copy(extension, &conn->cookie_stuffer, cookie_len));
+
+    return 0;
+}
+
+int s2n_cookie_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    notnull_check(conn);
+    notnull_check(out);
+
+    GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_COOKIE));
+    GUARD(s2n_stuffer_write_uint16(out, s2n_cookie_len(conn)));
+    GUARD(s2n_stuffer_copy(&conn->cookie_stuffer, out, s2n_cookie_len(conn)));
+
+    return 0;
+}

--- a/tls/extensions/s2n_cookie.h
+++ b/tls/extensions/s2n_cookie.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+
+#pragma once
+
+#include "tls/s2n_connection.h"
+#include "stuffer/s2n_stuffer.h"
+
+/* Return the length of cookie data in the connection */
+extern int s2n_cookie_len(struct s2n_connection *conn);
+
+/* Write the connection's cookie data to the output stuffer */
+extern int s2n_cookie_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+
+/* Read cookie data out of the received extension, and save it in the connection */
+extern int s2n_cookie_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
+
+/* Functions specific to the server/client side cookie operations */
+extern int s2n_extensions_server_cookie_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+extern int s2n_extensions_server_cookie_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
+extern int s2n_extensions_client_cookie_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+extern int s2n_extensions_client_cookie_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_server_cookie.c
+++ b/tls/extensions/s2n_server_cookie.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "tls/s2n_tls.h"
+
+#include "tls/extensions/s2n_cookie.h"
+
+int s2n_extensions_server_cookie_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    /* Until HelloRetryRequests are supported, the server does not support cookies */
+    S2N_ERROR(S2N_ERR_UNIMPLEMENTED);
+
+    return 0;
+}
+
+int s2n_extensions_server_cookie_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    /* Until HelloRetryRequests are supported, the server does not support cookies */
+    S2N_ERROR(S2N_ERR_UNIMPLEMENTED);
+
+    return 0;
+}

--- a/tls/s2n_client_extensions.c
+++ b/tls/s2n_client_extensions.c
@@ -40,6 +40,7 @@
 #include "extensions/s2n_client_pq_kem.h"
 #include "extensions/s2n_client_ec_point_format.h"
 #include "extensions/s2n_client_renegotiation_info.h"
+
 #include "stuffer/s2n_stuffer.h"
 
 #include "tls/s2n_tls.h"

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -281,6 +281,9 @@ struct s2n_connection {
 
     /* application protocols overridden */
     struct s2n_blob application_protocols_overridden;
+
+    /* Cookie extension data */
+    struct s2n_stuffer cookie_stuffer;
 };
 
 int s2n_connection_is_managed_corked(const struct s2n_connection *s2n_connection);

--- a/tls/s2n_tls_parameters.h
+++ b/tls/s2n_tls_parameters.h
@@ -92,6 +92,7 @@
 
 /* TLS 1.3 extensions from https://tools.ietf.org/html/rfc8446#section-4.2 */
 #define TLS_EXTENSION_SUPPORTED_VERSIONS   43
+#define TLS_EXTENSION_COOKIE               44
 #define TLS_EXTENSION_KEY_SHARE            51
 
 /* TLS Signature Algorithms - RFC 5246 7.4.1.4.1 */
@@ -232,4 +233,3 @@
 #define TLS_HANDSHAKE_HEADER_LENGTH   4
 
 #define S2N_MAX_SERVER_NAME 255
-


### PR DESCRIPTION
 * Add cookie support to the connection
 * Add basic functions to allow the extension to be written and read
 * Full support not available until HelloRetryRequests are implemented

**Issue # (if available):** Fixes #969 

**Description of changes:** 

* I've limited the size of cookie extension data to 128 bytes. Since we plan to use cookies for HelloRetryRequests, these cookies will only contain a hash value. I don't see the advantage of allowing the RFC specified size.
* I have not fully supported cookies in the extension parsers since we don't support HelloRetryRequests yet. Until we support HRR, there is nothing we use cookies for.
* I've used a uint8_t array to hold cookie data instead of a blob. Using a blob required extra work to determine if an allocation was required. It also added complexity to the unit tests. The byte array is similar to how server name and application_protocol are stored.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
