### PR TITLE
Fail integ tests on error

### DIFF
--- a/tests/integration/Makefile
+++ b/tests/integration/Makefile
@@ -29,7 +29,7 @@ ifeq ($(S2N_CORKED_IO),true)
 endif
 
 .PHONY : all
-all: tls13 client_endpoints dynamic_record old_s_client s_client s_server gnutls_cli gnutls_serv sslyze pq_handshake
+all: client_endpoints dynamic_record old_s_client s_client s_server gnutls_cli gnutls_serv sslyze pq_handshake
 
 tls13:
 	( \

--- a/tests/integration/common/s2n_test_openssl.py
+++ b/tests/integration/common/s2n_test_openssl.py
@@ -77,6 +77,6 @@ def get_openssl(scenario):
     return openssl
 
 
-def run_openssl_connection_test(scenarios, test_func=None):
-    return util.run_connection_test(get_openssl, scenarios, test_func)
+def run_openssl_connection_test(scenarios, **kwargs):
+    return util.run_connection_test(get_openssl, scenarios, **kwargs)
 


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** https://github.com/awslabs/s2n/issues/1659

**Description of changes:** Quick fix to fail the test if any errors are produced. Also prints more than just the first line of stderr.

Example output after:
```
Mode:client  Version:TLS13   Curve:P-256 Cipher:TLS_CHACHA20_POLY1305_SHA256                         PASSED
Mode:server  Version:TLS13   Curve:P-256 Cipher:TLS_CHACHA20_POLY1305_SHA256                         FAILED
	Can't use SSL_get_servername
	depth=0 C = US, ST = WA, L = Seattle, O = Amazon, OU = s2n, CN = localhost
	verify error:num=20:unable to get local issuer certificate
	verify return:1
	depth=0 C = US, ST = WA, L = Seattle, O = Amazon, OU = s2n, CN = localhost
	verify error:num=21:unable to verify the first certificate
	verify return:1
	139660335171328:error:1414D17A:SSL routines:tls12_check_peer_sigalg:wrong curve:ssl/t1_lib.c:1053:
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
