### PR TITLE
Update memcpy in tests to include EXPECT_ macros 

### DIFF
--- a/tests/s2n_test.h
+++ b/tests/s2n_test.h
@@ -153,3 +153,13 @@ int test_count;
 
 /* Ensures fuzz test input length is greater than or equal to the minimum needed for the test */
 #define S2N_FUZZ_ENSURE_MIN_LEN( len , min ) do {if ( (len) < (min) ) return 0;} while (0)
+
+#define EXPECT_MEMCPY_SUCCESS(d, s, n)                                         \
+    do {                                                                       \
+        __typeof(n) __tmp_n = (n);                                             \
+        if (__tmp_n) {                                                         \
+            if (memcpy((d), (s), (__tmp_n)) == NULL) {                         \
+                FAIL_MSG(#d "is NULL, memcpy() failed");                       \
+            }                                                                  \
+        }                                                                      \
+    } while (0)

--- a/tests/unit/s2n_cbc_verify_test.c
+++ b/tests/unit/s2n_cbc_verify_test.c
@@ -153,7 +153,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_hmac_init(&record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
 
-        memcpy(fragment, random_data, i - 20 - 1);
+        EXPECT_MEMCPY_SUCCESS(fragment, random_data, i - 20 - 1);
         EXPECT_SUCCESS(s2n_hmac_update(&record_mac, fragment, i - 20 - 1));
         EXPECT_SUCCESS(s2n_hmac_digest(&record_mac, fragment + (i - 20 - 1), 20));
 
@@ -197,7 +197,7 @@ int main(int argc, char **argv)
             fragment[i - j] = 254;
         }
 
-        memcpy(fragment, random_data, i - 20 - 255);
+        EXPECT_MEMCPY_SUCCESS(fragment, random_data, i - 20 - 255);
         EXPECT_SUCCESS(s2n_hmac_update(&record_mac, fragment, i - 20 - 255));
         EXPECT_SUCCESS(s2n_hmac_digest(&record_mac, fragment + (i - 20 - 255), 20));
 
@@ -240,7 +240,7 @@ int main(int argc, char **argv)
             fragment[i - j] = 15;
         }
 
-        memcpy(fragment, random_data, i - 20 - 16);
+        EXPECT_MEMCPY_SUCCESS(fragment, random_data, i - 20 - 16);
         EXPECT_SUCCESS(s2n_hmac_update(&record_mac, fragment, i - 20 - 16));
         EXPECT_SUCCESS(s2n_hmac_digest(&record_mac, fragment + (i - 20 - 16), 20));
 

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -456,8 +456,8 @@ int main(int argc, char **argv)
         };
 
         EXPECT_NOT_NULL(sent_client_hello = malloc(sent_client_hello_len));
-        memcpy(sent_client_hello, client_hello_prefix, client_hello_prefix_len);
-        memcpy(sent_client_hello + client_hello_prefix_len, client_extensions, client_extensions_len);
+        EXPECT_MEMCPY_SUCCESS(sent_client_hello, client_hello_prefix, client_hello_prefix_len);
+        EXPECT_MEMCPY_SUCCESS(sent_client_hello + client_hello_prefix_len, client_extensions, client_extensions_len);
 
         /* Create nonblocking pipes */
         struct s2n_test_piped_io piped_io;
@@ -512,7 +512,7 @@ int main(int argc, char **argv)
 
         /* Verify the collected client hello matches what was sent except for the zero-ed client random */
         EXPECT_NOT_NULL(expected_client_hello = malloc(sent_client_hello_len));
-        memcpy(expected_client_hello, sent_client_hello, sent_client_hello_len);
+        EXPECT_MEMCPY_SUCCESS(expected_client_hello, sent_client_hello, sent_client_hello_len);
         memset_check(expected_client_hello + client_random_offset, 0, S2N_TLS_RANDOM_DATA_LEN);
         EXPECT_SUCCESS(memcmp(collected_client_hello, expected_client_hello, sent_client_hello_len));
 
