### PR TITLE
Update Server Cipher Suite selection

### DIFF
--- a/tests/unit/s2n_cipher_suite_match_test.c
+++ b/tests/unit/s2n_cipher_suite_match_test.c
@@ -538,7 +538,7 @@ int main(int argc, char **argv)
             #if S2N_OPENSSL_VERSION_AT_LEAST(1,1,0)
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers2, count));
             EXPECT_EQUAL(conn->secure.cipher_suite, &s2n_tls13_chacha20_poly1305_sha256);
-            #else
+            #elif
             EXPECT_FAILURE(s2n_set_cipher_as_tls_server(conn, wire_ciphers2, count));
             #endif
 

--- a/tests/unit/s2n_cipher_suite_match_test.c
+++ b/tests/unit/s2n_cipher_suite_match_test.c
@@ -538,7 +538,7 @@ int main(int argc, char **argv)
             #if S2N_OPENSSL_VERSION_AT_LEAST(1,1,0)
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers2, count));
             EXPECT_EQUAL(conn->secure.cipher_suite, &s2n_tls13_chacha20_poly1305_sha256);
-            #elif
+            #else
             EXPECT_FAILURE(s2n_set_cipher_as_tls_server(conn, wire_ciphers2, count));
             #endif
 

--- a/tests/unit/s2n_cipher_suite_match_test.c
+++ b/tests/unit/s2n_cipher_suite_match_test.c
@@ -526,16 +526,22 @@ int main(int argc, char **argv)
             uint8_t wire_ciphers2[] = {
                 TLS_RSA_WITH_3DES_EDE_CBC_SHA,
                 TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
-                TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-                TLS_CHACHA20_POLY1305_SHA256,
+                TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, /* tls 1.2 */
+                TLS_CHACHA20_POLY1305_SHA256, /* tls 1.3 */
             };
 
             const uint8_t count = sizeof(wire_ciphers2) / S2N_TLS_CIPHER_SUITE_LEN;
             s2n_connection_set_cipher_preferences(conn, "test_all");
             conn->client_protocol_version = S2N_TLS13;
             conn->actual_protocol_version = S2N_TLS13;
+
+            #if S2N_OPENSSL_VERSION_AT_LEAST(1,1,0)
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers2, count));
             EXPECT_EQUAL(conn->secure.cipher_suite, &s2n_tls13_chacha20_poly1305_sha256);
+            #elif
+            EXPECT_FAILURE(s2n_set_cipher_as_tls_server(conn, wire_ciphers2, count));
+            #endif
+
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
         }
 

