### PR TITLE
Factor out common test pipe logic

### DIFF
--- a/tests/testlib/s2n_connection_test_utils.c
+++ b/tests/testlib/s2n_connection_test_utils.c
@@ -19,7 +19,17 @@
 
 #include "tls/s2n_connection.h"
 #include "utils/s2n_safety.h"
+#include "utils/s2n_socket.h"
 #include "testlib/s2n_testlib.h"
+
+
+int s2n_fd_set_blocking(int fd) {
+    return fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) ^ O_NONBLOCK);
+}
+
+int s2n_fd_set_non_blocking(int fd) {
+    return fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) | O_NONBLOCK);
+}
 
 static int buffer_read(void *io_context, uint8_t *buf, uint32_t len)
 {
@@ -83,6 +93,70 @@ int s2n_connection_set_io_stuffers(struct s2n_stuffer *input, struct s2n_stuffer
     GUARD(s2n_connection_set_recv_ctx(conn, input));
     GUARD(s2n_connection_set_send_ctx(conn, output));
 
+    return 0;
+}
+
+int s2n_piped_io_init(struct s2n_test_piped_io *piped_io) {
+    signal(SIGPIPE, SIG_IGN);
+
+    int server_to_client[2];
+    int client_to_server[2];
+
+    GUARD(pipe(server_to_client));
+    GUARD(pipe(client_to_server));
+
+    piped_io->client_read = server_to_client[0];
+    piped_io->client_write = client_to_server[1];
+
+    piped_io->server_read = client_to_server[0];
+    piped_io->server_write = server_to_client[1];
+
+    return 0;
+}
+
+int s2n_piped_io_init_non_blocking(struct s2n_test_piped_io *piped_io) {
+    GUARD(s2n_piped_io_init(piped_io));
+
+    GUARD(s2n_fd_set_non_blocking(piped_io->client_read));
+    GUARD(s2n_fd_set_non_blocking(piped_io->client_write));
+    GUARD(s2n_fd_set_non_blocking(piped_io->server_read));
+    GUARD(s2n_fd_set_non_blocking(piped_io->server_write));
+
+    return 0;
+}
+
+int s2n_connection_set_piped_io(struct s2n_connection *conn, struct s2n_test_piped_io* piped_io) {
+    if (conn->mode == S2N_CLIENT) {
+        GUARD(s2n_connection_set_read_fd(conn, piped_io->client_read));
+        GUARD(s2n_connection_set_write_fd(conn, piped_io->client_write));
+    } else if (conn->mode == S2N_SERVER) {
+        GUARD(s2n_connection_set_read_fd(conn, piped_io->server_read));
+        GUARD(s2n_connection_set_write_fd(conn, piped_io->server_write));
+    }
+
+    return 0;
+}
+
+int s2n_connections_set_piped_io(struct s2n_connection *client, struct s2n_connection *server, struct s2n_test_piped_io* piped_io) {
+    GUARD(s2n_connection_set_piped_io(client, piped_io));
+    GUARD(s2n_connection_set_piped_io(server, piped_io));
+    return 0;
+}
+
+int s2n_piped_io_close(struct s2n_test_piped_io *piped_io) {
+    GUARD(s2n_piped_io_close_one_end(piped_io, S2N_CLIENT));
+    GUARD(s2n_piped_io_close_one_end(piped_io, S2N_SERVER));
+    return 0;
+}
+
+int s2n_piped_io_close_one_end(struct s2n_test_piped_io *piped_io, int mode_to_close) {
+    if (mode_to_close == S2N_CLIENT) {
+        GUARD(close(piped_io->client_read));
+        GUARD(close(piped_io->client_write));
+    } else if(mode_to_close == S2N_SERVER) {
+        GUARD(close(piped_io->server_read));
+        GUARD(close(piped_io->server_write));
+    }
     return 0;
 }
 

--- a/tests/testlib/s2n_testlib.h
+++ b/tests/testlib/s2n_testlib.h
@@ -35,7 +35,25 @@ extern int s2n_stuffer_write_uint64_hex(struct s2n_stuffer *stuffer, uint64_t u)
 extern int s2n_stuffer_alloc_ro_from_hex_string(struct s2n_stuffer *stuffer, const char *str);
 
 void s2n_print_connection(struct s2n_connection *conn, const char *marker);
+
 int s2n_connection_set_io_stuffers(struct s2n_stuffer *input, struct s2n_stuffer *output, struct s2n_connection *conn);
+
+struct s2n_test_piped_io {
+    int client_read;
+    int client_write;
+    int server_read;
+    int server_write;
+};
+int s2n_piped_io_init(struct s2n_test_piped_io *piped_io);
+int s2n_piped_io_init_non_blocking(struct s2n_test_piped_io *piped_io);
+int s2n_piped_io_close(struct s2n_test_piped_io *piped_io);
+int s2n_piped_io_close_one_end(struct s2n_test_piped_io *piped_io, int mode_to_close);
+
+int s2n_connection_set_piped_io(struct s2n_connection *conn, struct s2n_test_piped_io* piped_io);
+int s2n_connections_set_piped_io(struct s2n_connection *client, struct s2n_connection *server, struct s2n_test_piped_io* piped_io);
+
+int s2n_fd_set_blocking(int fd);
+int s2n_fd_set_non_blocking(int fd);
 
 #define S2N_MAX_TEST_PEM_SIZE 4096
 

--- a/tests/unit/s2n_cert_chain_and_key_test.c
+++ b/tests/unit/s2n_cert_chain_and_key_test.c
@@ -27,18 +27,9 @@
 
 #define NUM_TIED_CERTS 100
 
-struct s2n_connection *create_conn(s2n_mode mode, struct s2n_config *config, int s_to_c[], int c_to_s[]) {
+struct s2n_connection *create_conn(s2n_mode mode, struct s2n_config *config) {
     struct s2n_connection *conn = s2n_connection_new(mode);
     GUARD_PTR(s2n_connection_set_config(conn, config));
-    
-    if (mode == S2N_SERVER) {
-        GUARD_PTR(s2n_connection_set_read_fd(conn, c_to_s[0]));
-        GUARD_PTR(s2n_connection_set_write_fd(conn, s_to_c[1]));
-    } else {
-        GUARD_PTR(s2n_connection_set_read_fd(conn, s_to_c[0]));
-        GUARD_PTR(s2n_connection_set_write_fd(conn, c_to_s[1]));
-    }
-
     return conn;
 }
 
@@ -60,14 +51,15 @@ int main(int argc, char **argv)
     struct s2n_config *client_config;
     struct s2n_connection *server_conn;
     struct s2n_connection *client_conn;
-    int server_to_client[2];
-    int client_to_server[2];
     char *alligator_cert;
     char *alligator_key;
     char *cert_chain;
     char *private_key;
 
     BEGIN_TEST();
+
+    struct s2n_test_piped_io piped_io;
+    EXPECT_SUCCESS(s2n_piped_io_init_non_blocking(&piped_io));
 
     EXPECT_NOT_NULL(alligator_cert = malloc(S2N_MAX_TEST_PEM_SIZE));
     EXPECT_NOT_NULL(alligator_key = malloc(S2N_MAX_TEST_PEM_SIZE));
@@ -79,14 +71,6 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key, S2N_MAX_TEST_PEM_SIZE));
 
     EXPECT_SUCCESS(setenv("S2N_DONT_MLOCK", "1", 0));
-
-    /* Create nonblocking pipes */
-    EXPECT_SUCCESS(pipe(server_to_client));
-    EXPECT_SUCCESS(pipe(client_to_server));
-    for (int i = 0; i < 2; i++) {
-       EXPECT_NOT_EQUAL(fcntl(server_to_client[i], F_SETFL, fcntl(server_to_client[i], F_GETFL) | O_NONBLOCK), -1);
-       EXPECT_NOT_EQUAL(fcntl(client_to_server[i], F_SETFL, fcntl(client_to_server[i], F_GETFL) | O_NONBLOCK), -1);
-    }
 
     EXPECT_NOT_NULL(client_config = s2n_config_new());
     EXPECT_SUCCESS(s2n_config_disable_x509_verification(client_config));
@@ -114,8 +98,9 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, tied_certs[i]));
         }
 
-        EXPECT_NOT_NULL(server_conn = create_conn(S2N_SERVER, server_config, server_to_client, client_to_server));
-        EXPECT_NOT_NULL(client_conn = create_conn(S2N_CLIENT, client_config, server_to_client, client_to_server));
+        EXPECT_NOT_NULL(server_conn = create_conn(S2N_SERVER, server_config));
+        EXPECT_NOT_NULL(client_conn = create_conn(S2N_CLIENT, client_config));
+        EXPECT_SUCCESS(s2n_connections_set_piped_io(client_conn, server_conn, &piped_io));
         EXPECT_SUCCESS(s2n_set_server_name(client_conn, "www.alligator.com"));
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
         EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn->handshake.handshake_type));
@@ -141,8 +126,9 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key(server_config, cert_chain, private_key));
 
-        EXPECT_NOT_NULL(server_conn = create_conn(S2N_SERVER, server_config, server_to_client, client_to_server));
-        EXPECT_NOT_NULL(client_conn = create_conn(S2N_CLIENT, client_config, server_to_client, client_to_server));
+        EXPECT_NOT_NULL(server_conn = create_conn(S2N_SERVER, server_config));
+        EXPECT_NOT_NULL(client_conn = create_conn(S2N_CLIENT, client_config));
+        EXPECT_SUCCESS(s2n_connections_set_piped_io(client_conn, server_conn, &piped_io));
 
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
         EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn->handshake.handshake_type));
@@ -153,11 +139,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_free(server_config));
     }
 
-    for (int i = 0; i < 2; i++) {
-       EXPECT_SUCCESS(close(server_to_client[i]));
-       EXPECT_SUCCESS(close(client_to_server[i]));
-    }
-
+    EXPECT_SUCCESS(s2n_piped_io_close(&piped_io));
     EXPECT_SUCCESS(s2n_config_free(client_config));
 
     free(cert_chain);

--- a/tests/unit/s2n_client_record_version_test.c
+++ b/tests/unit/s2n_client_record_version_test.c
@@ -48,8 +48,6 @@ int main(int argc, char **argv)
         struct s2n_connection *client_conn;
         struct s2n_config *client_config;
         s2n_blocked_status client_blocked;
-        int server_to_client[2];
-        int client_to_server[2];
 
         uint8_t server_hello_message[] = {
             /* Protocol version TLS 1.2 */
@@ -85,16 +83,11 @@ int main(int argc, char **argv)
         };
 
         /* Create nonblocking pipes */
-        EXPECT_SUCCESS(pipe(server_to_client));
-        EXPECT_SUCCESS(pipe(client_to_server));
-        for (int i = 0; i < 2; i++) {
-            EXPECT_NOT_EQUAL(fcntl(server_to_client[i], F_SETFL, fcntl(server_to_client[i], F_GETFL) | O_NONBLOCK), -1);
-            EXPECT_NOT_EQUAL(fcntl(client_to_server[i], F_SETFL, fcntl(client_to_server[i], F_GETFL) | O_NONBLOCK), -1);
-        }
+        struct s2n_test_piped_io piped_io;
+        EXPECT_SUCCESS(s2n_piped_io_init_non_blocking(&piped_io));
 
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(client_conn, server_to_client[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(client_conn, client_to_server[1]));
+        EXPECT_SUCCESS(s2n_connection_set_piped_io(client_conn, &piped_io));
 
         EXPECT_NOT_NULL(client_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "test_all"));
