### PR TITLE
ci: restrict where scheduled fuzz tests run

### DIFF
--- a/.github/workflows/fuzz_scheduled_codebuild.yml
+++ b/.github/workflows/fuzz_scheduled_codebuild.yml
@@ -1,12 +1,12 @@
 ---
-name: s2nPrivateFuzzScheduled
+name: s2nFuzzScheduled
 
 on:
   schedule:
     - cron: '0 13 * * *'
 jobs:
   fuzz:
-    if: contains(github.repository, 'private-s2n')
+    if: contains(github.repository, 'private-s2n-fuzz')
     runs-on: ubuntu-18.04
     strategy:
       matrix:


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Description of changes:** 
Restrict GHA repo where scheduled fuzz tests run.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
