### PR TITLE
Sig scheme curve must match cert curve

### DIFF
--- a/crypto/s2n_ecdsa.c
+++ b/crypto/s2n_ecdsa.c
@@ -25,6 +25,7 @@
 #include "utils/s2n_safety.h"
 
 #include "crypto/s2n_ecdsa.h"
+#include "crypto/s2n_ecc_evp.h"
 #include "crypto/s2n_hash.h"
 #include "crypto/s2n_openssl.h"
 #include "crypto/s2n_pkey.h"
@@ -156,5 +157,17 @@ int s2n_ecdsa_pkey_init(struct s2n_pkey *pkey) {
     pkey->match = &s2n_ecdsa_keys_match;
     pkey->free = &s2n_ecdsa_key_free;
     pkey->check_key = &s2n_ecdsa_check_key_exists;
+    return 0;
+}
+
+int s2n_ecdsa_pkey_matches_curve(const struct s2n_ecdsa_key *ecdsa_key, const struct s2n_ecc_named_curve *curve)
+{
+    notnull_check(ecdsa_key);
+    notnull_check(ecdsa_key->ec_key);
+    notnull_check(curve);
+
+    int curve_id = EC_GROUP_get_curve_name(EC_KEY_get0_group(ecdsa_key->ec_key));
+    eq_check(curve_id, curve->libcrypto_nid);
+
     return 0;
 }

--- a/crypto/s2n_ecdsa.h
+++ b/crypto/s2n_ecdsa.h
@@ -21,6 +21,7 @@
 
 #include "stuffer/s2n_stuffer.h"
 
+#include "crypto/s2n_ecc_evp.h"
 #include "crypto/s2n_hash.h"
 
 #include "utils/s2n_blob.h"
@@ -36,6 +37,7 @@ typedef struct s2n_ecdsa_key s2n_ecdsa_public_key;
 typedef struct s2n_ecdsa_key s2n_ecdsa_private_key;
 
 extern int s2n_ecdsa_pkey_init(struct s2n_pkey *pkey);
+extern int s2n_ecdsa_pkey_matches_curve(const struct s2n_ecdsa_key *ecdsa_key, const struct s2n_ecc_named_curve *curve);
 
 extern int s2n_evp_pkey_to_ecdsa_public_key(s2n_ecdsa_public_key *ecdsa_key, EVP_PKEY *pkey);
 extern int s2n_evp_pkey_to_ecdsa_private_key(s2n_ecdsa_private_key *ecdsa_key, EVP_PKEY *pkey);

--- a/tests/integration/common/s2n_test_common.py
+++ b/tests/integration/common/s2n_test_common.py
@@ -22,7 +22,6 @@ import uuid
 
 from common.s2n_test_scenario import Mode, Version, run_scenarios
 from common.s2n_test_reporting import Result
-from s2n_test_constants import TEST_ECDSA_CERT, TEST_ECDSA_KEY
 
 
 def get_error(process, line_limit=10):
@@ -142,8 +141,8 @@ def get_s2n_cmd(scenario):
                 "--insecure"]
 
     if scenario.s2n_mode.is_server():
-        s2n_cmd.extend(["--key", TEST_ECDSA_KEY])
-        s2n_cmd.extend(["--cert", TEST_ECDSA_CERT])
+        s2n_cmd.extend(["--key", scenario.cert.key])
+        s2n_cmd.extend(["--cert", scenario.cert.cert])
     else:
         s2n_cmd.append("--echo")
 

--- a/tests/integration/common/s2n_test_openssl.py
+++ b/tests/integration/common/s2n_test_openssl.py
@@ -19,7 +19,6 @@ Common functions used to create test openssl servers and clients.
 
 import common.s2n_test_common as util
 from common.s2n_test_scenario import Mode, Version
-from s2n_test_constants import TEST_ECDSA_CERT, TEST_ECDSA_KEY
 from time import sleep
 
 
@@ -45,8 +44,8 @@ def get_openssl_cmd(scenario):
     else:
         openssl_cmd.extend(["s_client", "-connect", str(scenario.host) + ":" + str(scenario.port)])
 