@@ -111,7 +104,7 @@ int main(int argc, char **argv)
 
         /* we need only first 10 bytes to get to ClientHello protocol version */
         while (buf_occupied < 10) {
-            ssize_t n = read(client_to_server[0], buf + buf_occupied, sizeof(buf) - buf_occupied);
+            ssize_t n = read(piped_io.server_read, buf + buf_occupied, sizeof(buf) - buf_occupied);
 
             /* We should be able to read 10 bytes without blocking */
             EXPECT_TRUE(n > 0);
@@ -130,7 +123,7 @@ int main(int argc, char **argv)
 
         /* Read the rest of the pipe */
         while (1) {
-            ssize_t n = read(client_to_server[0], buf, sizeof(buf));
+            ssize_t n = read(piped_io.server_read, buf, sizeof(buf));
 
             if (n > 0) {
                 continue;
@@ -143,9 +136,9 @@ int main(int argc, char **argv)
         }
 
         /* Write the server hello */
-        EXPECT_EQUAL(write(server_to_client[1], record_header, sizeof(record_header)), sizeof(record_header));
-        EXPECT_EQUAL(write(server_to_client[1], message_header, sizeof(message_header)), sizeof(message_header));
-        EXPECT_EQUAL(write(server_to_client[1], server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
+        EXPECT_EQUAL(write(piped_io.server_write, record_header, sizeof(record_header)), sizeof(record_header));
+        EXPECT_EQUAL(write(piped_io.server_write, message_header, sizeof(message_header)), sizeof(message_header));
+        EXPECT_EQUAL(write(piped_io.server_write, server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
 
         /* Verify that we proceed with handshake */
         EXPECT_EQUAL(s2n_negotiate(client_conn, &client_blocked), -1);
@@ -166,7 +159,7 @@ int main(int argc, char **argv)
         buf_occupied = 0;
         /* We need only first 5 bytes to get to record protocol version */
         while (buf_occupied < 5) {
-            ssize_t n = read(client_to_server[0], buf + buf_occupied, sizeof(buf) - buf_occupied);
+            ssize_t n = read(piped_io.server_read, buf + buf_occupied, sizeof(buf) - buf_occupied);
 
             /* We should be able to read 5 bytes without blocking */
             EXPECT_TRUE(n > 0);
@@ -179,10 +172,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
         EXPECT_SUCCESS(s2n_config_free(client_config));
 
-        for (int i = 0; i < 2; i++) {
-            EXPECT_SUCCESS(close(server_to_client[i]));
-            EXPECT_SUCCESS(close(client_to_server[i]));
-        }
+        EXPECT_SUCCESS(s2n_piped_io_close(&piped_io));
     }
 
     /* Server negotiates SSLv3 */
@@ -190,8 +180,6 @@ int main(int argc, char **argv)
         struct s2n_connection *client_conn;
         struct s2n_config *client_config;
         s2n_blocked_status client_blocked;
-        int server_to_client[2];
-        int client_to_server[2];
 
         uint8_t server_hello_message[] = {
             /* Protocol version SSLv3 */
@@ -227,16 +215,11 @@ int main(int argc, char **argv)
         };
 
         /* Create nonblocking pipes */
-        EXPECT_SUCCESS(pipe(server_to_client));
-        EXPECT_SUCCESS(pipe(client_to_server));
-        for (int i = 0; i < 2; i++) {
-            EXPECT_NOT_EQUAL(fcntl(server_to_client[i], F_SETFL, fcntl(server_to_client[i], F_GETFL) | O_NONBLOCK), -1);
-            EXPECT_NOT_EQUAL(fcntl(client_to_server[i], F_SETFL, fcntl(client_to_server[i], F_GETFL) | O_NONBLOCK), -1);
-        }
+        struct s2n_test_piped_io piped_io;
+        EXPECT_SUCCESS(s2n_piped_io_init_non_blocking(&piped_io));
 
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(client_conn, server_to_client[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(client_conn, client_to_server[1]));
+        EXPECT_SUCCESS(s2n_connection_set_piped_io(client_conn, &piped_io));
 
         EXPECT_NOT_NULL(client_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "test_all"));
@@ -253,7 +236,7 @@ int main(int argc, char **argv)
 
         /* we need only first 10 bytes to get to ClientHello protocol version */
         while (buf_occupied < 10) {
-            ssize_t n = read(client_to_server[0], buf + buf_occupied, sizeof(buf) - buf_occupied);
+            ssize_t n = read(piped_io.server_read, buf + buf_occupied, sizeof(buf) - buf_occupied);
 
             /* We should be able to read 10 bytes without blocking */
             EXPECT_TRUE(n > 0);
@@ -272,7 +255,7 @@ int main(int argc, char **argv)
 
         /* Read the rest of the pipe */
         while (1) {
-            ssize_t n = read(client_to_server[0], buf, sizeof(buf));
+            ssize_t n = read(piped_io.server_read, buf, sizeof(buf));
 
             if (n > 0) {
                 continue;
@@ -285,9 +268,9 @@ int main(int argc, char **argv)
         }
 
         /* Write the server hello */
-        EXPECT_EQUAL(write(server_to_client[1], record_header, sizeof(record_header)), sizeof(record_header));
-        EXPECT_EQUAL(write(server_to_client[1], message_header, sizeof(message_header)), sizeof(message_header));
-        EXPECT_EQUAL(write(server_to_client[1], server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
+        EXPECT_EQUAL(write(piped_io.server_write, record_header, sizeof(record_header)), sizeof(record_header));
+        EXPECT_EQUAL(write(piped_io.server_write, message_header, sizeof(message_header)), sizeof(message_header));
+        EXPECT_EQUAL(write(piped_io.server_write, server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
 
         /* Verify that we proceed with handshake */
         EXPECT_EQUAL(s2n_negotiate(client_conn, &client_blocked), -1);
@@ -308,7 +291,7 @@ int main(int argc, char **argv)
         buf_occupied = 0;
         /* We need only first 5 bytes to get to record protocol version */
         while (buf_occupied < 5) {
-            ssize_t n = read(client_to_server[0], buf + buf_occupied, sizeof(buf) - buf_occupied);
+            ssize_t n = read(piped_io.server_read, buf + buf_occupied, sizeof(buf) - buf_occupied);
 
             /* We should be able to read 5 bytes without blocking */
             EXPECT_TRUE(n > 0);
@@ -321,10 +304,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
         EXPECT_SUCCESS(s2n_config_free(client_config));
 
-        for (int i = 0; i < 2; i++) {
-            EXPECT_SUCCESS(close(server_to_client[i]));
-            EXPECT_SUCCESS(close(client_to_server[i]));
-        }
+        EXPECT_SUCCESS(s2n_piped_io_close(&piped_io));
     }
 
     free(cert_chain);

--- a/tests/unit/s2n_client_secure_renegotiation_test.c
+++ b/tests/unit/s2n_client_secure_renegotiation_test.c
@@ -50,8 +50,6 @@ int main(int argc, char **argv)
         struct s2n_connection *client_conn;
         struct s2n_config *client_config;
         s2n_blocked_status client_blocked;
-        int server_to_client[2];
-        int client_to_server[2];
 
         uint8_t server_extensions[] = {
             /* Extension type TLS_EXTENSION_RENEGOTIATION_INFO */
@@ -96,16 +94,11 @@ int main(int argc, char **argv)
         };
 
         /* Create nonblocking pipes */
-        EXPECT_SUCCESS(pipe(server_to_client));
-        EXPECT_SUCCESS(pipe(client_to_server));
-        for (int i = 0; i < 2; i++) {
-            EXPECT_NOT_EQUAL(fcntl(server_to_client[i], F_SETFL, fcntl(server_to_client[i], F_GETFL) | O_NONBLOCK), -1);
-            EXPECT_NOT_EQUAL(fcntl(client_to_server[i], F_SETFL, fcntl(client_to_server[i], F_GETFL) | O_NONBLOCK), -1);
-        }
+        struct s2n_test_piped_io piped_io;
+        EXPECT_SUCCESS(s2n_piped_io_init_non_blocking(&piped_io));
 
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(client_conn, server_to_client[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(client_conn, client_to_server[1]));
+        EXPECT_SUCCESS(s2n_connection_set_piped_io(client_conn, &piped_io));
 
         EXPECT_NOT_NULL(client_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
@@ -116,10 +109,10 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(client_blocked, S2N_BLOCKED_ON_READ);
 
         /* Write the server hello */
-        EXPECT_EQUAL(write(server_to_client[1], record_header, sizeof(record_header)), sizeof(record_header));
-        EXPECT_EQUAL(write(server_to_client[1], message_header, sizeof(message_header)), sizeof(message_header));
-        EXPECT_EQUAL(write(server_to_client[1], server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
-        EXPECT_EQUAL(write(server_to_client[1], server_extensions, sizeof(server_extensions)), sizeof(server_extensions));
+        EXPECT_EQUAL(write(piped_io.server_write, record_header, sizeof(record_header)), sizeof(record_header));
+        EXPECT_EQUAL(write(piped_io.server_write, message_header, sizeof(message_header)), sizeof(message_header));
+        EXPECT_EQUAL(write(piped_io.server_write, server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
+        EXPECT_EQUAL(write(piped_io.server_write, server_extensions, sizeof(server_extensions)), sizeof(server_extensions));
 
         /* Verify that we proceed with handshake */
         EXPECT_EQUAL(s2n_negotiate(client_conn, &client_blocked), -1);
@@ -129,14 +122,9 @@ int main(int argc, char **argv)
         /* Secure renegotiation is set */
         EXPECT_EQUAL(client_conn->secure_renegotiation, 1);
 
+        EXPECT_SUCCESS(s2n_piped_io_close(&piped_io));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
-
         EXPECT_SUCCESS(s2n_config_free(client_config));
-
-        for (int i = 0; i < 2; i++) {
-            EXPECT_SUCCESS(close(server_to_client[i]));
-            EXPECT_SUCCESS(close(client_to_server[i]));
-        }
     }
 
     /* Success: server doesn't send an renegotiation_info extension */
@@ -144,8 +132,6 @@ int main(int argc, char **argv)
         struct s2n_connection *client_conn;
         struct s2n_config *client_config;
         s2n_blocked_status client_blocked;
-        int server_to_client[2];
-        int client_to_server[2];
 
         uint8_t server_hello_message[] = {
             /* Protocol version TLS 1.2 */
@@ -181,16 +167,11 @@ int main(int argc, char **argv)
         };
 
         /* Create nonblocking pipes */
-        EXPECT_SUCCESS(pipe(server_to_client));
-        EXPECT_SUCCESS(pipe(client_to_server));
-        for (int i = 0; i < 2; i++) {
-            EXPECT_NOT_EQUAL(fcntl(server_to_client[i], F_SETFL, fcntl(server_to_client[i], F_GETFL) | O_NONBLOCK), -1);
-            EXPECT_NOT_EQUAL(fcntl(client_to_server[i], F_SETFL, fcntl(client_to_server[i], F_GETFL) | O_NONBLOCK), -1);
-        }
+        struct s2n_test_piped_io piped_io;
+        EXPECT_SUCCESS(s2n_piped_io_init_non_blocking(&piped_io));
 
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(client_conn, server_to_client[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(client_conn, client_to_server[1]));
+        EXPECT_SUCCESS(s2n_connection_set_piped_io(client_conn, &piped_io));
 
         EXPECT_NOT_NULL(client_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
@@ -201,9 +182,9 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(client_blocked, S2N_BLOCKED_ON_READ);
 
         /* Write the server hello */
-        EXPECT_EQUAL(write(server_to_client[1], record_header, sizeof(record_header)), sizeof(record_header));
-        EXPECT_EQUAL(write(server_to_client[1], message_header, sizeof(message_header)), sizeof(message_header));
-        EXPECT_EQUAL(write(server_to_client[1], server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
+        EXPECT_EQUAL(write(piped_io.server_write, record_header, sizeof(record_header)), sizeof(record_header));
+        EXPECT_EQUAL(write(piped_io.server_write, message_header, sizeof(message_header)), sizeof(message_header));
+        EXPECT_EQUAL(write(piped_io.server_write, server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
 
         /* Verify that we proceed with handshake */
         EXPECT_EQUAL(s2n_negotiate(client_conn, &client_blocked), -1);
@@ -213,14 +194,9 @@ int main(int argc, char **argv)
         /* Secure renegotiation is not set, as server doesn't support it */
         EXPECT_EQUAL(client_conn->secure_renegotiation, 0);
 
+        EXPECT_SUCCESS(s2n_piped_io_close(&piped_io));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
-
         EXPECT_SUCCESS(s2n_config_free(client_config));
-
-        for (int i = 0; i < 2; i++) {
-            EXPECT_SUCCESS(close(server_to_client[i]));
-            EXPECT_SUCCESS(close(client_to_server[i]));
-        }
     }
 
     /* Failure: server sends a non-empty initial renegotiation_info */
@@ -228,8 +204,6 @@ int main(int argc, char **argv)
         struct s2n_connection *client_conn;
         struct s2n_config *client_config;
         s2n_blocked_status client_blocked;
-        int server_to_client[2];
-        int client_to_server[2];
 
         uint8_t server_extensions[] = {
             /* Extension type TLS_EXTENSION_RENEGOTIATION_INFO */
@@ -276,16 +250,11 @@ int main(int argc, char **argv)
         };
 
         /* Create nonblocking pipes */
-        EXPECT_SUCCESS(pipe(server_to_client));
-        EXPECT_SUCCESS(pipe(client_to_server));
-        for (int i = 0; i < 2; i++) {
-            EXPECT_NOT_EQUAL(fcntl(server_to_client[i], F_SETFL, fcntl(server_to_client[i], F_GETFL) | O_NONBLOCK), -1);
-            EXPECT_NOT_EQUAL(fcntl(client_to_server[i], F_SETFL, fcntl(client_to_server[i], F_GETFL) | O_NONBLOCK), -1);
-        }
+        struct s2n_test_piped_io piped_io;
+        EXPECT_SUCCESS(s2n_piped_io_init_non_blocking(&piped_io));
 
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(client_conn, server_to_client[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(client_conn, client_to_server[1]));
+        EXPECT_SUCCESS(s2n_connection_set_piped_io(client_conn, &piped_io));
 
         EXPECT_NOT_NULL(client_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
@@ -296,24 +265,19 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(client_blocked, S2N_BLOCKED_ON_READ);
 
         /* Write the server hello */
-        EXPECT_EQUAL(write(server_to_client[1], record_header, sizeof(record_header)), sizeof(record_header));
-        EXPECT_EQUAL(write(server_to_client[1], message_header, sizeof(message_header)), sizeof(message_header));
-        EXPECT_EQUAL(write(server_to_client[1], server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
-        EXPECT_EQUAL(write(server_to_client[1], server_extensions, sizeof(server_extensions)), sizeof(server_extensions));
+        EXPECT_EQUAL(write(piped_io.server_write, record_header, sizeof(record_header)), sizeof(record_header));
+        EXPECT_EQUAL(write(piped_io.server_write, message_header, sizeof(message_header)), sizeof(message_header));
+        EXPECT_EQUAL(write(piped_io.server_write, server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
+        EXPECT_EQUAL(write(piped_io.server_write, server_extensions, sizeof(server_extensions)), sizeof(server_extensions));
 
         /* Verify that we fail for non-empty renegotiated_connection */
         EXPECT_SUCCESS(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));
         EXPECT_EQUAL(s2n_negotiate(client_conn, &client_blocked), -1);
         EXPECT_EQUAL(s2n_errno, S2N_ERR_NON_EMPTY_RENEGOTIATION_INFO);
 
+        EXPECT_SUCCESS(s2n_piped_io_close(&piped_io));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
-
         EXPECT_SUCCESS(s2n_config_free(client_config));
-
-        for (int i = 0; i < 2; i++) {
-            EXPECT_SUCCESS(close(server_to_client[i]));
-            EXPECT_SUCCESS(close(client_to_server[i]));
-        }
     }
 
     free(cert_chain);

--- a/tests/unit/s2n_drain_alert_test.c
+++ b/tests/unit/s2n_drain_alert_test.c
@@ -86,19 +86,15 @@ int main(int argc, char **argv)
     struct s2n_connection *server_conn;
     struct s2n_config *server_config;
     s2n_blocked_status server_blocked;
-    int server_to_client[2];
-    int client_to_server[2];
     char *cert_chain = malloc(S2N_MAX_TEST_PEM_SIZE);
     char *private_key = malloc(S2N_MAX_TEST_PEM_SIZE);
     struct s2n_cert_chain_and_key *chain_and_key;
 
-    signal(SIGPIPE, SIG_IGN);
-    EXPECT_SUCCESS(pipe(server_to_client));
-    EXPECT_SUCCESS(pipe(client_to_server));
+    struct s2n_test_piped_io piped_io;
+    EXPECT_SUCCESS(s2n_piped_io_init_non_blocking(&piped_io));
 
     EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-    EXPECT_SUCCESS(s2n_connection_set_read_fd(server_conn, client_to_server[0]));
-    EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
+    EXPECT_SUCCESS(s2n_connection_set_piped_io(server_conn, &piped_io));
 
     EXPECT_NOT_NULL(server_config = s2n_config_new());
     EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
@@ -109,16 +105,16 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
     /* Send the client hello */
-    EXPECT_EQUAL(write(client_to_server[1], record_header, sizeof(record_header)), sizeof(record_header));
-    EXPECT_EQUAL(write(client_to_server[1], message_header, sizeof(message_header)), sizeof(message_header));
-    EXPECT_EQUAL(write(client_to_server[1], client_hello_message, sizeof(client_hello_message)), sizeof(client_hello_message));
+    EXPECT_EQUAL(write(piped_io.client_write, record_header, sizeof(record_header)), sizeof(record_header));
+    EXPECT_EQUAL(write(piped_io.client_write, message_header, sizeof(message_header)), sizeof(message_header));
+    EXPECT_EQUAL(write(piped_io.client_write, client_hello_message, sizeof(client_hello_message)), sizeof(client_hello_message));
 
     /* Send an alert from client to server */
-    EXPECT_EQUAL(write(client_to_server[1], alert_record, sizeof(alert_record)), sizeof(alert_record));
+    EXPECT_EQUAL(write(piped_io.client_write, alert_record, sizeof(alert_record)), sizeof(alert_record));
 
     /* Close the client read/write end */
-    EXPECT_SUCCESS(close(server_to_client[0]));
-    EXPECT_SUCCESS(close(client_to_server[1]));
+    EXPECT_SUCCESS(close(piped_io.client_read));
+    EXPECT_SUCCESS(close(piped_io.client_write));
 
     /* Expect the server to fail due to an incoming alert. We should not fail due to an I/O error(EPIPE). */
     s2n_negotiate(server_conn, &server_blocked);
@@ -131,8 +127,8 @@ int main(int argc, char **argv)
     free(cert_chain);
     free(private_key);
 
-    EXPECT_SUCCESS(close(server_to_client[1]));
-    EXPECT_SUCCESS(close(client_to_server[0]));
+    EXPECT_SUCCESS(close(piped_io.server_read));
+    EXPECT_SUCCESS(close(piped_io.server_write));
 
     END_TEST();
 }

--- a/tests/unit/s2n_mem_usage_test.c
+++ b/tests/unit/s2n_mem_usage_test.c
@@ -36,7 +36,7 @@
 /* This is roughly the current memory usage per connection */
 #define MEM_PER_CONNECTION (106 * 1024)
 
-/* This is the maximum  memory per conneciton including 4KB of slack */
+/* This is the maximum memory per connection including 4KB of slack */
 #define MAX_MEM_PER_CONNECTION (MEM_PER_CONNECTION + 4 * 1024)
 
 ssize_t get_vm_data_size()
@@ -73,6 +73,9 @@ int main(int argc, char **argv)
 
     BEGIN_TEST();
 
+    struct s2n_test_piped_io piped_io;
+    EXPECT_SUCCESS(s2n_piped_io_init_non_blocking(&piped_io));
+
     /* Skip the test when running under valgrind or address sanitizer, as those tools
      * impact the memory usage. */
     if (getenv("S2N_VALGRIND") != NULL || getenv("S2N_ADDRESS_SANITIZER") != NULL) {
@@ -89,8 +92,6 @@ int main(int argc, char **argv)
 
     const ssize_t maxAllowedMemDiff = 2 * connectionsToUse * MAX_MEM_PER_CONNECTION;
 
-    int *server_to_client = calloc(2 * connectionsToUse, sizeof(int));
-    int *client_to_server = calloc(2 * connectionsToUse, sizeof(int));
     struct s2n_connection **clients = calloc(connectionsToUse, sizeof(struct s2n_connection *));
     struct s2n_connection **servers = calloc(connectionsToUse, sizeof(struct s2n_connection *));
 
@@ -117,26 +118,14 @@ int main(int argc, char **argv)
     /* Allocate all connections */
     for (int i = 0; i < connectionsToUse; i++)
     {
-        /* Create nonblocking pipes */
-        EXPECT_SUCCESS(pipe(server_to_client + 2 * i));
-        EXPECT_SUCCESS(pipe(client_to_server + 2 * i));
-        for (int j = i * 2; j < (i + 1) * 2; j++) {
-            EXPECT_NOT_EQUAL(fcntl(server_to_client[j], F_SETFL, fcntl(server_to_client[j], F_GETFL) | O_NONBLOCK), -1);
-            EXPECT_NOT_EQUAL(fcntl(client_to_server[j], F_SETFL, fcntl(client_to_server[j], F_GETFL) | O_NONBLOCK), -1);
-        }
-
         struct s2n_connection *client_conn;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(client_conn, server_to_client[i * 2]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(client_conn, client_to_server[i * 2 + 1]));
         EXPECT_SUCCESS(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));
         clients[i] = client_conn;
 
         struct s2n_connection *server_conn;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(server_conn, client_to_server[i * 2]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[i * 2 + 1]));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
         EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
         servers[i] = server_conn;
@@ -146,6 +135,8 @@ int main(int argc, char **argv)
     EXPECT_NOT_EQUAL(vm_data_after_allocation, -1);
 
     for (int i = 0; i < connectionsToUse; i++) {
+        EXPECT_SUCCESS(s2n_connections_set_piped_io(clients[i], servers[i], &piped_io));
+
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(servers[i], clients[i]));
     }
 
@@ -169,21 +160,15 @@ int main(int argc, char **argv)
     for (int i = 0; i < connectionsToUse; i++) {
         EXPECT_SUCCESS(s2n_connection_free(clients[i]));
         EXPECT_SUCCESS(s2n_connection_free(servers[i]));
-
-        for (int j = i * 2; j < (i + 1) * 2; j++) {
-            EXPECT_SUCCESS(close(server_to_client[j]));
-            EXPECT_SUCCESS(close(client_to_server[j]));
-        }
     }
 
+    EXPECT_SUCCESS(s2n_piped_io_close(&piped_io));
     EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
     EXPECT_SUCCESS(s2n_config_free(server_config));
     EXPECT_SUCCESS(s2n_config_free(client_config));
 
     free(cert_chain);
     free(private_key);
-    free(server_to_client);
-    free(client_to_server);
     free(clients);
     free(servers);
 
@@ -195,7 +180,7 @@ int main(int argc, char **argv)
     fprintf(stdout, "VmData after free handshake: %10zu\n", vm_data_after_free_handshake);
     fprintf(stdout, "VmData after release:        %10zu\n", vm_data_after_release_buffers);
     fprintf(stdout, "Max VmData diff allowed:     %10zu\n", maxAllowedMemDiff);
-    fprintf(stdout, "Number of connecitons used:  %10zu\n", connectionsToUse);
+    fprintf(stdout, "Number of connections used:  %10zu\n", connectionsToUse);
 #endif
 
     EXPECT_TRUE(vm_data_after_allocation - vm_data_initial < maxAllowedMemDiff);

--- a/tests/unit/s2n_optional_client_auth_test.c
+++ b/tests/unit/s2n_optional_client_auth_test.c
@@ -97,8 +97,6 @@ int main(int argc, char **argv)
         struct s2n_cipher_preferences server_cipher_preferences;
         struct s2n_connection *client_conn;
         struct s2n_connection *server_conn;
-        int client_to_server[2];
-        int server_to_client[2];
 
         /* Craft a cipher preference with a cipher_idx cipher. */
         memcpy(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
@@ -115,22 +113,16 @@ int main(int argc, char **argv)
         server_config->cipher_preferences = &server_cipher_preferences;
 
         /* Create nonblocking pipes. */
-        EXPECT_SUCCESS(pipe(client_to_server));
-        EXPECT_SUCCESS(pipe(server_to_client));
-        for (int i = 0; i < 2; i++) {
-            EXPECT_NOT_EQUAL(fcntl(client_to_server[i], F_SETFL, fcntl(client_to_server[i], F_GETFL) | O_NONBLOCK), -1);
-            EXPECT_NOT_EQUAL(fcntl(server_to_client[i], F_SETFL, fcntl(server_to_client[i], F_GETFL) | O_NONBLOCK), -1);
-        }
+        struct s2n_test_piped_io piped_io;
+        EXPECT_SUCCESS(s2n_piped_io_init_non_blocking(&piped_io));
 
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(client_conn, server_to_client[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(client_conn, client_to_server[1]));
 
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(server_conn, client_to_server[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
+
+        EXPECT_SUCCESS(s2n_connections_set_piped_io(client_conn, server_conn, &piped_io));
 
         /* Verify the handshake was successful. */
         EXPECT_SUCCESS(try_handshake(server_conn, client_conn));
@@ -141,11 +133,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
-
-        for (int i = 0; i < 2; i++) {
-           EXPECT_SUCCESS(close(server_to_client[i]));
-           EXPECT_SUCCESS(close(client_to_server[i]));
-        }
+        EXPECT_SUCCESS(s2n_piped_io_close(&piped_io));
     }
 
     EXPECT_SUCCESS(s2n_config_free(client_config));
@@ -168,8 +156,6 @@ int main(int argc, char **argv)
         struct s2n_cipher_preferences server_cipher_preferences;
         struct s2n_connection *client_conn;
         struct s2n_connection *server_conn;
-        int client_to_server[2];
-        int server_to_client[2];
 
         /* Craft a cipher preference with a cipher_idx cipher. */
         memcpy(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
@@ -186,22 +172,16 @@ int main(int argc, char **argv)
         server_config->cipher_preferences = &server_cipher_preferences;
 
         /* Create nonblocking pipes. */
-        EXPECT_SUCCESS(pipe(client_to_server));
-        EXPECT_SUCCESS(pipe(server_to_client));
-        for (int i = 0; i < 2; i++) {
-            EXPECT_NOT_EQUAL(fcntl(client_to_server[i], F_SETFL, fcntl(client_to_server[i], F_GETFL) | O_NONBLOCK), -1);
-            EXPECT_NOT_EQUAL(fcntl(server_to_client[i], F_SETFL, fcntl(server_to_client[i], F_GETFL) | O_NONBLOCK), -1);
-        }
+        struct s2n_test_piped_io piped_io;
+        EXPECT_SUCCESS(s2n_piped_io_init_non_blocking(&piped_io));
 
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(client_conn, server_to_client[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(client_conn, client_to_server[1]));
 
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(server_conn, client_to_server[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
+
+        EXPECT_SUCCESS(s2n_connections_set_piped_io(client_conn, server_conn, &piped_io));
 
         /* Verify the handshake was successful. */
         EXPECT_SUCCESS(try_handshake(server_conn, client_conn));
@@ -212,11 +192,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
-
-        for (int i = 0; i < 2; i++) {
-           EXPECT_SUCCESS(close(server_to_client[i]));
-           EXPECT_SUCCESS(close(client_to_server[i]));
-        }
+        EXPECT_SUCCESS(s2n_piped_io_close(&piped_io));
     }
 
     EXPECT_SUCCESS(s2n_config_free(client_config));
@@ -239,8 +215,6 @@ int main(int argc, char **argv)
         struct s2n_cipher_preferences server_cipher_preferences;
         struct s2n_connection *client_conn;
         struct s2n_connection *server_conn;
-        int client_to_server[2];
-        int server_to_client[2];
 
         /* Craft a cipher preference with a cipher_idx cipher. */
         memcpy(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
@@ -257,22 +231,16 @@ int main(int argc, char **argv)
         server_config->cipher_preferences = &server_cipher_preferences;
 
         /* Create nonblocking pipes. */
-        EXPECT_SUCCESS(pipe(client_to_server));
-        EXPECT_SUCCESS(pipe(server_to_client));
-        for (int i = 0; i < 2; i++) {
-            EXPECT_NOT_EQUAL(fcntl(client_to_server[i], F_SETFL, fcntl(client_to_server[i], F_GETFL) | O_NONBLOCK), -1);
-            EXPECT_NOT_EQUAL(fcntl(server_to_client[i], F_SETFL, fcntl(server_to_client[i], F_GETFL) | O_NONBLOCK), -1);
-        }
+        struct s2n_test_piped_io piped_io;
+        EXPECT_SUCCESS(s2n_piped_io_init_non_blocking(&piped_io));
 
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(client_conn, server_to_client[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(client_conn, client_to_server[1]));
 
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(server_conn, client_to_server[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
+
+        EXPECT_SUCCESS(s2n_connections_set_piped_io(client_conn, server_conn, &piped_io));
 
         /* Verify the handshake was successful. */
         EXPECT_SUCCESS(try_handshake(server_conn, client_conn));
@@ -283,6 +251,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_piped_io_close(&piped_io));
     }
     
     EXPECT_SUCCESS(s2n_config_free(client_config));
@@ -306,8 +275,6 @@ int main(int argc, char **argv)
         struct s2n_cipher_preferences server_cipher_preferences;
         struct s2n_connection *client_conn;
         struct s2n_connection *server_conn;
-        int client_to_server[2];
-        int server_to_client[2];
 
         /* Craft a cipher preference with a cipher_idx cipher. */
         memcpy(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
@@ -324,25 +291,19 @@ int main(int argc, char **argv)
         server_config->cipher_preferences = &server_cipher_preferences;
 
         /* Create nonblocking pipes. */
-        EXPECT_SUCCESS(pipe(client_to_server));
-        EXPECT_SUCCESS(pipe(server_to_client));
-        for (int i = 0; i < 2; i++) {
-            EXPECT_NOT_EQUAL(fcntl(client_to_server[i], F_SETFL, fcntl(client_to_server[i], F_GETFL) | O_NONBLOCK), -1);
-            EXPECT_NOT_EQUAL(fcntl(server_to_client[i], F_SETFL, fcntl(server_to_client[i], F_GETFL) | O_NONBLOCK), -1);
-        }
+        struct s2n_test_piped_io piped_io;
+        EXPECT_SUCCESS(s2n_piped_io_init_non_blocking(&piped_io));
 
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(client_conn, server_to_client[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(client_conn, client_to_server[1]));
 
         /* Override the config setting on the connection. */
         EXPECT_SUCCESS(s2n_connection_set_client_auth_type(client_conn, S2N_CERT_AUTH_REQUIRED));
 
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(server_conn, client_to_server[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
+
+        EXPECT_SUCCESS(s2n_connections_set_piped_io(client_conn, server_conn, &piped_io));
 
         /* Override the config setting on the connection. */
         EXPECT_SUCCESS(s2n_connection_set_client_auth_type(server_conn, S2N_CERT_AUTH_OPTIONAL));
@@ -356,11 +317,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
-
-        for (int i = 0; i < 2; i++) {
-           EXPECT_SUCCESS(close(server_to_client[i]));
-           EXPECT_SUCCESS(close(client_to_server[i]));
-        }
+        EXPECT_SUCCESS(s2n_piped_io_close(&piped_io));
     }
 
     EXPECT_SUCCESS(s2n_config_free(client_config));
@@ -383,8 +340,6 @@ int main(int argc, char **argv)
         struct s2n_cipher_preferences server_cipher_preferences;
         struct s2n_connection *client_conn;
         struct s2n_connection *server_conn;
-        int client_to_server[2];
-        int server_to_client[2];
 
         /* Craft a cipher preference with a cipher_idx cipher. */
         memcpy(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
@@ -401,25 +356,19 @@ int main(int argc, char **argv)
         server_config->cipher_preferences = &server_cipher_preferences;
 
         /* Create nonblocking pipes. */
-        EXPECT_SUCCESS(pipe(client_to_server));
-        EXPECT_SUCCESS(pipe(server_to_client));
-        for (int i = 0; i < 2; i++) {
-            EXPECT_NOT_EQUAL(fcntl(client_to_server[i], F_SETFL, fcntl(client_to_server[i], F_GETFL) | O_NONBLOCK), -1);
-            EXPECT_NOT_EQUAL(fcntl(server_to_client[i], F_SETFL, fcntl(server_to_client[i], F_GETFL) | O_NONBLOCK), -1);
-        }
+        struct s2n_test_piped_io piped_io;
+        EXPECT_SUCCESS(s2n_piped_io_init_non_blocking(&piped_io));
 
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(client_conn, server_to_client[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(client_conn, client_to_server[1]));
 
         /* Override the config setting on the connection. */
         EXPECT_SUCCESS(s2n_connection_set_client_auth_type(client_conn, S2N_CERT_AUTH_OPTIONAL));
 
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(server_conn, client_to_server[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
+
+        EXPECT_SUCCESS(s2n_connections_set_piped_io(client_conn, server_conn, &piped_io));
 
         /* Override the config setting on the connection. */
         EXPECT_SUCCESS(s2n_connection_set_client_auth_type(server_conn, S2N_CERT_AUTH_OPTIONAL));
@@ -433,11 +382,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
-
-        for (int i = 0; i < 2; i++) {
-           EXPECT_SUCCESS(close(server_to_client[i]));
-           EXPECT_SUCCESS(close(client_to_server[i]));
-        }
+        EXPECT_SUCCESS(s2n_piped_io_close(&piped_io));
     }
 
     EXPECT_SUCCESS(s2n_config_free(client_config));
@@ -468,8 +413,6 @@ int main(int argc, char **argv)
         struct s2n_cipher_preferences server_cipher_preferences;
         struct s2n_connection *client_conn;
         struct s2n_connection *server_conn;
-        int client_to_server[2];
-        int server_to_client[2];
 
         /* Craft a cipher preference with a cipher_idx cipher. */
         memcpy(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
@@ -486,22 +429,16 @@ int main(int argc, char **argv)
         server_config->cipher_preferences = &server_cipher_preferences;
 
         /* Create nonblocking pipes. */
-        EXPECT_SUCCESS(pipe(client_to_server));
-        EXPECT_SUCCESS(pipe(server_to_client));
-        for (int i = 0; i < 2; i++) {
-            EXPECT_NOT_EQUAL(fcntl(client_to_server[i], F_SETFL, fcntl(client_to_server[i], F_GETFL) | O_NONBLOCK), -1);
-            EXPECT_NOT_EQUAL(fcntl(server_to_client[i], F_SETFL, fcntl(server_to_client[i], F_GETFL) | O_NONBLOCK), -1);
-        }
+        struct s2n_test_piped_io piped_io;
+        EXPECT_SUCCESS(s2n_piped_io_init_non_blocking(&piped_io));
 
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(client_conn, server_to_client[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(client_conn, client_to_server[1]));
 
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(server_conn, client_to_server[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
+
+        EXPECT_SUCCESS(s2n_connections_set_piped_io(client_conn, server_conn, &piped_io));
 
         /* Verify the handshake failed. Blinding is disabled for the failure case to speed up tests. */
         EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
@@ -513,6 +450,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_piped_io_close(&piped_io));
     }
     
     EXPECT_SUCCESS(s2n_config_free(client_config));

--- a/tests/unit/s2n_release_non_empty_buffers.c
+++ b/tests/unit/s2n_release_non_empty_buffers.c
@@ -35,7 +35,7 @@
 
 static const uint8_t buf_to_send[1023] = { 27 };
 
-int mock_client(int writefd, int readfd)
+int mock_client(struct s2n_test_piped_io *piped_io)
 {
     struct s2n_connection *conn;
     struct s2n_config *client_config;
@@ -48,8 +48,7 @@ int mock_client(int writefd, int readfd)
     s2n_connection_set_config(conn, client_config);
 
     /* Unlike the server, the client just passes ownership of I/O to s2n */
-    s2n_connection_set_read_fd(conn, readfd);
-    s2n_connection_set_write_fd(conn, writefd);
+    s2n_connection_set_piped_io(conn, piped_io);
 
     result = s2n_negotiate(conn, &blocked);
     if (result < 0) {
@@ -79,8 +78,6 @@ int main(int argc, char **argv)
     s2n_blocked_status blocked;
     int status;
     pid_t pid;
-    int server_to_client[2];
-    int client_to_server[2];
     char *cert_chain_pem;
     char *private_key_pem;
     struct s2n_cert_chain_and_key *chain_and_key;
@@ -100,15 +97,14 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
 
     /* Create a pipe */
-    EXPECT_SUCCESS(pipe(server_to_client));
-    EXPECT_SUCCESS(pipe(client_to_server));
+    struct s2n_test_piped_io piped_io;
+    EXPECT_SUCCESS(s2n_piped_io_init(&piped_io));
 
     /* Create a child process */
     pid = fork();
     if (pid == 0) {
-        /* This is the child process, close the read end of the pipe */
-        EXPECT_SUCCESS(close(client_to_server[0]));
-        EXPECT_SUCCESS(close(server_to_client[1]));
+        /* This is the client process, close the server end of the pipe */
+        EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_SERVER));
 
         /* Free the config */
         EXPECT_SUCCESS(s2n_config_free(config));
@@ -116,19 +112,18 @@ int main(int argc, char **argv)
         free(private_key_pem);
 
         /* Run the client */
-        mock_client(client_to_server[1], server_to_client[0]);
+        mock_client(&piped_io);
     }
 
-    /* This is the parent, close the write end of the pipe */
-    EXPECT_SUCCESS(close(client_to_server[1]));
-    EXPECT_SUCCESS(close(server_to_client[0]));
+    /* This is the server process, close the client end of the pipe */
+    EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_CLIENT));
 
     EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
     EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
     /* Make pipes non-blocking */
-    EXPECT_NOT_EQUAL(fcntl(client_to_server[0], F_SETFL, fcntl(client_to_server[0], F_GETFL) | O_NONBLOCK), -1);
-    EXPECT_NOT_EQUAL(fcntl(server_to_client[1], F_SETFL, fcntl(server_to_client[1], F_GETFL) | O_NONBLOCK), -1);
+    EXPECT_SUCCESS(s2n_fd_set_non_blocking(piped_io.server_read));
+    EXPECT_SUCCESS(s2n_fd_set_non_blocking(piped_io.server_write));
 
     /* Set up our I/O callbacks. Use stuffers for the "I/O context" */
     EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&in, 0));
@@ -142,14 +137,14 @@ int main(int argc, char **argv)
 
         /* check to see if we need to copy more over from the pipes to the buffers
          * to continue the handshake */
-        s2n_stuffer_recv_from_fd(&in, client_to_server[0], MAX_BUF_SIZE);
-        s2n_stuffer_send_to_fd(&out, server_to_client[1], s2n_stuffer_data_available(&out));
+        s2n_stuffer_recv_from_fd(&in, piped_io.server_read, MAX_BUF_SIZE);
+        s2n_stuffer_send_to_fd(&out, piped_io.server_write, s2n_stuffer_data_available(&out));
     } while (blocked);
 
     /* Receive only 100 bytes of the record and try to call s2n_recv */
     n = 0;
     while (n < 100) {
-        ret = s2n_stuffer_recv_from_fd(&in, client_to_server[0], 100 - n);
+        ret = s2n_stuffer_recv_from_fd(&in, piped_io.server_read, 100 - n);
 
         if (ret < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
             continue;
@@ -168,7 +163,7 @@ int main(int argc, char **argv)
 
     /* Read the rest of the buffer and expect s2n_recv to succeed */
     do {
-        ret = s2n_stuffer_recv_from_fd(&in, client_to_server[0], MAX_BUF_SIZE);
+        ret = s2n_stuffer_recv_from_fd(&in, piped_io.server_read, MAX_BUF_SIZE);
 
         if (ret < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
             continue;
@@ -194,8 +189,8 @@ int main(int argc, char **argv)
             server_shutdown = 1;
         }
 
-        s2n_stuffer_recv_from_fd(&in, client_to_server[0], MAX_BUF_SIZE);
-        s2n_stuffer_send_to_fd(&out, server_to_client[1], s2n_stuffer_data_available(&out));
+        s2n_stuffer_recv_from_fd(&in, piped_io.server_read, MAX_BUF_SIZE);
+        s2n_stuffer_send_to_fd(&out, piped_io.server_write, s2n_stuffer_data_available(&out));
     } while (!server_shutdown);
 
     EXPECT_SUCCESS(s2n_connection_free(conn));

--- a/tests/unit/s2n_self_talk_alerts_test.c
+++ b/tests/unit/s2n_self_talk_alerts_test.c
@@ -43,7 +43,7 @@ struct alert_ctx {
     uint8_t code;
 };
 
-int mock_client(int writefd, int readfd, s2n_alert_behavior alert_behavior, int expect_failure)
+int mock_client(struct s2n_test_piped_io *piped_io, s2n_alert_behavior alert_behavior, int expect_failure)
 {
     struct s2n_connection *conn;
     struct s2n_config *config;
@@ -60,8 +60,7 @@ int mock_client(int writefd, int readfd, s2n_alert_behavior alert_behavior, int 
     s2n_config_set_alert_behavior(config, alert_behavior);
     s2n_connection_set_config(conn, config);
 
-    s2n_connection_set_read_fd(conn, readfd);
-    s2n_connection_set_write_fd(conn, writefd);
+    s2n_connection_set_piped_io(conn, piped_io);
 
     rc = s2n_negotiate(conn, &blocked);
     if (expect_failure) {
@@ -88,8 +87,7 @@ int mock_client(int writefd, int readfd, s2n_alert_behavior alert_behavior, int 
     s2n_connection_free(conn);
     s2n_config_free(config);
 
-    close(writefd);
-    close(readfd);
+    s2n_piped_io_close_one_end(piped_io, S2N_CLIENT);
 
     s2n_cleanup();
 
@@ -135,8 +133,6 @@ int main(int argc, char **argv)
     s2n_blocked_status blocked;
     int status;
     pid_t pid;
-    int server_to_client[2];
-    int client_to_server[2];
     char *cert_chain_pem;
     char *private_key_pem;
     struct s2n_cert_chain_and_key *chain_and_key;
@@ -158,33 +154,31 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
 
         /* Create a pipe */
-        EXPECT_SUCCESS(pipe(server_to_client));
-        EXPECT_SUCCESS(pipe(client_to_server));
+        struct s2n_test_piped_io piped_io;
+        EXPECT_SUCCESS(s2n_piped_io_init(&piped_io));
 
         /* Set up the callback to send an alert after receiving ClientHello */
-        struct alert_ctx warning_alert = {.write_fd = server_to_client[1], .invoked = 0, .level = TLS_ALERT_LEVEL_WARNING, .code = TLS_ALERT_UNRECOGNIZED_NAME};
+        struct alert_ctx warning_alert = {.write_fd = piped_io.server_write, .invoked = 0, .level = TLS_ALERT_LEVEL_WARNING, .code = TLS_ALERT_UNRECOGNIZED_NAME};
         EXPECT_SUCCESS(s2n_config_set_client_hello_cb(config, client_hello_send_alert, &warning_alert));
 
         /* Create a child process */
         pid = fork();
         if (pid == 0) {
-            /* This is the child process, close the read end of the pipe */
-            EXPECT_SUCCESS(close(client_to_server[0]));
-            EXPECT_SUCCESS(close(server_to_client[1]));
+            /* This is the client process, close the server end of the pipe */
+            EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_SERVER));
 
-            mock_client(client_to_server[1], server_to_client[0], S2N_ALERT_IGNORE_WARNINGS, 0);
+            mock_client(&piped_io, S2N_ALERT_IGNORE_WARNINGS, 0);
         }
 
         /* This is the parent */
-        EXPECT_SUCCESS(close(client_to_server[1]));
-        EXPECT_SUCCESS(close(server_to_client[0]));
+        /* This is the server process, close the client end of the pipe */
+        EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_CLIENT));
 
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
         /* Set up the connection to read from the fd */
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(conn, client_to_server[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(conn, server_to_client[1]));
+        EXPECT_SUCCESS(s2n_connection_set_piped_io(conn, &piped_io));
 
         /* Negotiate the handshake. */
         EXPECT_SUCCESS(s2n_negotiate(conn, &blocked));
@@ -211,8 +205,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_shutdown(conn, &blocked));
         EXPECT_SUCCESS(s2n_connection_free(conn));
-        EXPECT_SUCCESS(close(client_to_server[0]));
-        EXPECT_SUCCESS(close(server_to_client[1]));
+        EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_SERVER));
 
         /* Clean up */
         EXPECT_EQUAL(waitpid(-1, &status, 0), pid);
@@ -226,33 +219,30 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
 
         /* Create a pipe */
-        EXPECT_SUCCESS(pipe(server_to_client));
-        EXPECT_SUCCESS(pipe(client_to_server));
+        struct s2n_test_piped_io piped_io;
+        EXPECT_SUCCESS(s2n_piped_io_init(&piped_io));
 
         /* Set up the callback to send an alert after receiving ClientHello */
-        struct alert_ctx fatal_alert = {.write_fd = server_to_client[1], .invoked = 0, .level = TLS_ALERT_LEVEL_FATAL, .code = TLS_ALERT_UNRECOGNIZED_NAME};
+        struct alert_ctx fatal_alert = {.write_fd = piped_io.server_write, .invoked = 0, .level = TLS_ALERT_LEVEL_FATAL, .code = TLS_ALERT_UNRECOGNIZED_NAME};
         EXPECT_SUCCESS(s2n_config_set_client_hello_cb(config, client_hello_send_alert, &fatal_alert));
 
         /* Create a child process */
         pid = fork();
         if (pid == 0) {
-            /* This is the child process, close the read end of the pipe */
-            EXPECT_SUCCESS(close(client_to_server[0]));
-            EXPECT_SUCCESS(close(server_to_client[1]));
+            /* This is the client process, close the server end of the pipe */
+            EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_SERVER));
 
-            mock_client(client_to_server[1], server_to_client[0], S2N_ALERT_IGNORE_WARNINGS, 1);
+            mock_client(&piped_io, S2N_ALERT_IGNORE_WARNINGS, 1);
         }
 
-        /* This is the parent */
-        EXPECT_SUCCESS(close(client_to_server[1]));
-        EXPECT_SUCCESS(close(server_to_client[0]));
+        /* This is the server process, close the client end of the pipe */
+        EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_CLIENT));
 
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
         /* Set up the connection to read from the fd */
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(conn, client_to_server[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(conn, server_to_client[1]));
+        EXPECT_SUCCESS(s2n_connection_set_piped_io(conn, &piped_io));
 
         /* Negotiate the handshake. */
         EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
@@ -261,8 +251,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(fatal_alert.invoked, 1);
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
-        EXPECT_SUCCESS(close(client_to_server[0]));
-        EXPECT_SUCCESS(close(server_to_client[1]));
+        EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_SERVER));
 
         /* Clean up */
         EXPECT_EQUAL(waitpid(-1, &status, 0), pid);
@@ -276,33 +265,30 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
 
         /* Create a pipe */
-        EXPECT_SUCCESS(pipe(server_to_client));
-        EXPECT_SUCCESS(pipe(client_to_server));
+        struct s2n_test_piped_io piped_io;
+        EXPECT_SUCCESS(s2n_piped_io_init(&piped_io));
 
         /* Set up the callback to send an alert after receiving ClientHello */
-        struct alert_ctx warning_alert = {.write_fd = server_to_client[1], .invoked = 0, .level = TLS_ALERT_LEVEL_WARNING, .code = TLS_ALERT_UNRECOGNIZED_NAME};
+        struct alert_ctx warning_alert = {.write_fd = piped_io.server_write, .invoked = 0, .level = TLS_ALERT_LEVEL_WARNING, .code = TLS_ALERT_UNRECOGNIZED_NAME};
         EXPECT_SUCCESS(s2n_config_set_client_hello_cb(config, client_hello_send_alert, &warning_alert));
 
         /* Create a child process */
         pid = fork();
         if (pid == 0) {
-            /* This is the child process, close the read end of the pipe */
-            EXPECT_SUCCESS(close(client_to_server[0]));
-            EXPECT_SUCCESS(close(server_to_client[1]));
+            /* This is the client process, close the server end of the pipe */
+            EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_SERVER));
 
-            mock_client(client_to_server[1], server_to_client[0], S2N_ALERT_FAIL_ON_WARNINGS, 1);
+            mock_client(&piped_io, S2N_ALERT_FAIL_ON_WARNINGS, 1);
         }
 
-        /* This is the parent */
-        EXPECT_SUCCESS(close(client_to_server[1]));
-        EXPECT_SUCCESS(close(server_to_client[0]));
+        /* This is the server process, close the client end of the pipe */
+        EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_CLIENT));
 
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
         /* Set up the connection to read from the fd */
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(conn, client_to_server[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(conn, server_to_client[1]));
+        EXPECT_SUCCESS(s2n_connection_set_piped_io(conn, &piped_io));
 
         /* Negotiate the handshake. */
         EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
@@ -311,8 +297,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(warning_alert.invoked, 1);
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
-        EXPECT_SUCCESS(close(client_to_server[0]));
-        EXPECT_SUCCESS(close(server_to_client[1]));
+        EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_SERVER));
 
         /* Clean up */
         EXPECT_EQUAL(waitpid(-1, &status, 0), pid);

--- a/tests/unit/s2n_self_talk_client_hello_cb_test.c
+++ b/tests/unit/s2n_self_talk_client_hello_cb_test.c
@@ -31,7 +31,7 @@ struct client_hello_context {
     struct s2n_config *config;
 };
 
-int mock_client(int writefd, int readfd, int expect_failure, int expect_server_name_used)
+int mock_client(struct s2n_test_piped_io *piped_io, int expect_failure, int expect_server_name_used)
 {
     struct s2n_connection *conn;
     struct s2n_config *config;
@@ -49,8 +49,7 @@ int mock_client(int writefd, int readfd, int expect_failure, int expect_server_n
     s2n_config_disable_x509_verification(config);
     s2n_connection_set_config(conn, config);
 
-    s2n_connection_set_read_fd(conn, readfd);
-    s2n_connection_set_write_fd(conn, writefd);
+    s2n_connection_set_piped_io(conn, piped_io);
 
     s2n_set_server_name(conn, "example.com");
 
@@ -92,6 +91,7 @@ int mock_client(int writefd, int readfd, int expect_failure, int expect_server_n
     sleep(1);
 
     s2n_cleanup();
+    s2n_piped_io_close_one_end(piped_io, S2N_CLIENT);
 
     _exit(result);
 }
@@ -176,8 +176,6 @@ int main(int argc, char **argv)
     s2n_blocked_status blocked;
     int status;
     pid_t pid;
-    int server_to_client[2];
-    int client_to_server[2];
     struct client_hello_context client_hello_ctx;
     char *cert_chain_pem;
     char *private_key_pem;
@@ -214,29 +212,26 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_config_set_client_hello_cb(config, client_hello_swap_config, &client_hello_ctx));
 
     /* Create a pipe */
-    EXPECT_SUCCESS(pipe(server_to_client));
-    EXPECT_SUCCESS(pipe(client_to_server));
+    struct s2n_test_piped_io piped_io;
+    EXPECT_SUCCESS(s2n_piped_io_init(&piped_io));
 
     /* Create a child process */
     pid = fork();
     if (pid == 0) {
-        /* This is the child process, close the read end of the pipe */
-        EXPECT_SUCCESS(close(client_to_server[0]));
-        EXPECT_SUCCESS(close(server_to_client[1]));
+        /* This is the client process, close the server end of the pipe */
+        EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_SERVER));
 
-        mock_client(client_to_server[1], server_to_client[0], 0, 1);
+        mock_client(&piped_io, 0, 1);
     }
 
-    /* This is the parent */
-    EXPECT_SUCCESS(close(client_to_server[1]));
-    EXPECT_SUCCESS(close(server_to_client[0]));
+    /* This is the server process, close the client end of the pipe */
+    EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_CLIENT));
 
     EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
     EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
     /* Set up the connection to read from the fd */
-    EXPECT_SUCCESS(s2n_connection_set_read_fd(conn, client_to_server[0]));
-    EXPECT_SUCCESS(s2n_connection_set_write_fd(conn, server_to_client[1]));
+    EXPECT_SUCCESS(s2n_connection_set_piped_io(conn, &piped_io));
 
     /* Negotiate the handshake. */
     EXPECT_SUCCESS(s2n_negotiate(conn, &blocked));
@@ -287,29 +282,27 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_config_set_client_hello_cb(config, client_hello_swap_config, &client_hello_ctx));
 
     /* Create a pipe */
-    EXPECT_SUCCESS(pipe(server_to_client));
-    EXPECT_SUCCESS(pipe(client_to_server));
+    EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_SERVER));
+    EXPECT_SUCCESS(s2n_piped_io_init(&piped_io));
 
     /* Create a child process */
     pid = fork();
     if (pid == 0) {
-        /* This is the child process, close the read end of the pipe */
-        EXPECT_SUCCESS(close(client_to_server[0]));
-        EXPECT_SUCCESS(close(server_to_client[1]));
+        /* This is the client process, close the server end of the pipe */
+        EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_SERVER));
 
-        mock_client(client_to_server[1], server_to_client[0], 0, 0);
+        mock_client(&piped_io, 0, 0);
     }
 
     /* This is the parent */
-    EXPECT_SUCCESS(close(client_to_server[1]));
-    EXPECT_SUCCESS(close(server_to_client[0]));
+    /* This is the server process, close the client end of the pipe */
+    EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_CLIENT));
 
     EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
     EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
     /* Set up the connection to read from the fd */
-    EXPECT_SUCCESS(s2n_connection_set_read_fd(conn, client_to_server[0]));
-    EXPECT_SUCCESS(s2n_connection_set_write_fd(conn, server_to_client[1]));
+    EXPECT_SUCCESS(s2n_connection_set_piped_io(conn, &piped_io));
 
     /* Negotiate the handshake. */
     EXPECT_SUCCESS(s2n_negotiate(conn, &blocked));
@@ -358,22 +351,20 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_config_set_client_hello_cb(config, client_hello_fail_handshake, &client_hello_ctx));
 
     /* Create a pipe */
-    EXPECT_SUCCESS(pipe(server_to_client));
-    EXPECT_SUCCESS(pipe(client_to_server));
+    EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_SERVER));
+    EXPECT_SUCCESS(s2n_piped_io_init(&piped_io));
 
     /* Create a child process */
     pid = fork();
     if (pid == 0) {
-        /* This is the child process, close the read end of the pipe */
-        EXPECT_SUCCESS(close(client_to_server[0]));
-        EXPECT_SUCCESS(close(server_to_client[1]));
+        /* This is the client process, close the server end of the pipe */
+        EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_SERVER));
 
-        mock_client(client_to_server[1], server_to_client[0], 1, 0);
+        mock_client(&piped_io, 1, 0);
     }
 
-    /* This is the parent */
-    EXPECT_SUCCESS(close(client_to_server[1]));
-    EXPECT_SUCCESS(close(server_to_client[0]));
+    /* This is the server process, close the client end of the pipe */
+    EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_CLIENT));
 
     EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
     EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
@@ -384,8 +375,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_connection_set_blinding(conn, S2N_SELF_SERVICE_BLINDING));
 
     /* Set up the connection to read from the fd */
-    EXPECT_SUCCESS(s2n_connection_set_read_fd(conn, client_to_server[0]));
-    EXPECT_SUCCESS(s2n_connection_set_write_fd(conn, server_to_client[1]));
+    EXPECT_SUCCESS(s2n_connection_set_piped_io(conn, &piped_io));
 
     /* Negotiate the handshake. */
     EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate(conn, &blocked), S2N_ERR_CANCELLED);

--- a/tests/unit/s2n_self_talk_custom_io_test.c
+++ b/tests/unit/s2n_self_talk_custom_io_test.c
@@ -33,7 +33,7 @@
 
 #define MAX_BUF_SIZE 10000
 
-int mock_client(int writefd, int readfd)
+int mock_client(struct s2n_test_piped_io *piped_io)
 {
     struct s2n_connection *conn;
     struct s2n_config *client_config;
@@ -46,8 +46,7 @@ int mock_client(int writefd, int readfd)
     s2n_connection_set_config(conn, client_config);
 
     /* Unlike the server, the client just passes ownership of I/O to s2n */
-    s2n_connection_set_read_fd(conn, readfd);
-    s2n_connection_set_write_fd(conn, writefd);
+    s2n_connection_set_piped_io(conn, piped_io);
 
     result = s2n_negotiate(conn, &blocked);
     if (result < 0) {
@@ -58,6 +57,7 @@ int mock_client(int writefd, int readfd)
     s2n_connection_free(conn);
     s2n_config_free(client_config);
     s2n_cleanup();
+    s2n_piped_io_close_one_end(piped_io, S2N_CLIENT);
 
     _exit(0);
 }
@@ -75,8 +75,6 @@ int main(int argc, char **argv)
     s2n_blocked_status blocked;
     int status;
     pid_t pid;
-    int server_to_client[2];
-    int client_to_server[2];
     char *cert_chain_pem;
     char *private_key_pem;
     char *dhparams_pem;
@@ -103,15 +101,14 @@ int main(int argc, char **argv)
     signal(SIGPIPE, SIG_IGN);
 
     /* Create a pipe */
-    EXPECT_SUCCESS(pipe(server_to_client));
-    EXPECT_SUCCESS(pipe(client_to_server));
+    struct s2n_test_piped_io piped_io;
+    EXPECT_SUCCESS(s2n_piped_io_init(&piped_io));
 
     /* Create a child process */
     pid = fork();
     if (pid == 0) {
-        /* This is the child process, close the read end of the pipe */
-        EXPECT_SUCCESS(close(client_to_server[0]));
-        EXPECT_SUCCESS(close(server_to_client[1]));
+        /* This is the client process, close the server end of the pipe */
+        EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_SERVER));
 
         /* Free the config */
         EXPECT_SUCCESS(s2n_config_free(config));
@@ -120,12 +117,11 @@ int main(int argc, char **argv)
         free(dhparams_pem);
 
         /* Run the client */
-        mock_client(client_to_server[1], server_to_client[0]);
+        mock_client(&piped_io);
     }
 
-    /* This is the parent, close the write end of the pipe */
-    EXPECT_SUCCESS(close(client_to_server[1]));
-    EXPECT_SUCCESS(close(server_to_client[0]));
+    /* This is the server process, close the client end of the pipe */
+    EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_CLIENT));
 
     EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
     EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
@@ -138,8 +134,8 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&in, &out, conn));
     
     /* Make our pipes non-blocking */
-    EXPECT_NOT_EQUAL(fcntl(client_to_server[0], F_SETFL, fcntl(client_to_server[0], F_GETFL) | O_NONBLOCK), -1);
-    EXPECT_NOT_EQUAL(fcntl(server_to_client[1], F_SETFL, fcntl(server_to_client[1], F_GETFL) | O_NONBLOCK), -1);
+    EXPECT_SUCCESS(s2n_fd_set_non_blocking(piped_io.server_read));
+    EXPECT_SUCCESS(s2n_fd_set_non_blocking(piped_io.server_write));
 
     /* Negotiate the handshake. */
     do {
@@ -151,8 +147,8 @@ int main(int argc, char **argv)
         /* check to see if we need to copy more over from the pipes to the buffers
          * to continue the handshake
          */
-        s2n_stuffer_recv_from_fd(&in, client_to_server[0], MAX_BUF_SIZE);
-        s2n_stuffer_send_to_fd(&out, server_to_client[1], s2n_stuffer_data_available(&out));
+        s2n_stuffer_recv_from_fd(&in, piped_io.server_read, MAX_BUF_SIZE);
+        s2n_stuffer_send_to_fd(&out, piped_io.server_write, s2n_stuffer_data_available(&out));
     } while (blocked);
    
     /* Shutdown after negotiating */
@@ -165,9 +161,9 @@ int main(int argc, char **argv)
         if (ret == 0) {
             server_shutdown = 1;
         }
-        
-        s2n_stuffer_recv_from_fd(&in, client_to_server[0], MAX_BUF_SIZE);
-        s2n_stuffer_send_to_fd(&out, server_to_client[1], s2n_stuffer_data_available(&out));
+
+        s2n_stuffer_recv_from_fd(&in, piped_io.server_read, MAX_BUF_SIZE);
+        s2n_stuffer_send_to_fd(&out, piped_io.server_write, s2n_stuffer_data_available(&out));
     } while (!server_shutdown);
     
     EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -177,6 +173,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_stuffer_free(&out));
     EXPECT_EQUAL(waitpid(-1, &status, 0), pid);
     EXPECT_EQUAL(status, 0);
