### PR TITLE
Decouple RSA PSS conditional for signing and certificate support

### DIFF
--- a/crypto/s2n_rsa_pss.c
+++ b/crypto/s2n_rsa_pss.c
@@ -33,12 +33,13 @@
 #include "utils/s2n_safety.h"
 #include "utils/s2n_blob.h"
 
-#if PSS_CERTS_SUPPORTED
-
-int s2n_is_pss_certs_supported()
+/* Checks whether PSS Certs is supported */
+int s2n_is_rsa_pss_certs_supported()
 {
-    return 1;
+    return RSA_PSS_CERTS_SUPPORTED;
 }
+
+#if RSA_PSS_CERTS_SUPPORTED
 
 static int s2n_rsa_pss_size(const struct s2n_pkey *key)
 {
@@ -221,11 +222,6 @@ int s2n_rsa_pss_pkey_init(struct s2n_pkey *pkey)
 }
 
 #else
-
-int s2n_is_pss_certs_supported()
-{
-    return 0;
-}
 
 int s2n_evp_pkey_to_rsa_pss_public_key(struct s2n_rsa_key *rsa_pss_key, EVP_PKEY *pkey)
 {

--- a/crypto/s2n_rsa_pss.c
+++ b/crypto/s2n_rsa_pss.c
@@ -33,9 +33,9 @@
 #include "utils/s2n_safety.h"
 #include "utils/s2n_blob.h"
 
-#if RSA_PSS_SUPPORTED
+#if PSS_CERTS_SUPPORTED
 
-int s2n_is_rsa_pss_supported()
+int s2n_is_pss_certs_supported()
 {
     return 1;
 }
@@ -222,7 +222,7 @@ int s2n_rsa_pss_pkey_init(struct s2n_pkey *pkey)
 
 #else
 
-int s2n_is_rsa_pss_supported()
+int s2n_is_pss_certs_supported()
 {
     return 0;
 }

--- a/crypto/s2n_rsa_pss.h
+++ b/crypto/s2n_rsa_pss.h
@@ -33,13 +33,13 @@
  *
  * This feature requires this Openssl commit for Openssl 1.1.x versions: openssl/openssl@4088b92
  */
-#if RSA_PSS_SUPPORTED && OPENSSL_VERSION_NUMBER > 0x1010104fL
-#define PSS_CERTS_SUPPORTED 1
+#if RSA_PSS_SIGNING_SUPPORTED && OPENSSL_VERSION_NUMBER > 0x1010104fL
+#define RSA_PSS_CERTS_SUPPORTED 1
 #else
-#define PSS_CERTS_SUPPORTED 0
+#define RSA_PSS_CERTS_SUPPORTED 0
 #endif
 
-int s2n_is_pss_certs_supported();
+int s2n_is_rsa_pss_certs_supported();
 int s2n_rsa_pss_pkey_init(struct s2n_pkey *pkey);
 int s2n_evp_pkey_to_rsa_pss_public_key(struct s2n_rsa_key *rsa_key, EVP_PKEY *pkey);
 int s2n_evp_pkey_to_rsa_pss_private_key(struct s2n_rsa_key *rsa_key, EVP_PKEY *pkey);

--- a/crypto/s2n_rsa_pss.h
+++ b/crypto/s2n_rsa_pss.h
@@ -20,6 +20,7 @@
 
 #include "crypto/s2n_openssl.h"
 #include "crypto/s2n_rsa.h"
+#include "crypto/s2n_rsa_signing.h"
 
 #define RSA_PSS_SIGN_VERIFY_RANDOM_BLOB_SIZE    32
 #define RSA_PSS_SIGN_VERIFY_SIGNATURE_SIZE      256
@@ -32,13 +33,13 @@
  *
  * This feature requires this Openssl commit for Openssl 1.1.x versions: openssl/openssl@4088b92
  */
-#if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 1) && !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER != 0x1010104fL
-#define RSA_PSS_SUPPORTED 1
+#if RSA_PSS_SUPPORTED && OPENSSL_VERSION_NUMBER > 0x1010104fL
+#define PSS_CERTS_SUPPORTED 1
 #else
-#define RSA_PSS_SUPPORTED 0
+#define PSS_CERTS_SUPPORTED 0
 #endif
 
-int s2n_is_rsa_pss_supported();
+int s2n_is_pss_certs_supported();
 int s2n_rsa_pss_pkey_init(struct s2n_pkey *pkey);
 int s2n_evp_pkey_to_rsa_pss_public_key(struct s2n_rsa_key *rsa_key, EVP_PKEY *pkey);
 int s2n_evp_pkey_to_rsa_pss_private_key(struct s2n_rsa_key *rsa_key, EVP_PKEY *pkey);

--- a/crypto/s2n_rsa_signing.c
+++ b/crypto/s2n_rsa_signing.c
@@ -92,6 +92,16 @@ int s2n_rsa_pkcs1v15_verify(const struct s2n_pkey *pub, struct s2n_hash_state *d
     return 0;
 }
 
+/* this function returns whether PSS signing is supported */
+int s2n_is_rsa_pss_supported()
+{
+#if RSA_PSS_SUPPORTED
+    return 1;
+#else
+    return 0;
+#endif
+}
+
 #if RSA_PSS_SUPPORTED
 
 const EVP_MD* s2n_hash_alg_to_evp_alg(s2n_hash_algorithm alg)

--- a/crypto/s2n_rsa_signing.c
+++ b/crypto/s2n_rsa_signing.c
@@ -92,17 +92,13 @@ int s2n_rsa_pkcs1v15_verify(const struct s2n_pkey *pub, struct s2n_hash_state *d
     return 0;
 }
 
-/* this function returns whether PSS signing is supported */
-int s2n_is_rsa_pss_supported()
+/* this function returns whether RSA PSS signing is supported */
+int s2n_is_rsa_pss_signing_supported()
 {
-#if RSA_PSS_SUPPORTED
-    return 1;
-#else
-    return 0;
-#endif
+    return RSA_PSS_SIGNING_SUPPORTED;
 }
 
-#if RSA_PSS_SUPPORTED
+#if RSA_PSS_SIGNING_SUPPORTED
 
 const EVP_MD* s2n_hash_alg_to_evp_alg(s2n_hash_algorithm alg)
 {

--- a/crypto/s2n_rsa_signing.h
+++ b/crypto/s2n_rsa_signing.h
@@ -18,9 +18,20 @@
 #include <s2n.h>
 
 #include "utils/s2n_blob.h"
+#include "crypto/s2n_openssl.h"
+#include "crypto/s2n_rsa.h"
+
+/* RSA PSS Signing is supported in OpenSSL 1.0.2 and above */
+#if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 1) && !defined(LIBRESSL_VERSION_NUMBER)
+#define RSA_PSS_SUPPORTED 1
+#else
+#define RSA_PSS_SUPPORTED 0
+#endif
 
 int s2n_rsa_pkcs1v15_sign(const struct s2n_pkey *priv, struct s2n_hash_state *digest, struct s2n_blob *signature);
 int s2n_rsa_pkcs1v15_verify(const struct s2n_pkey *pub, struct s2n_hash_state *digest, struct s2n_blob *signature);
 
 int s2n_rsa_pss_sign(const struct s2n_pkey *priv, struct s2n_hash_state *digest, struct s2n_blob *signature_out);
 int s2n_rsa_pss_verify(const struct s2n_pkey *pub, struct s2n_hash_state *digest, struct s2n_blob *signature_in);
+
+int s2n_is_rsa_pss_supported();

--- a/crypto/s2n_rsa_signing.h
+++ b/crypto/s2n_rsa_signing.h
@@ -21,11 +21,11 @@
 #include "crypto/s2n_openssl.h"
 #include "crypto/s2n_rsa.h"
 
-/* RSA PSS Signing is supported in OpenSSL 1.0.2 and above */
+/* Check for libcrypto 1.1 for RSA PSS Signing and EV_Key usage */
 #if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 1) && !defined(LIBRESSL_VERSION_NUMBER)
-#define RSA_PSS_SUPPORTED 1
+#define RSA_PSS_SIGNING_SUPPORTED 1
 #else
-#define RSA_PSS_SUPPORTED 0
+#define RSA_PSS_SIGNING_SUPPORTED 0
 #endif
 
 int s2n_rsa_pkcs1v15_sign(const struct s2n_pkey *priv, struct s2n_hash_state *digest, struct s2n_blob *signature);
@@ -34,4 +34,4 @@ int s2n_rsa_pkcs1v15_verify(const struct s2n_pkey *pub, struct s2n_hash_state *d
 int s2n_rsa_pss_sign(const struct s2n_pkey *priv, struct s2n_hash_state *digest, struct s2n_blob *signature_out);
 int s2n_rsa_pss_verify(const struct s2n_pkey *pub, struct s2n_hash_state *digest, struct s2n_blob *signature_in);
 
-int s2n_is_rsa_pss_supported();
+int s2n_is_rsa_pss_signing_supported();

--- a/tests/unit/s2n_auth_selection_test.c
+++ b/tests/unit/s2n_auth_selection_test.c
@@ -32,8 +32,8 @@
 #define ECDSA_AUTH_CIPHER_SUITE &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha
 #define NO_AUTH_CIPHER_SUITE &s2n_tls13_aes_128_gcm_sha256
 
-#define EXPECT_SUCCESS_IF_PSS_CERTS_SUPPORTED(x) \
-    if ( s2n_is_pss_certs_supported() ) { \
+#define EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(x) \
+    if ( s2n_is_rsa_pss_certs_supported() ) { \
         EXPECT_SUCCESS(x); \
     } else { \
         EXPECT_FAILURE(x); \
@@ -83,7 +83,7 @@ int main(int argc, char **argv)
     struct s2n_cert_chain_and_key *rsa_pss_cert_chain = NULL;
     struct s2n_config *rsa_pss_cert_config = s2n_config_new();
 
-#if PSS_CERTS_SUPPORTED
+#if RSA_PSS_CERTS_SUPPORTED
     EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&rsa_pss_cert_chain,
             S2N_RSA_PSS_2048_SHA256_LEAF_CERT, S2N_RSA_PSS_2048_SHA256_LEAF_KEY));
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(rsa_pss_cert_config, rsa_pss_cert_chain));
@@ -110,9 +110,9 @@ int main(int argc, char **argv)
 
             /* RSA-PSS certs exist */
             s2n_connection_set_config(conn, rsa_pss_cert_config);
-            EXPECT_SUCCESS_IF_PSS_CERTS_SUPPORTED(s2n_is_cipher_suite_valid_for_auth(conn, RSA_AUTH_CIPHER_SUITE));
+            EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_is_cipher_suite_valid_for_auth(conn, RSA_AUTH_CIPHER_SUITE));
             EXPECT_FAILURE(s2n_is_cipher_suite_valid_for_auth(conn, ECDSA_AUTH_CIPHER_SUITE));
-            EXPECT_SUCCESS_IF_PSS_CERTS_SUPPORTED(s2n_is_cipher_suite_valid_for_auth(conn, NO_AUTH_CIPHER_SUITE));
+            EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_is_cipher_suite_valid_for_auth(conn, NO_AUTH_CIPHER_SUITE));
 
             /* ECDSA certs exist */
             s2n_connection_set_config(conn, ecdsa_cert_config);
