### PR TITLE
Turn off TLS1.3 SAW tests

### DIFF
--- a/tests/saw/spec/handshake/handshake.saw
+++ b/tests/saw/spec/handshake/handshake.saw
@@ -26,7 +26,10 @@
 
 include "handshake_io_lowlevel.saw";
 import "rfc_handshake_tls12.cry";
-import "rfc_handshake_tls13.cry";
+
+// TLS1.3 is temporarily removed from SAW testing.
+// import "rfc_handshake_tls13.cry";
+
 import "cork_uncork.cry";
 
 // Verification tactic: use the Yices prover and print detailed information in
@@ -77,8 +80,9 @@ let prove_state_machine = do {
     print "Checking proof that the TLS1.2 RFC simulates our Cryptol s2n spec";
     prove_print abc {{ tls12rfcSimulatesS2N `{16} }};
 
-    print "Checking proof that the TLS1.3 RFC simulates our Cryptol s2n spec";
-    prove_print z3 {{ tls13rfcSimulatesS2N `{16} }};
+    // TLS1.3 is temporarily removed from SAW testing.
+    // print "Checking proof that the TLS1.3 RFC simulates our Cryptol s2n spec";
+    // prove_print z3 {{ tls13rfcSimulatesS2N `{16} }};
     
     return ();
 };

--- a/tests/saw/spec/handshake/handshake_io_lowlevel.saw
+++ b/tests/saw/spec/handshake/handshake_io_lowlevel.saw
@@ -107,7 +107,8 @@ let setup_connection = do {
    let corked_io = {{1 : [8]}};
    crucible_points_to (conn_corked_io pconn) (crucible_term corked_io); 
    
-   version <- crucible_fresh_var "version" (llvm_int 8);
+   // TLS1.3 is temporarily removed from SAW testing, force the TLS1.2 version
+   let version = {{33 : [8]}};
    crucible_points_to (crucible_field pconn "actual_protocol_version") (crucible_term version);
    
    mode <- crucible_fresh_var "mode" (llvm_int 32);
@@ -295,14 +296,18 @@ let s2n_advance_message_spec = do {
     // handshake/cork-uncork state machine is equivalent to the one in
     // s2n
     crucible_points_to (crucible_global "handshakes") (crucible_term {{ handshakes }});
-    crucible_points_to (crucible_global "tls13_handshakes") (crucible_term {{ tls13_handshakes }});
+
+    // TLS1.3 is temporarily removed from SAW testing.
+    // crucible_points_to (crucible_global "tls13_handshakes") (crucible_term {{ tls13_handshakes }});
     
     let messages = [ {{CLIENT_HELLO : [5]}}, {{SERVER_HELLO : [5]}}, {{SERVER_CERT : [5]}}, {{SERVER_NEW_SESSION_TICKET : [5]}}, {{SERVER_CERT_STATUS : [5]}}, 
       {{SERVER_KEY : [5]}}, {{SERVER_CERT : [5]}}, {{SERVER_CERT_REQ : [5]}}, {{SERVER_HELLO_DONE : [5]}}, {{CLIENT_CERT : [5]}}, {{CLIENT_KEY : [5]}}, {{CLIENT_CERT_VERIFY : [5]}}, 
       {{CLIENT_CHANGE_CIPHER_SPEC : [5]}}, {{SERVER_FINISHED : [5]}}, {{ENCRYPTED_EXTENSIONS : [5]}}, {{SERVER_CERT_VERIFY : [5]}}, {{APPLICATION_DATA : [5]}} ];
 
     for messages (verify_state_machine_elem (crucible_global "state_machine") {{ state_machine }} );
-    for messages (verify_state_machine_elem (crucible_global "tls13_state_machine") {{ tls13_state_machine }} );
+
+    // TLS1.3 is temporarily removed from SAW testing.
+    // for messages (verify_state_machine_elem (crucible_global "tls13_state_machine") {{ tls13_state_machine }} );
 
     // assert that s2n_advance_message returns 0 (true if the 4
     // functions it calls don't fail)


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
Fixes #1814 

**Description of changes:** 
Turn off the TLS1.3 SAW tests temporarily.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
