### PR TITLE
Reduce highest version to TLS 1.2 for non TLS 1.3 Cipher Preferences

### DIFF
--- a/tests/unit/s2n_cipher_preference_test.c
+++ b/tests/unit/s2n_cipher_preference_test.c
@@ -29,12 +29,14 @@ int main(int argc, char **argv)
         EXPECT_TRUE(s2n_ecc_extension_required(preferences));
         EXPECT_FALSE(s2n_pq_kem_extension_required(preferences));
         EXPECT_EQUAL(0, preferences->kem_count);
+        EXPECT_FALSE(s2n_cipher_preference_supports_tls13(preferences));
         EXPECT_NULL(preferences->kems);
 
         preferences = NULL;
         EXPECT_SUCCESS(s2n_find_cipher_pref_from_version("default_tls13", &preferences));
         EXPECT_TRUE(s2n_ecc_extension_required(preferences));
         EXPECT_FALSE(s2n_pq_kem_extension_required(preferences));
+        EXPECT_TRUE(s2n_cipher_preference_supports_tls13(preferences));
         EXPECT_EQUAL(0, preferences->kem_count);
         EXPECT_NULL(preferences->kems);
 
@@ -42,6 +44,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_find_cipher_pref_from_version("test_all", &preferences));
         EXPECT_TRUE(s2n_ecc_extension_required(preferences));
         EXPECT_TRUE(s2n_pq_kem_extension_required(preferences));
+        EXPECT_TRUE(s2n_cipher_preference_supports_tls13(preferences));
         EXPECT_EQUAL(4, preferences->kem_count);
         EXPECT_NOT_NULL(preferences->kems);
         EXPECT_EQUAL(preferences->kems, pq_kems_r2r1);
@@ -50,6 +53,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_find_cipher_pref_from_version("KMS-TLS-1-0-2018-10", &preferences));
         EXPECT_TRUE(s2n_ecc_extension_required(preferences));
         EXPECT_FALSE(s2n_pq_kem_extension_required(preferences));
+        EXPECT_FALSE(s2n_cipher_preference_supports_tls13(preferences));
         EXPECT_EQUAL(0, preferences->kem_count);
         EXPECT_NULL(preferences->kems);
 
@@ -57,6 +61,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_find_cipher_pref_from_version("KMS-PQ-TLS-1-0-2019-06", &preferences));
         EXPECT_TRUE(s2n_ecc_extension_required(preferences));
         EXPECT_TRUE(s2n_pq_kem_extension_required(preferences));
+        EXPECT_FALSE(s2n_cipher_preference_supports_tls13(preferences));
         EXPECT_EQUAL(2, preferences->kem_count);
         EXPECT_NOT_NULL(preferences->kems);
         EXPECT_EQUAL(preferences->kems, pq_kems_r1);
@@ -65,6 +70,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_find_cipher_pref_from_version("PQ-SIKE-TEST-TLS-1-0-2019-11", &preferences));
         EXPECT_TRUE(s2n_ecc_extension_required(preferences));
         EXPECT_TRUE(s2n_pq_kem_extension_required(preferences));
+        EXPECT_FALSE(s2n_cipher_preference_supports_tls13(preferences));
         EXPECT_EQUAL(1, preferences->kem_count);
         EXPECT_NOT_NULL(preferences->kems);
         EXPECT_EQUAL(preferences->kems, pq_kems_sike_r1);
@@ -73,6 +79,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_find_cipher_pref_from_version("PQ-SIKE-TEST-TLS-1-0-2020-02", &preferences));
         EXPECT_TRUE(s2n_ecc_extension_required(preferences));
         EXPECT_TRUE(s2n_pq_kem_extension_required(preferences));
+        EXPECT_FALSE(s2n_cipher_preference_supports_tls13(preferences));
         EXPECT_EQUAL(2, preferences->kem_count);
         EXPECT_NOT_NULL(preferences->kems);
         EXPECT_EQUAL(preferences->kems, pq_kems_sike_r2r1);
@@ -81,6 +88,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_find_cipher_pref_from_version("KMS-PQ-TLS-1-0-2020-02", &preferences));
         EXPECT_TRUE(s2n_ecc_extension_required(preferences));
         EXPECT_TRUE(s2n_pq_kem_extension_required(preferences));
+        EXPECT_FALSE(s2n_cipher_preference_supports_tls13(preferences));
         EXPECT_EQUAL(4, preferences->kem_count);
         EXPECT_NOT_NULL(preferences->kems);
         EXPECT_EQUAL(preferences->kems, pq_kems_r2r1);
@@ -93,11 +101,80 @@ int main(int argc, char **argv)
         EXPECT_NULL(preferences->kems);
     }
 