@@ -155,7 +155,7 @@ int main(int argc, char **argv)
             /* RSA-PSS certs exist */
             s2n_connection_set_config(conn, rsa_pss_cert_config);
             EXPECT_FAILURE(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA));
-            EXPECT_SUCCESS_IF_PSS_CERTS_SUPPORTED(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_PSS));
+            EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_PSS));
             EXPECT_FAILURE(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_RSAE));
             EXPECT_FAILURE(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_ECDSA));
 
@@ -169,7 +169,7 @@ int main(int argc, char **argv)
             /* All certs exist */
             s2n_connection_set_config(conn, all_certs_config);
             EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA));
-            EXPECT_SUCCESS_IF_PSS_CERTS_SUPPORTED(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_PSS));
+            EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_PSS));
             EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_RSAE));
             EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_ECDSA));
         }
@@ -181,7 +181,7 @@ int main(int argc, char **argv)
             /* RSA auth type */
             conn->secure.cipher_suite = RSA_AUTH_CIPHER_SUITE;
             EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA));
-            EXPECT_SUCCESS_IF_PSS_CERTS_SUPPORTED(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_PSS));
+            EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_PSS));
             EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_RSAE));
             EXPECT_FAILURE(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_ECDSA));
 
@@ -200,7 +200,7 @@ int main(int argc, char **argv)
             /* ephemeral key */
             conn->secure.cipher_suite = &s2n_dhe_rsa_with_3des_ede_cbc_sha; /* kex = (dhe) */
             EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA));
