### PR TITLE
client side HelloRetryRequest

### DIFF
--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -33,6 +33,7 @@
 #include "common.h"
 #include <error/s2n_errno.h>
 
+#include "tls/s2n_config.h"
 #include "tls/s2n_tls13.h"
 #include "utils/s2n_safety.h"
 
@@ -79,7 +80,9 @@ void usage()
     fprintf(stderr, "    Turn on corked io\n");
     if (S2N_IN_TEST) {
         fprintf(stderr, "  --tls13\n");
-        fprintf(stderr, "    Turn on experimental TLS1.3 support for testing.");
+        fprintf(stderr, "    Turn on experimental TLS1.3 support for testing.\n");
+        fprintf(stderr, "  --keyshare [curve name]\n");
+        fprintf(stderr, "    Name of curve to generate a keyshare for. Default is all supported curves\n");
     }
     fprintf(stderr, "\n");
     exit(1);
@@ -223,6 +226,7 @@ int main(int argc, char *const *argv)
     const char *server_name = NULL;
     const char *ca_file = NULL;
     const char *ca_dir = NULL;
+    const char *keyshare = NULL;
     uint16_t mfl_value = 0;
     uint8_t insecure = 0;
     int reconnect = 0;
@@ -256,11 +260,12 @@ int main(int argc, char *const *argv)
         {"timeout", required_argument, 0, 't'},
         {"corked-io", no_argument, 0, 'C'},
         {"tls13", no_argument, 0, '3'},
