### PR TITLE
ci: fix scheduled actions with different repo var.

### DIFF
--- a/.github/workflows/private_fork_scheduled_codebuild.yml
+++ b/.github/workflows/private_fork_scheduled_codebuild.yml
@@ -6,7 +6,7 @@ on:
     - cron: '0 13 * * *'
 jobs:
   fuzz:
-    if: startsWith(github.event.repository.name, 'private-')
+    if: contains(${{ github.repository }}, 'private-s2n')
     runs-on: ubuntu-18.04
     strategy:
       matrix:


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Description of changes:** 
GH Actions run from cron don't appear to have the event.* vars, use the top level repo name variable instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
