### PR TITLE
Allow CMake Build to work with git submodules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,8 +115,8 @@ else()
     enable_language(ASM)
     try_compile(PQ_ASM_COMPILES ${CMAKE_BINARY_DIR}
             SOURCES
-            "${CMAKE_SOURCE_DIR}/tests/unit/s2n_pq_asm_noop_test.c"
-            "${CMAKE_SOURCE_DIR}/pq-crypto/sike_r2/fp_x64_asm.S")
+            "${CMAKE_CURRENT_LIST_DIR}/tests/unit/s2n_pq_asm_noop_test.c"
+            "${CMAKE_CURRENT_LIST_DIR}/pq-crypto/sike_r2/fp_x64_asm.S")
     if(PQ_ASM_COMPILES)
         message(STATUS "PQ ASM try_compile succeeded - using optimized x86_64 assembly for PQ crypto")
         file(GLOB PQ_X86_64_ASM "pq-crypto/sike_r2/fp_x64_asm.S")


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** N/A

**Description of changes:** 
If a parent repo adds s2n as a submodule, then `CMAKE_SOURCE_DIR` contains the directory of the parent repo, not the s2n source directory.

We instead want the directory that contains the current `CMakeLists.txt` file, which will be present in the `CMAKE_CURRENT_LIST_DIR` env variable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
