### PR TITLE
ci: GitHub Action to replicate to other repos

### DIFF
--- a/.github/workflows/private_sync.yml
+++ b/.github/workflows/private_sync.yml
@@ -1,0 +1,27 @@
+name: force_push
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Push cbmc
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.private_repos_s2n_20200214 }}
+          repository: awslabs/private-s2n-cbmc
+          branch: master
+          force: true
+      - name: Push fuzz
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.private_repos_s2n_20200214 }}
+          repository: awslabs/private-s2n-fuzz
+          branch: master
+          force: true


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Description of changes:** 
GitHub Action to replicate to other repos

Draft until repo permissions are sorted out.

Tested between CryptoTools repo and a personal private repo [here](https://github.com/aws/crypto-tools/runs/470900715?check_suite_focus=true)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