-    openssl_cmd.extend(["-cert", TEST_ECDSA_CERT,
-                        "-key", TEST_ECDSA_KEY,
+    openssl_cmd.extend(["-cert", scenario.cert.cert,
+                        "-key", scenario.cert.key,
                         "-tlsextdebug"])
 
     if scenario.version:

--- a/tests/integration/common/s2n_test_scenario.py
+++ b/tests/integration/common/s2n_test_scenario.py
@@ -57,6 +57,21 @@ class Mode(Enum):
         return Mode.server if self.is_client() else Mode.client
 
 
+class Cert():
+    def __init__(self, name, prefix, location="../pems/"):
+        self.name = name
+        self.cert = location + prefix + "_cert.pem"
+        self.key = location + prefix + "_key.pem"
+
+    def __str__(self):
+        return self.name
+
+ALL_CERTS = [
+    Cert("ECDSA_256", "ecdsa_p256_pkcs1"),
+    Cert("ECDSA_384", "ecdsa_p384_pkcs1"),
+]
+
+
 class Cipher():
     def __init__(self, name, min_version):
         self.name = name
@@ -111,7 +126,8 @@ class Scenario:
 
     """
 
-    def __init__(self, s2n_mode, host, port, version=None, cipher=None, curve=None, s2n_flags=[], peer_flags=[]):
+    def __init__(self, s2n_mode, host, port, version=None, cipher=None, curve=None,
+                 cert=ALL_CERTS[0], s2n_flags=[], peer_flags=[]):
         """
         Args:
             s2n_mode: whether s2n should act as a client or server.
@@ -131,14 +147,16 @@ class Scenario:
         self.version = version
         self.cipher = cipher
         self.curve = curve
+        self.cert = cert
         self.s2n_flags = s2n_flags
         self.peer_flags = peer_flags
 
     def __str__(self):
         version = self.version if self.version else "DEFAULT"
         cipher = self.cipher if self.cipher else "ANY"
-        result = "Mode:%s %s Version:%s Curve:%s Cipher:%s" % \
-            (self.s2n_mode, " ".join(self.s2n_flags), str(version).ljust(7), self.curve, str(cipher).ljust(30))
+        result = "Mode:%s %s Version:%s Curve:%s Cert:%s Cipher:%s" % \
+            (self.s2n_mode, " ".join(self.s2n_flags), str(version).ljust(7), self.curve,
+             str(self.cert).ljust(10), str(cipher).ljust(30))
 
         return result.ljust(100)
 
@@ -174,12 +192,13 @@ def run_scenarios(test_func, scenarios):
     return failed
 
 
-def get_scenarios(host, start_port, s2n_modes=Mode.all(), versions=[None], ciphers=[None], curves=ALL_CURVES, s2n_flags=[], peer_flags=[]):
+def get_scenarios(host, start_port, s2n_modes=Mode.all(), versions=[None], ciphers=[None],
+                  curves=ALL_CURVES, certs=ALL_CERTS, s2n_flags=[], peer_flags=[]):
     port = start_port
     scenarios = []
 
-    combos = itertools.product(versions, s2n_modes, ciphers, curves)
-    for (version, s2n_mode, cipher, curve) in combos:
+    combos = itertools.product(versions, s2n_modes, ciphers, curves, certs)
+    for (version, s2n_mode, cipher, curve, cert) in combos:
         if cipher and not cipher.valid_for(version):
             continue
 
@@ -191,6 +210,7 @@ def get_scenarios(host, start_port, s2n_modes=Mode.all(), versions=[None], ciphe
                 version=version,
                 cipher=cipher,
                 curve=curve,
+                cert=cert,
                 s2n_flags=s2n_flags,
                 peer_flags=peer_flags))
             port += 1

--- a/tests/integration/s2n_test_constants.py
+++ b/tests/integration/s2n_test_constants.py
@@ -128,14 +128,11 @@ S2N_PROTO_VERS_TO_GNUTLS = {
 
 TEST_CERT_DIRECTORY="../pems/"
 
-TEST_RSA_CERT=TEST_CERT_DIRECTORY + "rsa_2048_sha256_wildcard_cert.pem"
-TEST_RSA_KEY=TEST_CERT_DIRECTORY + "rsa_2048_sha256_wildcard_key.pem"
+TEST_RSA_CERT = TEST_CERT_DIRECTORY + "rsa_2048_sha256_wildcard_cert.pem"
+TEST_RSA_KEY  = TEST_CERT_DIRECTORY + "rsa_2048_sha256_wildcard_key.pem"
 
-# TODO: These key/certs needs to be configurable. We should be able
-# to choose different types of certs.
-# https://github.com/awslabs/s2n/issues/1673
-TEST_ECDSA_CERT=TEST_CERT_DIRECTORY + "ecdsa_p256_pkcs1_cert.pem"
-TEST_ECDSA_KEY=TEST_CERT_DIRECTORY + "ecdsa_p256_pkcs1_key.pem"
+TEST_ECDSA_CERT = TEST_CERT_DIRECTORY + "ecdsa_p384_pkcs1_cert.pem"
+TEST_ECDSA_KEY  = TEST_CERT_DIRECTORY + "ecdsa_p384_pkcs1_key.pem"
 
 TEST_DH_PARAMS=TEST_CERT_DIRECTORY + "dhparams_2048.pem"
 

--- a/tests/testlib/s2n_testlib.h
+++ b/tests/testlib/s2n_testlib.h
@@ -64,9 +64,11 @@ int s2n_fd_set_non_blocking(int fd);
 #define S2N_RSA_2048_PKCS1_CERT_CHAIN   "../pems/rsa_2048_pkcs1_cert.pem"
 
 #define S2N_RSA_2048_PKCS1_LEAF_CERT    "../pems/rsa_2048_pkcs1_leaf.pem"
+#define S2N_ECDSA_P256_PKCS1_CERT_CHAIN "../pems/ecdsa_p256_pkcs1_cert.pem"
 #define S2N_ECDSA_P384_PKCS1_CERT_CHAIN "../pems/ecdsa_p384_pkcs1_cert.pem"
 #define S2N_RSA_CERT_CHAIN_CRLF         "../pems/rsa_2048_pkcs1_cert_crlf.pem"
 #define S2N_RSA_KEY_CRLF                "../pems/rsa_2048_pkcs1_key_crlf.pem"
+#define S2N_ECDSA_P256_PKCS1_KEY        "../pems/ecdsa_p256_pkcs1_key.pem"
 #define S2N_ECDSA_P384_PKCS1_KEY        "../pems/ecdsa_p384_pkcs1_key.pem"
 #define S2N_RSA_2048_PKCS1_KEY          "../pems/rsa_2048_pkcs1_key.pem"
 #define S2N_RSA_2048_PKCS8_KEY          "../pems/rsa_2048_pkcs8_key.pem"

--- a/tests/unit/s2n_auth_selection_test.c
+++ b/tests/unit/s2n_auth_selection_test.c
@@ -32,6 +32,12 @@
 #define ECDSA_AUTH_CIPHER_SUITE &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha
 #define NO_AUTH_CIPHER_SUITE &s2n_tls13_aes_128_gcm_sha256
 
+#define RSA_PKCS1_SIG_SCHEME &s2n_rsa_pkcs1_md5_sha1
+#define RSA_PSS_PSS_SIG_SCHEME &s2n_rsa_pss_pss_sha256
+#define RSA_PSS_RSAE_SIG_SCHEME &s2n_rsa_pss_rsae_sha256
+#define ECDSA_SIG_SCHEME &s2n_ecdsa_secp384r1_sha384
+#define ECDSA_SIG_SCHEME_OTHER_CURVE &s2n_ecdsa_secp256r1_sha256
+
 #define EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(x) \
     if ( s2n_is_rsa_pss_certs_supported() ) { \
         EXPECT_SUCCESS(x); \
@@ -40,7 +46,7 @@
     } \
 
 static int s2n_test_auth_combo(struct s2n_connection *conn,
-        struct s2n_cipher_suite *cipher_suite, s2n_signature_algorithm sig_alg,
+        struct s2n_cipher_suite *cipher_suite, const struct s2n_signature_scheme *sig_scheme,
         struct s2n_cert_chain_and_key *expected_cert_chain)
 {
     struct s2n_cert_chain_and_key *actual_cert_chain;
@@ -48,8 +54,8 @@ static int s2n_test_auth_combo(struct s2n_connection *conn,
     GUARD(s2n_is_cipher_suite_valid_for_auth(conn, cipher_suite));
     conn->secure.cipher_suite = cipher_suite;
 
-    GUARD(s2n_is_sig_alg_valid_for_auth(conn, sig_alg));
-    conn->secure.conn_sig_scheme.sig_alg = sig_alg;
+    GUARD(s2n_is_sig_scheme_valid_for_auth(conn, sig_scheme));
+    conn->secure.conn_sig_scheme.sig_alg = sig_scheme->sig_alg;
 
     GUARD(s2n_select_certs_for_server_auth(conn, &actual_cert_chain));
     eq_check(actual_cert_chain, expected_cert_chain);
@@ -130,7 +136,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
-    /* s2n_is_sig_alg_valid_for_auth */
+    /* s2n_is_sig_scheme_valid_for_auth */
     {
         struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
 
@@ -140,38 +146,62 @@ int main(int argc, char **argv)
 
             /* No certs exist */
             s2n_connection_set_config(conn, no_certs_config);
-            EXPECT_FAILURE(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA));
-            EXPECT_FAILURE(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_PSS));
-            EXPECT_FAILURE(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_RSAE));
-            EXPECT_FAILURE(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_ECDSA));
+            EXPECT_FAILURE(s2n_is_sig_scheme_valid_for_auth(conn, RSA_PKCS1_SIG_SCHEME));
+            EXPECT_FAILURE(s2n_is_sig_scheme_valid_for_auth(conn, RSA_PSS_PSS_SIG_SCHEME));
+            EXPECT_FAILURE(s2n_is_sig_scheme_valid_for_auth(conn, RSA_PSS_RSAE_SIG_SCHEME));
+            EXPECT_FAILURE(s2n_is_sig_scheme_valid_for_auth(conn, ECDSA_SIG_SCHEME));
 
             /* RSA certs exist */
             s2n_connection_set_config(conn, rsa_cert_config);
-            EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA));
-            EXPECT_FAILURE(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_PSS));
-            EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_RSAE));
-            EXPECT_FAILURE(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_ECDSA));
+            EXPECT_SUCCESS(s2n_is_sig_scheme_valid_for_auth(conn, RSA_PKCS1_SIG_SCHEME));
+            EXPECT_FAILURE(s2n_is_sig_scheme_valid_for_auth(conn, RSA_PSS_PSS_SIG_SCHEME));
+            EXPECT_SUCCESS(s2n_is_sig_scheme_valid_for_auth(conn, RSA_PSS_RSAE_SIG_SCHEME));
+            EXPECT_FAILURE(s2n_is_sig_scheme_valid_for_auth(conn, ECDSA_SIG_SCHEME));
 
             /* RSA-PSS certs exist */
             s2n_connection_set_config(conn, rsa_pss_cert_config);
