### PR TITLE
Fix extension size bug

### DIFF
--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -21,14 +21,15 @@
 
 #include "utils/s2n_blob.h"
 
+typedef uint32_t s2n_stuffer_cursor_t;
 struct s2n_stuffer {
     /* The data for the s2n_stuffer */
     struct s2n_blob blob;
 
     /* Cursors to the current read/write position in the s2n_stuffer */
-    uint32_t read_cursor;
-    uint32_t write_cursor;
-    uint32_t high_water_mark;
+    s2n_stuffer_cursor_t read_cursor;
+    s2n_stuffer_cursor_t write_cursor;
+    s2n_stuffer_cursor_t high_water_mark;
 
     /* Was this stuffer alloc()'d ? */
     unsigned int alloced:1;
@@ -96,6 +97,10 @@ extern int s2n_stuffer_write_uint16(struct s2n_stuffer *stuffer, const uint16_t 
 extern int s2n_stuffer_write_uint24(struct s2n_stuffer *stuffer, const uint32_t u);
 extern int s2n_stuffer_write_uint32(struct s2n_stuffer *stuffer, const uint32_t u);
 extern int s2n_stuffer_write_uint64(struct s2n_stuffer *stuffer, const uint64_t u);
+
+/* Write vector lengths in network order */
+extern int s2n_stuffer_start_vector(struct s2n_stuffer *stuffer, s2n_stuffer_cursor_t *vector_cursor, const uint8_t bytes_for_length);
+extern int s2n_stuffer_end_vector(struct s2n_stuffer *stuffer, const s2n_stuffer_cursor_t vector_cursor, const uint8_t bytes_for_length);
 
 /* Copy one stuffer to another */
 extern int s2n_stuffer_copy(struct s2n_stuffer *from, struct s2n_stuffer *to, uint32_t len);

--- a/tls/extensions/s2n_extension_type.c
+++ b/tls/extensions/s2n_extension_type.c
@@ -99,13 +99,12 @@ int s2n_extension_send(const s2n_extension_type *extension_type, struct s2n_conn
 
     GUARD(s2n_stuffer_write_uint16(out, extension_type->iana_value));
 
-    struct s2n_stuffer size_stuffer = *out;
-    GUARD(s2n_stuffer_skip_write(out, TLS_EXTENSION_DATA_LENGTH_BYTES));
+    s2n_stuffer_cursor_t extension_start_cursor;
+    GUARD(s2n_stuffer_start_vector(out, &extension_start_cursor, TLS_EXTENSION_DATA_LENGTH_BYTES));
 
     GUARD(extension_type->send(conn, out));
 
-    GUARD(s2n_stuffer_write_uint16(&size_stuffer,
-            s2n_stuffer_data_available(out) - s2n_stuffer_data_available(&size_stuffer) - TLS_EXTENSION_DATA_LENGTH_BYTES));
+    GUARD(s2n_stuffer_end_vector(out, extension_start_cursor, TLS_EXTENSION_DATA_LENGTH_BYTES));
 
     /* Set request bit flag */
     if (!extension_type->is_response) {


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 

**Description of changes:** 
As part of the extensions refactor, I want to remove the repetitive logic of calculating the length of an extension before writing it. However, my current solution to that problem does not work if the output stuffer resizes (which it probably will).

If a stuffer resizes, it no longer has the same underlying memory location. s2n_stuffer_raw_write handles this by marking the stuffer "tainted", preventing any more writes and therefore any resizes. But the logic I used for extensions doesn't handle it at all, and the "tainted" flag won't work for the vector model because we need to keep writing to the stuffer.

Here, I add two new stuffer methods to handle the common case of needing to write the length before a vector of unknown size. I avoid the resize problem by storing a cursor location instead of a direct memory location.

I used the existing s2n_stuffer_write_uintX() functions to keep the change small, but I could rewrite all those functions to use a common s2n_stuffer_write_network_order() function if we want to go that direction.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