--- a/tests/unit/s2n_tls13_support_test.c
+++ b/tests/unit/s2n_tls13_support_test.c
@@ -162,26 +162,19 @@ int main(int argc, char **argv)
     {
         uint8_t value[2] = { 0x13, 0x01 };
         EXPECT_TRUE(s2n_is_valid_tls13_cipher(value));
-        value[0] = 0x13;
-        value[1] = 0x02;
+        value[0] = 0x13; value[1] = 0x02;
         EXPECT_TRUE(s2n_is_valid_tls13_cipher(value));
-        value[0] = 0x13;
-        value[1] = 0x03;
+        value[0] = 0x13; value[1] = 0x03;
         EXPECT_TRUE(s2n_is_valid_tls13_cipher(value));
-        value[0] = 0x13;
-        value[1] = 0x04;
+        value[0] = 0x13; value[1] = 0x04;
         EXPECT_TRUE(s2n_is_valid_tls13_cipher(value));
-        value[0] = 0x13;
-        value[1] = 0x05;
+        value[0] = 0x13; value[1] = 0x05;
         EXPECT_TRUE(s2n_is_valid_tls13_cipher(value));
-        value[0] = 0x13;
-        value[1] = 0x06;
+        value[0] = 0x13; value[1] = 0x06;
         EXPECT_FALSE(s2n_is_valid_tls13_cipher(value));
-        value[0] = 0x13;
-        value[1] = 0x00;
+        value[0] = 0x13; value[1] = 0x00;
         EXPECT_FALSE(s2n_is_valid_tls13_cipher(value));
-        value[0] = 0x12;
-        value[1] = 0x01;
+        value[0] = 0x12; value[1] = 0x01;
         EXPECT_FALSE(s2n_is_valid_tls13_cipher(value));
 
         EXPECT_FALSE(s2n_is_valid_tls13_cipher(s2n_dhe_rsa_with_3des_ede_cbc_sha.iana_value));

--- a/tests/unit/s2n_tls13_support_test.c
+++ b/tests/unit/s2n_tls13_support_test.c
@@ -162,26 +162,19 @@ int main(int argc, char **argv)
     {
         uint8_t value[2] = { 0x13, 0x01 };
         EXPECT_TRUE(s2n_is_valid_tls13_cipher(value));
-        value[0] = 0x13;
-        value[1] = 0x02;
+        value = { 0x13, 0x02 };
         EXPECT_TRUE(s2n_is_valid_tls13_cipher(value));
-        value[0] = 0x13;
-        value[1] = 0x03;
+        value = { 0x13, 0x03 };
         EXPECT_TRUE(s2n_is_valid_tls13_cipher(value));
-        value[0] = 0x13;
-        value[1] = 0x04;
+        value = { 0x13, 0x04 };
         EXPECT_TRUE(s2n_is_valid_tls13_cipher(value));
-        value[0] = 0x13;
-        value[1] = 0x05;
+        value = { 0x13, 0x05 };
         EXPECT_TRUE(s2n_is_valid_tls13_cipher(value));
-        value[0] = 0x13;
-        value[1] = 0x06;
+        value = { 0x13, 0x06 };
         EXPECT_FALSE(s2n_is_valid_tls13_cipher(value));
-        value[0] = 0x13;
-        value[1] = 0x00;
+        value = { 0x13, 0x00 };
         EXPECT_FALSE(s2n_is_valid_tls13_cipher(value));
-        value[0] = 0x12;
-        value[1] = 0x01;
+        value = { 0x12, 0x01 };
         EXPECT_FALSE(s2n_is_valid_tls13_cipher(value));
 
         EXPECT_FALSE(s2n_is_valid_tls13_cipher(s2n_dhe_rsa_with_3des_ede_cbc_sha.iana_value));

--- a/tests/unit/s2n_tls13_support_test.c
+++ b/tests/unit/s2n_tls13_support_test.c
@@ -162,19 +162,26 @@ int main(int argc, char **argv)
     {
         uint8_t value[2] = { 0x13, 0x01 };
         EXPECT_TRUE(s2n_is_valid_tls13_cipher(value));
-        value = { 0x13, 0x02 };
+        value[0] = 0x13;
+        value[1] = 0x02;
         EXPECT_TRUE(s2n_is_valid_tls13_cipher(value));
-        value = { 0x13, 0x03 };
+        value[0] = 0x13;
+        value[1] = 0x03;
         EXPECT_TRUE(s2n_is_valid_tls13_cipher(value));
-        value = { 0x13, 0x04 };
+        value[0] = 0x13;
+        value[1] = 0x04;
         EXPECT_TRUE(s2n_is_valid_tls13_cipher(value));
-        value = { 0x13, 0x05 };
+        value[0] = 0x13;
+        value[1] = 0x05;
         EXPECT_TRUE(s2n_is_valid_tls13_cipher(value));
-        value = { 0x13, 0x06 };
+        value[0] = 0x13;
+        value[1] = 0x06;
         EXPECT_FALSE(s2n_is_valid_tls13_cipher(value));
-        value = { 0x13, 0x00 };
+        value[0] = 0x13;
+        value[1] = 0x00;
         EXPECT_FALSE(s2n_is_valid_tls13_cipher(value));
-        value = { 0x12, 0x01 };
+        value[0] = 0x12;
+        value[1] = 0x01;
         EXPECT_FALSE(s2n_is_valid_tls13_cipher(value));
 
         EXPECT_FALSE(s2n_is_valid_tls13_cipher(s2n_dhe_rsa_with_3des_ede_cbc_sha.iana_value));

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -1073,11 +1073,6 @@ int s2n_connection_is_valid_for_cipher_preferences(struct s2n_connection *conn, 
     return 0;
 }
 
-/* Valid TLS 1.3 Ciphers are 0x1301, 0x1302, 0x1303, 0x1304, 0x1305 */
-static bool s2n_is_valid_tls13_cipher(const uint8_t version[2]) {
-    return version[0] == 0x13 && version[1] >= 0x01 && version[1] <= 0x05;
-}
-
 int s2n_cipher_preferences_init()
 {
     for (int i = 0; selection[i].version != NULL; i++) {

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -16,9 +16,9 @@
 #pragma once
 
 #include <stdint.h>
-
 #include "tls/s2n_cipher_suites.h"
 #include "tls/s2n_kem.h"
+#include "tls/s2n_tls13.h"
 
 struct s2n_cipher_preferences {
     uint8_t count;

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -25,6 +25,7 @@
 #include "tls/s2n_auth_selection.h"
 #include "tls/s2n_cipher_preferences.h"
 #include "tls/s2n_tls.h"
+#include "tls/s2n_tls13.h"
 #include "tls/s2n_kex.h"
 #include "utils/s2n_safety.h"
 
@@ -1116,6 +1117,11 @@ static int s2n_set_cipher_as_server(struct s2n_connection *conn, uint8_t * wire,
     /* s2n supports only server order */
     for (int i = 0; i < cipher_preferences->count; i++) {
         const uint8_t *ours = cipher_preferences->suites[i]->iana_value;
+
+        /* if the connection is using TLS 1.3, skip non-TLS 1.3 ciphers */
+        if (conn->actual_protocol_version >= S2N_TLS13 && !s2n_is_valid_tls13_cipher(ours)) {
+            continue;
+        }
 
         if (s2n_wire_ciphers_contain(ours, wire, count, cipher_suite_len)) {
             /* We have a match */

--- a/tls/s2n_tls13.c
+++ b/tls/s2n_tls13.c
@@ -35,3 +35,9 @@ int s2n_disable_tls13()
     s2n_highest_protocol_version = S2N_TLS12;
     return 0;
 }
+
+/* Returns whether a uint16 iana value is a valid TLS 1.3 cipher suite */
+bool s2n_is_valid_tls13_cipher(const uint8_t version[2]) {
+    /* Valid TLS 1.3 Ciphers are 0x1301, 0x1302, 0x1303, 0x1304, 0x1305 */
+    return version[0] == 0x13 && version[1] >= 0x01 && version[1] <= 0x05;
+}

--- a/tls/s2n_tls13.c
+++ b/tls/s2n_tls13.c
@@ -38,6 +38,9 @@ int s2n_disable_tls13()
 
 /* Returns whether a uint16 iana value is a valid TLS 1.3 cipher suite */
 bool s2n_is_valid_tls13_cipher(const uint8_t version[2]) {
-    /* Valid TLS 1.3 Ciphers are 0x1301, 0x1302, 0x1303, 0x1304, 0x1305 */
+    /* Valid TLS 1.3 Ciphers are
+     * 0x1301, 0x1302, 0x1303, 0x1304, 0x1305.
+     * (https://tools.ietf.org/html/rfc8446#appendix-B.4)
+     */
     return version[0] == 0x13 && version[1] >= 0x01 && version[1] <= 0x05;
 }

--- a/tls/s2n_tls13.h
+++ b/tls/s2n_tls13.h
@@ -18,3 +18,4 @@
 int s2n_is_tls13_enabled();
 int s2n_enable_tls13();
 int s2n_disable_tls13();
+bool s2n_is_valid_tls13_cipher(const uint8_t version[2]);


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
https://github.com/awslabs/s2n/issues/1670

**Description of changes:** 
- skip non-TLS 1.3 cipher suites for TLS 1.3 connections
- updated tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
