### PR TITLE
Test: Clean up default config behavior (#1622) and update (#1575)

### DIFF
--- a/tests/testlib/s2n_hybrid_kem_tests.c
+++ b/tests/testlib/s2n_hybrid_kem_tests.c
@@ -65,7 +65,8 @@ int s2n_test_hybrid_ecdhe_kem_with_kat(const struct s2n_kem *kem, struct s2n_cip
 
     struct s2n_config *server_config, *client_config;
 
-    client_config = s2n_fetch_unsafe_client_testing_config();
+    GUARD_NONNULL(client_config = s2n_config_new());
+    GUARD(s2n_config_set_unsafe_for_testing(client_config));
     GUARD(s2n_connection_set_config(client_conn, client_config));
 
     /* Part 1.1 setup server's keypair and the give the client the certificate */
@@ -187,6 +188,7 @@ int s2n_test_hybrid_ecdhe_kem_with_kat(const struct s2n_kem *kem, struct s2n_cip
     GUARD(s2n_connection_free(client_conn));
     GUARD(s2n_connection_free(server_conn));
     GUARD(s2n_config_free(server_config));
+    GUARD(s2n_config_free(client_config));
     free(cert_chain);
     free(client_chain);
     free(private_key);

--- a/tests/unit/s2n_config_test.c
+++ b/tests/unit/s2n_config_test.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include <stdlib.h>
+#include <s2n.h>
+
+#include "crypto/s2n_fips.h"
+
+#include "tls/s2n_connection.h"
+#include "tls/s2n_cipher_preferences.h"
+#include "tls/s2n_config.h"
+#include "tls/s2n_tls13.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    const struct s2n_cipher_preferences *default_cipher_preferences, *tls13_cipher_preferences, *fips_cipher_preferences;
+    EXPECT_SUCCESS(s2n_find_cipher_pref_from_version("default_tls13", &tls13_cipher_preferences));
+    EXPECT_SUCCESS(s2n_find_cipher_pref_from_version("default_fips", &fips_cipher_preferences));
+    EXPECT_SUCCESS(s2n_find_cipher_pref_from_version("default", &default_cipher_preferences));
+
+    /* Test: s2n_config_new and tls13_default_config match */
+    {
+        struct s2n_config *config, *default_config;
+
+        EXPECT_NOT_NULL(config = s2n_config_new());
+        EXPECT_NOT_NULL(default_config = s2n_fetch_default_config());
+
+        /* s2n_config_new() matches s2n_fetch_default_config() */
+        EXPECT_EQUAL(default_config->cipher_preferences, config->cipher_preferences);
+        EXPECT_EQUAL(default_config->signature_preferences, config->signature_preferences);
+        EXPECT_EQUAL(default_config->client_cert_auth_type, config->client_cert_auth_type);
+
+        /* Calling s2n_fetch_default_config() repeatedly returns the same object */
+        EXPECT_EQUAL(default_config, s2n_fetch_default_config());
+
+        /* TLS1.3 default does not match non-TLS1.3 default */
+        EXPECT_SUCCESS(s2n_enable_tls13());
+        EXPECT_NOT_EQUAL(default_config, s2n_fetch_default_config());
+        EXPECT_SUCCESS(s2n_disable_tls13());
+
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
+    /* Connections created with default configs */
+    {
+        /* For TLS1.2 */
+        if (!s2n_is_in_fips_mode()) {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+            EXPECT_EQUAL(conn->config, s2n_fetch_default_config());
+            EXPECT_EQUAL(conn->config->cipher_preferences, default_cipher_preferences);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* For TLS1.3 */
+        {
+            EXPECT_SUCCESS(s2n_enable_tls13());
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+            EXPECT_EQUAL(conn->config, s2n_fetch_default_config());
+            EXPECT_EQUAL(conn->config->cipher_preferences, tls13_cipher_preferences);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_disable_tls13());
+        }
+
+        /* For fips */
+        if (s2n_is_in_fips_mode()) {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+            EXPECT_EQUAL(conn->config, s2n_fetch_default_config());
+            EXPECT_EQUAL(conn->config->cipher_preferences, fips_cipher_preferences);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_disable_tls13());
+        }
+    }
+
+    END_TEST();
+}

--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -182,8 +182,9 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
         EXPECT_SUCCESS(s2n_config_add_dhparams(server_config, dhparams_pem));
-    
-        client_config = s2n_fetch_unsafe_client_testing_config();
+
+        GUARD_NONNULL(client_config = s2n_config_new());
+        GUARD(s2n_config_set_unsafe_for_testing(client_config));
         
         EXPECT_SUCCESS(s2n_config_set_verification_ca_location(client_config, S2N_DEFAULT_TEST_CERT_CHAIN, NULL));
 
@@ -192,6 +193,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
         EXPECT_SUCCESS(s2n_config_free(server_config));
+        EXPECT_SUCCESS(s2n_config_free(client_config));
     }
 
     /*  Test: ECDSA cert */
@@ -203,12 +205,13 @@ int main(int argc, char **argv)
                 S2N_ECDSA_P384_PKCS1_CERT_CHAIN, S2N_ECDSA_P384_PKCS1_KEY));
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "test_all_ecdsa"));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
         EXPECT_SUCCESS(s2n_config_add_dhparams(server_config, dhparams_pem));
 
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "test_all_ecdsa"));
-
-        EXPECT_NOT_NULL(client_config = s2n_fetch_unsafe_client_ecdsa_testing_config());
+        EXPECT_NOT_NULL(client_config = s2n_config_new());
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "test_all_ecdsa"));
+        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(client_config));
 
         EXPECT_SUCCESS(s2n_config_set_verification_ca_location(client_config, S2N_ECDSA_P384_PKCS1_CERT_CHAIN, NULL));
         
