### PR TITLE
Fix TLS13 bug where handshake hashes were updated unexpectedly

### DIFF
--- a/tests/unit/s2n_tls13_handshake_test.c
+++ b/tests/unit/s2n_tls13_handshake_test.c
@@ -412,8 +412,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
 
         /* Client sends ClientHello */
+        EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), CLIENT_HELLO);
         EXPECT_SUCCESS(s2n_handshake_write_io(client_conn));
-        EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), SERVER_HELLO);
 
         EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS13);
         EXPECT_EQUAL(server_conn->actual_protocol_version, 0);
@@ -421,11 +421,13 @@ int main(int argc, char **argv)
         s2n_tls13_connection_keys(server_secrets_0, server_conn);
         EXPECT_EQUAL(server_secrets_0.size, 0);
 
-        /* Server reads ClientHello */
         EXPECT_EQUAL(server_conn->handshake.handshake_type, INITIAL);
+
+        /* Server reads ClientHello */
+        EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), CLIENT_HELLO);
         EXPECT_SUCCESS(s2n_handshake_read_io(server_conn));
+
         EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS13); /* Server is now on TLS13 */
-        EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), SERVER_HELLO);
         EXPECT_EQUAL(server_conn->handshake.handshake_type, NEGOTIATED | FULL_HANDSHAKE);
 
         s2n_tls13_connection_keys(server_secrets, server_conn);
@@ -434,20 +436,26 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_conn_set_handshake_type(server_conn));
 
         /* Server sends ServerHello */
+        EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), SERVER_HELLO);
         EXPECT_SUCCESS(s2n_handshake_write_io(server_conn));
-        EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), SERVER_CHANGE_CIPHER_SPEC);
 
         /* Server sends CCS */
+        EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), SERVER_CHANGE_CIPHER_SPEC);
         EXPECT_SUCCESS(s2n_handshake_write_io(server_conn));
-        EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), ENCRYPTED_EXTENSIONS);
         S2N_BLOB_EXPECT_EQUAL(server_seq, seq_0);
 
         /* Server sends EncryptedExtensions */
+        EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), ENCRYPTED_EXTENSIONS);
         EXPECT_SUCCESS(s2n_handshake_write_io(server_conn));
-        EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), SERVER_CERT);
         S2N_BLOB_EXPECT_EQUAL(server_seq, seq_1);
 
-        /* Client reads CCS */
+        /* Client reads ServerHello */
+        EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), SERVER_HELLO);
+        EXPECT_SUCCESS(s2n_handshake_read_io(client_conn));
+
+        /* Client reads CCS
+         * The CCS message does not affect its place in the state machine. */
+        EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), ENCRYPTED_EXTENSIONS);
         EXPECT_SUCCESS(s2n_handshake_read_io(client_conn));
         EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), ENCRYPTED_EXTENSIONS);
 
@@ -459,8 +467,8 @@ int main(int argc, char **argv)
         S2N_BLOB_EXPECT_EQUAL(server_secrets.extract_secret, client_secrets.extract_secret);
 
         /* Client reads Encrypted extensions */
-        EXPECT_SUCCESS(s2n_handshake_read_io(client_conn));
         EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), ENCRYPTED_EXTENSIONS);
