### PR TITLE
Move server extension send functions to their own extension files

### DIFF
--- a/tests/unit/s2n_server_renegotiation_info_test.c
+++ b/tests/unit/s2n_server_renegotiation_info_test.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include <stdint.h>
+
+#include "tls/s2n_config.h"
+#include "tls/s2n_connection.h"
+#include "tls/s2n_tls.h"
+#include "tls/s2n_tls13.h"
+#include "tls/extensions/s2n_server_renegotiation_info.h"
+
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    struct s2n_config *config;
+    EXPECT_NOT_NULL(config = s2n_config_new());
+
+    /* Test server_renegotiation_info send and recv */
+    {
+        struct s2n_connection *server_conn, *client_conn;
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
+       /* Zero length extension expected as conn cannot send ext */
+        EXPECT_EQUAL(0, s2n_server_renegotiation_info_ext_size(server_conn));
+
+        /* Set connection to be able to send extension and verify size */
+        uint16_t expected_ext_length = 5;
+
+        server_conn->actual_protocol_version = S2N_TLS12;
+        server_conn->secure_renegotiation = 1;
+        EXPECT_EQUAL(expected_ext_length, s2n_server_renegotiation_info_ext_size(server_conn));
+
+        struct s2n_stuffer extension;
+        s2n_stuffer_alloc(&extension, s2n_server_renegotiation_info_ext_size(server_conn));
+
+        EXPECT_SUCCESS(s2n_send_server_renegotiation_info_ext(server_conn, &extension));
+        EXPECT_EQUAL(s2n_stuffer_data_available(&extension), s2n_server_renegotiation_info_ext_size(server_conn));
+
+        uint16_t extension_type, extension_length;
+        s2n_stuffer_read_uint16(&extension, &extension_type);
+        s2n_stuffer_read_uint16(&extension, &extension_length);
+        EXPECT_EQUAL(extension_type, TLS_EXTENSION_RENEGOTIATION_INFO);
+        EXPECT_EQUAL(extension_length, 1);
+        EXPECT_EQUAL(s2n_stuffer_data_available(&extension), extension_length);
+
+        EXPECT_SUCCESS(s2n_recv_server_renegotiation_info_ext(client_conn, &extension));
+        EXPECT_EQUAL(client_conn->secure_renegotiation, 1);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&extension));
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+    }
+
+    EXPECT_SUCCESS(s2n_config_free(config));
+
+    END_TEST();
+    return 0;
+}

--- a/tests/unit/s2n_server_session_ticket_extension_test.c
+++ b/tests/unit/s2n_server_session_ticket_extension_test.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include <stdint.h>
+
+#include "tls/s2n_config.h"
+#include "tls/s2n_connection.h"
+#include "tls/s2n_tls.h"
+#include "tls/s2n_tls13.h"
+#include "tls/extensions/s2n_server_session_ticket.h"
+
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    struct s2n_config *config;
+    EXPECT_NOT_NULL(config = s2n_config_new());
+
+    /* Test server_session_ticket send and recv */
+    {
+        struct s2n_connection *server_conn, *client_conn;
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+        
+        /* Zero length extension expected as conn cannot send ext */
+        EXPECT_EQUAL(0, s2n_server_session_ticket_ext_size(server_conn));
+
+        /* Set connection to be able to send extension and verify size */
+        uint16_t expected_ext_length = 4;
+
+        server_conn->actual_protocol_version = S2N_TLS12;
+        server_conn->config->use_tickets = 1;
+        server_conn->session_ticket_status = S2N_NEW_TICKET;
+        EXPECT_EQUAL(expected_ext_length, s2n_server_session_ticket_ext_size(server_conn));
+
+        struct s2n_stuffer extension;
+        s2n_stuffer_alloc(&extension, s2n_server_session_ticket_ext_size(server_conn));
+
+        EXPECT_SUCCESS(s2n_send_server_session_ticket_ext(server_conn, &extension));
+        EXPECT_EQUAL(s2n_stuffer_data_available(&extension), s2n_server_session_ticket_ext_size(server_conn));
+
+        uint16_t extension_type, extension_length;
+        s2n_stuffer_read_uint16(&extension, &extension_type);
+        s2n_stuffer_read_uint16(&extension, &extension_length);
+        EXPECT_EQUAL(extension_type, TLS_EXTENSION_SESSION_TICKET);
+        EXPECT_EQUAL(extension_length, 0);
+
+        EXPECT_SUCCESS(s2n_recv_server_session_ticket_ext(client_conn, &extension));
+        EXPECT_EQUAL(client_conn->session_ticket_status, S2N_NEW_TICKET);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&extension));
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+    }
+
+    EXPECT_SUCCESS(s2n_config_free(config));
+
+    END_TEST();
+    return 0;
+}

--- a/tls/extensions/s2n_server_renegotiation_info.h
+++ b/tls/extensions/s2n_server_renegotiation_info.h
@@ -15,4 +15,6 @@
 
 #pragma once
 
-extern int s2n_recv_server_renegotiation_info_ext(struct s2n_connection *conn, struct s2n_stuffer *extension);
+int s2n_recv_server_renegotiation_info_ext(struct s2n_connection *conn, struct s2n_stuffer *extension);
+int s2n_send_server_renegotiation_info_ext(struct s2n_connection *conn, struct s2n_stuffer *out);
+uint16_t s2n_server_renegotiation_info_ext_size(struct s2n_connection *conn);

--- a/tls/extensions/s2n_server_session_ticket.h
+++ b/tls/extensions/s2n_server_session_ticket.h
@@ -15,4 +15,6 @@
 
 #pragma once
 