-            EXPECT_SUCCESS_IF_PSS_CERTS_SUPPORTED(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_PSS));
+            EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_PSS));
             EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_RSAE));
 
             /* non-ephemeral key */
@@ -212,7 +212,7 @@ int main(int argc, char **argv)
             /* no kex at all */
             conn->secure.cipher_suite = NO_AUTH_CIPHER_SUITE; /* kex = NULL */
             EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA));
-            EXPECT_SUCCESS_IF_PSS_CERTS_SUPPORTED(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_PSS));
+            EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_PSS));
             EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_RSAE));
         }
 
@@ -260,7 +260,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(chosen_certs, rsa_cert_chain);
 
         conn->secure.conn_sig_scheme.sig_alg = S2N_SIGNATURE_RSA_PSS_PSS;
-        EXPECT_SUCCESS_IF_PSS_CERTS_SUPPORTED(s2n_select_certs_for_server_auth(conn, &chosen_certs));
+        EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_select_certs_for_server_auth(conn, &chosen_certs));
         EXPECT_EQUAL(chosen_certs, rsa_pss_cert_chain);
 
         conn->secure.conn_sig_scheme.sig_alg = S2N_SIGNATURE_RSA_PSS_RSAE;
@@ -338,7 +338,7 @@ int main(int argc, char **argv)
         s2n_connection_set_config(conn, rsa_pss_cert_config);
 
         EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA, NULL));
