### PR TITLE
Revert "Fix mac build"

### DIFF
--- a/crypto/s2n_rsa_signing.h
+++ b/crypto/s2n_rsa_signing.h
@@ -22,7 +22,7 @@
 #include "crypto/s2n_rsa.h"
 
 /* Check for libcrypto 1.1 for RSA PSS Signing and EV_Key usage */
-#if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 1) && !defined(LIBRESSL_VERSION_NUMBER) && !defined(__APPLE__)
+#if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 1) && !defined(LIBRESSL_VERSION_NUMBER)
 #define RSA_PSS_SIGNING_SUPPORTED 1
 #else
 #define RSA_PSS_SIGNING_SUPPORTED 0


### PR DESCRIPTION
Reverts awslabs/s2n#1807

This breaks RSA PSS signing on mac.