### PR TITLE
Update server cipher suite selection to skip choices higher than server can negotiate

### DIFF
--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -1132,13 +1132,18 @@ static int s2n_set_cipher_as_server(struct s2n_connection *conn, uint8_t * wire,
                 match = match->sslv3_cipher_suite;
             }
 
-            /* Make sure the cipher is valid for available certs */
-            if (s2n_is_cipher_suite_valid_for_auth(conn, match) != S2N_SUCCESS) {
+            /* Skip the suite if we don't have an available implementation */
+            if (!match->available) {
                 continue;
             }
 
-            /* Skip the suite if we don't have an available implementation */
-            if (!match->available) {
+            /* Skip if cipher suite requires a higher version than what server is supporting */
+            if (match->minimum_required_tls_version > conn->server_protocol_version) {
+                continue;
+            }
+
+            /* Make sure the cipher is valid for available certs */
+            if (s2n_is_cipher_suite_valid_for_auth(conn, match) != S2N_SUCCESS) {
                 continue;
             }
 


### PR DESCRIPTION
Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
https://github.com/awslabs/s2n/issues/1461#issuecomment-601780922

**Description of changes:** 
never pick a cipher suite that requires a version higher than the server is willing to negotiate.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
