### PR TITLE
fix build error for shadowing a global declaration

### DIFF
--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -406,10 +406,10 @@ struct s2n_ticket_key *s2n_get_ticket_encrypt_decrypt_key(struct s2n_config *con
         return s2n_set_get(config->ticket_keys, encrypt_decrypt_keys_index[0]);
     }
 
-    int8_t index;
-    GUARD_PTR(index = s2n_compute_weight_of_encrypt_decrypt_keys(config, encrypt_decrypt_keys_index, num_encrypt_decrypt_keys, now));
+    int8_t idx;
+    GUARD_PTR(idx = s2n_compute_weight_of_encrypt_decrypt_keys(config, encrypt_decrypt_keys_index, num_encrypt_decrypt_keys, now));
 
-    return s2n_set_get(config->ticket_keys, index);
+    return s2n_set_get(config->ticket_keys, idx);
 }
 
 /* This function is used in s2n_decrypt_session_ticket in order for s2n to


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
declaration of 'index' shadows a global declaration /usr/include/strings.h:48: warning: shadowed declaration is here


**Description of changes:** 
rename the variable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
