### PR TITLE
Cloudwatch Scheduled CodeBuild

### DIFF
--- a/codebuild/README.md
+++ b/codebuild/README.md
@@ -55,3 +55,11 @@ To bootstrap the CodeBuild jobs, the python script:
 - CodeBuild's environment is more restrictive than Travis- these jobs require elevated privilege to function.
 - Warning message from the fuzzer about test speed appear in CodeBuild output, but not in Travis-CI with the same test (See comments on AWS forums about a difference in ANSI TERM support); this also affects colorized output.
 - macOS/OSX platform files were not copied because CodeBuild does not support macOS builds.
+
+
+### Querying codebuild projects
+
+Here is a sample of how to double check the size of the build hosts, as an example.
+```
+for i in $(cat jobs); do echo -e "$i\t";aws codebuild batch-get-projects --name "$i" |jq '.projects[].environment.computeType'; done
+```

--- a/codebuild/README.md
+++ b/codebuild/README.md
@@ -49,6 +49,11 @@ To bootstrap the CodeBuild jobs, the python script:
 - Use CloudFormation to create the stack with the generated template.
 - Open the CodeBuild projects in the console and setup the Source correctly, using your OTP credentials to connect to Github
 
+### Words about CodeBuild instance size and concurrency
+
+The [AWS Codebuild](https://docs.aws.amazon.com/codebuild/latest/userguide/limits.html) docs list the number of concurrent jobs at 60.
+With extensive testing, we've learned this number appears to be weighted based on [instance size](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-compute-types.html) (or provisioning limits), so running all tests on the largest possible instances will reduce actual concurrency.  Additionally provisioning time is currently longer for larger instances, so there is a time penalty that might not be recovered by using a larger instance for short lived tests.
+
 ### Notes on moving from Travis-ci
 
 - Install_clang from Travis is using google chromium clang commit from 2017- which requires python2.7 (EOL); updated for CodeBuild.
@@ -57,9 +62,11 @@ To bootstrap the CodeBuild jobs, the python script:
 - macOS/OSX platform files were not copied because CodeBuild does not support macOS builds.
 
 
-### Querying codebuild projects
+### Querying CodeBuild projects
 
-Here is a sample of how to double check the size of the build hosts, as an example.
+Here is a sample of how to double check the size of the build hosts, as an example.  AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY for an associated AWS account will need to be set for this to work, as well as a file called jobs, listing the names of all the CodeBuild jobs you'd like to check.
+
+
 ```
 for i in $(cat jobs); do echo -e "$i\t";aws codebuild batch-get-projects --name "$i" |jq '.projects[].environment.computeType'; done
 ```

--- a/codebuild/bin/s2n_codebuild.sh
+++ b/codebuild/bin/s2n_codebuild.sh
@@ -81,10 +81,8 @@ if [[ "$TESTS" == "ALL" || "$TESTS" == "sawHMAC" ]] && [[ "$OS_NAME" == "linux" 
 if [[ "$TESTS" == "ALL" || "$TESTS" == "sawDRBG" ]]; then make -C tests/saw tmp/verify_drbg.log ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "tls" ]]; then make -C tests/saw tmp/verify_handshake.log ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "sawHMACFailure" ]]; then make -C tests/saw failure-tests ; fi
-if [[ "$TESTS" == "ALL" || "$TESTS" == "sawSIKE_r1" ]]; then make -C tests/saw sike_r1 ; fi
-if [[ "$TESTS" == "ALL" || "$TESTS" == "sawSIKE_r2" ]]; then make -C tests/saw sike_r2 ; fi
-if [[ "$TESTS" == "ALL" || "$TESTS" == "sawSIKE_r2_x64" ]]; then make -C tests/saw sike_r2_x64 ; fi
-if [[ "$TESTS" == "ALL" || "$TESTS" == "sawBIKE_r1" ]]; then make -C tests/saw bike_r1 ; fi
+# Below runs sike r_1 r_2 and x86
+if [[ "$TESTS" == "ALL" || "$TESTS" == "sawSIKE" ]]; then make -C tests/saw sike ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "sawBIKE_r2" ]]; then make -C tests/saw bike_r2 ; fi
 
 # Generate *.gcov files that can be picked up by the CodeCov.io Bash helper script. Don't run lcov or genhtml 

--- a/codebuild/codebuild.config
+++ b/codebuild/codebuild.config
@@ -13,7 +13,6 @@ image : aws/codebuild/standard:2.0
 env_type: LINUX_CONTAINER
 compute_type: BUILD_GENERAL1_2XLARGE
 buildspec: codebuild/spec/buildspec_ubuntu.yml
-# Testing- TODO: update prior to merge
 source_location: https://github.com/awslabs/s2n.git
 source_type : GITHUB
 source_clonedepth: 1
@@ -95,29 +94,9 @@ snippet: UbuntuBoilerplate2XL
 env: S2N_LIBCRYPTO=openssl-1.0.2-fips BUILD_S2N=true TESTS=valgrind GCC_VERSION=6
 
 # SAW tests