+        {"keyshare", no_argument, 0, 'k'},
     };
 
     while (1) {
         int option_index = 0;
-        int c = getopt_long(argc, argv, "a:c:ehn:sf:d:D:t:irTC", long_options, &option_index);
+        int c = getopt_long(argc, argv, "a:c:ehn:sf:d:D:t:k:irTC", long_options, &option_index);
         if (c == -1) {
             break;
         }
@@ -316,6 +321,9 @@ int main(int argc, char *const *argv)
             break;
         case '3':
             use_tls13 = 1;
+            break;
+        case 'k':
+            keyshare = optarg;
             break;
         case '?':
         default:
@@ -382,6 +390,9 @@ int main(int argc, char *const *argv)
 
         struct s2n_config *config = s2n_config_new();
         setup_s2n_config(config, cipher_prefs, type, &unsafe_verify_data, host, alpn_protocols, mfl_value);
+        if (keyshare) {
+            s2n_config_add_keyshare_by_name(config, &keyshare);
+        }
 
         if (ca_file || ca_dir) {
             if (s2n_config_set_verification_ca_location(config, ca_file, ca_dir) < 0) {

--- a/crypto/s2n_ecc_evp.c
+++ b/crypto/s2n_ecc_evp.c
@@ -352,12 +352,16 @@ int s2n_ecc_evp_write_params_point(struct s2n_ecc_evp_params *ecc_evp_params, st
 
     size_t size = EVP_PKEY_get1_tls_encodedpoint(ecc_evp_params->evp_pkey, &encoded_point);
     if (size != ecc_evp_params->negotiated_curve->share_size) {
+        OPENSSL_free(encoded_point);
+        encoded_point = NULL;
         S2N_ERROR(S2N_ERR_ECDHE_SERIALIZING);
     }
 
     point_blob.data = s2n_stuffer_raw_write(out, ecc_evp_params->negotiated_curve->share_size);
     notnull_check(point_blob.data);
     memcpy_check(point_blob.data, encoded_point, size);
+    OPENSSL_free(encoded_point);
+    encoded_point = NULL;
 #else
     uint8_t point_len;
     struct s2n_blob point_blob = {0};

--- a/crypto/s2n_ecc_evp.h
+++ b/crypto/s2n_ecc_evp.h
@@ -74,3 +74,7 @@ int s2n_ecc_evp_parse_params(struct s2n_ecdhe_raw_server_params *raw_server_ecc_
                              struct s2n_ecc_evp_params *ecc_evp_params);
 int s2n_ecc_evp_find_supported_curve(struct s2n_blob *iana_ids, const struct s2n_ecc_named_curve **found);
 int s2n_ecc_evp_params_free(struct s2n_ecc_evp_params *ecc_evp_params);
+
+int s2n_connection_add_preferred_key_share(struct s2n_connection *conn, const char *curve_name);
+int s2n_connection_add_preferred_key_share_by_group(struct s2n_connection *conn, uint16_t iana_id);
+bool s2n_is_curve_selected(const struct s2n_ecc_named_curve *curve);

--- a/tests/testlib/s2n_testlib_ecc_keys.c
+++ b/tests/testlib/s2n_testlib_ecc_keys.c
@@ -27,7 +27,7 @@ int s2n_public_ecc_keys_are_equal(struct s2n_ecc_evp_params *params_1, struct s2
     struct s2n_stuffer point_stuffer;
     int size = params_1->negotiated_curve->share_size;
 
-    if (params_1->negotiated_curve != params_2->negotiated_curve) {
+    if (memcmp(params_1->negotiated_curve, params_2->negotiated_curve, sizeof(struct s2n_ecc_named_curve)) != 0) {
         return 0;
     }
 

--- a/tests/unit/s2n_client_key_share_extension_test.c
+++ b/tests/unit/s2n_client_key_share_extension_test.c
@@ -74,14 +74,19 @@ int main(int argc, char **argv)
         {
             struct s2n_stuffer key_share_extension;
             struct s2n_connection *conn;
-            EXPECT_SUCCESS(s2n_stuffer_alloc(&key_share_extension, s2n_extensions_client_key_share_size(NULL)));
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
+            /* XXX: This is only happening because the connection clears all keyshares, this is part of the HRR test */
+            for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
+                EXPECT_SUCCESS(s2n_connection_add_preferred_key_share_by_group(conn, s2n_ecc_evp_supported_curves_list[i]->iana_id));
+            }
+
+            EXPECT_SUCCESS(s2n_stuffer_alloc(&key_share_extension, s2n_extensions_client_key_share_size(conn)));
             EXPECT_SUCCESS(s2n_extensions_client_key_share_send(conn, &key_share_extension));
 
             for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
                 struct s2n_ecc_evp_params *ecc_evp_params = &conn->secure.client_ecc_evp_params[i];
-                EXPECT_EQUAL(ecc_evp_params->negotiated_curve, s2n_ecc_evp_supported_curves_list[i]);
+                EXPECT_BYTEARRAY_EQUAL(ecc_evp_params->negotiated_curve, s2n_ecc_evp_supported_curves_list[i], sizeof(struct s2n_ecc_evp_params));
                 EXPECT_NOT_NULL(ecc_evp_params->evp_pkey);
             }
 
@@ -93,8 +98,14 @@ int main(int argc, char **argv)
         {
             struct s2n_stuffer key_share_extension;
             struct s2n_connection *conn;
-            EXPECT_SUCCESS(s2n_stuffer_alloc(&key_share_extension, s2n_extensions_client_key_share_size(NULL)));
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+            /* XXX: This is only happening because the connection clears all keyshares, this is part of the HRR test */
+            for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
+                EXPECT_SUCCESS(s2n_connection_add_preferred_key_share_by_group(conn, s2n_ecc_evp_supported_curves_list[i]->iana_id));
+            }
+
+            EXPECT_SUCCESS(s2n_stuffer_alloc(&key_share_extension, s2n_extensions_client_key_share_size(conn)));
 
             EXPECT_SUCCESS(s2n_extensions_client_key_share_send(conn, &key_share_extension));
 
@@ -138,10 +149,16 @@ int main(int argc, char **argv)
         {
             struct s2n_connection *client_conn, *server_conn;
             struct s2n_stuffer key_share_extension;
-            EXPECT_SUCCESS(s2n_stuffer_alloc(&key_share_extension, s2n_extensions_client_key_share_size(NULL)));
 
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+
+            /* XXX: This is only happening because the connection clears all keyshares, this is part of the HRR test */
+            for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
+                EXPECT_SUCCESS(s2n_connection_add_preferred_key_share_by_group(client_conn, s2n_ecc_evp_supported_curves_list[i]->iana_id));
+            }
+
+            EXPECT_SUCCESS(s2n_stuffer_alloc(&key_share_extension, s2n_extensions_client_key_share_size(client_conn)));
 
             EXPECT_SUCCESS(s2n_extensions_client_key_share_send(client_conn, &key_share_extension));
 
@@ -173,13 +190,13 @@ int main(int argc, char **argv)
         {
             struct s2n_connection *conn;
             struct s2n_stuffer key_share_extension;
-            EXPECT_SUCCESS(s2n_stuffer_alloc(&key_share_extension, s2n_extensions_client_key_share_size(NULL)));
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            EXPECT_SUCCESS(s2n_stuffer_alloc(&key_share_extension, s2n_extensions_client_key_share_size(conn)));
 
             EXPECT_SUCCESS(s2n_stuffer_write_uint16(&key_share_extension, s2n_ecc_evp_supported_curves_list[0]->share_size * 10));
             EXPECT_SUCCESS(s2n_write_named_curve(&key_share_extension, s2n_ecc_evp_supported_curves_list[0]));
 
-            EXPECT_FAILURE(s2n_extensions_client_key_share_recv(conn, &key_share_extension));
+            EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_client_key_share_recv(conn, &key_share_extension), S2N_ERR_BAD_MESSAGE);
 
             EXPECT_SUCCESS(s2n_stuffer_free(&key_share_extension));
             EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -189,8 +206,8 @@ int main(int argc, char **argv)
         {
             struct s2n_connection *conn;
             struct s2n_stuffer key_share_extension;
-            EXPECT_SUCCESS(s2n_stuffer_alloc(&key_share_extension, s2n_extensions_client_key_share_size(NULL)));
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            EXPECT_SUCCESS(s2n_stuffer_alloc(&key_share_extension, s2n_extensions_client_key_share_size(conn)));
 
             /* Write curve with huge length */
             S2N_PREPARE_DATA_LENGTH(&key_share_extension);
@@ -208,8 +225,13 @@ int main(int argc, char **argv)
         {
             struct s2n_connection *conn;
             struct s2n_stuffer key_share_extension;
-            EXPECT_SUCCESS(s2n_stuffer_alloc(&key_share_extension, s2n_extensions_client_key_share_size(NULL)));
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            /* XXX: This is only happening because the connection clears all keyshares, this is part of the HRR test */
+            for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
+                EXPECT_SUCCESS(s2n_connection_add_preferred_key_share_by_group(conn, s2n_ecc_evp_supported_curves_list[i]->iana_id));
+            }
+
+            EXPECT_SUCCESS(s2n_stuffer_alloc(&key_share_extension, s2n_extensions_client_key_share_size(conn)));
 
             /* Write only first curve */
             S2N_PREPARE_DATA_LENGTH(&key_share_extension);
@@ -242,8 +264,13 @@ int main(int argc, char **argv)
         {
             struct s2n_connection *server_conn;
             struct s2n_stuffer key_share_extension;
-            EXPECT_SUCCESS(s2n_stuffer_alloc(&key_share_extension, s2n_extensions_client_key_share_size(NULL)));
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+            /* XXX: This is only happening because the connection clears all keyshares, this is part of the HRR test */
+            for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
+                EXPECT_SUCCESS(s2n_connection_add_preferred_key_share_by_group(server_conn, s2n_ecc_evp_supported_curves_list[i]->iana_id));
+            }
+
+            EXPECT_SUCCESS(s2n_stuffer_alloc(&key_share_extension, s2n_extensions_client_key_share_size(server_conn)));
 
             EXPECT_SUCCESS(s2n_stuffer_write_uint16(&key_share_extension, 0));
 
@@ -264,8 +291,13 @@ int main(int argc, char **argv)
         {
             struct s2n_connection *conn;
             struct s2n_stuffer key_share_extension;
-            EXPECT_SUCCESS(s2n_stuffer_alloc(&key_share_extension, s2n_extensions_client_key_share_size(NULL)));
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            /* XXX: This is only happening because the connection clears all keyshares, this is part of the HRR test */
+            for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
+                EXPECT_SUCCESS(s2n_connection_add_preferred_key_share_by_group(conn, s2n_ecc_evp_supported_curves_list[i]->iana_id));
+            }
+
+            EXPECT_SUCCESS(s2n_stuffer_alloc(&key_share_extension, s2n_extensions_client_key_share_size(conn)));
 
             S2N_PREPARE_DATA_LENGTH(&key_share_extension);
 
@@ -299,8 +331,13 @@ int main(int argc, char **argv)
         {
             struct s2n_connection *conn;
             struct s2n_stuffer key_share_extension;
-            EXPECT_SUCCESS(s2n_stuffer_alloc(&key_share_extension, s2n_extensions_client_key_share_size(NULL)));
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            /* XXX: This is only happening because the connection clears all keyshares, this is part of the HRR test */
+            for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
+                EXPECT_SUCCESS(s2n_connection_add_preferred_key_share_by_group(conn, s2n_ecc_evp_supported_curves_list[i]->iana_id));
+            }
+
+            EXPECT_SUCCESS(s2n_stuffer_alloc(&key_share_extension, s2n_extensions_client_key_share_size(conn)));
 
             /* Write supported curve, but with a different curve's size */
             S2N_PREPARE_DATA_LENGTH(&key_share_extension);
@@ -330,8 +367,13 @@ int main(int argc, char **argv)
             struct s2n_stuffer key_share_extension;
             struct s2n_ecc_evp_params first_params, second_params;
             int supported_curve_index = 0;
-            EXPECT_SUCCESS(s2n_stuffer_alloc(&key_share_extension, s2n_extensions_client_key_share_size(NULL)));
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+            /* XXX: This is only happening because the connection clears all keyshares, this is part of the HRR test */
+            for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
+                EXPECT_SUCCESS(s2n_connection_add_preferred_key_share_by_group(server_conn, s2n_ecc_evp_supported_curves_list[i]->iana_id));
+            }
+
+            EXPECT_SUCCESS(s2n_stuffer_alloc(&key_share_extension, s2n_extensions_client_key_share_size(server_conn)));
 
             S2N_PREPARE_DATA_LENGTH(&key_share_extension);
 
@@ -366,8 +408,13 @@ int main(int argc, char **argv)
         {
             struct s2n_connection *conn;
             struct s2n_stuffer key_share_extension;
-            EXPECT_SUCCESS(s2n_stuffer_alloc(&key_share_extension, s2n_extensions_client_key_share_size(NULL)));
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            /* XXX: This is only happening because the connection clears all keyshares, this is part of the HRR test */
+            for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
+                EXPECT_SUCCESS(s2n_connection_add_preferred_key_share_by_group(conn, s2n_ecc_evp_supported_curves_list[i]->iana_id));
+            }
+
+            EXPECT_SUCCESS(s2n_stuffer_alloc(&key_share_extension, s2n_extensions_client_key_share_size(conn)));
 
             /* Write first curve */
             S2N_PREPARE_DATA_LENGTH(&key_share_extension);

--- a/tests/unit/s2n_client_key_share_extension_test.c
+++ b/tests/unit/s2n_client_key_share_extension_test.c
@@ -76,7 +76,7 @@ int main(int argc, char **argv)
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
-            /* XXX: This is only happening because the connection clears all keyshares, this is part of the HRR test */
+            /* ISSUE 1657: This is only happening because the connection clears all keyshares, this is part of the HRR test */
             for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
                 EXPECT_SUCCESS(s2n_connection_add_preferred_key_share_by_group(conn, s2n_ecc_evp_supported_curves_list[i]->iana_id));
             }
@@ -100,7 +100,7 @@ int main(int argc, char **argv)
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
-            /* XXX: This is only happening because the connection clears all keyshares, this is part of the HRR test */
+            /* ISSUE 1657: This is only happening because the connection clears all keyshares, this is part of the HRR test */
             for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
                 EXPECT_SUCCESS(s2n_connection_add_preferred_key_share_by_group(conn, s2n_ecc_evp_supported_curves_list[i]->iana_id));
             }
@@ -153,7 +153,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
 
-            /* XXX: This is only happening because the connection clears all keyshares, this is part of the HRR test */
+            /* ISSUE 1657: This is only happening because the connection clears all keyshares, this is part of the HRR test */
             for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
                 EXPECT_SUCCESS(s2n_connection_add_preferred_key_share_by_group(client_conn, s2n_ecc_evp_supported_curves_list[i]->iana_id));
             }
@@ -226,7 +226,7 @@ int main(int argc, char **argv)
             struct s2n_connection *conn;
             struct s2n_stuffer key_share_extension;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-            /* XXX: This is only happening because the connection clears all keyshares, this is part of the HRR test */
+            /* ISSUE 1657: This is only happening because the connection clears all keyshares, this is part of the HRR test */
             for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
                 EXPECT_SUCCESS(s2n_connection_add_preferred_key_share_by_group(conn, s2n_ecc_evp_supported_curves_list[i]->iana_id));
             }
@@ -265,7 +265,7 @@ int main(int argc, char **argv)
             struct s2n_connection *server_conn;
             struct s2n_stuffer key_share_extension;
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-            /* XXX: This is only happening because the connection clears all keyshares, this is part of the HRR test */
+            /* ISSUE 1657: This is only happening because the connection clears all keyshares, this is part of the HRR test */
             for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
                 EXPECT_SUCCESS(s2n_connection_add_preferred_key_share_by_group(server_conn, s2n_ecc_evp_supported_curves_list[i]->iana_id));
             }
