### PR TITLE
Select highest priority mutually supported keyshare

### DIFF
--- a/tests/unit/s2n_choose_supported_group_test.c
+++ b/tests/unit/s2n_choose_supported_group_test.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+#include "tls/s2n_tls.h"
+#include "tls/s2n_tls13.h"
+#include "tls/extensions/s2n_client_supported_groups.h"
+
+int main(int argc, char **argv) 
+{
+    struct s2n_connection *server_conn;
+
+    BEGIN_TEST();
+    /* This test checks the logic in the function s2n_choose_supported_group, which should select the highest
+     * supported group or, if none are available, select NULL.
+     */
+    {
+        /* If the list of mutually supported groups is empty, chosen curve should be set to null */
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+        for (int i = 0; i < S2N_ECC_EVP_SUPPORTED_CURVES_COUNT; i++) {
+            EXPECT_NULL(server_conn->secure.mutually_supported_groups[i]);
+        }
+        uint16_t supported_groups_size =  s2n_array_len(server_conn->secure.mutually_supported_groups);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_choose_supported_group(server_conn->secure.mutually_supported_groups,
+            supported_groups_size, &server_conn->secure.server_ecc_evp_params), S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
+
+        EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+    }
+
+    {
+        /* If the list of mutually supported groups has one match, chosen curve should be set to that
+         * match.
+         */
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+        server_conn->secure.mutually_supported_groups[1] = s2n_ecc_evp_supported_curves_list[1];
+
+        uint16_t supported_groups_size =  s2n_array_len(server_conn->secure.mutually_supported_groups);
+        EXPECT_SUCCESS(s2n_choose_supported_group(server_conn->secure.mutually_supported_groups, supported_groups_size, 
+            &server_conn->secure.server_ecc_evp_params));
+
+        EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, s2n_ecc_evp_supported_curves_list[1]);
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+
+    }
+
+    {
+        /* If the list of mutually supported groups has several matches, chosen curve should be set to the first
+         * match.
+         */
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+        for (int i = 0; i < S2N_ECC_EVP_SUPPORTED_CURVES_COUNT; i++) {
+            server_conn->secure.mutually_supported_groups[i] = s2n_ecc_evp_supported_curves_list[i];
+        }
+        uint16_t supported_groups_size =  s2n_array_len(server_conn->secure.mutually_supported_groups);
+        EXPECT_SUCCESS(s2n_choose_supported_group(server_conn->secure.mutually_supported_groups, supported_groups_size,
+            &server_conn->secure.server_ecc_evp_params));
+
+        EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, s2n_ecc_evp_supported_curves_list[0]);
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+
+    }
+
+    END_TEST();
+    return 0;
+
+}