+    /* Test s2n_cipher_preference_supports_tls13() with all cipher preferences */
+    {
+        char tls12_only_cipher_preference_strings[][255] = {
+            "default",
+            "default_fips",
+            "ELBSecurityPolicy-TLS-1-0-2015-04",
+            "ELBSecurityPolicy-TLS-1-0-2015-05",
+            "ELBSecurityPolicy-2016-08",
+            "ELBSecurityPolicy-TLS-1-1-2017-01",
+            "ELBSecurityPolicy-TLS-1-2-2017-01",
+            "ELBSecurityPolicy-TLS-1-2-Ext-2018-06",
+            "ELBSecurityPolicy-FS-2018-06",
+            "ELBSecurityPolicy-FS-1-2-2019-08",
+            "ELBSecurityPolicy-FS-1-1-2019-08",
+            "ELBSecurityPolicy-FS-1-2-Res-2019-08",
+            "CloudFront-Upstream",
+            "CloudFront-SSL-v-3",
+            "CloudFront-TLS-1-0-2014",
+            "CloudFront-TLS-1-0-2016",
+            "CloudFront-TLS-1-1-2016",
+            "CloudFront-TLS-1-2-2018",
+            "CloudFront-TLS-1-2-2019",
+            "KMS-TLS-1-0-2018-10",
+            "KMS-PQ-TLS-1-0-2019-06",
+            "KMS-PQ-TLS-1-0-2020-02",
+            "PQ-SIKE-TEST-TLS-1-0-2019-11",
+            "PQ-SIKE-TEST-TLS-1-0-2020-02",
+            "KMS-FIPS-TLS-1-2-2018-10",
+            "20140601",
+            "20141001",
+            "20150202",
+            "20150214",
+            "20150306",
+            "20160411",
+            "20160804",
+            "20160824",
+            "20170210",
+            "20170328",
+            "20190214",
+            "20170405",
+            "20170718",
+            "20190120",
+            "20190121",
+            "20190122",
+            "test_all_fips",
+            "test_all_ecdsa",
+            "test_ecdsa_priority",
+            "test_all_tls12",
+        };
+
+        for (uint8_t i = 0; i < s2n_array_len(tls12_only_cipher_preference_strings); i++) {
+            preferences = NULL;
+            EXPECT_SUCCESS(s2n_find_cipher_pref_from_version(tls12_only_cipher_preference_strings[i], &preferences));
+            EXPECT_FALSE(s2n_cipher_preference_supports_tls13(preferences));
+        }
+
+        char tls13_cipher_preference_strings[][255] = {
+            "default_tls13",
+            "test_all",
+            "test_all_tls13",
+        };
+        for (uint8_t i = 0; i < s2n_array_len(tls13_cipher_preference_strings); i++) {
+            preferences = NULL;
+            EXPECT_SUCCESS(s2n_find_cipher_pref_from_version(tls13_cipher_preference_strings[i], &preferences));
+            EXPECT_TRUE(s2n_cipher_preference_supports_tls13(preferences));
+        }
+    }
+
     /* Test that null fails */
     {
         preferences = NULL;
         EXPECT_FAILURE(s2n_ecc_extension_required(preferences));
         EXPECT_FAILURE(s2n_pq_kem_extension_required(preferences));
+        EXPECT_FAILURE(s2n_cipher_preference_supports_tls13(preferences));
     }
 
     /* Test that anything not automatically configured in s2n_cipher_preferences_init fails */
@@ -113,6 +190,7 @@ int main(int argc, char **argv)
         preferences = &fake_preferences;
         EXPECT_FAILURE(s2n_ecc_extension_required(preferences));
         EXPECT_FAILURE(s2n_pq_kem_extension_required(preferences));
+        EXPECT_FAILURE(s2n_cipher_preference_supports_tls13(preferences));
     }
 
     END_TEST();

--- a/tests/unit/s2n_cipher_preference_test.c
+++ b/tests/unit/s2n_cipher_preference_test.c
@@ -151,7 +151,7 @@ int main(int argc, char **argv)
             "test_all_tls12",
         };
 
-        for (uint8_t i = 0; i < s2n_array_len(tls12_only_cipher_preference_strings); i++) {
+        for (size_t i = 0; i < s2n_array_len(tls12_only_cipher_preference_strings); i++) {
             preferences = NULL;
             EXPECT_SUCCESS(s2n_find_cipher_pref_from_version(tls12_only_cipher_preference_strings[i], &preferences));
             EXPECT_FALSE(s2n_cipher_preference_supports_tls13(preferences));
@@ -162,7 +162,7 @@ int main(int argc, char **argv)
             "test_all",
             "test_all_tls13",
         };
-        for (uint8_t i = 0; i < s2n_array_len(tls13_cipher_preference_strings); i++) {
+        for (size_t i = 0; i < s2n_array_len(tls13_cipher_preference_strings); i++) {
             preferences = NULL;
             EXPECT_SUCCESS(s2n_find_cipher_pref_from_version(tls13_cipher_preference_strings[i], &preferences));
             EXPECT_TRUE(s2n_cipher_preference_supports_tls13(preferences));
@@ -174,7 +174,7 @@ int main(int argc, char **argv)
         preferences = NULL;
         EXPECT_FAILURE(s2n_ecc_extension_required(preferences));
         EXPECT_FAILURE(s2n_pq_kem_extension_required(preferences));
-        EXPECT_FAILURE(s2n_cipher_preference_supports_tls13(preferences));
+        EXPECT_FALSE(s2n_cipher_preference_supports_tls13(preferences));
     }
 
     /* Test that anything not automatically configured in s2n_cipher_preferences_init fails */
@@ -190,7 +190,7 @@ int main(int argc, char **argv)
         preferences = &fake_preferences;
         EXPECT_FAILURE(s2n_ecc_extension_required(preferences));
         EXPECT_FAILURE(s2n_pq_kem_extension_required(preferences));
-        EXPECT_FAILURE(s2n_cipher_preference_supports_tls13(preferences));
+        EXPECT_FALSE(s2n_cipher_preference_supports_tls13(preferences));
     }
 
     END_TEST();

--- a/tests/unit/s2n_client_hello_recv_test.c
+++ b/tests/unit/s2n_client_hello_recv_test.c
@@ -38,7 +38,7 @@ int main(int argc, char **argv)
     struct s2n_connection *server_conn;
     struct s2n_connection *client_conn;
     struct s2n_stuffer *hello_stuffer;
-    struct s2n_config *config;
+    struct s2n_config *tls12_config;
     struct s2n_config *tls13_config;
     struct s2n_cert_chain_and_key *chain_and_key;
     struct s2n_cert_chain_and_key *tls13_chain_and_key;
@@ -51,32 +51,37 @@ int main(int argc, char **argv)
 
     EXPECT_NOT_NULL(cert_chain = malloc(S2N_MAX_TEST_PEM_SIZE));
     EXPECT_NOT_NULL(private_key = malloc(S2N_MAX_TEST_PEM_SIZE));
-    EXPECT_NOT_NULL(config = s2n_config_new());
+    EXPECT_NOT_NULL(tls12_config = s2n_config_new());
     EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
-   
+    s2n_config_set_cipher_preferences(tls12_config, "test_all_tls12");
+
     EXPECT_NOT_NULL(tls13_cert_chain = malloc(S2N_MAX_TEST_PEM_SIZE));
     EXPECT_NOT_NULL(tls13_private_key = malloc(S2N_MAX_TEST_PEM_SIZE));
     EXPECT_NOT_NULL(tls13_config = s2n_config_new());
     EXPECT_NOT_NULL(tls13_chain_and_key = s2n_cert_chain_and_key_new());
+    s2n_config_set_cipher_preferences(tls13_config, "test_all");
 
     EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
     EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key, S2N_MAX_TEST_PEM_SIZE));
     EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain, private_key));
