### PR TITLE
 Small refactors to the integv2 tests.

### DIFF
--- a/tests/integrationv2/configuration.py
+++ b/tests/integrationv2/configuration.py
@@ -1,6 +1,7 @@
 import threading
 from contextlib import contextmanager
 from common import Ciphersuites, Curves
+from providers import S2N, OpenSSL, BoringSSL
 
 
 # List of ciphersuites that will be tested.
@@ -16,6 +17,10 @@ CURVES = [
     Curves.P256,
     Curves.P384
 ]
+
+
+# List of providers that will be tested.
+PROVIDERS = [S2N, OpenSSL, BoringSSL]
 
 
 class AvailablePorts():

--- a/tests/integrationv2/fixtures.py
+++ b/tests/integrationv2/fixtures.py
@@ -29,7 +29,10 @@ def managed_process():
     try:
         yield _fn
     except Exception as e:
-        print("Gracefully handling exception")
+        # The ManagedProcess already prints information to stdout, so there
+        # is nothing to capture here.
+        pass
     finally:
+        # Whether the processes succeeded or not, clean then up.
         for p in processes:
             p.join()

--- a/tests/integrationv2/test_happy_path.py
+++ b/tests/integrationv2/test_happy_path.py
@@ -3,15 +3,15 @@ import os
 import pytest
 import time
 
-from configuration import available_ports, CIPHERSUITES, CURVES
+from configuration import available_ports, CIPHERSUITES, CURVES, PROVIDERS
 from common import ProviderOptions
 from fixtures import managed_process
-from providers import S2N, provider_list
+from providers import S2N
 
 
 @pytest.mark.parametrize("cipher", CIPHERSUITES)
 @pytest.mark.parametrize("curve", CURVES)
-@pytest.mark.parametrize("provider", provider_list)
+@pytest.mark.parametrize("provider", PROVIDERS)
 def test_s2n_server_happy_path(managed_process, cipher, curve, provider):
     host = "localhost"
     port = next(available_ports)
@@ -52,7 +52,7 @@ def test_s2n_server_happy_path(managed_process, cipher, curve, provider):
 
 @pytest.mark.parametrize("cipher", CIPHERSUITES)
 @pytest.mark.parametrize("curve", CURVES)
-@pytest.mark.parametrize("provider", provider_list)
+@pytest.mark.parametrize("provider", PROVIDERS)
 def test_s2n_client_happy_path(managed_process, cipher, curve, provider):
     host = "localhost"
     port = next(available_ports)


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._


**Description of changes:** 
 * Add BoringSSL server happy path
 * More comments, make it clear why input is
   provided to processes at certain points

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
