### PR TITLE
Move debug message tests out of s2n_handshake_test

### DIFF
--- a/tests/s2n_test.h
+++ b/tests/s2n_test.h
@@ -137,6 +137,7 @@
 #define EXPECT_BYTEARRAY_NOT_EQUAL( p1, p2, l ) EXPECT_NOT_EQUAL( memcmp( (p1), (p2), (l) ), 0 )
 
 #define EXPECT_STRING_EQUAL( p1, p2 ) EXPECT_EQUAL( strcmp( (p1), (p2) ), 0 )
+#define EXPECT_STRING_NOT_EQUAL( p1, p2 ) EXPECT_NOT_EQUAL( strcmp( (p1), (p2) ), 0 )
 
 #define S2N_TEST_ENTER_FIPS_MODE()    { if (FIPS_mode_set(1) == 0) { \
                                             unsigned long fips_rc = ERR_get_error(); \

--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -158,17 +158,8 @@ int test_cipher_preferences(struct s2n_config *server_config, struct s2n_config 
                 return -1;
             }
 
-            /* Calling the same funciton on the same connection again should get the same handshake name */
-            if (strcmp(s2n_connection_get_handshake_type_name(client_conn), handshake_type_name) != 0) {
-                return -1;
-            }
-
             handshake_type_name = s2n_connection_get_handshake_type_name(server_conn);
             if (NULL == strstr(handshake_type_name, "NEGOTIATED|FULL_HANDSHAKE")) {
-                return -1;
-            }
-
-            if (strcmp(s2n_connection_get_handshake_type_name(server_conn), handshake_type_name) != 0) {
                 return -1;
             }
 

--- a/tests/unit/s2n_tls12_handshake_test.c
+++ b/tests/unit/s2n_tls12_handshake_test.c
@@ -232,6 +232,64 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
+    /* Test: TLS 1.2 handshake types are all properly printed */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+
+        conn->handshake.handshake_type = INITIAL;
+        EXPECT_STRING_EQUAL("INITIAL", s2n_connection_get_handshake_type_name(conn));
+
+        conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
+        EXPECT_STRING_EQUAL("NEGOTIATED|FULL_HANDSHAKE", s2n_connection_get_handshake_type_name(conn));
+
+        const char* all_flags_handshake_type_name = "NEGOTIATED|FULL_HANDSHAKE|TLS12_PERFECT_FORWARD_SECRECY|"
+                "OCSP_STATUS|CLIENT_AUTH|WITH_SESSION_TICKET|NO_CLIENT_CERT";
+        conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE | TLS12_PERFECT_FORWARD_SECRECY | \
+                OCSP_STATUS | CLIENT_AUTH | WITH_SESSION_TICKET | NO_CLIENT_CERT;
+        EXPECT_STRING_EQUAL(all_flags_handshake_type_name, s2n_connection_get_handshake_type_name(conn));
+
+        const char *handshake_type_name;
+        for (int i = 0; i < valid_tls12_handshakes_size; i++) {
+            conn->handshake.handshake_type = i;
+
+            handshake_type_name = s2n_connection_get_handshake_type_name(conn);
+
+            /* The handshake type names must be unique */
+            for (int j = 0; j < valid_tls12_handshakes_size; j++) {
+                conn->handshake.handshake_type = j;
+                if (i == j) {
+                    EXPECT_STRING_EQUAL(handshake_type_name, s2n_connection_get_handshake_type_name(conn));
+                } else {
+                    EXPECT_STRING_NOT_EQUAL(handshake_type_name, s2n_connection_get_handshake_type_name(conn));
+                }
+            }
+        }
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test: TLS 1.2 message types are all properly printed */
+    {
+        uint32_t test_handshake_type = NEGOTIATED | FULL_HANDSHAKE | TLS12_PERFECT_FORWARD_SECRECY | \
+                OCSP_STATUS | CLIENT_AUTH | WITH_SESSION_TICKET;
+        const char* expected[] = { "CLIENT_HELLO",
+                "SERVER_HELLO", "SERVER_CERT", "SERVER_CERT_STATUS", "SERVER_KEY", "SERVER_CERT_REQ", "SERVER_HELLO_DONE",
+                "CLIENT_CERT", "CLIENT_KEY", "CLIENT_CERT_VERIFY", "CLIENT_CHANGE_CIPHER_SPEC", "CLIENT_FINISHED",
+                "SERVER_NEW_SESSION_TICKET", "SERVER_CHANGE_CIPHER_SPEC", "SERVER_FINISHED",
+                "APPLICATION_DATA" };
+
+        struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+
+        conn->handshake.handshake_type = test_handshake_type;
+
+        for (int i=0; i < sizeof(expected) / sizeof(char *); i++) {
+            conn->handshake.message_number = i;
+            EXPECT_STRING_EQUAL(expected[i], s2n_connection_get_last_message_name(conn));
+        }
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
     END_TEST();
     return 0;
 }