+    EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_SERVER));
     EXPECT_SUCCESS(s2n_config_free(config));
     EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
     free(cert_chain_pem);

--- a/tests/unit/s2n_self_talk_min_protocol_version.c
+++ b/tests/unit/s2n_self_talk_min_protocol_version.c
@@ -48,6 +48,7 @@ int mock_client(struct s2n_test_piped_io *piped_io)
 
     result = s2n_negotiate(client_conn, &blocked);
 
+    s2n_piped_io_close_one_end(piped_io, S2N_CLIENT);
     s2n_connection_free(client_conn);
     s2n_config_free(client_config);
 
@@ -64,17 +65,11 @@ int main(int argc, char **argv)
     s2n_blocked_status blocked;
     int status;
     pid_t pid;
-    char *cert_chain_pem;
-    char *private_key_pem;
+    char cert_chain_pem[S2N_MAX_TEST_PEM_SIZE];
+    char private_key_pem[S2N_MAX_TEST_PEM_SIZE];
     struct s2n_cert_chain_and_key *chain_and_key;
 
     BEGIN_TEST();
-
-    /* Ignore SIGPIPE */
-    signal(SIGPIPE, SIG_IGN);
-
-    EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
-    EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
 
     EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
     EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
@@ -128,8 +123,6 @@ int main(int argc, char **argv)
 
     EXPECT_SUCCESS(s2n_config_free(config));
     EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
