### PR TITLE
Refactor cookie extension

### DIFF
--- a/tls/extensions/s2n_cookie.h
+++ b/tls/extensions/s2n_cookie.h
@@ -20,16 +20,16 @@
 #include "stuffer/s2n_stuffer.h"
 
 /* Return the length of cookie data in the connection */
-extern int s2n_cookie_len(struct s2n_connection *conn);
+int s2n_extensions_cookie_size(struct s2n_connection *conn);
 
 /* Write the connection's cookie data to the output stuffer */
-extern int s2n_cookie_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+int s2n_extensions_cookie_send(struct s2n_connection *conn, struct s2n_stuffer *out);
 
 /* Read cookie data out of the received extension, and save it in the connection */
-extern int s2n_cookie_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
+int s2n_extensions_cookie_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
 
 /* Functions specific to the server/client side cookie operations */
-extern int s2n_extensions_server_cookie_send(struct s2n_connection *conn, struct s2n_stuffer *out);
-extern int s2n_extensions_server_cookie_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
-extern int s2n_extensions_client_cookie_send(struct s2n_connection *conn, struct s2n_stuffer *out);
-extern int s2n_extensions_client_cookie_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
+int s2n_extensions_server_cookie_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+int s2n_extensions_server_cookie_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
+int s2n_extensions_client_cookie_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+int s2n_extensions_client_cookie_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 964

**Description of changes:** 
This PR refactors the cookie extension to provide better support for HelloRetryRequests. This is in its own PR to reduce the size of the HelloRetryRequest PR.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
