### PR TITLE
Add s2n_config_new tests with tls 1.3

### DIFF
--- a/tests/unit/s2n_config_test.c
+++ b/tests/unit/s2n_config_test.c
@@ -98,20 +98,22 @@ int main(int argc, char **argv)
 
     /* Test for s2n_config_new() and tls 1.3 behavior */
     {
-        struct s2n_config *config;
-        EXPECT_NOT_NULL(config = s2n_config_new());
-        EXPECT_EQUAL(config->cipher_preferences, default_cipher_preferences);
-        EXPECT_EQUAL(config->signature_preferences, &s2n_signature_preferences_20140601);
-        EXPECT_EQUAL(config->ecc_preferences, &s2n_ecc_preferences_20140601);
-        EXPECT_SUCCESS(s2n_config_free(config));
+        if (!s2n_is_in_fips_mode()) {
+            struct s2n_config *config;
+            EXPECT_NOT_NULL(config = s2n_config_new());
+            EXPECT_EQUAL(config->cipher_preferences, default_cipher_preferences);
+            EXPECT_EQUAL(config->signature_preferences, &s2n_signature_preferences_20140601);
+            EXPECT_EQUAL(config->ecc_preferences, &s2n_ecc_preferences_20140601);
+            EXPECT_SUCCESS(s2n_config_free(config));
 
-        EXPECT_SUCCESS(s2n_enable_tls13());
-        EXPECT_NOT_NULL(config = s2n_config_new());
-        EXPECT_EQUAL(config->cipher_preferences, tls13_cipher_preferences);
-        EXPECT_EQUAL(config->signature_preferences, &s2n_signature_preferences_20200207);
-        EXPECT_EQUAL(config->ecc_preferences, &s2n_ecc_preferences_20200310);
-        EXPECT_SUCCESS(s2n_config_free(config));
-        EXPECT_SUCCESS(s2n_disable_tls13());
+            EXPECT_SUCCESS(s2n_enable_tls13());
+            EXPECT_NOT_NULL(config = s2n_config_new());
+            EXPECT_EQUAL(config->cipher_preferences, tls13_cipher_preferences);
+            EXPECT_EQUAL(config->signature_preferences, &s2n_signature_preferences_20200207);
+            EXPECT_EQUAL(config->ecc_preferences, &s2n_ecc_preferences_20200310);
+            EXPECT_SUCCESS(s2n_config_free(config));
+            EXPECT_SUCCESS(s2n_disable_tls13());
+        }
     }
 
     END_TEST();

--- a/tests/unit/s2n_config_test.c
+++ b/tests/unit/s2n_config_test.c
@@ -22,6 +22,7 @@
 #include "tls/s2n_connection.h"
 #include "tls/s2n_cipher_preferences.h"
 #include "tls/s2n_config.h"
+#include "tls/s2n_ecc_preferences.h"
 #include "tls/s2n_tls13.h"
 
 int main(int argc, char **argv)
@@ -93,6 +94,24 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_free(conn));
             EXPECT_SUCCESS(s2n_disable_tls13());
         }
+    }
+
+    /* Test for s2n_config_new() and tls 1.3 behavior */
+    {
+        struct s2n_config *config;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+        EXPECT_EQUAL(config->cipher_preferences, default_cipher_preferences);
+        EXPECT_EQUAL(config->signature_preferences, &s2n_signature_preferences_20140601);
+        EXPECT_EQUAL(config->ecc_preferences, &s2n_ecc_preferences_20140601);
+        EXPECT_SUCCESS(s2n_config_free(config));
+
+        EXPECT_SUCCESS(s2n_enable_tls13());
+        EXPECT_NOT_NULL(config = s2n_config_new());
+        EXPECT_EQUAL(config->cipher_preferences, tls13_cipher_preferences);
+        EXPECT_EQUAL(config->signature_preferences, &s2n_signature_preferences_20200207);
+        EXPECT_EQUAL(config->ecc_preferences, &s2n_ecc_preferences_20200310);
+        EXPECT_SUCCESS(s2n_config_free(config));
+        EXPECT_SUCCESS(s2n_disable_tls13());
     }
 
     END_TEST();


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
Close #1793

**Description of changes:** 
Add s2n_config_new tests with tls 1.3 for current behaviour. Enabling tls13 changes the
1. cipher preference
2. signature preferences
3. ecc preferences

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