-            EXPECT_FAILURE(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA));
-            EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_PSS));
-            EXPECT_FAILURE(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_RSAE));
-            EXPECT_FAILURE(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_ECDSA));
+            EXPECT_FAILURE(s2n_is_sig_scheme_valid_for_auth(conn, RSA_PKCS1_SIG_SCHEME));
+            EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_is_sig_scheme_valid_for_auth(conn, RSA_PSS_PSS_SIG_SCHEME));
+            EXPECT_FAILURE(s2n_is_sig_scheme_valid_for_auth(conn, RSA_PSS_RSAE_SIG_SCHEME));
+            EXPECT_FAILURE(s2n_is_sig_scheme_valid_for_auth(conn, ECDSA_SIG_SCHEME));
 
             /* ECDSA certs exist */
             s2n_connection_set_config(conn, ecdsa_cert_config);
-            EXPECT_FAILURE(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA));
-            EXPECT_FAILURE(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_PSS));
-            EXPECT_FAILURE(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_RSAE));
-            EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_ECDSA));
+            EXPECT_FAILURE(s2n_is_sig_scheme_valid_for_auth(conn, RSA_PKCS1_SIG_SCHEME));
+            EXPECT_FAILURE(s2n_is_sig_scheme_valid_for_auth(conn, RSA_PSS_PSS_SIG_SCHEME));
+            EXPECT_FAILURE(s2n_is_sig_scheme_valid_for_auth(conn, RSA_PSS_RSAE_SIG_SCHEME));
+            EXPECT_SUCCESS(s2n_is_sig_scheme_valid_for_auth(conn, ECDSA_SIG_SCHEME));
 
             /* All certs exist */
             s2n_connection_set_config(conn, all_certs_config);
