### PR TITLE
ci: Further restrict where an action runs

### DIFF
--- a/.github/workflows/private_sync.yml
+++ b/.github/workflows/private_sync.yml
@@ -5,7 +5,8 @@ on:
       - master
 jobs:
   build:
-    if: endsWith(github.repository, 's2n')
+    # This should only run in one place.
+    if: contains(github.repository, 'awslabs/s2n')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Description of changes:** 
These are running on private forks b/c the repository name isn't specific enough.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