@@ -292,7 +292,7 @@ int main(int argc, char **argv)
             struct s2n_connection *conn;
             struct s2n_stuffer key_share_extension;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-            /* XXX: This is only happening because the connection clears all keyshares, this is part of the HRR test */
+            /* ISSUE 1657: This is only happening because the connection clears all keyshares, this is part of the HRR test */
             for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
                 EXPECT_SUCCESS(s2n_connection_add_preferred_key_share_by_group(conn, s2n_ecc_evp_supported_curves_list[i]->iana_id));
             }
@@ -332,7 +332,7 @@ int main(int argc, char **argv)
             struct s2n_connection *conn;
             struct s2n_stuffer key_share_extension;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-            /* XXX: This is only happening because the connection clears all keyshares, this is part of the HRR test */
+            /* ISSUE 1657: This is only happening because the connection clears all keyshares, this is part of the HRR test */
             for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
                 EXPECT_SUCCESS(s2n_connection_add_preferred_key_share_by_group(conn, s2n_ecc_evp_supported_curves_list[i]->iana_id));
             }
@@ -368,7 +368,7 @@ int main(int argc, char **argv)
             struct s2n_ecc_evp_params first_params, second_params;
             int supported_curve_index = 0;
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-            /* XXX: This is only happening because the connection clears all keyshares, this is part of the HRR test */
+            /* ISSUE 1657: This is only happening because the connection clears all keyshares, this is part of the HRR test */
             for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
                 EXPECT_SUCCESS(s2n_connection_add_preferred_key_share_by_group(server_conn, s2n_ecc_evp_supported_curves_list[i]->iana_id));
             }
