### PR TITLE
ci: Move GHA scheduled to CodeBuild

### DIFF
--- a/codebuild/codebuild.config
+++ b/codebuild/codebuild.config
@@ -3,37 +3,8 @@
 #  https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html
 
 [Global]
-aws_region=us-west-2
-stack_name = s2nCodeBuildTests
-
-[CFNRole]
-account_number: 024603541914
-
-[BuildCache]
-bucket_prefix: s2nCodeBuildCache
-
-#Reusable templates - use the snippet:NAME
-[UbuntuBoilerplate2XL]
-image : aws/codebuild/standard:2.0
-env_type: LINUX_CONTAINER
-compute_type: BUILD_GENERAL1_2XLARGE
-timeout_in_min: 90
-buildspec: codebuild/spec/buildspec_ubuntu.yml
-source_location: https://github.com/awslabs/s2n.git
-source_type : GITHUB
-source_clonedepth: 1
-source_version: 
-
-[UbuntuBoilerplateLarge]
-image : aws/codebuild/standard:2.0
-env_type: LINUX_CONTAINER
-compute_type: BUILD_GENERAL1_LARGE
-timeout_in_min: 90
-buildspec: codebuild/spec/buildspec_ubuntu.yml
-source_location: https://github.com/awslabs/s2n.git
-source_type : GITHUB
-source_clonedepth: 1
-source_version:
+create_github_role = true
+stack_name: s2nCodeBuildTests
 
 # The prefix CodeBuild: is required for the script to build this as a CB project
 # Fuzzers
@@ -144,23 +115,3 @@ source_type : GITHUB
 source_clonedepth: 1
 source_version:
 env: TESTS=OverRiddenByGithubActions
-
-# GitHub Actions Codebuild Shim Job With Artifacts
-# There is an open issue for passing an Artifact config
-# via the aciton; until that's done, we need a Fuzz specific
-# artifact job.
-[CodeBuild:s2nGithubCodebuildFuzz]
-image : aws/codebuild/standard:2.0
-# This next value MUST match the buildspec files
-# secondary-artifacts, and can be a comma sep. list
-artifact_secondary_identifiers: logs
-artifact_s3_bucket: s2n-build-artifacts
-env_type: LINUX_CONTAINER
-compute_type: BUILD_GENERAL1_LARGE
-timeout_in_min: 480
-buildspec: codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
-source_location: https://github.com/awslabs/s2n.git
-source_type : GITHUB
-source_clonedepth: 1
-source_version:
-env: TESTS=OverRiddenByGithubActions FUZZ_TESTS=this_value_is_required

--- a/codebuild/common.config
+++ b/codebuild/common.config
@@ -1,0 +1,32 @@
+# Config file consumed by create_project
+# Helpful reminder about CodeBuild provided docker images:
+#  https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html
+
+[Global]
+aws_region=us-west-2
+
+[CFNRole]
+account_number: 024603541914
+
+#Reusable templates - use the snippet:NAME
+[UbuntuBoilerplate2XL]
+image : aws/codebuild/standard:2.0
+env_type: LINUX_CONTAINER
+compute_type: BUILD_GENERAL1_2XLARGE
+timeout_in_min: 90
+buildspec: codebuild/spec/buildspec_ubuntu.yml
+source_location: https://github.com/awslabs/s2n.git
+source_type : GITHUB
+source_clonedepth: 1
+source_version:
+
+[UbuntuBoilerplateLarge]
+image : aws/codebuild/standard:2.0
+env_type: LINUX_CONTAINER
+compute_type: BUILD_GENERAL1_LARGE
+timeout_in_min: 90
+buildspec: codebuild/spec/buildspec_ubuntu.yml
+source_location: https://github.com/awslabs/s2n.git
+source_type : GITHUB
+source_clonedepth: 1
+source_version:

--- a/codebuild/create_project.py
+++ b/codebuild/create_project.py
@@ -18,6 +18,7 @@ import argparse
 import boto3
 import configparser
 import hashlib
+import json
 import logging
 import os
 import sys
@@ -26,7 +27,6 @@ import time
 from awacs.aws import Action, Allow, Statement, Principal, PolicyDocument
 from awacs.sts import AssumeRole
 from botocore import exceptions
-from random import randrange
 from troposphere import GetAtt, Template, Ref, Output
 from troposphere.events import Rule, Target
 from troposphere.iam import Role, Policy
