### PR TITLE
Support sending data in one direction in integration tests.

### DIFF
--- a/bin/echo.c
+++ b/bin/echo.c
@@ -121,7 +121,7 @@ int echo(struct s2n_connection *conn, int sockfd)
         while ((p = poll(readers, 2, -1)) > 0) {
             char buffer[10240];
             int bytes_read, bytes_written;
-    
+
             if (readers[0].revents & POLLIN) {
                 do {
                     bytes_read = s2n_recv(conn, buffer, 10240, &blocked);
@@ -139,6 +139,7 @@ int echo(struct s2n_connection *conn, int sockfd)
                     }
                 } while (blocked);
             }
+
             if (readers[1].revents & POLLIN) {
                 int bytes_available;
                 if (ioctl(STDIN_FILENO, FIONREAD, &bytes_available) < 0) {
@@ -147,21 +148,21 @@ int echo(struct s2n_connection *conn, int sockfd)
                 if (bytes_available > sizeof(buffer)) {
                     bytes_available = sizeof(buffer);
                 }
-    
+
                 /* Read as many bytes as we think we can */
-    	    do {
-    	        bytes_read = read(STDIN_FILENO, buffer, bytes_available);
-    	        if(bytes_read < 0 && errno != EINTR){
-    	            fprintf(stderr, "Error reading from stdin\n");
-    	            exit(1);
-    	        }
-    	    } while (bytes_read < 0);
-    
+                do {
+                    bytes_read = read(STDIN_FILENO, buffer, bytes_available);
+                    if (bytes_read < 0 && errno != EINTR){
+                        fprintf(stderr, "Error reading from stdin\n");
+                        exit(1);
+                    }
+                } while (bytes_read < 0);
+
                 if (bytes_read == 0) {
                     /* Exit on EOF */
                     return 0;
                 }
-    
+
                 char *buf_ptr = buffer;
                 do {
                     bytes_written = s2n_send(conn, buf_ptr, bytes_available, &blocked);
@@ -169,15 +170,17 @@ int echo(struct s2n_connection *conn, int sockfd)
                         fprintf(stderr, "Error writing to connection: '%s'\n", s2n_strerror(s2n_errno, "EN"));
                         exit(1);
                     }
-    
+
                     bytes_available -= bytes_written;
                     buf_ptr += bytes_written;
                 } while (bytes_available || blocked);
             }
+
             if (readers[1].revents & POLLHUP) {
                 /* The stdin pipe hanged up, and we've handled all read from it above */
                 return 0;
             }
+
             if (readers[0].revents & (POLLERR | POLLHUP | POLLNVAL)) {
                 fprintf(stderr, "Error polling from socket: err=%d hup=%d nval=%d\n",
                         (readers[0].revents & POLLERR ) ? 1 : 0,
@@ -185,6 +188,7 @@ int echo(struct s2n_connection *conn, int sockfd)
                         (readers[0].revents & POLLNVAL ) ? 1 : 0);
                 S2N_ERROR(S2N_ERR_POLLING_FROM_SOCKET);
             }
