### PR TITLE
Update integration tests to support s2n built with BoringSSL and add C…

### DIFF
--- a/.travis/s2n_setup_env.sh
+++ b/.travis/s2n_setup_env.sh
@@ -36,6 +36,7 @@
 : "${OPENSSL_1_1_1_INSTALL_DIR:=$(pwd)/test-deps/openssl-1.1.1}"
 : "${OPENSSL_1_0_2_INSTALL_DIR:=$(pwd)/test-deps/openssl-1.0.2}"
 : "${OPENSSL_1_0_2_FIPS_INSTALL_DIR:=$(pwd)/test-deps/openssl-1.0.2-fips}"
+: "${BORINGSSL_INSTALL_DIR:=$(pwd)/test-deps/boringssl}"
 : "${LIBRESSL_INSTALL_DIR:=$(pwd)/test-deps/libressl-2.6.4}"
 : "${CPPCHECK_INSTALL_DIR:=$(pwd)/test-deps/cppcheck}"
 : "${CTVERIF_INSTALL_DIR:=$(pwd)/test-deps/ctverif}"
@@ -70,6 +71,7 @@ export OPENSSL_0_9_8_INSTALL_DIR
 export OPENSSL_1_1_1_INSTALL_DIR
 export OPENSSL_1_0_2_INSTALL_DIR
 export OPENSSL_1_0_2_FIPS_INSTALL_DIR
+export BORINGSSL_INSTALL_DIR
 export LIBRESSL_INSTALL_DIR
 export CPPCHECK_INSTALL_DIR
 export CTVERIF_INSTALL_DIR
@@ -90,6 +92,7 @@ if [[ "$S2N_LIBCRYPTO" == "openssl-1.0.2-fips" ]]; then
     export LIBCRYPTO_ROOT=$OPENSSL_1_0_2_FIPS_INSTALL_DIR ; 
     export S2N_TEST_IN_FIPS_MODE=1 ; 
 fi
+if [[ "$S2N_LIBCRYPTO" == "boringssl" ]]; then export LIBCRYPTO_ROOT=$BORINGSSL_INSTALL_DIR ; fi
 
 if [[ "$S2N_LIBCRYPTO" == "libressl" ]]; then export LIBCRYPTO_ROOT=$LIBRESSL_INSTALL_DIR ; fi
 

--- a/codebuild/bin/install_boringssl.sh
+++ b/codebuild/bin/install_boringssl.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+set -ex
+pushd "$(pwd)"
+
+usage() {
+    echo "install_boringssl.sh build_dir install_dir"
+    exit 1
+}
+
+if [ "$#" -ne "2" ]; then
+    usage
+fi
+
+BUILD_DIR=$1
+INSTALL_DIR=$2
+source codebuild/bin/jobs.sh
+
+cd "$BUILD_DIR"
+git clone https://github.com/google/boringssl.git
+mkdir build
+cd build
+
+cmake ../boringssl
+make -j $JOBS
+
+mkdir -p "${INSTALL_DIR}/lib"
+cp crypto/libcrypto.a "${INSTALL_DIR}/lib/libcrypto.a"
+cp -r ../boringssl/include "$INSTALL_DIR"
+
+popd
+
+exit 0

--- a/codebuild/bin/s2n_setup_env.sh
+++ b/codebuild/bin/s2n_setup_env.sh
@@ -37,6 +37,7 @@
 : "${OPENSSL_1_1_1_INSTALL_DIR:=$(pwd)/test-deps/openssl-1.1.1}"
 : "${OPENSSL_1_0_2_INSTALL_DIR:=$(pwd)/test-deps/openssl-1.0.2}"
 : "${OPENSSL_1_0_2_FIPS_INSTALL_DIR:=$(pwd)/test-deps/openssl-1.0.2-fips}"
+: "${BORINGSSL_INSTALL_DIR:=$(pwd)/test-deps/boringssl}"
 : "${LIBRESSL_INSTALL_DIR:=$(pwd)/test-deps/libressl-2.6.4}"
 : "${CPPCHECK_INSTALL_DIR:=$(pwd)/test-deps/cppcheck}"
 : "${CTVERIF_INSTALL_DIR:=$(pwd)/test-deps/ctverif}"
