### PR TITLE
Attempt to make s2n_dynamic_record_size_test fail less

### DIFF
--- a/tests/integration/s2n_dynamic_record_size_test.py
+++ b/tests/integration/s2n_dynamic_record_size_test.py
@@ -161,7 +161,7 @@ def run_test(host, port, ssl_version, cipher, threshold):
 
     ret = try_dynamic_record(host, port, cipher_name, ssl_version, threshold)
     # wait for pipe ready
-    sleep(1)
+    sleep(2)
     subprocess.call(["sudo", "killall", "-9", "tcpdump"])
     out = tcpdump.communicate()[0].decode("utf-8")
     if out == '':
@@ -169,7 +169,7 @@ def run_test(host, port, ssl_version, cipher, threshold):
         return 0
     out_array = out.split('\n')
     # Skip no cipher match error
-    if ret != -2: 
+    if ret != -2:
         failed += ret
     if 0 == ret:
         # print("\nAnalyzing tcpdump results for cipher {}".format(cipher_name))
@@ -228,8 +228,13 @@ def analyze_latency_dump(array):
 
 def analyze_throughput_dump(array):
     failed = 1
+    array_len = len(array)
 
     for i in range(18, 36):
+        if i >= array_len:
+            print("Array len is ", array_len, ", expecting >= ", i)
+            print(array)
+            return failed
         output = array[i]
         # print(output)
         pos = output.find("length")


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
#1537

```py
Traceback (most recent call last):
  File "s2n_dynamic_record_size_test.py", line 293, in <module>
    sys.exit(main())
  File "s2n_dynamic_record_size_test.py", line 282, in main
    failed += test(host, port, test_ciphers, int(file_size / 2))
  File "s2n_dynamic_record_size_test.py", line 196, in test
    result = run_test(host, port, ssl_version, cipher, threshold)
  File "s2n_dynamic_record_size_test.py", line 179, in run_test
    failed += analyze_throughput_dump(out_array)
  File "s2n_dynamic_record_size_test.py", line 233, in analyze_throughput_dump
    output = array[i]
IndexError: list index out of range
Makefile:52: recipe for target 'dynamic_record' failed
make[2]: *** [dynamic_record] Error 1
make[2]: Leaving directory '/home/travis/build/awslabs/s2n/tests/integration'
Makefile:39: recipe for target 'integration' failed
make[1]: *** [integration] Error 2
make[1]: Leaving directory '/home/travis/build/awslabs/s2n/tests'
Makefile:81: recipe for target 'integration' failed
make: *** [integration] Error 2
The command ".travis/s2n_travis_build.sh" exited with 2.
```

**Description of changes:** 
Increase wait time before killing tcpdump, also print more if it fails on insufficient array length

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