+        EXPECT_SUCCESS(s2n_handshake_read_io(client_conn));
 
         /* TODO add the rest of the handshakes tests
          * (ServerCert, CertVerify, ServerFinished, ClientFinished)
@@ -468,22 +476,36 @@ int main(int argc, char **argv)
 
         /*
          * // Server sends ServerCert
+         * EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), SERVER_CERT);
          * EXPECT_SUCCESS(s2n_handshake_write_io(server_conn));
-         * EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), SERVER_CERT_VERIFY);
          *
          * // Server sends CertVerify
+         * EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), SERVER_CERT_VERIFY);
          * EXPECT_SUCCESS(s2n_handshake_write_io(server_conn));
-         * EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), SERVER_FINISHED);
          *
          * // Server sends ServerFinished
-         * EXPECT_SUCCESS(s2n_handshake_write_io(server_conn));
          * EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), SERVER_FINISHED);
+         * EXPECT_SUCCESS(s2n_handshake_write_io(server_conn));
+         *
+         * // Client reads ServerCert
+         * EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), SERVER_CERT);
+         * EXPECT_SUCCESS(s2n_handshake_write_io(client_conn));
+         *
+         * // Client reads CertVerify
+         * EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), SERVER_CERT_VERIFY);
+         * EXPECT_SUCCESS(s2n_handshake_write_io(client_conn));
+         *
+         * // Client reads ServerFinished
+         * EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), SERVER_FINISHED);
+         * EXPECT_SUCCESS(s2n_handshake_write_io(client_conn));
          *
          * // Client sends ClientFinished
+         * EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), CLIENT_FINISHED);
          * EXPECT_SUCCESS(s2n_handshake_write_io(client_conn));
-         * EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), APPLICATION_DATA);
          *
-         * // Verify that sequence numbers reset
+         * EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), APPLICATION_DATA);
+         * EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), APPLICATION_DATA);
+         *
          */
 
         /* Clean up */

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -199,7 +199,7 @@ struct s2n_cipher_suite s2n_rsa_with_rc4_128_md5 = /* 0x00,0x04 */ {
     .all_record_algs = { &s2n_record_alg_rc4_md5 },
     .num_record_algs = 1,
     .sslv3_record_alg = &s2n_record_alg_rc4_sslv3_md5,
-    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .prf_alg = S2N_HMAC_SHA256,
     .minimum_required_tls_version = S2N_SSLv3,
 };
 
@@ -213,7 +213,7 @@ struct s2n_cipher_suite s2n_rsa_with_rc4_128_sha = /* 0x00,0x05 */ {
     .all_record_algs = { &s2n_record_alg_rc4_sha },
     .num_record_algs = 1,
     .sslv3_record_alg = &s2n_record_alg_rc4_sslv3_sha,
-    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .prf_alg = S2N_HMAC_SHA256,
     .minimum_required_tls_version = S2N_SSLv3,
 };
 
@@ -227,7 +227,7 @@ struct s2n_cipher_suite s2n_rsa_with_3des_ede_cbc_sha = /* 0x00,0x0A */ {
     .all_record_algs = { &s2n_record_alg_3des_sha },
     .num_record_algs = 1,
     .sslv3_record_alg = &s2n_record_alg_3des_sslv3_sha,
-    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .prf_alg = S2N_HMAC_SHA256,
     .minimum_required_tls_version = S2N_SSLv3,
 };
 
@@ -241,7 +241,7 @@ struct s2n_cipher_suite s2n_dhe_rsa_with_3des_ede_cbc_sha = /* 0x00,0x16 */ {
     .all_record_algs = { &s2n_record_alg_3des_sha },
     .num_record_algs = 1,
     .sslv3_record_alg = &s2n_record_alg_3des_sslv3_sha,
-    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .prf_alg = S2N_HMAC_SHA256,
     .minimum_required_tls_version = S2N_SSLv3,
 };
 
@@ -255,7 +255,7 @@ struct s2n_cipher_suite s2n_rsa_with_aes_128_cbc_sha = /* 0x00,0x2F */ {
     .all_record_algs = { &s2n_record_alg_aes128_sha_composite, &s2n_record_alg_aes128_sha },
     .num_record_algs = 2,
     .sslv3_record_alg = &s2n_record_alg_aes128_sslv3_sha,
-    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .prf_alg = S2N_HMAC_SHA256,
     .minimum_required_tls_version = S2N_SSLv3,
 };
 
@@ -269,7 +269,7 @@ struct s2n_cipher_suite s2n_dhe_rsa_with_aes_128_cbc_sha = /* 0x00,0x33 */ {
     .all_record_algs = { &s2n_record_alg_aes128_sha_composite, &s2n_record_alg_aes128_sha },
     .num_record_algs = 2,
     .sslv3_record_alg = &s2n_record_alg_aes128_sslv3_sha,
-    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .prf_alg = S2N_HMAC_SHA256,
     .minimum_required_tls_version = S2N_SSLv3,
 };
 