--- a/tests/unit/s2n_extensions_server_key_share_select_test.c
+++ b/tests/unit/s2n_extensions_server_key_share_select_test.c
@@ -1,0 +1,132 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+#include "tls/s2n_tls.h"
+#include "tls/s2n_tls13.h"
+#include "tls/extensions/s2n_server_key_share.h"
+
+int main(int argc, char **argv)
+{
+    struct s2n_connection *server_conn;
+
+    BEGIN_TEST();
+
+    EXPECT_SUCCESS(s2n_enable_tls13());
+
+    /* These tests check the server's logic when selecting a keyshare and supporting group. */
+
+    {
+        /* If client and server have no mutually supported groups and no mutually supported
+         * keyshares, a Hello Retry Request is not sent. 
+         */
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+        for (int i = 0; i < S2N_ECC_EVP_SUPPORTED_CURVES_COUNT; i++) {
+            EXPECT_NULL(server_conn->secure.client_ecc_evp_params[i].evp_pkey);
+            EXPECT_NULL(server_conn->secure.client_ecc_evp_params[i].negotiated_curve);
+            EXPECT_NULL(server_conn->secure.mutually_supported_groups[i]);
+        }
+
+        EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_server_key_share_select(server_conn), S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
+
+        EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+        /* Commented out until hello retry is implemented.
+        EXPECT_FALSE(s2n_server_requires_retry(server_conn)); */
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+    }
+
+    {
+        /* If client and server have no mutually supported groups but client and server have 
+         * found mutually supported keyshares(erroneous behavior), a Hello Retry Request flag is not set and the server
+         * ignores the mutually supported keyshare. 
+         */ 
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+        server_conn->secure.client_ecc_evp_params[0].negotiated_curve = s2n_ecc_evp_supported_curves_list[0];
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.client_ecc_evp_params[0]));
+
+        EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_server_key_share_select(server_conn), S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
+
+        EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+        /* Commented out until hello retry is implemented.
+        EXPECT_FALSE(s2n_server_requires_retry(server_conn)); */
+        EXPECT_SUCCESS(s2n_connection_free(server_conn)); 
+    }
+
+    {
+        /* If client has sent no keys but server and client have found a mutually supported group,
+         * send Hello Retry Request. 
+         */ 
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        server_conn->secure.server_ecc_evp_params.negotiated_curve = s2n_ecc_evp_supported_curves_list[0];
+        server_conn->secure.mutually_supported_groups[0] = s2n_ecc_evp_supported_curves_list[0];
+        for (int i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
+            EXPECT_NULL(server_conn->secure.client_ecc_evp_params[i].evp_pkey);
+            EXPECT_NULL(server_conn->secure.client_ecc_evp_params[i].negotiated_curve);
+        }
+
+        EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
+
+        EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, s2n_ecc_evp_supported_curves_list[0]);
+        /* Commented out until hello retry is implemented.
+        EXPECT_TRUE(s2n_server_requires_retry(server_conn)); */
+        EXPECT_SUCCESS(s2n_connection_free(server_conn)); 
+    }
+
+    {
+        /* When client and server mutually supported group 0 and group 1, but client has only sent a keyshare for
+         * group 1, Hello Retry Request is not sent and server chooses group 1.
+         */ 
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+        server_conn->secure.mutually_supported_groups[0] = s2n_ecc_evp_supported_curves_list[0];
+        server_conn->secure.mutually_supported_groups[1] = s2n_ecc_evp_supported_curves_list[1];
+
+        EXPECT_NULL(server_conn->secure.client_ecc_evp_params[0].evp_pkey);
+        EXPECT_NULL(server_conn->secure.client_ecc_evp_params[0].negotiated_curve);
+        server_conn->secure.client_ecc_evp_params[1].negotiated_curve = s2n_ecc_evp_supported_curves_list[1];
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.client_ecc_evp_params[1]));
+
+        EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
+
+        EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, s2n_ecc_evp_supported_curves_list[1]);
+        /* Commented out until hello retry is implemented.
+        EXPECT_FALSE(s2n_server_requires_retry(server_conn)); */
+        EXPECT_SUCCESS(s2n_connection_free(server_conn)); 
+    }
+
+    {
+        /* When client and server mutually supported group 0 and client has sent a keyshare for group 0,
+         * Hello Retry Request is not sent and server chooses group 0.
+         */
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+        server_conn->secure.mutually_supported_groups[0] = s2n_ecc_evp_supported_curves_list[0];
+        server_conn->secure.client_ecc_evp_params[0].negotiated_curve = s2n_ecc_evp_supported_curves_list[0];
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.client_ecc_evp_params[0]));
+
+        EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
+
+        EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, s2n_ecc_evp_supported_curves_list[0]);
+        /* Commented out until hello retry is implemented.
+        EXPECT_FALSE(s2n_server_requires_retry(server_conn)); */
+        EXPECT_SUCCESS(s2n_connection_free(server_conn)); 
+    } 
+
+    END_TEST();
+    return 0;
+}

--- a/tests/unit/s2n_extensions_server_key_share_select_test.c
+++ b/tests/unit/s2n_extensions_server_key_share_select_test.c
@@ -78,8 +78,9 @@ int main(int argc, char **argv)
             EXPECT_NULL(server_conn->secure.client_ecc_evp_params[i].evp_pkey);
             EXPECT_NULL(server_conn->secure.client_ecc_evp_params[i].negotiated_curve);
         }
