### PR TITLE
Only call the ClientHello retry once, even after a HelloRetryRequest …

### DIFF
--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -334,7 +334,7 @@ int s2n_client_hello_recv(struct s2n_connection *conn)
     conn->client_hello.parsed = 1;
 
     /* Call client_hello_cb if exists, letting application to modify s2n_connection or swap s2n_config */
-    if (conn->config->client_hello_cb) {
+    if (conn->config->client_hello_cb && conn->handshake.server_sent_hrr == 0) {
         int rc = conn->config->client_hello_cb(conn, conn->config->client_hello_cb_ctx);
         if (rc < 0) {
             GUARD(s2n_queue_reader_handshake_failure_alert(conn));


### PR DESCRIPTION
_Note: This is for review, but we shouldn't merge into the test branch until our internal testing is done._

_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
#1636 

**Description of changes:** 
* If a HelloRetryRequest was sent by the server, don't call the ClientHello callback on the second invocation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
