### PR TITLE
Update FindLibCrypto.cmake to search for libcrypto.dylib as well to s…

### DIFF
--- a/cmake/modules/FindLibCrypto.cmake
+++ b/cmake/modules/FindLibCrypto.cmake
@@ -22,7 +22,7 @@ find_path(LibCrypto_INCLUDE_DIR
         ${CMAKE_INSTALL_PREFIX}/include
     )
 find_library(LibCrypto_SHARED_LIBRARY
-    NAMES libcrypto.so
+    NAMES libcrypto.so libcrypto.dylib
     HINTS
     ${CMAKE_PREFIX_PATH}/build/crypto
     ${CMAKE_PREFIX_PATH}/build


### PR DESCRIPTION
…upport Macs

_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
N/A
**Description of changes:** 
On Macs the shared library extension is `.dylib`. This updates FindLibCrypto to find either.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