-
-        EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
+        /* Commented out until hello retry request is implemented in issue #1607.
+        EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn)); */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_server_key_share_select(server_conn), S2N_ERR_BAD_KEY_SHARE);
 
         EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, s2n_ecc_evp_supported_curves_list[0]);
         /* Commented out until hello retry is implemented in issue #1607.

--- a/tests/unit/s2n_extensions_server_key_share_select_test.c
+++ b/tests/unit/s2n_extensions_server_key_share_select_test.c
@@ -44,7 +44,7 @@ int main(int argc, char **argv)
         EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_server_key_share_select(server_conn), S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
 
         EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
-        /* Commented out until hello retry is implemented.
+        /* Commented out until hello retry is implemented in issue #1607.
         EXPECT_FALSE(s2n_server_requires_retry(server_conn)); */
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
     }
@@ -62,7 +62,7 @@ int main(int argc, char **argv)
         EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_server_key_share_select(server_conn), S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
 
         EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
-        /* Commented out until hello retry is implemented.
+        /* Commented out until hello retry is implemented in issue #1607.
         EXPECT_FALSE(s2n_server_requires_retry(server_conn)); */
         EXPECT_SUCCESS(s2n_connection_free(server_conn)); 
     }
@@ -82,7 +82,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
 
         EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, s2n_ecc_evp_supported_curves_list[0]);
-        /* Commented out until hello retry is implemented.
+        /* Commented out until hello retry is implemented in issue #1607.
         EXPECT_TRUE(s2n_server_requires_retry(server_conn)); */
         EXPECT_SUCCESS(s2n_connection_free(server_conn)); 
     }
@@ -104,7 +104,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
 
         EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, s2n_ecc_evp_supported_curves_list[1]);
-        /* Commented out until hello retry is implemented.
+        /* Commented out until hello retry is implemented in issue #1607.
         EXPECT_FALSE(s2n_server_requires_retry(server_conn)); */
         EXPECT_SUCCESS(s2n_connection_free(server_conn)); 
     }
@@ -122,7 +122,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
 
         EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, s2n_ecc_evp_supported_curves_list[0]);
-        /* Commented out until hello retry is implemented.
+        /* Commented out until hello retry is implemented in issue #1607.
         EXPECT_FALSE(s2n_server_requires_retry(server_conn)); */
         EXPECT_SUCCESS(s2n_connection_free(server_conn)); 
     } 

--- a/tests/unit/s2n_parse_client_supported_groups_list_test.c
+++ b/tests/unit/s2n_parse_client_supported_groups_list_test.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+#include "tls/s2n_tls.h"
+#include "tls/s2n_tls13.h"
+#include "utils/s2n_blob.h"
+#include "tls/extensions/s2n_client_supported_groups.h"
+
+int main(int argc, char **argv)
+{
+    struct s2n_connection *server_conn;
+    struct s2n_blob iana_ids;
+    struct s2n_stuffer out;
+
+    BEGIN_TEST();
+
+    EXPECT_SUCCESS(s2n_enable_tls13());
+
+    /* These tests check how the server parses the supported groups sent by the client */
+    {
+        /* If the client sent a supported group that the server also supports, mutually_supported_groups
+         * should contain the sent group.
+         */
+        uint8_t data[2];
+        EXPECT_SUCCESS(s2n_blob_init(&iana_ids, data, sizeof(data)));
+        EXPECT_SUCCESS(s2n_stuffer_init(&out, &iana_ids));
+        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&out, s2n_ecc_evp_supported_curves_list[0]->iana_id));
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        for (int i = 0; i < S2N_ECC_EVP_SUPPORTED_CURVES_COUNT; i++) {
+            EXPECT_NULL(server_conn->secure.mutually_supported_groups[i]);
+        }
+
+        EXPECT_SUCCESS(s2n_parse_client_supported_groups_list(&iana_ids, server_conn->secure.mutually_supported_groups));
+
+        EXPECT_EQUAL(server_conn->secure.mutually_supported_groups[0], s2n_ecc_evp_supported_curves_list[0]);
+        EXPECT_NULL(server_conn->secure.mutually_supported_groups[1]);
+
+        EXPECT_SUCCESS(s2n_connection_free(server_conn)); 
+    }
+
+    { 
+        /* If the client sent no supported groups at all, mutually_supported_groups should contain
+        * NULL values and no supported group should be chosen.
+        */
+        uint8_t data[2];
+        EXPECT_SUCCESS(s2n_blob_init(&iana_ids, data, sizeof(data)));
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+
+        EXPECT_SUCCESS(s2n_parse_client_supported_groups_list(&iana_ids, server_conn->secure.mutually_supported_groups));
+
+        for (int i = 0; i < S2N_ECC_EVP_SUPPORTED_CURVES_COUNT; i++) {
+            EXPECT_NULL(server_conn->secure.mutually_supported_groups[i]);
+        }
+        EXPECT_SUCCESS(s2n_connection_free(server_conn)); 
+    }
+
+    {
+        /* If the client has sent one mutually supported group and several groups the server does not support,
+        * mutually_supported_groups should contain only the group that the server supports.
+        */
+
+        uint8_t data[6];
+        EXPECT_SUCCESS(s2n_blob_init(&iana_ids, data, sizeof(data)));
+        EXPECT_SUCCESS(s2n_stuffer_init(&out, &iana_ids));
+        /* 17 and 18 are unsupported ids */
+        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&out, 17));
+        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&out, 18));
+        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&out, s2n_ecc_evp_supported_curves_list[1]->iana_id));
+
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+
+        EXPECT_SUCCESS(s2n_parse_client_supported_groups_list(&iana_ids, server_conn->secure.mutually_supported_groups));
+
+        EXPECT_NULL(server_conn->secure.mutually_supported_groups[0]);
+        EXPECT_EQUAL(server_conn->secure.mutually_supported_groups[1], s2n_ecc_evp_supported_curves_list[1]);
+        EXPECT_SUCCESS(s2n_connection_free(server_conn)); 
+    }
+
+    END_TEST();
+    return 0;
+}