-    free(cert_chain_pem);
-    free(private_key_pem);
     END_TEST();
 
     return 0;

--- a/tests/unit/s2n_self_talk_min_protocol_version.c
+++ b/tests/unit/s2n_self_talk_min_protocol_version.c
@@ -27,7 +27,7 @@
 #include "tls/s2n_connection.h"
 #include "tls/s2n_handshake.h"
 
-int mock_client(int writefd, int readfd)
+int mock_client(struct s2n_test_piped_io *piped_io)
 {
     struct s2n_connection *client_conn;
     struct s2n_config *client_config;
@@ -44,8 +44,7 @@ int mock_client(int writefd, int readfd)
     /* Force TLSv1 on a client so that server fail handshake */
     client_conn->client_protocol_version = S2N_TLS10;
 
-    s2n_connection_set_read_fd(client_conn, readfd);
-    s2n_connection_set_write_fd(client_conn, writefd);
+    s2n_connection_set_piped_io(client_conn, piped_io);
 
     result = s2n_negotiate(client_conn, &blocked);
 
@@ -65,8 +64,6 @@ int main(int argc, char **argv)
     s2n_blocked_status blocked;
     int status;
     pid_t pid;
-    int server_to_client[2];
-    int client_to_server[2];
     char *cert_chain_pem;
     char *private_key_pem;
     struct s2n_cert_chain_and_key *chain_and_key;
@@ -90,31 +87,28 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "CloudFront-TLS-1-2-2019"));
 
     /* Create a pipe */
