### PR TITLE
TLS 1.3 Server and Encrypted Extensions Fixes Part 1

### DIFF
--- a/tests/unit/s2n_server_extensions_test.c
+++ b/tests/unit/s2n_server_extensions_test.c
@@ -51,6 +51,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
             struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
+            EXPECT_EQUAL(s2n_server_extensions_send_size(conn), 0);
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
             S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, 0);
             EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -62,11 +63,16 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
             struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
+
+            /* server name is sent when used */
             conn->server_name_used = 1;
+            EXPECT_EQUAL(s2n_server_extensions_send_size(conn), 4);
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
             S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, 4 + EXTENSION_LEN);
 
+            /* server name is not sent when not used */
             conn->server_name_used = 0;
+            EXPECT_EQUAL(s2n_server_extensions_send_size(conn), 0);
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
             S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, 0);
             EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -80,14 +86,81 @@ int main(int argc, char **argv)
             struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
             strcpy(conn->application_protocol, "h2");
             const uint8_t application_protocol_len = strlen(conn->application_protocol);
-            EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
 
             const uint8_t ALPN_LEN = 7 + application_protocol_len;
+            EXPECT_EQUAL(s2n_server_extensions_send_size(conn), ALPN_LEN);
+            EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
             S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, ALPN_LEN + EXTENSION_LEN);
 
             strcpy(conn->application_protocol, "");
+            EXPECT_EQUAL(s2n_server_extensions_send_size(conn), 0);
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
             S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, 0);
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Test Server Extensions Send - Maximum Fragment Length (MFL) */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+            struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
+
+            conn->mfl_code = 0;
+            EXPECT_EQUAL(s2n_server_extensions_send_size(conn), 0);
+            EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
+            S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, 0);
+
+            int MFL_EXT_SIZE = 2 + 2 + 1;
+            conn->mfl_code = S2N_TLS_MAX_FRAG_LEN_1024;
+            EXPECT_EQUAL(s2n_server_extensions_send_size(conn), MFL_EXT_SIZE);
+            EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
+            S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, MFL_EXT_SIZE + EXTENSION_LEN);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Test Server Extensions Send - Signed Certificate Timestamp extension */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+            struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
+
+            struct s2n_cert_chain_and_key fake_chain_and_key = {0};
+            static uint8_t sct_list[] = { 0xff, 0xff, 0xff };
+            s2n_blob_init(&fake_chain_and_key.sct_list, sct_list, sizeof(sct_list));
+
+            conn->ct_level_requested = S2N_CT_SUPPORT_REQUEST;
+            conn->handshake_params.our_chain_and_key = &fake_chain_and_key;
+
+            int size = 4 + sizeof(sct_list);
+            EXPECT_EQUAL(s2n_server_extensions_send_size(conn), size);
+            EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
+            S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, size + EXTENSION_LEN);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Test Server Extensions Send - OCSP Status Request */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+            struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
+
+            struct s2n_cert_chain_and_key fake_chain_and_key = {0};
+            static uint8_t fake_ocsp[] = { 0xff, 0xff, 0xff };
+            s2n_blob_init(&fake_chain_and_key.ocsp_status, fake_ocsp, sizeof(fake_ocsp));
+
+            conn->status_type = S2N_STATUS_REQUEST_OCSP;
+            conn->handshake_params.our_chain_and_key = &fake_chain_and_key;
+
+            int size = 4;
+            EXPECT_EQUAL(s2n_server_extensions_send_size(conn), size);
+            EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
+            S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, size + EXTENSION_LEN);
+
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }
 
@@ -97,11 +170,14 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
             struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
+
             conn->secure_renegotiation = 1;
+            EXPECT_EQUAL(s2n_server_extensions_send_size(conn), SECURE_RENEGOTIATION_SIZE);
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
             S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, SECURE_RENEGOTIATION_SIZE + EXTENSION_LEN);
 
             conn->secure_renegotiation = 0;
+            EXPECT_EQUAL(s2n_server_extensions_send_size(conn), 0);
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
             S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, 0);
             EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -113,11 +189,14 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
             struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
+
+            EXPECT_EQUAL(s2n_server_extensions_send_size(conn), 0);
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
             S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, 0);
 
             conn->config->use_tickets = 1;
             conn->session_ticket_status = S2N_NEW_TICKET;