-            EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA));
-            EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_PSS));
-            EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_RSAE));
-            EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_ECDSA));
+            EXPECT_SUCCESS(s2n_is_sig_scheme_valid_for_auth(conn, RSA_PKCS1_SIG_SCHEME));
+            EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_is_sig_scheme_valid_for_auth(conn, RSA_PSS_PSS_SIG_SCHEME));
+            EXPECT_SUCCESS(s2n_is_sig_scheme_valid_for_auth(conn, RSA_PSS_RSAE_SIG_SCHEME));
+            EXPECT_SUCCESS(s2n_is_sig_scheme_valid_for_auth(conn, ECDSA_SIG_SCHEME));
+        }
+
+        /* Test: If signature algorithm specifies curve, must match cert curve */
+        {
+            struct s2n_cert_chain_and_key *ecdsa_cert_chain_for_other_curve;
+            EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&ecdsa_cert_chain_for_other_curve,
+                    S2N_ECDSA_P256_PKCS1_CERT_CHAIN, S2N_ECDSA_P256_PKCS1_KEY));
+
+            struct s2n_config *ecdsa_cert_config_for_other_curve = s2n_config_new();
+            EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(
+                    ecdsa_cert_config_for_other_curve, ecdsa_cert_chain_for_other_curve));
+
+            conn->secure.cipher_suite = NO_AUTH_CIPHER_SUITE;
+
+            s2n_connection_set_config(conn, ecdsa_cert_config);
+            EXPECT_SUCCESS(s2n_is_sig_scheme_valid_for_auth(conn, ECDSA_SIG_SCHEME));
+            EXPECT_FAILURE(s2n_is_sig_scheme_valid_for_auth(conn, ECDSA_SIG_SCHEME_OTHER_CURVE));
+
+            s2n_connection_set_config(conn, ecdsa_cert_config_for_other_curve);
+            EXPECT_FAILURE(s2n_is_sig_scheme_valid_for_auth(conn, ECDSA_SIG_SCHEME));
+            EXPECT_SUCCESS(s2n_is_sig_scheme_valid_for_auth(conn, ECDSA_SIG_SCHEME_OTHER_CURVE));
+
+            EXPECT_SUCCESS(s2n_config_free(ecdsa_cert_config_for_other_curve));
+            EXPECT_SUCCESS(s2n_cert_chain_and_key_free(ecdsa_cert_chain_for_other_curve));
         }
 
         /* Test: If cipher suite specifies auth type, auth type must be valid for sig alg */
