### PR TITLE
HRR State machine update

### DIFF
--- a/tests/unit/s2n_client_key_share_extension_test.c
+++ b/tests/unit/s2n_client_key_share_extension_test.c
@@ -265,6 +265,7 @@ int main(int argc, char **argv)
             struct s2n_connection *server_conn;
             struct s2n_stuffer key_share_extension;
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+
             /* ISSUE 1657: This is only happening because the connection clears all keyshares, this is part of the HRR test */
             for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
                 EXPECT_SUCCESS(s2n_connection_add_preferred_key_share_by_group(server_conn, s2n_ecc_evp_supported_curves_list[i]->iana_id));
@@ -292,6 +293,7 @@ int main(int argc, char **argv)
             struct s2n_connection *conn;
             struct s2n_stuffer key_share_extension;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+
             /* ISSUE 1657: This is only happening because the connection clears all keyshares, this is part of the HRR test */
             for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
                 EXPECT_SUCCESS(s2n_connection_add_preferred_key_share_by_group(conn, s2n_ecc_evp_supported_curves_list[i]->iana_id));
@@ -332,6 +334,7 @@ int main(int argc, char **argv)
             struct s2n_connection *conn;
             struct s2n_stuffer key_share_extension;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+
             /* ISSUE 1657: This is only happening because the connection clears all keyshares, this is part of the HRR test */
             for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
                 EXPECT_SUCCESS(s2n_connection_add_preferred_key_share_by_group(conn, s2n_ecc_evp_supported_curves_list[i]->iana_id));
@@ -368,6 +371,7 @@ int main(int argc, char **argv)
             struct s2n_ecc_evp_params first_params, second_params;
             int supported_curve_index = 0;
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+
             /* ISSUE 1657: This is only happening because the connection clears all keyshares, this is part of the HRR test */
             for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
                 EXPECT_SUCCESS(s2n_connection_add_preferred_key_share_by_group(server_conn, s2n_ecc_evp_supported_curves_list[i]->iana_id));
@@ -409,6 +413,7 @@ int main(int argc, char **argv)
             struct s2n_connection *conn;
             struct s2n_stuffer key_share_extension;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+
             /* ISSUE 1657: This is only happening because the connection clears all keyshares, this is part of the HRR test */
             for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
                 EXPECT_SUCCESS(s2n_connection_add_preferred_key_share_by_group(conn, s2n_ecc_evp_supported_curves_list[i]->iana_id));

--- a/tests/unit/s2n_server_hello_retry_test.c
+++ b/tests/unit/s2n_server_hello_retry_test.c
@@ -102,8 +102,8 @@ int main(int argc, char **argv)
 
         EXPECT_EQUAL(s2n_stuffer_data_available(client_stuffer), 0);
 
-        EXPECT_EQUAL(client_conn->handshake.client_received_hrr, 1);
-        EXPECT_EQUAL(server_conn->handshake.server_sent_hrr, 1);
+        EXPECT_EQUAL(client_conn->handshake.hello_retry_request, 1);
+        EXPECT_EQUAL(server_conn->handshake.hello_retry_request, 1);
 
         /* Verify that multiple hello retry messages will fail */
         EXPECT_SUCCESS(s2n_stuffer_reread(client_stuffer));
@@ -136,7 +136,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_server_should_retry(conn));
         EXPECT_SUCCESS(s2n_server_hello_send(conn));
 
-        EXPECT_EQUAL(conn->handshake.server_sent_hrr, 1);
+        EXPECT_EQUAL(conn->handshake.hello_retry_request, 1);
 
         /* If the server has to send another HelloRetryRequest, then it should fail the connection */
         EXPECT_FAILURE(s2n_server_should_retry(conn));
@@ -178,7 +178,7 @@ int main(int argc, char **argv)
 
         EXPECT_FAILURE_WITH_ERRNO(s2n_server_hello_recv(conn), S2N_ERR_BAD_MESSAGE);
 
