### PR TITLE
ci: Codebuild artifacts for fuzzers

### DIFF
--- a/.github/workflows/fuzz_scheduled_codebuild.yml
+++ b/.github/workflows/fuzz_scheduled_codebuild.yml
@@ -31,7 +31,6 @@ jobs:
           - s2n_hybrid_ecdhe_bike_r2_fuzz_test
           - s2n_hybrid_ecdhe_sike_r1_fuzz_test
           - s2n_hybrid_ecdhe_sike_r2_fuzz_test
-          - s2n_memory_leak_negative_test
           - s2n_openssl_diff_pem_parsing_test
           - s2n_recv_client_supported_groups_test
           - s2n_select_server_cert_test

--- a/codebuild/codebuild.config
+++ b/codebuild/codebuild.config
@@ -1,6 +1,10 @@
 # Config file consumed by create_project
 # Helpful reminder about CodeBuild provided docker images:
 #  https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html
+
+[Global]
+aws_region=us-west-2
+
 [CFNRole]
 account_number: 024603541914
 
@@ -138,4 +142,20 @@ source_location: https://github.com/awslabs/s2n.git
 source_type : GITHUB
 source_clonedepth: 1
 source_version:
-env: TESTS=OverRiddenByGithub
+env: TESTS=OverRiddenByGithubActions
+
+# GitHub Actions Codebuild Shim Job With Artifacts
+# There is an open issue for passing an Artifact config
+# via the aciton; until that's done, we need a Fuzz specific
+# artifact job.
+[CodeBuild:s2nGithubCodebuildFuzz]
+image : aws/codebuild/standard:2.0
+env_type: LINUX_CONTAINER
+compute_type: BUILD_GENERAL1_LARGE
+timeout_in_min: 480
+buildspec: codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
+source_location: https://github.com/awslabs/s2n.git
+source_type : GITHUB
+source_clonedepth: 1
+source_version:
+env: TESTS=OverRiddenByGithubActions FUZZ_TESTS=this_value_is_required

--- a/codebuild/codebuild.config
+++ b/codebuild/codebuild.config
@@ -150,6 +150,10 @@ env: TESTS=OverRiddenByGithubActions
 # artifact job.
 [CodeBuild:s2nGithubCodebuildFuzz]
 image : aws/codebuild/standard:2.0
+# This next value MUST match the buildspec files
+# secondary-artifacts, and can be a comma sep. list
+artifact_secondary_identifiers: logs
+artifact_s3_bucket: s2n-build-artifacts
 env_type: LINUX_CONTAINER
 compute_type: BUILD_GENERAL1_LARGE
 timeout_in_min: 480

--- a/codebuild/codebuild.config
+++ b/codebuild/codebuild.config
@@ -4,6 +4,7 @@
 
 [Global]
 aws_region=us-west-2
+stack_name = s2nCodeBuildTests
 
 [CFNRole]
 account_number: 024603541914

--- a/codebuild/spec/buildspec_ubuntu_artifacts.yml
+++ b/codebuild/spec/buildspec_ubuntu_artifacts.yml
@@ -1,0 +1,66 @@
+---
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      python: 3.7
+    commands:
+      - echo Entered the install phase...
+      - apt-key list
+      - apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 6B05F25D762E3157
+      - add-apt-repository ppa:ubuntu-toolchain-r/test -y
+      - apt-get update -o Acquire::CompressionTypes::Order::=gz
+      - apt-get update -y
+      - |
+        if expr "${GCC_VERSION}" : "9" >/dev/null; then
+          apt-get install -y --no-install-recommends g++ g++-9 gcc gcc-9;
+        fi
+      - |
+        if expr "${GCC_VERSION}" : "6" >/dev/null; then
+          apt-get install -y --no-install-recommends g++ g++-6 gcc gcc-6;
+        fi
+
+      # Don't install old clang and llvm if LATEST_CLANG is enabled, handle it in install_clang.sh instead
+      - |
+        if expr "${LATEST_CLANG}" != "true" >/dev/null; then
+          apt-get install -y --no-install-recommends clang-3.9 llvm-3.9;
+        fi
+      - apt-get install -y --no-install-recommends indent kwstyle lcov libssl-dev m4 make net-tools nettle-bin nettle-dev pkg-config psmisc python3-pip shellcheck sudo tcpdump unzip valgrind zlib1g-dev zlibc cmake
+  pre_build:
+    commands:
+      - codebuild/bin/install_default_dependencies.sh
+  build:
+    commands:
+      - printenv
+      - codebuild/bin/s2n_codebuild.sh
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      - echo Uploading CodeCov.io artifacts
+      - codebuild/bin/s2n_after_codebuild.sh
+artifacts:
+  files:
+    - "*.bin"
+  name: test-logs-$(date +%Y%m%d)-$CODEBUILD_BUILD_NUMBER
+  discard-paths: yes
+  base-directory: "/build/logs"
+  secondary-artifacts:
+    coveragefiles:
+      files:
+        - "**/*"
+      name: test-all-$(date +%Y%m%d)-$CODEBUILD_BUILD_NUMBER
+      discard-paths: yes
+      base-directory: "/build"

