### PR TITLE
Fix cipher suite match tests with boringssl

### DIFF
--- a/codebuild/bin/install_clang.sh
+++ b/codebuild/bin/install_clang.sh
@@ -58,8 +58,8 @@ if [[ -v FUZZ_COVERAGE ]]; then
 	LLVM_INSTALL_DIR="$CLANG_INSTALL_DIR"/../llvm
 	mkdir -p "$LLVM_INSTALL_DIR"
 	python3 "$CLANG_DOWNLOAD_DIR"/clang/scripts/update.py --package="coverage_tools" --output-dir="$LLVM_INSTALL_DIR"
-	ln -s $LLVM_INSTALL_DIR/bin/llvm-cov /usr/bin/llvm-cov
-        ln -s $LLVM_INSTALL_DIR/bin/llvm-profdata /usr/bin/llvm-profdata
+	ln -sf $LLVM_INSTALL_DIR/bin/llvm-cov /usr/bin/llvm-cov
+	ln -sf $LLVM_INSTALL_DIR/bin/llvm-profdata /usr/bin/llvm-profdata
 fi
 
 mkdir -p "$CLANG_INSTALL_DIR" && cp -rf "$CLANG_DOWNLOAD_DIR"/third_party/llvm-build/Release+Asserts/* "$CLANG_INSTALL_DIR"

--- a/tests/unit/s2n_cipher_suite_match_test.c
+++ b/tests/unit/s2n_cipher_suite_match_test.c
@@ -535,13 +535,12 @@ int main(int argc, char **argv)
             conn->client_protocol_version = S2N_TLS13;
             conn->actual_protocol_version = S2N_TLS13;
 
-            #if S2N_OPENSSL_VERSION_AT_LEAST(1,1,0)
-            EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers2, count));
-            EXPECT_EQUAL(conn->secure.cipher_suite, &s2n_tls13_chacha20_poly1305_sha256);
-            #else
-            EXPECT_FAILURE(s2n_set_cipher_as_tls_server(conn, wire_ciphers2, count));
-            #endif
-
+            if (s2n_chacha20_poly1305.is_available()) {
+                EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers2, count));
+                EXPECT_EQUAL(conn->secure.cipher_suite, &s2n_tls13_chacha20_poly1305_sha256);
+            } else {
+                EXPECT_FAILURE(s2n_set_cipher_as_tls_server(conn, wire_ciphers2, count));
+            }
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
         }
 


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
- tests are failing when built against boringssl

**Description of changes:** 
- Use s2n_chacha20_poly1305.is_available() to check availability()

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
