### PR TITLE
Support Sending TLS 1.3 Encrypted Extensions 

### DIFF
--- a/tests/unit/s2n_encrypted_extensions_test.c
+++ b/tests/unit/s2n_encrypted_extensions_test.c
@@ -73,7 +73,7 @@ int main(int argc, char **argv)
     {
         const uint8_t ENCRYPTED_EXTENSIONS_HEADER_SIZE = 2;
         struct s2n_connection *server_conn;
-        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
         server_conn->actual_protocol_version = S2N_TLS13;
         EXPECT_EQUAL(s2n_encrypted_extensions_send_size(server_conn), 0);

--- a/tests/unit/s2n_encrypted_extensions_test.c
+++ b/tests/unit/s2n_encrypted_extensions_test.c
@@ -28,8 +28,6 @@
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_safety.h"
 
-int s2n_encrypted_extensions_send_size(struct s2n_connection *conn);
-
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
@@ -75,7 +73,7 @@ int main(int argc, char **argv)
     {
         const uint8_t ENCRYPTED_EXTENSIONS_HEADER_SIZE = 2;
         struct s2n_connection *server_conn;
-        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER);
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
         server_conn->actual_protocol_version = S2N_TLS13;
         EXPECT_EQUAL(s2n_encrypted_extensions_send_size(server_conn), 0);

--- a/tests/unit/s2n_server_extensions_test.c
+++ b/tests/unit/s2n_server_extensions_test.c
@@ -283,7 +283,7 @@ int main(int argc, char **argv)
 
             const uint8_t size = P256_KEYSHARE_SIZE + SUPPORTED_VERSION_SIZE;
 
-            EXPECT_EQUAL(s2n_extensions_server_supported_versions_size(), SUPPORTED_VERSION_SIZE);
+            EXPECT_EQUAL(s2n_extensions_server_supported_versions_size(conn), SUPPORTED_VERSION_SIZE);
             EXPECT_EQUAL(s2n_extensions_server_key_share_send_size(conn), P256_KEYSHARE_SIZE);
 
             EXPECT_EQUAL(s2n_server_extensions_send_size(conn), size);
@@ -325,7 +325,7 @@ int main(int argc, char **argv)
             conn->secure.client_ecc_evp_params[0].negotiated_curve = s2n_ecc_evp_supported_curves_list[0];
             /* secure_renegotiation extension not send >=TLS13*/
             uint8_t size = s2n_extensions_server_key_share_send_size(conn)
-                + s2n_extensions_server_supported_versions_size();
+                + s2n_extensions_server_supported_versions_size(conn);
 
             EXPECT_EQUAL(s2n_server_extensions_send_size(conn), size);
             EXPECT_FAILURE(s2n_server_extensions_send(conn, hello_stuffer));
@@ -370,7 +370,7 @@ int main(int argc, char **argv)
 
             /* nst extension not send >=TLS13*/
             uint8_t size = s2n_extensions_server_key_share_send_size(conn)
-                + s2n_extensions_server_supported_versions_size()
+                + s2n_extensions_server_supported_versions_size(conn)
             ;
 
             EXPECT_EQUAL(s2n_server_extensions_send_size(conn), size);
@@ -424,7 +424,7 @@ int main(int argc, char **argv)
             conn->secure.client_ecc_evp_params[0].negotiated_curve = s2n_ecc_evp_supported_curves_list[0];
 
             uint8_t size = s2n_extensions_server_key_share_send_size(conn)
-                + s2n_extensions_server_supported_versions_size();
+                + s2n_extensions_server_supported_versions_size(conn);
 
             EXPECT_EQUAL(s2n_server_extensions_send_size(conn), size);
             EXPECT_FAILURE(s2n_server_extensions_send(conn, hello_stuffer));

--- a/tls/extensions/s2n_server_alpn.c
+++ b/tls/extensions/s2n_server_alpn.c
@@ -22,6 +22,37 @@
 
 #include "tls/extensions/s2n_server_alpn.h"
 
+
+/* Precalculate size of extension */
+int s2n_server_extensions_alpn_send_size(struct s2n_connection *conn)
+{
+    const uint8_t application_protocol_len = strlen(conn->application_protocol);
+
+    if (!application_protocol_len) {
+        return 0;
+    }
+
+    return 7 + application_protocol_len;
+}
+
+/* Write ALPN extension */
+int s2n_server_extensions_alpn_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    const uint8_t application_protocol_len = strlen(conn->application_protocol);
+
+    if (!application_protocol_len) {
+        return 0;
+    }
+
+    GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_ALPN));
+    GUARD(s2n_stuffer_write_uint16(out, application_protocol_len + 3));
+    GUARD(s2n_stuffer_write_uint16(out, application_protocol_len + 1));
+    GUARD(s2n_stuffer_write_uint8(out, application_protocol_len));
+    GUARD(s2n_stuffer_write_bytes(out, (uint8_t *) conn->application_protocol, application_protocol_len));
+
+    return 0;
+}
+
 int s2n_recv_server_alpn(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
     uint16_t size_of_all;

--- a/tls/extensions/s2n_server_alpn.c
+++ b/tls/extensions/s2n_server_alpn.c
@@ -32,7 +32,7 @@ int s2n_server_extensions_alpn_send_size(struct s2n_connection *conn)
         return 0;
     }
 
