### PR TITLE
Add CloudFront-TLS-1-2-2020 policy to cipher preferences

### DIFF
--- a/tests/unit/s2n_cipher_preference_test.c
+++ b/tests/unit/s2n_cipher_preference_test.c
@@ -146,6 +146,7 @@ int main(int argc, char **argv)
             "CloudFront-TLS-1-1-2016",
             "CloudFront-TLS-1-2-2018",
             "CloudFront-TLS-1-2-2019",
+            "CloudFront-TLS-1-2-2020",
             "KMS-TLS-1-0-2018-10",
 #if !defined(S2N_NO_PQ)
             "KMS-PQ-TLS-1-0-2019-06",

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -934,6 +934,20 @@ const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_2_2019 =
     .kems = NULL,
 };
 
+struct s2n_cipher_suite *cipher_suites_cloudfront_tls_1_2_2020[] = {
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_rsa_with_chacha20_poly1305_sha256
+};
+
+const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_2_2020 = {
+    .count = s2n_array_len(cipher_suites_cloudfront_tls_1_2_2020),
+    .suites = cipher_suites_cloudfront_tls_1_2_2020,
+    .minimum_protocol_version = S2N_TLS12,
+    .kem_count = 0,
+    .kems = NULL,
+};
+
 struct s2n_cipher_suite *cipher_suites_kms_tls_1_0_2018_10[] = {
     &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
     &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
@@ -1075,6 +1089,7 @@ struct {
     { .version="CloudFront-TLS-1-1-2016", .preferences=&cipher_preferences_cloudfront_tls_1_1_2016, .ecc_extension_required=0, .pq_kem_extension_required=0},
     { .version="CloudFront-TLS-1-2-2018", .preferences=&cipher_preferences_cloudfront_tls_1_2_2018, .ecc_extension_required=0, .pq_kem_extension_required=0},
     { .version="CloudFront-TLS-1-2-2019", .preferences=&cipher_preferences_cloudfront_tls_1_2_2019, .ecc_extension_required=0, .pq_kem_extension_required=0},
+    { .version="CloudFront-TLS-1-2-2020", .preferences=&cipher_preferences_cloudfront_tls_1_2_2020, .ecc_extension_required=0, .pq_kem_extension_required=0},
     { .version="KMS-TLS-1-0-2018-10", .preferences=&cipher_preferences_kms_tls_1_0_2018_10, .ecc_extension_required=0, .pq_kem_extension_required=0},
 #if !defined(S2N_NO_PQ)
     { .version="KMS-PQ-TLS-1-0-2019-06", .preferences=&cipher_preferences_kms_pq_tls_1_0_2019_06, .ecc_extension_required=0, .pq_kem_extension_required=0},


### PR DESCRIPTION
**Description of changes:** 

- This removes all less secure non-GCM and CBC ciphersuites from
  CloudFront-TLS-1-2-2019 based on advisories. 
- Adds support for Chacha20Poly1305
- This would be the safer preference for use with TLS 1.2 currently.

CloudFront-TLS-1-2-2020 contains
- ECDHE-RSA-AES128-GCM-SHA256
- ECDHE-RSA-AES256-GCM-SHA384
- ECDHE-RSA-CHACHA20-POLY1305


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