@@ -283,7 +283,7 @@ struct s2n_cipher_suite s2n_rsa_with_aes_256_cbc_sha = /* 0x00,0x35 */ {
     .all_record_algs = { &s2n_record_alg_aes256_sha_composite , &s2n_record_alg_aes256_sha },
     .num_record_algs = 2,
     .sslv3_record_alg = &s2n_record_alg_aes256_sslv3_sha,
-    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .prf_alg = S2N_HMAC_SHA256,
     .minimum_required_tls_version = S2N_SSLv3,
 };
 
@@ -297,7 +297,7 @@ struct s2n_cipher_suite s2n_dhe_rsa_with_aes_256_cbc_sha = /* 0x00,0x39 */ {
     .all_record_algs = { &s2n_record_alg_aes256_sha_composite , &s2n_record_alg_aes256_sha },
     .num_record_algs = 2,
     .sslv3_record_alg = &s2n_record_alg_aes256_sslv3_sha,
-    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .prf_alg = S2N_HMAC_SHA256,
     .minimum_required_tls_version = S2N_SSLv3,
 };
 
@@ -311,7 +311,7 @@ struct s2n_cipher_suite s2n_rsa_with_aes_128_cbc_sha256 = /* 0x00,0x3C */ {
     .all_record_algs = { &s2n_record_alg_aes128_sha256_composite, &s2n_record_alg_aes128_sha256 },
     .num_record_algs = 2,
     .sslv3_record_alg = NULL,
-    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .prf_alg = S2N_HMAC_SHA256,
     .minimum_required_tls_version = S2N_TLS12,
 };
 
@@ -325,7 +325,7 @@ struct s2n_cipher_suite s2n_rsa_with_aes_256_cbc_sha256 = /* 0x00,0x3D */ {
     .all_record_algs = { &s2n_record_alg_aes256_sha256_composite, &s2n_record_alg_aes256_sha256 },
     .num_record_algs = 2,
     .sslv3_record_alg = NULL,
-    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .prf_alg = S2N_HMAC_SHA256,
     .minimum_required_tls_version = S2N_TLS12,
 };
 
@@ -339,7 +339,7 @@ struct s2n_cipher_suite s2n_dhe_rsa_with_aes_128_cbc_sha256 = /* 0x00,0x67 */ {
     .all_record_algs = { &s2n_record_alg_aes128_sha256_composite, &s2n_record_alg_aes128_sha256 },
     .num_record_algs = 2,
     .sslv3_record_alg = NULL,
-    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .prf_alg = S2N_HMAC_SHA256,
     .minimum_required_tls_version = S2N_TLS12,
 };
 
@@ -353,7 +353,7 @@ struct s2n_cipher_suite s2n_dhe_rsa_with_aes_256_cbc_sha256 = /* 0x00,0x6B */ {
     .all_record_algs = { &s2n_record_alg_aes256_sha256_composite, &s2n_record_alg_aes256_sha256 },
     .num_record_algs = 2,
     .sslv3_record_alg = NULL,
-    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .prf_alg = S2N_HMAC_SHA256,
     .minimum_required_tls_version = S2N_TLS12,
 };
 
@@ -367,7 +367,7 @@ struct s2n_cipher_suite s2n_rsa_with_aes_128_gcm_sha256 = /* 0x00,0x9C */ {
     .all_record_algs = { &s2n_record_alg_aes128_gcm },
     .num_record_algs = 1,
     .sslv3_record_alg = NULL,
-    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .prf_alg = S2N_HMAC_SHA256,
     .minimum_required_tls_version = S2N_TLS12,
 };
 
@@ -381,7 +381,7 @@ struct s2n_cipher_suite s2n_rsa_with_aes_256_gcm_sha384 = /* 0x00,0x9D */ {
     .all_record_algs = { &s2n_record_alg_aes256_gcm },
     .num_record_algs = 1,
     .sslv3_record_alg = NULL,
-    .tls12_prf_alg = S2N_HMAC_SHA384,
+    .prf_alg = S2N_HMAC_SHA384,
     .minimum_required_tls_version = S2N_TLS12,
 };
 
