### PR TITLE
ci: Pin Openssl1.1.1 to 1.1.1f

### DIFF
--- a/.travis/install_openssl_1_1_1.sh
+++ b/.travis/install_openssl_1_1_1.sh
@@ -28,11 +28,12 @@ fi
 BUILD_DIR=$1
 INSTALL_DIR=$2
 PLATFORM=$3
+RELEASE=1_1_1f
 
 cd "$BUILD_DIR"
-curl --retry 3 -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1-stable.zip --output OpenSSL_1_1_1-stable.zip
-unzip OpenSSL_1_1_1-stable.zip
-cd openssl-OpenSSL_1_1_1-stable
+curl --retry 3 -L https://github.com/openssl/openssl/archive/OpenSSL_${RELEASE}.zip --output OpenSSL_${RELEASE}.zip
+unzip OpenSSL_${RELEASE}.zip
+cd openssl-OpenSSL_${RELEASE}
 
 if [ "$PLATFORM" == "linux" ]; then
     CONFIGURE="./config -d"

--- a/codebuild/bin/install_openssl_1_1_1.sh
+++ b/codebuild/bin/install_openssl_1_1_1.sh
@@ -29,11 +29,12 @@ BUILD_DIR=$1
 INSTALL_DIR=$2
 OS_NAME=$3
 source codebuild/bin/jobs.sh
+RELEASE=1_1_1f
 
 cd "$BUILD_DIR"
-curl --retry 3 -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1-stable.zip --output OpenSSL_1_1_1-stable.zip
-unzip OpenSSL_1_1_1-stable.zip
-cd openssl-OpenSSL_1_1_1-stable
+curl --retry 3 -L https://github.com/openssl/openssl/archive/OpenSSL_${RELEASE}.zip --output OpenSSL_${RELEASE}.zip
+unzip OpenSSL_${RELEASE}.zip
+cd openssl-OpenSSL_${RELEASE}
 
 if [ "$OS_NAME" == "linux" ]; then
     CONFIGURE="./config -d"


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
Our CI was downloading OpenSSL1.1.1 stable, which appears to be from master and not a tagged release, the following commit broke master:
https://github.com/openssl/openssl/commit/069165d10646a22000c596095cc04d43bbf1f807

**Description of changes:** 
Pin OpenSSL1.1.1 to f

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
