### PR TITLE
Fix memset of parsed_extensions_mask

### DIFF
--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -239,7 +239,7 @@ static int s2n_populate_client_hello_extensions(struct s2n_client_hello *ch)
     GUARD(s2n_stuffer_write(&in, &ch->extensions));
 
     static __thread s2n_tls_extension_mask parsed_extensions_mask;
-    memset(&parsed_extensions_mask, 0, sizeof(s2n_tls_extension_mask));
+    memset(parsed_extensions_mask, 0, sizeof(s2n_tls_extension_mask));
 
     while (s2n_stuffer_data_available(&in)) {
         uint16_t ext_size, ext_type;


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 

N/A

**Description of changes:** 

Pass the correct parameter into `memset`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
