### PR TITLE
Keep sslyze < v3.0.0 

### DIFF
--- a/.travis/install_sslyze.sh
+++ b/.travis/install_sslyze.sh
@@ -16,6 +16,7 @@
 set -e
 
 pip3 install --user --upgrade pip setuptools
+
 # Version 3.0.0 introduces backwards incompatible changes in the JSON we parse.
 # If we upgrade, the json format changes, breaking either Travis OR Codebuild.
 pip3 install --user "sslyze<3.0.0"

--- a/.travis/install_sslyze.sh
+++ b/.travis/install_sslyze.sh
@@ -16,7 +16,9 @@
 set -e
 
 pip3 install --user --upgrade pip setuptools
-pip3 install --user sslyze
+# Version 3.0.0 introduces backwards incompatible changes in the JSON we parse.
+# If we upgrade, the json format changes, breaking either Travis OR Codebuild.
+pip3 install --user "sslyze<3.0.0"
 
 which sslyze
 sslyze --version

--- a/codebuild/bin/install_sslyze.sh
+++ b/codebuild/bin/install_sslyze.sh
@@ -16,7 +16,9 @@
 set -ex
 
 python3 -m pip install --user --upgrade pip setuptools
-python3 -m pip install --user sslyze
+# Version 3.0.0 introduces backwards incompatible changes in the JSON we parse.
+# If we upgrade, the json format changes, breaking either Travis OR Codebuild.
+python3 -m pip install --user "sslyze<3.0.0"
 
 sudo ln -s /root/.local/bin/sslyze /usr/bin/sslyze || true
 

--- a/codebuild/bin/install_sslyze.sh
+++ b/codebuild/bin/install_sslyze.sh
@@ -16,6 +16,7 @@
 set -ex
 
 python3 -m pip install --user --upgrade pip setuptools
+
 # Version 3.0.0 introduces backwards incompatible changes in the JSON we parse.
 # If we upgrade, the json format changes, breaking either Travis OR Codebuild.
 python3 -m pip install --user "sslyze<3.0.0"


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** fixes https://github.com/awslabs/s2n/issues/1719

**Description of changes:** 
Travis and Codebuild are using different versions of sslyze. The newer version used by Codebuild includes a backwards incompatible change to the JSON format of the results, which our test depends on being able to parse.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