@@ -180,17 +210,17 @@ int main(int argc, char **argv)
 
             /* RSA auth type */
             conn->secure.cipher_suite = RSA_AUTH_CIPHER_SUITE;
-            EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA));
-            EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_PSS));
-            EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_RSAE));
-            EXPECT_FAILURE(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_ECDSA));
+            EXPECT_SUCCESS(s2n_is_sig_scheme_valid_for_auth(conn, RSA_PKCS1_SIG_SCHEME));
+            EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_is_sig_scheme_valid_for_auth(conn, RSA_PSS_PSS_SIG_SCHEME));
+            EXPECT_SUCCESS(s2n_is_sig_scheme_valid_for_auth(conn, RSA_PSS_RSAE_SIG_SCHEME));
+            EXPECT_FAILURE(s2n_is_sig_scheme_valid_for_auth(conn, ECDSA_SIG_SCHEME));
 
             /* ECDSA auth type */
             conn->secure.cipher_suite = ECDSA_AUTH_CIPHER_SUITE;
-            EXPECT_FAILURE(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA));
-            EXPECT_FAILURE(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_PSS));
-            EXPECT_FAILURE(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_RSAE));
-            EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_ECDSA));
+            EXPECT_FAILURE(s2n_is_sig_scheme_valid_for_auth(conn, RSA_PKCS1_SIG_SCHEME));
+            EXPECT_FAILURE(s2n_is_sig_scheme_valid_for_auth(conn, RSA_PSS_PSS_SIG_SCHEME));
+            EXPECT_FAILURE(s2n_is_sig_scheme_valid_for_auth(conn, RSA_PSS_RSAE_SIG_SCHEME));
+            EXPECT_SUCCESS(s2n_is_sig_scheme_valid_for_auth(conn, ECDSA_SIG_SCHEME));
         }
 
         /* Test: RSA-PSS requires a non-ephemeral kex */
@@ -199,21 +229,21 @@ int main(int argc, char **argv)
 
             /* ephemeral key */
             conn->secure.cipher_suite = &s2n_dhe_rsa_with_3des_ede_cbc_sha; /* kex = (dhe) */