-    return 7 + application_protocol_len;
+    return 3 * sizeof(uint16_t) + 1 * sizeof(uint8_t) + application_protocol_len;
 }
 
 /* Write ALPN extension */

--- a/tls/extensions/s2n_server_alpn.h
+++ b/tls/extensions/s2n_server_alpn.h
@@ -15,4 +15,6 @@
 
 #pragma once
 
-extern int s2n_recv_server_alpn(struct s2n_connection *conn, struct s2n_stuffer *extension);
+int s2n_server_extensions_alpn_send_size(struct s2n_connection *conn);
+int s2n_server_extensions_alpn_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+int s2n_recv_server_alpn(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_server_max_fragment_length.c
+++ b/tls/extensions/s2n_server_max_fragment_length.c
@@ -24,6 +24,28 @@
 
 #include "tls/extensions/s2n_server_max_fragment_length.h"
 
+/* Precalculate size of extension */
+int s2n_server_extensions_max_fragment_length_send_size(struct s2n_connection *conn)
+{
+    if (!conn->mfl_code) {
+        return 0;
+    }
+    return 5;
+}
+
+/* Write MFL extension */
+int s2n_server_extensions_max_fragment_length_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    if (!conn->mfl_code) {
+        return 0;
+    }
+    GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_MAX_FRAG_LEN));
+    GUARD(s2n_stuffer_write_uint16(out, sizeof(uint8_t)));
+    GUARD(s2n_stuffer_write_uint8(out, conn->mfl_code));
+
+    return 0;
+}
+
 int s2n_recv_server_max_fragment_length(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
     uint8_t mfl_code;

--- a/tls/extensions/s2n_server_max_fragment_length.c
+++ b/tls/extensions/s2n_server_max_fragment_length.c
@@ -30,7 +30,7 @@ int s2n_server_extensions_max_fragment_length_send_size(struct s2n_connection *c
     if (!conn->mfl_code) {
         return 0;
     }
-    return 5;
+    return 2 * sizeof(uint16_t) + 1 * sizeof(uint8_t);
 }
 
 /* Write MFL extension */

--- a/tls/extensions/s2n_server_max_fragment_length.h
+++ b/tls/extensions/s2n_server_max_fragment_length.h
@@ -15,4 +15,7 @@
 
 #pragma once
 
-extern int s2n_recv_server_max_fragment_length(struct s2n_connection *conn, struct s2n_stuffer *extension);
+/* Precalculate size of extension */
+int s2n_server_extensions_max_fragment_length_send_size(struct s2n_connection *conn);
+int s2n_server_extensions_max_fragment_length_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+int s2n_recv_server_max_fragment_length(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_server_max_fragment_length.h
+++ b/tls/extensions/s2n_server_max_fragment_length.h
@@ -15,7 +15,6 @@
 
 #pragma once
 
-/* Precalculate size of extension */
 int s2n_server_extensions_max_fragment_length_send_size(struct s2n_connection *conn);
 int s2n_server_extensions_max_fragment_length_send(struct s2n_connection *conn, struct s2n_stuffer *out);
 int s2n_recv_server_max_fragment_length(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_server_server_name.c
+++ b/tls/extensions/s2n_server_server_name.c
@@ -18,6 +18,29 @@
 #include "tls/s2n_connection.h"
 #include "tls/extensions/s2n_server_server_name.h"
 
+#define s2n_server_can_send_server_name(conn) ((conn)->server_name_used && \
+        !s2n_connection_is_session_resumed((conn)))
+
+int s2n_server_extensions_server_name_send_size(struct s2n_connection *conn) {
+    if (!s2n_server_can_send_server_name(conn)) {
+        return 0;
+    }
+
+    return 4;
+}
+
+int s2n_server_extensions_server_name_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    if (!s2n_server_can_send_server_name(conn)) {
+        return 0;
+    }
+
+    GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_SERVER_NAME));
+    GUARD(s2n_stuffer_write_uint16(out, 0));
+
+    return 0;
+}
+
 int s2n_recv_server_server_name(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
     conn->server_name_used = 1;

--- a/tls/extensions/s2n_server_server_name.c
+++ b/tls/extensions/s2n_server_server_name.c
@@ -26,7 +26,7 @@ int s2n_server_extensions_server_name_send_size(struct s2n_connection *conn) {
         return 0;
     }
 
-    return 4;
+    return 2 * sizeof(uint16_t);
 }
 
 int s2n_server_extensions_server_name_send(struct s2n_connection *conn, struct s2n_stuffer *out)