-    EXPECT_SUCCESS(pipe(server_to_client));
-    EXPECT_SUCCESS(pipe(client_to_server));
+    struct s2n_test_piped_io piped_io;
+    EXPECT_SUCCESS(s2n_piped_io_init(&piped_io));
 
     /* Create a child process */
     pid = fork();
     if (pid == 0) {
-        /* This is the child process, close the read end of the pipe */
-        EXPECT_SUCCESS(close(client_to_server[0]));
-        EXPECT_SUCCESS(close(server_to_client[1]));
+        /* This is the client process, close the server end of the pipe */
+        EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_SERVER));
 
         /* Send the client hello with TLSv1 and validate that we failed handshake */
-        mock_client(client_to_server[1], server_to_client[0]);
+        mock_client(&piped_io);
     }
 
-    /* This is the parent */
-    EXPECT_SUCCESS(close(client_to_server[1]));
-    EXPECT_SUCCESS(close(server_to_client[0]));
+    /* This is the server process, close the client end of the pipe */
+    EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_CLIENT));
 
     EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
     EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
     EXPECT_SUCCESS(s2n_connection_set_blinding(conn, S2N_SELF_SERVICE_BLINDING));
 
     /* Set up the connection to read from the fd */
-    EXPECT_SUCCESS(s2n_connection_set_read_fd(conn, client_to_server[0]));
-    EXPECT_SUCCESS(s2n_connection_set_write_fd(conn, server_to_client[1]));
+    EXPECT_SUCCESS(s2n_connection_set_piped_io(conn, &piped_io));
 
     /* Negotiate the handshake. */
     EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate(conn, &blocked), S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