-        EXPECT_SUCCESS_IF_PSS_CERTS_SUPPORTED(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, rsa_pss_cert_chain));
+        EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, rsa_pss_cert_chain));
         EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_RSAE, NULL));
         EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_ECDSA, NULL));
 
@@ -348,7 +348,7 @@ int main(int argc, char **argv)
         EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_ECDSA, NULL));
 
         EXPECT_FAILURE(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA, NULL));
-        EXPECT_SUCCESS_IF_PSS_CERTS_SUPPORTED(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, rsa_pss_cert_chain));
+        EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, rsa_pss_cert_chain));
         EXPECT_FAILURE(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_RSAE, NULL));
         EXPECT_FAILURE(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_ECDSA, NULL));
 
@@ -374,7 +374,7 @@ int main(int argc, char **argv)
         s2n_connection_set_config(conn, all_certs_config);
 
         EXPECT_SUCCESS(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA, rsa_cert_chain));
-        EXPECT_SUCCESS_IF_PSS_CERTS_SUPPORTED(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, rsa_pss_cert_chain));
+        EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, rsa_pss_cert_chain));
         EXPECT_SUCCESS(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_RSAE, rsa_cert_chain));
         EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_ECDSA, ecdsa_cert_chain));
 
@@ -384,7 +384,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_ECDSA, ecdsa_cert_chain));
 
         EXPECT_SUCCESS(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA, rsa_cert_chain));
-        EXPECT_SUCCESS_IF_PSS_CERTS_SUPPORTED(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, rsa_pss_cert_chain));
+        EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, rsa_pss_cert_chain));
         EXPECT_SUCCESS(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_RSAE, rsa_cert_chain));
         EXPECT_SUCCESS(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_ECDSA, ecdsa_cert_chain));
 

--- a/tests/unit/s2n_auth_selection_test.c
+++ b/tests/unit/s2n_auth_selection_test.c
@@ -32,8 +32,8 @@
 #define ECDSA_AUTH_CIPHER_SUITE &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha
 #define NO_AUTH_CIPHER_SUITE &s2n_tls13_aes_128_gcm_sha256
 
-#define EXPECT_SUCCESS_IF_RSA_PSS_SUPPORTED(x) \
-    if ( s2n_is_rsa_pss_supported() ) { \
+#define EXPECT_SUCCESS_IF_PSS_CERTS_SUPPORTED(x) \
+    if ( s2n_is_pss_certs_supported() ) { \
         EXPECT_SUCCESS(x); \
     } else { \
         EXPECT_FAILURE(x); \
@@ -82,7 +82,8 @@ int main(int argc, char **argv)
 
     struct s2n_cert_chain_and_key *rsa_pss_cert_chain = NULL;
     struct s2n_config *rsa_pss_cert_config = s2n_config_new();
-#if RSA_PSS_SUPPORTED
+
+#if PSS_CERTS_SUPPORTED
     EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&rsa_pss_cert_chain,
             S2N_RSA_PSS_2048_SHA256_LEAF_CERT, S2N_RSA_PSS_2048_SHA256_LEAF_KEY));
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(rsa_pss_cert_config, rsa_pss_cert_chain));
@@ -109,9 +110,9 @@ int main(int argc, char **argv)
 
             /* RSA-PSS certs exist */
             s2n_connection_set_config(conn, rsa_pss_cert_config);
-            EXPECT_SUCCESS_IF_RSA_PSS_SUPPORTED(s2n_is_cipher_suite_valid_for_auth(conn, RSA_AUTH_CIPHER_SUITE));
+            EXPECT_SUCCESS_IF_PSS_CERTS_SUPPORTED(s2n_is_cipher_suite_valid_for_auth(conn, RSA_AUTH_CIPHER_SUITE));
             EXPECT_FAILURE(s2n_is_cipher_suite_valid_for_auth(conn, ECDSA_AUTH_CIPHER_SUITE));
-            EXPECT_SUCCESS_IF_RSA_PSS_SUPPORTED(s2n_is_cipher_suite_valid_for_auth(conn, NO_AUTH_CIPHER_SUITE));
+            EXPECT_SUCCESS_IF_PSS_CERTS_SUPPORTED(s2n_is_cipher_suite_valid_for_auth(conn, NO_AUTH_CIPHER_SUITE));
 
             /* ECDSA certs exist */
             s2n_connection_set_config(conn, ecdsa_cert_config);
@@ -154,7 +155,7 @@ int main(int argc, char **argv)
             /* RSA-PSS certs exist */
             s2n_connection_set_config(conn, rsa_pss_cert_config);
             EXPECT_FAILURE(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA));
-            EXPECT_SUCCESS_IF_RSA_PSS_SUPPORTED(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_PSS));
+            EXPECT_SUCCESS_IF_PSS_CERTS_SUPPORTED(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_PSS));
             EXPECT_FAILURE(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_RSAE));
             EXPECT_FAILURE(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_ECDSA));
 
