### PR TITLE
Use GCC's static analyzer if compiling with >= version 10.

### DIFF
--- a/s2n.mk
+++ b/s2n.mk
@@ -95,10 +95,14 @@ ifdef GCC_VERSION
 	ifneq ("$(GCC_VERSION)","NONE")
 		CC=gcc-$(GCC_VERSION)
 	endif
-# Make doesn't support greater than checks, this uses `test` to compare values, then `echo $$?` to return the value of test's
-# exit code and finally using the built in make `ifeq` to check if it was true and then add the extra flag.
-	ifeq ($(shell test $(GCC_VERSION) -gt 7; echo $$?),0)
+	# Make doesn't support greater than checks, this uses `test` to compare values, then `echo $$?` to return the value of test's
+	# exit code and finally using the built in make `ifeq` to check if it was true and then add the extra flag.
+	ifeq ($(shell test $(GCC_VERSION) -gt 7; echo $$?), 0)
 		CFLAGS += -Wimplicit-fallthrough
+	endif
+
+	ifeq ($(shell test $(GCC_VERSION) -ge 10; echo $$?), 0)
+		CFLAGS += -fanalyzer
 	endif
 endif
 


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
**Description of changes:** 

Compile with static analyzer that can catch issues like double free, malloc leak etc.

Related links
- https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html
- https://www.phoronix.com/scan.php?page=news_item&px=GCC-Static-Analysis-RH-Patches


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