@@ -126,8 +120,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_connection_free(conn));
 
     /* Close the pipes */
-    EXPECT_SUCCESS(close(client_to_server[0]));
-    EXPECT_SUCCESS(close(server_to_client[1]));
+    EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_SERVER));
 
     /* Clean up */
     EXPECT_EQUAL(waitpid(-1, &status, 0), pid);

--- a/tests/unit/s2n_self_talk_nonblocking_test.c
+++ b/tests/unit/s2n_self_talk_nonblocking_test.c
@@ -30,7 +30,7 @@
 #include "tls/s2n_connection.h"
 #include "tls/s2n_handshake.h"
 
-int mock_client(int writefd, int readfd, uint8_t *expected_data, uint32_t size)
+int mock_client(struct s2n_test_piped_io *piped_io, uint8_t *expected_data, uint32_t size)
 {
     uint8_t *buffer = malloc(size);
     uint8_t *ptr = buffer;
@@ -47,8 +47,7 @@ int mock_client(int writefd, int readfd, uint8_t *expected_data, uint32_t size)
     s2n_config_disable_x509_verification(client_config);
     s2n_connection_set_config(client_conn, client_config);
 
-    s2n_connection_set_read_fd(client_conn, readfd);
-    s2n_connection_set_write_fd(client_conn, writefd);
+    s2n_connection_set_piped_io(client_conn, piped_io);
 
     result = s2n_negotiate(client_conn, &blocked);
     if (result < 0) {
@@ -86,7 +85,7 @@ int mock_client(int writefd, int readfd, uint8_t *expected_data, uint32_t size)
     return 0;
 }
 
-int mock_client_iov(int writefd, int readfd, struct iovec *iov, uint32_t iov_size)
+int mock_client_iov(struct s2n_test_piped_io *piped_io, struct iovec *iov, uint32_t iov_size)
 {
     struct s2n_connection *client_conn;
     struct s2n_config *client_config;
@@ -108,8 +107,7 @@ int mock_client_iov(int writefd, int readfd, struct iovec *iov, uint32_t iov_siz
     s2n_config_disable_x509_verification(client_config);
     s2n_connection_set_config(client_conn, client_config);
 
-    s2n_connection_set_read_fd(client_conn, readfd);
-    s2n_connection_set_write_fd(client_conn, writefd);
+    s2n_connection_set_piped_io(client_conn, piped_io);
 
     result = s2n_negotiate(client_conn, &blocked);
     if (result < 0) {
@@ -171,8 +169,6 @@ int test_send(int use_iov)
     s2n_blocked_status blocked;
     int status;
     pid_t pid;
-    int server_to_client[2];
-    int client_to_server[2];
     struct s2n_cert_chain_and_key *chain_and_key;
 
     EXPECT_NOT_NULL(config = s2n_config_new());
@@ -206,26 +202,25 @@ int test_send(int use_iov)
     }
 
     /* Create a pipe */
-    EXPECT_SUCCESS(pipe(server_to_client));
-    EXPECT_SUCCESS(pipe(client_to_server));
+    struct s2n_test_piped_io piped_io;
+    EXPECT_SUCCESS(s2n_piped_io_init(&piped_io));
 
     /* Create a child process */
     pid = fork();
     if (pid == 0) {
-        /* This is the child process, close the read end of the pipe */
-        EXPECT_SUCCESS(close(client_to_server[0]));
-        EXPECT_SUCCESS(close(server_to_client[1]));
+        /* This is the client process, close the server end of the pipe */
+        EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_SERVER));
 
         /* Run the client */
-        const int client_rc = !use_iov ? mock_client(client_to_server[1], server_to_client[0], blob.data, data_size)
-            : mock_client_iov(client_to_server[1], server_to_client[0], iov, iov_size);
+        const int client_rc = !use_iov ? mock_client(&piped_io, blob.data, data_size)
+            : mock_client_iov(&piped_io, iov, iov_size);
 
+        EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_CLIENT));
         _exit(client_rc);
     }
 
