### PR TITLE
Update s2n_aead_chacha20_poly1305_set_encryption_key to use correct EVP …

### DIFF
--- a/crypto/s2n_aead_cipher_chacha20_poly1305.c
+++ b/crypto/s2n_aead_cipher_chacha20_poly1305.c
@@ -114,11 +114,11 @@ static int s2n_aead_chacha20_poly1305_set_encryption_key(struct s2n_session_key 
 #ifdef S2N_CHACHA20_POLY1305_AVAILABLE
     eq_check(in->size, S2N_TLS_CHACHA20_POLY1305_KEY_LEN);
 
-    GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_chacha20_poly1305(), NULL, NULL, NULL), S2N_ERR_KEY_INIT);
+    GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_chacha20_poly1305(), NULL, NULL, NULL), S2N_ERR_KEY_INIT);
 
     EVP_CIPHER_CTX_ctrl(key->evp_cipher_ctx, EVP_CTRL_AEAD_SET_IVLEN, S2N_TLS_CHACHA20_POLY1305_IV_LEN, NULL);
 
-    GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, in->data, NULL), S2N_ERR_KEY_INIT);
+    GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
     return 0;
 #else


### PR DESCRIPTION
…init function

_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
N/A

**Description of changes:** 
This fixes the weird looking (but harmless) code calling `EVP_DecryptInit_ex` in `s2n_aead_chacha20_poly1305_set_encryption_key`. This has no impact because the correct `EVP_EncryptInit_ex` is called before use in `s2n_aead_chacha20_poly1305_encrypt`.

The only difference between `EVP_DecryptInit_ex` and `EVP_EncryptInit_ex` is the `enc` direction in the context https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/crypto/evp/evp_enc.c#L234 which is only used to track the direction if using the `EVP_CipherUpdate` functions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