@@ -168,7 +169,7 @@ int main(int argc, char **argv)
             /* All certs exist */
             s2n_connection_set_config(conn, all_certs_config);
             EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA));
-            EXPECT_SUCCESS_IF_RSA_PSS_SUPPORTED(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_PSS));
+            EXPECT_SUCCESS_IF_PSS_CERTS_SUPPORTED(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_PSS));
             EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_RSAE));
             EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_ECDSA));
         }
@@ -180,7 +181,7 @@ int main(int argc, char **argv)
             /* RSA auth type */
             conn->secure.cipher_suite = RSA_AUTH_CIPHER_SUITE;
             EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA));
-            EXPECT_SUCCESS_IF_RSA_PSS_SUPPORTED(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_PSS));
+            EXPECT_SUCCESS_IF_PSS_CERTS_SUPPORTED(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_PSS));
             EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_RSAE));
             EXPECT_FAILURE(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_ECDSA));
 
@@ -199,7 +200,7 @@ int main(int argc, char **argv)
             /* ephemeral key */
             conn->secure.cipher_suite = &s2n_dhe_rsa_with_3des_ede_cbc_sha; /* kex = (dhe) */
             EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA));
-            EXPECT_SUCCESS_IF_RSA_PSS_SUPPORTED(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_PSS));
+            EXPECT_SUCCESS_IF_PSS_CERTS_SUPPORTED(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_PSS));
             EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_RSAE));
 
             /* non-ephemeral key */
@@ -211,7 +212,7 @@ int main(int argc, char **argv)
             /* no kex at all */
             conn->secure.cipher_suite = NO_AUTH_CIPHER_SUITE; /* kex = NULL */
             EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA));
-            EXPECT_SUCCESS_IF_RSA_PSS_SUPPORTED(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_PSS));
+            EXPECT_SUCCESS_IF_PSS_CERTS_SUPPORTED(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_PSS));
             EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_RSAE));
         }
 
@@ -259,7 +260,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(chosen_certs, rsa_cert_chain);
 
         conn->secure.conn_sig_scheme.sig_alg = S2N_SIGNATURE_RSA_PSS_PSS;
-        EXPECT_SUCCESS_IF_RSA_PSS_SUPPORTED(s2n_select_certs_for_server_auth(conn, &chosen_certs));
+        EXPECT_SUCCESS_IF_PSS_CERTS_SUPPORTED(s2n_select_certs_for_server_auth(conn, &chosen_certs));
         EXPECT_EQUAL(chosen_certs, rsa_pss_cert_chain);
 
         conn->secure.conn_sig_scheme.sig_alg = S2N_SIGNATURE_RSA_PSS_RSAE;
@@ -337,7 +338,7 @@ int main(int argc, char **argv)
         s2n_connection_set_config(conn, rsa_pss_cert_config);
 
         EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA, NULL));
-        EXPECT_SUCCESS_IF_RSA_PSS_SUPPORTED(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, rsa_pss_cert_chain));
+        EXPECT_SUCCESS_IF_PSS_CERTS_SUPPORTED(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, rsa_pss_cert_chain));
         EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_RSAE, NULL));
         EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_ECDSA, NULL));
 
@@ -347,7 +348,7 @@ int main(int argc, char **argv)
         EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_ECDSA, NULL));
 
         EXPECT_FAILURE(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA, NULL));
-        EXPECT_SUCCESS_IF_RSA_PSS_SUPPORTED(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, rsa_pss_cert_chain));
+        EXPECT_SUCCESS_IF_PSS_CERTS_SUPPORTED(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, rsa_pss_cert_chain));
         EXPECT_FAILURE(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_RSAE, NULL));
         EXPECT_FAILURE(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_ECDSA, NULL));
 
@@ -373,7 +374,7 @@ int main(int argc, char **argv)
         s2n_connection_set_config(conn, all_certs_config);
 
         EXPECT_SUCCESS(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA, rsa_cert_chain));
-        EXPECT_SUCCESS_IF_RSA_PSS_SUPPORTED(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, rsa_pss_cert_chain));
+        EXPECT_SUCCESS_IF_PSS_CERTS_SUPPORTED(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, rsa_pss_cert_chain));
         EXPECT_SUCCESS(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_RSAE, rsa_cert_chain));
         EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_ECDSA, ecdsa_cert_chain));
 
@@ -383,7 +384,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_ECDSA, ecdsa_cert_chain));
 
         EXPECT_SUCCESS(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA, rsa_cert_chain));
