### PR TITLE
Clean up S2N_UNIT_TEST

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,10 +266,6 @@ if (BUILD_TESTING)
 
         set_property(
         TEST
-            ${test_case_name})
-
-        set_property(
-        TEST
             ${test_case_name}
         PROPERTY
             ENVIRONMENT S2N_DONT_MLOCK=1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,9 +266,7 @@ if (BUILD_TESTING)
 
         set_property(
         TEST
-            ${test_case_name}
-        PROPERTY
-            ENVIRONMENT S2N_UNIT_TEST=1)
+            ${test_case_name})
 
         set_property(
         TEST

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -56,7 +56,6 @@ $(UNIT_TESTS)::
 	@${CC} ${CFLAGS} -o $@ $@.c ${LDFLAGS} 2>&1
 	@DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" \
 	LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
-	S2N_UNIT_TEST=1 \
 	./$@
 else
 $(UNIT_TESTS)::
@@ -64,7 +63,6 @@ $(UNIT_TESTS)::
 	@DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" \
 	LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
 	LD_PRELOAD="../LD_PRELOAD/allocator_overrides.so" \
-	S2N_UNIT_TEST=1 \
 	./$@
 endif
 
@@ -73,7 +71,6 @@ $(VALGRIND_TESTS)::
 	@DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" \
 	LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
 	S2N_VALGRIND=1 \
-	S2N_UNIT_TEST=1 \
 	valgrind --leak-check=full --run-libc-freeres=no -q --error-exitcode=9 --gen-suppressions=all --log-fd=2 --num-callers=40 --leak-resolution=high --undef-value-errors=no --trace-children=yes --suppressions=valgrind.suppressions \
 	./$(@:.valgrind=)
 


### PR DESCRIPTION

**Description of changes:** 
- the environmental variable S2N_UNIT_TEST is no longer required
- it was replaced with s2n_in_unit_test() in a previous PR (#1252)
- remove remaining references to avoid confusion


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
