### PR TITLE
Check that key exchange algorithm is never null

### DIFF
--- a/tls/s2n_server_key_exchange.c
+++ b/tls/s2n_server_key_exchange.c
@@ -39,6 +39,7 @@ int s2n_server_key_recv(struct s2n_connection *conn)
 {
     struct s2n_hash_state *signature_hash = &conn->secure.signature_hash;
     const struct s2n_kex *key_exchange = conn->secure.cipher_suite->key_exchange_alg;
+    notnull_check(key_exchange);
     struct s2n_stuffer *in = &conn->handshake.io;
     struct s2n_blob data_to_verify = {0};
 

--- a/tls/s2n_server_key_exchange.c
+++ b/tls/s2n_server_key_exchange.c
@@ -37,9 +37,12 @@ static int s2n_write_signature_blob(struct s2n_stuffer *out, const struct s2n_pk
 
 int s2n_server_key_recv(struct s2n_connection *conn)
 {
+    notnull_check(conn);
+    notnull_check(conn->secure.cipher_suite);
+    notnull_check(conn->secure.cipher_suite->key_exchange_alg);
+
     struct s2n_hash_state *signature_hash = &conn->secure.signature_hash;
     const struct s2n_kex *key_exchange = conn->secure.cipher_suite->key_exchange_alg;
-    notnull_check(key_exchange);
     struct s2n_stuffer *in = &conn->handshake.io;
     struct s2n_blob data_to_verify = {0};
 


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
- bad cipher suites configuration shouldn't cause segfaults
https://github.com/awslabs/s2n/issues/1461#issuecomment-601780922

**Description of changes:** 
- add null check for kex algorithm

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