--- a/tls/extensions/s2n_client_supported_groups.h
+++ b/tls/extensions/s2n_client_supported_groups.h
@@ -20,3 +20,5 @@
 
 extern int s2n_extensions_client_supported_groups_send(struct s2n_connection *conn, struct s2n_stuffer *out);
 extern int s2n_recv_client_supported_groups(struct s2n_connection *conn, struct s2n_stuffer *extension);
+int s2n_parse_client_supported_groups_list(struct s2n_blob *iana_ids, const struct s2n_ecc_named_curve **supported_groups);
+int s2n_choose_supported_group(const struct s2n_ecc_named_curve **group_options, uint16_t group_options_length, struct s2n_ecc_evp_params *chosen_group);

--- a/tls/extensions/s2n_server_key_share.c
+++ b/tls/extensions/s2n_server_key_share.c
@@ -17,6 +17,7 @@
 
 #include "tls/s2n_client_extensions.h"
 #include "utils/s2n_safety.h"
+#include "tls/s2n_tls.h"
 
 /*
  * Check whether client has sent a corresponding curve and key_share
@@ -44,6 +45,27 @@ int s2n_extensions_server_key_share_send_check(struct s2n_connection *conn)
     S2N_ERROR_IF(client_ecc_evp.evp_pkey == NULL, S2N_ERR_BAD_KEY_SHARE);
 
     return 0;
+}
+/*
+ * Selects highest priority mutually supported keyshare
+ */
+int s2n_extensions_server_key_share_select(struct s2n_connection *conn)
+{
+    for (uint32_t i = 0; i < s2n_ecc_evp_supported_curves_list_len; i++) {
+        /* Checks supported group and keyshare have both been sent */
+        if (conn->secure.client_ecc_evp_params[i].negotiated_curve &&
+             conn->secure.mutually_supported_groups[i]) {
+            conn->secure.server_ecc_evp_params.negotiated_curve = conn->secure.client_ecc_evp_params[i].negotiated_curve;
+            return 0;
+        }
+    }
+    /* Client sent no keyshares, need to send Hello Retry Request with first negotiated curve */
+    if (conn->secure.server_ecc_evp_params.negotiated_curve) {
+        /* Commented out until retry is implemented 
+        GUARD(s2n_server_should_retry(conn)); */
+        return 0;
+    }   
+    S2N_ERROR(S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
 }
 
 /*

--- a/tls/extensions/s2n_server_key_share.c
+++ b/tls/extensions/s2n_server_key_share.c
@@ -61,7 +61,7 @@ int s2n_extensions_server_key_share_select(struct s2n_connection *conn)
     }
     /* Client sent no keyshares, need to send Hello Retry Request with first negotiated curve */
     if (conn->secure.server_ecc_evp_params.negotiated_curve) {
-        /* Commented out until retry is implemented 
+        /* Commented out until retry is implemented in issue #1607.
         GUARD(s2n_server_should_retry(conn)); */
         return 0;
     }   

--- a/tls/extensions/s2n_server_key_share.c
+++ b/tls/extensions/s2n_server_key_share.c
@@ -61,9 +61,11 @@ int s2n_extensions_server_key_share_select(struct s2n_connection *conn)
     }
     /* Client sent no keyshares, need to send Hello Retry Request with first negotiated curve */
     if (conn->secure.server_ecc_evp_params.negotiated_curve) {
-        /* Commented out until retry is implemented in issue #1607.
-        GUARD(s2n_server_should_retry(conn)); */
-        return 0;
+        /* Once hello retry request is implemented in issue #1607, lines can
+         be uncommented and error can be removed. 
+        GUARD(s2n_server_should_retry(conn));
+        return 0; */
+        S2N_ERROR(S2N_ERR_BAD_KEY_SHARE);
     }   
     S2N_ERROR(S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
 }