@@ -395,7 +395,7 @@ struct s2n_cipher_suite s2n_dhe_rsa_with_aes_128_gcm_sha256 = /* 0x00,0x9E */ {
     .all_record_algs = { &s2n_record_alg_aes128_gcm },
     .num_record_algs = 1,
     .sslv3_record_alg = NULL,
-    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .prf_alg = S2N_HMAC_SHA256,
     .minimum_required_tls_version = S2N_TLS12,
 };
 
@@ -409,7 +409,7 @@ struct s2n_cipher_suite s2n_dhe_rsa_with_aes_256_gcm_sha384 = /* 0x00,0x9F */ {
     .all_record_algs = { &s2n_record_alg_aes256_gcm },
     .num_record_algs = 1,
     .sslv3_record_alg = NULL,
-    .tls12_prf_alg = S2N_HMAC_SHA384,
+    .prf_alg = S2N_HMAC_SHA384,
     .minimum_required_tls_version = S2N_TLS12,
 };
 
@@ -423,7 +423,7 @@ struct s2n_cipher_suite s2n_ecdhe_ecdsa_with_aes_128_cbc_sha = /* 0xC0,0x09 */ {
     .all_record_algs = { &s2n_record_alg_aes128_sha_composite, &s2n_record_alg_aes128_sha },
     .num_record_algs = 2,
     .sslv3_record_alg = &s2n_record_alg_aes128_sslv3_sha,
-    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .prf_alg = S2N_HMAC_SHA256,
     .minimum_required_tls_version = S2N_SSLv3,
 };
 
@@ -437,7 +437,7 @@ struct s2n_cipher_suite s2n_ecdhe_ecdsa_with_aes_256_cbc_sha = /* 0xC0,0x0A */ {
     .all_record_algs = { &s2n_record_alg_aes256_sha_composite, &s2n_record_alg_aes256_sha },
     .num_record_algs = 2,
     .sslv3_record_alg = &s2n_record_alg_aes256_sslv3_sha,
-    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .prf_alg = S2N_HMAC_SHA256,
     .minimum_required_tls_version = S2N_SSLv3,
 };
 
@@ -451,7 +451,7 @@ struct s2n_cipher_suite s2n_ecdhe_rsa_with_rc4_128_sha = /* 0xC0,0x11 */ {
     .all_record_algs = { &s2n_record_alg_rc4_sha },
     .num_record_algs = 1,
     .sslv3_record_alg = &s2n_record_alg_rc4_sslv3_sha,
-    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .prf_alg = S2N_HMAC_SHA256,
     .minimum_required_tls_version = S2N_SSLv3,
 };
 
@@ -465,7 +465,7 @@ struct s2n_cipher_suite s2n_ecdhe_rsa_with_3des_ede_cbc_sha = /* 0xC0,0x12 */ {
     .all_record_algs = { &s2n_record_alg_3des_sha },
     .num_record_algs = 1,
     .sslv3_record_alg = &s2n_record_alg_3des_sslv3_sha,
-    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .prf_alg = S2N_HMAC_SHA256,
     .minimum_required_tls_version = S2N_SSLv3,
 };
 
@@ -479,7 +479,7 @@ struct s2n_cipher_suite s2n_ecdhe_rsa_with_aes_128_cbc_sha = /* 0xC0,0x13 */ {
     .all_record_algs = { &s2n_record_alg_aes128_sha_composite, &s2n_record_alg_aes128_sha },
     .num_record_algs = 2,
     .sslv3_record_alg = &s2n_record_alg_aes128_sslv3_sha,
-    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .prf_alg = S2N_HMAC_SHA256,
     .minimum_required_tls_version = S2N_SSLv3,
 };
 
@@ -493,7 +493,7 @@ struct s2n_cipher_suite s2n_ecdhe_rsa_with_aes_256_cbc_sha = /* 0xC0,0x14 */ {
     .all_record_algs = { &s2n_record_alg_aes256_sha_composite , &s2n_record_alg_aes256_sha },
     .num_record_algs = 2,
     .sslv3_record_alg = &s2n_record_alg_aes256_sslv3_sha,
-    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .prf_alg = S2N_HMAC_SHA256,
     .minimum_required_tls_version = S2N_SSLv3,
 };
 
