### PR TITLE
Make sure we munlock the same amount of memory we mlocked

### DIFF
--- a/error/s2n_errno.h
+++ b/error/s2n_errno.h
@@ -276,6 +276,8 @@ extern __thread const char *s2n_debug_str;
 #define S2N_OBJECT_PTR_IS_READABLE(ptr) S2N_MEM_IS_READABLE((ptr), sizeof(*(ptr)))
 #define S2N_OBJECT_PTR_IS_WRITABLE(ptr) S2N_MEM_IS_WRITABLE((ptr), sizeof(*(ptr)))
 
+#define IMPLIES(a, b) (!(a) || (b))
+
 /** Calculate and print stacktraces */
 struct s2n_stacktrace {
   char **trace;

--- a/error/s2n_errno.h
+++ b/error/s2n_errno.h
@@ -276,7 +276,7 @@ extern __thread const char *s2n_debug_str;
 #define S2N_OBJECT_PTR_IS_READABLE(ptr) S2N_MEM_IS_READABLE((ptr), sizeof(*(ptr)))
 #define S2N_OBJECT_PTR_IS_WRITABLE(ptr) S2N_MEM_IS_WRITABLE((ptr), sizeof(*(ptr)))
 
-#define IMPLIES(a, b) (!(a) || (b))
+#define S2N_IMPLIES(a, b) (!(a) || (b))
 
 /** Calculate and print stacktraces */
 struct s2n_stacktrace {

--- a/tests/cbmc/source/cbmc_utils.c
+++ b/tests/cbmc/source/cbmc_utils.c
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+#include <assert.h>
 #include <cbmc_proof/cbmc_utils.h>
 
 void assert_bytes_match(const uint8_t *const a, const uint8_t *const b, const size_t len) {

--- a/utils/s2n_blob.c
+++ b/utils/s2n_blob.c
@@ -25,14 +25,12 @@
 
 bool s2n_blob_is_valid(const struct s2n_blob* b)
 {
-    if (!S2N_OBJECT_PTR_IS_READABLE(b)) {
-        return 0;
-    }
-    if(b->growable) {
-        return S2N_MEM_IS_READABLE(b->data,b->allocated) && b->size <= b->allocated;
-    } else {
-        return S2N_MEM_IS_READABLE(b->data,b->size) && b->allocated == 0;
-    }
+
+    return
+	b != NULL &&
+	S2N_OBJECT_PTR_IS_READABLE(b) &&
+	S2N_MEM_IS_READABLE(b->data,b->size) &&
+	IMPLIES(b->growable, b->size <= b->allocated);
 }
 
 int s2n_blob_init(struct s2n_blob *b, uint8_t * data, uint32_t size)

--- a/utils/s2n_blob.c
+++ b/utils/s2n_blob.c
@@ -31,6 +31,7 @@ bool s2n_blob_is_valid(const struct s2n_blob* b)
 	S2N_OBJECT_PTR_IS_READABLE(b) &&
 	S2N_MEM_IS_READABLE(b->data,b->size) &&
 	IMPLIES(!b->growable, b->allocated == 0) &&
+	IMPLIES(b->growable, S2N_MEM_IS_READABLE(b->data,b->allocated)) &&
 	IMPLIES(b->growable, b->size <= b->allocated);
 }
 

--- a/utils/s2n_blob.c
+++ b/utils/s2n_blob.c
@@ -30,6 +30,7 @@ bool s2n_blob_is_valid(const struct s2n_blob* b)
 	b != NULL &&
 	S2N_OBJECT_PTR_IS_READABLE(b) &&
 	S2N_MEM_IS_READABLE(b->data,b->size) &&
+	IMPLIES(!b->growable, b->allocated == 0) &&
 	IMPLIES(b->growable, b->size <= b->allocated);
 }
 

--- a/utils/s2n_blob.c
+++ b/utils/s2n_blob.c
@@ -30,9 +30,9 @@ bool s2n_blob_is_valid(const struct s2n_blob* b)
 	b != NULL &&
 	S2N_OBJECT_PTR_IS_READABLE(b) &&
 	S2N_MEM_IS_READABLE(b->data,b->size) &&
-	IMPLIES(!b->growable, b->allocated == 0) &&
-	IMPLIES(b->growable, S2N_MEM_IS_READABLE(b->data,b->allocated)) &&
-	IMPLIES(b->growable, b->size <= b->allocated);
+	S2N_IMPLIES(!b->growable, b->allocated == 0) &&
+	S2N_IMPLIES(b->growable, S2N_MEM_IS_READABLE(b->data, b->allocated)) &&
+	S2N_IMPLIES(b->growable, b->size <= b->allocated);
 }
 
 int s2n_blob_init(struct s2n_blob *b, uint8_t * data, uint32_t size)

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -121,7 +121,7 @@ int s2n_free(struct s2n_blob *b)
     S2N_ERROR_IF(!s2n_blob_is_growable(b), S2N_ERR_FREE_STATIC_BLOB);
     /* To avoid memory leaks, still free the data even if we can't unlock / wipe it */
     int zero_rc = s2n_blob_zero(b);
-    int munlock_rc = b->mlocked ? munlock(b->data, b->size) : 0;
+    int munlock_rc = b->mlocked ? munlock(b->data, b->allocated) : 0;
     free(b->data);
     *b = (struct s2n_blob) {0};
     S2N_ERROR_IF(munlock_rc < 0, S2N_ERR_MUNLOCK);


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
https://github.com/awslabs/s2n/issues/1502
**Description of changes:** 
if `realloc` has been called, `size` may be less than `alloced`.  In that case, we won't `munlock` the right set of memory, and will leak mlocked space.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
