### PR TITLE
Turn on support for Curve x25519 in the test branch 

### DIFF
--- a/crypto/s2n_ecc_evp.c
+++ b/crypto/s2n_ecc_evp.c
@@ -65,6 +65,9 @@ const struct s2n_ecc_named_curve s2n_ecc_curve_x25519 = {
 const struct s2n_ecc_named_curve *const s2n_ecc_evp_supported_curves_list[] = {
     &s2n_ecc_curve_secp256r1,
     &s2n_ecc_curve_secp384r1,
+#if MODERN_EC_SUPPORTED	
+    &s2n_ecc_curve_x25519,	
+#endif
 };
 
 const size_t s2n_ecc_evp_supported_curves_list_len = s2n_array_len(s2n_ecc_evp_supported_curves_list);

--- a/crypto/s2n_ecc_evp.c
+++ b/crypto/s2n_ecc_evp.c
@@ -81,7 +81,7 @@ static EC_POINT *s2n_ecc_evp_blob_to_point(struct s2n_blob *blob, const EC_KEY *
 #endif
 static int s2n_ecc_evp_generate_key_nist_curves(const struct s2n_ecc_named_curve *named_curve, EVP_PKEY **evp_pkey);
 static int s2n_ecc_evp_generate_own_key(const struct s2n_ecc_named_curve *named_curve, EVP_PKEY **evp_pkey);
-static int s2n_ecc_evp_compute_shared_secret(EVP_PKEY *own_key, EVP_PKEY *peer_public, struct s2n_blob *shared_secret);
+static int s2n_ecc_evp_compute_shared_secret(EVP_PKEY *own_key, EVP_PKEY *peer_public, uint16_t iana_id, struct s2n_blob *shared_secret);
 
 #if MODERN_EC_SUPPORTED
 static int s2n_ecc_evp_generate_key_x25519(const struct s2n_ecc_named_curve *named_curve, EVP_PKEY **evp_pkey) {
@@ -132,14 +132,19 @@ static int s2n_ecc_evp_generate_own_key(const struct s2n_ecc_named_curve *named_
     S2N_ERROR(S2N_ERR_ECDHE_GEN_KEY);
 }
 
-static int s2n_ecc_evp_compute_shared_secret(EVP_PKEY *own_key, EVP_PKEY *peer_public, struct s2n_blob *shared_secret) {
+static int s2n_ecc_evp_compute_shared_secret(EVP_PKEY *own_key, EVP_PKEY *peer_public, uint16_t iana_id, struct s2n_blob *shared_secret) {
     notnull_check(peer_public);
     notnull_check(own_key);
 
-    /* Peers MUST validate each other’s public key */
-    DEFER_CLEANUP(EC_KEY *ec_key = EVP_PKEY_get1_EC_KEY(peer_public), EC_KEY_free_pointer);
-    S2N_ERROR_IF(ec_key == NULL, S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
-    GUARD_OSSL(EC_KEY_check_key(ec_key), S2N_ERR_ECDHE_SHARED_SECRET);
+    /* From RFC 8446 Section 4.2.8.2: For the curves secp256r1 and secp384r1 peers MUST validate each other's
+     * public value Q by ensuring that the point is a valid point on the elliptic curve.
+     * For the curve x25519 the peer public-key validation check doesn't apply.
+     */
+    if (iana_id == TLS_EC_CURVE_SECP_256_R1 || iana_id == TLS_EC_CURVE_SECP_384_R1) {
+        DEFER_CLEANUP(EC_KEY *ec_key = EVP_PKEY_get1_EC_KEY(peer_public), EC_KEY_free_pointer);
+        S2N_ERROR_IF(ec_key == NULL, S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
+        GUARD_OSSL(EC_KEY_check_key(ec_key), S2N_ERR_ECDHE_SHARED_SECRET);
+    }
 
     size_t shared_secret_size;
     
@@ -178,7 +183,7 @@ int s2n_ecc_evp_compute_shared_secret_from_params(struct s2n_ecc_evp_params *pri
     S2N_ERROR_IF(private_ecc_evp_params->negotiated_curve->iana_id != public_ecc_evp_params->negotiated_curve->iana_id,
                  S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
     GUARD(s2n_ecc_evp_compute_shared_secret(private_ecc_evp_params->evp_pkey, public_ecc_evp_params->evp_pkey,
-                                            shared_key));
+                                            private_ecc_evp_params->negotiated_curve->iana_id, shared_key));
     return 0;
 }
 
@@ -223,7 +228,8 @@ int s2n_ecc_evp_compute_shared_secret_as_server(struct s2n_ecc_evp_params *ecc_e
     S2N_ERROR_IF(success == 0, S2N_ERR_BAD_MESSAGE);
 #endif
 
-    return s2n_ecc_evp_compute_shared_secret(ecc_evp_params->evp_pkey, peer_key, shared_key);
+    return s2n_ecc_evp_compute_shared_secret(ecc_evp_params->evp_pkey, peer_key,
+                                             ecc_evp_params->negotiated_curve->iana_id, shared_key);
 
 }
 
@@ -237,7 +243,8 @@ int s2n_ecc_evp_compute_shared_secret_as_client(struct s2n_ecc_evp_params *ecc_e
     GUARD(s2n_ecc_evp_generate_own_key(client_params.negotiated_curve, &client_params.evp_pkey));
     S2N_ERROR_IF(client_params.evp_pkey == NULL, S2N_ERR_ECDHE_GEN_KEY);
 
-    if (s2n_ecc_evp_compute_shared_secret(client_params.evp_pkey, ecc_evp_params->evp_pkey, shared_key) != 0) {
+    if (s2n_ecc_evp_compute_shared_secret(client_params.evp_pkey, ecc_evp_params->evp_pkey, 
+                                          ecc_evp_params->negotiated_curve->iana_id, shared_key) != 0) {
         S2N_ERROR(S2N_ERR_ECDHE_SHARED_SECRET);
     }
 

--- a/crypto/s2n_ecc_evp.h
+++ b/crypto/s2n_ecc_evp.h
@@ -35,12 +35,13 @@ struct s2n_ecc_named_curve {
 extern const struct s2n_ecc_named_curve s2n_ecc_curve_secp256r1;
 extern const struct s2n_ecc_named_curve s2n_ecc_curve_secp384r1;
 
-#define S2N_ECC_EVP_SUPPORTED_CURVES_COUNT 2
 #if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0) && !defined(LIBRESSL_VERSION_NUMBER)
 #define MODERN_EC_SUPPORTED 1
+#define S2N_ECC_EVP_SUPPORTED_CURVES_COUNT 3
 extern const struct s2n_ecc_named_curve s2n_ecc_curve_x25519;
 #else
 #define MODERN_EC_SUPPORTED 0
+#define S2N_ECC_EVP_SUPPORTED_CURVES_COUNT 2
 #endif
 
 extern const struct s2n_ecc_named_curve *const s2n_ecc_evp_supported_curves_list[];

--- a/tests/integration/s2n_handshake_test_s_client.py
+++ b/tests/integration/s2n_handshake_test_s_client.py
@@ -82,13 +82,13 @@ use_corked_io=False
 
 def get_supported_curves_list_by_version(libcrypto_version):
     if libcrypto_version == "openssl-1.1.1":
-        return  ["P-256", "P-384"]
+        return  ["P-256", "P-384", "X25519"]
     else:
         return  ["P-256", "P-384"]
 
 def get_supported_curves_str_by_version(libcrypto_version):
     if libcrypto_version == "openssl-1.1.1":
-        return "P-256:P-384"
+        return "P-256:P-384:X25519"
     else:
         return "P-256:P-384"
 

--- a/tests/integration/s2n_handshake_test_s_server.py
+++ b/tests/integration/s2n_handshake_test_s_server.py
@@ -39,7 +39,7 @@ use_corked_io=False
 
 def get_supported_curves_list_by_version(libcrypto_version):
     if libcrypto_version == "openssl-1.1.1":
-        return ["P-256", "P-384"]
+        return ["P-256", "P-384", "X25519"]
     else:
         return ["P-256", "P-384"]
 


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 

**Description of changes:** 

Turning on support for Curve x25519 in the test branch for all versions of TLS.

- Added `s2n_ecc_curve_x25519` to the `s2n_ecc_evp_supported_curves_list`.
- Added curve x25519 to the integration tests.
- For the curve x25519 the peer public-key validation doesnot apply, added conditional statement for the validation to be done only for curves secp256r1 and secp384r1.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
