### PR TITLE
tls1.3 integ tests run basic echo test by default

### DIFF
--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -242,7 +242,7 @@ int main(int argc, char *const *argv)
     static struct option long_options[] = {
         {"alpn", required_argument, 0, 'a'},
         {"ciphers", required_argument, 0, 'c'},
-        {"echo", required_argument, 0, 'e'},
+        {"echo", no_argument, 0, 'e'},
         {"help", no_argument, 0, 'h'},
         {"name", required_argument, 0, 'n'},
         {"status", no_argument, 0, 's'},
@@ -453,6 +453,8 @@ int main(int argc, char *const *argv)
         }
 
         if (echo_input == 1) {
+            fflush(stdout);
+            fflush(stderr);
             echo(conn, sockfd);
         }
 

--- a/tests/integration/Makefile
+++ b/tests/integration/Makefile
@@ -29,7 +29,7 @@ ifeq ($(S2N_CORKED_IO),true)
 endif
 
 .PHONY : all
-all: tls13 client_endpoints dynamic_record old_s_client s_client s_server gnutls_cli gnutls_serv sslyze pq_handshake
+all: client_endpoints dynamic_record old_s_client s_client s_server gnutls_cli gnutls_serv sslyze pq_handshake
 
 tls13:
 	( \

--- a/tests/integration/Makefile
+++ b/tests/integration/Makefile
@@ -29,7 +29,7 @@ ifeq ($(S2N_CORKED_IO),true)
 endif
 
 .PHONY : all
-all: client_endpoints dynamic_record old_s_client s_client s_server gnutls_cli gnutls_serv sslyze pq_handshake
+all: tls13 client_endpoints dynamic_record old_s_client s_client s_server gnutls_cli gnutls_serv sslyze pq_handshake
 
 tls13:
 	( \

--- a/tests/integration/common/s2n_test_common.py
+++ b/tests/integration/common/s2n_test_common.py
@@ -55,14 +55,14 @@ def get_process(cmd):
 
 
 def basic_write_test(server, client):
-    server_msg = "Message:"+str(uuid.uuid4())
+    server_msg = "Message:" + str(uuid.uuid4())
     server.stdin.write((server_msg + "\n\n").encode("utf-8"))
     server.stdin.flush()
 
     if not wait_for_output(client, server_msg, line_limit=100):
         return Result("Failed to write '%s' from server to client" % (server_msg))
 
-    client_msg = "Message:"+str(uuid.uuid4())
+    client_msg = "Message:" + str(uuid.uuid4())
     client.stdin.write((client_msg + "\n\n").encode("utf-8"))
     client.stdin.flush()
 

--- a/tests/integration/common/s2n_test_common.py
+++ b/tests/integration/common/s2n_test_common.py
@@ -18,14 +18,22 @@ Common functions to run s2n integration tests.
 """
 
 import subprocess
+import uuid
 
 from common.s2n_test_scenario import Mode, Version, run_scenarios
 from common.s2n_test_reporting import Result
 from s2n_test_constants import TEST_ECDSA_CERT, TEST_ECDSA_KEY
 
 
-def get_error(process):
-    return process.stderr.readline().decode("utf-8")
+def get_error(process, line_limit=10):
+    error = ""
+    for count in range(line_limit):
+        line = process.stderr.readline().decode("utf-8")
+        if line:
+            error += line + "\t"
+        else:
+            return error
+    return error
 
 
 def wait_for_output(process, marker, line_limit=10):
@@ -46,6 +54,24 @@ def get_process(cmd):
     return subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
 
+def basic_write_test(server, client):
+    server_msg = "Message:"+str(uuid.uuid4())
+    server.stdin.write((server_msg + "\n\n").encode("utf-8"))
+    server.stdin.flush()
+
+    if not wait_for_output(client, server_msg, line_limit=100):
+        return Result("Failed to write '%s' from server to client" % (server_msg))
+
+    client_msg = "Message:"+str(uuid.uuid4())
+    client.stdin.write((client_msg + "\n\n").encode("utf-8"))
+    client.stdin.flush()
+
+    if not wait_for_output(server, client_msg, line_limit=100):
+        return Result("Failed to write %s from client to server" % (client_msg))
+
+    return Result()
+
+
 def connect(get_peer, scenario):
     """
     Perform a handshake between s2n and another TLS process.
@@ -64,7 +90,7 @@ def connect(get_peer, scenario):
     return (server, client)
 
 
-def run_connection_test(get_peer, scenarios, test_func=None):
+def run_connection_test(get_peer, scenarios, test_func=basic_write_test):
     """
     For each scenarios, s2n will attempt to perform a handshake with another TLS process
     and then run the given test.
@@ -85,19 +111,25 @@ def run_connection_test(get_peer, scenarios, test_func=None):
     def __test(scenario):
         client = None
         server = None
+        result = Result("Unknown Error")
         try:
             server, client = connect(get_peer, scenario)
             result = test_func(server, client) if test_func else Result()
-            if client.poll():
-                raise AssertionError("Client process crashed")
-            if server.poll():
-                raise AssertionError("Server process crashed")
 
-            return result
+            if result.is_success() and client.poll() is not None:
+                result = Result("Client process crashed")
+            if result.is_success() and server.poll() is not None:
+                result = Result("Server process crashed")
+
         except AssertionError as error:
-            return Result(error)
+            result = Result(error)
         finally:
             cleanup_processes(server, client)
+            if client:
+                result.client_error = get_error(client)
+            if server:
+                result.server_error = get_error(server)
+            return result
 
     return run_scenarios(__test, scenarios)
 
@@ -112,6 +144,8 @@ def get_s2n_cmd(scenario):
     if scenario.s2n_mode.is_server():
         s2n_cmd.extend(["--key", TEST_ECDSA_KEY])
         s2n_cmd.extend(["--cert", TEST_ECDSA_CERT])
+    else:
+        s2n_cmd.append("--echo")
 
     if scenario.version is Version.TLS13:
         s2n_cmd.append("--tls13")

--- a/tests/integration/common/s2n_test_openssl.py
+++ b/tests/integration/common/s2n_test_openssl.py
@@ -77,6 +77,6 @@ def get_openssl(scenario):
     return openssl
 
 
-def run_openssl_connection_test(scenarios, test_func=None):
-    return util.run_connection_test(get_openssl, scenarios, test_func)
+def run_openssl_connection_test(scenarios, **kwargs):
+    return util.run_connection_test(get_openssl, scenarios, **kwargs)
 

--- a/tests/integration/common/s2n_test_reporting.py
+++ b/tests/integration/common/s2n_test_reporting.py
@@ -49,7 +49,7 @@ class Result:
         self.error_msg = error_msg
         self.client_error = None
         self.server_error = None
-        self.status = Status.PASSED if error_msg == None else Status.FAILED
+        self.status = Status.PASSED if error_msg is None else Status.FAILED
 
     def is_success(self):
         return self.status is not Status.FAILED

--- a/tests/integration/common/s2n_test_reporting.py
+++ b/tests/integration/common/s2n_test_reporting.py
@@ -21,13 +21,18 @@ import sys
 from enum import Enum
 
 
+class Color(Enum):
+    RED = 31
+    GREEN = 32
+
+
 class Status(Enum):
     """
     Enum to represent success/failure. The values are the
     color codes used to print the status.
     """
-    PASSED = 32
-    FAILED = 31
+    PASSED = Color.GREEN
+    FAILED = Color.RED
 
     def __str__(self):
         return with_color(self.name, self.value)
@@ -40,23 +45,32 @@ class Result:
 
     """
 
-    def __init__(self, error=None):
-        self.error = error
-        self.status = Status.PASSED if error == None else Status.FAILED
+    def __init__(self, error_msg=None):
+        self.error_msg = error_msg
+        self.client_error = None
+        self.server_error = None
+        self.status = Status.PASSED if error_msg == None else Status.FAILED
 
     def is_success(self):
         return self.status is not Status.FAILED
 
     def __str__(self):
         result = str(self.status)
-        if self.error:
-            result += "\n\t%s" % self.error
+        if self.error_msg:
+            result += "\n\t" + with_color(self.error_msg, Color.RED)
+            if self.client_error:
+                result += with_color("\n\tClient: ", Color.RED)
+                result += self.client_error.rstrip()
+            if self.server_error:
+                result += with_color("\n\tServer: ", Color.RED)
+                result += self.server_error.rstrip()
+
         return result
 
 
 def with_color(msg, color):
     if sys.stdout.isatty():
-        return "\033[%d;1m%s\033[0m" % (color, msg)
+        return "\033[%d;1m%s\033[0m" % (color.value, msg)
     else:
         return msg
 

--- a/tests/integration/s2n_dynamic_record_size_test.py
+++ b/tests/integration/s2n_dynamic_record_size_test.py
@@ -118,6 +118,10 @@ def try_dynamic_record(endpoint, port, cipher, ssl_version, threshold, server_ce
     file_input = open(test_file)
     s2nc = subprocess.Popen(s2nc_cmd, stdin=file_input, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
+    # Wait file send complete
+    s2nc.wait()
+    cleanup_processes(s_server)
+
     # Read from s2nc until we get successful connection message
     found = 0
     seperators = 0
@@ -125,10 +129,6 @@ def try_dynamic_record(endpoint, port, cipher, ssl_version, threshold, server_ce
         output = s2nc.stdout.readline().decode("utf-8")
         if output.strip() == "Connected to {}:{}".format(endpoint, port):
             found = 1
-
-    # Wait file send complete        
-    s2nc.wait()
-    cleanup_processes(s_server)
 
     if not found:
         sys.stderr.write("= TEST FAILED =\ns_server cmd: {}\n s_server STDERR: {}\n\ns2nc cmd: {}\nSTDERR {}\n".format(" ".join(s_server_cmd), s_server.stderr.read().decode("utf-8"), " ".join(s2nc_cmd), s2nc.stderr.read().decode("utf-8")))


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 

**Description of changes:** Added basic echo test. I had to fix the echo functionality in s2nc, because apparently we haven't used it before. I also verified that all tests succeed with Ryan's cert fix.

Without Ryan's fix:
```
Mode:client  Version:TLS13   Curve:P-256 Cipher:TLS_AES_256_GCM_SHA384                               PASSED
Mode:server  Version:TLS13   Curve:P-384 Cipher:TLS_CHACHA20_POLY1305_SHA256                         FAILED
	Failed to write 'Message:a2eddf19-9477-46da-81bb-18f879982940' from server to client
	Client: Can't use SSL_get_servername
	depth=0 C = US, ST = WA, L = Seattle, O = Amazon, OU = s2n, CN = localhost
	verify error:num=20:unable to get local issuer certificate
	verify return:1
	depth=0 C = US, ST = WA, L = Seattle, O = Amazon, OU = s2n, CN = localhost
	verify error:num=21:unable to verify the first certificate
	verify return:1
	139976974862080:error:1414D17A:SSL routines:tls12_check_peer_sigalg:wrong curve:ssl/t1_lib.c:1053:
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