+            EXPECT_EQUAL(s2n_server_extensions_send_size(conn), NEW_SESSION_TICKET_SIZE);
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
             S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, NEW_SESSION_TICKET_SIZE + EXTENSION_LEN);
             EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -139,22 +218,24 @@ int main(int argc, char **argv)
             conn->secure.client_ecc_evp_params[0].negotiated_curve = s2n_ecc_evp_supported_curves_list[0];
 
             uint8_t size = s2n_extensions_server_key_share_send_size(conn)
-                + s2n_extensions_server_supported_versions_size()
-                + EXTENSION_LEN;
+                + s2n_extensions_server_supported_versions_size();
 
+            EXPECT_EQUAL(s2n_server_extensions_send_size(conn), size);
             EXPECT_FAILURE(s2n_server_extensions_send(conn, hello_stuffer));
 
+            EXPECT_SUCCESS(s2n_stuffer_wipe(hello_stuffer));
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
 
-            EXPECT_SUCCESS(s2n_stuffer_skip_read(hello_stuffer, s2n_stuffer_data_available(hello_stuffer)));
+            EXPECT_EQUAL(s2n_server_extensions_send_size(conn), size);
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
 
-            S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, size);
+            S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, size + EXTENSION_LEN);
 
             /* Test that s2n_server_extensions_send() do not send extension < TLS13 */
             conn->actual_protocol_version = S2N_TLS12;
 
             s2n_stuffer_skip_read(hello_stuffer, s2n_stuffer_data_available(hello_stuffer));
+            EXPECT_EQUAL(s2n_server_extensions_send_size(conn), 0);
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
             S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, 0);
             EXPECT_SUCCESS(s2n_disable_tls13());
@@ -178,22 +259,24 @@ int main(int argc, char **argv)
             conn->secure.client_ecc_evp_params[0].negotiated_curve = s2n_ecc_evp_supported_curves_list[0];
             /* secure_renegotiation extension not send >=TLS13*/
             uint8_t size = s2n_extensions_server_key_share_send_size(conn)
-                + s2n_extensions_server_supported_versions_size()
-                + EXTENSION_LEN;
+                + s2n_extensions_server_supported_versions_size();
 
+            EXPECT_EQUAL(s2n_server_extensions_send_size(conn), size);
             EXPECT_FAILURE(s2n_server_extensions_send(conn, hello_stuffer));
 
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
 
             EXPECT_SUCCESS(s2n_stuffer_skip_read(hello_stuffer, s2n_stuffer_data_available(hello_stuffer)));
+            EXPECT_EQUAL(s2n_server_extensions_send_size(conn), size);
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
 
-            S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, size);
+            S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, size + EXTENSION_LEN);
 
             /* Only sending secure_renegotiation(if it is requested) < TLS13 */
             conn->actual_protocol_version = S2N_TLS12;
             uint8_t tls12_server_extension_size = SECURE_RENEGOTIATION_SIZE + EXTENSION_LEN;
             s2n_stuffer_skip_read(hello_stuffer, s2n_stuffer_data_available(hello_stuffer));
+            EXPECT_EQUAL(s2n_server_extensions_send_size(conn), SECURE_RENEGOTIATION_SIZE);
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
             S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, tls12_server_extension_size);
             EXPECT_SUCCESS(s2n_disable_tls13());
@@ -222,21 +305,24 @@ int main(int argc, char **argv)
             /* nst extension not send >=TLS13*/
             uint8_t size = s2n_extensions_server_key_share_send_size(conn)
                 + s2n_extensions_server_supported_versions_size()
-                + EXTENSION_LEN;
+            ;
 
+            EXPECT_EQUAL(s2n_server_extensions_send_size(conn), size);
             EXPECT_FAILURE(s2n_server_extensions_send(conn, hello_stuffer));
 
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
 
             EXPECT_SUCCESS(s2n_stuffer_skip_read(hello_stuffer, s2n_stuffer_data_available(hello_stuffer)));
+            EXPECT_EQUAL(s2n_server_extensions_send_size(conn), size);
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
 
-            S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, size);
+            S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, size + EXTENSION_LEN);
 
             /* Sending nst (if it is requested) < TLS13 */
             conn->actual_protocol_version = S2N_TLS12;
 
             s2n_stuffer_skip_read(hello_stuffer, s2n_stuffer_data_available(hello_stuffer));
