### PR TITLE
fix: Role policy was incorrect

### DIFF
--- a/codebuild/create_project.py
+++ b/codebuild/create_project.py
@@ -23,7 +23,7 @@ from awacs.sts import AssumeRole
 from random import randrange
 from troposphere import GetAtt, Template, Ref, Output
 from troposphere.events import Rule, Target
-from troposphere.iam import Role
+from troposphere.iam import Role, Policy
 from troposphere.codebuild import Artifacts, Environment, Source, Project
 
 logging.getLogger(__name__)
@@ -65,14 +65,27 @@ def build_cw_cb_role(template=None, role_name="s2nEventsInvokeCodeBuildRole"):
                 Statement=[
                     Statement(
                         Effect=Allow,
-                        Action=[Action("codebuild", "StartBuild"),
+                        Action=[Action("sts", "AssumeRole"),
                                 ],
+                        Principal=Principal("Service",["events.amazonaws.com"])
+                    )
+                ]
+            ),
+            Policies=[ Policy(
+                PolicyName=f"EventsInvokeCBRole",
+                PolicyDocument=PolicyDocument(
+                Statement=[
+                    Statement(
+                        Effect=Allow,
+                        Action=[Action("codebuild", "StartBuild")],
                         Resource=[
                             "arn:aws:codebuild:us-west-2:024603541914:project/*",
                         ]
                     )
                 ]
+                )
             )
+            ]
         )
     )
     return role_id


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Description of changes:** 
The CloudFormation for the Event Role policy was incorrect; this fixes it so the schedule jobs have permission to run.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
