### PR TITLE
Add line buffering to tcpdump's stdout.

### DIFF
--- a/tests/integration/s2n_dynamic_record_size_test.py
+++ b/tests/integration/s2n_dynamic_record_size_test.py
@@ -156,7 +156,7 @@ def run_test(host, port, ssl_version, cipher, threshold):
 
     failed = 0
     tcpdump_filter = "dst port " + str(port)
-    tcpdump_cmd = ["sudo", "tcpdump", "-i", "lo", "-n", "-B", "65535", tcpdump_filter]
+    tcpdump_cmd = ["sudo", "tcpdump", "-l", "-i", "lo", "-n", "-B", "65535", tcpdump_filter]
     tcpdump = subprocess.Popen(tcpdump_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     ret = try_dynamic_record(host, port, cipher_name, ssl_version, threshold)


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
#1537

**Description of changes:** 
This addresses a problem which looks to be the root cause of the dynamic record failures. 

Sometimes dynrecord tests would fail due to indexing errors. Those indexing errors were  caused by not having enough data to process. Lack of data was caused by some internal buffering that tcpdump does for performance.

While there are all kinds of issues with this test, this is the smallest change which addresses the buffering problem which was preventing the required data from being available for processing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
