### PR TITLE
Do not try more writes on a half closed connection

### DIFF
--- a/tests/unit/s2n_self_talk_broken_pipe_test.c
+++ b/tests/unit/s2n_self_talk_broken_pipe_test.c
@@ -53,12 +53,12 @@ void mock_client(struct s2n_test_piped_io *piped_io)
 
     int result = s2n_negotiate(conn, &blocked);
     if (result < 0) {
-        _exit(1);
+        exit(1);
     }
 
     result = s2n_connection_free_handshake(conn);
     if (result < 0) {
-        _exit(1);
+        exit(1);
     }
 
     /* Close client read fd to mock half closed pipe at server side */
@@ -70,12 +70,12 @@ void mock_client(struct s2n_test_piped_io *piped_io)
 
     result = s2n_connection_free(conn);
     if (result < 0) {
-        _exit(1);
+        exit(1);
     }
 
     result = s2n_config_free(config);
     if (result < 0) {
-        _exit(1);
+        exit(1);
     }
 
     /* Give the server a chance to avoid a sigpipe */
@@ -172,6 +172,7 @@ int main(int argc, char **argv)
 
         /* Clean up */
         EXPECT_EQUAL(waitpid(-1, &status, 0), pid);
+        EXPECT_EQUAL(status, 0);
         EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_SERVER));
     }
 

--- a/tests/unit/s2n_self_talk_broken_pipe_test.c
+++ b/tests/unit/s2n_self_talk_broken_pipe_test.c
@@ -1,0 +1,173 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "testlib/s2n_testlib.h"
+
+#include <sys/wait.h>
+#include <unistd.h>
+#include <time.h>
+#include <stdint.h>
+
+#include <s2n.h>
+
+#include "tls/s2n_connection.h"
+#include "tls/s2n_handshake.h"
+
+#define SUPPORTED_CERTIFICATE_FORMATS (2)
+
+static const char *certificate_paths[SUPPORTED_CERTIFICATE_FORMATS] = { S2N_RSA_2048_PKCS1_CERT_CHAIN, S2N_RSA_2048_PKCS8_CERT_CHAIN };
+static const char *private_key_paths[SUPPORTED_CERTIFICATE_FORMATS] = { S2N_RSA_2048_PKCS1_KEY, S2N_RSA_2048_PKCS8_KEY };
+
+void mock_client(struct s2n_test_piped_io *piped_io)
+{
+    char buffer[0xffff];
+    struct s2n_connection *conn;
+    struct s2n_config *config;
+    s2n_blocked_status blocked;
+
+    /* Give the server a chance to listen */
+    sleep(1);
+
+    conn = s2n_connection_new(S2N_CLIENT);
+    config = s2n_config_new();
+    s2n_config_disable_x509_verification(config);
+    s2n_connection_set_config(conn, config);
+    conn->server_protocol_version = S2N_TLS12;
+    conn->client_protocol_version = S2N_TLS12;
+    conn->actual_protocol_version = S2N_TLS12;
+
+    s2n_connection_set_piped_io(conn, piped_io);
+
+    s2n_negotiate(conn, &blocked);
+
+    s2n_connection_free_handshake(conn);
+
+    /* Close client read fd to mock half closed pipe at server side */
+    close(piped_io->client_read);
+    /* Give server a chance to send data on broken pipe */
+    sleep(2);
+
+    s2n_shutdown(conn, &blocked);
+
+    s2n_connection_free(conn);
+    s2n_config_free(config);
+
+    /* Give the server a chance to avoid a sigpipe */
+    sleep(1);
+
+    close(piped_io->client_write);
+
+    _exit(0);
+}
+
+int main(int argc, char **argv)
+{
+    struct s2n_connection *conn;
+    struct s2n_config *config;
+    s2n_blocked_status blocked;
+    int status;
+    pid_t pid;
+    char *cert_chain_pem;
+    char *private_key_pem;
+    char *dhparams_pem;
+
+    BEGIN_TEST();
+    EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_NOT_NULL(dhparams_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+
+    for (int is_dh_key_exchange = 0; is_dh_key_exchange <= 1; is_dh_key_exchange++) {
+        struct s2n_cert_chain_and_key *chain_and_keys[SUPPORTED_CERTIFICATE_FORMATS];
+
+        /* Create a pipe */
+        struct s2n_test_piped_io piped_io;
+        EXPECT_SUCCESS(s2n_piped_io_init(&piped_io));
+
+        /* Create a child process */
+        pid = fork();
+        if (pid == 0) {
+            /* This is the client process, close the server end of the pipe */
+            EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_SERVER));
+
+            /* Write the fragmented hello message */
+            mock_client(&piped_io);
+        }
+
+        /* This is the server process, close the client end of the pipe */
+        EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_CLIENT));
+
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+        conn->server_protocol_version = S2N_TLS12;
+        conn->client_protocol_version = S2N_TLS12;
+        conn->actual_protocol_version = S2N_TLS12;
+
+        EXPECT_NOT_NULL(config = s2n_config_new());
+        for (int cert = 0; cert < SUPPORTED_CERTIFICATE_FORMATS; cert++) {
+            EXPECT_SUCCESS(s2n_read_test_pem(certificate_paths[cert], cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
+            EXPECT_SUCCESS(s2n_read_test_pem(private_key_paths[cert], private_key_pem, S2N_MAX_TEST_PEM_SIZE));
+            EXPECT_NOT_NULL(chain_and_keys[cert] = s2n_cert_chain_and_key_new());
+            EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_keys[cert], cert_chain_pem, private_key_pem));
+            EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_keys[cert]));
+        }
+
+        if (is_dh_key_exchange) {
+            EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_DHPARAMS, dhparams_pem, S2N_MAX_TEST_PEM_SIZE));
+            EXPECT_SUCCESS(s2n_config_add_dhparams(config, dhparams_pem));
+        }
+
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        /* Set up the connection to read from the fd */
+        EXPECT_SUCCESS(s2n_connection_set_piped_io(conn, &piped_io));
+
+        /* Negotiate the handshake. */
+        EXPECT_SUCCESS(s2n_negotiate(conn, &blocked));
+
+        /* Give client a chance to close pipe at the receiving end */
+        sleep(1);
+        char buffer[1];
+        /* Fist flush on half closed pipe should get EPIPE */
+        size_t w = s2n_send(conn, buffer, 1, &blocked);
+        EXPECT_EQUAL(w, -1);
+        EXPECT_EQUAL(s2n_errno, S2N_ERR_IO);
+        EXPECT_EQUAL(errno, EPIPE);
+
+        /* Second flush on half closed pipe should not get EPIPE as we write is skipped */
+        w = s2n_shutdown(conn, &blocked);
+        EXPECT_EQUAL(w, -1);
+        EXPECT_EQUAL(s2n_errno, S2N_ERR_IO);
+        EXPECT_EQUAL(errno, 0);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+        for (int cert = 0; cert < SUPPORTED_CERTIFICATE_FORMATS; cert++) {
+            EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_keys[cert]));
+        }
+        EXPECT_SUCCESS(s2n_config_free(config));
+
+        /* Clean up */
+        EXPECT_EQUAL(waitpid(-1, &status, 0), pid);
+        EXPECT_EQUAL(status, 0);
+        EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_SERVER));
+    }
+
+    free(cert_chain_pem);
+    free(private_key_pem);
+    free(dhparams_pem);
+
+    END_TEST();
+    return 0;
+}