+            EXPECT_EQUAL(s2n_server_extensions_send_size(conn), NEW_SESSION_TICKET_SIZE);
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
             uint8_t tls12_server_extension_size = NEW_SESSION_TICKET_SIZE + EXTENSION_LEN;
             S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, tls12_server_extension_size);
@@ -272,22 +358,24 @@ int main(int argc, char **argv)
             conn->secure.client_ecc_evp_params[0].negotiated_curve = s2n_ecc_evp_supported_curves_list[0];
 
             uint8_t size = s2n_extensions_server_key_share_send_size(conn)
-                + s2n_extensions_server_supported_versions_size()
-                + EXTENSION_LEN;
+                + s2n_extensions_server_supported_versions_size();
 
+            EXPECT_EQUAL(s2n_server_extensions_send_size(conn), size);
             EXPECT_FAILURE(s2n_server_extensions_send(conn, hello_stuffer));
 
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
 
             EXPECT_SUCCESS(s2n_stuffer_skip_read(hello_stuffer, s2n_stuffer_data_available(hello_stuffer)));
+            EXPECT_EQUAL(s2n_server_extensions_send_size(conn), size);
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
 
-            S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, size);
+            S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, size + EXTENSION_LEN);
 
             /* Test that s2n_server_extensions_send() do not send extension < TLS13 */
             conn->actual_protocol_version = S2N_TLS12;
 
             s2n_stuffer_skip_read(hello_stuffer, s2n_stuffer_data_available(hello_stuffer));
+            EXPECT_EQUAL(s2n_server_extensions_send_size(conn), 0);
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
             S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, 0);
             EXPECT_SUCCESS(s2n_disable_tls13());

--- a/tests/unit/s2n_server_extensions_test.c
+++ b/tests/unit/s2n_server_extensions_test.c
@@ -33,7 +33,8 @@ const uint8_t NEW_SESSION_TICKET_SIZE = 4;
 
 const uint8_t SUPPORTED_VERSION_SIZE = 6;
 const uint8_t P256_KEYSHARE_SIZE = ( 32 * 2 ) + 1 + 8;
-const uint8_t MIN_TLS13_EXTENSION_SIZE = P256_KEYSHARE_SIZE + SUPPORTED_VERSION_SIZE;
+const uint8_t MIN_TLS13_EXTENSION_SIZE = ( 32 * 2 ) + 1 + 8 + 6; /* expanded from
+                    P256_KEYSHARE_SIZE + SUPPORTED_VERSION_SIZE because gcc... */
 
 /* set up minimum parameters for a tls13 connection so server extensions can work */
 static int configure_tls13_connection(struct s2n_connection *conn)
@@ -81,7 +82,7 @@ int main(int argc, char **argv)
             struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
 
             /* server name size */
-            int size = 4;
+            const uint8_t size = 4;
 
             /* server name is sent when used */
             conn->server_name_used = 1;
@@ -150,7 +151,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
             S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, 0);
 
-            int MFL_EXT_SIZE = 2 + 2 + 1;
+            const uint8_t MFL_EXT_SIZE = 2 + 2 + 1;
             conn->mfl_code = S2N_TLS_MAX_FRAG_LEN_1024;
             EXPECT_EQUAL(s2n_server_extensions_send_size(conn), MFL_EXT_SIZE);
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
@@ -180,7 +181,7 @@ int main(int argc, char **argv)
 
             conn->ct_level_requested = S2N_CT_SUPPORT_REQUEST;
             conn->handshake_params.our_chain_and_key = &fake_chain_and_key;
-            int size = 4 + sizeof(sct_list);
+            const uint8_t size = 4 + sizeof(sct_list);
             EXPECT_EQUAL(s2n_server_extensions_send_size(conn), size);
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
             S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, size + EXTENSION_LEN);
@@ -210,7 +211,7 @@ int main(int argc, char **argv)
             conn->status_type = S2N_STATUS_REQUEST_OCSP;
             conn->handshake_params.our_chain_and_key = &fake_chain_and_key;
 
-            int size = 4;
+            const uint8_t size = 4;
             EXPECT_EQUAL(s2n_server_extensions_send_size(conn), size);
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
             S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, size + EXTENSION_LEN);
@@ -280,7 +281,7 @@ int main(int argc, char **argv)
             /* key_share_send() requires a negotiated_curve */
             conn->secure.client_ecc_evp_params[0].negotiated_curve = s2n_ecc_evp_supported_curves_list[0];
 
