### PR TITLE
Fix the s2n_stuffer_wipe_n proof to work with the new flags

### DIFF
--- a/error/s2n_errno.h
+++ b/error/s2n_errno.h
@@ -275,8 +275,8 @@ extern __thread const char *s2n_debug_str;
  * Violations of the function contracts are undefined behaviour.
  */
 #ifdef CBMC
-#    define S2N_MEM_IS_READABLE(base, len) __CPROVER_r_ok((base), (len))
-#    define S2N_MEM_IS_WRITABLE(base, len) __CPROVER_w_ok((base), (len))
+#    define S2N_MEM_IS_READABLE(base, len) (((len) == 0) || __CPROVER_r_ok((base), (len)))
+#    define S2N_MEM_IS_WRITABLE(base, len) (((len) == 0) || __CPROVER_w_ok((base), (len)))
 #else
 /* the C runtime does not give a way to check these properties,
  * but we can at least check that the pointer is valid */

--- a/tests/cbmc/proofs/s2n_stuffer_wipe_n/s2n_stuffer_wipe_n_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_wipe_n/s2n_stuffer_wipe_n_harness.c
@@ -21,7 +21,7 @@
 
 void s2n_stuffer_wipe_n_harness() {
   struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
-  int n;
+  uint32_t n;
 
   __CPROVER_assume( s2n_stuffer_is_valid(stuffer) );
 

--- a/utils/s2n_blob.c
+++ b/utils/s2n_blob.c
@@ -25,14 +25,13 @@
 
 bool s2n_blob_is_valid(const struct s2n_blob* b)
 {
-
     return
         b != NULL &&
         S2N_OBJECT_PTR_IS_READABLE(b) &&
-        S2N_MEM_IS_READABLE(b->data,b->size) &&
         S2N_IMPLIES(!b->growable, b->allocated == 0) &&
+        S2N_IMPLIES(b->growable, b->size <= b->allocated) &&
         S2N_IMPLIES(b->growable, S2N_MEM_IS_READABLE(b->data, b->allocated)) &&
-        S2N_IMPLIES(b->growable, b->size <= b->allocated);
+        S2N_MEM_IS_READABLE(b->data,b->size);
 }
 
 int s2n_blob_init(struct s2n_blob *b, uint8_t * data, uint32_t size)


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 

**Description of changes:** 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
