### PR TITLE
Fix pq-crypto incompatibility with Clang 3.9

### DIFF
--- a/pq-crypto/bike_r1/gf2x_mul.c
+++ b/pq-crypto/bike_r1/gf2x_mul.c
@@ -20,6 +20,9 @@
 // 3n/2 + 3n/4 + 3n/8 = 3(n/2 + n/4 + n/8) < 3n
 #  define SECURE_BUFFER_SIZE (3 * R_PADDED_SIZE)
 
+// Calculate number of uint64_t values needed to store SECURE_BUFFER_SIZE bytes. Rounding up to the next whole integer.
+#  define SECURE_BUFFER_SIZE_64_BIT  ((SECURE_BUFFER_SIZE / sizeof(uint64_t)) + ((SECURE_BUFFER_SIZE % sizeof(uint64_t)) != 0))
+
 // This functions assumes that n is even.
 _INLINE_ void
 karatzuba(OUT uint64_t *res,
@@ -75,7 +78,8 @@ gf2x_mod_mul(OUT uint64_t *res, IN const uint64_t *a, IN const uint64_t *b)
 {
   bike_static_assert((R_PADDED_QW % 2 == 0), karatzuba_n_is_odd);
 
-  ALIGN(sizeof(uint64_t)) uint8_t secure_buffer[SECURE_BUFFER_SIZE];
+  ALIGN(sizeof(uint64_t)) uint64_t secure_buffer[SECURE_BUFFER_SIZE_64_BIT];
+
   /* make sure we have the correct size allocation. */
   bike_static_assert(sizeof(secure_buffer) % sizeof(uint64_t) == 0,
                      secure_buffer_not_eligable_for_uint64_t);
@@ -85,7 +89,7 @@ gf2x_mod_mul(OUT uint64_t *res, IN const uint64_t *a, IN const uint64_t *b)
   // This function implicitly assumes that the size of res is 2*R_PADDED_QW.
   red(res);
 
-  secure_clean(secure_buffer, sizeof(secure_buffer));
+  secure_clean((uint8_t*)secure_buffer, sizeof(secure_buffer));
 
   return SUCCESS;
 }

--- a/pq-crypto/bike_r2/gf2x_mul.c
+++ b/pq-crypto/bike_r2/gf2x_mul.c
@@ -20,6 +20,9 @@
 // 3n/2 + 3n/4 + 3n/8 = 3(n/2 + n/4 + n/8) < 3n
 #  define SECURE_BUFFER_SIZE (3 * R_PADDED_SIZE)
 
+// Calculate number of uint64_t values needed to store SECURE_BUFFER_SIZE bytes. Rounding up to the next whole integer.
+#  define SECURE_BUFFER_SIZE_64_BIT  ((SECURE_BUFFER_SIZE / sizeof(uint64_t)) + ((SECURE_BUFFER_SIZE % sizeof(uint64_t)) != 0))
+
 // This functions assumes that n is even.
 _INLINE_ void
 karatzuba(OUT uint64_t *res,
@@ -75,7 +78,8 @@ gf2x_mod_mul(OUT uint64_t *res, IN const uint64_t *a, IN const uint64_t *b)
 {
   bike_static_assert((R_PADDED_QW % 2 == 0), karatzuba_n_is_odd);
 
-  ALIGN(sizeof(uint64_t)) uint8_t secure_buffer[SECURE_BUFFER_SIZE];
+  ALIGN(sizeof(uint64_t)) uint64_t secure_buffer[SECURE_BUFFER_SIZE_64_BIT];
+
   /* make sure we have the correct size allocation. */
   bike_static_assert(sizeof(secure_buffer) % sizeof(uint64_t) == 0,
                      secure_buffer_not_eligable_for_uint64_t);
@@ -85,7 +89,7 @@ gf2x_mod_mul(OUT uint64_t *res, IN const uint64_t *a, IN const uint64_t *b)
   // This function implicitly assumes that the size of res is 2*R_PADDED_QW.
   red(res);
 
-  secure_clean(secure_buffer, sizeof(secure_buffer));
+  secure_clean((uint8_t*)secure_buffer, sizeof(secure_buffer));
 
   return SUCCESS;
 }


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):**
CI for https://github.com/awslabs/aws-c-io/pull/245 was failing since latest s2n doesn't compile with Clang 3. 

```
/home/ANT.AMAZON.COM/aweibel/workspace/github/s2n/pq-crypto/bike_r1/gf2x_mul.c:83:37: error: cast from 'uint8_t *' (aka 'unsigned char *') to 'uint64_t *'
      (aka 'unsigned long *') increases required alignment from 1 to 8 [-Werror,-Wcast-align]
  karatzuba(res, a, b, R_PADDED_QW, (uint64_t *)secure_buffer);
```

**Description of changes:** 
Fixed issues that were causing Clang 3 to fail the build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