@@ -507,7 +507,7 @@ struct s2n_cipher_suite s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256 = /* 0xC0,0x23 *
     .all_record_algs = { &s2n_record_alg_aes128_sha256_composite, &s2n_record_alg_aes128_sha256 },
     .num_record_algs = 2,
     .sslv3_record_alg = NULL,
-    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .prf_alg = S2N_HMAC_SHA256,
     .minimum_required_tls_version = S2N_TLS12,
 };
 
@@ -521,7 +521,7 @@ struct s2n_cipher_suite s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384 = /* 0xC0,0x24 *
     .all_record_algs = { &s2n_record_alg_aes256_sha384 },
     .num_record_algs = 1,
     .sslv3_record_alg = NULL,
-    .tls12_prf_alg = S2N_HMAC_SHA384,
+    .prf_alg = S2N_HMAC_SHA384,
     .minimum_required_tls_version = S2N_TLS12,
 };
 
@@ -535,7 +535,7 @@ struct s2n_cipher_suite s2n_ecdhe_rsa_with_aes_128_cbc_sha256 = /* 0xC0,0x27 */ 
     .all_record_algs = { &s2n_record_alg_aes128_sha256_composite, &s2n_record_alg_aes128_sha256 },
     .num_record_algs = 2,
     .sslv3_record_alg = NULL,
-    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .prf_alg = S2N_HMAC_SHA256,
     .minimum_required_tls_version = S2N_TLS12,
 };
 
@@ -549,7 +549,7 @@ struct s2n_cipher_suite s2n_ecdhe_rsa_with_aes_256_cbc_sha384 = /* 0xC0,0x28 */ 
     .all_record_algs = { &s2n_record_alg_aes256_sha384 },
     .num_record_algs = 1,
     .sslv3_record_alg = NULL,
-    .tls12_prf_alg = S2N_HMAC_SHA384,
+    .prf_alg = S2N_HMAC_SHA384,
     .minimum_required_tls_version = S2N_TLS12,
 };
 
@@ -563,7 +563,7 @@ struct s2n_cipher_suite s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256 = /* 0xC0,0x2B *
     .all_record_algs = { &s2n_record_alg_aes128_gcm },
     .num_record_algs = 1,
     .sslv3_record_alg = NULL,
-    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .prf_alg = S2N_HMAC_SHA256,
     .minimum_required_tls_version = S2N_TLS12,
 };
 
@@ -577,7 +577,7 @@ struct s2n_cipher_suite s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384 = /* 0xC0,0x2C *
     .all_record_algs = { &s2n_record_alg_aes256_gcm },
     .num_record_algs = 1,
     .sslv3_record_alg = NULL,
-    .tls12_prf_alg = S2N_HMAC_SHA384,
+    .prf_alg = S2N_HMAC_SHA384,
     .minimum_required_tls_version = S2N_TLS12,
 };
 
@@ -591,7 +591,7 @@ struct s2n_cipher_suite s2n_ecdhe_rsa_with_aes_128_gcm_sha256 = /* 0xC0,0x2F */ 
     .all_record_algs = { &s2n_record_alg_aes128_gcm },
     .num_record_algs = 1,
     .sslv3_record_alg = NULL,
-    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .prf_alg = S2N_HMAC_SHA256,
     .minimum_required_tls_version = S2N_TLS12,
 };
 
@@ -605,7 +605,7 @@ struct s2n_cipher_suite s2n_ecdhe_rsa_with_aes_256_gcm_sha384 = /* 0xC0,0x30 */ 
     .all_record_algs = { &s2n_record_alg_aes256_gcm },
     .num_record_algs = 1,
     .sslv3_record_alg = NULL,
-    .tls12_prf_alg = S2N_HMAC_SHA384,
+    .prf_alg = S2N_HMAC_SHA384,
     .minimum_required_tls_version = S2N_TLS12,
 };
 