--- a/tls/extensions/s2n_server_server_name.h
+++ b/tls/extensions/s2n_server_server_name.h
@@ -15,4 +15,6 @@
 
 #pragma once
 
-extern int s2n_recv_server_server_name(struct s2n_connection *conn, struct s2n_stuffer *extension);
+int s2n_server_extensions_server_name_send_size(struct s2n_connection *conn);
+int s2n_server_extensions_server_name_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+int s2n_recv_server_server_name(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_server_supported_versions.c
+++ b/tls/extensions/s2n_server_supported_versions.c
@@ -38,7 +38,7 @@
  * Selected Version (2 byte)
  **/
 
-int s2n_extensions_server_supported_versions_size()
+int s2n_extensions_server_supported_versions_size(struct s2n_connection *conn)
 {
     return 6;
 }
@@ -72,7 +72,7 @@ int s2n_extensions_server_supported_versions_recv(struct s2n_connection *conn, s
 
 int s2n_extensions_server_supported_versions_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    int extension_length = s2n_extensions_server_supported_versions_size();
+    int extension_length = s2n_extensions_server_supported_versions_size(conn);
 
     GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_SUPPORTED_VERSIONS));
     GUARD(s2n_stuffer_write_uint16(out, extension_length - 4));

--- a/tls/extensions/s2n_server_supported_versions.h
+++ b/tls/extensions/s2n_server_supported_versions.h
@@ -19,6 +19,6 @@
 #include "tls/s2n_connection.h"
 #include "stuffer/s2n_stuffer.h"
 
-extern int s2n_extensions_server_supported_versions_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
-extern int s2n_extensions_server_supported_versions_send(struct s2n_connection *conn, struct s2n_stuffer *out);
-extern int s2n_extensions_server_supported_versions_size();
+int s2n_extensions_server_supported_versions_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
+int s2n_extensions_server_supported_versions_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+int s2n_extensions_server_supported_versions_size(struct s2n_connection *conn);

--- a/tls/s2n_encrypted_extensions.c
+++ b/tls/s2n_encrypted_extensions.c
@@ -57,9 +57,7 @@ int s2n_encrypted_extensions_send(struct s2n_connection *conn)
     struct s2n_stuffer *out = &conn->handshake.io;
 
     const int total_size = s2n_encrypted_extensions_send_size(conn);
-
-    GUARD(total_size);
-    S2N_ERROR_IF(total_size > 65535, S2N_ERR_INTEGER_OVERFLOW);
+    inclusive_range_check(0, total_size, 65535);
 
     /* Write length of extensions */
     GUARD(s2n_stuffer_write_uint16(out, total_size));
@@ -68,8 +66,7 @@ int s2n_encrypted_extensions_send(struct s2n_connection *conn)
         return 0;
     }
 
-    /* Write the extensions to the out buffer.
-     */
+    /* Write the extensions to the out buffer. */
     GUARD(s2n_server_extensions_server_name_send(conn, out));
     GUARD(s2n_server_extensions_max_fragment_length_send(conn, out));
     GUARD(s2n_server_extensions_alpn_send(conn, out));

