### PR TITLE
Update cloudfront_tls_1_2_2019 ciphers

### DIFF
--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -920,10 +920,10 @@ const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_2_2018 =
 };
 
 struct s2n_cipher_suite *cipher_suites_cloudfront_tls_1_2_2019[] = {
-    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
     &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
-    &s2n_rsa_with_aes_128_gcm_sha256,
-    &s2n_rsa_with_aes_256_gcm_sha384
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256
 };
 
 const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_2_2019 = {


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** internal: CF-Caching-19818

**Description of changes:** 

Update cloudfront_tls_1_2_2019. This policy is not currently being used, as it has not been publicly launched.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