-            uint8_t size = P256_KEYSHARE_SIZE + SUPPORTED_VERSION_SIZE;
+            const uint8_t size = P256_KEYSHARE_SIZE + SUPPORTED_VERSION_SIZE;
 
             EXPECT_EQUAL(s2n_extensions_server_supported_versions_size(), SUPPORTED_VERSION_SIZE);
             EXPECT_EQUAL(s2n_extensions_server_key_share_send_size(conn), P256_KEYSHARE_SIZE);

--- a/tls/s2n_server_extensions.c
+++ b/tls/s2n_server_extensions.c
@@ -99,7 +99,7 @@ int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *
 {
     int total_size = s2n_server_extensions_send_size(conn);
 
-    GUARD(total_size);
+    GUARD(total_size >= 0 && total_size <= 65535);
 
     if (total_size == 0) {
         return 0;

--- a/tls/s2n_server_extensions.c
+++ b/tls/s2n_server_extensions.c
@@ -99,11 +99,11 @@ int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *
 {
     int total_size = s2n_server_extensions_send_size(conn);
 
-    GUARD(total_size >= 0 && total_size <= 65535);
-
+    GUARD(total_size);
     if (total_size == 0) {
         return 0;
     }
+    S2N_ERROR_IF(total_size > 65535, S2N_ERR_INTEGER_OVERFLOW);
 
     GUARD(s2n_stuffer_write_uint16(out, total_size));
 

--- a/tls/s2n_server_extensions.c
+++ b/tls/s2n_server_extensions.c
@@ -107,7 +107,7 @@ int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *
 
     GUARD(s2n_stuffer_write_uint16(out, total_size));
 
-    bool is_tls13_conn = conn->actual_protocol_version == S2N_TLS13;
+    const bool is_tls13_conn = conn->actual_protocol_version == S2N_TLS13;
 
     /* Write supported versions extension if TLS 1.3 or greater */
     if (is_tls13_conn) {

--- a/tls/s2n_server_extensions.c
+++ b/tls/s2n_server_extensions.c
@@ -50,21 +50,19 @@
         (conn)->actual_protocol_version < S2N_TLS13)
 
 /* compute size server extensions send requires */
-uint16_t s2n_server_extensions_send_size(struct s2n_connection *conn)
+int s2n_server_extensions_send_size(struct s2n_connection *conn)
 {
     uint16_t total_size = 0;
+    bool is_tls13_conn = conn->actual_protocol_version == S2N_TLS13;
 
     const uint8_t application_protocol_len = strlen(conn->application_protocol);
 
-    if (s2n_server_can_send_server_name(conn)) {
+    if (s2n_server_can_send_server_name(conn) && !is_tls13_conn) {
         total_size += 4;
     }
 
-    if (application_protocol_len) {
+    if (application_protocol_len && !is_tls13_conn) {
         total_size += 7 + application_protocol_len;
-    }
-    if (s2n_server_can_send_ocsp(conn)) {
-        total_size += 4;
     }
     if (s2n_server_can_send_secure_renegotiation(conn)) {
         total_size += 5;
@@ -74,10 +72,15 @@ uint16_t s2n_server_extensions_send_size(struct s2n_connection *conn)
         total_size += s2n_kex_server_extension_size(conn->secure.cipher_suite->key_exchange_alg, conn);
     }
 
-    if (s2n_server_can_send_sct_list(conn)) {
+    if (s2n_server_can_send_ocsp(conn) && !is_tls13_conn) {
+        total_size += 4;
+    }
+
+    if (s2n_server_can_send_sct_list(conn) && !is_tls13_conn) {
         total_size += 4 + conn->handshake_params.our_chain_and_key->sct_list.size;
     }
-    if (conn->mfl_code) {
+
+    if (conn->mfl_code && !is_tls13_conn) {
         total_size += 5;
     }
     if (s2n_server_can_send_nst(conn)) {
@@ -94,7 +97,9 @@ uint16_t s2n_server_extensions_send_size(struct s2n_connection *conn)
 
 int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    uint16_t total_size = s2n_server_extensions_send_size(conn);
+    int total_size = s2n_server_extensions_send_size(conn);
+
+    GUARD(total_size);
 
     if (total_size == 0) {
         return 0;
@@ -102,13 +107,15 @@ int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *
 
     GUARD(s2n_stuffer_write_uint16(out, total_size));
 
+    bool is_tls13_conn = conn->actual_protocol_version == S2N_TLS13;
+
     /* Write supported versions extension if TLS 1.3 or greater */
-    if (conn->actual_protocol_version >= S2N_TLS13) {
+    if (is_tls13_conn) {
         GUARD(s2n_extensions_server_supported_versions_send(conn, out));
     }
 
     /* Write server name extension */
-    if (s2n_server_can_send_server_name(conn)) {
+    if (s2n_server_can_send_server_name(conn) && !is_tls13_conn) {
         GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_SERVER_NAME));
         GUARD(s2n_stuffer_write_uint16(out, 0));
     }
@@ -129,7 +136,7 @@ int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *
     const uint8_t application_protocol_len = strlen(conn->application_protocol);
 
     /* Write ALPN extension */
-    if (application_protocol_len) {
+    if (application_protocol_len && !is_tls13_conn) {
         GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_ALPN));
         GUARD(s2n_stuffer_write_uint16(out, application_protocol_len + 3));
         GUARD(s2n_stuffer_write_uint16(out, application_protocol_len + 1));
@@ -138,20 +145,20 @@ int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *
     }
 
     /* Write OCSP extension */
-    if (s2n_server_can_send_ocsp(conn)) {
+    if (s2n_server_can_send_ocsp(conn) && !is_tls13_conn) {
         GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_STATUS_REQUEST));
         GUARD(s2n_stuffer_write_uint16(out, 0));
     }
 
     /* Write Signed Certificate Timestamp extension */
-    if (s2n_server_can_send_sct_list(conn)) {
+    if (s2n_server_can_send_sct_list(conn) && !is_tls13_conn) {
         GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_SCT_LIST));
         GUARD(s2n_stuffer_write_uint16(out, conn->handshake_params.our_chain_and_key->sct_list.size));
         GUARD(s2n_stuffer_write_bytes(out, conn->handshake_params.our_chain_and_key->sct_list.data,
                                       conn->handshake_params.our_chain_and_key->sct_list.size));
     }
 
-    if (conn->mfl_code) {
+    if (conn->mfl_code && !is_tls13_conn) {
         GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_MAX_FRAG_LEN));
         GUARD(s2n_stuffer_write_uint16(out, sizeof(uint8_t)));
         GUARD(s2n_stuffer_write_uint8(out, conn->mfl_code));

--- a/tls/s2n_server_extensions.c
+++ b/tls/s2n_server_extensions.c
@@ -52,8 +52,8 @@
 /* compute size server extensions send requires */
 int s2n_server_extensions_send_size(struct s2n_connection *conn)
 {
-    uint16_t total_size = 0;
-    bool is_tls13_conn = conn->actual_protocol_version == S2N_TLS13;
+    int total_size = 0;
+    const bool is_tls13_conn = conn->actual_protocol_version == S2N_TLS13;
 
     const uint8_t application_protocol_len = strlen(conn->application_protocol);
 

--- a/tls/s2n_tls.h
+++ b/tls/s2n_tls.h
@@ -75,7 +75,7 @@ extern int s2n_read_full_record(struct s2n_connection *conn, uint8_t * record_ty
 extern int s2n_recv_close_notify(struct s2n_connection *conn, s2n_blocked_status * blocked);
 extern int s2n_client_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *out);
 extern int s2n_client_extensions_recv(struct s2n_connection *conn, struct s2n_array *parsed_extensions);
-extern uint16_t s2n_server_extensions_send_size(struct s2n_connection *conn);
+extern int s2n_server_extensions_send_size(struct s2n_connection *conn);
 extern int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *out);
 extern int s2n_server_extensions_recv(struct s2n_connection *conn, struct s2n_blob *extensions);
 

--- a/tls/s2n_tls.h
+++ b/tls/s2n_tls.h
@@ -75,6 +75,7 @@ extern int s2n_read_full_record(struct s2n_connection *conn, uint8_t * record_ty
 extern int s2n_recv_close_notify(struct s2n_connection *conn, s2n_blocked_status * blocked);
 extern int s2n_client_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *out);
 extern int s2n_client_extensions_recv(struct s2n_connection *conn, struct s2n_array *parsed_extensions);
+extern uint16_t s2n_server_extensions_send_size(struct s2n_connection *conn);
 extern int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *out);
 extern int s2n_server_extensions_recv(struct s2n_connection *conn, struct s2n_blob *extensions);
 


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
#1641

**Description of changes:** 
- [x] part 0 - add tests
- [x] part 1 - disable bad tls13 server extensions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
