### PR TITLE
ci: Update tests to use OpenSSL1.1.1g

### DIFF
--- a/.travis/install_openssl_1_1_1.sh
+++ b/.travis/install_openssl_1_1_1.sh
@@ -28,7 +28,7 @@ fi
 BUILD_DIR=$1
 INSTALL_DIR=$2
 PLATFORM=$3
-RELEASE=1_1_1f
+RELEASE=1_1_1g
 
 cd "$BUILD_DIR"
 curl --retry 3 -L https://github.com/openssl/openssl/archive/OpenSSL_${RELEASE}.zip --output OpenSSL_${RELEASE}.zip

--- a/codebuild/bin/install_openssl_1_1_1.sh
+++ b/codebuild/bin/install_openssl_1_1_1.sh
@@ -29,7 +29,7 @@ BUILD_DIR=$1
 INSTALL_DIR=$2
 OS_NAME=$3
 source codebuild/bin/jobs.sh
-RELEASE=1_1_1f
+RELEASE=1_1_1g
 
 cd "$BUILD_DIR"
 curl --retry 3 -L https://github.com/openssl/openssl/archive/OpenSSL_${RELEASE}.zip --output OpenSSL_${RELEASE}.zip


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
CVE-2020-1967

**Description of changes:** 
Use latest OpenSSL 1.1.1g

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
