### PR TITLE
Fuzz Test Coverage Reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,6 @@ jobs:
     dist: bionic
     env: S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=6 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true
 
-  - os: linux
-    # coverage + fuzz flags don't work simultaneously on bionic
-    dist: trusty
-    env: S2N_LIBCRYPTO=openssl-1.1.1 LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=90 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true
-
 # Normal Build Targets
   - os: linux
     dist: bionic

--- a/.travis/s2n_after_travis_build.sh
+++ b/.travis/s2n_after_travis_build.sh
@@ -17,5 +17,9 @@ set -ex
 
 # Upload Code Coverage Information to CodeCov.io
 if [[ -n "$CODECOV_IO_UPLOAD" ]]; then
-    bash <(curl -s https://codecov.io/bash) -F ${TESTS};
+    if [[ -n "$FUZZ_COVERAGE" ]]; then
+        bash <(curl -s https://codecov.io/bash) -f coverage/fuzz/codecov.txt
+    else
+        bash <(curl -s https://codecov.io/bash) -F ${TESTS};
+    fi
 fi

--- a/codebuild/bin/install_clang.sh
+++ b/codebuild/bin/install_clang.sh
@@ -46,12 +46,21 @@ git clone https://chromium.googlesource.com/chromium/src/tools/clang
 echo "Updating Clang..."
 python3 "$CLANG_DOWNLOAD_DIR"/clang/scripts/update.py
 
-# "third_party" directory is created above $CLANG_DOWNLOAD_DIR after running 
+# "third_party" directory is created above $CLANG_DOWNLOAD_DIR after running
 # update, move it into $CLANG_DOWNLOAD_DIR once update is complete.
 mv ../third_party "$CLANG_DOWNLOAD_DIR"
 
 echo "Installed Clang Version: "
 "$CLANG_DOWNLOAD_DIR"/third_party/llvm-build/Release+Asserts/bin/clang --version
+
+# Install matching LLVM if FUZZ_COVERAGE is enabled
+if [[ -v FUZZ_COVERAGE ]]; then
+	LLVM_INSTALL_DIR="$CLANG_INSTALL_DIR"/../llvm
+	mkdir -p "$LLVM_INSTALL_DIR"
+	python3 "$CLANG_DOWNLOAD_DIR"/clang/scripts/update.py --package="coverage_tools" --output-dir="$LLVM_INSTALL_DIR"
+	ln -s $LLVM_INSTALL_DIR/bin/llvm-cov /usr/bin/llvm-cov
+        ln -s $LLVM_INSTALL_DIR/bin/llvm-profdata /usr/bin/llvm-profdata
+fi
 
 mkdir -p "$CLANG_INSTALL_DIR" && cp -rf "$CLANG_DOWNLOAD_DIR"/third_party/llvm-build/Release+Asserts/* "$CLANG_INSTALL_DIR"
 

--- a/codebuild/bin/s2n_after_codebuild.sh
+++ b/codebuild/bin/s2n_after_codebuild.sh
@@ -17,5 +17,10 @@ set -ex
 
 # Upload Code Coverage Information to CodeCov.io
 if [[ -n "$CODECOV_IO_UPLOAD" ]]; then
-    bash <(curl -s https://codecov.io/bash) -F ${TESTS};
+    if [[ -n "$FUZZ_COVERAGE" ]]; then
+        bash <(curl -s https://codecov.io/bash) -f coverage/fuzz/codecov.txt
+    else
+        bash <(curl -s https://codecov.io/bash) -F ${TESTS};
+    fi
 fi
+

--- a/codebuild/bin/s2n_codebuild.sh
+++ b/codebuild/bin/s2n_codebuild.sh
@@ -87,6 +87,6 @@ if [[ "$TESTS" == "ALL" || "$TESTS" == "sawBIKE_r1" ]]; then make -C tests/saw b
 
 # Generate *.gcov files that can be picked up by the CodeCov.io Bash helper script. Don't run lcov or genhtml 
 # since those will delete .gcov files as they're processed.
-if [[ -n "$CODECOV_IO_UPLOAD" ]]; then
+if [[ -n "$CODECOV_IO_UPLOAD" && -z "$FUZZ_COVERAGE" ]]; then
     make run-gcov;
 fi

--- a/codebuild/bin/s2n_setup_env.sh
+++ b/codebuild/bin/s2n_setup_env.sh
@@ -72,6 +72,11 @@ export FUZZ_TIMEOUT_SEC
 export OS_NAME
 export S2N_CORKED_IO
 
+# S2N_COVERAGE should not be used with fuzz tests, use FUZZ_COVERAGE instead
+if [[ -v S2N_COVERAGE && "$TESTS" == "fuzz" ]]; then
+    unset S2N_COVERAGE
+    export FUZZ_COVERAGE=true
+fi
 
 # Select the libcrypto to build s2n against. If this is unset, default to the latest stable version(Openssl 1.1.1)
 if [[ -z $S2N_LIBCRYPTO ]]; then export LIBCRYPTO_ROOT=$OPENSSL_1_1_1_INSTALL_DIR ; fi

--- a/codebuild/codebuild.config
+++ b/codebuild/codebuild.config
@@ -23,7 +23,7 @@ source_version:
 # Fuzzers
 [CodeBuild:s2nfuzzerOpenSSL111Coverage]
 snippet: UbuntuBoilerplate2XL
-env: S2N_LIBCRYPTO=openssl-1.1.1 LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=120 S2N_COVERAGE=true
+env: S2N_LIBCRYPTO=openssl-1.1.1 LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=120 FUZZ_COVERAGE=true CODECOV_IO_UPLOAD=true
 
 [CodeBuild:s2nfuzzerOpenSSL102FIPS]
 snippet: UbuntuBoilerplate2XL

--- a/codebuild/spec/buildspec_ubuntu.yml
+++ b/codebuild/spec/buildspec_ubuntu.yml
@@ -32,7 +32,13 @@ phases:
         if expr "${GCC_VERSION}" : "6" >/dev/null; then
           apt-get install -y --no-install-recommends g++ g++-6 gcc gcc-6;
         fi
-      - apt-get install -y --no-install-recommends indent kwstyle lcov libssl-dev clang-3.9 llvm-3.9 m4 make net-tools nettle-bin nettle-dev pkg-config psmisc python3-pip shellcheck sudo tcpdump unzip valgrind zlib1g-dev zlibc
+
+      # Don't install old clang and llvm if LATEST_CLANG is enabled, handle it in install_clang.sh instead
+      - |
+        if expr "${LATEST_CLANG}" != "true" >/dev/null; then
+          apt-get install -y --no-install-recommends clang-3.9 llvm-3.9;
+        fi
+      - apt-get install -y --no-install-recommends indent kwstyle lcov libssl-dev m4 make net-tools nettle-bin nettle-dev pkg-config psmisc python3-pip shellcheck sudo tcpdump unzip valgrind zlib1g-dev zlibc
   pre_build:
     commands:
       - codebuild/bin/install_default_dependencies.sh

--- a/coverage/Makefile
+++ b/coverage/Makefile
@@ -18,4 +18,4 @@ include ../s2n.mk
 .PHONY : clean
 clean: decruft
 	rm -rf ./html/*
-
+	rm -rf ./fuzz/*

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -20,12 +20,16 @@ all: libs2n.a libs2n.so libs2n.dylib
 
 include ../s2n.mk
 
+ifdef FUZZ_COVERAGE
+	FUZZCOV_FLAGS = -fprofile-instr-generate -fcoverage-mapping
+endif
+
 libs2n.a: ${OBJS}
 	$(AR) cru libs2n.a ${OBJS}
 	$(RANLIB) libs2n.a
 
 libs2n.so: ${OBJS}
-	${CC} -shared -o libs2n.so ${OBJS} ${LIBS} -L${LIBCRYPTO_ROOT}/lib ${CRYPTO_LIBS}
+	${CC} ${FUZZCOV_FLAGS} -shared -o libs2n.so ${OBJS} ${LIBS} -L${LIBCRYPTO_ROOT}/lib ${CRYPTO_LIBS}
 
 libs2n.dylib: ${OBJS}
 	test ! -f /usr/lib/libSystem.dylib || libtool -dynamic  ${LIBS} -L${LIBCRYPTO_ROOT}/lib ${CRYPTO_LIBS} -o libs2n.dylib ${OBJS}

--- a/s2n.mk
+++ b/s2n.mk
@@ -44,9 +44,17 @@ DEFAULT_CFLAGS = -pedantic -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-su
 COVERAGE_CFLAGS = -fprofile-arcs -ftest-coverage
 COVERAGE_LDFLAGS = --coverage
 
-ifdef S2N_COVERAGE
-    DEFAULT_CFLAGS += ${COVERAGE_CFLAGS}
-    LIBS += ${COVERAGE_LDFLAGS}
+FUZZ_CFLAGS = -fsanitize-coverage=trace-pc-guard -fsanitize=address,undefined,leak
+
+# Define FUZZ_COVERAGE - to be used for generating coverage reports on fuzz tests
+#                !!! NOT COMPATIBLE WITH S2N_COVERAGE !!!
+ifdef FUZZ_COVERAGE
+	FUZZ_CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+else
+	ifdef S2N_COVERAGE
+		DEFAULT_CFLAGS += ${COVERAGE_CFLAGS}
+		LIBS += ${COVERAGE_LDFLAGS}
+	endif
 endif
 
 # Add a flag to disable stack protector for alternative libcs without
@@ -88,7 +96,6 @@ ifdef S2N_DEBUG
 	CFLAGS += ${DEBUG_CFLAGS}
 endif
 
-FUZZ_CFLAGS = -fsanitize-coverage=trace-pc-guard -fsanitize=address,undefined,leak
 LLVM_GCOV_MARKER_FILE=${COVERAGE_DIR}/use-llvm-gcov.tmp
 
 ifeq ($(S2N_UNSAFE_FUZZING_MODE),1)

--- a/tests/fuzz/Makefile
+++ b/tests/fuzz/Makefile
@@ -30,13 +30,12 @@ ifndef FUZZ_TESTS
     export FUZZ_TESTS=${TESTS}
 endif
 
-
 .PHONY : all
 all : run_tests
 
 include ../../s2n.mk
 
-CRUFT += $(wildcard *_test) $(wildcard fuzz-*.log) $(wildcard *_test_output.txt) $(wildcard *_test_results.txt) $(wildcard LD_PRELOAD/*.so)
+CRUFT += $(wildcard *_test) $(wildcard fuzz-*.log) $(wildcard *_test_output.txt) $(wildcard *_test_results.txt) $(wildcard LD_PRELOAD/*.so) $(wildcard *.prof*)
 LIBS += -lm -ltests2n
 
 CFLAGS += -Wno-unreachable-code -O0 -I$(LIBCRYPTO_ROOT)/include/ -I../
@@ -59,7 +58,9 @@ run_tests:: $(TESTS) ld-preload
 	./runFuzzTest.sh $${test_name} ${FUZZ_TIMEOUT_SEC} || fail_count=`expr $$fail_count + 1`; done; \
 	exit $${fail_count}; \
 	)
+	@./calcTotalCov.sh
 
 .PHONY : clean
 clean: decruft
 	${MAKE} -C LD_PRELOAD decruft
+	rm -rf profiles

--- a/tests/fuzz/Readme.md
+++ b/tests/fuzz/Readme.md
@@ -1,5 +1,7 @@
 # Fuzz Tests
-Every test in this directory will be run as a Fuzz test for several minutes during builds. To run all fuzz tests simply run `make fuzz` from the top `s2n` directory to compile s2n with the proper flags and run the fuzz tests.
+By default, every test in this directory will be run as a fuzz test for several minutes each during builds. To run all fuzz tests simply run `make fuzz` from the top `s2n` directory to compile s2n with the proper flags and run the fuzz tests. To run a specific subset of fuzz tests, simply set the FUZZ_TESTS variable as follows:
+
+> FUZZ_TESTS="test1 test2 test3"
 
 #### Each Fuzz Test should conform to the following rules:
 1. End in either `*_test.c` or `*_negative_test.c`.
@@ -9,6 +11,17 @@ Every test in this directory will be run as a Fuzz test for several minutes duri
 3. If a Positive Fuzz test, it should have a non-empty corpus directory with inputs that have a relatively high branch coverage.
 4. Have a function `int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)` that will perform any initialization that will be run only once at startup.
 5. Have a function `int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)` that will pass `buf` to one of s2n's API's
+
+## Fuzz Test Coverage
+To generate coverage reports for fuzz tests, simply set the FUZZ_COVERAGE environment variable to any non-null value and run `make fuzz`. This will report the target function coverage and overall S2N coverage when running the tests. In order to define target functions for a fuzz test, simply add the following line to your fuzz test below the copyright notice:
+
+> /* Target Functions: function1 function2 function3 */
+
+As the tests run, more detailed coverage reports are placed in the following directory:
+
+> s2n/coverage/fuzz
+
+Each test outputs an HTML file which displays line by line coverage statistics and a .txt report which gives per-function coverage statistics in human-readable ASCII. After all fuzz tests have ran, a matching pair of coverage reports is generated for the total coverage of S2N by the entire set of tests performed.
 
 ## Fuzz Test Directory Structure
 For a test with name `$TEST_NAME`, its files should be laid out with the following structure:

--- a/tests/fuzz/calcTotalCov.sh
+++ b/tests/fuzz/calcTotalCov.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+set -e
+
+usage() {
+    echo "Usage: calcTotalCov.sh"
+    exit 1
+}
+
+if [ "$#" -ne "0" ]; then
+    usage
+fi
+
+if [[ ! -v S2N_ROOT ]]; then
+    S2N_ROOT=../..
+fi
+
+FUZZCOV_SOURCES="${S2N_ROOT}/api ${S2N_ROOT}/bin ${S2N_ROOT}/crypto ${S2N_ROOT}/error ${S2N_ROOT}/pq-crypto ${S2N_ROOT}/stuffer ${S2N_ROOT}/tls ${S2N_ROOT}/utils"
+
+
+# Outputs fuzz coverage results if the FUZZ_COVERAGE environment variable is set
+# Total coverage is overlayed on source code in s2n_cov.html and coverage statistics are available in s2n_cov.txt
+# If using LLVM version 9 or greater, coverage is output in LCOV format instead of HTML
+# All files are stored in the s2n coverage directory
+if [[ -v FUZZ_COVERAGE ]]; then
+
+    printf "Calculating total s2n coverage... "
+
+    # The llvm-profdata merge command warns that the profraws were created from different binaries (which is true) but
+    # works fine for what we care about (the s2n library). Therefore, for user clarity all output is suppressed.
+    llvm-profdata merge -sparse ./profiles/*/*.profdata -o ./profiles/s2n_cov.profdata > /dev/null 2>&1
+    llvm-cov report -instr-profile=./profiles/s2n_cov.profdata ${S2N_ROOT}/lib/libs2n.so ${FUZZCOV_SOURCES} > ${COVERAGE_DIR}/fuzz/s2n_cov.txt
+
+    # Use LCOV format instead of HTML if the LLVM version we're using supports it
+    if [[ $(grep -Eo "[0-9]*" <<< `llvm-cov --version` | head -1) > 8 ]]; then
+        llvm-cov export -instr-profile=./profiles/s2n_cov.profdata ${S2N_ROOT}/lib/libs2n.so ${FUZZCOV_SOURCES} -format=lcov > ${COVERAGE_DIR}/fuzz/s2n_cov.info
+        genhtml -q -o ${COVERAGE_DIR}/html/overall_fuzz_coverage ${COVERAGE_DIR}/fuzz/s2n_cov.info
+    else
+        llvm-cov show -instr-profile=./profiles/s2n_cov.profdata ${S2N_ROOT}/lib/libs2n.so ${FUZZCOV_SOURCES} -use-color -format=html > ${COVERAGE_DIR}/fuzz/s2n_cov.html
+    fi
+    # Generate coverage report compatible with codecov.io
+    llvm-cov show -instr-profile=./profiles/s2n_cov.profdata ${S2N_ROOT}/lib/libs2n.so ${FUZZCOV_SOURCES} > ${COVERAGE_DIR}/fuzz/codecov.txt
+
+    S2N_COV=`grep -Eo '[0-9]*\.[0-9]*\%' ${COVERAGE_DIR}/fuzz/s2n_cov.txt | tail -1`
+    printf "total s2n coverage from fuzz tests: %s\n" $S2N_COV
+fi

--- a/tests/fuzz/runFuzzTest.sh
+++ b/tests/fuzz/runFuzzTest.sh
@@ -45,6 +45,8 @@ LIBFUZZER_ARGS+="-timeout=5 -max_len=4096 -print_final_stats=1 -jobs=${NUM_CPU_T
 TEST_SPECIFIC_OVERRIDES="${PWD}/LD_PRELOAD/${TEST_NAME}_overrides.so"
 GLOBAL_OVERRIDES="${PWD}/LD_PRELOAD/global_overrides.so"
 
+FUZZCOV_SOURCES="${S2N_ROOT}/api ${S2N_ROOT}/bin ${S2N_ROOT}/crypto ${S2N_ROOT}/error ${S2N_ROOT}/pq-crypto ${S2N_ROOT}/stuffer ${S2N_ROOT}/tls ${S2N_ROOT}/utils"
+
 if [ -e $TEST_SPECIFIC_OVERRIDES ];
 then
     export LD_PRELOAD="$TEST_SPECIFIC_OVERRIDES $GLOBAL_OVERRIDES"
@@ -68,18 +70,69 @@ ACTUAL_TEST_FAILURE=0
 TEMP_CORPUS_DIR="$(mktemp -d)"
 cp -r ./corpus/${TEST_NAME}/. "${TEMP_CORPUS_DIR}"
 
-
 printf "Running %-s %-40s for %5d sec with %2d threads... " "${FIPS_TEST_MSG}" ${TEST_NAME} ${FUZZ_TIMEOUT_SEC} ${NUM_CPU_THREADS}
-./${TEST_NAME} ${LIBFUZZER_ARGS} ${TEMP_CORPUS_DIR} > ${TEST_NAME}_output.txt 2>&1 || ACTUAL_TEST_FAILURE=1
+
+# Setup and clean profile structure if FUZZ_COVERAGE is enabled, otherwise run as normal
+if [[ -v FUZZ_COVERAGE ]]; then
+    mkdir -p "./profiles/${TEST_NAME}"
+    rm -f ./profiles/${TEST_NAME}/*.profraw
+    LLVM_PROFILE_FILE="./profiles/${TEST_NAME}/${TEST_NAME}.%p.profraw" ./${TEST_NAME} ${LIBFUZZER_ARGS} ${TEMP_CORPUS_DIR} > ${TEST_NAME}_output.txt 2>&1 || ACTUAL_TEST_FAILURE=1
+else
+    ./${TEST_NAME} ${LIBFUZZER_ARGS} ${TEMP_CORPUS_DIR} > ${TEST_NAME}_output.txt 2>&1 || ACTUAL_TEST_FAILURE=1
+fi
+
 
 TEST_COUNT=`grep -o "stat::number_of_executed_units: [0-9]*" ${TEST_NAME}_output.txt | awk '{test_count += $2} END {print test_count}'`
 TESTS_PER_SEC=`echo $(($TEST_COUNT / $FUZZ_TIMEOUT_SEC))`
 FEATURE_COVERAGE=`grep -o "ft: [0-9]*" ${TEST_NAME}_output.txt | awk '{print $2}' | sort | tail -1`
+TARGET_FUNCS=''
+declare -i TARGET_TOTAL=0
+declare -i TARGET_COV=0
+
+# Outputs fuzz coverage results if the FUZZ_COVERAGE environment variable is set
+# Coverage is overlayed on source code in ${TEST_NAME}_cov.html, and coverage statistics are available in ${TEST_NAME}_cov.txt
+# If using LLVM version 9 or greater, coverage is output in LCOV format instead of HTML
+# All files are stored in the s2n coverage directory
+if [[ -v FUZZ_COVERAGE ]]; then
+    mkdir -p ${COVERAGE_DIR}/fuzz
+    llvm-profdata merge -sparse ./profiles/${TEST_NAME}/*.profraw -o ./profiles/${TEST_NAME}/${TEST_NAME}.profdata
+    llvm-cov report -instr-profile=./profiles/${TEST_NAME}/${TEST_NAME}.profdata ${S2N_ROOT}/lib/libs2n.so ${FUZZCOV_SOURCES} -show-functions > ${COVERAGE_DIR}/fuzz/${TEST_NAME}_cov.txt
+
+    # Use LCOV format instead of HTML if the LLVM version we're using supports it
+    if [[ $(grep -Eo "[0-9]*" <<< `llvm-cov --version` | head -1) > 8 ]]; then
+        llvm-cov export -instr-profile=./profiles/${TEST_NAME}/${TEST_NAME}.profdata ${S2N_ROOT}/lib/libs2n.so ${FUZZCOV_SOURCES} -format=lcov > ${COVERAGE_DIR}/fuzz/${TEST_NAME}_cov.info
+        genhtml -q -o ${COVERAGE_DIR}/html/${TEST_NAME} ${COVERAGE_DIR}/fuzz/${TEST_NAME}_cov.info
+    else
+        llvm-cov show -instr-profile=./profiles/${TEST_NAME}/${TEST_NAME}.profdata ${S2N_ROOT}/lib/libs2n.so ${FUZZCOV_SOURCES} -use-color -format=html > ${COVERAGE_DIR}/fuzz/${TEST_NAME}_cov.html
+    fi
+
+    # Extract target functions from test source
+    TARGET_FUNCS=`grep -Pzo "(?<=/\* Target Functions: )[\w\s]*" ${TEST_NAME}.c | tr -d "\0"`
+
+    # Find line coverage statistics for target functions
+    if [[ ! -z TARGET_FUNCS ]];
+    then
+        for TARGET in ${TARGET_FUNCS}
+        do
+            TARGET_TOTAL+=`sed -n "s/^.*${TARGET} .*% *\([0-9]*\) .*$/\1/p" ${COVERAGE_DIR}/fuzz/${TEST_NAME}_cov.txt`
+            TARGET_COV+=`sed -n "s/^.*${TARGET} .*% *[0-9]* *\([0-9]*\) .*$/\1/p" ${COVERAGE_DIR}/fuzz/${TEST_NAME}_cov.txt`
+        done
+    fi
+fi
 
 if [ $ACTUAL_TEST_FAILURE == $EXPECTED_TEST_FAILURE ];
 then
-    printf "\033[32;1mPASSED\033[0m %8d tests, %6d test/sec, %5d features covered" $TEST_COUNT $TESTS_PER_SEC $FEATURE_COVERAGE
-    
+    printf "\033[32;1mPASSED\033[0m %8d tests, %6d test/sec" $TEST_COUNT $TESTS_PER_SEC
+
+    # Output target function coverage percentage if target functions are defined and fuzzing coverage is enabled
+    # Otherwise, print number of features covered
+    if [[ -v FUZZ_COVERAGE && ! -z TARGET_FUNCS && $EXPECTED_TEST_FAILURE != 1 && $TARGET_TOTAL != 0 ]];
+    then
+        printf ", %6.2f%% target coverage" "$(( 10000 * ($TARGET_TOTAL - $TARGET_COV) / $TARGET_TOTAL ))e-2"
+    else
+        printf ", %5d features covered" $FEATURE_COVERAGE
+    fi
+
     if [ $EXPECTED_TEST_FAILURE == 1 ];
     then
         # Clean up LibFuzzer corpus files if the test is negative.
@@ -89,11 +142,11 @@ then
         # TEMP_CORPUS_DIR may contain many new inputs that only covers a small set of new branches. 
         # Instead of copying all new inputs to the corpus directory,  only copy back minimum number of new inputs that reach new branches.
         ./${TEST_NAME} -merge=1 "./corpus/${TEST_NAME}" "${TEMP_CORPUS_DIR}" > ${TEST_NAME}_results.txt 2>&1
-        
+
         # Print number of new files and branches found in new Inputs (if any)
         RESULTS=`grep -Eo "[0-9]+ new files .*$" ${TEST_NAME}_results.txt | tail -1`
         printf ", ${RESULTS}\n"
-       
+
         if [ "$TESTS_PER_SEC" -lt $MIN_TEST_PER_SEC ]; then
             printf "\033[33;1mWARNING!\033[0m ${TEST_NAME} is only ${TESTS_PER_SEC} tests/sec, which is below ${MIN_TEST_PER_SEC}/sec! Fuzz tests are more effective at higher rates.\n\n"
         fi
@@ -103,7 +156,7 @@ then
             exit -1;
         fi
     fi
-    
+
 else
     cat ${TEST_NAME}_output.txt
     printf "\033[31;1mFAILED\033[0m %10d tests, %6d features covered\n" $TEST_COUNT $FEATURE_COVERAGE

--- a/tests/fuzz/s2n_bike_r1_fuzz_test.c
+++ b/tests/fuzz/s2n_bike_r1_fuzz_test.c
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+/* Target Functions: s2n_kem_decapsulate BIKE_L1_R1_crypto_kem_dec */
+
 #include "tests/s2n_test.h"
 #include "tests/testlib/s2n_nist_kats.h"
 #include "tests/testlib/s2n_testlib.h"

--- a/tests/fuzz/s2n_certificate_extensions_parse_test.c
+++ b/tests/fuzz/s2n_certificate_extensions_parse_test.c
@@ -13,12 +13,15 @@
  * permissions and limitations under the License.
  */
 
+/* Target Functions: s2n_certificate_extensions_parse s2n_recv_server_sct_list
+                     s2n_server_certificate_status_parse */
+
 #include <stdint.h>
 
 #include <openssl/crypto.h>
 #include <openssl/err.h>
 
-#include "tls/extensions/s2n_certificate_extensions.c"
+#include "tls/extensions/s2n_certificate_extensions.h"
 
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"

--- a/tests/fuzz/s2n_client_cert_recv_test.c
+++ b/tests/fuzz/s2n_client_cert_recv_test.c
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+/* Target Functions: s2n_client_cert_recv s2n_x509_validator_validate_cert_chain */
+
 #include <errno.h>
 #include <fcntl.h>
 #include <stddef.h>

--- a/tests/fuzz/s2n_client_cert_req_recv_test.c
+++ b/tests/fuzz/s2n_client_cert_req_recv_test.c
@@ -13,6 +13,11 @@
  * permissions and limitations under the License.
  */
 
+/* Target Functions: s2n_client_cert_req_recv s2n_recv_client_cert_preferences
+                     s2n_cert_type_to_pkey_type s2n_recv_supported_sig_scheme_list
+                     s2n_choose_sig_scheme_from_peer_preference_list
+                     s2n_set_cert_chain_as_client */
+
 #include <errno.h>
 #include <fcntl.h>
 #include <stddef.h>

--- a/tests/fuzz/s2n_client_cert_verify_recv_test.c
+++ b/tests/fuzz/s2n_client_cert_verify_recv_test.c
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+/* Target Functions: s2n_client_cert_verify_recv s2n_get_and_validate_negotiated_signature_scheme s2n_pkey_verify */
+
 #include <openssl/crypto.h>
 #include <openssl/err.h>
 

--- a/tests/fuzz/s2n_client_fuzz_test.c
+++ b/tests/fuzz/s2n_client_fuzz_test.c
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+/* Target Functions: s2n_negotiate */
+
 #include <errno.h>
 #include <fcntl.h>
 #include <stddef.h>

--- a/tests/fuzz/s2n_client_hello_recv_fuzz_test.c
+++ b/tests/fuzz/s2n_client_hello_recv_fuzz_test.c
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+/* Target Functions: s2n_client_hello_recv s2n_parse_client_hello s2n_populate_client_hello_extensions s2n_process_client_hello s2n_conn_set_handshake_type */
+
 #include <stdint.h>
 
 #include <openssl/crypto.h>

--- a/tests/fuzz/s2n_client_key_recv_fuzz_test.c
+++ b/tests/fuzz/s2n_client_key_recv_fuzz_test.c
@@ -13,6 +13,11 @@
  * permissions and limitations under the License.
  */
 
+/* Target Functions: s2n_client_key_recv s2n_kex_client_key_recv calculate_keys
+                     s2n_hybrid_client_action s2n_kex_tls_prf s2n_prf_key_expansion
+                     s2n_rsa_client_key_recv s2n_dhe_client_key_recv
+                     s2n_ecdhe_client_key_recv s2n_kem_client_key_recv */
+
 #include <stdint.h>
 
 #include <openssl/crypto.h>

--- a/tests/fuzz/s2n_encrypted_extensions_recv_test.c
+++ b/tests/fuzz/s2n_encrypted_extensions_recv_test.c
@@ -13,12 +13,13 @@
  * permissions and limitations under the License.
  */
 
+/* Target Functions: s2n_encrypted_extensions_recv s2n_server_encrypted_extensions_parse s2n_recv_server_server_name */
+/* Target Functions: s2n_recv_server_alpn s2n_recv_server_max_fragment_length */
+
 #include <stdint.h>
 
 #include <openssl/crypto.h>
 #include <openssl/err.h>
-
-#include "tls/s2n_encrypted_extensions.c"
 
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"

--- a/tests/fuzz/s2n_extensions_client_key_share_recv_test.c
+++ b/tests/fuzz/s2n_extensions_client_key_share_recv_test.c
@@ -13,6 +13,9 @@
  * permissions and limitations under the License.
  */
 
+/* Target Functions: s2n_extensions_client_key_share_recv s2n_ecc_evp_read_params_point
+                     s2n_ecc_evp_parse_params_point  s2n_ecc_evp_params_free */
+
 #include <stdint.h>
 
 #include <openssl/crypto.h>

--- a/tests/fuzz/s2n_extensions_client_supported_versions_recv_test.c
+++ b/tests/fuzz/s2n_extensions_client_supported_versions_recv_test.c
@@ -13,6 +13,9 @@
  * permissions and limitations under the License.
  */
 
+/* Target Functions: s2n_extensions_client_supported_versions_recv s2n_extensions_client_supported_versions_process
+                     s2n_connection_get_minimum_supported_version */
+
 #include <stdint.h>
 
 #include <openssl/crypto.h>
@@ -75,3 +78,4 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     }
     return 0;
 }
+

--- a/tests/fuzz/s2n_extensions_server_key_share_recv_test.c
+++ b/tests/fuzz/s2n_extensions_server_key_share_recv_test.c
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+/* Target Functions: s2n_extensions_server_key_share_recv s2n_ecc_evp_read_params_point s2n_ecc_evp_parse_params_point */
+
 #include <stdint.h>
 
 #include <openssl/crypto.h>

--- a/tests/fuzz/s2n_extensions_server_supported_versions_recv_test.c
+++ b/tests/fuzz/s2n_extensions_server_supported_versions_recv_test.c
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+/* Target Functions: s2n_extensions_server_supported_versions_process */
+
 #include <stdint.h>
 
 #include <openssl/crypto.h>

--- a/tests/fuzz/s2n_hybrid_ecdhe_sike_r1_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_sike_r1_fuzz_test.c
@@ -13,6 +13,10 @@
  * permissions and limitations under the License.
  */
 
+/* Target Functions: s2n_client_key_recv s2n_kex_client_key_recv calculate_keys
+                     s2n_kex_tls_prf s2n_prf_key_expansion s2n_ecdhe_client_key_recv
+                     s2n_kem_client_key_recv s2n_hybrid_client_action */
+
 #include "crypto/s2n_crypto.h"
 #include "crypto/s2n_drbg.h"
 #include "crypto/s2n_hash.h"

--- a/tests/fuzz/s2n_openssl_diff_pem_parsing_test.c
+++ b/tests/fuzz/s2n_openssl_diff_pem_parsing_test.c
@@ -13,6 +13,9 @@
  * permissions and limitations under the License.
  */
 
+/* Target Functions: s2n_parse_cert_chain s2n_create_cert_chain_from_stuffer
+                     s2n_cert_chain_and_key_free */
+
 #include <errno.h>
 #include <fcntl.h>
 #include <stddef.h>

--- a/tests/fuzz/s2n_recv_client_supported_groups_test.c
+++ b/tests/fuzz/s2n_recv_client_supported_groups_test.c
@@ -13,12 +13,14 @@
  * permissions and limitations under the License.
  */
 
+/* Target Functions: s2n_recv_client_supported_groups s2n_ecc_evp_find_supported_curve */
+
 #include <stdint.h>
 
 #include <openssl/crypto.h>
 #include <openssl/err.h>
 
-#include "tls/extensions/s2n_client_supported_groups.c"
+#include "tls/extensions/s2n_client_supported_groups.h"
 
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"

--- a/tests/fuzz/s2n_select_server_cert_test.c
+++ b/tests/fuzz/s2n_select_server_cert_test.c
@@ -13,6 +13,9 @@
  * permissions and limitations under the License.
  */
 
+/* Target Functions: s2n_conn_find_name_matching_certs s2n_config_add_cert_chain_and_key_to_store
+                     s2n_server_received_server_name s2n_find_cert_matches s2n_create_wildcard_hostname */
+
 #include <errno.h>
 #include <fcntl.h>
 #include <stddef.h>

--- a/tests/fuzz/s2n_server_extensions_recv_test.c
+++ b/tests/fuzz/s2n_server_extensions_recv_test.c
@@ -13,12 +13,17 @@
  * permissions and limitations under the License.
  */
 
+/* Target Functions: s2n_server_extensions_recv s2n_recv_server_server_name
+                     s2n_recv_server_renegotiation_info_ext s2n_recv_server_alpn
+                     s2n_recv_server_status_request s2n_recv_server_sct_list
+                     s2n_recv_server_max_fragment_length s2n_recv_server_session_ticket_ext */
+
 #include <stdint.h>
 
 #include <openssl/crypto.h>
 #include <openssl/err.h>
 
-#include "tls/s2n_server_extensions.c"
+#include "tls/s2n_tls.h"
 
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"

--- a/tests/fuzz/s2n_server_fuzz_test.c
+++ b/tests/fuzz/s2n_server_fuzz_test.c
@@ -13,6 +13,9 @@
  * permissions and limitations under the License.
  */
 
+/* Target Functions: s2n_negotiate s2n_flush s2n_handshake_handle_app_data
+                     s2n_handshake_write_io s2n_handshake_read_io s2n_try_delete_session_cache */
+
 #include <errno.h>
 #include <fcntl.h>
 #include <stddef.h>

--- a/tests/fuzz/s2n_sike_r1_fuzz_test.c
+++ b/tests/fuzz/s2n_sike_r1_fuzz_test.c
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+/* Target Functions: s2n_kem_decapsulate SIKE_P503_r1_crypto_kem_dec */
+
 #include "stuffer/s2n_stuffer.h"
 
 #include "tests/s2n_test.h"

--- a/tests/fuzz/s2n_sike_r2_fuzz_test.c
+++ b/tests/fuzz/s2n_sike_r2_fuzz_test.c
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+/* Target Functions: s2n_kem_decapsulate SIKE_P434_r2_crypto_kem_dec */
+
 #include "stuffer/s2n_stuffer.h"
 
 #include "tests/s2n_test.h"

--- a/tests/fuzz/s2n_stuffer_pem_fuzz_test.c
+++ b/tests/fuzz/s2n_stuffer_pem_fuzz_test.c
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+/* Target Functions: s2n_stuffer_pem_read_encapsulation_line s2n_stuffer_pem_read_contents */
+
 #include <errno.h>
 #include <fcntl.h>
 #include <stddef.h>


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Description of changes:** This PR adds accurate, granular coverage reporting for fuzz tests to S2N. If the FUZZ_COVERAGE environment variable is set, S2N will be built with Clang's profiling instrumentation, and on each run of a fuzz test generate coverage data for it. This coverage data is stored in the s2n/coverage/fuzz directory as HTML, LCOV, and human-readable ASCII files, and is also shown to the user after a test has been ran through a percentage coverage of target functions. Target functions are defined in each fuzz test through a simple comment-based API, and represent functions that we want to fully cover during a specific fuzz test. This PR adds target functions to existing fuzz tests, but these will need to be revisited at a later date to confirm that there are no other target functions we'd like to add to any fuzz tests. After all fuzz tests have been ran, the overall percentage coverage of S2N is printed, and if the CODECOV_IO_UPLOAD environment variable is set the coverage results are sent to Codecov.io to integrate with our current coverage reporting system.

This PR also adds the functionality needed for Codebuild to generate the fuzz test coverage reports automatically and send them to Codecov.io. It may work with Travis as well, but this is untested since we use Codebuild for fuzz testing due to its efficiency. Documentation has been added and modified to provide clarity into the fuzz test coverage reporting process and to allow others to easily utilize it.

(Side note: Previously the codecov.io report stated that this increased coverage by 2%, but until this PR is accepted I can't turn on submission of the fuzz test coverage to codecov.io without breaking every other PR, so the coverage reported here doesn't actually include the fuzz test coverage.)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