--- a/tls/s2n_encrypted_extensions.c
+++ b/tls/s2n_encrypted_extensions.c
@@ -56,7 +56,7 @@ int s2n_encrypted_extensions_send(struct s2n_connection *conn)
     S2N_ERROR_IF(conn->actual_protocol_version != S2N_TLS13, S2N_ERR_BAD_MESSAGE);
     struct s2n_stuffer *out = &conn->handshake.io;
 
-    int total_size = s2n_encrypted_extensions_send_size(conn);
+    const int total_size = s2n_encrypted_extensions_send_size(conn);
 
     GUARD(total_size);
     S2N_ERROR_IF(total_size > 65535, S2N_ERR_INTEGER_OVERFLOW);

--- a/tls/s2n_encrypted_extensions.c
+++ b/tls/s2n_encrypted_extensions.c
@@ -39,18 +39,27 @@
 
 static int s2n_server_encrypted_extensions_parse(struct s2n_connection *conn, struct s2n_blob *extensions);
 
+int s2n_encrypted_extensions_send_size(struct s2n_connection *conn)
+{
+    /* Calculate size of encrypted extensions. */
+    int total_size = 0;
+
+    total_size += s2n_server_extensions_server_name_send_size(conn);
+    total_size += s2n_server_extensions_max_fragment_length_send_size(conn);
+    total_size += s2n_server_extensions_alpn_send_size(conn);
+
+    return total_size;
+}
+
 int s2n_encrypted_extensions_send(struct s2n_connection *conn)
 {
     S2N_ERROR_IF(conn->actual_protocol_version != S2N_TLS13, S2N_ERR_BAD_MESSAGE);
     struct s2n_stuffer *out = &conn->handshake.io;
 
-    /* Calculate size of encrypted extensions.
-     */
-    uint16_t total_size = 0;
+    int total_size = s2n_encrypted_extensions_send_size(conn);
 
-    total_size += s2n_server_extensions_server_name_send_size(conn);
-    total_size += s2n_server_extensions_alpn_send_size(conn);
-    total_size += s2n_server_extensions_max_fragment_length_send_size(conn);
+    GUARD(total_size);
+    S2N_ERROR_IF(total_size > 65535, S2N_ERR_INTEGER_OVERFLOW);
 
     /* Write length of extensions */
     GUARD(s2n_stuffer_write_uint16(out, total_size));
@@ -62,8 +71,8 @@ int s2n_encrypted_extensions_send(struct s2n_connection *conn)
     /* Write the extensions to the out buffer.
      */
     GUARD(s2n_server_extensions_server_name_send(conn, out));
-    GUARD(s2n_server_extensions_alpn_send(conn, out));
     GUARD(s2n_server_extensions_max_fragment_length_send(conn, out));
+    GUARD(s2n_server_extensions_alpn_send(conn, out));
 
     return 0;
 }

--- a/tls/s2n_encrypted_extensions.c
+++ b/tls/s2n_encrypted_extensions.c
@@ -27,26 +27,30 @@
 
 /**
   * Specified in https://tools.ietf.org/html/rfc8446#section-4.3.1
-  * 
+  *
   * In all handshakes, the server MUST send the EncryptedExtensions
-  * message immediately after the ServerHello message.  
+  * message immediately after the ServerHello message.
   *
   * The EncryptedExtensions message contains extensions that can be
   * protected, i.e., any which are not needed to establish the
   * cryptographic context but which are not associated with individual
-  * certificates. 
+  * certificates.
   **/
 
 static int s2n_server_encrypted_extensions_parse(struct s2n_connection *conn, struct s2n_blob *extensions);
 
 int s2n_encrypted_extensions_send(struct s2n_connection *conn)
 {
+    S2N_ERROR_IF(conn->actual_protocol_version != S2N_TLS13, S2N_ERR_BAD_MESSAGE);
     struct s2n_stuffer *out = &conn->handshake.io;
 
-    /* Calculate size of encrypted extensions. For minimal TLS 1.3, this is 0
-     * as we are sending an empty EE message
+    /* Calculate size of encrypted extensions.
      */
     uint16_t total_size = 0;
+
+    total_size += s2n_server_extensions_server_name_send_size(conn);
+    total_size += s2n_server_extensions_alpn_send_size(conn);
+    total_size += s2n_server_extensions_max_fragment_length_send_size(conn);
 
     /* Write length of extensions */
     GUARD(s2n_stuffer_write_uint16(out, total_size));
@@ -55,10 +59,12 @@ int s2n_encrypted_extensions_send(struct s2n_connection *conn)
         return 0;
     }
 
