### PR TITLE
TLS 1.3 endpoint handshake testing

### DIFF
--- a/tests/integration/Makefile
+++ b/tests/integration/Makefile
@@ -45,7 +45,7 @@ client_endpoints:
 	DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" \
 	LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
 	S2N_INTEG_TEST=1 \
-	python3 s2n_client_endpoint_handshake_test.py $(S2ND_HOST) $(S2ND_PORT); \
+	python3 s2n_client_endpoint_handshake_test.py; \
 	)
 
 dynamic_record:

--- a/tests/integration/s2n_client_endpoint_handshake_test.py
+++ b/tests/integration/s2n_client_endpoint_handshake_test.py
@@ -19,6 +19,7 @@ import time
 import socket
 import subprocess
 import itertools
+import argparse
 from s2n_test_constants import *
 
 
@@ -81,17 +82,32 @@ def try_client_handshake(endpoint, arguments, expected_cipher):
 
     return 0
 
-def well_known_endpoints_test(use_corked_io):
+def well_known_endpoints_test(use_corked_io, tls13_enabled):
+
     arguments = []
-    msg = "\n\tTesting s2n Client with Well Known Endpoints:"
+    msg = "\n\tTesting s2n Client with Well Known Endpoints"
+    opt_list = []
+
+    if tls13_enabled:
+        arguments += ["--tls13", "--ciphers", "default_tls13"]
+        opt_list += ["TLS 1.3"]
     if use_corked_io:
-        msg = "\n\tTesting s2n Client with Well Known Endpoints using Corked IO:"
         arguments += ["-C"]
-    print(msg)
+        opt_list += ["Corked IO"]
+
+    if len(opt_list) != 0:
+        msg += " using "
+        if len(opt_list) > 1:
+            msg += ", ".join(opt_list[:-2] + [opt_list[-2] + " and " + opt_list[-1]])
+        else:
+            msg += opt_list[0]
+
+    print(msg + ":")
 
     maxRetries = 5
     failed = 0
     for endpoint_config in well_known_endpoints:
+
         endpoint = endpoint_config["endpoint"]
         expected_cipher = endpoint_config.get("expected_cipher")
 
@@ -104,6 +120,8 @@ def well_known_endpoints_test(use_corked_io):
             if ret is 0:
                 break
             else:
+                if endpoint in allowed_endpoints_failures:
+                    break
                 time.sleep(i)
 
         print_result("Endpoint: %-35sExpected Cipher: %-40s... " % (endpoint, expected_cipher if expected_cipher else "Any"), ret)
@@ -113,16 +131,22 @@ def well_known_endpoints_test(use_corked_io):
     return failed
 
 def main(argv):
-    if len(argv) < 2:
-        print("s2n_handshake_test_s_client.py host port")
-        sys.exit(1)
 
-    host = argv[0]
-    port = argv[1]
+    parser = argparse.ArgumentParser(description="Run client endpoint handshake tests")
+    parser.add_argument("--no-tls13", action="store_true", help="Disable TLS 1.3 tests")
+    args = parser.parse_args()
 
     failed = 0
-    failed += well_known_endpoints_test(False)
-    failed += well_known_endpoints_test(True)
+
+    # TLS 1.2 Tests
+    failed += well_known_endpoints_test(use_corked_io=False, tls13_enabled=False)
+    failed += well_known_endpoints_test(use_corked_io=True, tls13_enabled=False)
+
+    # TLS 1.3 Tests
+    if not args.no_tls13:
+        failed += well_known_endpoints_test(use_corked_io=False, tls13_enabled=True)
+        failed += well_known_endpoints_test(use_corked_io=True, tls13_enabled=True)
+
     return failed
 
 if __name__ == "__main__":


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** https://github.com/awslabs/s2n/issues/1458

**Description of changes:** This PR updates s2n_client_endpoint_handshake_test.py so that it now runs a second set of endpoint handshake tests, but with TLS 1.3 enabled.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
