### PR TITLE
Fixes s2n_sidetrail build failure on Codebuild

### DIFF
--- a/codebuild/spec/buildspec_sidetrail.yml
+++ b/codebuild/spec/buildspec_sidetrail.yml
@@ -20,7 +20,6 @@ phases:
     commands:
       - echo Entered the install phase...
       - apt-key list
-      - apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 6B05F25D762E3157
       - add-apt-repository ppa:ubuntu-toolchain-r/test -y
       - apt-get update -o Acquire::CompressionTypes::Order::=gz
       - apt-get update -y


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 

Fixes sidetrail CodeBuild failure:
```
gpg: requesting key 762E3157 from hkp server keyserver.ubuntu.com
gpgkeys: key 6B05F25D762E3157 can't be retrieved
gpg: no valid OpenPGP data found.
gpg: Total number processed: 0
[Container] 2020/04/30 21:11:00 Command did not exit successfully apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 6B05F25D762E3157 exit status 2
[Container] 2020/04/30 21:11:00 Phase complete: INSTALL State: FAILED 
```

This line is not required in this build file, and was cleaned up in other build config files earlier. 

**Description of changes:** 



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