--- a/tests/unit/s2n_tls13_state_machine_handshake_test.c
+++ b/tests/unit/s2n_tls13_state_machine_handshake_test.c
@@ -338,6 +338,61 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
+    /* Test: TLS 1.3 handshake types are all properly printed */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+        conn->actual_protocol_version = S2N_TLS13;
+
+        conn->handshake.handshake_type = INITIAL;
+        EXPECT_STRING_EQUAL("INITIAL", s2n_connection_get_handshake_type_name(conn));
+
+        conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
+        EXPECT_STRING_EQUAL("NEGOTIATED|FULL_HANDSHAKE", s2n_connection_get_handshake_type_name(conn));
+
+        const char* all_flags_handshake_type_name = "NEGOTIATED|FULL_HANDSHAKE|CLIENT_AUTH|WITH_SESSION_TICKET|NO_CLIENT_CERT";
+        conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH | WITH_SESSION_TICKET | NO_CLIENT_CERT;
+        EXPECT_STRING_EQUAL(all_flags_handshake_type_name, s2n_connection_get_handshake_type_name(conn));
+
+        const char *handshake_type_name;
+        for (int i = 0; i < valid_tls13_handshakes_size; i++) {
+            conn->handshake.handshake_type = i;
+
+            handshake_type_name = s2n_connection_get_handshake_type_name(conn);
+
+            /* The handshake type names must be unique */
+            for (int j = 0; j < valid_tls13_handshakes_size; j++) {
+                conn->handshake.handshake_type = j;
+                if (i == j) {
+                    EXPECT_STRING_EQUAL(handshake_type_name, s2n_connection_get_handshake_type_name(conn));
+                } else {
+                    EXPECT_STRING_NOT_EQUAL(handshake_type_name, s2n_connection_get_handshake_type_name(conn));
+                }
+            }
+        }
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test: TLS 1.3 message types are all properly printed */
+    {
+        uint32_t test_handshake_type = NEGOTIATED | FULL_HANDSHAKE;
+        const char* expected[] = { "CLIENT_HELLO", "SERVER_HELLO", "SERVER_CHANGE_CIPHER_SPEC",
+                "ENCRYPTED_EXTENSIONS", "SERVER_CERT", "SERVER_CERT_VERIFY", "SERVER_FINISHED",
+                "CLIENT_CHANGE_CIPHER_SPEC", "CLIENT_FINISHED", "APPLICATION_DATA" };
+
+        struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+        conn->actual_protocol_version = S2N_TLS13;
+
+        conn->handshake.handshake_type = test_handshake_type;
+
+        for (int i=0; i < sizeof(expected) / sizeof(char *); i++) {
+            conn->handshake.message_number = i;
+            EXPECT_STRING_EQUAL(expected[i], s2n_connection_get_last_message_name(conn));
+        }
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
     END_TEST();
     return 0;
 }


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 

**Description of changes:** 
We were kind of incidentally testing our debug messaging in s2n_handshake_test.c. Moving them to their own dedicated tests and testing a little more thoroughly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