-        EXPECT_EQUAL(conn->handshake.client_received_hrr, 0);
+        EXPECT_EQUAL(conn->handshake.hello_retry_request, 0);
 
         EXPECT_SUCCESS(s2n_config_free(conf));
         EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -216,7 +216,7 @@ int main(int argc, char **argv)
 
         EXPECT_FAILURE_WITH_ERRNO(s2n_server_hello_recv(conn), S2N_ERR_BAD_MESSAGE);
 
-        EXPECT_EQUAL(conn->handshake.client_received_hrr, 0);
+        EXPECT_EQUAL(conn->handshake.hello_retry_request, 0);
 
         EXPECT_SUCCESS(s2n_config_free(conf));
         EXPECT_SUCCESS(s2n_connection_free(conn));

--- a/tests/unit/s2n_tls13_state_machine_handshake_test.c
+++ b/tests/unit/s2n_tls13_state_machine_handshake_test.c
@@ -305,7 +305,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
-    /* Test: TLS1.3 s2n_conn_set_handshake_type only sets FULL_HANDSHAKE */
+    /* Test: TLS1.3 s2n_conn_set_handshake_type only sets FULL_HANDSHAKE or FULL_HANDSHAKE|HELLO_RETRY_REQUEST */
     {
         struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
 
@@ -335,6 +335,12 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_conn_set_handshake_type(conn));
         EXPECT_EQUAL(conn->handshake.handshake_type, NEGOTIATED | FULL_HANDSHAKE);
 
+        /* Verify that tls1.3 DOES NOT set the flags even when a retry is required */
+        conn->actual_protocol_version = S2N_TLS13;
+        conn->handshake.server_requires_hrr = 1;
+        EXPECT_SUCCESS(s2n_conn_set_handshake_type(conn));
+        EXPECT_EQUAL(conn->handshake.handshake_type, NEGOTIATED | FULL_HANDSHAKE);
+
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
@@ -348,6 +354,9 @@ int main(int argc, char **argv)
 
         conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
         EXPECT_STRING_EQUAL("NEGOTIATED|FULL_HANDSHAKE", s2n_connection_get_handshake_type_name(conn));
+
+        conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE | HELLO_RETRY_REQUEST;
+        EXPECT_STRING_EQUAL("NEGOTIATED|FULL_HANDSHAKE|HELLO_RETRY_REQUEST", s2n_connection_get_handshake_type_name(conn));
 
         const char* all_flags_handshake_type_name = "NEGOTIATED|FULL_HANDSHAKE|CLIENT_AUTH|WITH_SESSION_TICKET|NO_CLIENT_CERT";
         conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH | WITH_SESSION_TICKET | NO_CLIENT_CERT;