@@ -409,7 +409,7 @@ int main(int argc, char **argv)
             struct s2n_connection *conn;
             struct s2n_stuffer key_share_extension;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-            /* XXX: This is only happening because the connection clears all keyshares, this is part of the HRR test */
+            /* ISSUE 1657: This is only happening because the connection clears all keyshares, this is part of the HRR test */
             for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
                 EXPECT_SUCCESS(s2n_connection_add_preferred_key_share_by_group(conn, s2n_ecc_evp_supported_curves_list[i]->iana_id));
             }

--- a/tests/unit/s2n_server_hello_retry_test.c
+++ b/tests/unit/s2n_server_hello_retry_test.c
@@ -17,8 +17,10 @@
 
 #include "testlib/s2n_testlib.h"
 
+#include "tls/extensions/s2n_cookie.h"
 #include "tls/extensions/s2n_key_share.h"
 #include "tls/extensions/s2n_server_supported_versions.h"
+#include "tls/extensions/s2n_server_key_share.h"
 
 #include "tls/s2n_cipher_preferences.h"
 #include "tls/s2n_cipher_suites.h"
@@ -26,9 +28,9 @@
 #include "tls/s2n_tls13.h"
 #include "tls/s2n_tls13_handshake.h"
 
-#include "tls/extensions/s2n_server_key_share.h"
-
 #include "error/s2n_errno.h"
+
+#define TEST_COOKIE_SIZE    32
 
 const uint8_t SESSION_ID_SIZE = 1;
 const uint8_t COMPRESSION_METHOD_SIZE = 1;

--- a/tests/unit/s2n_server_key_share_extension_test.c
+++ b/tests/unit/s2n_server_key_share_extension_test.c
@@ -272,7 +272,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&client_hello_key_share, 1024));
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&server_hello_key_share, 1024));
 
-            /* XXX: This is only happening because the connection clears all keyshares, this is part of the HRR test */
+            /* ISSUE 1657: This is only happening because the connection clears all keyshares, this is part of the HRR test */
             EXPECT_SUCCESS(s2n_connection_add_preferred_key_share_by_group(client_conn, s2n_ecc_evp_supported_curves_list[i]->iana_id));
 
             /* Client sends ClientHello key_share */

--- a/tests/unit/s2n_server_key_share_extension_test.c
+++ b/tests/unit/s2n_server_key_share_extension_test.c
@@ -272,12 +272,15 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&client_hello_key_share, 1024));
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&server_hello_key_share, 1024));
 
+            /* XXX: This is only happening because the connection clears all keyshares, this is part of the HRR test */
+            EXPECT_SUCCESS(s2n_connection_add_preferred_key_share_by_group(client_conn, s2n_ecc_evp_supported_curves_list[i]->iana_id));
+
             /* Client sends ClientHello key_share */
             EXPECT_SUCCESS(s2n_extensions_client_key_share_send(client_conn, &client_hello_key_share));
 
             /* Server receives ClientHello key_share */
             S2N_STUFFER_READ_EXPECT_EQUAL(&client_hello_key_share, TLS_EXTENSION_KEY_SHARE, uint16);
-            S2N_STUFFER_READ_EXPECT_EQUAL(&client_hello_key_share, s2n_extensions_client_key_share_size(server_conn) - 4, uint16);
+            S2N_STUFFER_READ_EXPECT_EQUAL(&client_hello_key_share, s2n_extensions_client_key_share_size(client_conn) - 4, uint16);
             EXPECT_SUCCESS(s2n_extensions_client_key_share_recv(server_conn, &client_hello_key_share));
             EXPECT_EQUAL(s2n_stuffer_data_available(&client_hello_key_share), 0);
 
@@ -297,6 +300,7 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve->iana_id, s2n_ecc_evp_supported_curves_list[i]->iana_id);
 
             /* Server sends ServerHello key_share */
+            EXPECT_SUCCESS(s2n_connection_add_preferred_key_share(server_conn, "secp256r1"));
             EXPECT_SUCCESS(s2n_extensions_server_key_share_send(server_conn, &server_hello_key_share));
 
             /* Client receives ServerHello key_share */