-    /* This is the parent */
-    EXPECT_SUCCESS(close(client_to_server[1]));
-    EXPECT_SUCCESS(close(server_to_client[0]));
+    /* This is the server process, close the client end of the pipe */
+    EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_CLIENT));
 
     EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
     EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
@@ -234,8 +229,7 @@ int test_send(int use_iov)
     EXPECT_SUCCESS(s2n_connection_prefer_low_latency(conn));
 
     /* Set up the connection to read from the fd */
-    EXPECT_SUCCESS(s2n_connection_set_read_fd(conn, client_to_server[0]));
-    EXPECT_SUCCESS(s2n_connection_set_write_fd(conn, server_to_client[1]));
+    EXPECT_SUCCESS(s2n_connection_set_piped_io(conn, &piped_io));
 
     EXPECT_SUCCESS(s2n_connection_use_corked_io(conn));
 
@@ -246,8 +240,8 @@ int test_send(int use_iov)
     EXPECT_SUCCESS(kill(pid, SIGSTOP));
 
     /* Make our pipes non-blocking */
-    EXPECT_NOT_EQUAL(fcntl(client_to_server[0], F_SETFL, fcntl(client_to_server[0], F_GETFL) | O_NONBLOCK), -1);
-    EXPECT_NOT_EQUAL(fcntl(server_to_client[1], F_SETFL, fcntl(server_to_client[1], F_GETFL) | O_NONBLOCK), -1);
+    s2n_fd_set_non_blocking(piped_io.server_read);
+    s2n_fd_set_non_blocking(piped_io.server_write);
 
     /* Try to all 10MB of data, should be enough to fill PIPEBUF, so
        we'll get blocked at some point */
@@ -278,8 +272,8 @@ int test_send(int use_iov)
     EXPECT_SUCCESS(kill(pid, SIGCONT));
 
     /* Make our sockets blocking again */
-    EXPECT_NOT_EQUAL(fcntl(client_to_server[0], F_SETFL, fcntl(client_to_server[0], F_GETFL) ^ O_NONBLOCK), -1);
-    EXPECT_NOT_EQUAL(fcntl(server_to_client[1], F_SETFL, fcntl(server_to_client[1], F_GETFL) ^ O_NONBLOCK), -1);
+    s2n_fd_set_blocking(piped_io.server_read);
+    s2n_fd_set_blocking(piped_io.server_write);
 
     /* Actually send the remaining data */
     while (remaining) {
@@ -307,6 +301,7 @@ int test_send(int use_iov)
     EXPECT_EQUAL(status, 0);
     EXPECT_SUCCESS(s2n_config_free(config));
     EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+    EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_SERVER));
 
     if (iov) {
         for (int i = 0; i < iov_size; i++) {

--- a/tests/unit/s2n_self_talk_test.c
+++ b/tests/unit/s2n_self_talk_test.c
@@ -32,7 +32,7 @@
 static const char *certificate_paths[SUPPORTED_CERTIFICATE_FORMATS] = { S2N_RSA_2048_PKCS1_CERT_CHAIN, S2N_RSA_2048_PKCS8_CERT_CHAIN };
 static const char *private_key_paths[SUPPORTED_CERTIFICATE_FORMATS] = { S2N_RSA_2048_PKCS1_KEY, S2N_RSA_2048_PKCS8_KEY };
 
-void mock_client(int writefd, int readfd)
+void mock_client(struct s2n_test_piped_io *piped_io)
 {
     char buffer[0xffff];
     struct s2n_connection *conn;
@@ -50,8 +50,7 @@ void mock_client(int writefd, int readfd)
     conn->client_protocol_version = S2N_TLS12;
     conn->actual_protocol_version = S2N_TLS12;
 
-    s2n_connection_set_read_fd(conn, readfd);
-    s2n_connection_set_write_fd(conn, writefd);
+    s2n_connection_set_piped_io(conn, piped_io);
 
     s2n_negotiate(conn, &blocked);
 
@@ -98,6 +97,8 @@ void mock_client(int writefd, int readfd)
     /* Give the server a chance to a void a sigpipe */
     sleep(1);
 
+    s2n_piped_io_close_one_end(piped_io, S2N_CLIENT);
+
     _exit(0);
 }
 
@@ -108,8 +109,6 @@ int main(int argc, char **argv)
     s2n_blocked_status blocked;
     int status;
     pid_t pid;
-    int server_to_client[2];
-    int client_to_server[2];
     char *cert_chain_pem;
     char *private_key_pem;
     char *dhparams_pem;
@@ -123,23 +122,21 @@ int main(int argc, char **argv)
         struct s2n_cert_chain_and_key *chain_and_keys[SUPPORTED_CERTIFICATE_FORMATS];
 
         /* Create a pipe */
-        EXPECT_SUCCESS(pipe(server_to_client));
-        EXPECT_SUCCESS(pipe(client_to_server));
+        struct s2n_test_piped_io piped_io;
+        EXPECT_SUCCESS(s2n_piped_io_init(&piped_io));
 
         /* Create a child process */
         pid = fork();
         if (pid == 0) {
-            /* This is the child process, close the read end of the pipe */
-            EXPECT_SUCCESS(close(client_to_server[0]));
-            EXPECT_SUCCESS(close(server_to_client[1]));
+            /* This is the client process, close the server end of the pipe */
+            EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_SERVER));
 
             /* Write the fragmented hello message */
-            mock_client(client_to_server[1], server_to_client[0]);
+            mock_client(&piped_io);
         }
 
-        /* This is the parent */
-        EXPECT_SUCCESS(close(client_to_server[1]));
-        EXPECT_SUCCESS(close(server_to_client[0]));
+        /* This is the server process, close the client end of the pipe */
+        EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_CLIENT));
 
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         conn->server_protocol_version = S2N_TLS12;
@@ -163,8 +160,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
         /* Set up the connection to read from the fd */
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(conn, client_to_server[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(conn, server_to_client[1]));
+        EXPECT_SUCCESS(s2n_connection_set_piped_io(conn, &piped_io));
 
         /* Negotiate the handshake. */
         EXPECT_SUCCESS(s2n_negotiate(conn, &blocked));
@@ -205,6 +201,7 @@ int main(int argc, char **argv)
         /* Clean up */
         EXPECT_EQUAL(waitpid(-1, &status, 0), pid);
         EXPECT_EQUAL(status, 0);
+        EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_SERVER));
     }
 
     free(cert_chain_pem);

--- a/tests/unit/s2n_session_cache_async_test.c
+++ b/tests/unit/s2n_session_cache_async_test.c
@@ -125,7 +125,7 @@ int cache_delete(struct s2n_connection *conn, void *ctx, const void *key, uint64
     return 0;
 }
 
-void mock_client(int writefd, int readfd)
+void mock_client(struct s2n_test_piped_io *piped_io)
 {
     size_t serialized_session_state_length = 0;
     uint8_t serialized_session_state[256] = { 0 };
@@ -144,8 +144,7 @@ void mock_client(int writefd, int readfd)
     s2n_config_disable_x509_verification(config);
     s2n_connection_set_config(conn, config);
 
-    s2n_connection_set_read_fd(conn, readfd);
-    s2n_connection_set_write_fd(conn, writefd);
+    s2n_connection_set_piped_io(conn, piped_io);
 
     /* Set the session id to ensure we're able to fallback to full handshake if session is not in server cache */
     memcpy(conn->session_id, SESSION_ID, S2N_TLS_SESSION_ID_MAX_LEN);
@@ -196,8 +195,7 @@ void mock_client(int writefd, int readfd)
 
     /* Session resumption */
     conn = s2n_connection_new(S2N_CLIENT);
-    s2n_connection_set_read_fd(conn, readfd);
-    s2n_connection_set_write_fd(conn, writefd);
+    s2n_connection_set_piped_io(conn, piped_io);
 
     /* Set session state on client connection */
     if (s2n_connection_set_session(conn, serialized_session_state, serialized_session_state_length) < 0) {
@@ -229,8 +227,7 @@ void mock_client(int writefd, int readfd)
 
     /* Session resumption with bad session state */
     conn = s2n_connection_new(S2N_CLIENT);
-    s2n_connection_set_read_fd(conn, readfd);
-    s2n_connection_set_write_fd(conn, writefd);
+    s2n_connection_set_piped_io(conn, piped_io);
 
     /* Change the format of the session state and check we cannot deserialize it */
     serialized_session_state[0] = 3;
@@ -277,8 +274,6 @@ int main(int argc, char **argv)
     s2n_blocked_status blocked;
     int status;
     pid_t pid;
-    int server_to_client[2];
-    int client_to_server[2];
     char *cert_chain_pem;
     char *private_key_pem;
     char buffer[256];
@@ -299,23 +294,21 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(setenv("S2N_ENABLE_CLIENT_MODE", "1", 0));
 
     /* Create a pipe */
-    EXPECT_SUCCESS(pipe(server_to_client));
-    EXPECT_SUCCESS(pipe(client_to_server));
+    struct s2n_test_piped_io piped_io;
+    EXPECT_SUCCESS(s2n_piped_io_init(&piped_io));
 
     /* Create a child process */
     pid = fork();
     if (pid == 0) {
-        /* This is the child process, close the read end of the pipe */
-        EXPECT_SUCCESS(close(client_to_server[0]));
-        EXPECT_SUCCESS(close(server_to_client[1]));
+        /* This is the client process, close the server end of the pipe */
+        EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_SERVER));
 
         /* Write the fragmented hello message */
-        mock_client(client_to_server[1], server_to_client[0]);
+        mock_client(&piped_io);
     }
 
-    /* This is the parent */
-    EXPECT_SUCCESS(close(client_to_server[1]));
-    EXPECT_SUCCESS(close(server_to_client[0]));
+    /* This is the server process, close the client end of the pipe */
+    EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_CLIENT));
 
     /* initial handshake */
     {
@@ -330,8 +323,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
         /* Set up the connection to read from the fd */
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(conn, client_to_server[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(conn, server_to_client[1]));
+        EXPECT_SUCCESS(s2n_connection_set_piped_io(conn, &piped_io));
 
         /* Negotiate the handshake. */
         s2n_errno = S2N_ERR_T_OK;
@@ -368,8 +360,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
         /* Set up the connection to read from the fd */
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(conn, client_to_server[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(conn, server_to_client[1]));
+        EXPECT_SUCCESS(s2n_connection_set_piped_io(conn, &piped_io));
 
         /* Negotiate the handshake. */
         s2n_errno = S2N_ERR_T_OK;
@@ -402,8 +393,7 @@ int main(int argc, char **argv)
     }
 
     /* Close the pipes */
-    EXPECT_SUCCESS(close(client_to_server[0]));
-    EXPECT_SUCCESS(close(server_to_client[1]));
+    EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_SERVER));
 
     /* Clean up */
     EXPECT_SUCCESS(s2n_config_free(config));