--- a/tls/extensions/s2n_server_key_share.c
+++ b/tls/extensions/s2n_server_key_share.c
@@ -86,7 +86,7 @@ int s2n_extensions_server_key_share_send_size(struct s2n_connection *conn)
 {
     const struct s2n_ecc_named_curve* curve = conn->secure.server_ecc_evp_params.negotiated_curve;
 
-    /* Retry requests have a different key share format, so the size is only includes the named group */
+    /* Retry requests have a different key share format, so the size only includes the named group */
     if (s2n_server_requires_retry(conn)) {
         const int retry_key_share_size = S2N_SIZE_OF_EXTENSION_TYPE
             + S2N_SIZE_OF_EXTENSION_DATA_SIZE

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -174,6 +174,9 @@ struct s2n_handshake {
 #define WITH_SESSION_TICKET         0x20
 #define IS_ISSUING_NEW_SESSION_TICKET( type )   ( (type) & WITH_SESSION_TICKET )
 
+/* A HelloRetryRequest was needed to proceed with the handshake */
+#define HELLO_RETRY_REQUEST         0x80
+
     /* Which handshake message number are we processing */
     int message_number;
 
@@ -181,10 +184,10 @@ struct s2n_handshake {
     uint8_t rsa_failed;
 
     /* Used by the client to tracks if a HelloRetryRequest has already been seen */
-    unsigned client_received_hrr:1;
+    /* unsigned client_received_hrr:1; */
 
     /* Used by the server to track whether a HelloRetryRequest was sent */
-    unsigned server_sent_hrr:1;
+    unsigned hello_retry_request:1;
 
     /* Used by the server to determine whether a HelloRetryRequest is needed */
     unsigned server_requires_hrr:1;

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -119,7 +119,7 @@ static const char *message_names[] = {
 };
 
 /* Maximum number of valid handshakes */
-#define S2N_HANDSHAKES_COUNT        128
+#define S2N_HANDSHAKES_COUNT        256
 
 /* Maximum number of messages in a handshake */
 #define S2N_MAX_HANDSHAKE_LENGTH    32
@@ -360,6 +360,15 @@ static message_type_t tls13_handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_L
             CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
             APPLICATION_DATA
     },
+
+    [NEGOTIATED | HELLO_RETRY_REQUEST | FULL_HANDSHAKE] = {
+            CLIENT_HELLO,
+            SERVER_HELLO,
+            CLIENT_HELLO,
+            SERVER_HELLO, SERVER_CHANGE_CIPHER_SPEC, ENCRYPTED_EXTENSIONS, SERVER_CERT, SERVER_CERT_VERIFY, SERVER_FINISHED,
+            CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
+            APPLICATION_DATA
+    },
 };
 
 #define MAX_HANDSHAKE_TYPE_LEN 128
@@ -372,7 +381,8 @@ static const char* handshake_type_names[] = {
     "OCSP_STATUS|",
     "CLIENT_AUTH|",
     "WITH_SESSION_TICKET|",
-    "NO_CLIENT_CERT|"
+    "NO_CLIENT_CERT|",
+    "HELLO_RETRY_REQUEST|"
 };
 
 #define IS_TLS13_HANDSHAKE( conn )    ((conn)->actual_protocol_version == S2N_TLS13)
@@ -402,23 +412,6 @@ static int s2n_advance_message(struct s2n_connection *conn)
     char this_mode = 'S';
     if (conn->mode == S2N_CLIENT) {
         this_mode = 'C';
-    }
-
-    /* If this SERVER_HELLO message is actually a HelloRetryRequest (inbound or outbound) then we need to reset the handshake state */
-    if (s2n_conn_get_current_message_type(conn) == SERVER_HELLO && (s2n_server_requires_retry(conn) || s2n_server_hello_retry_is_valid(conn))) {
-        /* Reset handshake state */
-        conn->handshake.server_sent_hrr = 1;
-        conn->handshake.server_requires_hrr = 0;
-        conn->handshake.client_hello_received = 0;
-        conn->handshake.handshake_type = INITIAL;
-        conn->handshake.message_number = CLIENT_HELLO;
-
-        /* Reset client hello state */
-        GUARD(s2n_stuffer_wipe(&conn->client_hello.raw_message));
-        GUARD(s2n_stuffer_resize(&conn->client_hello.raw_message, 0));
-        GUARD(s2n_client_hello_free(&conn->client_hello));
-        GUARD(s2n_stuffer_growable_alloc(&conn->client_hello.raw_message, 0));
-        return 0;
     }
 
     /* Actually advance the message number */
@@ -486,6 +479,11 @@ int s2n_conn_set_handshake_type(struct s2n_connection *conn)
     /* In the initial TLS1.3 release, we will only support the basic handshake. */
     if (IS_TLS13_HANDSHAKE(conn)) {
         conn->handshake.handshake_type |= FULL_HANDSHAKE;
+
+        if (conn->handshake.hello_retry_request == 1) {
+            conn->handshake.handshake_type |= HELLO_RETRY_REQUEST;
+        }
+
         return 0;
     }
 


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
#964 
**Description of changes:** 

* Modify the way we advance through the state machine when a HelloRetryRequest is needed.
* Update self talk tests to expect handshake type changes. Integ tests still work as expected for the server.
* Client side is manually tested because we don't have a finalized method to select curves for the client.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