-        EXPECT_SUCCESS_IF_RSA_PSS_SUPPORTED(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, rsa_pss_cert_chain));
+        EXPECT_SUCCESS_IF_PSS_CERTS_SUPPORTED(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, rsa_pss_cert_chain));
         EXPECT_SUCCESS(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_RSAE, rsa_cert_chain));
         EXPECT_SUCCESS(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_ECDSA, ecdsa_cert_chain));
 

--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -223,12 +223,12 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_free(client_config));
     }
 
-    /* Stop here if RSA_PSS unsupported */
+    /* Stop here if RSA PSS signing is unsupported */
     if (!s2n_is_rsa_pss_supported()) {
         END_TEST();
     }
 
-    /*  Test: RSA cert with RSA_PSS signatures */
+    /*  Test: RSA cert with RSA PSS signatures */
     {
         const struct s2n_signature_scheme* const rsa_pss_rsae_sig_schemes[] = {
                 /* RSA PSS */
@@ -267,6 +267,11 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
         EXPECT_SUCCESS(s2n_config_free(server_config));
         EXPECT_SUCCESS(s2n_config_free(client_config));
+    }
+
+    /* Stop here if RSA PSS CERTS is unsupported */
+    if (!s2n_is_pss_certs_supported()) {
+        END_TEST();
     }
 
     /*  Test: RSA_PSS cert with RSA_PSS signatures */

--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -223,12 +223,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_free(client_config));
     }
 
-    /* Stop here if RSA PSS signing is unsupported */
-    if (!s2n_is_rsa_pss_supported()) {
-        END_TEST();
-    }
-
     /*  Test: RSA cert with RSA PSS signatures */
+    if (s2n_is_rsa_pss_signing_supported())
     {
         const struct s2n_signature_scheme* const rsa_pss_rsae_sig_schemes[] = {
                 /* RSA PSS */
@@ -269,12 +265,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_free(client_config));
     }
 
-    /* Stop here if RSA PSS CERTS is unsupported */
-    if (!s2n_is_pss_certs_supported()) {
-        END_TEST();
-    }
-
     /*  Test: RSA_PSS cert with RSA_PSS signatures */
+    if (s2n_is_rsa_pss_certs_supported())
     {
         s2n_enable_tls13();
 

--- a/tests/unit/s2n_rsa_pss_rsae_test.c
+++ b/tests/unit/s2n_rsa_pss_rsae_test.c
@@ -148,11 +148,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_pkey_free(&rsa_public_key));
     }
 
-    /* End tests early if RSA PSS Certs are not supported */
-    #if !RSA_PSS_CERTS_SUPPORTED
-        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(rsa_cert_chain));
-        END_TEST();
-    #endif
+    #if RSA_PSS_CERTS_SUPPORTED
 
     struct s2n_cert_chain_and_key *rsa_pss_cert_chain;
     EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&rsa_pss_cert_chain,
@@ -266,8 +262,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_pkey_free(&rsa_public_key));
     }
 
-
     EXPECT_SUCCESS(s2n_cert_chain_and_key_free(rsa_pss_cert_chain));
+    #endif
     EXPECT_SUCCESS(s2n_cert_chain_and_key_free(rsa_cert_chain));
     END_TEST();
 }

--- a/tests/unit/s2n_rsa_pss_test.c
+++ b/tests/unit/s2n_rsa_pss_test.c
@@ -39,12 +39,15 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
-    /* We can't use RSA-PSS if RSA-PSS is unsupported */
-#if !RSA_PSS_SUPPORTED
-    EXPECT_FALSE(s2n_is_rsa_pss_supported());
+    /* Don't use RSA-PSS certs if unsupported */
+#if !RSA_PSS_CERTS_SUPPORTED
+    EXPECT_FALSE(s2n_is_rsa_pss_certs_supported());
     END_TEST();
 #endif
