### PR TITLE
Add s2n_align_to() function, and use it in s2n_get_memory()

### DIFF
--- a/tests/unit/s2n_safety_test.c
+++ b/tests/unit/s2n_safety_test.c
@@ -336,18 +336,30 @@ int main(int argc, char **argv)
     CHECK_OVF(s2n_mul_overflow, uint32_t, ~0u, ~0u);
 
     uint32_t result = 1;
-    EXPECT_SUCCESS(s2n_align_to(0,10,&result));
+    EXPECT_SUCCESS(s2n_align_to(0, 10, &result));
     EXPECT_EQUAL(result, 0);
 
-    EXPECT_FAILURE(s2n_align_to(1,0,&result));
+    EXPECT_FAILURE(s2n_align_to(1, 0, &result));
 
-    EXPECT_SUCCESS(s2n_align_to(10,16,&result));
+    EXPECT_SUCCESS(s2n_align_to(10, 16, &result));
     EXPECT_EQUAL(result, 16);
 
-    EXPECT_SUCCESS(s2n_align_to(20,16,&result));
+    EXPECT_SUCCESS(s2n_align_to(20, 16, &result));
     EXPECT_EQUAL(result, 32);
 
     EXPECT_FAILURE(s2n_align_to(UINT32_MAX, 4, &result));
+
+    EXPECT_SUCCESS(s2n_align_to(10, 4096, &result));
+    EXPECT_EQUAL(result, 4096);
+
+    EXPECT_SUCCESS(s2n_align_to(4097, 4096, &result));
+    EXPECT_EQUAL(result, 8192);
+
+    EXPECT_SUCCESS(s2n_align_to(4096, 4096, &result));
+    EXPECT_EQUAL(result, 4096);
+
+    EXPECT_FAILURE(s2n_align_to(UINT32_MAX - 4000, 4096, &result));
+    EXPECT_FAILURE(s2n_align_to(UINT32_MAX, 4096, &result));
     END_TEST();
     return 0;
 }

--- a/tests/unit/s2n_safety_test.c
+++ b/tests/unit/s2n_safety_test.c
@@ -335,6 +335,19 @@ int main(int argc, char **argv)
     CHECK_OVF(s2n_mul_overflow, uint32_t, 0x1FFFF, 0x1FFFF);
     CHECK_OVF(s2n_mul_overflow, uint32_t, ~0u, ~0u);
 
+    uint32_t result = 1;
+    EXPECT_SUCCESS(s2n_align_to(0,10,&result));
+    EXPECT_EQUAL(result, 0);
+
+    EXPECT_FAILURE(s2n_align_to(1,0,&result));
+
+    EXPECT_SUCCESS(s2n_align_to(10,16,&result));
+    EXPECT_EQUAL(result, 16);
+
+    EXPECT_SUCCESS(s2n_align_to(20,16,&result));
+    EXPECT_EQUAL(result, 32);
+
+    EXPECT_FAILURE(s2n_align_to(UINT32_MAX, 4, &result));
     END_TEST();
     return 0;
 }

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -63,7 +63,8 @@ static int s2n_get_memory(struct s2n_blob *b, uint32_t size)
 {
     if(use_mlock) {
         /* Page aligned allocation required for mlock */
-        uint32_t allocate = page_size * (((size - 1) / page_size) + 1);
+        uint32_t allocate;
+        GUARD(s2n_align_to(size, page_size, &allocate));
         *b = (struct s2n_blob) {.data = NULL, .size = size, .allocated = allocate, .mlocked = 1, .growable = 1};
         S2N_ERROR_IF(posix_memalign((void**) &b->data, page_size, allocate), S2N_ERR_ALLOC);
 #ifdef MADV_DONTDUMP

--- a/utils/s2n_safety.c
+++ b/utils/s2n_safety.c
@@ -166,7 +166,7 @@ int s2n_in_unit_test_set(bool newval)
 
 int s2n_mul_overflow(uint32_t a, uint32_t b, uint32_t* out)
 {
-    uint64_t result = ((uint64_t) a) * ((uint64_t) b);
+    const uint64_t result = ((uint64_t) a) * ((uint64_t) b);
     S2N_ERROR_IF(result > UINT32_MAX, S2N_ERR_INTEGER_OVERFLOW);
     *out = (uint32_t) result;
     return S2N_SUCCESS;
@@ -179,9 +179,9 @@ int s2n_align_to(uint32_t initial, uint32_t alignment, uint32_t* out)
 	*out = 0;
 	return S2N_SUCCESS;
     }
-    uint64_t i = initial;
-    uint64_t a = alignment;
-    uint64_t result = a * (((i - 1) / a) + 1);
+    const uint64_t i = initial;
+    const uint64_t a = alignment;
+    const uint64_t result = a * (((i - 1) / a) + 1);
     S2N_ERROR_IF(result > UINT32_MAX, S2N_ERR_INTEGER_OVERFLOW);
     *out = (uint32_t) result;
     return S2N_SUCCESS;

--- a/utils/s2n_safety.c
+++ b/utils/s2n_safety.c
@@ -171,3 +171,18 @@ int s2n_mul_overflow(uint32_t a, uint32_t b, uint32_t* out)
     *out = (uint32_t) result;
     return S2N_SUCCESS;
 }
+
+int s2n_align_to(uint32_t initial, uint32_t alignment, uint32_t* out)
+{
+    S2N_PRECONDITION(alignment != 0);
+    if (initial == 0) {
+	*out = 0;
+	return S2N_SUCCESS;
+    }
+    uint64_t i = initial;
+    uint64_t a = alignment;
+    uint64_t result = a * (((i - 1) / a) + 1);
+    S2N_ERROR_IF(result > UINT32_MAX, S2N_ERR_INTEGER_OVERFLOW);
+    *out = (uint32_t) result;
+    return S2N_SUCCESS;
+}

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -165,4 +165,10 @@ extern int s2n_constant_time_pkcs1_unpad_or_dont(uint8_t * dst, const uint8_t * 
 #define s2n_array_len(array) (sizeof(array) / sizeof(array[0]))
 
 extern int s2n_mul_overflow(uint32_t a, uint32_t b, uint32_t* out);
+
+/**
+ * Rounds "initial" up to a multiple of "alignment", and stores the result in "out".
+ * Raises an error if overflow would occur.
+ * NOT CONSTANT TIME.
+ */
 extern int s2n_align_to(uint32_t initial, uint32_t alignment, uint32_t* out);

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -165,3 +165,4 @@ extern int s2n_constant_time_pkcs1_unpad_or_dont(uint8_t * dst, const uint8_t * 
 #define s2n_array_len(array) (sizeof(array) / sizeof(array[0]))
 
 extern int s2n_mul_overflow(uint32_t a, uint32_t b, uint32_t* out);
+extern int s2n_align_to(uint32_t initial, uint32_t alignment, uint32_t* out);


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 

**Description of changes:** 
What it says in the title.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
