### PR TITLE
ci: Run fuzz jobs in parallel on a schedule in another repo.

### DIFF
--- a/.github/workflows/private_fork_pr_codebuild.yml
+++ b/.github/workflows/private_fork_pr_codebuild.yml
@@ -38,6 +38,6 @@ jobs:
           S2N_LIBCRYPTO: ${{ matrix.openssl_version }}
           TESTS: "fuzz"
           LAGEST_CLANG: "true"
-          FUZZ_TIMEOUT_SEC: 43200
+          FUZZ_TIMEOUT_SEC: 1800
           requester: ${{ github.actor }}
           event-name: ${{ github.event_name }}

--- a/.github/workflows/private_fork_scheduled_codebuild.yml
+++ b/.github/workflows/private_fork_scheduled_codebuild.yml
@@ -1,0 +1,73 @@
+---
+name: s2nPrivateFuzzScheduled
+
+on:
+  schedule:
+    - cron: '0 13 * * *'
+jobs:
+  fuzz:
+    if: startsWith(github.event.repository.name, 'private-')
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        openssl_version:
+          - openssl-1.1.1
+        specific_test:
+          - s2n_bike_r1_fuzz_test
+          - s2n_bike_r2_fuzz_test
+          - s2n_certificate_extensions_parse_test
+          - s2n_client_cert_recv_test
+          - s2n_client_cert_req_recv_test
+          - s2n_client_cert_verify_recv_test
+          - s2n_client_fuzz_test
+          - s2n_client_hello_recv_fuzz_test
+          - s2n_client_key_recv_fuzz_test
+          - s2n_encrypted_extensions_recv_test
+          - s2n_extensions_client_key_share_recv_test
+          - s2n_extensions_client_supported_versions_recv_test
+          - s2n_extensions_server_key_share_recv_test
+          - s2n_extensions_server_supported_versions_recv_test
+          - s2n_hybrid_ecdhe_bike_r1_fuzz_test
+          - s2n_hybrid_ecdhe_bike_r2_fuzz_test
+          - s2n_hybrid_ecdhe_sike_r1_fuzz_test
+          - s2n_hybrid_ecdhe_sike_r2_fuzz_test
+          - s2n_memory_leak_negative_test
+          - s2n_openssl_diff_pem_parsing_test
+          - s2n_recv_client_supported_groups_test
+          - s2n_select_server_cert_test
+          - s2n_server_cert_recv_test
+          - s2n_server_extensions_recv_test
+          - s2n_server_fuzz_test
+          - s2n_server_hello_recv_test
+          - s2n_sike_r1_fuzz_test
+          - s2n_sike_r2_fuzz_test
+          - s2n_stuffer_pem_fuzz_test
+      fail-fast: true
+    steps:
+      - uses: actions/setup-node@v1
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      - name: S2n Fuzz CodeBuild
+        uses: aws-actions/aws-codebuild-run-build@master
+        with:
+          project-name: 's2nGithubCodebuild'
+          env-vars-for-codebuild: |
+            S2N_LIBCRYPTO,
+            TESTS,
+            LATEST_CLANG,
+            FUZZ_TESTS,
+            FUZZ_TIMEOUT_SEC,
+            requester,
+            event-name
+        env:
+          S2N_LIBCRYPTO: ${{ matrix.openssl_version }}
+          TESTS: "fuzz"
+          FUZZ_TESTS: ${{ matrix.specific_test }}
+          LAGEST_CLANG: "true"
+          FUZZ_TIMEOUT_SEC: 28500
+          requester: ${{ github.actor }}
+          event-name: ${{ github.event_name }}

--- a/codebuild/codebuild.config
+++ b/codebuild/codebuild.config
@@ -12,6 +12,7 @@ bucket_prefix: s2nCodeBuildCache
 image : aws/codebuild/standard:2.0
 env_type: LINUX_CONTAINER
 compute_type: BUILD_GENERAL1_2XLARGE
+timeout_in_min: 90
 buildspec: codebuild/spec/buildspec_ubuntu.yml
 source_location: https://github.com/awslabs/s2n.git
 source_type : GITHUB
@@ -22,13 +23,12 @@ source_version:
 image : aws/codebuild/standard:2.0
 env_type: LINUX_CONTAINER
 compute_type: BUILD_GENERAL1_LARGE
+timeout_in_min: 90
 buildspec: codebuild/spec/buildspec_ubuntu.yml
-# Testing- TODO: update prior to merge
 source_location: https://github.com/awslabs/s2n.git
 source_type : GITHUB
 source_clonedepth: 1
 source_version:
-
 
 # The prefix CodeBuild: is required for the script to build this as a CB project
 # Fuzzers
@@ -38,7 +38,7 @@ env: S2N_LIBCRYPTO=openssl-1.1.1 LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=1
 
 [CodeBuild:s2nfuzzerOpenSSL102FIPS]
 snippet: UbuntuBoilerplate2XL
-env: S2N_LIBCRYPTO=openssl-1.0.2-fips LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=120
+env: S2N_LIBCRYPTO=openssl-1.0.2-fips LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=60
 
 # Integration tests
 
@@ -129,5 +129,13 @@ env: TESTS=sidetrail
 
 # GitHub Actions Codebuild Shim Job
 [CodeBuild:s2nGithubCodebuild]
-snippet: UbuntuBoilerplateLarge
+image : aws/codebuild/standard:2.0
+env_type: LINUX_CONTAINER
+compute_type: BUILD_GENERAL1_LARGE
+timeout_in_min: 480
+buildspec: codebuild/spec/buildspec_ubuntu.yml
+source_location: https://github.com/awslabs/s2n.git
+source_type : GITHUB
+source_clonedepth: 1
+source_version:
 env: TESTS=OverRiddenByGithub

--- a/codebuild/create_project.py
+++ b/codebuild/create_project.py
@@ -161,6 +161,7 @@ def build_project(template=Template(), section=None, project_name=None, raw_env=
         Artifacts=artifacts,
         Environment=environment,
         Name=project_name,
+        TimeoutInMinutes=config.get(section, 'timeout_in_min'),
         ServiceRole=Ref(service_role),
         Source=source,
         SourceVersion=config.get(section, 'source_version'),


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Description of changes:** 
- Correct the runtime on the PR fuzz test
- Create scheduled, 8 hour runtime Fuzz tests in parallel once a day (CodeBuild max build time).

**NOTE**: GitHub might throttle this many Actions and we may need to break it up into two groups. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
