### PR TITLE
Allow cbmc-batch.yaml to be clobbered at CI time

### DIFF
--- a/tests/cbmc/proofs/Makefile.common
+++ b/tests/cbmc/proofs/Makefile.common
@@ -96,12 +96,10 @@ LOG_FROM_GOTO = $(patsubst $(GOTODIR)%,$(LOGDIR)%,$(1:.goto=.log))
 CBMCFLAGS += --bounds-check
 CBMCFLAGS += --conversion-check
 CBMCFLAGS += --div-by-zero-check
-CBMCFLAGS += --enum-range-check
 CBMCFLAGS += --float-overflow-check
 CBMCFLAGS += --nan-check
 CBMCFLAGS += --pointer-check
 CBMCFLAGS += --pointer-overflow-check
-CBMCFLAGS += --pointer-primitive-check
 CBMCFLAGS += --signed-overflow-check
 CBMCFLAGS += --undefined-shift-check
 CBMCFLAGS += --unsigned-overflow-check

--- a/tests/cbmc/proofs/prepare.py
+++ b/tests/cbmc/proofs/prepare.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+#
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The CBMC CI system, at https://github.com/awslabs/aws-batch-cbmc, runs
+# this program as part of preparing the source code. This program runs
+# before any proof is built.
+
+
+import logging
+import os
+import subprocess
+import sys
+
+
+def main():
+    # Unconditionally rebuild the cbmc-batch.yaml file for every proof in
+    # the source tree, so that the CI parameters for each proof are updated
+    # before the proof is run.
+    cmd = ["make", "-B", "cbmc-batch.yaml"]
+    ok = True
+    for root, _, fyles in os.walk("."):
+        if "cbmc-batch.yaml" in fyles:
+            proc = subprocess.run(cmd, cwd=root)
+            if proc.returncode:
+                ok = False
+                logging.error(
+                    "Failed to build cbmc-batch.yaml in %s (return code %d)",
+                    root, proc.returncode)
+
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/cbmc/proofs/s2n_stuffer_alloc/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;6"
-expected: "SUCCESSFUL"
-goto: gotos/s2n_stuffer_alloc_harness.goto
-jobos: ubuntu16
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_copy/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_copy/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;6"
-expected: "SUCCESSFUL"
-goto: gotos/s2n_stuffer_copy_harness.goto
-jobos: ubuntu16
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_erase_and_read/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_erase_and_read/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;6"
-expected: "SUCCESSFUL"
-goto: gotos/s2n_stuffer_erase_and_read_harness.goto
-jobos: ubuntu16
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_erase_and_read_bytes/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_erase_and_read_bytes/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;6"
-expected: "SUCCESSFUL"
-goto: gotos/s2n_stuffer_erase_and_read_bytes_harness.goto
-jobos: ubuntu16
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_free/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_free/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
-expected: "SUCCESSFUL"
-goto: gotos/s2n_stuffer_free_harness.goto
-jobos: ubuntu16
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_init/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_init/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
-expected: "SUCCESSFUL"
-goto: gotos/s2n_stuffer_init_harness.goto
-jobos: ubuntu16
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_raw_read/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_raw_read/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
-expected: "SUCCESSFUL"
-goto: gotos/s2n_stuffer_raw_read_harness.goto
-jobos: ubuntu16
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_raw_read/s2n_stuffer_raw_read_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_raw_read/s2n_stuffer_raw_read_harness.c
@@ -14,6 +14,7 @@
  */
 
 #include "api/s2n.h"
+#include "error/s2n_errno.h"
 #include "stuffer/s2n_stuffer.h"
 #include <assert.h>
 #include <cbmc_proof/proof_allocators.h>
@@ -31,7 +32,7 @@ void s2n_stuffer_raw_read_harness() {
     void *result = s2n_stuffer_raw_read(stuffer, size);
     if (result) {
         assert(stuffer->tainted == 1);
-        assert(__CPROVER_r_ok(result, size));
+        assert(S2N_MEM_IS_READABLE(result, size));
         assert(stuffer->read_cursor == old_stuffer.read_cursor + size);
     } else {
         assert(stuffer->read_cursor == old_stuffer.read_cursor);

--- a/tests/cbmc/proofs/s2n_stuffer_read/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_read/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;6"
-expected: "SUCCESSFUL"
-goto: gotos/s2n_stuffer_read_harness.goto
-jobos: ubuntu16
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_read_bytes/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_read_bytes/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;6"
-expected: "SUCCESSFUL"
-goto: gotos/s2n_stuffer_read_bytes_harness.goto
-jobos: ubuntu16
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_reread/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_reread/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
-expected: "SUCCESSFUL"
-goto: gotos/s2n_stuffer_reread_harness.goto
-jobos: ubuntu16
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_skip_read/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_read/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;6"
-expected: "SUCCESSFUL"
-goto: gotos/s2n_stuffer_skip_read_harness.goto
-jobos: ubuntu16
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_wipe/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_wipe/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
-expected: "SUCCESSFUL"
-goto: gotos/s2n_stuffer_wipe_harness.goto
-jobos: ubuntu16
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_wipe_n/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_wipe_n/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
-expected: "SUCCESSFUL"
-goto: gotos/s2n_stuffer_wipe_n_harness.goto
-jobos: ubuntu16
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.


### PR DESCRIPTION
This commit replaces all cbmc-batch.yaml files with a
syntactically-incorrect YAML document. It also adds a script,
prepare.py, which is recognized by the CBMC CI system and which will be
executed before running any of the proofs. prepare.py replaces all of
the malformed YAML files with the CI parameters, which are specified in
each proof's Makefile.

This commit is intended to prevent YAML files from becoming stale with
respect to the Makefile. The source-of-truth for CI parameters is in the
Makefile, but it is possible to update the Makefile and forget to update
the YAML files. By unconditionally regenerating the YAML files on every
CI run, we guarantee that the YAML files contain up-to-date information
from the Makefile. We are still committing the YAML files, even though
they are generated, because the CBMC CI system identifies proof
directories as those containing cbmc-batch.yaml files.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
