### PR TITLE
Fixes to allow s2n to build on Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,14 @@ else()
     endif()
 endif()
 
+# Probe for execinfo.h extensions (not present on some systems, notably android)
+include(CheckCSourceCompiles)
+check_c_source_compiles("
+    #include <execinfo.h>
+    int main() {
+        return 0;
+    }" S2N_HAVE_EXECINFO)
+
 if(APPLE)
     set(OS_LIBS c Threads::Threads)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
@@ -190,6 +198,10 @@ endif()
 
 if(PQ_ASM_COMPILES_ADX)
     target_compile_options(${PROJECT_NAME} PUBLIC -D_ADX_)
+endif()
+
+if(S2N_HAVE_EXECINFO)
+    target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_HAVE_EXECINFO)
 endif()
 
 target_compile_options(${PROJECT_NAME} PUBLIC -fPIC)

--- a/error/s2n_errno.c
+++ b/error/s2n_errno.c
@@ -18,12 +18,15 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <execinfo.h>
 #include "error/s2n_errno.h"
 
 #include <s2n.h>
 #include "utils/s2n_map.h"
 #include "utils/s2n_safety.h"
+
+#if S2N_HAVE_EXECINFO
+#   include <execinfo.h>
+#endif
 
 __thread int s2n_errno;
 __thread const char *s2n_debug_str;
@@ -289,7 +292,7 @@ int s2n_error_get_type(int error)
 
 
 /* https://www.gnu.org/software/libc/manual/html_node/Backtraces.html */
-static bool s_s2n_stack_traces_enabled;
+static bool s_s2n_stack_traces_enabled = false;
 
 bool s2n_stack_traces_enabled()
 {
@@ -301,6 +304,8 @@ int s2n_stack_traces_enabled_set(bool newval)
     s_s2n_stack_traces_enabled = newval;
     return S2N_SUCCESS;
 }
+
+#ifdef S2N_HAVE_EXECINFO
 
 #define MAX_BACKTRACE_DEPTH 20
 __thread struct s2n_stacktrace tl_stacktrace = {0};
@@ -350,3 +355,30 @@ int s2n_print_stacktrace(FILE *fptr)
     }
     return S2N_SUCCESS;
 }
+
+#else /* !S2N_HAVE_EXECINFO */
+int s2n_free_stacktrace(void)
+{
+    return S2N_ERR_UNIMPLEMENTED;
+}
+
+int s2n_calculate_stacktrace(void)
+{
+    if (!s_s2n_stack_traces_enabled)
+    {
+        return S2N_SUCCESS;
+    }
+
+    return S2N_ERR_UNIMPLEMENTED;
+}
+
+int s2n_get_stacktrace(struct s2n_stacktrace *trace)
+{
+    return S2N_ERR_UNIMPLEMENTED;
+}
+
+int s2n_print_stacktrace(FILE *fptr)
+{
+    return S2N_ERR_UNIMPLEMENTED;
+}
+#endif /* S2N_HAVE_EXECINFO */

--- a/error/s2n_errno.c
+++ b/error/s2n_errno.c
@@ -359,7 +359,7 @@ int s2n_print_stacktrace(FILE *fptr)
 #else /* !S2N_HAVE_EXECINFO */
 int s2n_free_stacktrace(void)
 {
-    return S2N_ERR_UNIMPLEMENTED;
+    S2N_ERROR(S2N_ERR_UNIMPLEMENTED);
 }
 
 int s2n_calculate_stacktrace(void)
@@ -369,16 +369,16 @@ int s2n_calculate_stacktrace(void)
         return S2N_SUCCESS;
     }
 
-    return S2N_ERR_UNIMPLEMENTED;
+    S2N_ERROR(S2N_ERR_UNIMPLEMENTED);
 }
 
 int s2n_get_stacktrace(struct s2n_stacktrace *trace)
 {
-    return S2N_ERR_UNIMPLEMENTED;
+    S2N_ERROR(S2N_ERR_UNIMPLEMENTED);
 }
 
 int s2n_print_stacktrace(FILE *fptr)
 {
-    return S2N_ERR_UNIMPLEMENTED;
+    S2N_ERROR(S2N_ERR_UNIMPLEMENTED);
 }
 #endif /* S2N_HAVE_EXECINFO */

--- a/s2n.mk
+++ b/s2n.mk
@@ -84,6 +84,11 @@ ifdef S2N_NO_PQ_ASM
 	DEFAULT_CFLAGS += -DS2N_NO_PQ_ASM
 endif
 
+# All native platforms have execinfo.h, cross-compile targets often don't (android, ARM/alpine)
+ifndef CROSS_COMPILE
+	DEFAULT_CFLAGS += -DS2N_HAVE_EXECINFO
+endif
+
 CFLAGS += ${DEFAULT_CFLAGS}
 
 ifdef GCC_VERSION


### PR DESCRIPTION
**Description of changes:** Added a check for the presence of execinfo.h, allows Android NDK to compile s2n


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
