### PR TITLE
Clean up s2n_get_memory proof stub

### DIFF
--- a/tests/cbmc/proofs/s2n_stuffer_copy/s2n_stuffer_copy_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_copy/s2n_stuffer_copy_harness.c
@@ -22,16 +22,6 @@
 #include <cbmc_proof/make_common_datastructures.h>
 #include <error/s2n_errno.h>
 
-/* The stuffer function s2n_get_memory fails the cbmc proof. This stub is needed
-until that proof has been written. */
-int s2n_get_memory(struct s2n_blob *b, uint32_t size)
-{
-    *b = (struct s2n_blob) {.data = nondet_bool() ? malloc(size) : 0,
-            .size = size, .allocated = size, .mlocked = 0, .growable = 1};
-    S2N_ERROR_IF(b->data == NULL, S2N_ERR_ALLOC);
-    return S2N_SUCCESS;
-}
-
 void s2n_stuffer_copy_harness() {
     struct s2n_stuffer *from = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(from));

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -59,7 +59,7 @@ bool s2n_blob_is_growable(const struct s2n_blob* b)
   return b && (b->growable || (b->data == NULL && b->size == 0 && b->allocated == 0));
 }
 
-int s2n_get_memory(struct s2n_blob *b, uint32_t size)
+static int s2n_get_memory(struct s2n_blob *b, uint32_t size)
 {
     if(use_mlock) {
         /* Page aligned allocation required for mlock */


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
#1507 
**Description of changes:** 
- Originally this cbmc proof needed a stub for the s2n_get_memory function and it is no longer needed.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