--- a/tests/unit/s2n_tls13_handshake_test.c
+++ b/tests/unit/s2n_tls13_handshake_test.c
@@ -57,7 +57,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&client_hello_key_share, 1024));
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&server_hello_key_share, 1024));
 
-        /* XXX: This is only happening because the connection clears all keyshares, this is part of the HRR test */
+        /* ISSUE 1657: This is only happening because the connection clears all keyshares, this is part of the HRR test */
         EXPECT_SUCCESS(s2n_connection_add_preferred_key_share_by_group(client_conn, s2n_ecc_evp_supported_curves_list[0]->iana_id));
 
         /* Client sends ClientHello key_share */
@@ -613,7 +613,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "default_tls13"));
         EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
 
-        /* XXX: This is only happening because the connection clears all keyshares, this is part of the HRR test */
+        /* ISSUE 1657: This is only happening because the connection clears all keyshares, this is part of the HRR test */
         EXPECT_SUCCESS(s2n_connection_add_preferred_key_share_by_group(client_conn, s2n_ecc_evp_supported_curves_list[0]->iana_id));
 
         /* Client sends ClientHello */

--- a/tls/extensions/s2n_client_key_share.c
+++ b/tls/extensions/s2n_client_key_share.c
@@ -45,24 +45,6 @@
  * - Key shares for named groups not in the client's supported_groups extension.
  **/
 
-uint32_t s2n_client_key_share_extension_size;
-
-static int s2n_ecdhe_supported_curves_send(struct s2n_connection *conn, struct s2n_stuffer *out);
-
-int s2n_client_key_share_init()
-{
-    s2n_client_key_share_extension_size = S2N_SIZE_OF_EXTENSION_TYPE
-            + S2N_SIZE_OF_EXTENSION_DATA_SIZE
-            + S2N_SIZE_OF_CLIENT_SHARES_SIZE;
-
-    for (uint32_t i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
-        s2n_client_key_share_extension_size += S2N_SIZE_OF_KEY_SHARE_SIZE + S2N_SIZE_OF_NAMED_GROUP;
-        s2n_client_key_share_extension_size += s2n_ecc_evp_supported_curves_list[i]->share_size;
-    }
-
-    return 0;
-}
-
 int s2n_extensions_client_key_share_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
     notnull_check(conn);
@@ -140,26 +122,21 @@ int s2n_extensions_client_key_share_recv(struct s2n_connection *conn, struct s2n
 
 uint32_t s2n_extensions_client_key_share_size(struct s2n_connection *conn)
 {
+    uint32_t s2n_client_key_share_extension_size = S2N_SIZE_OF_EXTENSION_TYPE
+            + S2N_SIZE_OF_EXTENSION_DATA_SIZE
+            + S2N_SIZE_OF_CLIENT_SHARES_SIZE;
+
+    /* Only curves that the customer has selected, or that a server has specified in
+     * a HelloRetryRequest, should be included in the size */
+    for (uint32_t i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
+        struct s2n_ecc_named_curve *c = &conn->secure.preferred_key_shares[i];
+        if (s2n_is_curve_selected(c)) {
+            s2n_client_key_share_extension_size += S2N_SIZE_OF_KEY_SHARE_SIZE + S2N_SIZE_OF_NAMED_GROUP;
+            s2n_client_key_share_extension_size += c->share_size;
+        }
+    }
+
     return s2n_client_key_share_extension_size;
-}
-
-int s2n_extensions_client_key_share_send(struct s2n_connection *conn, struct s2n_stuffer *out)
-{
-    notnull_check(out);
-
-    const uint16_t extension_type = TLS_EXTENSION_KEY_SHARE;
-    const uint16_t extension_data_size =
-            s2n_client_key_share_extension_size - S2N_SIZE_OF_EXTENSION_TYPE - S2N_SIZE_OF_EXTENSION_DATA_SIZE;
-    const uint16_t client_shares_size =
-            extension_data_size - S2N_SIZE_OF_CLIENT_SHARES_SIZE;
-
-    GUARD(s2n_stuffer_write_uint16(out, extension_type));
-    GUARD(s2n_stuffer_write_uint16(out, extension_data_size));
-    GUARD(s2n_stuffer_write_uint16(out, client_shares_size));
-
-    GUARD(s2n_ecdhe_supported_curves_send(conn, out));
-
-    return 0;
 }
 
 static int s2n_ecdhe_supported_curves_send(struct s2n_connection *conn, struct s2n_stuffer *out)
@@ -171,12 +148,34 @@ static int s2n_ecdhe_supported_curves_send(struct s2n_connection *conn, struct s
 
     for (uint32_t i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
         ecc_evp_params = &conn->secure.client_ecc_evp_params[i];
-        named_curve = s2n_ecc_evp_supported_curves_list[i];
+        named_curve = &conn->secure.preferred_key_shares[i];
 
-        ecc_evp_params->negotiated_curve = named_curve;
-        ecc_evp_params->evp_pkey = NULL;
-        GUARD(s2n_ecdhe_parameters_send(ecc_evp_params, out));
+        /* Only generate key shares for the curves that have been added to the preferred list */
+        if (s2n_is_curve_selected(named_curve)) {
+            ecc_evp_params->negotiated_curve = named_curve;
+            ecc_evp_params->evp_pkey = NULL;
+            GUARD(s2n_ecdhe_parameters_send(ecc_evp_params, out));
+        }
     }
+
+    return 0;
+}
+
+int s2n_extensions_client_key_share_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    notnull_check(out);
+
+    const uint16_t extension_type = TLS_EXTENSION_KEY_SHARE;
+    const uint16_t extension_data_size =
+            s2n_extensions_client_key_share_size(conn) - S2N_SIZE_OF_EXTENSION_TYPE - S2N_SIZE_OF_EXTENSION_DATA_SIZE;
+    const uint16_t client_shares_size =
+            extension_data_size - S2N_SIZE_OF_CLIENT_SHARES_SIZE;
+
+    GUARD(s2n_stuffer_write_uint16(out, extension_type));
+    GUARD(s2n_stuffer_write_uint16(out, extension_data_size));
+    GUARD(s2n_stuffer_write_uint16(out, client_shares_size));
+
+    GUARD(s2n_ecdhe_supported_curves_send(conn, out));
 
     return 0;
 }

