### PR TITLE
Allow pre-TLS1.3 to fall back to default sig algs

### DIFF
--- a/tests/unit/s2n_client_signature_algorithms_extension_test.c
+++ b/tests/unit/s2n_client_signature_algorithms_extension_test.c
@@ -88,7 +88,8 @@ int main(int argc, char **argv)
         parsed_named_group_extension->extension_type = TLS_EXTENSION_SIGNATURE_ALGORITHMS;
         parsed_named_group_extension->extension = signature_algorithms_extension.blob;
 
-        /* If only unknown algorithms are offered, expect choosing a scheme to fail */
+        /* If only unknown algorithms are offered, expect choosing a scheme to fail for TLS1.3 */
+        conn->actual_protocol_version = S2N_TLS13;
         EXPECT_SUCCESS(s2n_client_extensions_recv(conn, parsed_extensions));
         EXPECT_EQUAL(conn->handshake_params.client_sig_hash_algs.len, sig_hash_algs.len);
         EXPECT_FAILURE(s2n_choose_sig_scheme_from_peer_preference_list(conn, &conn->handshake_params.client_sig_hash_algs,

--- a/tls/s2n_signature_algorithms.c
+++ b/tls/s2n_signature_algorithms.c
@@ -52,7 +52,7 @@ static int s2n_signature_scheme_valid_to_accept(struct s2n_connection *conn, con
     return 0;
 }
 
-int s2n_choose_sig_scheme(struct s2n_connection *conn, struct s2n_sig_scheme_list *peer_wire_prefs,
+static int s2n_choose_sig_scheme(struct s2n_connection *conn, struct s2n_sig_scheme_list *peer_wire_prefs,
                           struct s2n_signature_scheme *chosen_scheme_out)
 {
     const struct s2n_signature_preferences *signature_preferences = conn->config->signature_preferences;
@@ -77,14 +77,13 @@ int s2n_choose_sig_scheme(struct s2n_connection *conn, struct s2n_sig_scheme_lis
 
             if (candidate->iana_value == their_iana_val) {
                 *chosen_scheme_out = *candidate;
-                return 0;
+                return S2N_SUCCESS;
             }
         }
     }
 
     S2N_ERROR(S2N_ERR_INVALID_SIGNATURE_SCHEME);
 }
-
 
 int s2n_get_and_validate_negotiated_signature_scheme(struct s2n_connection *conn, struct s2n_stuffer *in,
                                              struct s2n_signature_scheme *chosen_sig_scheme)
@@ -146,12 +145,18 @@ int s2n_choose_sig_scheme_from_peer_preference_list(struct s2n_connection *conn,
 
     struct s2n_signature_scheme chosen_scheme;
 
+    GUARD(s2n_choose_default_sig_scheme(conn, &chosen_scheme));
+
     /* SignatureScheme preference list was first added in TLS 1.2. It will be empty in older TLS versions. */
     if (peer_wire_prefs != NULL && peer_wire_prefs->len > 0) {
-        GUARD(s2n_choose_sig_scheme(conn, peer_wire_prefs, &chosen_scheme));
+        int result = s2n_choose_sig_scheme(conn, peer_wire_prefs, &chosen_scheme);
+
+        /* We require an exact match in TLS 1.3, but all previous versions can fall back to the default.
+         * The pre-TLS1.3 behavior is an intentional choice to maximize support. */
+        S2N_ERROR_IF(result != S2N_SUCCESS && conn->actual_protocol_version == S2N_TLS13,
+                S2N_ERR_INVALID_SIGNATURE_SCHEME);
     } else {
         S2N_ERROR_IF(conn->actual_protocol_version == S2N_TLS13, S2N_ERR_EMPTY_SIGNATURE_SCHEME);
-        GUARD(s2n_choose_default_sig_scheme(conn, &chosen_scheme));
     }
 
     /* In TLS 1.3, SigScheme also defines the ECDSA curve to use (instead of reusing whatever ECDHE Key Exchange curve
@@ -169,7 +174,7 @@ int s2n_choose_sig_scheme_from_peer_preference_list(struct s2n_connection *conn,
 
     *sig_scheme_out = chosen_scheme;
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_send_supported_sig_scheme_list(struct s2n_connection *conn, struct s2n_stuffer *out)


### PR DESCRIPTION


_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** https://github.com/awslabs/s2n/issues/1619

**Description of changes:** 
When choosing hash algs, s2n would fall back to its defaults if it did not find a match with its peer's list. We lost that behavior when we refactored to support signature schemes. We need to add it back to support potentially oddly behaved clients.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