-    EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+    EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(tls12_config, chain_and_key));
 
     EXPECT_SUCCESS(s2n_read_test_pem(S2N_ECDSA_P384_PKCS1_CERT_CHAIN, tls13_cert_chain, S2N_MAX_TEST_PEM_SIZE));
     EXPECT_SUCCESS(s2n_read_test_pem(S2N_ECDSA_P384_PKCS1_KEY, tls13_private_key, S2N_MAX_TEST_PEM_SIZE));
     EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(tls13_chain_and_key, tls13_cert_chain, tls13_private_key));
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(tls13_config, tls13_chain_and_key));
 
-    /* These tests verify the logic behind the setting of these three connection fields: 
-    server_protocol_version, client_protocol_version, and actual_protocol version. */ 
+    /* These tests verify the logic behind the setting of these three connection fields:
+    server_protocol_version, client_protocol_version, and actual_protocol version. */
 
     /* Test we can successfully receive an sslv2 client hello and set a
      * tls12 connection */
+    for (uint8_t i = 0; i < 2; i++)
     {
+        if (i == 1) { EXPECT_SUCCESS(s2n_enable_tls13()); }
+
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, tls12_config));
 
         /* Record version and protocol version are in the header for SSLv2 */
         server_conn->client_hello_version = S2N_SSLv2;
@@ -86,7 +91,8 @@ int main(int argc, char **argv)
             SSLv2_CLIENT_HELLO_PREFIX,
             SSLv2_CLIENT_HELLO_CIPHER_SUITES,
             SSLv2_CLIENT_HELLO_CHALLENGE,
-	};
+        };
+
         struct s2n_blob client_hello = {
             .data = sslv2_client_hello,
             .size = sizeof(sslv2_client_hello),
@@ -97,24 +103,29 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &client_hello));
         EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
 
-        EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS12);
+        EXPECT_EQUAL(server_conn->server_protocol_version, i == 0 ? S2N_TLS12 : S2N_TLS13);
         EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS12);
         EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS12);
         EXPECT_EQUAL(server_conn->client_hello_version, S2N_SSLv2);
         EXPECT_EQUAL(server_conn->client_hello.parsed, 1);
 
         s2n_connection_free(server_conn);
+
+        EXPECT_SUCCESS(s2n_disable_tls13());
     }
-    
-    /* Test that a tls12 client legacy version and tls12 server version 
+
+    /* Test that a tls12 client legacy version and tls12 server version
     will successfully set a tls12 connection, since tls13 is not enabled. */
     {
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
-        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
-        
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, tls12_config));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, tls12_config));
+
         EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
+        EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS12);
+        EXPECT_EQUAL(client_conn->client_protocol_version, S2N_TLS12);
+
         EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &client_conn->handshake.io.blob));
         EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
 
@@ -125,16 +136,45 @@ int main(int argc, char **argv)
         s2n_connection_free(server_conn);
         s2n_connection_free(client_conn);
     }
-    /* Test that a tls11 client legacy version and tls12 server version 
-    will successfully set a tls11 connection. */
+
+    /* Test that a tls12 client legacy version and tls12 server version
+    will successfully set a tls12 connection, even when tls13 is enabled. */
     {
+        EXPECT_SUCCESS(s2n_enable_tls13());
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
-        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, tls12_config));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, tls12_config));
+
+        EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
+        EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS12);
+        EXPECT_EQUAL(client_conn->client_protocol_version, S2N_TLS12);
+
+        EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &client_conn->handshake.io.blob));
+        EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
+
+        EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS12);
+        EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS12);
+        EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS12);
+
+        s2n_connection_free(server_conn);
+        s2n_connection_free(client_conn);
+        EXPECT_SUCCESS(s2n_disable_tls13());
+    }
+
+    /* Test that a tls11 client legacy version and tls12 server version
+    will successfully set a tls11 connection. */
+    for (uint8_t i = 0; i < 2; i++)
+    {
+        if (i == 1) { EXPECT_SUCCESS(s2n_enable_tls13()); }
+
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, tls12_config));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, tls12_config));
 
         client_conn->client_protocol_version = S2N_TLS11;