--- a/tests/unit/s2n_session_ticket_test.c
+++ b/tests/unit/s2n_session_ticket_test.c
@@ -52,8 +52,6 @@ int main(int argc, char **argv)
     struct s2n_connection *server_conn;
     struct s2n_config *client_config;
     struct s2n_config *server_config;
-    int server_to_client[2];
-    int client_to_server[2];
     uint64_t now;
 
     size_t serialized_session_state_length = 0;
@@ -100,6 +98,9 @@ int main(int argc, char **argv)
 
     BEGIN_TEST();
 
+    struct s2n_test_piped_io piped_io;
+    EXPECT_SUCCESS(s2n_piped_io_init_non_blocking(&piped_io));
+
     EXPECT_NOT_NULL(cert_chain = malloc(S2N_MAX_TEST_PEM_SIZE));
     EXPECT_NOT_NULL(private_key = malloc(S2N_MAX_TEST_PEM_SIZE));
     EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
@@ -109,19 +110,9 @@ int main(int argc, char **argv)
 
     EXPECT_SUCCESS(setenv("S2N_DONT_MLOCK", "1", 0));
 
-    /* Create nonblocking pipes */
-    EXPECT_SUCCESS(pipe(server_to_client));
-    EXPECT_SUCCESS(pipe(client_to_server));
-    for (int i = 0; i < 2; i++) {
-       EXPECT_NOT_EQUAL(fcntl(server_to_client[i], F_SETFL, fcntl(server_to_client[i], F_GETFL) | O_NONBLOCK), -1);
-       EXPECT_NOT_EQUAL(fcntl(client_to_server[i], F_SETFL, fcntl(client_to_server[i], F_GETFL) | O_NONBLOCK), -1);
-    }
-
     /* Client sends empty ST extension. Server issues NST. */
     {
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(client_conn, server_to_client[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(client_conn, client_to_server[1]));
 
         EXPECT_NOT_NULL(client_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(client_config, 1));
@@ -129,12 +120,12 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
 
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(server_conn, client_to_server[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
-
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(server_config, 1));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
+
+        /* Create nonblocking pipes */
+        EXPECT_SUCCESS(s2n_connections_set_piped_io(client_conn, server_conn, &piped_io));
 
         /* Set session state lifetime for 15 hours which is equal to the default lifetime of a ticket key */
         EXPECT_SUCCESS(s2n_config_set_session_state_lifetime(server_config, S2N_SESSION_STATE_CONFIGURABLE_LIFETIME_IN_SECS));
@@ -175,21 +166,18 @@ int main(int argc, char **argv)
      * to issue NST due to absence of an encrypt-decrypt key. */
     {
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(client_conn, server_to_client[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(client_conn, client_to_server[1]));
-
         EXPECT_NOT_NULL(client_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(client_config, 1));
         EXPECT_SUCCESS(s2n_config_disable_x509_verification(client_config));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
 
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(server_conn, client_to_server[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
-
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(server_config, 1));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
+
+        /* Create nonblocking pipes */
+        EXPECT_SUCCESS(s2n_connections_set_piped_io(client_conn, server_conn, &piped_io));
 
         /* Set session state lifetime for 15 hours which is equal to the default lifetime of a ticket key */
         EXPECT_SUCCESS(s2n_config_set_session_state_lifetime(server_config, S2N_SESSION_STATE_CONFIGURABLE_LIFETIME_IN_SECS));
@@ -214,8 +202,6 @@ int main(int argc, char **argv)
     /* Client sends non-empty ST extension. Server does an abbreviated handshake without issuing NST. */
     {
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(client_conn, server_to_client[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(client_conn, client_to_server[1]));
 
         /* Set client ST and session state */
         EXPECT_SUCCESS(s2n_connection_set_session(client_conn, serialized_session_state, serialized_session_state_length));
@@ -225,12 +211,12 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
 
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(server_conn, client_to_server[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
-
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(server_config, 1));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
+
+        /* Create nonblocking pipes */
+        EXPECT_SUCCESS(s2n_connections_set_piped_io(client_conn, server_conn, &piped_io));
 
         /* Set session state lifetime for 15 hours which is equal to the default lifetime of a ticket key */
         EXPECT_SUCCESS(s2n_config_set_session_state_lifetime(server_config, S2N_SESSION_STATE_CONFIGURABLE_LIFETIME_IN_SECS));
@@ -271,8 +257,6 @@ int main(int argc, char **argv)
      */
     {
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(client_conn, server_to_client[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(client_conn, client_to_server[1]));
 
         /* Set client ST and session state */
         EXPECT_SUCCESS(s2n_connection_set_session(client_conn, serialized_session_state, serialized_session_state_length));
@@ -282,12 +266,13 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
 
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(server_conn, client_to_server[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(server_config, 1));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
+
+        /* Create nonblocking pipes */
+        EXPECT_SUCCESS(s2n_connections_set_piped_io(client_conn, server_conn, &piped_io));
 
         /* Set session state lifetime for 15 hours which is equal to the default lifetime of a ticket key */
         EXPECT_SUCCESS(s2n_config_set_session_state_lifetime(server_config, S2N_SESSION_STATE_CONFIGURABLE_LIFETIME_IN_SECS));
@@ -338,8 +323,6 @@ int main(int argc, char **argv)
      */
     {
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(client_conn, server_to_client[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(client_conn, client_to_server[1]));
 
         /* Set client ST and session state */
         EXPECT_SUCCESS(s2n_connection_set_session(client_conn, serialized_session_state, serialized_session_state_length));
@@ -349,12 +332,13 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
 
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(server_conn, client_to_server[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(server_config, 1));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
+
+        /* Create nonblocking pipes */
+        EXPECT_SUCCESS(s2n_connections_set_piped_io(client_conn, server_conn, &piped_io));
 
         /* Set session state lifetime for 15 hours which is equal to the default lifetime of a ticket key */
         EXPECT_SUCCESS(s2n_config_set_session_state_lifetime(server_config, S2N_SESSION_STATE_CONFIGURABLE_LIFETIME_IN_SECS));
@@ -403,16 +387,15 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_session(client_conn, serialized_session_state, serialized_session_state_length));
 
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(client_conn, server_to_client[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(client_conn, client_to_server[1]));
 
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(server_conn, client_to_server[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(server_config, 1));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
+
+        /* Create nonblocking pipes */
+        EXPECT_SUCCESS(s2n_connections_set_piped_io(client_conn, server_conn, &piped_io));
 
         /* Set session state lifetime for 15 hours which is equal to the default lifetime of a ticket key */
         EXPECT_SUCCESS(s2n_config_set_session_state_lifetime(server_config, S2N_SESSION_STATE_CONFIGURABLE_LIFETIME_IN_SECS));
@@ -457,16 +440,15 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_session(client_conn, serialized_session_state, serialized_session_state_length));
 
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(client_conn, server_to_client[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(client_conn, client_to_server[1]));
 
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(server_conn, client_to_server[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(server_config, 1));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
+
+        /* Create nonblocking pipes */
+        EXPECT_SUCCESS(s2n_connections_set_piped_io(client_conn, server_conn, &piped_io));
 
         /* Set session state lifetime for 15 hours which is equal to the default lifetime of a ticket key */
         EXPECT_SUCCESS(s2n_config_set_session_state_lifetime(server_config, S2N_SESSION_STATE_CONFIGURABLE_LIFETIME_IN_SECS));
@@ -532,16 +514,15 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_session(client_conn, tampered_session_state, serialized_session_state_length - 1));
 
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(client_conn, server_to_client[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(client_conn, client_to_server[1]));
 
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(server_conn, client_to_server[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(server_config, 1));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
+
+        /* Create nonblocking pipes */
+        EXPECT_SUCCESS(s2n_connections_set_piped_io(client_conn, server_conn, &piped_io));
 
         /* Set session state lifetime for 15 hours which is equal to the default lifetime of a ticket key */
         EXPECT_SUCCESS(s2n_config_set_session_state_lifetime(server_config, S2N_SESSION_STATE_CONFIGURABLE_LIFETIME_IN_SECS));
@@ -584,15 +565,14 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_session(client_conn, serialized_session_state, serialized_session_state_length));
 
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(client_conn, server_to_client[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(client_conn, client_to_server[1]));
 
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(server_conn, client_to_server[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
+
+        /* Create nonblocking pipes */
+        EXPECT_SUCCESS(s2n_connections_set_piped_io(client_conn, server_conn, &piped_io));
 
         /* Not enabling resumption using ST */
 
@@ -695,16 +675,15 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
 
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(client_conn, server_to_client[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(client_conn, client_to_server[1]));
 
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(server_conn, client_to_server[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(server_config, 1));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
+
+        /* Create nonblocking pipes */
+        EXPECT_SUCCESS(s2n_connections_set_piped_io(client_conn, server_conn, &piped_io));
 
         /* Set session state lifetime for 15 hours which is equal to the default lifetime of a ticket key */
         EXPECT_SUCCESS(s2n_config_set_session_state_lifetime(server_config, S2N_SESSION_STATE_CONFIGURABLE_LIFETIME_IN_SECS));
@@ -753,16 +732,15 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
 
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(client_conn, server_to_client[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(client_conn, client_to_server[1]));
 
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(server_conn, client_to_server[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(server_config, 1));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
+
+        /* Create nonblocking pipes */
+        EXPECT_SUCCESS(s2n_connections_set_piped_io(client_conn, server_conn, &piped_io));
 
         /* Set session state lifetime for 15 hours which is equal to the default lifetime of a ticket key */
         EXPECT_SUCCESS(s2n_config_set_session_state_lifetime(server_config, S2N_SESSION_STATE_CONFIGURABLE_LIFETIME_IN_SECS));
@@ -816,16 +794,15 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
 
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(client_conn, server_to_client[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(client_conn, client_to_server[1]));
 
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(server_conn, client_to_server[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(server_config, 1));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
+
+        /* Create nonblocking pipes */
+        EXPECT_SUCCESS(s2n_connections_set_piped_io(client_conn, server_conn, &piped_io));
 
         /* Set session state lifetime for 15 hours which is equal to the default lifetime of a ticket key */
         EXPECT_SUCCESS(s2n_config_set_session_state_lifetime(server_config, S2N_SESSION_STATE_CONFIGURABLE_LIFETIME_IN_SECS));
@@ -884,16 +861,15 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
 
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(client_conn, server_to_client[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(client_conn, client_to_server[1]));
 
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(server_conn, client_to_server[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(server_config, 1));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
+
+        /* Create nonblocking pipes */
+        EXPECT_SUCCESS(s2n_connections_set_piped_io(client_conn, server_conn, &piped_io));
 
         /* Set session state lifetime for 15 hours which is equal to the default lifetime of a ticket key */
         EXPECT_SUCCESS(s2n_config_set_session_state_lifetime(server_config, S2N_SESSION_STATE_CONFIGURABLE_LIFETIME_IN_SECS));
@@ -949,21 +925,20 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_set_client_auth_type(client_config, S2N_CERT_AUTH_OPTIONAL));
 
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(client_conn, server_to_client[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(client_conn, client_to_server[1]));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
 
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_SUCCESS(s2n_connection_set_read_fd(server_conn, client_to_server[0]));
-        EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
 
         /* Server has session ticket and mutual auth enabled */
         EXPECT_SUCCESS(s2n_connection_set_client_auth_type(server_conn, S2N_CERT_AUTH_OPTIONAL));
         EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(server_config, 1));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
+
+        /* Create nonblocking pipes */
+        EXPECT_SUCCESS(s2n_connections_set_piped_io(client_conn, server_conn, &piped_io));
 
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
@@ -981,11 +956,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_free(client_config));
     }
 
-    for (int i = 0; i < 2; i++) {
-       EXPECT_SUCCESS(close(server_to_client[i]));
-       EXPECT_SUCCESS(close(client_to_server[i]));
-    }
-
+    EXPECT_SUCCESS(s2n_piped_io_close(&piped_io));
     EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
     free(cert_chain);
     free(private_key);


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 

**Description of changes:** 
We have a lot of duplicate code in our tests. One common piece of functionality in the unit tests is setting up pipes for io. I moved that functionality to the test lib and made it easier to work with. File descriptors now have readable names like "client_read" instead of "server_to_client[0]" :)

This PR is unfortunately quite long, but is mostly just the results of find+replace. Interesting files:
* s2n_connection_test_utils.c: the new test functions
* s2n_testlib.h : the new test function definitions
* s2n_mem_usage_test.c: all connections now share a pipe. I don't THINK that violates the spirit of the test (our array of file descriptors was a fixed size), but could use a second opinion.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
