### PR TITLE
Refactor error handling in the handshake tests

### DIFF
--- a/tests/integration/s2n_handshake_test_s_client.py
+++ b/tests/integration/s2n_handshake_test_s_client.py
@@ -47,6 +47,27 @@ S_CLIENT_START_OF_SERVER_CERTIFICATE="Server certificate"
 S_CLIENT_LAST_CERTIFICATE_LINE_PATTERN=re.compile("-----END.*CERTIFICATE-----")
 S_CLIENT_SERVER_NAME_EXTENSION='TLS server extension "server name"'
 
+
+class IntegrationTestFailure(Exception):
+    """
+    Raised when a single integration test fails.
+    This allows the script to exit early when an error is detected.
+    """
+    pass
+
+
+class ProcessFailed(Exception):
+    """
+    Raised when a process like s2nc or s2nd fails.
+    """
+    def __init__(self, output, retcode):
+        self.output = output
+        self.retcode = retcode
+
+    def __str__(self):
+        return "Process exited with code {}: {}".format(self.retcode, self.output)
+
+
 class TlsExtensionServerName:
     def s_client_validate(s_client_out):
         s_client_out_len = len(s_client_out)
@@ -197,8 +218,7 @@ def read_process_output_until(process, marker):
         if marker in line:
             return output
         if terminated is not None:
-            print("Process exited with code {}: {}".format(terminated, output))
-            return output
+            raise ProcessFailed(output, terminated)
 
     return output
 