-        
+
         EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
         EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &client_conn->handshake.io.blob));
         EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
@@ -145,21 +185,26 @@ int main(int argc, char **argv)
 
         s2n_connection_free(server_conn);
         s2n_connection_free(client_conn);
+
+        EXPECT_SUCCESS(s2n_disable_tls13());
     }
-    /* Test that a tls12 client and tls13 server will successfully 
-    set a tls12 connection. */ 
+    /* Test that a tls12 client and tls13 server will successfully
+    set a tls12 connection. */
     {
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
-        EXPECT_SUCCESS(s2n_enable_tls13());
-        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, tls12_config));
 
-        EXPECT_SUCCESS(s2n_client_hello_send(client_conn)); 
-        
+        EXPECT_SUCCESS(s2n_enable_tls13());
+
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, tls13_config));
+
+        EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
+        EXPECT_EQUAL(client_conn->client_protocol_version, S2N_TLS12);
+
         EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &client_conn->handshake.io.blob));
-        EXPECT_SUCCESS(s2n_client_hello_recv(server_conn)); 
-      
+        EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
+
         EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS13);
         EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS12);
         EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS12);
@@ -167,32 +212,36 @@ int main(int argc, char **argv)
         s2n_connection_free(server_conn);
         s2n_connection_free(client_conn);
         EXPECT_SUCCESS(s2n_disable_tls13());
-    } 
-    /* Test that an erroneous client legacy version and tls13 server version 
+    }
+    /* Test that an erroneous client legacy version and tls13 server version
     will still successfully set a tls13 connection, when real client version is tls13. */
     {
         EXPECT_SUCCESS(s2n_enable_tls13());
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, tls13_config));
-        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, tls12_config));
 
         EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "default_tls13"));
         EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
 
         hello_stuffer = &client_conn->handshake.io;
 
-        EXPECT_SUCCESS(s2n_client_hello_send(client_conn)); 
+        EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
 
-        /* Overwrite the client legacy version so that it reads tls13 (incorrectly) */ 
+        /* Overwrite the client legacy version so that it reads tls13 (incorrectly) */
         uint8_t incorrect_protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN];
         incorrect_protocol_version[0] = S2N_TLS13 / 10;
         incorrect_protocol_version[1] = S2N_TLS13 % 10;
         EXPECT_SUCCESS(s2n_stuffer_rewrite(hello_stuffer));
         EXPECT_SUCCESS(s2n_stuffer_write_bytes(hello_stuffer, incorrect_protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));
-        
+
         EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &hello_stuffer->blob));
-        EXPECT_SUCCESS(s2n_client_hello_recv(server_conn)); 
+        EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
+
+        EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS13);
+        EXPECT_EQUAL(client_conn->client_protocol_version, S2N_TLS13);
+        EXPECT_EQUAL(client_conn->client_hello_version, S2N_TLS13);
 
         EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS13);
         EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS13);
@@ -201,24 +250,25 @@ int main(int argc, char **argv)
         s2n_connection_free(server_conn);
         s2n_connection_free(client_conn);
         EXPECT_SUCCESS(s2n_disable_tls13());
-    } 
-    /* Test that a tls12 client legacy version and tls13 server version 
+    }
+
+    /* Test that a tls12 client legacy version and tls13 server version
     will still successfully set a tls13 connection, if possible. */
     {
         EXPECT_SUCCESS(s2n_enable_tls13());
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, tls13_config));
-        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, tls12_config));
 
         EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "default_tls13"));
         EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
 
-        EXPECT_SUCCESS(s2n_client_hello_send(client_conn)); 
-        
+        EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
+
         EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &client_conn->handshake.io.blob));
-        EXPECT_SUCCESS(s2n_client_hello_recv(server_conn)); 
-       
+        EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
+
         EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS13);
         EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS13);
         EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS13);
@@ -226,32 +276,32 @@ int main(int argc, char **argv)
         s2n_connection_free(server_conn);
         s2n_connection_free(client_conn);
         EXPECT_SUCCESS(s2n_disable_tls13());
-    } 
-     /* Test that an erroneous(tls13) client legacy version and tls13 server version 
+    }
+     /* Test that an erroneous(tls13) client legacy version and tls13 server version
     will still successfully set a tls12 connection, if tls12 is the true client version. */
     {
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, tls12_config));
         EXPECT_SUCCESS(s2n_enable_tls13());
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, tls12_config));
 
         EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
-        
+
         hello_stuffer = &client_conn->handshake.io;
 
-        EXPECT_SUCCESS(s2n_client_hello_send(client_conn)); 
+        EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
 
-        /* Overwrite the client legacy version so that it reads tls13 (incorrectly) */ 
+        /* Overwrite the client legacy version so that it reads tls13 (incorrectly) */
         uint8_t incorrect_protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN];
         incorrect_protocol_version[0] = S2N_TLS13 / 10;
         incorrect_protocol_version[1] = S2N_TLS13 % 10;
         EXPECT_SUCCESS(s2n_stuffer_rewrite(hello_stuffer));
         EXPECT_SUCCESS(s2n_stuffer_write_bytes(hello_stuffer, incorrect_protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));
-        
+
         EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &hello_stuffer->blob));
-        EXPECT_SUCCESS(s2n_client_hello_recv(server_conn)); 
-    
+        EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
+
         EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS13);
         EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS12);
         EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS12);
@@ -259,9 +309,9 @@ int main(int argc, char **argv)
         s2n_connection_free(server_conn);
         s2n_connection_free(client_conn);
         EXPECT_SUCCESS(s2n_disable_tls13());