-extern int s2n_recv_server_session_ticket_ext(struct s2n_connection *conn, struct s2n_stuffer *extension);
+int s2n_recv_server_session_ticket_ext(struct s2n_connection *conn, struct s2n_stuffer *extension);
+int s2n_send_server_session_ticket_ext(struct s2n_connection *conn, struct s2n_stuffer *out);
+uint16_t s2n_server_session_ticket_ext_size(struct s2n_connection *conn);

--- a/tls/s2n_kex.c
+++ b/tls/s2n_kex.c
@@ -232,16 +232,24 @@ const struct s2n_kex s2n_hybrid_ecdhe_kem = {
 
 int s2n_kex_server_extension_size(const struct s2n_kex *kex, const struct s2n_connection *conn)
 {
-    notnull_check(kex);
-    notnull_check(kex->get_server_extension_size);
-    return kex->get_server_extension_size(conn);
+    if (s2n_server_can_send_kex(conn)) {
+        notnull_check(kex);
+        notnull_check(kex->get_server_extension_size);
+        return kex->get_server_extension_size(conn);
+    }
+
+    return 0;
 }
 
 int s2n_kex_write_server_extension(const struct s2n_kex *kex, const struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    notnull_check(kex);
-    notnull_check(kex->write_server_extensions);
-    return kex->write_server_extensions(conn, out);
+    if (s2n_server_can_send_kex(conn)) {
+        notnull_check(kex);
+        notnull_check(kex->write_server_extensions);
+        return kex->write_server_extensions(conn, out);
+    }
+
+    return 0;
 }
 
 int s2n_kex_supported(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn)

--- a/tls/s2n_server_extensions.c
+++ b/tls/s2n_server_extensions.c
@@ -40,11 +40,6 @@
 #include "utils/s2n_safety.h"
 #include "utils/s2n_blob.h"
 
-#define s2n_server_can_send_secure_renegotiation(conn) ((conn)->secure_renegotiation && \
-        (conn)->actual_protocol_version < S2N_TLS13)
-
-#define s2n_server_can_send_nst(conn) (s2n_server_sending_nst((conn)) && \
-        (conn)->actual_protocol_version < S2N_TLS13)
 
 /* compute size server extensions send requires */
 int s2n_server_extensions_send_size(struct s2n_connection *conn)
@@ -61,14 +56,10 @@ int s2n_server_extensions_send_size(struct s2n_connection *conn)
 
     total_size += s2n_server_extensions_server_name_send_size(conn);
     total_size += s2n_server_extensions_alpn_send_size(conn);
-
-    if (s2n_server_can_send_secure_renegotiation(conn)) {
-        total_size += 5;
-    }
-
-    if (s2n_server_can_send_kex(conn)) {
-        total_size += s2n_kex_server_extension_size(conn->secure.cipher_suite->key_exchange_alg, conn);
-    }
+    total_size += s2n_server_renegotiation_info_ext_size(conn);
+    total_size += s2n_kex_server_extension_size(conn->secure.cipher_suite->key_exchange_alg, conn);
+    total_size += s2n_server_extensions_max_fragment_length_send_size(conn);
+    total_size += s2n_server_session_ticket_ext_size(conn);
 
     if (s2n_server_can_send_ocsp(conn)) {
         total_size += 4;
@@ -76,12 +67,6 @@ int s2n_server_extensions_send_size(struct s2n_connection *conn)
 
     if (s2n_server_can_send_sct_list(conn)) {
         total_size += 4 + conn->handshake_params.our_chain_and_key->sct_list.size;
-    }
-
-    total_size += s2n_server_extensions_max_fragment_length_send_size(conn);
-
-    if (s2n_server_can_send_nst(conn)) {
-        total_size += 4;
     }
 
     return total_size;
@@ -115,18 +100,11 @@ int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *
     /* Write server name extension */
     GUARD(s2n_server_extensions_server_name_send(conn, out));
 
-    if (s2n_server_can_send_kex(conn)) {
-        GUARD(s2n_kex_write_server_extension(conn->secure.cipher_suite->key_exchange_alg, conn, out));
-    }
-
+    /* Write kex extension */
+    GUARD(s2n_kex_write_server_extension(conn->secure.cipher_suite->key_exchange_alg, conn, out));
+    
     /* Write the renegotiation_info extension */
-    if (s2n_server_can_send_secure_renegotiation(conn)) {
-        GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_RENEGOTIATION_INFO));
-        /* renegotiation_info length */
-        GUARD(s2n_stuffer_write_uint16(out, 1));
-        /* renegotiated_connection length. Zero since we don't support renegotiation. */
-        GUARD(s2n_stuffer_write_uint8(out, 0));
-    }
+    GUARD(s2n_send_server_renegotiation_info_ext(conn, out));
 
     /* Write ALPN extension */
     GUARD(s2n_server_extensions_alpn_send(conn, out));
@@ -145,13 +123,11 @@ int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *
                                       conn->handshake_params.our_chain_and_key->sct_list.size));
     }
 
+    /* Write max fragment length extension */
     GUARD(s2n_server_extensions_max_fragment_length_send(conn, out));
 
     /* Write session ticket extension */
-    if (s2n_server_can_send_nst(conn)) {
-        GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_SESSION_TICKET));
-        GUARD(s2n_stuffer_write_uint16(out, 0));
-    }
+    GUARD(s2n_send_server_session_ticket_ext(conn, out));
 
     return 0;
 }


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):**  #1189 

**Description of changes:** 

Move server extension send functions to their own extension files
    * server_renegotiation
    * session_ticket
Add basic unit tests for the aforementioned extensions as none previously existed

Note: the remaining two extensions are addressed in this PR https://github.com/awslabs/s2n/pull/1695

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
