### PR TITLE
Nullcheck keyshare

### DIFF
--- a/tests/unit/s2n_tls13_compute_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_compute_shared_secret_test.c
@@ -69,7 +69,6 @@ int main(int argc, char **argv) {
         EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_shared_secret(client_conn, &client_shared_secret), S2N_ERR_NULL);
 
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
-
     }
 
     /* This test ensures that if a server sent a keyshare extension with a public key and curve, a client can
@@ -93,7 +92,6 @@ int main(int argc, char **argv) {
         EXPECT_SUCCESS(s2n_tls13_compute_shared_secret(client_conn, &client_shared_secret));
 
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
-
     }
 
     END_TEST();

--- a/tests/unit/s2n_tls13_compute_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_compute_shared_secret_test.c
@@ -48,7 +48,7 @@ int main(int argc, char **argv) {
         client_conn->secure.client_ecc_evp_params[0].negotiated_curve = client_conn->config->ecc_preferences->ecc_curves[0];
         EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.client_ecc_evp_params[0]));
 
-        DEFER_CLEANUP(struct s2n_blob client_shared_secret = { 0 }, s2n_free);
+        DEFER_CLEANUP(struct s2n_blob client_shared_secret = {0}, s2n_free);
         /* Compute fails because server's curve and public key are missing. */
         EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_shared_secret(client_conn, &client_shared_secret), S2N_ERR_NULL);
 
@@ -70,7 +70,7 @@ int main(int argc, char **argv) {
         /* Set curve server sent in server hello */
         client_conn->secure.server_ecc_evp_params.negotiated_curve = client_conn->config->ecc_preferences->ecc_curves[0];
 
-        DEFER_CLEANUP(struct s2n_blob client_shared_secret = { 0 }, s2n_free);
+        DEFER_CLEANUP(struct s2n_blob client_shared_secret = {0}, s2n_free);
         /* Compute fails because server's public key is missing */
         EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_shared_secret(client_conn, &client_shared_secret), S2N_ERR_NULL);
 
@@ -95,7 +95,7 @@ int main(int argc, char **argv) {
 
         /* Generate public key server sent in server hello */
         EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.server_ecc_evp_params));
-        DEFER_CLEANUP(struct s2n_blob client_shared_secret = { 0 }, s2n_free);
+        DEFER_CLEANUP(struct s2n_blob client_shared_secret = {0}, s2n_free);
         EXPECT_SUCCESS(s2n_tls13_compute_shared_secret(client_conn, &client_shared_secret));
 
         EXPECT_SUCCESS(s2n_connection_free(client_conn));

--- a/tests/unit/s2n_tls13_compute_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_compute_shared_secret_test.c
@@ -41,7 +41,8 @@ int main(int argc, char **argv) {
         client_conn->secure.client_ecc_evp_params[0].negotiated_curve = client_conn->config->ecc_preferences->ecc_curves[0];
         EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.client_ecc_evp_params[0]));
         /* Recreating conditions where negotiated curve was not set */
-        client_conn->secure.server_ecc_evp_params.negotiated_curve = NULL;
+        struct s2n_ecc_evp_params missing_params = {NULL,NULL};
+        client_conn->secure.server_ecc_evp_params = missing_params;
         DEFER_CLEANUP(struct s2n_blob client_shared_secret = {0}, s2n_free);
         /* Compute fails because server's curve and public key are missing. */
         EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_shared_secret(client_conn, &client_shared_secret), S2N_ERR_NULL);

--- a/tests/unit/s2n_tls13_compute_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_compute_shared_secret_test.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "testlib/s2n_testlib.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <s2n.h>
+
+/* Just to get access to the static functions / variables we need to test */
+#include "tls/s2n_tls13_handshake.c"
+
+
+int main(int argc, char **argv) {
+
+    BEGIN_TEST();
+
+    struct s2n_connection *client_conn;
+
+    /* This file ensures the function s2n_tls_compute_shared_secret is correctly error-checking for missing data
+     * in the server hello. */
+
+    {
+        /* This test ensures that if the server did not send a keyshare extension in the server hello function,
+         * a null pointer error is correctly thrown. */
+
+
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+
+        client_conn->actual_protocol_version = S2N_TLS13;
+
+        /* Select curve and generate key for client */
+        client_conn->secure.client_ecc_evp_params[0].negotiated_curve = client_conn->config->ecc_preferences->ecc_curves[0];
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.client_ecc_evp_params[0]));
+
+        DEFER_CLEANUP(struct s2n_blob client_shared_secret = { 0 }, s2n_free);
+        /* Compute fails because server's curve and public key are missing. */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_shared_secret(client_conn, &client_shared_secret), S2N_ERR_NULL);
+
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+    }
+
+    {
+        /* This test ensures that if a server sent a keyshare extension without a public key, a null pointer
+         * error is correctly thrown. */
+
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+
+        client_conn->actual_protocol_version = S2N_TLS13;
+
+        /* Select curve and generate key for client */
+        client_conn->secure.client_ecc_evp_params[0].negotiated_curve = client_conn->config->ecc_preferences->ecc_curves[0];
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.client_ecc_evp_params[0]));
+
+        /* Set curve server sent in server hello */
+        client_conn->secure.server_ecc_evp_params.negotiated_curve = client_conn->config->ecc_preferences->ecc_curves[0];
+
+        DEFER_CLEANUP(struct s2n_blob client_shared_secret = { 0 }, s2n_free);
+        /* Compute fails because server's public key is missing */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_shared_secret(client_conn, &client_shared_secret), S2N_ERR_NULL);
+
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+
+    }
+
+    {
+        /* This test ensures that if a server sent a keyshare extension with a public key and curve, a client can
+         * generate a shared secret from it. */
+
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+
+        client_conn->actual_protocol_version = S2N_TLS13;
+
+        /* Select curve and generate key for client */
+        client_conn->secure.client_ecc_evp_params[0].negotiated_curve = client_conn->config->ecc_preferences->ecc_curves[0];
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.client_ecc_evp_params[0]));
+
+        /* Set curve server sent in server hello */
+        client_conn->secure.server_ecc_evp_params.negotiated_curve = client_conn->config->ecc_preferences->ecc_curves[0];
+
+        /* Generate public key server sent in server hello */
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.server_ecc_evp_params));
+        DEFER_CLEANUP(struct s2n_blob client_shared_secret = { 0 }, s2n_free);
+        EXPECT_SUCCESS(s2n_tls13_compute_shared_secret(client_conn, &client_shared_secret));
+
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+
+    }
+
+    END_TEST();
+}

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -58,7 +58,7 @@ int s2n_tls13_compute_shared_secret(struct s2n_connection *conn, struct s2n_blob
     notnull_check(ecc_preferences);
     struct s2n_ecc_evp_params *server_key = &conn->secure.server_ecc_evp_params;
     notnull_check(server_key);
-
+    notnull_check(server_key->negotiated_curve);
     /* for now we do this tedious loop to find the matching client key selection.
      * this can be simplified if we get an index or a pointer to a specific key */
     int selection = -1;


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
 #1683
**Description of changes:** 
Ensures negotiated_curve sent in keyshare extension is not null by adding a nullcheck. Also included a unit test to make sure we aren't seg-faulting when missing server data.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