@@ -36,25 +36,42 @@ logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 
-def build_cw_event(template=Template, project_name=None, role=None):
+def build_cw_event(template=Template, project_name=None, role=None, target_job=None, hour=12, input_json=None):
     """ Create a CloudWatch Event to run a CodeBuild Project. """
-    # Run either at 12 or 13:00 UTC, 04/05:00 PST
-    hour = randrange(12, 14)
-    project_target = Target(
-        f"{project_name}Target",
-        Arn=GetAtt(project_name, "Arn"),
-        RoleArn=GetAtt(role, "Arn"),
-        Id=f"{project_name}CWid"
-    )
+    # CloudFormation doesn't allow underscores
+    project_name = project_name.replace('_', '')
+
+    # target_job is only expected in the case where multiple events are pointed at the same target.
+    # Use the project name as the dependency otherwise.
+    if not target_job:
+        target_job = project_name
+
+    # input_json is used to pass additional ENV variables to the codebuild job.
+    if input_json:
+        project_target = Target(
+            f"{project_name}Target",
+            Arn=GetAtt(target_job, "Arn"),
+            RoleArn=GetAtt(role, "Arn"),
+            Input=json.dumps(input_json),
+            Id=f"{project_name}CWid"
+        )
+    else:
+        project_target = Target(
+            f"{project_name}Target",
+            Arn=GetAtt(target_job, "Arn"),
+            RoleArn=GetAtt(role, "Arn"),
+            Id=f"{project_name}CWid"
+        )
+
     Rule(f"{project_name}Rule",
          template=template,
          Name=f"{project_name}Evernt",
          Description="scheduled run Build with CloudFormation",
          Targets=[project_target],
          State='ENABLED',
-         # Run at the top of a random hour.
+         # Run at the top of hour.
          ScheduleExpression=f"cron(0 {hour} * * ? *)",
-         DependsOn=project_name
+         DependsOn=target_job
          )
 
 
@@ -127,10 +144,10 @@ def build_artifacts(identifier: str, s3_bucketname: str) -> Artifacts:
         ArtifactIdentifier=identifier,
         EncryptionDisabled=True,
         Location=s3_bucketname,
-        NamespaceType='None',
+        NamespaceType='NONE',  # NOTE: case sensitive
         OverrideArtifactName=False,
-        Packaging='Zip',
-        Type='S3')
+        Packaging='ZIP',  # NOTE: case sensitive
+        Type='S3')  # NOTE: case sensitive
     return artifact
 
 
@@ -232,10 +249,10 @@ def build_codebuild_role(config, template=Template(), project_name: str = None, 
                 Statement(
                     Effect=Allow,
                     Action=[Action("s3", "PutObject"),
-                            Action("s3","GetObject"),
-                            Action("s3","GetObjectVersion"),
-                            Action("s3","GetBucketAcl"),
-                            Action("s3","GetBucketLocation")],
+                            Action("s3", "GetObject"),
+                            Action("s3", "GetObjectVersion"),
+                            Action("s3", "GetBucketAcl"),
+                            Action("s3", "GetBucketLocation")],
                     Resource=[
                         "arn:aws:s3:::s2n-build-artifacts/*",
                     ]
@@ -363,13 +380,15 @@ def main(args, config):
     temp_yaml_filename = args.output_dir + "/s2n_codebuild_projects.yml"
 
     # Role used by GitHub Actions.
-    build_github_role(codebuild, config)
+    if config.has_option('Global', 'create_github_role') and config.getboolean('Global', 'create_github_role'):
+        build_github_role(codebuild, config)
 
     # Walk the config file, adding each stanza to the Troposphere template.
     for job in config.sections():
-        if 'CodeBuild:' in job:
+        if ':' in job:
             job_title = job.split(':')[1]
-            service_role = build_codebuild_role(config, template=codebuild, project_name=job_title).to_dict()
+        if 'CodeBuild:' in job:
+            service_role = build_codebuild_role(config,template=codebuild, project_name=job_title).to_dict()
 
             # Pull the env out of the section, and use the snippet for the other values.
             # Note: only env is over-ridden with snippets.
@@ -378,7 +397,16 @@ def main(args, config):
                               service_role=service_role['Ref'], raw_env=config.get(job, 'env'))
             else:
                 build_project(template=codebuild, project_name=job_title, section=job, service_role=service_role['Ref'])
