### PR TITLE
Update the suppressions file to fix build failures

### DIFF
--- a/.travis/cppcheck_suppressions.txt
+++ b/.travis/cppcheck_suppressions.txt
@@ -18,6 +18,5 @@ redundantAssignment:tests/unit/s2n_timer_test.c
 // Reason: Cppcheck complains if you add a cppcheck-suppression that doesn't suppress anything, but different versions of cppcheck catch different issues. So ignore complaints about unneccessary cppcheck suppressions.
 unmatchedSuppression:*
 
-// cppcheck Message: [crypto/s2n_aead_cipher_chacha20_poly1305.c:163]: (error:syntaxError) syntax error
-// Reason: Cppcheck is not able to parse certain struct initialization syntaxes and complains that it can't tell if there might be a bug. Ignore these errors.
-syntaxError:*
+// This suppression is failing unless we list it twice.
+unmatchedSuppression:*

--- a/codebuild/bin/cppcheck_suppressions.txt
+++ b/codebuild/bin/cppcheck_suppressions.txt
@@ -18,6 +18,5 @@ redundantAssignment:tests/unit/s2n_timer_test.c
 // Reason: Cppcheck complains if you add a cppcheck-suppression that doesn't suppress anything, but different versions of cppcheck catch different issues. So ignore complaints about unneccessary cppcheck suppressions.
 unmatchedSuppression:*
 
-// cppcheck Message: [crypto/s2n_aead_cipher_chacha20_poly1305.c:163]: (error:syntaxError) syntax error
-// Reason: Cppcheck is not able to parse certain struct initialization syntaxes and complains that it can't tell if there might be a bug. Ignore these errors.
-syntaxError:*
+// This suppression is failing unless we list it twice.
+unmatchedSuppression:*


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
cppcheck was failing our builds.


**Description of changes:** 
A change was made which removed the need for the syntaxError suppressions. After removing this suppression, the unmatchedSuppressions suppression failed due to not matching the ConfigurationNotChecked suppressions. However, the ConfigurationNotChecked suppression is still needed.

Duplication the unmatchedSuppression line seems to have mitigated this, allowing us to build again.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