--- a/tls/extensions/s2n_client_key_share.h
+++ b/tls/extensions/s2n_client_key_share.h
@@ -18,8 +18,6 @@
 #include "tls/s2n_connection.h"
 #include "stuffer/s2n_stuffer.h"
 
-extern int s2n_client_key_share_init();
-extern int s2n_extensions_client_key_share_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
-extern uint32_t s2n_extensions_client_key_share_size(struct s2n_connection *conn);
-extern int s2n_extensions_client_key_share_send(struct s2n_connection *conn, struct s2n_stuffer *out);
-
+int s2n_extensions_client_key_share_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
+uint32_t s2n_extensions_client_key_share_size(struct s2n_connection *conn);
+int s2n_extensions_client_key_share_send(struct s2n_connection *conn, struct s2n_stuffer *out);

--- a/tls/extensions/s2n_server_key_share.c
+++ b/tls/extensions/s2n_server_key_share.c
@@ -140,6 +140,26 @@ int s2n_extensions_server_key_share_send(struct s2n_connection *conn, struct s2n
     return 0;
 }
 
+static int s2n_hello_retry_key_share_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    uint16_t named_group;
+
+    /* Make sure we can read the 2 byte named group */
+    S2N_ERROR_IF(s2n_stuffer_data_available(extension) < 2, S2N_ERR_BAD_KEY_SHARE);
+    GUARD(s2n_stuffer_read_uint16(extension, &named_group));
+
+    /* Our original key shares didn't cut it, so clear the list and fill it with what the server wants */
+    GUARD(s2n_connection_clear_all_key_shares(conn));
+
+    for (uint32_t i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
+        if (s2n_ecc_evp_supported_curves_list[i]->iana_id == named_group) {
+            GUARD(s2n_connection_add_preferred_key_share_by_group(conn, named_group));
+        }
+    }
+
+    return 0;
+}
+
 /*
  * Client receives a Server Hello key share.
  *
@@ -150,20 +170,17 @@ int s2n_extensions_server_key_share_recv(struct s2n_connection *conn, struct s2n
     notnull_check(conn);
     notnull_check(extension);
 
-    uint16_t named_group, share_size;
-
-    /* Make sure we can read the 2 byte named group */
-    S2N_ERROR_IF(s2n_stuffer_data_available(extension) < 2, S2N_ERR_BAD_KEY_SHARE);
-    GUARD(s2n_stuffer_read_uint16(extension, &named_group));
-
-    /* If this is a HelloRetryRequest, we won't have a key share. We just have the selected group.
-     * Exit early so a proper keyshare can be generated. */
+    /* If this is a HelloRetryRequest then we won't have a key share, just the selected group */
     if (s2n_server_hello_retry_is_valid(conn)) {
+        GUARD(s2n_hello_retry_key_share_recv(conn, extension));
         return 0;
     }
 
-    /* Make sure we can read the 2 byte key share size */
-    S2N_ERROR_IF(s2n_stuffer_data_available(extension) < 2, S2N_ERR_BAD_KEY_SHARE);
+    uint16_t named_group, share_size;
+
+    /* Make sure we can read 4 bytes to get the named group and share size */
+    S2N_ERROR_IF(s2n_stuffer_data_available(extension) < 4, S2N_ERR_BAD_KEY_SHARE);
+    GUARD(s2n_stuffer_read_uint16(extension, &named_group));
     GUARD(s2n_stuffer_read_uint16(extension, &share_size));
 
     /* Verify that *share_size* bytes are available in the stuffer */

--- a/tls/s2n_client_extensions.c
+++ b/tls/s2n_client_extensions.c
@@ -105,6 +105,7 @@ int s2n_client_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *
     if (conn->client_protocol_version >= S2N_TLS13) {
         total_size += s2n_extensions_client_supported_versions_size(conn);
         total_size += s2n_extensions_client_key_share_size(conn);
+        total_size += s2n_extensions_cookie_size(conn);
     }
 
     GUARD(s2n_stuffer_write_uint16(out, total_size));
@@ -112,6 +113,7 @@ int s2n_client_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *
     if (conn->client_protocol_version >= S2N_TLS13) {
         GUARD(s2n_extensions_client_supported_versions_send(conn, out));
         GUARD(s2n_extensions_client_key_share_send(conn, out));
+        GUARD(s2n_extensions_cookie_send(conn, out));
     }
 
     if (conn->actual_protocol_version >= S2N_TLS12) {

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -25,6 +25,7 @@
 #include "tls/s2n_tls13.h"
 #include "utils/s2n_safety.h"
 #include "crypto/s2n_hkdf.h"
+#include "crypto/s2n_ecc_evp.h"
 #include "utils/s2n_map.h"
 #include "utils/s2n_blob.h"
 

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -22,6 +22,7 @@
 #include "crypto/s2n_fips.h"
 
 #include "tls/s2n_cipher_preferences.h"
+#include "tls/s2n_config.h"
 #include "tls/s2n_tls13.h"
 #include "utils/s2n_safety.h"
 #include "crypto/s2n_hkdf.h"
@@ -139,6 +140,9 @@ static int s2n_config_init(struct s2n_config *config)
     s2n_x509_trust_store_init_empty(&config->trust_store);
     s2n_x509_trust_store_from_system_defaults(&config->trust_store);
 
+    /* ISSUE #1657: Temp change to allow individual keyshares */
+    config->key_shares = s2n_array_new(sizeof(const char *));
+
     return 0;
 }
 