-            EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA));
-            EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_PSS));
-            EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_RSAE));
+            EXPECT_SUCCESS(s2n_is_sig_scheme_valid_for_auth(conn, RSA_PKCS1_SIG_SCHEME));
+            EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_is_sig_scheme_valid_for_auth(conn, RSA_PSS_PSS_SIG_SCHEME));
+            EXPECT_SUCCESS(s2n_is_sig_scheme_valid_for_auth(conn, RSA_PSS_RSAE_SIG_SCHEME));
 
             /* non-ephemeral key */
             conn->secure.cipher_suite = &s2n_rsa_with_rc4_128_md5; /* kex = (rsa) */
-            EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA));
-            EXPECT_FAILURE(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_PSS));
-            EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_RSAE));
+            EXPECT_SUCCESS(s2n_is_sig_scheme_valid_for_auth(conn, RSA_PKCS1_SIG_SCHEME));
+            EXPECT_FAILURE(s2n_is_sig_scheme_valid_for_auth(conn, RSA_PSS_PSS_SIG_SCHEME));
+            EXPECT_SUCCESS(s2n_is_sig_scheme_valid_for_auth(conn, RSA_PSS_RSAE_SIG_SCHEME));
 
             /* no kex at all */
             conn->secure.cipher_suite = NO_AUTH_CIPHER_SUITE; /* kex = NULL */
-            EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA));
-            EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_PSS));
-            EXPECT_SUCCESS(s2n_is_sig_alg_valid_for_auth(conn, S2N_SIGNATURE_RSA_PSS_RSAE));
+            EXPECT_SUCCESS(s2n_is_sig_scheme_valid_for_auth(conn, RSA_PKCS1_SIG_SCHEME));
+            EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_is_sig_scheme_valid_for_auth(conn, RSA_PSS_PSS_SIG_SCHEME));
+            EXPECT_SUCCESS(s2n_is_sig_scheme_valid_for_auth(conn, RSA_PSS_RSAE_SIG_SCHEME));
         }
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -301,92 +331,92 @@ int main(int argc, char **argv)
         /* No certs exist */
         s2n_connection_set_config(conn, no_certs_config);
 
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA, NULL));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, NULL));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_RSAE, NULL));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_ECDSA, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, RSA_PKCS1_SIG_SCHEME, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, RSA_PSS_PSS_SIG_SCHEME, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, RSA_PSS_RSAE_SIG_SCHEME, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, ECDSA_SIG_SCHEME, NULL));
 
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA, NULL));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, NULL));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_RSAE, NULL));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_ECDSA, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, RSA_PKCS1_SIG_SCHEME, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, RSA_PSS_PSS_SIG_SCHEME, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, RSA_PSS_RSAE_SIG_SCHEME, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, ECDSA_SIG_SCHEME, NULL));
 
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA, NULL));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, NULL));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_RSAE, NULL));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_ECDSA, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, RSA_PKCS1_SIG_SCHEME, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, RSA_PSS_PSS_SIG_SCHEME, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, RSA_PSS_RSAE_SIG_SCHEME, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, ECDSA_SIG_SCHEME, NULL));
 
         /* RSA certs exist */
         s2n_connection_set_config(conn, rsa_cert_config);
 
-        EXPECT_SUCCESS(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA, rsa_cert_chain));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, NULL));
-        EXPECT_SUCCESS(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_RSAE, rsa_cert_chain));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_ECDSA, NULL));
+        EXPECT_SUCCESS(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, RSA_PKCS1_SIG_SCHEME, rsa_cert_chain));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, RSA_PSS_PSS_SIG_SCHEME, NULL));
+        EXPECT_SUCCESS(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, RSA_PSS_RSAE_SIG_SCHEME, rsa_cert_chain));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, ECDSA_SIG_SCHEME, NULL));
 
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA, NULL));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, NULL));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_RSAE, NULL));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_ECDSA, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, RSA_PKCS1_SIG_SCHEME, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, RSA_PSS_PSS_SIG_SCHEME, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, RSA_PSS_RSAE_SIG_SCHEME, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, ECDSA_SIG_SCHEME, NULL));
 