@@ -217,6 +220,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
         EXPECT_SUCCESS(s2n_config_free(server_config));
+        EXPECT_SUCCESS(s2n_config_free(client_config));
     }
 
     /* Stop here if RSA_PSS unsupported */

--- a/tests/unit/s2n_tls13_handshake_test.c
+++ b/tests/unit/s2n_tls13_handshake_test.c
@@ -501,8 +501,10 @@ int main(int argc, char **argv)
         struct s2n_connection *client_conn;
         struct s2n_connection *server_conn;
 
-        struct s2n_config *server_config;
+        struct s2n_config *server_config, *client_config;
         EXPECT_NOT_NULL(server_config = s2n_config_new());
+        EXPECT_NOT_NULL(client_config = s2n_config_new());
+        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(client_config));
 
         char *cert_chain = NULL;
         char *private_key = NULL;
@@ -520,7 +522,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
-        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, s2n_fetch_unsafe_client_testing_config()));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
 
         struct s2n_stuffer client_to_server;
         struct s2n_stuffer server_to_client;
@@ -649,6 +651,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(default_cert));
         EXPECT_SUCCESS(s2n_config_free(server_config));
+        EXPECT_SUCCESS(s2n_config_free(client_config));
 
         free(private_key);
         free(cert_chain);

--- a/tests/unit/s2n_tls13_handshake_test.c
+++ b/tests/unit/s2n_tls13_handshake_test.c
@@ -374,8 +374,10 @@ int main(int argc, char **argv)
         struct s2n_connection *client_conn;
         struct s2n_connection *server_conn;
 
-        struct s2n_config *server_config;
+        struct s2n_config *server_config, *client_config;
         EXPECT_NOT_NULL(server_config = s2n_config_new());
+        EXPECT_NOT_NULL(client_config = s2n_config_new());
+        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(client_config));	
 
         char *cert_chain = NULL;
         char *private_key = NULL;
