### PR TITLE
Turning on support for Curve x25519 in test branch

### DIFF
--- a/crypto/s2n_ecc_evp.h
+++ b/crypto/s2n_ecc_evp.h
@@ -35,12 +35,13 @@ struct s2n_ecc_named_curve {
 extern const struct s2n_ecc_named_curve s2n_ecc_curve_secp256r1;
 extern const struct s2n_ecc_named_curve s2n_ecc_curve_secp384r1;
 
-#define S2N_ECC_EVP_SUPPORTED_CURVES_COUNT 2
 #if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0) && !defined(LIBRESSL_VERSION_NUMBER)
 #define MODERN_EC_SUPPORTED 1
+#define S2N_ECC_EVP_SUPPORTED_CURVES_COUNT 3
 extern const struct s2n_ecc_named_curve s2n_ecc_curve_x25519;
 #else
 #define MODERN_EC_SUPPORTED 0
+#define S2N_ECC_EVP_SUPPORTED_CURVES_COUNT 2
 #endif
 
 extern const struct s2n_ecc_named_curve *const s2n_ecc_evp_supported_curves_list[];

--- a/tests/integration/s2n_handshake_test_s_client.py
+++ b/tests/integration/s2n_handshake_test_s_client.py
@@ -82,13 +82,13 @@ use_corked_io=False
 
 def get_supported_curves_list_by_version(libcrypto_version):
     if libcrypto_version == "openssl-1.1.1":
-        return  ["P-256", "P-384"]
+        return  ["P-256", "P-384", "X25519"]
     else:
         return  ["P-256", "P-384"]
 
 def get_supported_curves_str_by_version(libcrypto_version):
     if libcrypto_version == "openssl-1.1.1":
-        return "P-256:P-384"
+        return "P-256:P-384:X25519"
     else:
         return "P-256:P-384"
 

--- a/tests/integration/s2n_handshake_test_s_server.py
+++ b/tests/integration/s2n_handshake_test_s_server.py
@@ -39,7 +39,7 @@ use_corked_io=False
 
 def get_supported_curves_list_by_version(libcrypto_version):
     if libcrypto_version == "openssl-1.1.1":
-        return ["P-256", "P-384"]
+        return ["P-256", "P-384", "X25519"]
     else:
         return ["P-256", "P-384"]
 


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 


**Description of changes:** 
Turning on support for Curve x25519 in the test branch for all versions of TLS. 
- Added `s2n_ecc_curve_x25519` to the `s2n_ecc_evp_supported_curves_list`.
- Added  curve x25519 to the integration tests.
- Reverted change that does peer validation, as the function (`EC_KEY_check_key`) used to validate required an ec_key object and for Curve x25519 an ec_key object cannot be obtained from the evp_pkey, there is no alternative function in OpenSSL that I am aware of.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