-        EXPECT_SUCCESS(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA, rsa_cert_chain));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, NULL));
-        EXPECT_SUCCESS(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_RSAE, rsa_cert_chain));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_ECDSA, NULL));
+        EXPECT_SUCCESS(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, RSA_PKCS1_SIG_SCHEME, rsa_cert_chain));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, RSA_PSS_PSS_SIG_SCHEME, NULL));
+        EXPECT_SUCCESS(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, RSA_PSS_RSAE_SIG_SCHEME, rsa_cert_chain));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, ECDSA_SIG_SCHEME, NULL));
 
         /* RSA_PSS certs exist */
         s2n_connection_set_config(conn, rsa_pss_cert_config);
 
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA, NULL));
-        EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, rsa_pss_cert_chain));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_RSAE, NULL));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_ECDSA, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, RSA_PKCS1_SIG_SCHEME, NULL));
+        EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, RSA_PSS_PSS_SIG_SCHEME, rsa_pss_cert_chain));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, RSA_PSS_RSAE_SIG_SCHEME, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, ECDSA_SIG_SCHEME, NULL));
 
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA, NULL));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, NULL));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_RSAE, NULL));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_ECDSA, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, RSA_PKCS1_SIG_SCHEME, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, RSA_PSS_PSS_SIG_SCHEME, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, RSA_PSS_RSAE_SIG_SCHEME, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, ECDSA_SIG_SCHEME, NULL));
 
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA, NULL));
-        EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, rsa_pss_cert_chain));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_RSAE, NULL));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_ECDSA, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, RSA_PKCS1_SIG_SCHEME, NULL));
+        EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, RSA_PSS_PSS_SIG_SCHEME, rsa_pss_cert_chain));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, RSA_PSS_RSAE_SIG_SCHEME, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, ECDSA_SIG_SCHEME, NULL));
 
         /* ECDSA certs exist */
         s2n_connection_set_config(conn, ecdsa_cert_config);
 
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA, NULL));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, NULL));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_RSAE, NULL));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_ECDSA, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, RSA_PKCS1_SIG_SCHEME, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, RSA_PSS_PSS_SIG_SCHEME, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, RSA_PSS_RSAE_SIG_SCHEME, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, ECDSA_SIG_SCHEME, NULL));
 
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA, NULL));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, NULL));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_RSAE, NULL));
-        EXPECT_SUCCESS(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_ECDSA, ecdsa_cert_chain));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, RSA_PKCS1_SIG_SCHEME, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, RSA_PSS_PSS_SIG_SCHEME, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, RSA_PSS_RSAE_SIG_SCHEME, NULL));
+        EXPECT_SUCCESS(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, ECDSA_SIG_SCHEME, ecdsa_cert_chain));
 
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA, NULL));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, NULL));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_RSAE, NULL));
-        EXPECT_SUCCESS(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_ECDSA, ecdsa_cert_chain));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, RSA_PKCS1_SIG_SCHEME, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, RSA_PSS_PSS_SIG_SCHEME, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, RSA_PSS_RSAE_SIG_SCHEME, NULL));
+        EXPECT_SUCCESS(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, ECDSA_SIG_SCHEME, ecdsa_cert_chain));
 
         /* All certs exist */
         s2n_connection_set_config(conn, all_certs_config);
 
-        EXPECT_SUCCESS(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA, rsa_cert_chain));
-        EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, rsa_pss_cert_chain));
-        EXPECT_SUCCESS(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_RSAE, rsa_cert_chain));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_ECDSA, ecdsa_cert_chain));
+        EXPECT_SUCCESS(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, RSA_PKCS1_SIG_SCHEME, rsa_cert_chain));
+        EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, RSA_PSS_PSS_SIG_SCHEME, rsa_pss_cert_chain));
+        EXPECT_SUCCESS(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, RSA_PSS_RSAE_SIG_SCHEME, rsa_cert_chain));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, RSA_AUTH_CIPHER_SUITE, ECDSA_SIG_SCHEME, NULL));
 
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA, rsa_cert_chain));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, rsa_pss_cert_chain));
-        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_RSAE, rsa_cert_chain));
-        EXPECT_SUCCESS(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, S2N_SIGNATURE_ECDSA, ecdsa_cert_chain));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, RSA_PKCS1_SIG_SCHEME, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, RSA_PSS_PSS_SIG_SCHEME, NULL));
+        EXPECT_FAILURE(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, RSA_PSS_RSAE_SIG_SCHEME, NULL));
+        EXPECT_SUCCESS(s2n_test_auth_combo(conn, ECDSA_AUTH_CIPHER_SUITE, ECDSA_SIG_SCHEME, ecdsa_cert_chain));
 
