### PR TITLE
Cleaning-up Sidetrail's `safety.patch` to ensure that it applies cleanly

### DIFF
--- a/tests/sidetrail/working/s2n-cbc/patches/safety.patch
+++ b/tests/sidetrail/working/s2n-cbc/patches/safety.patch
@@ -1,8 +1,8 @@
 diff --git a/tests/sidetrail/working/s2n-cbc/utils/s2n_safety.c b/tests/sidetrail/working/s2n-cbc/utils/s2n_safety.c
-index 3af0262..261285a 100644
+index 630f13ef..32004681 100644
 --- a/tests/sidetrail/working/s2n-cbc/utils/s2n_safety.c
 +++ b/tests/sidetrail/working/s2n-cbc/utils/s2n_safety.c
-@@ -55,8 +55,8 @@ pid_t s2n_actual_getpid()
+@@ -57,8 +57,8 @@ pid_t s2n_actual_getpid()
   */
  int s2n_constant_time_equals(const uint8_t * a, const uint8_t * b, uint32_t len)
  {
@@ -14,20 +14,20 @@ index 3af0262..261285a 100644
      
      uint8_t xor = 0;
 diff --git a/tests/sidetrail/working/s2n-cbc/utils/s2n_safety.h b/tests/sidetrail/working/s2n-cbc/utils/s2n_safety.h
-index 704bb63..dc44360 100644
+index 1c754ecc..6bcc86ca 100644
 --- a/tests/sidetrail/working/s2n-cbc/utils/s2n_safety.h
 +++ b/tests/sidetrail/working/s2n-cbc/utils/s2n_safety.h
-@@ -21,6 +21,8 @@
-
+@@ -23,6 +23,8 @@
+ 
  #include "error/s2n_errno.h"
-
+ 
 +void __VERIFIER_assume(int);
 +
  /* NULL check a pointer */
  #define notnull_check( ptr )           do { if ( (ptr) == NULL ) { S2N_ERROR(S2N_ERR_NULL); } } while(0)
  #define notnull_check_ptr( ptr )       do { if ( (ptr) == NULL ) { S2N_ERROR_PTR(S2N_ERR_NULL); } } while(0)
-@@ -61,8 +63,8 @@ static inline void* trace_memcpy_check(void *restrict to, const void *restrict f
-
+@@ -72,8 +74,8 @@ static inline void* trace_memcpy_check(void *restrict to, const void *restrict f
+ 
  /* Range check a number */
  #define gte_check(n, min)  do { if ( (n) < min ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)
 -#define lte_check(n, max)  do { if ( (n) > max ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)
@@ -37,12 +37,12 @@ index 704bb63..dc44360 100644
  #define lt_check(n, max)  do { if ( (n) >= max ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)
  #define eq_check(a, b)  do { if ( (a) != (b) ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)
  #define ne_check(a, b)  do { if ( (a) == (b) ) { S2N_ERROR(S2N_ERR_SAFETY); } } while(0)
-@@ -79,7 +81,7 @@ static inline void* trace_memcpy_check(void *restrict to, const void *restrict f
-     lt_check(__tmp_n, high);                    \
-   } while (0)
-
--#define GUARD( x )              if ( (x) < 0 ) return -1
+@@ -93,7 +95,7 @@ static inline void* trace_memcpy_check(void *restrict to, const void *restrict f
+ /* Check for specific classes of errors */
+ #define ERR_IS_BLOCKING( x )    ( x == S2N_ERR_BLOCKED || x == S2N_CALLBACK_BLOCKED )
+ 
+-#define GUARD( x )              do {if ( (x) < 0 ) return S2N_FAILURE;} while (0)
 +#define GUARD( x ) __VERIFIER_assume( (x) >= 0 )
- #define GUARD_GOTO( x , label ) if ( (x) < 0 ) goto label
- #define GUARD_PTR( x )          if ( (x) < 0 ) return NULL
-
+ #define GUARD_STRICT( x )       do {if ( (x) != 0 ) return S2N_FAILURE;} while (0)
+ #define GUARD_GOTO( x , label ) do {if ( (x) < 0 ) goto label;} while (0)
+ #define GUARD_PTR( x )          do {if ( (x) < 0 ) return NULL;} while (0)


### PR DESCRIPTION
Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>

_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

## Issue

In `s2n`'s master, the file `safety.patch` (from Sidetrail) does not cleanly apply:

```
$ git rev-parse --abbrev-ref HEAD
master
$ git rev-parse --short HEAD
75f7d991
$ git clean -f -d -x . && git checkout . && patch -p5 < tests/sidetrail/working/s2n-cbc/patches/safety.patch
Updated 0 paths from the index
patching file utils/s2n_safety.c
Hunk #1 succeeded at 57 (offset 2 lines).
patching file utils/s2n_safety.h
Hunk #1 succeeded at 23 (offset 2 lines).
Hunk #2 succeeded at 74 (offset 11 lines).
Hunk #3 FAILED at 81.
1 out of 3 hunks FAILED -- saving rejects to file utils/s2n_safety.h.rej
```

## Description of changes

This PR regenerates (and fixes) `safety.patch` against `master`/`75f7d991` such that the above now works:

```
$ git rev-parse --abbrev-ref HEAD
fix_safety_patch
$ git rev-parse --short HEAD
2b0ff08d
$ git clean -f -d -x . && git checkout . && patch -p5 < tests/sidetrail/working/s2n-cbc/patches/safety.patch
Updated 0 paths from the index
patching file utils/s2n_safety.c
patching file utils/s2n_safety.h
```

At least for me (`GNU patch 2.7.6`) the lines containing only whitespace (in the diff) are required, otherwise the patch only applies with "fuzz":

```
$ git clean -f -d -x . && git checkout . && sed -i "s#^\s*\$##g" tests/sidetrail/working/s2n-cbc/patches/safety.patch && patch -p5 < tests/sidetrail/working/s2n-cbc/patches/safety.patch
Removing utils/s2n_safety.c.orig
Updated 3 paths from the index
patching file utils/s2n_safety.c
Hunk #1 succeeded at 57 with fuzz 2.
patching file utils/s2n_safety.h
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