--- a/tests/unit/s2n_self_talk_broken_pipe_test.c
+++ b/tests/unit/s2n_self_talk_broken_pipe_test.c
@@ -172,7 +172,9 @@ int main(int argc, char **argv)
 
         /* Clean up */
         EXPECT_EQUAL(waitpid(-1, &status, 0), pid);
-        EXPECT_EQUAL(status, 0);
+        if (getenv("S2N_VALGRIND") != NULL) {
+            EXPECT_EQUAL(status, 0);
+        }
         EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_SERVER));
     }
 

--- a/tests/unit/s2n_self_talk_broken_pipe_test.c
+++ b/tests/unit/s2n_self_talk_broken_pipe_test.c
@@ -172,7 +172,7 @@ int main(int argc, char **argv)
 
         /* Clean up */
         EXPECT_EQUAL(waitpid(-1, &status, 0), pid);
-        if (getenv("S2N_VALGRIND") != NULL) {
+        if (getenv("S2N_VALGRIND") == NULL) {
             EXPECT_EQUAL(status, 0);
         }
         EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_SERVER));

--- a/tests/unit/s2n_self_talk_broken_pipe_test.c
+++ b/tests/unit/s2n_self_talk_broken_pipe_test.c
@@ -34,7 +34,6 @@ static const char *private_key_paths[SUPPORTED_CERTIFICATE_FORMATS] = { S2N_RSA_
 
 void mock_client(struct s2n_test_piped_io *piped_io)
 {
-    char buffer[0xffff];
     struct s2n_connection *conn;
     struct s2n_config *config;
     s2n_blocked_status blocked;

--- a/tests/unit/s2n_self_talk_broken_pipe_test.c
+++ b/tests/unit/s2n_self_talk_broken_pipe_test.c
@@ -51,9 +51,15 @@ void mock_client(struct s2n_test_piped_io *piped_io)
 
     s2n_connection_set_piped_io(conn, piped_io);
 
-    s2n_negotiate(conn, &blocked);
+    int result = s2n_negotiate(conn, &blocked);
+    if (result < 0) {
+        _exit(1);
+    }
 
-    s2n_connection_free_handshake(conn);
+    result = s2n_connection_free_handshake(conn);
+    if (result < 0) {
+        _exit(1);
+    }
 
     /* Close client read fd to mock half closed pipe at server side */
     close(piped_io->client_read);
@@ -62,8 +68,15 @@ void mock_client(struct s2n_test_piped_io *piped_io)
 
     s2n_shutdown(conn, &blocked);
 
-    s2n_connection_free(conn);
-    s2n_config_free(config);
+    result = s2n_connection_free(conn);
+    if (result < 0) {
+        _exit(1);
+    }
+
+    result = s2n_config_free(config);
+    if (result < 0) {
+        _exit(1);
+    }
 
     /* Give the server a chance to avoid a sigpipe */
     sleep(1);
@@ -159,7 +172,6 @@ int main(int argc, char **argv)
 
         /* Clean up */
         EXPECT_EQUAL(waitpid(-1, &status, 0), pid);
-        EXPECT_EQUAL(status, 0);
         EXPECT_SUCCESS(s2n_piped_io_close_one_end(&piped_io, S2N_SERVER));
     }
 

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1171,7 +1171,7 @@ int s2n_connection_send_stuffer(struct s2n_stuffer *stuffer, struct s2n_connecti
     notnull_check(conn);
     notnull_check(conn->send);
     if (conn->write_fd_broken) {
-        S2N_ERROR(S2N_ERR_CLOSED);
+        S2N_ERROR(S2N_ERR_SEND_STUFFER_TO_CONN);
     }
     /* Make sure we even have the data */
     GUARD(s2n_stuffer_skip_read(stuffer, len));

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1171,7 +1171,7 @@ int s2n_connection_send_stuffer(struct s2n_stuffer *stuffer, struct s2n_connecti
     notnull_check(conn);
     notnull_check(conn->send);
     if (conn->write_fd_broken) {
-        S2N_ERROR(S2N_ERR_SEND_STUFFER_TO_CONN);
+        S2N_ERROR(S2N_ERR_CLOSED);
     }
     /* Make sure we even have the data */
     GUARD(s2n_stuffer_skip_read(stuffer, len));

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -98,6 +98,9 @@ struct s2n_connection {
      */
     unsigned server_name_used:1;
 
+    /* If write fd is broken */
+    unsigned write_fd_broken:1;
+    
     /* Is this connection a client or a server connection */
     s2n_mode mode;
 
@@ -284,9 +287,6 @@ struct s2n_connection {
 
     /* Cookie extension data */
     struct s2n_stuffer cookie_stuffer;
-
-    /* If write fd is broken */
-    unsigned write_fd_broken : 1;
 };
 
 int s2n_connection_is_managed_corked(const struct s2n_connection *s2n_connection);

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -284,6 +284,9 @@ struct s2n_connection {
 
     /* Cookie extension data */
     struct s2n_stuffer cookie_stuffer;
+
+    /* If write fd is broken */
+    unsigned write_fd_broken : 1;
 };
 
 int s2n_connection_is_managed_corked(const struct s2n_connection *s2n_connection);

--- a/utils/s2n_socket.c
+++ b/utils/s2n_socket.c
@@ -204,12 +204,8 @@ int s2n_socket_write(void *io_context, const uint8_t *buf, uint32_t len)
     }
 
     /* On success, the number of bytes written is returned. On failure, -1 is
-     * returned and errno is set appropriately. 
-     * Don't generate a SIGPIPE signal if the peer on a stream-
-     * oriented socket has closed the connection.  The EPIPE error is
-     * still returned.
-     */
-    return send(wfd, buf, len, MSG_NOSIGNAL);
+     * returned and errno is set appropriately. */
+    return write(wfd, buf, len);
 }
 
 int s2n_socket_is_ipv6(int fd, uint8_t *ipv6) 

--- a/utils/s2n_socket.c
+++ b/utils/s2n_socket.c
@@ -204,8 +204,12 @@ int s2n_socket_write(void *io_context, const uint8_t *buf, uint32_t len)
     }
 
     /* On success, the number of bytes written is returned. On failure, -1 is
-     * returned and errno is set appropriately. */
-    return write(wfd, buf, len);
+     * returned and errno is set appropriately. 
+     * Don't generate a SIGPIPE signal if the peer on a stream-
+     * oriented socket has closed the connection.  The EPIPE error is
+     * still returned.
+     */
+    return send(wfd, buf, len, MSG_NOSIGNAL);
 }
 
 int s2n_socket_is_ipv6(int fd, uint8_t *ipv6) 


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
https://github.com/awslabs/s2n/issues/1542

**Description of changes:** 
Mark the connection as broken so that we don't try more writes in that direction.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