--- a/codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
+++ b/codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
@@ -52,15 +52,14 @@ phases:
       - codebuild/bin/s2n_after_codebuild.sh
 artifacts:
   files:
-    - "$FUZZ_TESTS/*"
+    - "./tests/fuzz/corpus/$FUZZ_TESTS/*"
   name: fuzz-corpus-$FUZZ_TESTS-$(date +%Y%m%d)-$CODEBUILD_BUILD_NUMBER
   discard-paths: no
-  base-directory: "./tests/fuzz/corpus"
   secondary-artifacts:
     logs:
       files:
-        - "**/*_results.txt"
-        - "**/*_output.txt"
-      name: fuzz-logs-$FUZZ_TESTS-$(date +%Y%m%d)-$CODEBUILD_BUILD_NUMBER
-      discard-paths: yes
-      base-directory: "./tests/fuzz"
+        - "./tests/fuzz/**/*_results.txt"
+        - "./tests/fuzz/**/*_output.txt"
+        - "./coverage/fuzz/**"
+      name: fuzz-cov-logs-$FUZZ_TESTS-$(date +%Y%m%d)-$CODEBUILD_BUILD_NUMBER
+      discard-paths: no

--- a/codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
+++ b/codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
@@ -20,7 +20,6 @@ phases:
     commands:
       - echo Entered the install phase...
       - apt-key list
-      - apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 6B05F25D762E3157
       - add-apt-repository ppa:ubuntu-toolchain-r/test -y
       - apt-get update -o Acquire::CompressionTypes::Order::=gz
       - apt-get update -y

--- a/codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
+++ b/codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
@@ -32,7 +32,6 @@ phases:
         if expr "${GCC_VERSION}" : "6" >/dev/null; then
           apt-get install -y --no-install-recommends g++ g++-6 gcc gcc-6;
         fi
-
       # Don't install old clang and llvm if LATEST_CLANG is enabled, handle it in install_clang.sh instead
       - |
         if expr "${LATEST_CLANG}" != "true" >/dev/null; then
@@ -42,6 +41,7 @@ phases:
   pre_build:
     commands:
       - codebuild/bin/install_default_dependencies.sh
+      - touch tests/fuzz/placeholder_results.txt tests/fuzz/placeholder_output.txt 
   build:
     commands:
       - printenv
@@ -53,14 +53,15 @@ phases:
       - codebuild/bin/s2n_after_codebuild.sh
 artifacts:
   files:
-    - "*.bin"
-  name: test-logs-$(date +%Y%m%d)-$CODEBUILD_BUILD_NUMBER
-  discard-paths: yes
-  base-directory: "/build/logs"
+    - "$FUZZ_TESTS/*"
+  name: fuzz-corpus-$FUZZ_TESTS-$(date +%Y%m%d)-$CODEBUILD_BUILD_NUMBER
+  discard-paths: no
+  base-directory: "./tests/fuzz/corpus"
   secondary-artifacts:
-    coveragefiles:
+    logs:
       files:
-        - "**/*"
-      name: test-all-$(date +%Y%m%d)-$CODEBUILD_BUILD_NUMBER
+        - "**/*_results.txt"
+        - "**/*_output.txt"
+      name: fuzz-logs-$FUZZ_TESTS-$(date +%Y%m%d)-$CODEBUILD_BUILD_NUMBER
       discard-paths: yes
-      base-directory: "/build"
+      base-directory: "./tests/fuzz"


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Description of changes:** 
Add artifact storage configuration to CloudFormation script and a new buildspec file for CodeBuild.

There has been some drift in the CFN config vs. CodeBuild, so also capturing an increased job timeout value of 90 minutes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
