### PR TITLE
Use TLS12 in the protocol version field if sending a TLS13 ServerHello

### DIFF
--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -195,7 +195,6 @@ int s2n_server_hello_send(struct s2n_connection *conn)
     struct s2n_stuffer *out = &conn->handshake.io;
     struct s2n_stuffer server_random = {0};
     struct s2n_blob b, rand_data;
-    uint8_t protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN];
 
     b.data = conn->secure.server_random;
     b.size = S2N_TLS_RANDOM_DATA_LEN;
@@ -208,8 +207,11 @@ int s2n_server_hello_send(struct s2n_connection *conn)
     notnull_check(rand_data.data);
     GUARD(s2n_get_public_random_data(&rand_data));
 
-    protocol_version[0] = (uint8_t)(conn->actual_protocol_version / 10);
-    protocol_version[1] = (uint8_t)(conn->actual_protocol_version % 10);
+    /* Server hello should respond with the legacy version */
+    uint16_t legacy_protocol_version = MIN(conn->actual_protocol_version, S2N_TLS12);
+    uint8_t protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN];
+    protocol_version[0] = (uint8_t)(legacy_protocol_version / 10);
+    protocol_version[1] = (uint8_t)(legacy_protocol_version % 10);
 
     GUARD(s2n_server_add_downgrade_mechanism(conn));
 


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 

**Description of changes:** 

ServerHello should use the actual protocol version when <TLS13, but use TLS12 when the protocol version is TLS13.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