@@ -619,7 +619,7 @@ struct s2n_cipher_suite s2n_ecdhe_rsa_with_chacha20_poly1305_sha256 = /* 0xCC,0x
     .all_record_algs = { &s2n_record_alg_chacha20_poly1305 },
     .num_record_algs = 1,
     .sslv3_record_alg = NULL,
-    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .prf_alg = S2N_HMAC_SHA256,
     .minimum_required_tls_version = S2N_TLS12,
 };
 
@@ -633,7 +633,7 @@ struct s2n_cipher_suite s2n_ecdhe_ecdsa_with_chacha20_poly1305_sha256 = /* 0xCC,
     .all_record_algs = { &s2n_record_alg_chacha20_poly1305 },
     .num_record_algs = 1,
     .sslv3_record_alg = NULL,
-    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .prf_alg = S2N_HMAC_SHA256,
     .minimum_required_tls_version = S2N_TLS12,
 };
 
@@ -647,7 +647,7 @@ struct s2n_cipher_suite s2n_dhe_rsa_with_chacha20_poly1305_sha256 = /* 0xCC,0xAA
     .all_record_algs = { &s2n_record_alg_chacha20_poly1305 },
     .num_record_algs = 1,
     .sslv3_record_alg = NULL,
-    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .prf_alg = S2N_HMAC_SHA256,
     .minimum_required_tls_version = S2N_TLS12,
 };
 
@@ -662,7 +662,7 @@ struct s2n_cipher_suite s2n_ecdhe_bike_rsa_with_aes_256_gcm_sha384 = /* 0xFF, 0x
         .all_record_algs = { &s2n_record_alg_aes256_gcm },
         .num_record_algs = 1,
         .sslv3_record_alg = NULL,
-        .tls12_prf_alg = S2N_HMAC_SHA384,
+        .prf_alg = S2N_HMAC_SHA384,
         .minimum_required_tls_version = S2N_TLS12,
 };
 
@@ -676,7 +676,7 @@ struct s2n_cipher_suite s2n_ecdhe_sike_rsa_with_aes_256_gcm_sha384 = /* 0xFF, 0x
         .all_record_algs = { &s2n_record_alg_aes256_gcm },
         .num_record_algs = 1,
         .sslv3_record_alg = NULL,
-        .tls12_prf_alg = S2N_HMAC_SHA384,
+        .prf_alg = S2N_HMAC_SHA384,
         .minimum_required_tls_version = S2N_TLS12,
 };
 
@@ -690,7 +690,7 @@ struct s2n_cipher_suite s2n_tls13_aes_128_gcm_sha256 = {
     .all_record_algs = { &s2n_tls13_record_alg_aes128_gcm },
     .num_record_algs = 1,
     .sslv3_record_alg = NULL,
-    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .prf_alg = S2N_HMAC_SHA256,
     .minimum_required_tls_version = S2N_TLS13,
 };
 
@@ -704,7 +704,7 @@ struct s2n_cipher_suite s2n_tls13_aes_256_gcm_sha384 = {
     .all_record_algs = { &s2n_tls13_record_alg_aes256_gcm },
     .num_record_algs = 1,
     .sslv3_record_alg = NULL,
-    .tls12_prf_alg = S2N_HMAC_SHA384,
+    .prf_alg = S2N_HMAC_SHA384,
     .minimum_required_tls_version = S2N_TLS13,
 };
 
@@ -718,7 +718,7 @@ struct s2n_cipher_suite s2n_tls13_chacha20_poly1305_sha256 = {
     .all_record_algs = { &s2n_tls13_record_alg_chacha20_poly1305 },
     .num_record_algs = 1,
     .sslv3_record_alg = NULL,
-    .tls12_prf_alg = S2N_HMAC_SHA256,
+    .prf_alg = S2N_HMAC_SHA256,
     .minimum_required_tls_version = S2N_TLS13,
 };
 

--- a/tls/s2n_cipher_suites.h
+++ b/tls/s2n_cipher_suites.h
@@ -88,7 +88,7 @@ struct s2n_cipher_suite {
     /* RFC 5426(TLS1.2) allows cipher suite defined PRFs. Cipher suites defined in and before TLS1.2 will use
      * P_hash with SHA256 when TLS1.2 is negotiated.
      */
-    const s2n_hmac_algorithm tls12_prf_alg;
+    const s2n_hmac_algorithm prf_alg;
 
     const uint8_t minimum_required_tls_version;
 };

