### PR TITLE
Add missing guards on S2N_NO_PQ and provide a default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,8 @@ set(INSTALL_LIB_DIR lib CACHE PATH "Installaction directory for libraries")
 set(INSTALL_INCLUDE_DIR include CACHE PATH "installaction directory for header files")
 set(INSTALL_CMAKE_DIR lib/cmake CACHE PATH "Installation directory for cmake files")
 
-option(S2N_NO_PQ "Disables all Post Quantum Crypto code. You likely want this for older compilers or uncommon platforms.")
+option(S2N_NO_PQ "Disables all Post Quantum Crypto code. You likely want this
+for older compilers or uncommon platforms." OFF)
 option(S2N_NO_PQ_ASM "Turns off the ASM for PQ Crypto even if it's available for the toolchain. You likely want this on older compilers." OFF)
 
 ##header files

--- a/tests/unit/s2n_cipher_preference_test.c
+++ b/tests/unit/s2n_cipher_preference_test.c
@@ -43,13 +43,14 @@ int main(int argc, char **argv)
         preferences = NULL;
         EXPECT_SUCCESS(s2n_find_cipher_pref_from_version("test_all", &preferences));
         EXPECT_TRUE(s2n_ecc_extension_required(preferences));
-        EXPECT_TRUE(s2n_pq_kem_extension_required(preferences));
         EXPECT_TRUE(s2n_cipher_preference_supports_tls13(preferences));
-        EXPECT_EQUAL(4, preferences->kem_count);
 #if !defined(S2N_NO_PQ)
+        EXPECT_EQUAL(4, preferences->kem_count);
+        EXPECT_TRUE(s2n_pq_kem_extension_required(preferences));
         EXPECT_NOT_NULL(preferences->kems);
         EXPECT_EQUAL(preferences->kems, pq_kems_r2r1);
 #else
+        EXPECT_EQUAL(0, preferences->kem_count);
         EXPECT_NULL(preferences->kems);
 #endif
 
@@ -143,10 +144,12 @@ int main(int argc, char **argv)
             "CloudFront-TLS-1-2-2018",
             "CloudFront-TLS-1-2-2019",
             "KMS-TLS-1-0-2018-10",
+#if !defined(S2N_NO_PQ)
             "KMS-PQ-TLS-1-0-2019-06",
             "KMS-PQ-TLS-1-0-2020-02",
             "PQ-SIKE-TEST-TLS-1-0-2019-11",
             "PQ-SIKE-TEST-TLS-1-0-2020-02",
+#endif
             "KMS-FIPS-TLS-1-2-2018-10",
             "20140601",
             "20141001",

--- a/tests/unit/s2n_cipher_suite_match_test.c
+++ b/tests/unit/s2n_cipher_suite_match_test.c
@@ -231,6 +231,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(conn->secure.cipher_suite, s2n_cipher_suite_from_wire(expected_rsa_wire_choice));
         EXPECT_SUCCESS(s2n_connection_wipe(conn));
 
+#if !defined(S2N_NO_PQ)
         if (!s2n_is_in_fips_mode()) {
             /* There is no support for PQ KEMs while in FIPS mode */
             /* Test that clients that support PQ ciphers can negotiate them. */
@@ -266,6 +267,7 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_connection_wipe(conn));
             }
         }
+#endif
 
         /* Clean+free to setup for ECDSA tests */
         EXPECT_SUCCESS(s2n_config_free(server_config));

--- a/tests/unit/s2n_client_extensions_test.c
+++ b/tests/unit/s2n_client_extensions_test.c
@@ -1194,6 +1194,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_free(client_config));
     }
 
+#if !defined(S2N_NO_PQ)
     if (!s2n_is_in_fips_mode()) {
         /* PQ KEMs are not supported when in FIPS mode */
         /* All PQ KEM byte values are from https://tools.ietf.org/html/draft-campagna-tls-bike-sike-hybrid-02 */
@@ -1487,6 +1488,7 @@ int main(int argc, char **argv)
                                   "KMS-PQ-TLS-1-0-2019-06", -1, &piped_io));
         }
     }
+#endif
 
     EXPECT_SUCCESS(s2n_piped_io_close(&piped_io));
     free(cert_chain);

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -766,8 +766,10 @@ static struct s2n_cipher_suite *s2n_all_cipher_suites[] = {
     &s2n_ecdhe_rsa_with_chacha20_poly1305_sha256,   /* 0xCC,0xA8 */
     &s2n_ecdhe_ecdsa_with_chacha20_poly1305_sha256, /* 0xCC,0xA9 */
     &s2n_dhe_rsa_with_chacha20_poly1305_sha256,     /* 0xCC,0xAA */
+#if !defined(S2N_NO_PQ)
     &s2n_ecdhe_bike_rsa_with_aes_256_gcm_sha384,    /* 0xFF,0x04 */
     &s2n_ecdhe_sike_rsa_with_aes_256_gcm_sha384,    /* 0xFF,0x08 */
+#endif
 };
 
 /* All supported ciphers. Exposed for integration testing. */
@@ -821,16 +823,23 @@ static struct s2n_cipher_suite *s2n_all_tls12_cipher_suites[] = {
     &s2n_ecdhe_rsa_with_chacha20_poly1305_sha256,   /* 0xCC,0xA8 */
     &s2n_ecdhe_ecdsa_with_chacha20_poly1305_sha256, /* 0xCC,0xA9 */
     &s2n_dhe_rsa_with_chacha20_poly1305_sha256,     /* 0xCC,0xAA */
+#if !defined(S2N_NO_PQ)
     &s2n_ecdhe_bike_rsa_with_aes_256_gcm_sha384,    /* 0xFF,0x04 */
     &s2n_ecdhe_sike_rsa_with_aes_256_gcm_sha384,    /* 0xFF,0x08 */
+#endif
 };
 
 const struct s2n_cipher_preferences cipher_preferences_test_all_tls12 = {
     .count = s2n_array_len(s2n_all_tls12_cipher_suites),
     .suites = s2n_all_tls12_cipher_suites,
     .minimum_protocol_version = S2N_SSLv3,
+#if !defined(S2N_NO_PQ)
     .kem_count = s2n_array_len(pq_kems_r2r1),
     .kems = pq_kems_r2r1,
+#else
+    .kem_count = 0,
+    .kems = NULL,
+#endif
 };
 
 

--- a/tls/s2n_cipher_suites.h
+++ b/tls/s2n_cipher_suites.h
@@ -31,7 +31,13 @@
 #define S2N_KEY_EXCHANGE_ECC      0x04  /* Elliptic curve cryptography */
 
 #define S2N_MAX_POSSIBLE_RECORD_ALGS    2
-#define S2N_CIPHER_SUITE_COUNT          38 /* Kept up-to-date by s2n_cipher_suite_match_test */
+#if !defined(S2N_NO_PQ)
+#define S2N_PQ_CIPHER_SUITE_COUNT       2
+#else
+#define S2N_PQ_CIPHER_SUITE_COUNT       0
+#endif
+
+#define S2N_CIPHER_SUITE_COUNT          (36 + S2N_PQ_CIPHER_SUITE_COUNT) /* Kept up-to-date by s2n_cipher_suite_match_test */
 
 /* Record algorithm flags that can be OR'ed */
 #define S2N_TLS12_AES_GCM_AEAD_NONCE     0x01


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 

N/A

**Description of changes:** 

Add missing guards on S2N_NO_PQ and provide a default