+
             if (readers[1].revents & (POLLERR | POLLNVAL)) {
                 fprintf(stderr, "Error polling from socket: err=%d nval=%d\n",
                         (readers[1].revents & POLLERR ) ? 1 : 0,

--- a/tests/integrationv2/common.py
+++ b/tests/integrationv2/common.py
@@ -1,4 +1,25 @@
 import subprocess
+import string
+
+
+def data_bytes(n_bytes):
+    """
+    Generate bytes to send over the TLS connection.
+    These bytes purposefully fall outside of the ascii range
+    to prevent triggering "connected commands" present in
+    some SSL clients.
+    """
+    byte_array = [0] * n_bytes
+    allowed = [i for i in range(128, 255)]
+
+    j = 0
+    for i in range(n_bytes):
+        byte_array[i] = allowed[j]
+        j += 1
+        if j > 126:
+            j = 0
+
+    return bytes(byte_array)
 
 
 class TimeoutException(subprocess.SubprocessError):
@@ -78,6 +99,7 @@ class ProviderOptions(object):
             cert=None,
             use_session_ticket=False,
             insecure=False,
+            data_to_send=None,
             tls13=False):
 
         # Client or server
@@ -109,3 +131,6 @@ class ProviderOptions(object):
 
         # Boolean whether to use TLS1.3
         self.tls13 = tls13
+
+        # This data will be sent to the peer
+        self.data_to_send = data_to_send

--- a/tests/integrationv2/fixtures.py
+++ b/tests/integrationv2/fixtures.py
@@ -17,7 +17,7 @@ def managed_process():
     def _fn(provider_class: Provider, options: ProviderOptions, timeout=5):
         provider = provider_class(options)
         cmd_line = provider.get_cmd_line()
-        p = ManagedProcess(cmd_line, provider.set_provider_ready, timeout)
+        p = ManagedProcess(cmd_line, provider.set_provider_ready, ready_to_send=provider.ready_to_send_marker, data_source=options.data_to_send, timeout=timeout)
 
         processes.append(p)
         with p.ready_condition:

--- a/tests/integrationv2/processes.py
+++ b/tests/integrationv2/processes.py
@@ -1,8 +1,196 @@
 import os
+import io
 import time
+from time import monotonic as _time
 import threading
+import select
+import selectors
 import subprocess
 from common import Results, TimeoutException
+
+
+_PopenSelector = selectors.PollSelector
+_PIPE_BUF = getattr(select, 'PIPE_BUF', 512)
+
+
+class _processCommunicator(object):
+    """
+    This class allows greater control over stdin than using Popen.communicate().
+    Popen.communicate() closes stdin as soon as data is written. This causes
+    TLS clients (OpenSSL derivatives) to shut down before the handshake is complete.
+
+    To prevent a premature shutdown, we need to wait until the handshake is complete
+    before writing to stdin. To accomplish this we `poll` stdout for a ready_to_send
+    marker. Once that marker is found, we can write input data to stdin. The
+    benefit of using `poll` and `os.read` is that we get non-blocking IO. Our timeouts
+    are much more reliable, and we don't risk deadlocking on a readline() call which
+    will never complete.
+
+    Another method is to read stdout line by line. This removes a lot of code that
+    registers and unregisters file descriptors with a selector. It would make reading
+    and writing sequential (as opposed to event based), which can be easier to read
+    and maintain. The downsides with this method exist in the current integration test
+    framework. We rely on sleeps and waits, and still hit hard to debug deadlocks from
+    time to time.
+    """
+    def __init__(self, proc, ready_to_send):
+        self.proc = proc
+        self.ready_to_send = ready_to_send
+
+        # If the process times out, the caller can call communicate() once more
+        # to pick up any data remaining in stdout/stderr. We have to track that
+        # with a _communication_started flag
+        self._communication_started = False
+
+    def communicate(self, input_data=None, timeout=None):
+        stdout = None
+        stderr = None
+
+        try:
+            stdout, stderr = self._communicate(input_data, timeout)
+        finally:
+            self._communication_started = True
+
+        return (stdout, stderr)
+
+    def _communicate(self, input_data=None, timeout=None):
+        """
+        This method will read and write data to a subprocess in a non-blocking manner.
+        The code is heavily based on Popen.communicate. There are a couple differences:
+
+            * STDIN is not registered for events until the read_to_send marker is found
+            * STDIN is only closed after all registered events have been processed (including
+              pending stdout/stderr events, allowing more data to be stored).
+        """
+        if self.proc.stdin:
+            # Flush stdio buffer.  This might block, if the user has
+            # been writing to .stdin in an uncontrolled fashion.
+            try:
+                self.proc.stdin.flush()
+            except BrokenPipeError:
+                pass  # communicate() must ignore BrokenPipeError.
+
+        # The process' stdout and stderr are stored in a map, with two variable
+        # pointing to the file objects. This allows us to include stdout/stderr
+        # data in a timeout exception.
+        stdout = None
+        stderr = None
+
+        if not self._communication_started:
+            self._fileobj2output = {}
+            if self.proc.stdout:
+                self._fileobj2output[self.proc.stdout] = []
+                stdout = self._fileobj2output[self.proc.stdout]
+            if self.proc.stderr:
+                self._fileobj2output[self.proc.stderr] = []
+                stderr = self._fileobj2output[self.proc.stderr]
+
+        # Data destined for stdin is stored in a memoryview and the offset
+        # will be used incase multiple writes are needed.
+        if input_data:
+            input_view = memoryview(input_data)
+        input_data_offset = 0
+        input_data_sent = False
+
+        # Keeping track of the original timeout value, and the expected end
+        # time of the operation allow us to timeout while reads/writes are
+        # still pending. It also allows us to only wait for the remainder of
+        # the timeout after reads/writes have completed.
+        orig_timeout = timeout
+        if timeout is not None:
+            endtime = _time() + timeout
+        else:
+            endtime = None
+
+        with _PopenSelector() as selector:
+            if self.proc.stdout and not self.proc.stdout.closed:
+                selector.register(self.proc.stdout, selectors.EVENT_READ)
+            if self.proc.stderr and not self.proc.stderr.closed:
+                selector.register(self.proc.stderr, selectors.EVENT_READ)
+
+            while selector.get_map():
+                timeout = self._remaining_time(endtime)
+                if timeout is not None and timeout < 0:
+                    self._check_timeout(endtime, orig_timeout,
+                                        stdout, stderr,
+                                        skip_check_and_raise=True)
+                    raise RuntimeError(  # Impossible :)
+                        '_check_timeout(..., skip_check_and_raise=True) '
+                        'failed to raise TimeoutExpired.')
+
+                ready = selector.select(timeout)
+                self._check_timeout(endtime, orig_timeout, stdout, stderr)
+
+                for key, events in ready:
+                    # STDIN is only registered to receive events after the ready-to-send
+                    # marker is found.
+                    if key.fileobj is self.proc.stdin:
+                        chunk = input_view[input_data_offset :
+                                           input_data_offset + _PIPE_BUF]
+                        try:
+                            input_data_offset += os.write(key.fd, chunk)
+                        except BrokenPipeError:
+                            selector.unregister(key.fileobj)
+                        else:
+                            if input_data_offset >= len(input_data):
+                                selector.unregister(key.fileobj)
+                                input_data_sent = True
+                    elif key.fileobj in (self.proc.stdout, self.proc.stderr):
+                        data = os.read(key.fd, 32768)
+                        if not data:
+                            selector.unregister(key.fileobj)
+
+                        # fileobj2output[key.fileobj] is a list of data chunks
+                        # that get joined later
+                        self._fileobj2output[key.fileobj].append(data)
+
+                        # If we are looking for, and find, the ready-to-send marker, then
+                        # register STDIN to receive events. If there is no data to send,
+                        # just mark input_send as true so we can close out STDIN.
+                        if self.ready_to_send is not None and self.ready_to_send in str(data):
+                            if self.proc.stdin and input:
+                                selector.register(self.proc.stdin, selectors.EVENT_WRITE)
+                            else:
+                                input_data_sent = True
+
+                # If we have finished sending all our input, and have received the
+                # ready-to-send marker, we can close out stdin.
+                if self.proc.stdin and input_data_sent:
+                    self.proc.stdin.close()
+
+        self.proc.wait(timeout=self._remaining_time(endtime))
+
+        # All data exchanged.  Translate lists into strings.
+        if stdout is not None:
+            stdout = b''.join(stdout)
+        if stderr is not None:
+            stderr = b''.join(stderr)
+
+        return (stdout, stderr)
+
+    def _remaining_time(self, endtime):
+        """Convenience for _communicate when computing timeouts."""
+        if endtime is None:
+            return None
+        else:
+            return endtime - _time()
+
+    def _check_timeout(self, endtime, orig_timeout, stdout_seq, stderr_seq,
+                       skip_check_and_raise=False):
+        """
+        Convenience for checking if a timeout has expired.
+
+        NOTE: This method is included here to prevent our custom _communicate method
+        from relying on a particular version of Python.
+        """
+        if endtime is None:
+            return
+        if skip_check_and_raise or _time() > endtime:
+            raise subprocess.TimeoutExpired(
+                    self.proc.args, orig_timeout,
+                    output=b''.join(stdout_seq) if stdout_seq else None,
+                    stderr=b''.join(stderr_seq) if stderr_seq else None)
+
 
 
 class ManagedProcess(threading.Thread):
@@ -13,7 +201,7 @@ class ManagedProcess(threading.Thread):
     The stdin/stdout/stderr and exist code a monitored and results
     are made available to the caller.
     """
-    def __init__(self, cmd_line, provider_set_ready_condition, timeout, data_source=None):
+    def __init__(self, cmd_line, provider_set_ready_condition, ready_to_send=None, timeout=5, data_source=None):
         threading.Thread.__init__(self)
         self.cmd_line = cmd_line
         self.timeout = timeout
@@ -23,12 +211,17 @@ class ManagedProcess(threading.Thread):
         self.process_ready = False
         self.provider_set_ready_condition = provider_set_ready_condition
 
+        # Note: use this to set the ready condition correctly
+        self.ready_to_test = None
+
         # We always need some data for stdin, otherwise .communicate() won't setup the input
         # descriptor for the process. This causes some SSL providers to close the connection
         # immediately upon creation.
-        self.data_source = b"A few test bytes"
+        self.data_source = None
+        self.ready_to_send = None
         if data_source is not None:
             self.data_source = data_source
+            self.ready_to_send = ready_to_send
 
     def run(self):
         with self.results_condition:
@@ -38,22 +231,25 @@ class ManagedProcess(threading.Thread):
                 self.results = Results(None, None, None, ex)
                 raise ex
 
+            if self.ready_to_test is not None:
+                # We can read stdout here looking for a ready marker
+                pass
+
             self.provider_set_ready_condition()
 
             # Result should be available to the whole scope
             proc_results = None
+
             try:
-                # If the process' stdin is set, input *must* be provided. Otherwise stdin is closed
-                # almost immediately. This causes some SSL providers to close the connection before
-                # the s2n client can complete.
-                proc_results = proc.communicate(input=self.data_source, timeout=self.timeout)
+                communicator = _processCommunicator(proc, self.ready_to_send)
+                proc_results = communicator.communicate(input_data=self.data_source, timeout=self.timeout)
                 self.results = Results(proc_results[0], proc_results[1], proc.returncode, None)
             except subprocess.TimeoutExpired as ex:
                 proc.kill()
                 wrapped_ex = TimeoutException(ex)
 
                 # Read any remaining output
-                proc_results = proc.communicate()
+                proc_results = communicator.communicate()
                 self.results = Results(proc_results[0], proc_results[1], proc.returncode, wrapped_ex)
             except Exception as ex:
                 self.results = Results(None, None, None, ex)

--- a/tests/integrationv2/test_happy_path.py
+++ b/tests/integrationv2/test_happy_path.py
@@ -16,10 +16,12 @@ def test_s2n_server_happy_path(managed_process, cipher, curve, provider):
     host = "localhost"
     port = next(available_ports)
 
-    # S2ND can receive large amounts of data because all the data is
+    # s2nd can receive large amounts of data because all the data is
     # echo'd to stdout unmodified. This lets us compare received to
     # expected easily.
-    random_bytes = data_bytes(16384)
+    # The downside here is that, should the test fail, all 4 mbs will
+    # be dumped in the exception.
+    random_bytes = data_bytes(4194304)
     client_options = ProviderOptions(
         mode="client",
         host="localhost",

--- a/tests/integrationv2/test_happy_path.py
+++ b/tests/integrationv2/test_happy_path.py
@@ -4,7 +4,7 @@ import pytest
 import time
 
 from configuration import available_ports, CIPHERSUITES, CURVES, PROVIDERS
-from common import ProviderOptions
+from common import ProviderOptions, data_bytes
 from fixtures import managed_process
 from providers import S2N
 
@@ -16,16 +16,22 @@ def test_s2n_server_happy_path(managed_process, cipher, curve, provider):
     host = "localhost"
     port = next(available_ports)
 
+    # S2ND can receive large amounts of data because all the data is
+    # echo'd to stdout unmodified. This lets us compare received to
+    # expected easily.
+    random_bytes = data_bytes(16384)
     client_options = ProviderOptions(
         mode="client",
         host="localhost",
         port=port,
         cipher=cipher,
         curve=curve,
+        data_to_send=random_bytes,
         insecure=True,
         tls13=True)
 
     server_options = copy.copy(client_options)
+    server_options.data_to_send = None
     server_options.mode = "server"
     server_options.key = "../pems/ecdsa_p384_pkcs1_key.pem"
     server_options.cert = "../pems/ecdsa_p384_pkcs1_cert.pem"
@@ -48,6 +54,7 @@ def test_s2n_server_happy_path(managed_process, cipher, curve, provider):
         assert results.exception is None
         assert results.exit_code == 0
         assert b"Actual protocol version: 34" in results.stdout
+        assert random_bytes in results.stdout
 
 
 @pytest.mark.parametrize("cipher", CIPHERSUITES)
@@ -57,15 +64,23 @@ def test_s2n_client_happy_path(managed_process, cipher, curve, provider):
     host = "localhost"
     port = next(available_ports)
 
+    # We can only send 4096 bytes here because of the way some servers chunk
+    # output (when writing to stdout). If we send 8192 bytes, then openssl
+    # will print some debugging information in the middle of our chunk.
+    # We still want that debugging data in case of a failure, so we just
+    # send less data, rather than lose debug information.
+    random_bytes = data_bytes(4096)
     client_options = ProviderOptions(
         mode="client",
         host="localhost",
         port=port,
         cipher=cipher,
+        data_to_send=random_bytes,
         insecure=True,
         tls13=True)
 
     server_options = copy.copy(client_options)
+    server_options.data_to_send = None
     server_options.mode = "server"
     server_options.key = "../pems/ecdsa_p384_pkcs1_key.pem"
     server_options.cert = "../pems/ecdsa_p384_pkcs1_cert.pem"
@@ -88,3 +103,4 @@ def test_s2n_client_happy_path(managed_process, cipher, curve, provider):
     for results in server.get_results():
         assert results.exception is None
         assert results.exit_code == 0
+        assert random_bytes in results.stdout


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
Fixes #1485
Fixes #1802 
Fixes #1680 
Fixes #1554 
Fixes #1469 

**Description of changes:** 
This is a fully functional happy path setup. This particular PR does not fix the above issues, but this PR demonstrates working tests in the V2 framework. The V2 framework does fix the above issues.

* Subclass Popen to allow greater control over STDIN when communicating with a subprocess.
* Update happy path tests to send data, and verify the data has been sent.

**Design choices:**
One of the weaknesses identified in the existing integration test framework is blocking IO. These blocking calls cause Codebuild to timeout after 10 minutes, and no useful information is delivered to the user to find out what went wrong.

To address this we use non-blocking read and write calls in the process module. This code is heavily derived from the existing `Popen.communicate` method. The reason we don't simply use `Popen.communicate` is due to the way stdin is closed.  openssl (and derivative) clients shutdown as soon as stdin is closed, and this causes race conditions in the tests.

This implementation uses non-blocking calls to prevent timeouts due to blocking. It also waits for a ready-to-send marker (determined by the provider) before sending data to stdin. This prevents an early termination of the openssl client. It also gives us the ability to control two-way communication (#1841) at a later time.

The test interface does not change. The non-blocking and ready-to-send is all implemented in the backend.

**Future Work**
We need a protocol to send data and wait for a response from a peer. So far the only test that may require this is the KeyUpdate test. This work is tracked in #1841.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
