### PR TITLE
Fix S2N client's client_hello_version

### DIFF
--- a/tests/unit/s2n_client_hello_recv_test.c
+++ b/tests/unit/s2n_client_hello_recv_test.c
@@ -125,6 +125,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
         EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS12);
         EXPECT_EQUAL(client_conn->client_protocol_version, S2N_TLS12);
+        EXPECT_EQUAL(client_conn->client_hello_version, S2N_TLS12);
 
         EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &client_conn->handshake.io.blob));
         EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
@@ -149,6 +150,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
         EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS12);
         EXPECT_EQUAL(client_conn->client_protocol_version, S2N_TLS12);
+        EXPECT_EQUAL(client_conn->client_hello_version, S2N_TLS12);
 
         EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &client_conn->handshake.io.blob));
         EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
@@ -156,6 +158,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS12);
         EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS12);
         EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS12);
+        EXPECT_EQUAL(server_conn->client_hello_version, S2N_TLS12);
 
         s2n_connection_free(server_conn);
         s2n_connection_free(client_conn);
@@ -176,12 +179,15 @@ int main(int argc, char **argv)
         client_conn->client_protocol_version = S2N_TLS11;
 
         EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
+        EXPECT_EQUAL(client_conn->client_hello_version, S2N_TLS11);
+
         EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &client_conn->handshake.io.blob));
         EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
 
         EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS12);
         EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS11);
         EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS11);
+        EXPECT_EQUAL(server_conn->client_hello_version, S2N_TLS11);
 
         s2n_connection_free(server_conn);
         s2n_connection_free(client_conn);
@@ -201,6 +207,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
         EXPECT_EQUAL(client_conn->client_protocol_version, S2N_TLS12);
+        EXPECT_EQUAL(client_conn->client_hello_version, S2N_TLS12);
 
         EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &client_conn->handshake.io.blob));
         EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
@@ -208,6 +215,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS13);
         EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS12);
         EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS12);
+        EXPECT_EQUAL(server_conn->client_hello_version, S2N_TLS12);
 
         s2n_connection_free(server_conn);
         s2n_connection_free(client_conn);
@@ -241,11 +249,12 @@ int main(int argc, char **argv)
 
         EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS13);
         EXPECT_EQUAL(client_conn->client_protocol_version, S2N_TLS13);
-        EXPECT_EQUAL(client_conn->client_hello_version, S2N_TLS13);
+        EXPECT_EQUAL(client_conn->client_hello_version, S2N_TLS12);
 
         EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS13);
         EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS13);
         EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS13);
+        EXPECT_EQUAL(server_conn->client_hello_version, S2N_TLS12);
 
         s2n_connection_free(server_conn);
         s2n_connection_free(client_conn);
@@ -272,6 +281,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS13);
         EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS13);
         EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS13);
+        EXPECT_EQUAL(server_conn->client_hello_version, S2N_TLS12);
 
         s2n_connection_free(server_conn);
         s2n_connection_free(client_conn);
@@ -305,6 +315,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS13);
         EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS12);
         EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS12);
+        EXPECT_EQUAL(server_conn->client_hello_version, S2N_TLS12);
 
         s2n_connection_free(server_conn);
         s2n_connection_free(client_conn);

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -199,6 +199,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_client_hello_send(conn));
             EXPECT_EQUAL(conn->actual_protocol_version, S2N_TLS13);
             EXPECT_EQUAL(conn->client_protocol_version, S2N_TLS13);
+            EXPECT_EQUAL(conn->client_hello_version, S2N_TLS12);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }
@@ -217,6 +218,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_client_hello_send(conn));
             EXPECT_EQUAL(conn->actual_protocol_version, S2N_TLS12);
             EXPECT_EQUAL(conn->client_protocol_version, S2N_TLS12);
+            EXPECT_EQUAL(conn->client_hello_version, S2N_TLS12);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }
@@ -234,6 +236,7 @@ int main(int argc, char **argv)
 
             EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS13);
             EXPECT_EQUAL(client_conn->client_protocol_version, S2N_TLS13);
+            EXPECT_EQUAL(client_conn->client_hello_version, S2N_TLS12);
 
             /* Server configured with TLS 1.2 negotiates TLS12 version */
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
@@ -254,6 +257,7 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS12);
             EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS12);
             EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS13);
+            EXPECT_EQUAL(server_conn->client_hello_version, S2N_TLS12);
 
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
             EXPECT_SUCCESS(s2n_connection_free(client_conn));

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -394,7 +394,7 @@ int s2n_client_hello_send(struct s2n_connection *conn)
     uint8_t reported_protocol_version = MIN(conn->client_protocol_version, S2N_TLS12);
     client_protocol_version[0] = reported_protocol_version / 10;
     client_protocol_version[1] = reported_protocol_version % 10;
-    conn->client_hello_version = conn->client_protocol_version;
+    conn->client_hello_version = reported_protocol_version;
 
     GUARD(s2n_stuffer_write_bytes(out, client_protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));
     GUARD(s2n_stuffer_copy(&client_random, out, S2N_TLS_RANDOM_DATA_LEN));


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
- partially fix #1647, #1738

**Description of changes:** 
- use "legacy" version for client hello version.
- this makes it consistent to the behavior of a server connection's
  client_hello_version where it would never be > S2N_TLS12


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