@@ -152,6 +156,9 @@ static int s2n_config_cleanup(struct s2n_config *config)
     GUARD(s2n_config_free_dhparams(config));
     GUARD(s2n_free(&config->application_protocols));
     GUARD(s2n_map_free(config->domain_name_to_cert_map));
+
+    /* ISSUE #1657: Temp change to allow individual keyshares */
+    GUARD(s2n_array_free(config->key_shares));
 
     return 0;
 }
@@ -215,6 +222,35 @@ static int s2n_config_build_domain_name_to_cert_map(struct s2n_config *config, s
     }
 
     return 0;
+}
+
+int s2n_config_add_all_curves(struct s2n_config *conf)
+{
+    for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
+        const struct s2n_ecc_named_curve *curve = s2n_ecc_evp_supported_curves_list[i];
+        GUARD(s2n_array_insert_and_copy(conf->key_shares, &curve->name, conf->key_shares->num_of_elements));
+    }
+
+    return 0;
+}
+
+int s2n_config_clear_all_curves(struct s2n_config *conf)
+{
+    GUARD(s2n_array_free(conf->key_shares));
+    conf->key_shares = s2n_array_new(sizeof(const char *));
+    return 0;
+}
+
+int s2n_config_add_keyshare_by_name(struct s2n_config *conf, const char **curve_name)
+{
+    for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
+        if (!strcasecmp(*curve_name, s2n_ecc_evp_supported_curves_list[i]->name)) {
+            GUARD(s2n_array_insert_and_copy(conf->key_shares, curve_name, conf->key_shares->num_of_elements));
+            return 0;
+        }
+    }
+
+    S2N_ERROR(S2N_ERR_INVALID_CIPHER_PREFERENCES);
 }
 
 struct s2n_config *s2n_fetch_default_config(void)

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -55,6 +55,9 @@ struct s2n_config {
     const struct s2n_cipher_preferences *cipher_preferences;
     const struct s2n_signature_preferences *signature_preferences;
 
+    /* ISSUE #1657: Temp change to allow individual keyshares */
+    const struct s2n_ecc_named_curve *preferred_curves;
+
     void *sys_clock_ctx;
     void *monotonic_clock_ctx;
 
@@ -96,6 +99,8 @@ struct s2n_config {
 
     struct s2n_x509_trust_store trust_store;
     uint16_t max_verify_cert_chain_depth;
+
+    struct s2n_array *key_shares;
 };
 
 extern int s2n_config_defaults_init(void);
@@ -108,3 +113,7 @@ extern int s2n_config_free_session_ticket_keys(struct s2n_config *config);
 extern void s2n_wipe_static_configs(void);
 extern struct s2n_cert_chain_and_key *s2n_config_get_single_default_cert(struct s2n_config *config);
 extern int s2n_config_get_num_default_certs(struct s2n_config *config);
+
+/* ISSUE #1657: Temp change to allow individual keyshares */
+int s2n_config_add_all_curves(struct s2n_config *conf);
+int s2n_config_add_keyshare_by_name(struct s2n_config *conf, const char **curve_name);

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -473,6 +473,41 @@ int s2n_connection_free(struct s2n_connection *conn)
     return 0;
 }
 
+int s2n_connection_clear_all_key_shares(struct s2n_connection *conn)
+{
+    for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
+        memset_check(&conn->secure.preferred_key_shares[i], 0, sizeof(struct s2n_ecc_named_curve));
+        GUARD(s2n_ecc_evp_params_free(&conn->secure.client_ecc_evp_params[i]));
+        conn->secure.client_ecc_evp_params[i].negotiated_curve = NULL;
+    }
+
+    return 0;
+}
+
+int s2n_connection_add_preferred_key_share(struct s2n_connection *conn, const char *curve_name)
+{
+    for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
+        if (!strcasecmp(curve_name, s2n_ecc_evp_supported_curves_list[i]->name)) {
+            memcpy_check(&conn->secure.preferred_key_shares[i], s2n_ecc_evp_supported_curves_list[i], sizeof(struct s2n_ecc_named_curve));
+            return 0;
+        }
+    }
+
+    S2N_ERROR(S2N_ERR_INVALID_CIPHER_PREFERENCES);
+}
+
+int s2n_connection_add_preferred_key_share_by_group(struct s2n_connection *conn, uint16_t iana_id)
+{
+    for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
+        if (s2n_ecc_evp_supported_curves_list[i]->iana_id == iana_id) {
+            memcpy_check(&conn->secure.preferred_key_shares[i], s2n_ecc_evp_supported_curves_list[i], sizeof(struct s2n_ecc_named_curve));
+            return 0;
+        }
+    }
+
+    S2N_ERROR(S2N_ERR_INVALID_CIPHER_PREFERENCES);
+}
+
 int s2n_connection_set_config(struct s2n_connection *conn, struct s2n_config *config)
 {
     notnull_check(conn);
@@ -517,7 +552,11 @@ int s2n_connection_set_config(struct s2n_connection *conn, struct s2n_config *co
         }
     }
 
+    /* XXX: For testing, we start the connection with no generated key shares. This will force the server to send a retry. */
+    GUARD(s2n_connection_clear_all_key_shares(conn));
+
     conn->config = config;
+
     return 0;
 }
 

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -552,8 +552,12 @@ int s2n_connection_set_config(struct s2n_connection *conn, struct s2n_config *co
         }
     }
 
-    /* XXX: For testing, we start the connection with no generated key shares. This will force the server to send a retry. */
+    /* ISSUE #1657: Set the connection's preferred key shares based on the configuration */
     GUARD(s2n_connection_clear_all_key_shares(conn));