@@ -325,14 +345,22 @@ def try_handshake(endpoint, port, cipher, ssl_version, server_name=None, strict_
     end_of_msg_marker = "__end_of_msg__"
 
     # Wait until openssl and s2n have finished the handshake and are connected to each other
-    s_client_out += read_process_output_until(s_client, openssl_connect_marker)
-    s2nd_out += read_process_output_until(s2nd, openssl_connect_marker)
+    try:
+        s_client_out += read_process_output_until(s_client, openssl_connect_marker)
+        s2nd_out += read_process_output_until(s2nd, openssl_connect_marker)
+    except ProcessFailed as ex:
+        print("Client or daemon failed: {}".format(ex))
+        return -1
 
     if resume == True:
         for i in range(0,5):
             # Wait for openssl to resume connection 5 times in a row, and verify resumption works.
-            s_client_out += read_process_output_until(s_client, openssl_reconnect_marker)
-            s2nd_out += read_process_output_until(s2nd, openssl_connect_marker)
+            try:
+                s_client_out += read_process_output_until(s_client, openssl_reconnect_marker)
+                s2nd_out += read_process_output_until(s2nd, openssl_connect_marker)
+            except ProcessFailed as ex:
+                print("Client or daemon failed: {}".format(ex))
+                return -1
 
     data_to_validate = cipher + " " + str(uuid.uuid4())
 
@@ -346,8 +374,12 @@ def try_handshake(endpoint, port, cipher, ssl_version, server_name=None, strict_
     s2nd.stdin.flush()
 
     # Wait for the Data transfer to complete between OpenSSL and s2n
-    s_client_out += read_process_output_until(s_client, end_of_msg_marker)
-    s2nd_out += read_process_output_until(s2nd, end_of_msg_marker)
+    try:
+        s_client_out += read_process_output_until(s_client, end_of_msg_marker)
+        s2nd_out += read_process_output_until(s2nd, end_of_msg_marker)
+    except ProcessFailed as ex:
+        print("Client or daemon failed: {}".format(ex))
+        return -1
 
     cleanup_processes(s2nd, s_client)
 
@@ -430,13 +462,14 @@ def run_handshake_test(host, port, ssl_version, cipher, fips_mode, no_ticket, us
 
     return ret
 
+
 def handshake_test(host, port, test_ciphers, fips_mode, no_ticket=False, use_client_auth=None, use_client_cert=None, use_client_key=None):
     """
     Basic handshake tests using all valid combinations of supported cipher suites and TLS versions.
     """
     print("\n\tRunning handshake tests:")
     
-    failed = 0
+    failed = False
     for ssl_version in [S2N_TLS10, S2N_TLS11, S2N_TLS12, None]:
         print("\n\tTesting ciphers using client version: " + S2N_PROTO_VERS_TO_STR[ssl_version])
         threadpool = create_thread_pool()
@@ -452,32 +485,28 @@ def handshake_test(host, port, test_ciphers, fips_mode, no_ticket=False, use_cli
         threadpool.join()
         for async_result in results:
             if async_result.get() != 0:
-                failed = 1
+                failed = True
 
-    return failed
-    
+        if failed:
+            raise IntegrationTestFailure
+
 
 def client_auth_test(host, port, test_ciphers, fips_mode):
-    failed = 0
-
     print("\n\tRunning client auth tests:")
 
     for filename in os.listdir(TEST_CERT_DIRECTORY):
         if "client_cert" in filename and "rsa" in filename:
             client_cert_path = TEST_CERT_DIRECTORY + filename
             client_key_path = TEST_CERT_DIRECTORY + filename.replace("client_cert", "client_key")
-            ret = handshake_test(host, port, test_ciphers, fips_mode, no_ticket=True, use_client_auth=True, use_client_cert=client_cert_path, use_client_key=client_key_path)
-            if ret is not 0:
-                failed += 1
-                
-    return failed
+            handshake_test(host, port, test_ciphers, fips_mode, no_ticket=True, use_client_auth=True, use_client_cert=client_cert_path, use_client_key=client_key_path)
+
 
 def run_resume_test(host, port, cipher_name, ssl_version, resume, no_ticket, fips_mode):
     ret = try_handshake(host, port, cipher_name, ssl_version, resume=resume, no_ticket=no_ticket, enter_fips_mode=fips_mode)
     result_prefix = "Cipher: %-30s Vers: %-10s ... " % (cipher_name, S2N_PROTO_VERS_TO_STR[ssl_version])
     print_result(result_prefix, ret)
-
     return ret
+
 
 def resume_test(host, port, test_ciphers, fips_mode, no_ticket=False):
     """
@@ -488,7 +517,7 @@ def resume_test(host, port, test_ciphers, fips_mode, no_ticket=False):
     else:
         print("\n\tRunning resumption tests using session ticket:")
 
-    failed = 0
+    failed = False
     results = []
     for ssl_version in [S2N_TLS10, S2N_TLS11, S2N_TLS12, None]:
         port_offset = 0
@@ -514,9 +543,11 @@ def resume_test(host, port, test_ciphers, fips_mode, no_ticket=False):
 
         for async_result in results:
             if async_result.get() != 0:
-                failed = 1
+                failed = True 
 
-    return failed
+        if failed:
+            raise IntegrationTestFailure
+
 
 supported_sigs = ["RSA+SHA1", "RSA+SHA224", "RSA+SHA256", "RSA+SHA384", "RSA+SHA512"]
 unsupported_sigs = ["ECDSA+SHA256", "ECDSA+SHA512"]
@@ -537,7 +568,7 @@ def sigalg_test(host, port, fips_mode, use_client_auth=None, no_ticket=False):
     Acceptance test for supported signature algorithms. Tests all possible supported sigalgs with unsupported ones mixed in
     for noise.
     """
-    failed = 0
+    failed = False
 
     print("\n\tRunning signature algorithm tests:")
     print("\tExpected supported:   " + str(supported_sigs))
@@ -561,9 +592,11 @@ def sigalg_test(host, port, fips_mode, use_client_auth=None, no_ticket=False):
         threadpool.join()
         for async_result in results:
             if async_result.get() != 0:
-                failed = 1
+                failed = True
 
-    return failed
+        if failed:
+            raise IntegrationTestFailure
+
 
 def elliptic_curve_test(host, port, libcrypto_version, fips_mode):
     """
@@ -576,7 +609,7 @@ def elliptic_curve_test(host, port, libcrypto_version, fips_mode):
     print("\tExpected supported:   " + str(supported_curves))
     print("\tExpected unsupported: " + str(unsupported_curves))
 
-    failed = 0
+    failed = False
     for size in range(1, min(MAX_ITERATION_DEPTH, len(supported_curves)) + 1):
         print("\n\t\tTesting ciphers using curve list of size: " + str(size))
 
@@ -592,23 +625,24 @@ def elliptic_curve_test(host, port, libcrypto_version, fips_mode):
                 prefix = "Curves: %-40s Vers: %10s ... " % (':'.join(list(permutation)), S2N_PROTO_VERS_TO_STR[None])
                 print_result(prefix, ret)
                 if ret != 0:
-                    failed = 1
-    return failed
+                    failed = True
+
+        if failed:
+            raise IntegrationTestFailure
+
 
 def elliptic_curve_fallback_test(host, port, fips_mode):
     """
     Tests graceful fallback when s2n doesn't support any curves offered by the client. A non-ecc suite should be
     negotiated.
     """
-    failed = 0
     # Make sure s2n can still negotiate a non-EC kx(AES256-GCM-SHA384) suite if we don't match anything on the client
     unsupported_curves = ["B-163", "K-409"]
     ret = try_handshake(host, port, "ECDHE-RSA-AES128-SHA256:AES256-GCM-SHA384", None, curves=":".join(unsupported_curves), enter_fips_mode=fips_mode)
     print_result("%-65s ... " % "Testing curve mismatch fallback", ret)
     if ret != 0:
-        failed = 1
+        raise IntegrationTestFailure
 
-    return failed
 
 def handshake_fragmentation_test(host, port, fips_mode):
     """
@@ -616,7 +650,6 @@ def handshake_fragmentation_test(host, port, fips_mode):
     to fragment the ServerCertifcate message.
     """
     print("\n\tRunning handshake fragmentation tests:")
-    failed = 0
     for ssl_version in [S2N_TLS10, S2N_TLS11, S2N_TLS12, None]:
         print("\n\tTesting ciphers using client version: " + S2N_PROTO_VERS_TO_STR[ssl_version])
         # Cipher isn't relevant for this test, pick one available in all OpenSSL versions and all TLS versions
@@ -627,17 +660,14 @@ def handshake_fragmentation_test(host, port, fips_mode):
         result_prefix = "Cipher: %-30s Vers: %-10s ... " % (cipher_name, S2N_PROTO_VERS_TO_STR[ssl_version])
         print_result(result_prefix, ret)
         if ret != 0:
-            failed = 1
+            raise IntegrationTestFailure
 
-    failed = 0
-    return failed
 
 def ocsp_stapling_test(host, port, fips_mode):
     """
     Test s2n's server OCSP stapling capability
     """
     print("\n\tRunning OCSP stapling tests:")
-    failed = 0
     for ssl_version in [S2N_TLS10, S2N_TLS11, S2N_TLS12, None]:
         print("\n\tTesting ciphers using client version: " + S2N_PROTO_VERS_TO_STR[ssl_version])
         # Cipher isn't relevant for this test, pick one available in all TLS versions
@@ -648,16 +678,15 @@ def ocsp_stapling_test(host, port, fips_mode):
         result_prefix = "Cipher: %-30s Vers: %-10s ... " % (cipher_name, S2N_PROTO_VERS_TO_STR[ssl_version])
         print_result(result_prefix, ret)
         if ret != 0:
-            failed = 1
+            raise IntegrationTestFailure
 
-    return failed
 
 def cert_type_cipher_match_test(host, port, libcrypto_version):
     """
     Test s2n server's ability to correctly choose ciphers. (Especially RSA vs ECDSA)
     """
     print("\n\tRunning cipher matching tests:")
-    failed = 0
+    failed = False
 
     cipher = "ALL"
     supported_curves = get_supported_curves_str_by_version(libcrypto_version)
@@ -668,7 +697,7 @@ def cert_type_cipher_match_test(host, port, libcrypto_version):
     result_prefix = "Cert Type: rsa    Server Pref: ecdsa priority.  Vers: %-10s ... " % S2N_PROTO_VERS_TO_STR[None]
     print_result(result_prefix, rsa_ret)
     if rsa_ret != 0:
-        failed = 1
+        failed = True
 
     # Handshake with ECDSA cert + RSA priority server cipher prefs (must skip rsa ciphers)
     ecdsa_ret = try_handshake(host, port, cipher, None, curves=supported_curves,
@@ -676,9 +705,11 @@ def cert_type_cipher_match_test(host, port, libcrypto_version):
     result_prefix = "Cert Type: ecdsa  Server Pref: rsa priority.  Vers: %-10s ... " % S2N_PROTO_VERS_TO_STR[None]
     print_result(result_prefix, ecdsa_ret)
     if ecdsa_ret != 0:
-        failed = 1
+        failed = True
 
-    return failed
+    if failed:
+        raise IntegrationTestFailure
+
 
 def multiple_cert_type_test(host, port, libcrypto_version):
     """
@@ -697,7 +728,7 @@ def multiple_cert_type_test(host, port, libcrypto_version):
         result_prefix = "Certs: [RSA, ECDSA]  Client Prefs %s Server Pref: %s Vers: %-10s ... " % (cipher, server_prefs, S2N_PROTO_VERS_TO_STR[None])
         print_result(result_prefix, ret)
         if ret != 0:
-            return ret
+            raise IntegrationTestFailure
 
     # Handshake with ECDSA + RSA cert but no ecdsa ciphers configured on the server
     for cipher in ["ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-GCM-SHA256", "AES128-SHA"]:
@@ -709,7 +740,7 @@ def multiple_cert_type_test(host, port, libcrypto_version):
         result_prefix = "Certs: [RSA, ECDSA]  Client Prefs %s Server Pref: %s Vers: %-10s ... " % (cipher, server_prefs, S2N_PROTO_VERS_TO_STR[None])
         print_result(result_prefix, ret)
         if ret != 0:
-            return ret
+            raise IntegrationTestFailure
 
     # Handshake with ECDSA + RSA cert but no rsa ciphers configured on the server
     for cipher in ["ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-GCM-SHA256", "ECDHE-ECDSA-AES256-SHA"]:
@@ -721,7 +752,7 @@ def multiple_cert_type_test(host, port, libcrypto_version):
         result_prefix = "Certs: [RSA, ECDSA]  Client Prefs %s Server Pref: %s Vers: %-10s ... " % (cipher, server_prefs, S2N_PROTO_VERS_TO_STR[None])
         print_result(result_prefix, ret)
         if ret != 0:
-            return ret
+            raise IntegrationTestFailure
 
     # Handshake with ECDSA + RSA cert but no overlapping ecc curves for ECDHE kx.
     # s2n should fallback to a cipher with RSA kx.
@@ -735,9 +766,8 @@ def multiple_cert_type_test(host, port, libcrypto_version):
         result_prefix = "Certs: [RSA, ECDSA]  Client Prefs %s Server Pref: %s Vers: %-10s ... " % (cipher, server_prefs, S2N_PROTO_VERS_TO_STR[None])
         print_result(result_prefix, ret)
         if ret != 0:
-            return ret
+            raise IntegrationTestFailure
 
-    return 0
 
 def multiple_cert_domain_name_test(host, port):
     '''
@@ -761,9 +791,8 @@ def multiple_cert_domain_name_test(host, port):
                 expect_hostname_match)
         print_result(result_prefix, ret)
         if ret != 0:
-            return ret
+            raise IntegrationTestFailure
 
-    return 0
 
 def main():
     parser = argparse.ArgumentParser(description='Runs TLS server integration tests against s2nd using Openssl s_client')
@@ -791,22 +820,24 @@ def main():
     if use_corked_io == True:
         print("Corked IO is on")
 
-    failed = 0
-    failed += resume_test(host, port, test_ciphers, fips_mode, no_ticket=True)
-    failed += resume_test(host, port, test_ciphers, fips_mode)
-    failed += handshake_test(host, port, test_ciphers, fips_mode)
-    failed += client_auth_test(host, port, test_ciphers, fips_mode)
-    failed += sigalg_test(host, port, fips_mode)
-    failed += sigalg_test(host, port, fips_mode, use_client_auth=True, no_ticket=True)
-    failed += elliptic_curve_test(host, port, libcrypto_version, fips_mode)
-    failed += elliptic_curve_fallback_test(host, port, fips_mode)
-    failed += handshake_fragmentation_test(host, port, fips_mode)
-    failed += ocsp_stapling_test(host, port, fips_mode)
-    failed += cert_type_cipher_match_test(host, port, libcrypto_version)
-    failed += multiple_cert_type_test(host, port, libcrypto_version)
-    failed += multiple_cert_domain_name_test(host, port)
+    try:
+        resume_test(host, port, test_ciphers, fips_mode, no_ticket=True)
+        resume_test(host, port, test_ciphers, fips_mode)
+        handshake_test(host, port, test_ciphers, fips_mode)
+        client_auth_test(host, port, test_ciphers, fips_mode)
+        sigalg_test(host, port, fips_mode)
+        sigalg_test(host, port, fips_mode, use_client_auth=True, no_ticket=True)
+        elliptic_curve_test(host, port, libcrypto_version, fips_mode)
+        elliptic_curve_fallback_test(host, port, fips_mode)
+        handshake_fragmentation_test(host, port, fips_mode)
+        ocsp_stapling_test(host, port, fips_mode)
+        cert_type_cipher_match_test(host, port, libcrypto_version)
+        multiple_cert_type_test(host, port, libcrypto_version)
+        multiple_cert_domain_name_test(host, port)
+    except IntegrationTestFailure as ex:
+        return 1
 
-    return failed
+    return 0
 
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
Fixes #1483 
Supersedes #1487 
 
**Description of changes:** 
* Refactors the integration tests to display error information if a client/server fails to launch, or encounters another failure.
* Uses an exception to exit early instead of failure counts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