-    EXPECT_TRUE(s2n_is_rsa_pss_supported());
+    EXPECT_TRUE(s2n_is_rsa_pss_certs_supported());
+
+    /* Check that s2n_is_rsa_pss_certs_supported() is a superset of s2n_is_rsa_pss_signing_supported() */
+    EXPECT_TRUE(s2n_is_rsa_pss_signing_supported());
 
     /* Positive Test: Ensure we can sign and verify a randomly generated signature.
      * Pseudocode: assert(SUCCESS == verify(Key1_public, message, sign(Key1_private, message)))

--- a/tests/unit/s2n_server_cert_verify_test.c
+++ b/tests/unit/s2n_server_cert_verify_test.c
@@ -37,7 +37,7 @@ struct s2n_server_cert_verify_test {
 const struct s2n_server_cert_verify_test test_cases[] = {
         { .cert_file = S2N_ECDSA_P384_PKCS1_CERT_CHAIN, .key_file = S2N_ECDSA_P384_PKCS1_KEY,
           .sig_scheme = &s2n_ecdsa_secp256r1_sha256 },
-#if RSA_PSS_SUPPORTED
+#if RSA_PSS_CERTS_SUPPORTED
         { .cert_file = S2N_RSA_PSS_2048_SHA256_LEAF_CERT, .key_file = S2N_RSA_PSS_2048_SHA256_LEAF_KEY,
           .sig_scheme = &s2n_rsa_pss_pss_sha256 },
 #endif

--- a/tests/unit/s2n_signature_algorithms_test.c
+++ b/tests/unit/s2n_signature_algorithms_test.c
@@ -107,7 +107,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_read_uint16(&result, &size));
             EXPECT_EQUAL(size, s2n_supported_sig_scheme_list_size(conn));
 
-            for (int i=0; i < LENGTH; i++) {
+            for (int i = 0; i < LENGTH; i++) {
                 EXPECT_SUCCESS(s2n_stuffer_read_uint16(&result, &iana_value));
                 EXPECT_EQUAL(iana_value, test_signature_schemes[i]->iana_value);
             }
@@ -125,7 +125,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_read_uint16(&result, &size));
             EXPECT_EQUAL(size, s2n_supported_sig_scheme_list_size(conn));
 
-            for (int i=0; i < LENGTH; i++) {
+            for (int i = 0; i < LENGTH; i++) {
                 if (test_signature_schemes[i] != &s2n_ecdsa_secp384r1_sha384) {
                     EXPECT_SUCCESS(s2n_stuffer_read_uint16(&result, &iana_value));
                     EXPECT_EQUAL(iana_value, test_signature_schemes[i]->iana_value);
@@ -419,7 +419,7 @@ int main(int argc, char **argv)
 
         struct s2n_sig_scheme_list signatures;
 
-        for (int i=S2N_TLS10; i < S2N_TLS13; i++) {
+        for (int i = S2N_TLS10; i < S2N_TLS13; i++) {
             s2n_stuffer_wipe(&result);
             conn->actual_protocol_version = i;
 
@@ -432,9 +432,9 @@ int main(int argc, char **argv)
             /* Verify no duplicates - some preferences contain duplicates, but only
              * one should be valid at a time. */
             uint16_t iana, other_iana;