-    } 
+    }
 
-    s2n_config_free(config);
+    s2n_config_free(tls12_config);
     s2n_config_free(tls13_config);
     s2n_cert_chain_and_key_free(chain_and_key);
     free(cert_chain);

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -206,7 +206,7 @@ int main(int argc, char **argv)
         }
 
         {
-            /* TLS 1.2 client cipher preference uses TLS13 version */
+            /* TLS 1.2 client cipher preference uses TLS12 version */
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
@@ -237,7 +237,7 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS13);
             EXPECT_EQUAL(client_conn->client_protocol_version, S2N_TLS13);
 
-            /* Server configured with TLS 1.2 negotiates TLS12 */
+            /* Server configured with TLS 1.2 negotiates TLS12 version */
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
             struct s2n_config *server_config;
             EXPECT_NOT_NULL(server_config = s2n_config_new());

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -29,6 +29,7 @@
 #include "tls/s2n_tls.h"
 #include "tls/s2n_tls13.h"
 #include "tls/s2n_connection.h"
+#include "tls/s2n_cipher_preferences.h"
 #include "tls/s2n_client_hello.h"
 #include "tls/s2n_handshake.h"
 #include "tls/s2n_tls_parameters.h"
@@ -153,7 +154,9 @@ int main(int argc, char **argv)
                 struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
 
                 EXPECT_SUCCESS(s2n_client_hello_send(conn));
+
                 EXPECT_SUCCESS(s2n_stuffer_skip_read(hello_stuffer, LENGTH_TO_CIPHER_LIST));
+                EXPECT_EQUAL(conn->actual_protocol_version, S2N_TLS13);
 
                 uint16_t list_length = 0;
                 EXPECT_SUCCESS(s2n_stuffer_read_uint16(hello_stuffer, &list_length));
@@ -178,6 +181,91 @@ int main(int argc, char **argv)
         }
     }
 
+    /* Test that cipher suites enforce proper highest supported versions.
+     * Eg. server configs TLS 1.2 only ciphers should never negotiate TLS 1.3
+     */
+    {
+        EXPECT_SUCCESS(s2n_enable_tls13());
+
+        struct s2n_config *config;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+
+        {
+            /* TLS 1.3 client cipher preference uses TLS13 version */
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
+            EXPECT_TRUE(s2n_cipher_preference_supports_tls13(config->cipher_preferences));
+
+            EXPECT_SUCCESS(s2n_client_hello_send(conn));
+            EXPECT_EQUAL(conn->actual_protocol_version, S2N_TLS13);
+            EXPECT_EQUAL(conn->client_protocol_version, S2N_TLS13);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        {
+            /* TLS 1.2 client cipher preference uses TLS13 version */
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default"));
+
+            const struct s2n_cipher_preferences *cipher_preferences;
+            GUARD(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
+            EXPECT_FALSE(s2n_cipher_preference_supports_tls13(cipher_preferences));
+
+            EXPECT_SUCCESS(s2n_client_hello_send(conn));
+            EXPECT_EQUAL(conn->actual_protocol_version, S2N_TLS12);
+            EXPECT_EQUAL(conn->client_protocol_version, S2N_TLS12);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        {
+            /* TLS 1.3 client cipher preference uses TLS13 version */
+            struct s2n_connection *client_conn, *server_conn;
+            EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
+            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "test_all"));
+            EXPECT_TRUE(s2n_cipher_preference_supports_tls13(config->cipher_preferences));
+
+            EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
+
+            EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS13);
+            EXPECT_EQUAL(client_conn->client_protocol_version, S2N_TLS13);
+
+            /* Server configured with TLS 1.2 negotiates TLS12 */
+            EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+            struct s2n_config *server_config;
+            EXPECT_NOT_NULL(server_config = s2n_config_new());
+            EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
+            EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
+
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "test_all_tls12"));
+
+            const struct s2n_cipher_preferences *cipher_preferences;
+            GUARD(s2n_connection_get_cipher_preferences(server_conn, &cipher_preferences));
+            EXPECT_FALSE(s2n_cipher_preference_supports_tls13(cipher_preferences));
+
+            EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io, s2n_stuffer_data_available(&client_conn->handshake.io)));
+
+            EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
+            EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS12);
+            EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS12);
+            EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS13);
+
+            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+            EXPECT_SUCCESS(s2n_connection_free(client_conn));
+            EXPECT_SUCCESS(s2n_config_free(server_config));
+        }
+
+        EXPECT_SUCCESS(s2n_config_free(config));
+        EXPECT_SUCCESS(s2n_disable_tls13());
+    }
+
     /* SSlv2 client hello */
     {
         struct s2n_connection *server_conn;
@@ -188,7 +276,7 @@ int main(int argc, char **argv)
             SSLv2_CLIENT_HELLO_PREFIX,
             SSLv2_CLIENT_HELLO_CIPHER_SUITES,
             SSLv2_CLIENT_HELLO_CHALLENGE,
-	};
+        };
         int sslv2_client_hello_len = sizeof(sslv2_client_hello);
 
         uint8_t sslv2_client_hello_header[] = {

--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -182,9 +182,9 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
         EXPECT_SUCCESS(s2n_config_add_dhparams(server_config, dhparams_pem));
-    
+
         client_config = s2n_fetch_unsafe_client_testing_config();
-        
+
         EXPECT_SUCCESS(s2n_config_set_verification_ca_location(client_config, S2N_DEFAULT_TEST_CERT_CHAIN, NULL));
 
         EXPECT_SUCCESS(test_cipher_preferences(server_config, client_config,
@@ -211,7 +211,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(client_config = s2n_fetch_unsafe_client_ecdsa_testing_config());
 
         EXPECT_SUCCESS(s2n_config_set_verification_ca_location(client_config, S2N_ECDSA_P384_PKCS1_CERT_CHAIN, NULL));
-        
+
         EXPECT_SUCCESS(test_cipher_preferences(server_config, client_config,
                 chain_and_key, S2N_SIGNATURE_ECDSA));
 
@@ -276,12 +276,12 @@ int main(int argc, char **argv)
                 S2N_RSA_PSS_2048_SHA256_LEAF_CERT, S2N_RSA_PSS_2048_SHA256_LEAF_KEY));
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "test_tls13_null_key_exchange_alg"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "test_all_tls13"));
         EXPECT_SUCCESS(s2n_config_set_signature_preferences(server_config, "20200207"));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
 
         EXPECT_NOT_NULL(client_config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "test_tls13_null_key_exchange_alg"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "test_all_tls13"));
         EXPECT_SUCCESS(s2n_config_set_signature_preferences(client_config, "20200207"));
         client_config->client_cert_auth_type = S2N_CERT_AUTH_NONE;
         client_config->check_ocsp = 0;