-        EXPECT_SUCCESS(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA, rsa_cert_chain));
-        EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_PSS, rsa_pss_cert_chain));
-        EXPECT_SUCCESS(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_RSA_PSS_RSAE, rsa_cert_chain));
-        EXPECT_SUCCESS(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, S2N_SIGNATURE_ECDSA, ecdsa_cert_chain));
+        EXPECT_SUCCESS(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, RSA_PKCS1_SIG_SCHEME, rsa_cert_chain));
+        EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, RSA_PSS_PSS_SIG_SCHEME, rsa_pss_cert_chain));
+        EXPECT_SUCCESS(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, RSA_PSS_RSAE_SIG_SCHEME, rsa_cert_chain));
+        EXPECT_SUCCESS(s2n_test_auth_combo(conn, NO_AUTH_CIPHER_SUITE, ECDSA_SIG_SCHEME, ecdsa_cert_chain));
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }

--- a/tests/unit/s2n_ecdsa_test.c
+++ b/tests/unit/s2n_ecdsa_test.c
@@ -68,6 +68,29 @@ int main(int argc, char **argv)
 
     BEGIN_TEST();
 
+    /* s2n_ecdsa_pkey_matches_curve */
+    {
+        struct s2n_ecdsa_key *p256_key, *p384_key;
+        struct s2n_cert_chain_and_key *p256_chain, *p384_chain;
+
+        EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&p256_chain,
+                S2N_ECDSA_P256_PKCS1_CERT_CHAIN, S2N_ECDSA_P256_PKCS1_KEY));
+        EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&p384_chain,
+                S2N_ECDSA_P384_PKCS1_CERT_CHAIN, S2N_ECDSA_P384_PKCS1_KEY));
+
+        p256_key = &p256_chain->private_key->key.ecdsa_key;
+        p384_key = &p384_chain->private_key->key.ecdsa_key;
+
+        EXPECT_SUCCESS(s2n_ecdsa_pkey_matches_curve(p256_key, &s2n_ecc_curve_secp256r1));
+        EXPECT_SUCCESS(s2n_ecdsa_pkey_matches_curve(p384_key, &s2n_ecc_curve_secp384r1));
+
+        EXPECT_FAILURE(s2n_ecdsa_pkey_matches_curve(p256_key, &s2n_ecc_curve_secp384r1));
+        EXPECT_FAILURE(s2n_ecdsa_pkey_matches_curve(p384_key, &s2n_ecc_curve_secp256r1));
+
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(p256_chain));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(p384_chain));
+    }
+
     EXPECT_SUCCESS(s2n_stuffer_alloc(&certificate_in, S2N_MAX_TEST_PEM_SIZE));
     EXPECT_SUCCESS(s2n_stuffer_alloc(&certificate_out, S2N_MAX_TEST_PEM_SIZE));
     EXPECT_SUCCESS(s2n_stuffer_alloc(&ecdsa_key_in, S2N_MAX_TEST_PEM_SIZE));

--- a/tls/s2n_auth_selection.h
+++ b/tls/s2n_auth_selection.h
@@ -21,7 +21,7 @@
 #include "crypto/s2n_signature.h"
 
 int s2n_is_cipher_suite_valid_for_auth(struct s2n_connection *conn, struct s2n_cipher_suite *cipher_suite);
-int s2n_is_sig_alg_valid_for_auth(struct s2n_connection *conn, s2n_signature_algorithm sig_alg);
+int s2n_is_sig_scheme_valid_for_auth(struct s2n_connection *conn, const struct s2n_signature_scheme *sig_scheme);
 int s2n_is_cert_type_valid_for_auth(struct s2n_connection *conn, s2n_pkey_type cert_type);
 int s2n_select_certs_for_server_auth(struct s2n_connection *conn, struct s2n_cert_chain_and_key **chosen_certs);
 

--- a/tls/s2n_signature_algorithms.c
+++ b/tls/s2n_signature_algorithms.c
@@ -72,7 +72,7 @@ static int s2n_choose_sig_scheme(struct s2n_connection *conn, struct s2n_sig_sch
             continue;
         }
 
-        if (s2n_is_sig_alg_valid_for_auth(conn, candidate->sig_alg) != S2N_SUCCESS) {
+        if (s2n_is_sig_scheme_valid_for_auth(conn, candidate) != S2N_SUCCESS) {
             continue;
         }
 


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** https://github.com/awslabs/s2n/issues/1660

**Description of changes:** If a signature scheme specifies a curve, skip it if our cert uses a different curve. I also made the tests run with both supported ecdsa certs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