-[CodeBuild:s2nSawHmacMd5]
+[CodeBuild:s2nSawHmac]
 snippet: UbuntuBoilerplate2XL
-env: TESTS=sawHMAC SAW_HMAC_TEST=md5 SAW=true GCC_VERSION=NONE
-
-[CodeBuild:s2nSawHmacSha1]
-snippet: UbuntuBoilerplate2XL
-env: TESTS=sawHMAC SAW_HMAC_TEST=sha1 SAW=true GCC_VERSION=NONE
-
-[CodeBuild:s2nSawHmacSha224]
-snippet: UbuntuBoilerplate2XL
-env: TESTS=sawHMAC SAW_HMAC_TEST=sha224 SAW=true GCC_VERSION=NONE
-
-[CodeBuild:s2nSawHmacSha256]
-snippet: UbuntuBoilerplate2XL
-env: TESTS=sawHMAC SAW_HMAC_TEST=sha256 SAW=true GCC_VERSION=NONE
-
-[CodeBuild:s2nSawHmacsha384]
-snippet: UbuntuBoilerplate2XL
-env: TESTS=sawHMAC SAW_HMAC_TEST=sha384 SAW=true GCC_VERSION=NONE
-
-[CodeBuild:s2nSawHmacSha512]
-snippet: UbuntuBoilerplate2XL
-env: TESTS=sawHMAC SAW_HMAC_TEST=sha512 SAW=true GCC_VERSION=NONE
+env: TESTS=sawHMAC SAW=true GCC_VERSION=NONE
 
 [CodeBuild:s2nSawDrbg]
 snippet: UbuntuBoilerplate2XL
@@ -125,15 +104,7 @@ env: TESTS=sawDRBG SAW=true GCC_VERSION=NONE
 
 [CodeBuild:s2nSawSike]
 snippet: UbuntuBoilerplate2XL
-env: TESTS=sawSIKE_r1 SAW=true GCC_VERSION=NONE
-
-[CodeBuild:s2nSawSikeR2]
-snippet: UbuntuBoilerplate2XL
-env: TESTS=sawSIKE_r2 SAW=true GCC_VERSION=NONE
-
-[CodeBuild:s2nSawSikeR2X64]
-snippet: UbuntuBoilerplate2XL
-env: TESTS=sawSIKE_r2_x64 SAW=true GCC_VERSION=NONE
+env: TESTS=sawSIKE SAW=true GCC_VERSION=NONE
 
 [CodeBuild:s2nSawBike]
 snippet: UbuntuBoilerplate2XL

--- a/codebuild/codebuild.config
+++ b/codebuild/codebuild.config
@@ -19,6 +19,18 @@ source_type : GITHUB
 source_clonedepth: 1
 source_version: 
 
+[UbuntuBoilerplateLarge]
+image : aws/codebuild/standard:2.0
+env_type: LINUX_CONTAINER
+compute_type: BUILD_GENERAL1_LARGE
+buildspec: codebuild/spec/buildspec_ubuntu.yml
+# Testing- TODO: update prior to merge
+source_location: https://github.com/awslabs/s2n.git
+source_type : GITHUB
+source_clonedepth: 1
+source_version:
+
+
 # The prefix CodeBuild: is required for the script to build this as a CB project
 # Fuzzers
 [CodeBuild:s2nfuzzerOpenSSL111Coverage]
@@ -61,12 +73,12 @@ env: S2N_LIBCRYPTO=openssl-1.1.1 OPENSSL_ia32cap="~0x200000200000000" BUILD_S2N=
 
 # Unit Test
 [CodeBuild:s2nUnitOpenSSL111Gcc6]
-snippet: UbuntuBoilerplate2XL
+snippet: UbuntuBoilerplateLarge
 env: S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=unit GCC_VERSION=6 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true
 
 # Asan Test
 [CodeBuild:s2nAsanOpenSSL102Gcc6]
-snippet: UbuntuBoilerplate2XL
+snippet: UbuntuBoilerplateLarge
 env: S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=asan GCC_VERSION=6
 
 #Valgrind Test
@@ -139,3 +151,8 @@ env: TESTS=sawHMACFailure SAW=true
 [CodeBuild:s2nSidetrail]
 snippet: UbuntuBoilerplate2XL
 env: TESTS=sidetrail
+
+# GitHub Actions Codebuild Shim Job
+[CodeBuild:s2nGithubCodebuild]
+snippet: UbuntuBoilerplateLarge
+env: TESTS=OverRiddenByGithub

--- a/codebuild/create_project.py
+++ b/codebuild/create_project.py
@@ -18,14 +18,68 @@ import argparse
 import configparser
 import logging
 
-from awacs.aws import Allow, Statement, Principal, PolicyDocument
+from awacs.aws import Action, Allow, Statement, Principal, PolicyDocument
 from awacs.sts import AssumeRole
-from troposphere import Template, Ref, Output
+from random import randrange
+from troposphere import GetAtt, Template, Ref, Output
+from troposphere.events import Rule, Target
 from troposphere.iam import Role
 from troposphere.codebuild import Artifacts, Environment, Source, Project
 
 logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG)
