### PR TITLE
Add new dependency requirements so GCC9 installs

### DIFF
--- a/.travis/install_ubuntu_dependencies.sh
+++ b/.travis/install_ubuntu_dependencies.sh
@@ -19,7 +19,7 @@ apt-key list
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 6B05F25D762E3157
 apt-key list
 
-sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+sudo add-apt-repository ppa:jonathonf/gcc-9.2 -y
 sudo apt-get update -o Acquire::CompressionTypes::Order::=gz
 
 DEPENDENCIES="unzip make indent kwstyle libssl-dev tcpdump valgrind lcov m4 nettle-dev nettle-bin pkg-config gcc g++ zlibc zlib1g-dev python3-pip llvm"

--- a/codebuild/spec/buildspec_ubuntu.yml
+++ b/codebuild/spec/buildspec_ubuntu.yml
@@ -20,7 +20,7 @@ phases:
     commands:
       - echo Entered the install phase...
       - echo "We need a test PPA for gcc-9."
-      - add-apt-repository ppa:ubuntu-toolchain-r/test -y
+      - add-apt-repository ppa:jonathonf/gcc-9.2 -y
       - apt-get update -o Acquire::CompressionTypes::Order::=gz
       - apt-get update -y
       - |


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 

**Description of changes:** 
GCC9 was failing to install due to missing dependencies. This PR adds those dependencies back.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