-            for (int a=0; a < signatures.len; a++) {
+            for (int a = 0; a < signatures.len; a++) {
                 iana = signatures.iana_list[a];
-                for (int b=0; b < signatures.len; b++) {
+                for (int b = 0; b < signatures.len; b++) {
                     if (a == b) {
                         continue;
                     }
@@ -469,6 +469,13 @@ int main(int argc, char **argv)
         conn->actual_protocol_version = S2N_TLS13;
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
+        /* Check that s2n_is_pss_certs_supported() is a superset of s2n_is_rsa_pss_supported() */
+        {
+            if (s2n_is_pss_certs_supported()) {
+                EXPECT_TRUE(s2n_is_rsa_pss_supported());
+            }
+        }
+
         /* Do not offer PSS signatures schemes if unsupported:
          * s2n_send_supported_sig_scheme_list + PSS */
         {
@@ -480,8 +487,10 @@ int main(int argc, char **argv)
             uint16_t size;
             EXPECT_SUCCESS(s2n_stuffer_read_uint16(&result, &size));
             EXPECT_EQUAL(size, s2n_supported_sig_scheme_list_size(conn));
-            if (s2n_is_rsa_pss_supported()) {
-                EXPECT_NOT_EQUAL(size, 0);
+            if (s2n_is_pss_certs_supported()) {
+                EXPECT_EQUAL(size, 2 * sizeof(uint16_t));
+            }  else if (s2n_is_rsa_pss_supported()) {
+                EXPECT_EQUAL(size, 1 * sizeof(uint16_t));
             } else {
                 EXPECT_EQUAL(size, 0);
             }

--- a/tests/unit/s2n_signature_algorithms_test.c
+++ b/tests/unit/s2n_signature_algorithms_test.c
@@ -500,7 +500,7 @@ int main(int argc, char **argv)
 
             struct s2n_signature_scheme result;
 
-            if (s2n_is_rsa_pss_siging_supported()) {
+            if (s2n_is_rsa_pss_signing_supported()) {
                 EXPECT_SUCCESS(s2n_get_and_validate_negotiated_signature_scheme(conn, &choice, &result));
                 EXPECT_EQUAL(result.iana_value, s2n_rsa_pss_rsae_sha256.iana_value);
             } else {

--- a/tests/unit/s2n_signature_algorithms_test.c
+++ b/tests/unit/s2n_signature_algorithms_test.c
@@ -520,7 +520,7 @@ int main(int argc, char **argv)
 
             struct s2n_signature_scheme result;
 
-            if (s2n_is_rsa_pss_siging_supported()) {
+            if (s2n_is_rsa_pss_signing_supported()) {
                 EXPECT_SUCCESS(s2n_choose_sig_scheme_from_peer_preference_list(conn, &peer_list, &result));
                 EXPECT_EQUAL(result.iana_value, s2n_rsa_pss_rsae_sha256.iana_value);
             } else {

--- a/tests/unit/s2n_signature_algorithms_test.c
+++ b/tests/unit/s2n_signature_algorithms_test.c
@@ -469,13 +469,6 @@ int main(int argc, char **argv)
         conn->actual_protocol_version = S2N_TLS13;
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
-        /* Check that s2n_is_pss_certs_supported() is a superset of s2n_is_rsa_pss_supported() */
-        {
-            if (s2n_is_pss_certs_supported()) {
-                EXPECT_TRUE(s2n_is_rsa_pss_supported());
-            }
-        }
-
         /* Do not offer PSS signatures schemes if unsupported:
          * s2n_send_supported_sig_scheme_list + PSS */
         {
@@ -487,9 +480,9 @@ int main(int argc, char **argv)
             uint16_t size;
             EXPECT_SUCCESS(s2n_stuffer_read_uint16(&result, &size));
             EXPECT_EQUAL(size, s2n_supported_sig_scheme_list_size(conn));
-            if (s2n_is_pss_certs_supported()) {
+            if (s2n_is_rsa_pss_certs_supported()) {
                 EXPECT_EQUAL(size, 2 * sizeof(uint16_t));
-            }  else if (s2n_is_rsa_pss_supported()) {
+            }  else if (s2n_is_rsa_pss_signing_supported()) {
                 EXPECT_EQUAL(size, 1 * sizeof(uint16_t));
             } else {
                 EXPECT_EQUAL(size, 0);
@@ -507,7 +500,7 @@ int main(int argc, char **argv)
 
             struct s2n_signature_scheme result;
 
-            if (s2n_is_rsa_pss_supported()) {
+            if (s2n_is_rsa_pss_siging_supported()) {
                 EXPECT_SUCCESS(s2n_get_and_validate_negotiated_signature_scheme(conn, &choice, &result));
                 EXPECT_EQUAL(result.iana_value, s2n_rsa_pss_rsae_sha256.iana_value);
             } else {
@@ -527,7 +520,7 @@ int main(int argc, char **argv)
 
             struct s2n_signature_scheme result;
 
-            if (s2n_is_rsa_pss_supported()) {
+            if (s2n_is_rsa_pss_siging_supported()) {
                 EXPECT_SUCCESS(s2n_choose_sig_scheme_from_peer_preference_list(conn, &peer_list, &result));
                 EXPECT_EQUAL(result.iana_value, s2n_rsa_pss_rsae_sha256.iana_value);
             } else {

--- a/tls/s2n_signature_algorithms.c
+++ b/tls/s2n_signature_algorithms.c
@@ -32,11 +32,11 @@ static int s2n_signature_scheme_valid_to_offer(struct s2n_connection *conn, cons
     /* We don't know what protocol version we will eventually negotiate, but we know that it won't be any higher. */
     gte_check(conn->actual_protocol_version, scheme->minimum_protocol_version);
 
-    if (!s2n_is_rsa_pss_supported()) {
+    if (!s2n_is_rsa_pss_signing_supported()) {
         ne_check(scheme->sig_alg, S2N_SIGNATURE_RSA_PSS_RSAE);
     }
 
-    if (!s2n_is_pss_certs_supported()) {
+    if (!s2n_is_rsa_pss_certs_supported()) {
         ne_check(scheme->sig_alg, S2N_SIGNATURE_RSA_PSS_PSS);
     }
 

--- a/tls/s2n_signature_algorithms.c
+++ b/tls/s2n_signature_algorithms.c
@@ -14,6 +14,7 @@
  */
 
 #include "crypto/s2n_fips.h"
+#include "crypto/s2n_rsa_signing.h"
 #include "crypto/s2n_rsa_pss.h"
 #include "error/s2n_errno.h"
 
@@ -33,6 +34,9 @@ static int s2n_signature_scheme_valid_to_offer(struct s2n_connection *conn, cons
 
     if (!s2n_is_rsa_pss_supported()) {
         ne_check(scheme->sig_alg, S2N_SIGNATURE_RSA_PSS_RSAE);
+    }
+
+    if (!s2n_is_pss_certs_supported()) {
         ne_check(scheme->sig_alg, S2N_SIGNATURE_RSA_PSS_PSS);
     }
 


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
#1605 

**Description of changes:** 
- RSA PSS signing will be enabled for all versions of libcrypto 1.1.1 (`RSA_PSS_CERTS_SUPPORTED, s2n_is_rsa_pss_certs_supported()`)
- RSA Cert support is enabled only for libcrypto >1.1.1d (`RSA_PSS_SIGNING_SUPPORTED`, `s2n_is_rsa_pss_signing_supported()`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