@@ -775,8 +775,8 @@ int main(int argc, char **argv)
         };
 
         EXPECT_NOT_NULL(sent_client_hello = malloc(sent_client_hello_len));
-        memcpy(sent_client_hello, client_hello_prefix, client_hello_prefix_len);
-        memcpy(sent_client_hello + client_hello_prefix_len, client_extensions, client_extensions_len);
+        EXPECT_MEMCPY_SUCCESS(sent_client_hello, client_hello_prefix, client_hello_prefix_len);
+        EXPECT_MEMCPY_SUCCESS(sent_client_hello + client_hello_prefix_len, client_extensions, client_extensions_len);
 
         /* Create nonblocking pipes */
         struct s2n_test_piped_io piped_io;

--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -119,13 +119,13 @@ int test_cipher_preferences(struct s2n_config *server_config, struct s2n_config 
         }
 
         /* Craft a cipher preference with a cipher_idx cipher
-           NOTE: Its safe to use memcpy as the address of server_cipher_preferences
+           NOTE: Its safe to use EXPECT_MEMCPY_SUCCESS as the address of server_cipher_preferences
            will never be NULL */
-        memcpy(&server_cipher_preferences, cipher_preferences, sizeof(server_cipher_preferences));
+        EXPECT_MEMCPY_SUCCESS(&server_cipher_preferences, cipher_preferences, sizeof(server_cipher_preferences));
         server_cipher_preferences.count = 1;
         server_cipher_preferences.suites = &expected_cipher;
 
-        memcpy(&server_security_policy, security_policy, sizeof(server_security_policy));
+        EXPECT_MEMCPY_SUCCESS(&server_security_policy, security_policy, sizeof(server_security_policy));
         server_security_policy.cipher_preferences = &server_cipher_preferences;
 
         server_conn->security_policy_override = &server_security_policy;

--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -118,9 +118,7 @@ int test_cipher_preferences(struct s2n_config *server_config, struct s2n_config 
             expect_failure = 1;
         }
 
-        /* Craft a cipher preference with a cipher_idx cipher
-           NOTE: Its safe to use EXPECT_MEMCPY_SUCCESS as the address of server_cipher_preferences
-           will never be NULL */
+        /* Craft a cipher preference with a cipher_idx cipher */
         EXPECT_MEMCPY_SUCCESS(&server_cipher_preferences, cipher_preferences, sizeof(server_cipher_preferences));
         server_cipher_preferences.count = 1;
         server_cipher_preferences.suites = &expected_cipher;

--- a/tests/unit/s2n_mutual_auth_test.c
+++ b/tests/unit/s2n_mutual_auth_test.c
@@ -88,9 +88,7 @@ int main(int argc, char **argv)
         struct s2n_stuffer client_to_server;
         struct s2n_stuffer server_to_client;
 