@@ -65,6 +66,7 @@ export OPENSSL_0_9_8_INSTALL_DIR
 export OPENSSL_1_1_1_INSTALL_DIR
 export OPENSSL_1_0_2_INSTALL_DIR
 export OPENSSL_1_0_2_FIPS_INSTALL_DIR
+export BORINGSSL_INSTALL_DIR
 export LIBRESSL_INSTALL_DIR
 export CPPCHECK_INSTALL_DIR
 export CTVERIF_INSTALL_DIR
@@ -88,6 +90,7 @@ if [[ "$S2N_LIBCRYPTO" == "openssl-1.0.2-fips" ]]; then
     export LIBCRYPTO_ROOT=$OPENSSL_1_0_2_FIPS_INSTALL_DIR ; 
     export S2N_TEST_IN_FIPS_MODE=1 ; 
 fi
+if [[ "$S2N_LIBCRYPTO" == "boringssl" ]]; then export LIBCRYPTO_ROOT=$BORINGSSL_INSTALL_DIR ; fi
 
 if [[ "$S2N_LIBCRYPTO" == "libressl" ]]; then export LIBCRYPTO_ROOT=$LIBRESSL_INSTALL_DIR ; fi
 
@@ -105,6 +108,7 @@ fi
 echo "UID=$UID"
 echo "OS_NAME=$OS_NAME"
 echo "S2N_LIBCRYPTO=$S2N_LIBCRYPTO"
+echo "LIBCRYPTO_ROOT=$LIBCRYPTO_ROOT"
 echo "BUILD_S2N=$BUILD_S2N"
 echo "GCC_VERSION=$GCC_VERSION"
 echo "LATEST_CLANG=$LATEST_CLANG"

--- a/codebuild/codebuild.config
+++ b/codebuild/codebuild.config
@@ -70,6 +70,10 @@ env: S2N_LIBCRYPTO=openssl-1.0.2-fips BUILD_S2N=true TESTS=integration GCC_VERSI
 snippet: UbuntuBoilerplate2XL
 env: S2N_LIBCRYPTO=openssl-1.1.1 OPENSSL_ia32cap="~0x200000200000000" BUILD_S2N=true TESTS=integration GCC_VERSION=6
 
+[CodeBuild:s2nIntegrationBoringSSLGcc9]
+snippet: UbuntuBoilerplate2XL
+env: S2N_LIBCRYPTO=boringssl BUILD_S2N=true TESTS=integration GCC_VERSION=9
+
 # Unit Test
 [CodeBuild:s2nUnitOpenSSL111Gcc6]
 snippet: UbuntuBoilerplateLarge

--- a/tests/integration/common/s2n_test_scenario.py
+++ b/tests/integration/common/s2n_test_scenario.py
@@ -90,7 +90,8 @@ ALL_CIPHERS = [
     Cipher("TLS_AES_128_GCM_SHA256", Version.TLS13)
 ]
 