@@ -393,7 +395,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
-        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, s2n_fetch_unsafe_client_testing_config()));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
 
         struct s2n_stuffer client_to_server;
         struct s2n_stuffer server_to_client;
@@ -489,7 +491,8 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_config_free(server_config));
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(default_cert));
-
+        EXPECT_SUCCESS(s2n_config_free(client_config));
+	
         free(private_key);
         free(cert_chain);
     }

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -98,10 +98,9 @@ struct s2n_config {
     uint16_t max_verify_cert_chain_depth;
 };
 
+extern int s2n_config_defaults_init(void);
 extern struct s2n_config *s2n_fetch_default_config(void);
-extern struct s2n_config *s2n_fetch_default_fips_config(void);
-extern struct s2n_config *s2n_fetch_unsafe_client_testing_config(void);
-extern struct s2n_config *s2n_fetch_unsafe_client_ecdsa_testing_config(void);
+extern int s2n_config_set_unsafe_for_testing(struct s2n_config *config);
 
 extern int s2n_config_init_session_ticket_keys(struct s2n_config *config);
 extern int s2n_config_free_session_ticket_keys(struct s2n_config *config);

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -158,11 +158,7 @@ struct s2n_connection *s2n_connection_new(s2n_mode mode)
      */
     conn = (struct s2n_connection *)(void *)blob.data;
 
-    if (s2n_is_in_fips_mode()) {
-        s2n_connection_set_config(conn, s2n_fetch_default_fips_config());
-    } else {
-        s2n_connection_set_config(conn, s2n_fetch_default_config());
-    }
+    GUARD_PTR(s2n_connection_set_config(conn, s2n_fetch_default_config()));
 
     conn->mode = mode;
     conn->blinding = S2N_BUILT_IN_BLINDING;

--- a/tls/s2n_signature_scheme.c
+++ b/tls/s2n_signature_scheme.c
@@ -242,6 +242,7 @@ static struct {
     const struct s2n_signature_preferences *preferences;
 } selection[] = {
         {.version = "default", .preferences = &s2n_signature_preferences_20140601 },
+        {.version = "default_tls13", .preferences = &s2n_signature_preferences_20200207 },
         {.version = "20200207", .preferences = &s2n_signature_preferences_20200207 },
         {.version = "20140601", .preferences = &s2n_signature_preferences_20140601 },
         {.version = NULL, .preferences = NULL }, /* Sentinel */

--- a/utils/s2n_init.c
+++ b/utils/s2n_init.c
@@ -42,15 +42,9 @@ int s2n_init(void)
     GUARD(s2n_cipher_suites_init());
     GUARD(s2n_cipher_preferences_init());
     GUARD(s2n_client_key_share_init());
+    GUARD(s2n_config_defaults_init());
 
     S2N_ERROR_IF(atexit(s2n_cleanup_atexit) != 0, S2N_ERR_ATEXIT);
-
-    /* these functions do lazy init. Avoid the race conditions and just do it here. */
-    if (s2n_is_in_fips_mode()) {
-        s2n_fetch_default_fips_config();
-    } else {
-        s2n_fetch_default_config();
-    }
 
     /* Set the supported extension mask bits for each of the recognized
      * extensions */


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue #1622:** 

**Description of changes:** 
Cherry-picked commit for cleaning up default config behavior, addressing a merge conflict in tests/unit/s2n_handshake_test.c. Second commit (ea7d1bc) fixes:
```
s2n_tls13_handshake_test.c:396:63: error: passing argument 2 of ‘s2n_connection_set_config’ makes pointer from integer without a cast [-Werror=int-conversion]
  396 |         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, s2n_fetch_unsafe_client_testing_config()));
``` 
by updating code in tests/unit/s2n_tls13_handshake_test.c created by PR#1575 with the new client config for testing.

**Verification**
Verified on Ubuntu 18.04 with integration tests (S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=9) and ad-hoc s2nd/s2nc with ECDSA and RSA-PSS certificates.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
