### PR TITLE
feature: GitHub action to run CodeBuild on private fuzz PRs

### DIFF
--- a/.github/workflows/private_fork_pr_codebuild.yml
+++ b/.github/workflows/private_fork_pr_codebuild.yml
@@ -1,0 +1,43 @@
+---
+name: s2nPrivateFuzz
+
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  fuzz:
+    if: startsWith(github.event.repository.name, 'private-')        
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        openssl_version:
+          - openssl-1.0.2
+          - openssl-1.1.1
+      fail-fast: true
+    steps:
+      - uses: actions/setup-node@v1
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      - name: S2n Fuzz CodeBuild
+        uses: aws-actions/aws-codebuild-run-build@master
+        with:
+          project-name: 's2nGithubCodebuild'
+          env-vars-for-codebuild: |
+            S2N_LIBCRYPTO,
+            TESTS,
+            LATEST_CLANG,
+            FUZZ_TIMEOUT_SEC,
+            requester,
+            event-name
+        env:
+          S2N_LIBCRYPTO: ${{ matrix.openssl_version }}
+          TESTS: "fuzz"
+          LAGEST_CLANG: "true"
+          FUZZ_TIMEOUT_SEC: 43200
+          requester: ${{ github.actor }}
+          event-name: ${{ github.event_name }}

--- a/.github/workflows/private_sync.yml
+++ b/.github/workflows/private_sync.yml
@@ -5,6 +5,7 @@ on:
       - master
 jobs:
   build:
+    if: startsWith(github.event.repository.name, 's2n')        
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Description of changes:** 
* Create a Github Action that launches fuzz tests in a private repo on PR.
* Update the force push Action to only run on the public repo and the CodeBuild action to only run on the private repo.

Please comment on the fuzz time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
