### PR TITLE
ci: Incorrect parsing the longer variable broke pushes.

### DIFF
--- a/.github/workflows/private_sync.yml
+++ b/.github/workflows/private_sync.yml
@@ -5,7 +5,7 @@ on:
       - master
 jobs:
   build:
-    if: startsWith(github.repository, 's2n')
+    if: endsWith(github.repository, 's2n')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Description of changes:** 
github.repository is actually github_user+github_repository, alter the GHA function that checks the repo name (and yes, GHA's could really use test cases).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
