### PR TITLE
Fix bug in setting client sig scheme defaults

### DIFF
--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -455,7 +455,7 @@ int s2n_sslv2_client_hello_recv(struct s2n_connection *conn)
     GUARD(s2n_conn_find_name_matching_certs(conn));
 
     GUARD(s2n_set_cipher_as_sslv2_server(conn, cipher_suites, cipher_suites_length / S2N_SSLv2_CIPHER_SUITE_LEN));
-    GUARD(s2n_choose_sig_scheme_from_peer_preference_list(conn, NULL, &conn->secure.conn_sig_scheme));
+    GUARD(s2n_choose_default_sig_scheme(conn, &conn->secure.conn_sig_scheme));
     GUARD(s2n_select_certs_for_server_auth(conn, &conn->handshake_params.our_chain_and_key));
 
     S2N_ERROR_IF(session_id_length > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -181,16 +181,11 @@ int s2n_server_hello_recv(struct s2n_connection *conn)
         GUARD(s2n_prf_key_expansion(conn));
     }
 
-    /* We've selected the cipher, update the required hashes for this connection */
-    GUARD(s2n_conn_update_required_handshake_hashes(conn));
+    /* Choose a default signature scheme */
+    GUARD(s2n_choose_default_sig_scheme(conn, &conn->secure.conn_sig_scheme));
 
-    /* Default our signature digest algorithm to SHA1. Will be used when verifying a client certificate. */
-    conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha1;
-    if (conn->actual_protocol_version < S2N_TLS12 && !s2n_is_in_fips_mode()
-            && conn->secure.cipher_suite->auth_method == S2N_AUTHENTICATION_RSA) {
-        /* TLS prior to 1.2 defaults to MD5 SHA1 hash if authentication is RSA */
-        conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_md5_sha1;
-    }
+    /* Update the required hashes for this connection */
+    GUARD(s2n_conn_update_required_handshake_hashes(conn));
 
     return 0;
 }

--- a/tls/s2n_signature_algorithms.h
+++ b/tls/s2n_signature_algorithms.h
@@ -29,6 +29,7 @@ struct s2n_sig_scheme_list {
     uint8_t len;
 };
 
+int s2n_choose_default_sig_scheme(struct s2n_connection *conn, struct s2n_signature_scheme *sig_scheme_out);
 int s2n_choose_sig_scheme_from_peer_preference_list(struct s2n_connection *conn, struct s2n_sig_scheme_list *sig_hash_algs,
                                                             struct s2n_signature_scheme *sig_scheme_out);
 int s2n_get_and_validate_negotiated_signature_scheme(struct s2n_connection *conn, struct s2n_stuffer *in,


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 

**Description of changes:**
    The logic in s2n_server_hello_recv to choose a default signature
    scheme didn't consider ECDSA. This has no REAL impact, because:
    - The default was only used in pre-TLS1.2 s2n_server_key_recv, and
    - Only the hash algorithm from the default scheme was used, and that
      is the same for both RSA and ECDSA.

But it could have caused unexpected future bugs, and it broke a
    sanity check I added in another commit.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
