### PR TITLE
Have s2n connection get session length return uint32_t and check for overflow

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -249,7 +249,7 @@ extern int s2n_connection_get_client_cert_chain(struct s2n_connection *conn, uin
 extern int s2n_connection_set_session(struct s2n_connection *conn, const uint8_t *session, size_t length);
 extern int s2n_connection_get_session(struct s2n_connection *conn, uint8_t *session, size_t max_length);
 extern int s2n_connection_get_session_ticket_lifetime_hint(struct s2n_connection *conn);
-extern int s2n_connection_get_session_length(struct s2n_connection *conn);
+extern uint32_t s2n_connection_get_session_length(struct s2n_connection *conn);
 extern int s2n_connection_get_session_id_length(struct s2n_connection *conn);
 extern int s2n_connection_get_session_id(struct s2n_connection *conn, uint8_t *session_id, size_t max_length);
 extern int s2n_connection_is_session_resumed(struct s2n_connection *conn);

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -249,7 +249,7 @@ extern int s2n_connection_get_client_cert_chain(struct s2n_connection *conn, uin
 extern int s2n_connection_set_session(struct s2n_connection *conn, const uint8_t *session, size_t length);
 extern int s2n_connection_get_session(struct s2n_connection *conn, uint8_t *session, size_t max_length);
 extern int s2n_connection_get_session_ticket_lifetime_hint(struct s2n_connection *conn);
-extern uint32_t s2n_connection_get_session_length(struct s2n_connection *conn);
+extern int s2n_connection_get_session_length(struct s2n_connection *conn, uint32_t *length);
 extern int s2n_connection_get_session_id_length(struct s2n_connection *conn);
 extern int s2n_connection_get_session_id(struct s2n_connection *conn, uint8_t *session_id, size_t max_length);
 extern int s2n_connection_is_session_resumed(struct s2n_connection *conn);

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -219,7 +219,7 @@ int main(int argc, char *const *argv)
 {
     struct addrinfo hints, *ai_list, *ai;
     int r, sockfd = 0;
-    ssize_t session_state_length = 0;
+    uint32_t session_state_length = 0;
     uint8_t *session_state = NULL;
     /* Optional args */
     const char *alpn_protocols = NULL;
@@ -448,7 +448,7 @@ int main(int argc, char *const *argv)
                 exit(1);
             }
             free(session_state);
-            session_state_length = s2n_connection_get_session_length(conn);
+            GUARD_EXIT(s2n_connection_get_session_length(conn, &session_state_length), "Error getting session length");
             session_state = calloc(session_state_length, sizeof(uint8_t));
             if (s2n_connection_get_session(conn, session_state, session_state_length) != session_state_length) {
                 print_s2n_error("Error getting serialized session state");

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1354,7 +1354,7 @@ int s2n_config_set_session_state_lifetime(struct s2n_config *config, uint32_t li
 int s2n_connection_set_session(struct s2n_connection *conn, const uint8_t *session, size_t length);
 int s2n_connection_get_session(struct s2n_connection *conn, uint8_t *session, size_t max_length);
 int s2n_connection_get_session_ticket_lifetime_hint(struct s2n_connection *conn);
-int s2n_connection_get_session_length(struct s2n_connection *conn);
+uint32_t s2n_connection_get_session_length(struct s2n_connection *conn);
 int s2n_connection_get_session_id_length(struct s2n_connection *conn);
 int s2n_connection_get_session_id(struct s2n_connection *conn, uint8_t *session_id, size_t max_length);
 int s2n_connection_is_session_resumed(struct s2n_connection *conn);

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1354,7 +1354,7 @@ int s2n_config_set_session_state_lifetime(struct s2n_config *config, uint32_t li
 int s2n_connection_set_session(struct s2n_connection *conn, const uint8_t *session, size_t length);
 int s2n_connection_get_session(struct s2n_connection *conn, uint8_t *session, size_t max_length);
 int s2n_connection_get_session_ticket_lifetime_hint(struct s2n_connection *conn);
-uint32_t s2n_connection_get_session_length(struct s2n_connection *conn);
+int s2n_connection_get_session_length(struct s2n_connection *conn, uint32_t *length);
 int s2n_connection_get_session_id_length(struct s2n_connection *conn);
 int s2n_connection_get_session_id(struct s2n_connection *conn, uint8_t *session_id, size_t max_length);
 int s2n_connection_is_session_resumed(struct s2n_connection *conn);

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include <s2n.h>
+#include "tls/s2n_connection.h"
+
+int main(int argc, char **argv) {
+    BEGIN_TEST();
+
+    /* Test an overflow in s2n_connection_get_session_length() */
+    {
+        struct s2n_connection *conn;
+        struct s2n_config *config;
+
+        conn = s2n_connection_new(S2N_CLIENT);
+        config = s2n_config_new();
+        s2n_connection_set_config(conn, config);
+
+        config->use_tickets = true;
+        conn->client_ticket.size = UINT32_MAX;
+
+        EXPECT_FAILURE(s2n_connection_get_session_length(conn));
+    }
+
+    END_TEST();
+}
+

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -24,6 +24,7 @@ int main(int argc, char **argv) {
     {
         struct s2n_connection *conn;
         struct s2n_config *config;
+        uint32_t length;
 
         conn = s2n_connection_new(S2N_CLIENT);
         config = s2n_config_new();
@@ -32,7 +33,7 @@ int main(int argc, char **argv) {
         config->use_tickets = true;
         conn->client_ticket.size = UINT32_MAX;
 
-        EXPECT_FAILURE(s2n_connection_get_session_length(conn));
+        EXPECT_FAILURE(s2n_connection_get_session_length(conn, &length));
     }
 
     END_TEST();

--- a/tests/unit/s2n_self_talk_session_id_test.c
+++ b/tests/unit/s2n_self_talk_session_id_test.c
@@ -141,7 +141,7 @@ static void initialize_cache()
 
 void mock_client(struct s2n_test_piped_io *piped_io)
 {
-    size_t serialized_session_state_length = 0;
+    uint32_t serialized_session_state_length = 0;
     uint8_t serialized_session_state[256] = { 0 };
 
     struct s2n_connection *conn;
@@ -175,7 +175,7 @@ void mock_client(struct s2n_test_piped_io *piped_io)
 
     /* Save session state from the connection */
     memset(serialized_session_state, 0, sizeof(serialized_session_state));
-    serialized_session_state_length = s2n_connection_get_session_length(conn);
+    s2n_connection_get_session_length(conn, &serialized_session_state_length);
     if (serialized_session_state_length > sizeof(serialized_session_state)) {
         result = 3;
     }

--- a/tests/unit/s2n_session_ticket_test.c
+++ b/tests/unit/s2n_session_ticket_test.c
@@ -54,7 +54,7 @@ int main(int argc, char **argv)
     struct s2n_config *server_config;
     uint64_t now;
 
-    size_t serialized_session_state_length = 0;
+    uint32_t serialized_session_state_length = 0;
     uint8_t s2n_state_with_session_id = S2N_STATE_WITH_SESSION_ID;
     uint8_t serialized_session_state[S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES + S2N_TICKET_SIZE_IN_BYTES + S2N_STATE_SIZE_IN_BYTES] = { 0 };
 
@@ -146,7 +146,7 @@ int main(int argc, char **argv)
         EXPECT_TRUE(IS_ISSUING_NEW_SESSION_TICKET(server_conn->handshake.handshake_type));
 
         /* Verify that the client received NST */
-        serialized_session_state_length = s2n_connection_get_session_length(client_conn);
+        s2n_connection_get_session_length(client_conn, &serialized_session_state_length);
         EXPECT_EQUAL(s2n_connection_get_session(client_conn, serialized_session_state, serialized_session_state_length), serialized_session_state_length);
         EXPECT_BYTEARRAY_EQUAL(serialized_session_state + S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES, ticket_key_name1, strlen((char *)ticket_key_name1));
 
@@ -411,7 +411,7 @@ int main(int argc, char **argv)
         EXPECT_TRUE(IS_ISSUING_NEW_SESSION_TICKET(server_conn->handshake.handshake_type));
 
         /* Verify that the client received NST */
-        serialized_session_state_length = s2n_connection_get_session_length(client_conn);
+        s2n_connection_get_session_length(client_conn, &serialized_session_state_length);
         EXPECT_EQUAL(s2n_connection_get_session(client_conn, serialized_session_state, serialized_session_state_length), serialized_session_state_length);
         EXPECT_BYTEARRAY_EQUAL(serialized_session_state + S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES, ticket_key_name1, strlen((char *)ticket_key_name1));
 
@@ -476,7 +476,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(s2n_set_size(server_config->ticket_keys), 1);
 
         /* Verify that the client received NST */
-        serialized_session_state_length = s2n_connection_get_session_length(client_conn);
+        s2n_connection_get_session_length(client_conn, &serialized_session_state_length);
         EXPECT_EQUAL(s2n_connection_get_session(client_conn, serialized_session_state, serialized_session_state_length), serialized_session_state_length);
         EXPECT_BYTEARRAY_EQUAL(serialized_session_state + S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES, ticket_key_name2, strlen((char *)ticket_key_name2));
 
@@ -538,7 +538,7 @@ int main(int argc, char **argv)
         EXPECT_TRUE(IS_ISSUING_NEW_SESSION_TICKET(server_conn->handshake.handshake_type));
 
         /* Verify that the client received NST */
-        serialized_session_state_length = s2n_connection_get_session_length(client_conn);
+        s2n_connection_get_session_length(client_conn, &serialized_session_state_length);
         EXPECT_EQUAL(s2n_connection_get_session(client_conn, serialized_session_state, serialized_session_state_length), serialized_session_state_length);
         EXPECT_BYTEARRAY_EQUAL(serialized_session_state + S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES, ticket_key_name1, strlen((char *)ticket_key_name1));
 
@@ -708,7 +708,7 @@ int main(int argc, char **argv)
         EXPECT_TRUE(IS_ISSUING_NEW_SESSION_TICKET(server_conn->handshake.handshake_type));
 
         /* Verify that the client received NST which is encrypted using a key which is at it's peak encryption */
-        serialized_session_state_length = s2n_connection_get_session_length(client_conn);
+        s2n_connection_get_session_length(client_conn, &serialized_session_state_length);
         EXPECT_EQUAL(s2n_connection_get_session(client_conn, serialized_session_state, serialized_session_state_length), serialized_session_state_length);
         EXPECT_BYTEARRAY_EQUAL(serialized_session_state + S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES, ticket_key_name1, strlen((char *)ticket_key_name1));
 
@@ -769,7 +769,7 @@ int main(int argc, char **argv)
         EXPECT_TRUE(IS_ISSUING_NEW_SESSION_TICKET(server_conn->handshake.handshake_type));
 
         /* Verify that the client received NST which is encrypted using a key which is at it's peak encryption */
-        serialized_session_state_length = s2n_connection_get_session_length(client_conn);
+        s2n_connection_get_session_length(client_conn, &serialized_session_state_length);
         EXPECT_EQUAL(s2n_connection_get_session(client_conn, serialized_session_state, serialized_session_state_length), serialized_session_state_length);
         EXPECT_BYTEARRAY_EQUAL(serialized_session_state + S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES, ticket_key_name2, strlen((char *)ticket_key_name2));
 
@@ -837,7 +837,7 @@ int main(int argc, char **argv)
         EXPECT_TRUE(IS_ISSUING_NEW_SESSION_TICKET(server_conn->handshake.handshake_type));
 
         /* Verify that the client received NST which is encrypted using a key which is at it's peak encryption */
-        serialized_session_state_length = s2n_connection_get_session_length(client_conn);
+        s2n_connection_get_session_length(client_conn, &serialized_session_state_length);
         EXPECT_EQUAL(s2n_connection_get_session(client_conn, serialized_session_state, serialized_session_state_length), serialized_session_state_length);
         EXPECT_BYTEARRAY_EQUAL(serialized_session_state + S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES, ticket_key_name2, strlen((char *)ticket_key_name2));
 
@@ -897,7 +897,7 @@ int main(int argc, char **argv)
         EXPECT_TRUE(IS_ISSUING_NEW_SESSION_TICKET(server_conn->handshake.handshake_type));
 
         /* Verify that the client received NST which is encrypted using a key which is at it's peak encryption */
-        serialized_session_state_length = s2n_connection_get_session_length(client_conn);
+        s2n_connection_get_session_length(client_conn, &serialized_session_state_length);
         EXPECT_EQUAL(s2n_connection_get_session(client_conn, serialized_session_state, serialized_session_state_length), serialized_session_state_length);
         EXPECT_BYTEARRAY_EQUAL(serialized_session_state + S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES, ticket_key_name2, strlen((char *)ticket_key_name2));
 

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -284,11 +284,13 @@ int s2n_connection_get_session_ticket_lifetime_hint(struct s2n_connection *conn)
     return conn->ticket_lifetime_hint;
 }
 
-int s2n_connection_get_session_length(struct s2n_connection *conn)
+uint32_t s2n_connection_get_session_length(struct s2n_connection *conn)
 {
     /* Session resumption using session ticket "format (1) + session_ticket_len + session_ticket + session state" */
     if (conn->config->use_tickets && conn->client_ticket.size > 0) {
-        return S2N_STATE_FORMAT_LEN + S2N_SESSION_TICKET_SIZE_LEN + conn->client_ticket.size + S2N_STATE_SIZE_IN_BYTES;
+        uint32_t result;
+        GUARD(s2n_add_overflow(S2N_STATE_FORMAT_LEN + S2N_SESSION_TICKET_SIZE_LEN + S2N_STATE_SIZE_IN_BYTES, conn->client_ticket.size, &result));
+        return result;
     } else if (conn->session_id_len > 0) {
         /* Session resumption using session id: "format (0) + session_id_len + session_id + session state" */
         return S2N_STATE_FORMAT_LEN + 1 + conn->session_id_len + S2N_STATE_SIZE_IN_BYTES;

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -287,6 +287,7 @@ int s2n_connection_get_session_ticket_lifetime_hint(struct s2n_connection *conn)
 
 int s2n_connection_get_session_length(struct s2n_connection *conn, uint32_t *length)
 {
+    notnull_check(length);
     /* Session resumption using session ticket "format (1) + session_ticket_len + session_ticket + session state" */
     if (conn->config->use_tickets && conn->client_ticket.size > 0) {
         GUARD(s2n_add_overflow(S2N_STATE_FORMAT_LEN + S2N_SESSION_TICKET_SIZE_LEN + S2N_STATE_SIZE_IN_BYTES, conn->client_ticket.size, length));


### PR DESCRIPTION
**Issue # (if available):**  #1654

**Description of changes:** 
Change the return type of s2n_connection_get_session_length to uint32_t and check for integer overflow.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.