+    for (int i = 0; i < config->key_shares->num_of_elements; i++) {
+        char **curve = s2n_array_get(config->key_shares, i);
+        GUARD(s2n_connection_add_preferred_key_share(conn, *curve));
+    }
 
     conn->config = config;
 

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -304,3 +304,6 @@ extern int s2n_connection_get_protocol_preferences(struct s2n_connection *conn, 
 extern int s2n_connection_set_client_auth_type(struct s2n_connection *conn, s2n_cert_auth_type cert_auth_type);
 extern int s2n_connection_get_client_auth_type(struct s2n_connection *conn, s2n_cert_auth_type *client_cert_auth_type);
 extern int s2n_connection_get_client_cert_chain(struct s2n_connection *conn, uint8_t **der_cert_chain_out, uint32_t *cert_chain_len);
+
+int s2n_connection_clear_all_key_shares(struct s2n_connection *conn);
+int s2n_connection_add_preferred_key_share_by_group(struct s2n_connection *conn, uint16_t iana_id);

--- a/tls/s2n_crypto.h
+++ b/tls/s2n_crypto.h
@@ -72,6 +72,8 @@ struct s2n_crypto_parameters {
     struct s2n_ecc_evp_params server_ecc_evp_params;
     struct s2n_ecc_evp_params client_ecc_evp_params[S2N_ECC_EVP_SUPPORTED_CURVES_COUNT];
     const struct s2n_ecc_named_curve * mutually_supported_groups[S2N_ECC_EVP_SUPPORTED_CURVES_COUNT];
+    struct s2n_ecc_named_curve preferred_key_shares[S2N_ECC_EVP_SUPPORTED_CURVES_COUNT];
+    uint8_t preferred_key_shares_len;
     struct s2n_kem_keypair s2n_kem_keys;
     struct s2n_blob client_key_exchange_message;
     struct s2n_blob client_pq_kem_extension;

--- a/tls/s2n_handshake_transcript.c
+++ b/tls/s2n_handshake_transcript.c
@@ -33,8 +33,8 @@ int s2n_conn_post_handshake_hashes_update(struct s2n_connection *conn)
 
     switch(s2n_conn_get_current_message_type(conn)) {
     case SERVER_HELLO:
-        /* If we are sending a retry request, we didn't decide on a key share. There are no secrets to handle. */
-        if (s2n_server_requires_retry(conn)) {
+        /* If we are sending a retry request, or we just received a retry request, we didn't decide on a key share. There are no secrets to handle. */
+        if (s2n_server_requires_retry(conn) || s2n_server_hello_retry_is_valid(conn)) {
             break;
         }
 

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -242,7 +242,7 @@ int s2n_connection_set_session(struct s2n_connection *conn, const uint8_t *sessi
 
     DEFER_CLEANUP(struct s2n_blob session_data = {0}, s2n_free);
     GUARD(s2n_alloc(&session_data, length));
-    memcpy(session_data.data, session, length);
+    memcpy_check(session_data.data, session, length);
 
     struct s2n_stuffer from = {0};
     GUARD(s2n_stuffer_init(&from, &session_data));

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -248,6 +248,7 @@ int s2n_connection_set_session(struct s2n_connection *conn, const uint8_t *sessi
     GUARD(s2n_stuffer_init(&from, &session_data));
     GUARD(s2n_stuffer_write(&from, &session_data));
     GUARD(s2n_client_deserialize_resumption_state(conn, &from));
+
     return 0;
 }
 

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -177,10 +177,10 @@ int s2n_server_hello_recv(struct s2n_connection *conn)
     /* Read the message off the wire */
     GUARD(s2n_parse_server_hello(conn));
 
-    /* If this is a retry request, we have to move forward a little differently */
+    /* If this is a HelloRetryRequest, we don't process the ServerHello.
+     * Instead we proceed with retry logic. */
     if (s2n_server_hello_retry_is_valid(conn)) {
         GUARD(s2n_server_hello_retry_recv(conn));
-        conn->handshake.client_received_hrr = 1;
         return 0;
     }
 

--- a/utils/s2n_array.c
+++ b/utils/s2n_array.c
@@ -68,7 +68,8 @@ void *s2n_array_get(struct s2n_array *array, uint32_t index)
     return array->mem.data + array->element_size * index;
 }
 
-int s2n_array_insert_and_copy(struct s2n_array *array, void* element, uint32_t index)
+/* ISSUE 1657: Temporary change to allow single keyshare generation */
+int s2n_array_insert_and_copy(struct s2n_array *array, const void* element, uint32_t index)
 {
     void* insert_location = NULL;
     GUARD_NONNULL(insert_location = s2n_array_insert(array, index));

--- a/utils/s2n_array.h
+++ b/utils/s2n_array.h
@@ -41,4 +41,5 @@ extern void *s2n_array_insert(struct s2n_array *array, uint32_t index);
 extern int s2n_array_remove(struct s2n_array *array, uint32_t index);
 extern int s2n_array_free_p(struct s2n_array **parray);
 extern int s2n_array_free(struct s2n_array *array);
-extern int s2n_array_insert_and_copy(struct s2n_array *array, void* element, uint32_t index);
+/* ISSUE 1657: Temporary change to allow single keyshare generation */
+extern int s2n_array_insert_and_copy(struct s2n_array *array, const void* element, uint32_t index);

--- a/utils/s2n_init.c
+++ b/utils/s2n_init.c
@@ -41,7 +41,6 @@ int s2n_init(void)
     GUARD(s2n_rand_init());
     GUARD(s2n_cipher_suites_init());
     GUARD(s2n_cipher_preferences_init());
-    GUARD(s2n_client_key_share_init());
     GUARD(s2n_config_defaults_init());
 
     S2N_ERROR_IF(atexit(s2n_cleanup_atexit) != 0, S2N_ERR_ATEXIT);


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
#1630 

**Description of changes:** 
    Client Hello Retry Requests

     * Rewrite transcript after the HelloRetryRequest is received.
     * Remove POC api from config struct.
     * Client does not use keyshares when initiating a connection
       in order to force the server to issue a HelloRetryRequest.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