-# Older Openssl and libressl do not support CHACHA20
+# Older versions of Openssl do not support CHACHA20. Current versions of LibreSSL and BoringSSL use a different API
+# that is unsupported by s2n.
 LEGACY_COMPATIBLE_CIPHERS = list(filter(lambda x: "CHACHA20" not in x.name, ALL_CIPHERS))
 
 ALL_CIPHERS_PER_LIBCRYPTO_VERSION = {
@@ -98,6 +99,7 @@ ALL_CIPHERS_PER_LIBCRYPTO_VERSION = {
     "openssl-1.0.2"         : LEGACY_COMPATIBLE_CIPHERS,
     "openssl-1.0.2-fips"    : LEGACY_COMPATIBLE_CIPHERS,
     "libressl"              : LEGACY_COMPATIBLE_CIPHERS,
+    "boringssl"             : LEGACY_COMPATIBLE_CIPHERS,
 }
 
 

--- a/tests/integration/s2n_dynamic_record_size_test.py
+++ b/tests/integration/s2n_dynamic_record_size_test.py
@@ -263,7 +263,7 @@ def main():
     parser = argparse.ArgumentParser(description='Runs TLS server integration tests against Openssl s_server using s2nc')
     parser.add_argument('host', help='The host for s2nc to connect to')
     parser.add_argument('port', type=int, help='The port for s_server to bind to')
-    parser.add_argument('--libcrypto', default='openssl-1.1.1', choices=['openssl-1.0.2', 'openssl-1.0.2-fips', 'openssl-1.1.1', 'libressl'],
+    parser.add_argument('--libcrypto', default='openssl-1.1.1', choices=S2N_LIBCRYPTO_CHOICES,
             help="""The Libcrypto that s2n was built with. s2n supports different cipher suites depending on
                     libcrypto version. Defaults to openssl-1.1.1.""")
     args = parser.parse_args()

--- a/tests/integration/s2n_handshake_test_gnutls-cli.py
+++ b/tests/integration/s2n_handshake_test_gnutls-cli.py
@@ -150,7 +150,7 @@ def main():
     parser = argparse.ArgumentParser(description='Runs TLS server integration tests against s2nd using gnutls-cli')
     parser.add_argument('host', help='The host for s2nd to bind to')
     parser.add_argument('port', type=int, help='The port for s2nd to bind to')
-    parser.add_argument('--libcrypto', default='openssl-1.1.1', choices=['openssl-1.0.2', 'openssl-1.0.2-fips', 'openssl-1.1.1', 'libressl'],
+    parser.add_argument('--libcrypto', default='openssl-1.1.1', choices=S2N_LIBCRYPTO_CHOICES,
             help="""The Libcrypto that s2n was built with. s2n supports different cipher suites depending on
                     libcrypto version. Defaults to openssl-1.1.1.""")
     args = parser.parse_args()

--- a/tests/integration/s2n_handshake_test_gnutls-serv.py
+++ b/tests/integration/s2n_handshake_test_gnutls-serv.py
@@ -132,7 +132,7 @@ def main():
     parser = argparse.ArgumentParser(description='Runs TLS server integration tests against s2nd using gnutls-cli')
     parser.add_argument('host', help='The host for gnutls-serv to bind to')
     parser.add_argument('port', type=int, help='The port for gnutls-serv to bind to')
-    parser.add_argument('--libcrypto', default='openssl-1.1.1', choices=['openssl-1.0.2', 'openssl-1.0.2-fips', 'openssl-1.1.1', 'libressl'],
+    parser.add_argument('--libcrypto', default='openssl-1.1.1', choices=S2N_LIBCRYPTO_CHOICES,
             help="""The Libcrypto that s2n was built with. s2n supports different cipher suites depending on
                     libcrypto version. Defaults to openssl-1.1.1.""")
     args = parser.parse_args()

--- a/tests/integration/s2n_handshake_test_old_s_client.py
+++ b/tests/integration/s2n_handshake_test_old_s_client.py
@@ -332,7 +332,7 @@ def main():
     parser.add_argument('host', help='The host for s2nd to bind to')
     parser.add_argument('port', type=int, help='The port for s2nd to bind to')
     parser.add_argument('--use_corked_io', action='store_true', help='Turn corked IO on/off')
-    parser.add_argument('--libcrypto', default='openssl-1.1.1', choices=['openssl-1.0.2', 'openssl-1.0.2-fips', 'openssl-1.1.1', 'libressl'],
+    parser.add_argument('--libcrypto', default='openssl-1.1.1', choices=S2N_LIBCRYPTO_CHOICES,
             help="""The Libcrypto that s2n was built with. s2n supports different cipher suites depending on
                     libcrypto version. Defaults to openssl-1.1.1.""")
     args = parser.parse_args()

--- a/tests/integration/s2n_handshake_test_s_client.py
+++ b/tests/integration/s2n_handshake_test_s_client.py
@@ -799,7 +799,7 @@ def main():
     parser.add_argument('host', help='The host for s2nd to bind to')
     parser.add_argument('port', type=int, help='The port for s2nd to bind to')
     parser.add_argument('--use_corked_io', action='store_true', help='Turn corked IO on/off')
-    parser.add_argument('--libcrypto', default='openssl-1.1.1', choices=['openssl-1.0.2', 'openssl-1.0.2-fips', 'openssl-1.1.1', 'libressl'],
+    parser.add_argument('--libcrypto', default='openssl-1.1.1', choices=S2N_LIBCRYPTO_CHOICES,
             help="""The Libcrypto that s2n was built with. s2n supports different cipher suites depending on
                     libcrypto version. Defaults to openssl-1.1.1.""")
     args = parser.parse_args()

--- a/tests/integration/s2n_handshake_test_s_server.py
+++ b/tests/integration/s2n_handshake_test_s_server.py
@@ -331,7 +331,7 @@ def main():
     parser.add_argument('host', help='The host for s2nc to connect to')
     parser.add_argument('port', type=int, help='The port for s_server to bind to')
     parser.add_argument('--use_corked_io', action='store_true', help='Turn corked IO on/off')
-    parser.add_argument('--libcrypto', default='openssl-1.1.1', choices=['openssl-1.0.2', 'openssl-1.0.2-fips', 'openssl-1.1.1', 'libressl'],
+    parser.add_argument('--libcrypto', default='openssl-1.1.1', choices=S2N_LIBCRYPTO_CHOICES,
             help="""The Libcrypto that s2n was built with. s2n supports different cipher suites depending on
                     libcrypto version. Defaults to openssl-1.1.1.""")
     args = parser.parse_args()

--- a/tests/integration/s2n_sslyze_test.py
+++ b/tests/integration/s2n_sslyze_test.py
@@ -120,7 +120,7 @@ def main():
     parser = argparse.ArgumentParser(description='Runs SSLyze scan against s2nd')
     parser.add_argument('host', help='The host for s2nd to bind to')
     parser.add_argument('port', type=int, help='The port for s2nd to bind to')
-    parser.add_argument('--libcrypto', default='openssl-1.1.1', choices=['openssl-1.0.2', 'openssl-1.0.2-fips', 'openssl-1.1.1', 'libressl'],
+    parser.add_argument('--libcrypto', default='openssl-1.1.1', choices=S2N_LIBCRYPTO_CHOICES,
             help="""The Libcrypto that s2n was built with. s2n supports different cipher suites depending on
                     libcrypto version. Defaults to openssl-1.1.1.""")
     args = parser.parse_args()

--- a/tests/integration/s2n_test_constants.py
+++ b/tests/integration/s2n_test_constants.py
@@ -96,9 +96,10 @@ OPENSSL_1_0_2_TEST_CIPHERS = list(filter(lambda x: "CHACHA20" not in x.openssl_n
 # Test ciphers to use when s2n is built with Openssl 1.0.2 libcrypto that is linked with a FIPS module.
 OPENSSL_1_0_2_FIPS_TEST_CIPHERS = list(filter(lambda x: x.openssl_fips_compatible == True, ALL_TEST_CIPHERS))
 
-# Test ciphers to use when s2n is built with LibreSSL libcrypto. s2n does not implement the
-# ChaCha20-Poly1305 cipher offered by LibreSSL.
+# Test ciphers to use when s2n is built with LibreSSL or BoringSSL libcrypto. s2n does not implement the
+# ChaCha20-Poly1305 cipher offered by these libcryptos.
 LIBRESSL_TEST_CIPHERS = list(filter(lambda x: "CHACHA20" not in x.openssl_name, ALL_TEST_CIPHERS))
+BORINGSSL_TEST_CIPHERS = list(filter(lambda x: "CHACHA20" not in x.openssl_name, ALL_TEST_CIPHERS))
 
 # Dictionary to look up ciphers to use by libcrypto s2n is built with.
 # Libcrypto string will be an argument to test scripts.
@@ -107,7 +108,10 @@ S2N_LIBCRYPTO_TO_TEST_CIPHERS = {
     "openssl-1.0.2"         : OPENSSL_1_0_2_TEST_CIPHERS,
     "openssl-1.0.2-fips"    : OPENSSL_1_0_2_FIPS_TEST_CIPHERS,
     "libressl"              : LIBRESSL_TEST_CIPHERS,
+    "boringssl"             : BORINGSSL_TEST_CIPHERS,
 }
+
+S2N_LIBCRYPTO_CHOICES = ['openssl-1.0.2', 'openssl-1.0.2-fips', 'openssl-1.1.1', 'libressl', 'boringssl']
 
 S2N_PROTO_VERS_TO_STR = {
     S2N_SSLv3 : "SSLv3",


### PR DESCRIPTION
…odeBuild config to run a full s2n unit and integration test

_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
https://github.com/awslabs/s2n/issues/613
**Description of changes:** 
https://github.com/awslabs/s2n/pull/1621 added back support for BoringSSL. This change adds CI and test support to ensure BoringSSL compatibility is maintained. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