--- a/tls/s2n_handshake.c
+++ b/tls/s2n_handshake.c
@@ -145,11 +145,13 @@ int s2n_conn_update_required_handshake_hashes(struct s2n_connection *conn)
         GUARD(s2n_handshake_require_hash(&conn->handshake, S2N_HASH_SHA1));
         break;
     case S2N_TLS12:
+        /* fall through */
+    case S2N_TLS13:
     {
-        /* For TLS 1.2 the cipher suite defines the PRF hash alg */
-        s2n_hmac_algorithm tls12_prf_alg = conn->secure.cipher_suite->tls12_prf_alg;
+        /* For TLS 1.2 and TLS 1.3, the cipher suite defines the PRF hash alg */
+        s2n_hmac_algorithm prf_alg = conn->secure.cipher_suite->prf_alg;
         s2n_hash_algorithm hash_alg;
-        GUARD(s2n_hmac_hash_alg(tls12_prf_alg, &hash_alg));
+        GUARD(s2n_hmac_hash_alg(prf_alg, &hash_alg));
         GUARD(s2n_handshake_require_hash(&conn->handshake, hash_alg));
         break;
     }

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -361,7 +361,7 @@ static int s2n_prf(struct s2n_connection *conn, struct s2n_blob *secret, struct 
     conn->prf_space.tls.p_hash_hmac_impl = s2n_is_in_fips_mode() ? &s2n_evp_hmac : &s2n_hmac;
 
     if (conn->actual_protocol_version == S2N_TLS12) {
-        return s2n_p_hash(&conn->prf_space, conn->secure.cipher_suite->tls12_prf_alg, secret, label, seed_a, seed_b,
+        return s2n_p_hash(&conn->prf_space, conn->secure.cipher_suite->prf_alg, secret, label, seed_a, seed_b,
                           seed_c, out);
     }
 
@@ -479,7 +479,7 @@ int s2n_prf_client_finished(struct s2n_connection *conn)
     master_secret.data = conn->secure.master_secret;
     master_secret.size = sizeof(conn->secure.master_secret);
     if (conn->actual_protocol_version == S2N_TLS12) {
-        switch (conn->secure.cipher_suite->tls12_prf_alg) {
+        switch (conn->secure.cipher_suite->prf_alg) {
         case S2N_HMAC_SHA256:
             GUARD(s2n_hash_copy(&conn->handshake.prf_tls12_hash_copy, &conn->handshake.sha256));
             GUARD(s2n_hash_digest(&conn->handshake.prf_tls12_hash_copy, sha_digest, SHA256_DIGEST_LENGTH));
@@ -532,7 +532,7 @@ int s2n_prf_server_finished(struct s2n_connection *conn)
     master_secret.data = conn->secure.master_secret;
     master_secret.size = sizeof(conn->secure.master_secret);
     if (conn->actual_protocol_version == S2N_TLS12) {
-        switch (conn->secure.cipher_suite->tls12_prf_alg) {
+        switch (conn->secure.cipher_suite->prf_alg) {
         case S2N_HMAC_SHA256:
             GUARD(s2n_hash_copy(&conn->handshake.prf_tls12_hash_copy, &conn->handshake.sha256));
             GUARD(s2n_hash_digest(&conn->handshake.prf_tls12_hash_copy, sha_digest, SHA256_DIGEST_LENGTH));

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -44,7 +44,7 @@ static int s2n_tls13_keys_init_with_ref(struct s2n_tls13_keys *handshake, s2n_hm
 
 int s2n_tls13_keys_from_conn(struct s2n_tls13_keys *keys, struct s2n_connection *conn)
 {
-    GUARD(s2n_tls13_keys_init_with_ref(keys, conn->secure.cipher_suite->tls12_prf_alg, conn->secure.rsa_premaster_secret, conn->secure.master_secret));
+    GUARD(s2n_tls13_keys_init_with_ref(keys, conn->secure.cipher_suite->prf_alg, conn->secure.rsa_premaster_secret, conn->secure.master_secret));
 
     return 0;
 }


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
#1545

**Description of changes:** 
 * Add a case for the TLS1.3 protocol when setting required hashes.
 * Add @lrstewart tls13 handshake test updates, which pass after required hash change.
 * Rename tls12_prf_alg to prf_alg because that field handles both protocols.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