-        /* Craft a cipher preference with a cipher_idx cipher
-           NOTE: Its safe to use EXPECT_MEMCPY_SUCCESS as the address of server_cipher_preferences
-           will never be NULL */
+        /* Craft a cipher preference with a cipher_idx cipher */
         EXPECT_MEMCPY_SUCCESS(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
         server_cipher_preferences.count = 1;
         struct s2n_cipher_suite *cur_cipher = default_cipher_preferences->suites[cipher_idx];
@@ -164,9 +162,7 @@ int main(int argc, char **argv)
         struct s2n_stuffer client_to_server;
         struct s2n_stuffer server_to_client;
 
-        /* Craft a cipher preference with a cipher_idx cipher
-           NOTE: Its safe to use EXPECT_MEMCPY_SUCCESS as the address of server_cipher_preferences
-           will never be NULL */
+        /* Craft a cipher preference with a cipher_idx cipher */
         EXPECT_MEMCPY_SUCCESS(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
         server_cipher_preferences.count = 1;
         struct s2n_cipher_suite *cur_cipher = default_cipher_preferences->suites[cipher_idx];
@@ -235,9 +231,7 @@ int main(int argc, char **argv)
         struct s2n_stuffer client_to_server;
         struct s2n_stuffer server_to_client;
 
-        /* Craft a cipher preference with a cipher_idx cipher
-           NOTE: Its safe to use EXPECT_MEMCPY_SUCCESS as the address of server_cipher_preferences
-           will never be NULL */
+        /* Craft a cipher preference with a cipher_idx cipher */
         EXPECT_MEMCPY_SUCCESS(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
         server_cipher_preferences.count = 1;
         struct s2n_cipher_suite *cur_cipher = default_cipher_preferences->suites[cipher_idx];
@@ -311,9 +305,7 @@ int main(int argc, char **argv)
         struct s2n_stuffer client_to_server;
         struct s2n_stuffer server_to_client;
 
-        /* Craft a cipher preference with a cipher_idx cipher
-           NOTE: Its safe to use EXPECT_MEMCPY_SUCCESS as the address of server_cipher_preferences
-           will never be NULL */
+        /* Craft a cipher preference with a cipher_idx cipher */
         EXPECT_MEMCPY_SUCCESS(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
         server_cipher_preferences.count = 1;
         struct s2n_cipher_suite *cur_cipher = default_cipher_preferences->suites[cipher_idx];

--- a/tests/unit/s2n_mutual_auth_test.c
+++ b/tests/unit/s2n_mutual_auth_test.c
@@ -89,9 +89,9 @@ int main(int argc, char **argv)
         struct s2n_stuffer server_to_client;
 
         /* Craft a cipher preference with a cipher_idx cipher
-           NOTE: Its safe to use memcpy as the address of server_cipher_preferences
+           NOTE: Its safe to use EXPECT_MEMCPY_SUCCESS as the address of server_cipher_preferences
            will never be NULL */
-        memcpy(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
+        EXPECT_MEMCPY_SUCCESS(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
         server_cipher_preferences.count = 1;
         struct s2n_cipher_suite *cur_cipher = default_cipher_preferences->suites[cipher_idx];
 
@@ -102,7 +102,7 @@ int main(int argc, char **argv)
 
         server_cipher_preferences.suites = &cur_cipher;
 
-        memcpy(&server_security_policy, default_security_policy, sizeof(server_security_policy));
+        EXPECT_MEMCPY_SUCCESS(&server_security_policy, default_security_policy, sizeof(server_security_policy));
         server_security_policy.cipher_preferences = &server_cipher_preferences;
         
         config->security_policy = &server_security_policy;
@@ -165,9 +165,9 @@ int main(int argc, char **argv)
         struct s2n_stuffer server_to_client;
 
         /* Craft a cipher preference with a cipher_idx cipher
-           NOTE: Its safe to use memcpy as the address of server_cipher_preferences
+           NOTE: Its safe to use EXPECT_MEMCPY_SUCCESS as the address of server_cipher_preferences
            will never be NULL */
-        memcpy(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
+        EXPECT_MEMCPY_SUCCESS(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
         server_cipher_preferences.count = 1;
         struct s2n_cipher_suite *cur_cipher = default_cipher_preferences->suites[cipher_idx];
 
@@ -177,7 +177,7 @@ int main(int argc, char **argv)
         }
 
         server_cipher_preferences.suites = &cur_cipher;
-        memcpy(&server_security_policy, default_security_policy, sizeof(server_security_policy));
+        EXPECT_MEMCPY_SUCCESS(&server_security_policy, default_security_policy, sizeof(server_security_policy));
         server_security_policy.cipher_preferences = &server_cipher_preferences;
         config->security_policy = &server_security_policy;
 
@@ -236,9 +236,9 @@ int main(int argc, char **argv)
         struct s2n_stuffer server_to_client;
 
         /* Craft a cipher preference with a cipher_idx cipher
-           NOTE: Its safe to use memcpy as the address of server_cipher_preferences
+           NOTE: Its safe to use EXPECT_MEMCPY_SUCCESS as the address of server_cipher_preferences
            will never be NULL */
-        memcpy(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
+        EXPECT_MEMCPY_SUCCESS(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
         server_cipher_preferences.count = 1;
         struct s2n_cipher_suite *cur_cipher = default_cipher_preferences->suites[cipher_idx];
 
@@ -249,7 +249,7 @@ int main(int argc, char **argv)
 
         server_cipher_preferences.suites = &cur_cipher;
         
-        memcpy(&server_security_policy, default_security_policy, sizeof(server_security_policy));
+        EXPECT_MEMCPY_SUCCESS(&server_security_policy, default_security_policy, sizeof(server_security_policy));
         server_security_policy.cipher_preferences = &server_cipher_preferences;
         
         config->security_policy = &server_security_policy;
@@ -312,9 +312,9 @@ int main(int argc, char **argv)
         struct s2n_stuffer server_to_client;
 
         /* Craft a cipher preference with a cipher_idx cipher
-           NOTE: Its safe to use memcpy as the address of server_cipher_preferences
+           NOTE: Its safe to use EXPECT_MEMCPY_SUCCESS as the address of server_cipher_preferences
            will never be NULL */
-        memcpy(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
+        EXPECT_MEMCPY_SUCCESS(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
         server_cipher_preferences.count = 1;
         struct s2n_cipher_suite *cur_cipher = default_cipher_preferences->suites[cipher_idx];
 
@@ -325,7 +325,7 @@ int main(int argc, char **argv)
 
         server_cipher_preferences.suites = &cur_cipher;
 
-        memcpy(&server_security_policy, default_security_policy, sizeof(server_security_policy));
+        EXPECT_MEMCPY_SUCCESS(&server_security_policy, default_security_policy, sizeof(server_security_policy));
         server_security_policy.cipher_preferences = &server_cipher_preferences;
 
         config->security_policy = &server_security_policy;

--- a/tests/unit/s2n_optional_client_auth_test.c
+++ b/tests/unit/s2n_optional_client_auth_test.c
@@ -102,7 +102,7 @@ int main(int argc, char **argv)
         struct s2n_connection *server_conn;
 
         /* Craft a cipher preference with a cipher_idx cipher. */
-        memcpy(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
+        EXPECT_MEMCPY_SUCCESS(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
         server_cipher_preferences.count = 1;
         struct s2n_cipher_suite *cur_cipher = default_cipher_preferences->suites[cipher_idx];
 
@@ -113,7 +113,7 @@ int main(int argc, char **argv)
 
         server_cipher_preferences.suites = &cur_cipher;
         
-        memcpy(&security_policy, default_security_policy, sizeof(security_policy));
+        EXPECT_MEMCPY_SUCCESS(&security_policy, default_security_policy, sizeof(security_policy));
         security_policy.cipher_preferences = &server_cipher_preferences;
 
         client_config->security_policy = &security_policy;
@@ -166,7 +166,7 @@ int main(int argc, char **argv)
         struct s2n_connection *server_conn;
 
         /* Craft a cipher preference with a cipher_idx cipher. */
-        memcpy(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
+        EXPECT_MEMCPY_SUCCESS(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
         server_cipher_preferences.count = 1;
         struct s2n_cipher_suite *cur_cipher = default_cipher_preferences->suites[cipher_idx];
 
@@ -177,7 +177,7 @@ int main(int argc, char **argv)
 
         server_cipher_preferences.suites = &cur_cipher;
 
-        memcpy(&security_policy, default_security_policy, sizeof(security_policy));
+        EXPECT_MEMCPY_SUCCESS(&security_policy, default_security_policy, sizeof(security_policy));
         security_policy.cipher_preferences = &server_cipher_preferences;
 
         client_config->security_policy = &security_policy;
@@ -230,7 +230,7 @@ int main(int argc, char **argv)
         struct s2n_connection *server_conn;
 
         /* Craft a cipher preference with a cipher_idx cipher. */
-        memcpy(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
+        EXPECT_MEMCPY_SUCCESS(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
         server_cipher_preferences.count = 1;
         struct s2n_cipher_suite *cur_cipher = default_cipher_preferences->suites[cipher_idx];
 
@@ -241,7 +241,7 @@ int main(int argc, char **argv)
 
         server_cipher_preferences.suites = &cur_cipher;
 
-        memcpy(&security_policy, default_security_policy, sizeof(security_policy));
+        EXPECT_MEMCPY_SUCCESS(&security_policy, default_security_policy, sizeof(security_policy));
         security_policy.cipher_preferences = &server_cipher_preferences;
 
         client_config->security_policy = &security_policy;
@@ -295,7 +295,7 @@ int main(int argc, char **argv)
         struct s2n_connection *server_conn;
 
         /* Craft a cipher preference with a cipher_idx cipher. */
-        memcpy(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
+        EXPECT_MEMCPY_SUCCESS(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
         server_cipher_preferences.count = 1;
         struct s2n_cipher_suite *cur_cipher = default_cipher_preferences->suites[cipher_idx];
 
@@ -306,7 +306,7 @@ int main(int argc, char **argv)
 
         server_cipher_preferences.suites = &cur_cipher;
 
-        memcpy(&security_policy, default_security_policy, sizeof(security_policy));
+        EXPECT_MEMCPY_SUCCESS(&security_policy, default_security_policy, sizeof(security_policy));
         security_policy.cipher_preferences = &server_cipher_preferences;
 
         client_config->security_policy = &security_policy;
@@ -365,7 +365,7 @@ int main(int argc, char **argv)
         struct s2n_connection *server_conn;
 
         /* Craft a cipher preference with a cipher_idx cipher. */
-        memcpy(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
+        EXPECT_MEMCPY_SUCCESS(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
         server_cipher_preferences.count = 1;
         struct s2n_cipher_suite *cur_cipher = default_cipher_preferences->suites[cipher_idx];
 
@@ -376,7 +376,7 @@ int main(int argc, char **argv)
 
         server_cipher_preferences.suites = &cur_cipher;
 
-        memcpy(&security_policy, default_security_policy, sizeof(security_policy));
+        EXPECT_MEMCPY_SUCCESS(&security_policy, default_security_policy, sizeof(security_policy));
         security_policy.cipher_preferences = &server_cipher_preferences;
 
         client_config->security_policy = &security_policy;
@@ -443,7 +443,7 @@ int main(int argc, char **argv)
         struct s2n_connection *server_conn;
 
         /* Craft a cipher preference with a cipher_idx cipher. */
-        memcpy(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
+        EXPECT_MEMCPY_SUCCESS(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
         server_cipher_preferences.count = 1;
         struct s2n_cipher_suite *cur_cipher = default_cipher_preferences->suites[cipher_idx];
 
@@ -454,7 +454,7 @@ int main(int argc, char **argv)
 
         server_cipher_preferences.suites = &cur_cipher;
         
-        memcpy(&security_policy, default_security_policy, sizeof(security_policy));
+        EXPECT_MEMCPY_SUCCESS(&security_policy, default_security_policy, sizeof(security_policy));
         security_policy.cipher_preferences = &server_cipher_preferences;
 
         client_config->security_policy = &security_policy;

--- a/tests/unit/s2n_record_test.c
+++ b/tests/unit/s2n_record_test.c
@@ -175,7 +175,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
         uint8_t original_seq_num[8];
-        memcpy(original_seq_num, conn->server->client_sequence_number, 8);
+        EXPECT_MEMCPY_SUCCESS(original_seq_num, conn->server->client_sequence_number, 8);
 
         uint8_t content_type;
         uint16_t fragment_length;
@@ -192,7 +192,7 @@ int main(int argc, char **argv)
         EXPECT_FAILURE(s2n_record_parse(conn));
 
         /* Restore the original sequence number */
-        memcpy(conn->server->client_sequence_number, original_seq_num, 8);
+        EXPECT_MEMCPY_SUCCESS(conn->server->client_sequence_number, original_seq_num, 8);
 
         /* Deliberately corrupt a byte of the output and check that the record
          * won't parse 
@@ -348,7 +348,7 @@ int main(int argc, char **argv)
 
     /* Fast forward the sequence number */
     uint8_t max_num_records[] = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
-    memcpy(conn->initial.server_sequence_number, max_num_records, sizeof(max_num_records));
+    EXPECT_MEMCPY_SUCCESS(conn->initial.server_sequence_number, max_num_records, sizeof(max_num_records));
     EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
     /* Sequence number should wrap around */
     EXPECT_FAILURE(s2n_record_write(conn, TLS_APPLICATION_DATA, &empty_blob));

--- a/tests/unit/s2n_self_talk_session_id_test.c
+++ b/tests/unit/s2n_self_talk_session_id_test.c
@@ -56,8 +56,8 @@ int cache_store_callback(struct s2n_connection *conn, void *ctx, uint64_t ttl, c
 
     uint8_t index = ((const uint8_t *)key)[0];
 
-    memcpy(cache[index].key, key, key_size);
-    memcpy(cache[index].value, value, value_size);
+    EXPECT_MEMCPY_SUCCESS(cache[index].key, key, key_size);
+    EXPECT_MEMCPY_SUCCESS(cache[index].value, value, value_size);
 
     cache[index].key_len = key_size;
     cache[index].value_len = value_size;
@@ -96,7 +96,7 @@ int cache_retrieve_callback(struct s2n_connection *conn, void *ctx, const void *
     }
 
     *value_size = cache[index].value_len;
-    memcpy(value, cache[index].value, cache[index].value_len);
+    EXPECT_MEMCPY_SUCCESS(value, cache[index].value, cache[index].value_len);
 
     return 0;
 }
@@ -161,7 +161,7 @@ void mock_client(struct s2n_test_piped_io *piped_io)
     s2n_connection_set_piped_io(conn, piped_io);
 
     /* Set the session id to ensure we're able to fallback to full handshake if session is not in server cache */
-    memcpy(conn->session_id, SESSION_ID, S2N_TLS_SESSION_ID_MAX_LEN);
+    EXPECT_MEMCPY_SUCCESS(conn->session_id, SESSION_ID, S2N_TLS_SESSION_ID_MAX_LEN);
     conn->session_id_len = S2N_TLS_SESSION_ID_MAX_LEN;
 
     if (s2n_negotiate(conn, &blocked) != 0) {

--- a/tests/unit/s2n_session_ticket_test.c
+++ b/tests/unit/s2n_session_ticket_test.c
@@ -235,7 +235,7 @@ int main(int argc, char **argv)
 
         /* Verify that client_ticket is same as before because server didn't issue a NST */
         uint8_t old_session_ticket[S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES + S2N_TICKET_SIZE_IN_BYTES];
-        memcpy(old_session_ticket, serialized_session_state, S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES + S2N_TICKET_SIZE_IN_BYTES);
+        EXPECT_MEMCPY_SUCCESS(old_session_ticket, serialized_session_state, S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES + S2N_TICKET_SIZE_IN_BYTES);
         EXPECT_TRUE(s2n_connection_is_session_resumed(client_conn));
         s2n_connection_get_session(client_conn, serialized_session_state, serialized_session_state_length);
         EXPECT_BYTEARRAY_EQUAL(old_session_ticket, serialized_session_state, S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES + S2N_TICKET_SIZE_IN_BYTES);
@@ -297,7 +297,7 @@ int main(int argc, char **argv)
 
         /* Verify that client_ticket is not same as before because server issued a NST */
         uint8_t old_session_ticket[S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES + S2N_TICKET_SIZE_IN_BYTES];
-        memcpy(old_session_ticket, serialized_session_state, S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES + S2N_TICKET_SIZE_IN_BYTES);
+        EXPECT_MEMCPY_SUCCESS(old_session_ticket, serialized_session_state, S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES + S2N_TICKET_SIZE_IN_BYTES);
 
         s2n_connection_get_session(client_conn, serialized_session_state, serialized_session_state_length);
         EXPECT_TRUE(memcmp(old_session_ticket, serialized_session_state, S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES + S2N_TICKET_SIZE_IN_BYTES));
@@ -360,7 +360,7 @@ int main(int argc, char **argv)
 
         /* Verify that client_ticket is same as before because server did not issue a NST */
         uint8_t old_session_ticket[S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES + S2N_TICKET_SIZE_IN_BYTES];
-        memcpy(old_session_ticket, serialized_session_state, S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES + S2N_TICKET_SIZE_IN_BYTES);
+        EXPECT_MEMCPY_SUCCESS(old_session_ticket, serialized_session_state, S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES + S2N_TICKET_SIZE_IN_BYTES);
 
         s2n_connection_get_session(client_conn, serialized_session_state, serialized_session_state_length);
         EXPECT_FALSE(memcmp(old_session_ticket, serialized_session_state, S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES + S2N_TICKET_SIZE_IN_BYTES));
@@ -508,7 +508,7 @@ int main(int argc, char **argv)
         tampered_session_state[1] = serialized_session_state[1];
         tampered_session_state[2] = serialized_session_state[2] - 1;
         /* Skip 1 byte of the session ticket and copy the rest */
-        memcpy(tampered_session_state + 3, serialized_session_state + 4, sizeof(tampered_session_state) - 4);
+        EXPECT_MEMCPY_SUCCESS(tampered_session_state + 3, serialized_session_state + 4, sizeof(tampered_session_state) - 4);
 
         /* Set client tampered ST and session state */
         EXPECT_SUCCESS(s2n_connection_set_session(client_conn, tampered_session_state, serialized_session_state_length - 1));

--- a/tests/unit/s2n_tls_hybrid_prf_test.c
+++ b/tests/unit/s2n_tls_hybrid_prf_test.c
@@ -105,12 +105,12 @@ int main(int argc, char **argv)
         s2n_stuffer_write(&combined_stuffer, &classic_pms);
         s2n_stuffer_write(&combined_stuffer, &kem_pms);
 
-        memcpy(conn->secure.client_random, client_random, CLIENT_RANDOM_LENGTH);
-        memcpy(conn->secure.server_random, server_random, SERVER_RANDOM_LENGTH);
+        EXPECT_MEMCPY_SUCCESS(conn->secure.client_random, client_random, CLIENT_RANDOM_LENGTH);
+        EXPECT_MEMCPY_SUCCESS(conn->secure.server_random, server_random, SERVER_RANDOM_LENGTH);
 
         EXPECT_SUCCESS(s2n_alloc(&conn->secure.client_key_exchange_message, client_key_exchange_message_length));
 
-        memcpy(conn->secure.client_key_exchange_message.data, client_key_exchange_message, client_key_exchange_message_length);
+        EXPECT_MEMCPY_SUCCESS(conn->secure.client_key_exchange_message.data, client_key_exchange_message, client_key_exchange_message_length);
 
         EXPECT_SUCCESS(s2n_hybrid_prf_master_secret(conn, &combined_pms));
         EXPECT_BYTEARRAY_EQUAL(expected_master_secret, conn->secure.master_secret, S2N_TLS_SECRET_LEN);


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 

 resolves https://github.com/awslabs/s2n/issues/1824

**Description of changes:** 

- Define a new, testing-specific memcpy_check() macro called EXPECT_MEMCPY_SUCCESS  that fails the test instead of returning -1 as memcpy_check() does.
- Replaces the use of memcpy() in tests with the new macro.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
