### PR TITLE
Remove extra print line in sidetrail test, reducing size of logs.

### DIFF
--- a/tests/sidetrail/count_success.pl
+++ b/tests/sidetrail/count_success.pl
@@ -38,7 +38,6 @@ my $verified = 0;
 my $errors = 0;
 open (FILE, $filename) or die "Can't open $filename $!";
 while (my $line = <FILE>){
-    print $line;
     #Check if the code under test used unexpected functions
     if ($line =~ /warning: module contains undefined functions:([a-zA-Z0-9_, ]+)/) {
 	print "found undefined\n\n";


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** #1536

**Description of changes:** 
Remove an unnecessary print statement to reduce log file size.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