--- a/tests/unit/s2n_server_extensions_test.c
+++ b/tests/unit/s2n_server_extensions_test.c
@@ -262,7 +262,7 @@ int main(int argc, char **argv)
             struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
             conn->secure.server_ecc_evp_params.negotiated_curve = s2n_ecc_evp_supported_curves_list[0];
 
-            s2n_connection_set_cipher_preferences(conn, "test_tls13_null_key_exchange_alg");
+            s2n_connection_set_cipher_preferences(conn, "test_all_tls13");
             /* Test that s2n_server_extensions_send() only works when protocol version is TLS13 */
             conn->client_protocol_version = S2N_TLS13;
             conn->actual_protocol_version = S2N_TLS13;

--- a/tests/unit/s2n_tls13_support_test.c
+++ b/tests/unit/s2n_tls13_support_test.c
@@ -62,7 +62,7 @@ int main(int argc, char **argv)
         uint8_t original_data_size = s2n_stuffer_data_available(&extension_data);
 
         struct s2n_array *extensions = s2n_array_new(sizeof(struct s2n_client_hello_parsed_extension));
-        for (int i=0; i < sizeof(tls13_extensions) / sizeof(uint8_t); i++) {
+        for (int i=0; i < s2n_array_len(tls13_extensions); i++) {
             struct s2n_client_hello_parsed_extension *extension;
             EXPECT_NOT_NULL(extension = s2n_array_pushback(extensions));
 
@@ -120,7 +120,9 @@ int main(int argc, char **argv)
         struct s2n_client_hello_parsed_extension *extension;
         EXPECT_NOT_NULL(extension = s2n_array_pushback(extensions));
 
-        for (int i=0; i < sizeof(new_extensions) / sizeof(uint8_t); i++) {
+        /* Protocol version is required for key share extension parsing */
+        server_conn->actual_protocol_version = S2N_TLS13;
+        for (int i = 0; i < s2n_array_len(new_extensions); i++) {
             EXPECT_SUCCESS(s2n_stuffer_wipe(&extension_data));
             EXPECT_SUCCESS(s2n_stuffer_write_str(&extension_data, "bad extension"));
 

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -1064,7 +1064,7 @@ int s2n_connection_is_valid_for_cipher_preferences(struct s2n_connection *conn, 
 }
 
 /* Valid TLS 1.3 Ciphers are 0x1301, 0x1302, 0x1303, 0x1304, 0x1305 */
-static bool is_valid_tls13_cipher(const uint8_t version[2]) {
+static bool s2n_is_valid_tls13_cipher(const uint8_t version[2]) {
     return version[0] == 0x13 && version[1] >= 0x01 && version[1] <= 0x05;
 }
 
@@ -1085,7 +1085,7 @@ int s2n_cipher_preferences_init()
             }
 
             /* Sanity check that valid tls13 has minimum tls version set correctly */
-            S2N_ERROR_IF(is_valid_tls13_cipher(cipher->iana_value) ^
+            S2N_ERROR_IF(s2n_is_valid_tls13_cipher(cipher->iana_value) ^
                 (cipher->minimum_required_tls_version >= S2N_TLS13), S2N_ERR_INVALID_CIPHER_PREFERENCES);
 
             if (cipher->key_exchange_alg == &s2n_ecdhe || cipher->key_exchange_alg == &s2n_hybrid_ecdhe_kem) {
@@ -1147,7 +1147,7 @@ bool s2n_cipher_preference_supports_tls13(const struct s2n_cipher_preferences *p
 
     /* if cipher preference is not in the official list, compute the result */
     for (uint8_t i = 0; i < preferences->count; i++) {
-        if (is_valid_tls13_cipher(preferences->suites[i]->iana_value)) {
+        if (s2n_is_valid_tls13_cipher(preferences->suites[i]->iana_value)) {
             return true;
         }
     }

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -24,7 +24,6 @@ struct s2n_cipher_preferences {
     uint8_t count;
     struct s2n_cipher_suite **suites;
     uint8_t minimum_protocol_version;
-    uint8_t maximum_protocol_version;
     uint8_t kem_count;
     const struct s2n_kem **kems;
 };
@@ -72,4 +71,4 @@ extern int s2n_find_cipher_pref_from_version(const char *version, const struct s
 extern int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *version);
 extern int s2n_ecc_extension_required(const struct s2n_cipher_preferences *preferences);
 extern int s2n_pq_kem_extension_required(const struct s2n_cipher_preferences *preferences);
-extern int s2n_cipher_preference_supports_tls13(const struct s2n_cipher_preferences *preferences);
+extern bool s2n_cipher_preference_supports_tls13(const struct s2n_cipher_preferences *preferences);

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -23,7 +23,8 @@
 struct s2n_cipher_preferences {
     uint8_t count;
     struct s2n_cipher_suite **suites;
-    int minimum_protocol_version;
+    uint8_t minimum_protocol_version;
+    uint8_t maximum_protocol_version;
     uint8_t kem_count;
     const struct s2n_kem **kems;
 };
@@ -47,10 +48,12 @@ extern const struct s2n_cipher_preferences cipher_preferences_20170405;
 extern const struct s2n_cipher_preferences cipher_preferences_20170718;
 extern const struct s2n_cipher_preferences cipher_preferences_20190214;
 extern const struct s2n_cipher_preferences cipher_preferences_test_all;
+
+extern const struct s2n_cipher_preferences cipher_preferences_test_all_tls12;
 extern const struct s2n_cipher_preferences cipher_preferences_test_all_fips;
 extern const struct s2n_cipher_preferences cipher_preferences_test_all_ecdsa;
 extern const struct s2n_cipher_preferences cipher_preferences_test_ecdsa_priority;
-extern const struct s2n_cipher_preferences cipher_preferences_test_tls13_null_key_exchange_alg;
+extern const struct s2n_cipher_preferences cipher_preferences_test_all_tls13;
 
 /* See https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html */
 extern const struct s2n_cipher_preferences elb_security_policy_2015_04;
@@ -69,3 +72,4 @@ extern int s2n_find_cipher_pref_from_version(const char *version, const struct s
 extern int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *version);
 extern int s2n_ecc_extension_required(const struct s2n_cipher_preferences *preferences);
 extern int s2n_pq_kem_extension_required(const struct s2n_cipher_preferences *preferences);
+extern int s2n_cipher_preference_supports_tls13(const struct s2n_cipher_preferences *preferences);

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -779,6 +779,56 @@ const struct s2n_cipher_preferences cipher_preferences_test_all = {
     .kems = pq_kems_r2r1,
 };
 
+/* All TLS12 Cipher Suites */
+
+static struct s2n_cipher_suite *s2n_all_tls12_cipher_suites[] = {
+    &s2n_rsa_with_rc4_128_md5,                      /* 0x00,0x04 */
+    &s2n_rsa_with_rc4_128_sha,                      /* 0x00,0x05 */
+    &s2n_rsa_with_3des_ede_cbc_sha,                 /* 0x00,0x0A */
+    &s2n_dhe_rsa_with_3des_ede_cbc_sha,             /* 0x00,0x16 */
+    &s2n_rsa_with_aes_128_cbc_sha,                  /* 0x00,0x2F */
+    &s2n_dhe_rsa_with_aes_128_cbc_sha,              /* 0x00,0x33 */
+    &s2n_rsa_with_aes_256_cbc_sha,                  /* 0x00,0x35 */
+    &s2n_dhe_rsa_with_aes_256_cbc_sha,              /* 0x00,0x39 */
+    &s2n_rsa_with_aes_128_cbc_sha256,               /* 0x00,0x3C */
+    &s2n_rsa_with_aes_256_cbc_sha256,               /* 0x00,0x3D */
+    &s2n_dhe_rsa_with_aes_128_cbc_sha256,           /* 0x00,0x67 */
+    &s2n_dhe_rsa_with_aes_256_cbc_sha256,           /* 0x00,0x6B */
+    &s2n_rsa_with_aes_128_gcm_sha256,               /* 0x00,0x9C */
+    &s2n_rsa_with_aes_256_gcm_sha384,               /* 0x00,0x9D */
+    &s2n_dhe_rsa_with_aes_128_gcm_sha256,           /* 0x00,0x9E */
+    &s2n_dhe_rsa_with_aes_256_gcm_sha384,           /* 0x00,0x9F */
+
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha,          /* 0xC0,0x09 */
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha,          /* 0xC0,0x0A */
+    &s2n_ecdhe_rsa_with_rc4_128_sha,                /* 0xC0,0x11 */
+    &s2n_ecdhe_rsa_with_3des_ede_cbc_sha,           /* 0xC0,0x12 */
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha,            /* 0xC0,0x13 */
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha,            /* 0xC0,0x14 */
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,       /* 0xC0,0x23 */
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384,       /* 0xC0,0x24 */
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,         /* 0xC0,0x27 */
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,         /* 0xC0,0x28 */
+    &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,       /* 0xC0,0x2B */
+    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,       /* 0xC0,0x2C */
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,         /* 0xC0,0x2F */
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,         /* 0xC0,0x30 */
+    &s2n_ecdhe_rsa_with_chacha20_poly1305_sha256,   /* 0xCC,0xA8 */
+    &s2n_ecdhe_ecdsa_with_chacha20_poly1305_sha256, /* 0xCC,0xA9 */
+    &s2n_dhe_rsa_with_chacha20_poly1305_sha256,     /* 0xCC,0xAA */
+    &s2n_ecdhe_bike_rsa_with_aes_256_gcm_sha384,    /* 0xFF,0x04 */
+    &s2n_ecdhe_sike_rsa_with_aes_256_gcm_sha384,    /* 0xFF,0x08 */
+};
+
+const struct s2n_cipher_preferences cipher_preferences_test_all_tls12 = {
+    .count = s2n_array_len(s2n_all_tls12_cipher_suites),
+    .suites = s2n_all_tls12_cipher_suites,
+    .minimum_protocol_version = S2N_SSLv3,
+    .kem_count = s2n_array_len(pq_kems_r2r1),
+    .kems = pq_kems_r2r1,
+};
+
+
 /* All of the cipher suites that s2n can negotiate when in FIPS mode,
  * in order of IANA value. Exposed for the "test_all_fips" cipher preference list.
  */
@@ -883,15 +933,15 @@ const struct s2n_cipher_preferences cipher_preferences_test_ecdsa_priority = {
     .kems = NULL,
 };
 
-static struct s2n_cipher_suite *s2n_tls13_null_key_exchange_alg_cipher_suites[] = {
+static struct s2n_cipher_suite *s2n_all_tls13_cipher_suites[] = {
     &s2n_tls13_aes_128_gcm_sha256,                  /* 0x13,0x01 */
     &s2n_tls13_aes_256_gcm_sha384,                  /* 0x13,0x02 */
     &s2n_tls13_chacha20_poly1305_sha256,            /* 0x13,0x03 */
 };
 
-const struct s2n_cipher_preferences cipher_preferences_test_tls13_null_key_exchange_alg = {
-    .count = s2n_array_len(s2n_tls13_null_key_exchange_alg_cipher_suites),
-    .suites = s2n_tls13_null_key_exchange_alg_cipher_suites,
+const struct s2n_cipher_preferences cipher_preferences_test_all_tls13 = {
+    .count = s2n_array_len(s2n_all_tls13_cipher_suites),
+    .suites = s2n_all_tls13_cipher_suites,
     .minimum_protocol_version = S2N_SSLv3,
     .kem_count = 0,
     .kems = NULL,
@@ -1031,7 +1081,7 @@ static int s2n_set_cipher_as_server(struct s2n_connection *conn, uint8_t * wire,
      * version, and the client cipher list contains TLS_FALLBACK_SCSV, then the server must abort the connection since
      * TLS_FALLBACK_SCSV should only be present when the client previously failed to negotiate a higher TLS version.
      */
-    if (conn->client_protocol_version < s2n_highest_protocol_version) {
+    if (conn->client_protocol_version < conn->server_protocol_version) {
         uint8_t fallback_scsv[S2N_TLS_CIPHER_SUITE_LEN] = { TLS_FALLBACK_SCSV };
         if (s2n_wire_ciphers_contain(fallback_scsv, wire, count, cipher_suite_len)) {
             conn->closed = 1;

--- a/tls/s2n_client_extensions.c
+++ b/tls/s2n_client_extensions.c
@@ -207,12 +207,14 @@ int s2n_client_extensions_recv(struct s2n_connection *conn, struct s2n_array *pa
             GUARD(s2n_recv_pq_kem_extension(conn, &extension));
             break;
         case TLS_EXTENSION_SUPPORTED_VERSIONS:
+            /* allow supported versions to be parsed to get highest client version */
             if (s2n_is_tls13_enabled()) {
                 GUARD(s2n_extensions_client_supported_versions_recv(conn, &extension));
             }
             break;
         case TLS_EXTENSION_KEY_SHARE:
-            if (s2n_is_tls13_enabled()) {
+            /* parse key share only if negiotated protocol is in TLS 1.3 */
+            if (s2n_is_tls13_enabled() && conn->actual_protocol_version == S2N_TLS13) {
                 GUARD(s2n_extensions_client_key_share_recv(conn, &extension));
             }
             break;

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -290,7 +290,7 @@ int s2n_process_client_hello(struct s2n_connection *conn)
     GUARD(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
 
     /* Ensure that highest supported version is set correctly */
-    if (s2n_cipher_preference_supports_tls13(cipher_preferences) != 1) {
+    if (!s2n_cipher_preference_supports_tls13(cipher_preferences)) {
         conn->server_protocol_version = MIN(conn->server_protocol_version, S2N_TLS12);
         conn->actual_protocol_version = MIN(conn->server_protocol_version, S2N_TLS12);
     }
@@ -299,6 +299,7 @@ int s2n_process_client_hello(struct s2n_connection *conn)
         GUARD(s2n_client_extensions_recv(conn, client_hello->parsed_extensions));
     }
 
+    /* for pre TLS 1.3 connections, protocol selection is not done in supported_versions extensions, so do it here */
     if (conn->actual_protocol_version != S2N_TLS13) {
         conn->actual_protocol_version = MIN(conn->server_protocol_version, conn->client_protocol_version);
     }
@@ -360,7 +361,7 @@ int s2n_client_hello_send(struct s2n_connection *conn)
 
     /* Check whether cipher preference supports TLS 1.3. If it doesn't,
        our highest supported version is S2N_TLS12 */
-    if (s2n_cipher_preference_supports_tls13(cipher_preferences) != 1) {
+    if (!s2n_cipher_preference_supports_tls13(cipher_preferences)) {
         conn->client_protocol_version = MIN(conn->client_protocol_version, S2N_TLS12);
         conn->actual_protocol_version = MIN(conn->actual_protocol_version, S2N_TLS12);
     }


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
#1608, #1439

**Description of changes:** 
- this allows tls 1.3 to be enabled safely without affecting existing connections using tls1.2 only/non-tls1.3 ciphers cipher preferences
- add s2n_cipher_preference_supports_tls13(cipher_preference)
- add `test_all_tls12` cipher preference for all non tls1.3 ciphers
- renamed `test_tls13_null_key_exchange_alg` to `test_all_tls13`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
