### PR TITLE
Don't set client_protocol_version to an invalid version

### DIFF
--- a/tests/unit/s2n_client_supported_versions_extension_test.c
+++ b/tests/unit/s2n_client_supported_versions_extension_test.c
@@ -28,6 +28,7 @@
 #include "utils/s2n_safety.h"
 
 #define PROTOCOL_VERSION_ALERT 70
+#define GREASED_SUPPORTED_VERSION_EXTENSION_VALUES 0x0A0A, 0x1A1A, 0x2A2A, 0x3A3A, 0x4A4A, 0x5A5A, 0x6A6A, 0x7A7A, 0x8A8A, 0x9A9A, 0xAAAA, 0xBABA, 0xCACA, 0xDADA, 0xEAEA, 0xFAFA
 
 int get_alert(struct s2n_connection *conn) {
     uint8_t error[2];
@@ -103,7 +104,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
         uint8_t unsupported_client_version = 255;
-        uint8_t supported_version_list[] = { S2N_TLS11, S2N_TLS12, unsupported_client_version };
+        uint8_t supported_version_list[] = { S2N_TLS11, S2N_TLS12, S2N_TLS13, unsupported_client_version };
         uint8_t supported_version_list_length = sizeof(supported_version_list);
 
         struct s2n_stuffer extension;
@@ -113,9 +114,115 @@ int main(int argc, char **argv)
                 supported_version_list_length));
 
         EXPECT_SUCCESS(s2n_extensions_client_supported_versions_recv(server_conn, &extension));
-        EXPECT_EQUAL(server_conn->client_protocol_version, unsupported_client_version);
+        EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS13);
         EXPECT_EQUAL(server_conn->server_protocol_version, latest_version);
+        EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS13);
+
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_stuffer_free(&extension));
+    }
+
+    /* Server selects highest supported version shared by client (when server uses TLS1.2)
+     * but retains the client's requested version. */
+    {
+        EXPECT_SUCCESS(s2n_disable_tls13());
+        struct s2n_connection *server_conn;
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        uint8_t unsupported_client_version = 255;
+        uint8_t supported_version_list[] = { S2N_TLS11, S2N_TLS12, S2N_TLS13, unsupported_client_version };
+        uint8_t supported_version_list_length = sizeof(supported_version_list);
+
+        struct s2n_stuffer extension;
+        s2n_stuffer_alloc(&extension, supported_version_list_length * 2 + 1);
+
+        EXPECT_SUCCESS(write_test_supported_versions_list(&extension, supported_version_list,
+                supported_version_list_length));
+
+        EXPECT_SUCCESS(s2n_extensions_client_supported_versions_recv(server_conn, &extension));
+        EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS13);
+        EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS12);
         EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS12);
+
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_stuffer_free(&extension));
+        EXPECT_SUCCESS(s2n_enable_tls13());
+    }
+
+    /* Server terminates connection if there are no supported version in the list */
+    {
+        struct s2n_connection *server_conn;
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        uint16_t invalid_version_list[] = { 0x0020, 0x0021, 0x0403, 0x0305, 0x7a7a, 0x0201 };
+        uint8_t invalid_version_list_length = s2n_array_len(invalid_version_list);
+
+        struct s2n_stuffer extension;
+        s2n_stuffer_alloc(&extension, invalid_version_list_length * S2N_TLS_PROTOCOL_VERSION_LEN + 1);
+
+        GUARD(s2n_stuffer_write_uint8(&extension, invalid_version_list_length * S2N_TLS_PROTOCOL_VERSION_LEN));
+
+        for (int i = 0; i < invalid_version_list_length; i++) {
+            GUARD(s2n_stuffer_write_uint16(&extension, invalid_version_list[i]));
+        }
+
+        EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_client_supported_versions_recv(server_conn, &extension), S2N_ERR_BAD_MESSAGE);
+
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_stuffer_free(&extension));
+    }
+
+    /* Check grease values for the supported versions */
+    {
+        struct s2n_connection *server_conn;
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        uint16_t grease_version_list[] = { 0x0304, GREASED_SUPPORTED_VERSION_EXTENSION_VALUES };
+        uint8_t grease_version_list_length = s2n_array_len(grease_version_list);
+
+        struct s2n_stuffer extension;
+        s2n_stuffer_alloc(&extension, grease_version_list_length * S2N_TLS_PROTOCOL_VERSION_LEN + 1);
+
+        GUARD(s2n_stuffer_write_uint8(&extension, grease_version_list_length * S2N_TLS_PROTOCOL_VERSION_LEN));
+
+        for (int i = 0; i < grease_version_list_length; i++) {
+            GUARD(s2n_stuffer_write_uint16(&extension, grease_version_list[i]));
+        }
+
+        EXPECT_SUCCESS(s2n_extensions_client_supported_versions_recv(server_conn, &extension));
+        EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS13);
+        EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS13);
+        EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS13);
+
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_stuffer_free(&extension));
+    }
+
+    /* Server selects highest supported protocol among list of invalid protocols (that purposefully test our conversion methods) */
+    {
+        struct s2n_connection *server_conn;
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        uint16_t invalid_version_list[] = { 0x0020, 0x0200, 0x0201, 0x0304, 0x0021, 0x0305, 0x0403, 0x7a7a };
+        uint8_t invalid_version_list_length = s2n_array_len(invalid_version_list);
+
+        struct s2n_stuffer extension;
+        s2n_stuffer_alloc(&extension, invalid_version_list_length * S2N_TLS_PROTOCOL_VERSION_LEN + 1);
+
+        GUARD(s2n_stuffer_write_uint8(&extension, invalid_version_list_length * S2N_TLS_PROTOCOL_VERSION_LEN));
+
+        for (int i = 0; i < invalid_version_list_length; i++) {
+            GUARD(s2n_stuffer_write_uint16(&extension, invalid_version_list[i]));
+        }
+
+        EXPECT_SUCCESS(s2n_extensions_client_supported_versions_recv(server_conn, &extension));
+        EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS13);
+        EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS13);
+        EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS13);
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_stuffer_free(&extension));

--- a/tls/extensions/s2n_client_supported_versions.c
+++ b/tls/extensions/s2n_client_supported_versions.c
@@ -71,6 +71,13 @@ int s2n_extensions_client_supported_versions_process(struct s2n_connection *conn
         uint8_t client_version_parts[S2N_TLS_PROTOCOL_VERSION_LEN];
         GUARD(s2n_stuffer_read_bytes(extension, client_version_parts, S2N_TLS_PROTOCOL_VERSION_LEN));
 
+        /* If the client version is outside of our supported versions, then ignore the value.
+         * S2N does not support SSLv2 except for upgrading connections. Since this extension is
+         * a TLS1.3 extension, we will skip any SSLv2 values. */
+        if (client_version_parts[0] != 3 || client_version_parts[1] > 4) {
+            continue;
+        }
+
         uint16_t client_version = (client_version_parts[0] * 10) + client_version_parts[1];
 
         conn->client_protocol_version = MAX(client_version, conn->client_protocol_version);


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 

**Description of changes:** 

In the supported versions extension, don't modify the client protocol version until we know it is valid. This prevents an unsupported protocol version (such as a GREASE value) from being used as the client_protocol_version.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