+
+            # Scheduled runs triggered by CloudWatch.
             build_cw_event(template=codebuild, project_name=job_title, role=cw_event_role)
+        if 'CloudWatchEvent' in job:
+            # CloudWatch input allows us to over-ride environment variables passed to codebuild.
+            cw_input = json.loads(config.get(job, 'input'))
+            # Note that for Cloudwatch, we're need to reference an existing CodeBuild Job.
+            build_cw_event(template=codebuild, project_name=job_title, target_job=config.get(job, 'build_job_name'),
+                           role=cw_event_role,
+                           hour=config.get(job, 'start_time'), input_json=cw_input)
 
     # Write out a CloudFormation template.  This is ephemeral and is not used again.
     with(open(temp_yaml_filename, 'w')) as fh:
@@ -407,6 +435,7 @@ def main(args, config):
             create_new_stack(client, config, codebuild)
 
 
+
 if __name__ == '__main__':
     # Parse  options
     parser = argparse.ArgumentParser(description='Creates AWS CodeBuild Project CloudFormation files ' +
@@ -422,6 +451,8 @@ if __name__ == '__main__':
 
     config = configparser.RawConfigParser()
     logging.debug(f'Try to load config file {args.config}')
+    # The snippets/boilerplate should always be included.
+    config.read('common.config')
     config.read(args.config)
     assert config.get('CFNRole', 'account_number')
 

--- a/codebuild/fuzz_codebuild.config
+++ b/codebuild/fuzz_codebuild.config
@@ -1,0 +1,163 @@
+# Config file consumed by create_project
+# Helpful reminder about CodeBuild provided docker images:
+#  https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html
+[Global]
+stack_name: s2nScheduledFuzz
+
+# CodeBuild Scheduled Fuzz
+[CodeBuild:s2nFuzzScheduled]
+image : aws/codebuild/standard:2.0
+env_type: LINUX_CONTAINER
+compute_type: BUILD_GENERAL1_LARGE
+timeout_in_min: 480
+buildspec: codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
+source_location: https://github.com/awslabs/private-s2n-fuzz.git
+source_type : GITHUB
+source_clonedepth: 1
+source_version: master
+# This next value MUST match the buildspec files
+# secondary-artifacts, and can be a comma sep. list
+artifact_secondary_identifiers: logs
+artifact_s3_bucket: s2n-build-artifacts
+env: TESTS=fuzz FUZZ_TIMEOUT_SEC=28000
+
+[CloudWatchEvent:s2n_bike_r1_fuzz_test]
+start_time: 12:00
+build_job_name: s2nFuzzScheduled
+input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_bike_r1_fuzz_test"}]}
+
+[CloudWatchEvent:s2n_bike_r2_fuzz_test]
+start_time: 12:00
+build_job_name: s2nFuzzScheduled
+input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_bike_r2_fuzz_test"}]}
+
+[CloudWatchEvent:s2n_certificate_extensions_parse_test]
+start_time: 12:00
+build_job_name: s2nFuzzScheduled
+input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_certificate_extensions_parse_test"}]}
+
+[CloudWatchEvent:s2n_client_cert_recv_test]
+start_time: 12:00
+build_job_name: s2nFuzzScheduled
+input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_client_cert_recv_test"}]}
+
+[CloudWatchEvent:s2n_client_cert_req_recv_test]
+start_time: 12:00
+build_job_name: s2nFuzzScheduled
+input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_client_cert_req_recv_test"}]}
+
+[CloudWatchEvent:s2n_client_cert_verify_recv_test]
+start_time: 12:00
+build_job_name: s2nFuzzScheduled
+input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_client_cert_verify_recv_test"}]}
+
+[CloudWatchEvent:s2n_client_fuzz_test]
+start_time: 12:00
+build_job_name: s2nFuzzScheduled
+input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_client_fuzz_test"}]}
+
+[CloudWatchEvent:s2n_client_hello_recv_fuzz_test]
+start_time: 12:00
+build_job_name: s2nFuzzScheduled
+input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_client_hello_recv_fuzz_test"}]}
+
+[CloudWatchEvent:s2n_client_key_recv_fuzz_test]
+start_time: 12:00
+build_job_name: s2nFuzzScheduled
+input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_client_key_recv_fuzz_test"}]}
+
+[CloudWatchEvent:s2n_encrypted_extensions_recv_test]
+start_time: 12:00
+build_job_name: s2nFuzzScheduled
+input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_encrypted_extensions_recv_test"}]}
+
+[CloudWatchEvent:s2n_extensions_client_key_share_recv_test]
+start_time: 12:00
+build_job_name: s2nFuzzScheduled
+input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_extensions_client_key_share_recv_test"}]}
+
+[CloudWatchEvent:s2ns2n_extensions_client_supported_versions_recv_test_fuzz]
+start_time: 12:00
+build_job_name: s2nFuzzScheduled
+input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_extensions_client_supported_versions_recv_test"}]}
+
+[CloudWatchEvent:s2n_extensions_server_key_share_recv_test]
+start_time: 12:00
+build_job_name: s2nFuzzScheduled
+input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_extensions_server_key_share_recv_test"}]}
+
+[CloudWatchEvent:s2n_extensions_server_supported_versions_recv_test]
+start_time: 12:00
+build_job_name: s2nFuzzScheduled
+input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_extensions_server_supported_versions_recv_test"}]}
+
+[CloudWatchEvent:s2n_hybrid_ecdhe_bike_r1_fuzz_test]
+start_time: 12:00
+build_job_name: s2nFuzzScheduled
+input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_hybrid_ecdhe_bike_r1_fuzz_test"}]}
+
+[CloudWatchEvent:s2ns2n_hybrid_ecdhe_bike_r2_fuzz_test_fuzz]
+start_time: 12:00
+build_job_name: s2nFuzzScheduled
+input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_hybrid_ecdhe_bike_r2_fuzz_test"}]}
+
+[CloudWatchEvent:s2n_hybrid_ecdhe_sike_r1_fuzz_test]
+start_time: 12:00
+build_job_name: s2nFuzzScheduled
+input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_hybrid_ecdhe_sike_r1_fuzz_test"}]}
+
+[CloudWatchEvent:s2n_hybrid_ecdhe_sike_r2_fuzz_test]
+start_time: 12:00
+build_job_name: s2nFuzzScheduled
+input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_hybrid_ecdhe_sike_r2_fuzz_test"}]}
+
+[CloudWatchEvent:s2n_openssl_diff_pem_parsing_test]
+start_time: 12:00
+build_job_name: s2nFuzzScheduled
+input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_openssl_diff_pem_parsing_test"}]}
+
+[CloudWatchEvent:s2n_recv_client_supported_groups_test]
+start_time: 12:00
+build_job_name: s2nFuzzScheduled
+input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_recv_client_supported_groups_test"}]}
+
+[CloudWatchEvent:s2n_select_server_cert_test]
+start_time: 12:00
+build_job_name: s2nFuzzScheduled
+input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_select_server_cert_test"}]}
+
+[CloudWatchEvent:s2n_server_cert_recv_test]
+start_time: 12:00
+build_job_name: s2nFuzzScheduled
+input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_server_cert_recv_test"}]}
+
+[CloudWatchEvent:s2n_server_extensions_recv_test]
+start_time: 12:00
+build_job_name: s2nFuzzScheduled
+input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_server_extensions_recv_test"}]}
+
+[CloudWatchEvent:s2n_server_fuzz_test]
+start_time: 12:00
+build_job_name: s2nFuzzScheduled
+input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_server_fuzz_test"}]}
+
+[CloudWatchEvent:s2n_server_hello_recv_test]
+start_time: 12:00
+build_job_name: s2nFuzzScheduled
+input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_server_hello_recv_test"}]}
+
+[CloudWatchEvent:s2n_sike_r1_fuzz_test]
+start_time: 12:00
+build_job_name: s2nFuzzScheduled
+input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_sike_r1_fuzz_test"}]}
+
+[CloudWatchEvent:s2n_sike_r2_fuzz_test]
+start_time: 12:00
+build_job_name: s2nFuzzScheduled
+input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_sike_r2_fuzz_test"}]}
+
+[CloudWatchEvent:s2n_stuffer_pem_fuzz_test]
+start_time: 12:00
+build_job_name: s2nFuzzScheduled
+input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_stuffer_pem_fuzz_test"}]}
+


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Description of changes:** 
Script/config file changes to support:
* Adding CloudWatch events to kick off fuzzers with artifact storage
* Split CFN build script configs up to separate these into a new CFN stack.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