-    /* Write the extensions to the out buffer. For minimal TLS 1.3, this is
-     * a noop, as we are sending an empty EE message
+    /* Write the extensions to the out buffer.
      */
-    
+    GUARD(s2n_server_extensions_server_name_send(conn, out));
+    GUARD(s2n_server_extensions_alpn_send(conn, out));
+    GUARD(s2n_server_extensions_max_fragment_length_send(conn, out));
+
     return 0;
 }
 

--- a/tls/s2n_server_extensions.c
+++ b/tls/s2n_server_extensions.c
@@ -91,11 +91,10 @@ int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *
 {
     int total_size = s2n_server_extensions_send_size(conn);
 
-    GUARD(total_size);
     if (total_size == 0) {
         return 0;
     }
-    S2N_ERROR_IF(total_size > 65535, S2N_ERR_INTEGER_OVERFLOW);
+    inclusive_range_check(0, total_size, 65535);
 
     GUARD(s2n_stuffer_write_uint16(out, total_size));
 

--- a/tls/s2n_server_extensions.c
+++ b/tls/s2n_server_extensions.c
@@ -101,7 +101,7 @@ int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *
 
     const bool is_tls13_conn = conn->actual_protocol_version == S2N_TLS13;
 
-    /* Currently TLS 1.3 supported extensions*/
+    /* TLS 1.3 ServerHello extensions */
     if (is_tls13_conn) {
         /* Write supported versions extension */
         GUARD(s2n_extensions_server_supported_versions_send(conn, out));

--- a/tls/s2n_server_extensions.c
+++ b/tls/s2n_server_extensions.c
@@ -52,13 +52,15 @@ int s2n_server_extensions_send_size(struct s2n_connection *conn)
     int total_size = 0;
     const bool is_tls13_conn = conn->actual_protocol_version == S2N_TLS13;
 
-    if (!is_tls13_conn) {
-        total_size += s2n_server_extensions_server_name_send_size(conn);
+    if (is_tls13_conn) {
+        total_size += s2n_extensions_server_supported_versions_size(conn);
+        total_size += s2n_extensions_server_key_share_send_size(conn);
+
+        return total_size;
     }
 
-    if (!is_tls13_conn) {
-        total_size += s2n_server_extensions_alpn_send_size(conn);
-    }
+    total_size += s2n_server_extensions_server_name_send_size(conn);
+    total_size += s2n_server_extensions_alpn_send_size(conn);
 
     if (s2n_server_can_send_secure_renegotiation(conn)) {
         total_size += 5;
@@ -68,24 +70,18 @@ int s2n_server_extensions_send_size(struct s2n_connection *conn)
         total_size += s2n_kex_server_extension_size(conn->secure.cipher_suite->key_exchange_alg, conn);
     }
 
-    if (s2n_server_can_send_ocsp(conn) && !is_tls13_conn) {
+    if (s2n_server_can_send_ocsp(conn)) {
         total_size += 4;
     }
 
-    if (s2n_server_can_send_sct_list(conn) && !is_tls13_conn) {
+    if (s2n_server_can_send_sct_list(conn)) {
         total_size += 4 + conn->handshake_params.our_chain_and_key->sct_list.size;
     }
 
-    if (!is_tls13_conn) {
-        total_size += s2n_server_extensions_max_fragment_length_send_size(conn);
-    }
+    total_size += s2n_server_extensions_max_fragment_length_send_size(conn);
+
     if (s2n_server_can_send_nst(conn)) {
         total_size += 4;
-    }
-
-    if (conn->actual_protocol_version >= S2N_TLS13) {
-        total_size += s2n_extensions_server_supported_versions_size();
-        total_size += s2n_extensions_server_key_share_send_size(conn);
     }
 
     return total_size;
@@ -105,15 +101,20 @@ int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *
 
     const bool is_tls13_conn = conn->actual_protocol_version == S2N_TLS13;
 
-    /* Write supported versions extension if TLS 1.3 or greater */
+    /* Currently TLS 1.3 supported extensions*/
     if (is_tls13_conn) {
+        /* Write supported versions extension */
         GUARD(s2n_extensions_server_supported_versions_send(conn, out));
+        /* Write key share extension */
+        GUARD(s2n_extensions_server_key_share_send(conn, out));
+
+        return 0;
     }
 
+    /* TLS 1.2 Extensions */
+
     /* Write server name extension */
-    if (!is_tls13_conn) {
-        GUARD(s2n_server_extensions_server_name_send(conn, out));
-    }
+    GUARD(s2n_server_extensions_server_name_send(conn, out));
 
     if (s2n_server_can_send_kex(conn)) {
         GUARD(s2n_kex_write_server_extension(conn->secure.cipher_suite->key_exchange_alg, conn, out));
@@ -129,37 +130,28 @@ int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *
     }
 
     /* Write ALPN extension */
-    if (!is_tls13_conn) {
-        GUARD(s2n_server_extensions_alpn_send(conn, out));
-    }
+    GUARD(s2n_server_extensions_alpn_send(conn, out));
 
     /* Write OCSP extension */
-    if (s2n_server_can_send_ocsp(conn) && !is_tls13_conn) {
+    if (s2n_server_can_send_ocsp(conn)) {
         GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_STATUS_REQUEST));
         GUARD(s2n_stuffer_write_uint16(out, 0));
     }
 
     /* Write Signed Certificate Timestamp extension */
-    if (s2n_server_can_send_sct_list(conn) && !is_tls13_conn) {
+    if (s2n_server_can_send_sct_list(conn)) {
         GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_SCT_LIST));
         GUARD(s2n_stuffer_write_uint16(out, conn->handshake_params.our_chain_and_key->sct_list.size));
         GUARD(s2n_stuffer_write_bytes(out, conn->handshake_params.our_chain_and_key->sct_list.data,
                                       conn->handshake_params.our_chain_and_key->sct_list.size));
     }
 
-    if (!is_tls13_conn) {
-        GUARD(s2n_server_extensions_max_fragment_length_send(conn, out));
-    }
+    GUARD(s2n_server_extensions_max_fragment_length_send(conn, out));
 
     /* Write session ticket extension */
     if (s2n_server_can_send_nst(conn)) {
         GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_SESSION_TICKET));
         GUARD(s2n_stuffer_write_uint16(out, 0));
-    }
-
-    /* Write key share extension */
-    if (conn->actual_protocol_version >= S2N_TLS13) {
-        GUARD(s2n_extensions_server_key_share_send(conn, out));
     }
 
     return 0;

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -117,7 +117,7 @@ int s2n_server_hello_recv(struct s2n_connection *conn)
         S2N_ERROR_IF(extensions_size > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);
 
         struct s2n_blob extensions = {0};
-	GUARD(s2n_blob_init(&extensions, s2n_stuffer_raw_read(in, extensions.size), extensions_size));
+        GUARD(s2n_blob_init(&extensions, s2n_stuffer_raw_read(in, extensions.size), extensions_size));
         notnull_check(extensions.data);
 
         GUARD(s2n_server_extensions_recv(conn, &extensions));

--- a/tls/s2n_tls.h
+++ b/tls/s2n_tls.h
@@ -33,6 +33,7 @@ extern int s2n_server_hello_retry_recv(struct s2n_connection *conn);
 extern bool s2n_is_hello_retry_req(struct s2n_connection *conn);
 extern int s2n_server_hello_send(struct s2n_connection *conn);
 extern int s2n_server_hello_recv(struct s2n_connection *conn);
+extern int s2n_encrypted_extensions_send_size(struct s2n_connection *conn);
 extern int s2n_encrypted_extensions_send(struct s2n_connection *conn);
 extern int s2n_encrypted_extensions_recv(struct s2n_connection *conn);
 extern int s2n_server_cert_send(struct s2n_connection *conn);


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
https://github.com/awslabs/s2n/issues/1641 (Part A, step 2, EE)

**Description of changes:** 
This PR enables sending of "Server Name", "Max fragment length" and "Application Protocol" in Encrypted Extensions for TLS 1.3. The code for these extensions has been moved to their respective extensions files, cleaning up the code and logic in Server Hello extensions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
