### PR TITLE
ci: fix issues with long running fuzz jobs; remove apt pgp key download

### DIFF
--- a/.github/workflows/private_fork_pr_codebuild.yml
+++ b/.github/workflows/private_fork_pr_codebuild.yml
@@ -7,7 +7,7 @@ on:
       - master
 jobs:
   fuzz:
-    if: startsWith(github.event.repository.name, 'private-')        
+    if: startsWith(github.repository, 'private-')
     runs-on: ubuntu-18.04
     strategy:
       matrix:

--- a/.github/workflows/private_fork_scheduled_codebuild.yml
+++ b/.github/workflows/private_fork_scheduled_codebuild.yml
@@ -6,7 +6,7 @@ on:
     - cron: '0 13 * * *'
 jobs:
   fuzz:
-    if: contains(${{ github.repository }}, 'private-s2n')
+    if: contains(github.repository, 'private-s2n')
     runs-on: ubuntu-18.04
     strategy:
       matrix:
@@ -42,7 +42,7 @@ jobs:
           - s2n_sike_r1_fuzz_test
           - s2n_sike_r2_fuzz_test
           - s2n_stuffer_pem_fuzz_test
-      fail-fast: true
+      fail-fast: false
     steps:
       - uses: actions/setup-node@v1
       - name: Configure AWS Credentials
@@ -68,6 +68,6 @@ jobs:
           TESTS: "fuzz"
           FUZZ_TESTS: ${{ matrix.specific_test }}
           LAGEST_CLANG: "true"
-          FUZZ_TIMEOUT_SEC: 28500
+          FUZZ_TIMEOUT_SEC: 21000
           requester: ${{ github.actor }}
           event-name: ${{ github.event_name }}

--- a/.github/workflows/private_sync.yml
+++ b/.github/workflows/private_sync.yml
@@ -5,7 +5,7 @@ on:
       - master
 jobs:
   build:
-    if: startsWith(github.event.repository.name, 's2n')        
+    if: startsWith(github.repository, 's2n')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/codebuild/spec/buildspec_ubuntu.yml
+++ b/codebuild/spec/buildspec_ubuntu.yml
@@ -19,8 +19,7 @@ phases:
       python: 3.7
     commands:
       - echo Entered the install phase...
-      - apt-key list
-      - apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 6B05F25D762E3157
+      - echo "We need a test PPA for gcc-9."
       - add-apt-repository ppa:ubuntu-toolchain-r/test -y
       - apt-get update -o Acquire::CompressionTypes::Order::=gz
       - apt-get update -y


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Description of changes:** 
* Use consistent variable for repo name
* GHA timeout is lower than Codebuild- move to 6 hours
* Remove (constantly failing) apt pgp key download; comment as to why we need a test PPA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
