### PR TITLE
Remove tests from Travis-ci that can be run with CodeBuild/webhooks.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
+
 **Issue # (if available):** 
 
 **Description of changes:** 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,6 @@ cache:
 
 jobs:
   include:
-# Code Coverage Targets, will upload code coverage metrics during Pull Requests
-  - os: linux
-    dist: bionic
-    env: S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=unit GCC_VERSION=6 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true
-
   - os: linux
     dist: bionic
     env: S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=6 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true
@@ -50,7 +45,7 @@ jobs:
 
   - os: linux
     dist: bionic
-    env: S2N_LIBCRYPTO=libressl      BUILD_S2N=true TESTS=integration GCC_VERSION=6
+    env: S2N_LIBCRYPTO=libressl BUILD_S2N=true TESTS=integration GCC_VERSION=6
 
   - os: linux
     dist: bionic
@@ -72,15 +67,6 @@ jobs:
     dist: bionic
     env: S2N_LIBCRYPTO=openssl-1.0.2-fips LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=90
   
-# ASAN and Valgrind Tests
-  - os: linux
-    dist: bionic
-    env: S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=asan GCC_VERSION=6
-
-  - os: linux
-    dist: bionic
-    env: S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=valgrind GCC_VERSION=6
-
 # Formal Verification - Sidetrail
   - os : linux
     dist: trusty
@@ -89,56 +75,6 @@ jobs:
   - os : linux
     dist: trusty
     env: TESTS=sidetrail PART=2
-
-# Formal Verification - SAW
-  - os : linux
-    dist: trusty
-    env: TESTS=sawHMAC SAW_HMAC_TEST=md5 SAW=true GCC_VERSION=NONE
-    addons: &sawaddons
-      apt:
-        packages:
-          - clang-3.9
-          - llvm-3.9
-  - os : linux
-    dist: trusty
-    env: TESTS=sawHMAC SAW_HMAC_TEST=sha1   SAW=true GCC_VERSION=NONE
-    addons : *sawaddons
-  - os : linux
-    dist: trusty
-    env: TESTS=sawHMAC SAW_HMAC_TEST=sha224 SAW=true GCC_VERSION=NONE
-    addons : *sawaddons
-  - os : linux
-    dist: trusty
-    env: TESTS=sawHMAC SAW_HMAC_TEST=sha256 SAW=true GCC_VERSION=NONE
-    addons : *sawaddons
-  - os : linux
-    dist: trusty
-    env: TESTS=sawHMAC SAW_HMAC_TEST=sha384 SAW=true GCC_VERSION=NONE
-    addons : *sawaddons
-  - os : linux
-    dist: trusty
-    env: TESTS=sawHMAC SAW_HMAC_TEST=sha512 SAW=true GCC_VERSION=NONE
-    addons : *sawaddons
-  - os : linux
-    dist: trusty
-    env: TESTS=sawDRBG SAW=true GCC_VERSION=NONE
-    addons : *sawaddons
-  - os : linux
-    dist: trusty
-    env: TESTS=sawSIKE_r1 SAW=true GCC_VERSION=NONE
-    addons : *sawaddons
-  - os : linux
-    dist: trusty
-    env: TESTS=sawBIKE_r1 SAW=true GCC_VERSION=NONE S2N_LIBCRYPTO=openssl-1.0.2
-    addons : *sawaddons
-  - os : linux
-    dist: trusty
-    env: TESTS=tls SAW=true GCC_VERSION=NONE
-    addons : *sawaddons
-  - os : linux
-    dist: trusty
-    env: TESTS=sawHMACFailure SAW=true
-    addons : *sawaddons
 
 before_install:
   - source .travis/s2n_setup_env.sh


### PR DESCRIPTION
**Issue #469 :** 

**Description of changes:** 
While we sort out our CodeBuild solution, reduce travis-ci runtimes by removing tests that can be run from CodeBuild with a Github webhook, as follows:

- Travis-ci: Integration and Sidetrail
- CodeBuild: SAW(7), fuzz(2), valgrind(3), asan(1), unit(1)

Also place a banner in the PR template with some information.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
