### PR TITLE
Use key method instead of direct RSA accessor

### DIFF
--- a/crypto/s2n_rsa_pss.c
+++ b/crypto/s2n_rsa_pss.c
@@ -55,7 +55,10 @@ static int s2n_rsa_pss_size(const struct s2n_pkey *key)
 
 static int s2n_rsa_is_private_key(RSA *rsa_key)
 {
-    if (RSA_get0_d(rsa_key)) {
+    const BIGNUM *d = NULL;
+    RSA_get0_key(rsa_key, NULL, NULL, &d);
+
+    if (d) {
         return 1;
     }
     return 0;


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** N/A

**Description of changes:** 
This changes the `s2n_rsa_is_private_key` method in `s2n_rsa_pss.c` to use `RSA_get0_key` instead of `RSA_get0_d`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