--- a/tls/extensions/s2n_server_key_share.h
+++ b/tls/extensions/s2n_server_key_share.h
@@ -22,5 +22,6 @@
 
 extern int s2n_extensions_server_key_share_send_check(struct s2n_connection *conn);
 extern int s2n_extensions_server_key_share_send_size(struct s2n_connection *conn);
+extern int s2n_extensions_server_key_share_select(struct s2n_connection *conn);
 extern int s2n_extensions_server_key_share_send(struct s2n_connection *conn, struct s2n_stuffer *out);
 extern int s2n_extensions_server_key_share_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -34,6 +34,7 @@
 #include "tls/s2n_tls.h"
 #include "tls/s2n_client_extensions.h"
 #include "tls/s2n_tls_digest_preferences.h"
+#include "tls/extensions/s2n_server_key_share.h"
 
 #include "stuffer/s2n_stuffer.h"
 
@@ -297,6 +298,11 @@ int s2n_process_client_hello(struct s2n_connection *conn)
 
     if (client_hello->parsed_extensions != NULL && client_hello->parsed_extensions->num_of_elements > 0) {
         GUARD(s2n_client_extensions_recv(conn, client_hello->parsed_extensions));
+    }
+
+    /* After parsing extensions, select a curve and corresponding keyshare to use */
+    if (conn->actual_protocol_version >= S2N_TLS13) {
+        GUARD(s2n_extensions_server_key_share_select(conn));
     }
 
     /* for pre TLS 1.3 connections, protocol selection is not done in supported_versions extensions, so do it here */

--- a/tls/s2n_crypto.h
+++ b/tls/s2n_crypto.h
@@ -70,6 +70,7 @@ struct s2n_crypto_parameters {
     struct s2n_pkey client_public_key;
     struct s2n_dh_params server_dh_params;
     struct s2n_ecc_evp_params server_ecc_evp_params;
+    const struct s2n_ecc_named_curve * mutually_supported_groups[S2N_ECC_EVP_SUPPORTED_CURVES_COUNT];
     struct s2n_ecc_evp_params client_ecc_evp_params[S2N_ECC_EVP_SUPPORTED_CURVES_COUNT];
     struct s2n_kem_keypair s2n_kem_keys;
     struct s2n_blob client_key_exchange_message;


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
#1157, #1459
**Description of changes:** 
These changes have already been approved in the test branch, but now need to be merged into master: https://github.com/awslabs/s2n/pull/1556
- Added logic for selecting highest mutually supported keyshare instead of highest mutually supported groups and added logic for conditions to send a hello retry request
- Wrote unit tests to confirm correct behavior

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