+
+
+def build_cw_event(template=Template, project_name=None, role=None):
+    # Run during the business day PDT
+    hour = randrange(14, 23)
+    project_target = Target(
+        f"{project_name}Target",
+        Arn=GetAtt(project_name, "Arn"),
+        RoleArn=GetAtt(role, "Arn"),
+        Id=f"{project_name}CWid"
+    )
+    rule = template.add_resource(Rule(
+        f"{project_name}Rule",
+        Name=f"{project_name}Evernt",
+        Description="scheduled run Build with CloudFormation",
+        Targets=[project_target],
+        State='ENABLED',
+        # Run at the top of a random hour.
+        ScheduleExpression=f"cron(0 {hour} * * ? *)",
+        DependsOn=project_name
+    )
+    )
+
+
+def build_github_role(template=None, role_name="s2nCodeBuildGithubRole"):
+    """
+    Create a role for GitHub actions to use for launching CodeBuild jobs.
+    This is not attached to any other resource created in this file.
+    """
+    role_id = template.add_resource(
+        Role(
+            role_name,
+            Path='/',
+            AssumeRolePolicyDocument=PolicyDocument(
+                Statement=[
+                    Statement(
+                        Effect=Allow,
+                        Action=[Action("logs", "CreateLogGroup"),
+                                Action("logs", "CreateLogStream"),
+                                Action("logs", "PutLogEvents")],
+                        Resource=[
+                            "arn:aws:logs:us-west-2:024603541914:log-group:/aws/codebuild/s2nGithubCodebuild",
+                            "arn:aws:logs:us-west-2:024603541914:log-group:/aws/codebuild/s2nGithubCodebuild:*"
+                        ]
+                    )
+                ]
+            )
+        )
+    )
+
+    template.add_output([Output(role_name, Value=Ref(role_id))])
+    return Ref(role_id)
 
 
 def build_project(template=Template(), section=None, project_name=None, raw_env=None,
@@ -76,17 +130,16 @@ def build_project(template=Template(), section=None, project_name=None, raw_env=
     template.add_output([Output(f"CodeBuildProject{project_name}", Value=Ref(project_id))])
 
 
-def build_role(template=Template(), section="CFNRole", project_name: str = None, **kwargs) -> Ref:
+def build_codebuild_role(template=Template(), project_name: str = None, **kwargs) -> Ref:
     """ Build a role with a CodeBuild managed policy. """
-    template.set_version('2010-09-09')
     assert project_name
     project_name += 'Role'
 
-    # NOTE: By default CodeBuild manages the policies for this role.  If you delete a CFN stack and try to recreate the project
-    # or make changes to it when the Codebuild managed Policy still exists, you'll see an error in the UI:
+    # NOTE: By default CodeBuild manages the policies for this role.  If you delete a CFN stack and try to recreate the
+    # project or make changes to it when the Codebuild managed Policy still exists, you'll see an error in the UI:
     # `The policy is attached to 0 entities but it must be attached to a single role`. (CFN fails with fail to update)
-    # Orphaned policies created by CodeBuild will have CodeBuildBasePolicy prepended to them; search for policies with this
-    # name and no role and delete to clear the error.
+    # Orphaned policies created by CodeBuild will have CodeBuildBasePolicy prepended to them; search for policies with
+    # this name and no role and delete to clear the error.
     # TODO: Get a CloudFormation feature request to turn this off for project creation- let CFN manage the policy.
     role_id = template.add_resource(
         Role(
@@ -111,17 +164,21 @@ def build_role(template=Template(), section="CFNRole", project_name: str = None,
 def main(**kwargs):
     """ Create the CFN template and either write to screen or update/create boto3. """
     codebuild = Template()
+    codebuild.set_version('2010-09-09')
 
+    # TODO: There is a problem with the resource statement
+    #logging.info('Creating github role: {}', build_github_role(codebuild))
     for job in config.sections():
         if 'CodeBuild:' in job:
             job_title = job.split(':')[1]
-            service_role = build_role(template=codebuild, project_name=job_title).to_dict()
+            service_role = build_codebuild_role(template=codebuild, project_name=job_title).to_dict()
             # Pull the env out of the section, and use the snippet for the other values.
             if 'snippet' in config[job]:
                 build_project(template=codebuild, project_name=job_title, section=config.get(job, 'snippet'),
                               service_role=service_role['Ref'], raw_env=config.get(job, 'env'))
             else:
                 build_project(template=codebuild, project_name=job_title, section=job, service_role=service_role['Ref'])
+            build_cw_event(template=codebuild, project_name=job_title, role = service_role['Ref'])
 
     with(open(args.output_dir + "/codebuild_test_projects.yml", 'w')) as fh:
         fh.write(codebuild.to_yaml())


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Description of changes:** 
- Update the CloudFormation script to schedule daily runs of all CodeBuild jobs.
- Downsize host class for unit and asan tests based on runtimes (the larger instances take longer to provision) and added words about observed behaviors to the CodeBuild Readme.
- Record the GHA CodeBuild job
- Create a Role that grants CloudWatch permission to start CodeBuild
- Rework of Sike

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
