### PR TITLE
Fix memory leak in session ticket resumption

### DIFF
--- a/tests/unit/s2n_blob_test.c
+++ b/tests/unit/s2n_blob_test.c
@@ -69,27 +69,36 @@ int main(int argc, char **argv)
     EXPECT_TRUE(s2n_blob_is_growable(&g4));
     EXPECT_SUCCESS(s2n_free(&g4));
 
-    /* Alloced blob can be realloced */
+    /* Alloced blob can be realloced and data preserved */
     struct s2n_blob g5 = {0};
+    uint8_t hello_world[] = "HELLO WORLD";
     EXPECT_SUCCESS(s2n_alloc(&g5, 12));
     EXPECT_TRUE(s2n_blob_is_growable(&g5));
+    memcpy(g5.data, hello_world, sizeof(hello_world));
     EXPECT_SUCCESS(s2n_realloc(&g5, 24));
+    EXPECT_EQUAL(memcmp(g5.data, hello_world, sizeof(hello_world)), 0);
     EXPECT_SUCCESS(s2n_free(&g5));
 
-    /* Down-casing works */
+    /* Alloced blob can be reallocated without leaking memory */
     struct s2n_blob g6 = {0};
-    uint8_t hello_world[] = "HELLO WORLD";
-    EXPECT_SUCCESS(s2n_blob_init(&g6, hello_world, sizeof(hello_world)));
-    EXPECT_SUCCESS(s2n_blob_char_to_lower(&g6));
-    EXPECT_SUCCESS(memcmp(g6.data, "hello world", sizeof(hello_world)));
+    EXPECT_SUCCESS(s2n_alloc(&g6, 12));
+    g6.size = 0;
+    EXPECT_SUCCESS(s2n_realloc(&g6, g6.allocated + 12));
+    EXPECT_SUCCESS(s2n_free(&g6));
+
+    /* Down-casing works */
+    struct s2n_blob g7 = {0};
+    EXPECT_SUCCESS(s2n_blob_init(&g7, hello_world, sizeof(hello_world)));
+    EXPECT_SUCCESS(s2n_blob_char_to_lower(&g7));
+    EXPECT_SUCCESS(memcmp(g7.data, "hello world", sizeof(hello_world)));
 
     /* Slicing works */
-    struct s2n_blob g7 = {0};
+    struct s2n_blob g8 = {0};
     uint8_t hello[] = "hello ";
     uint8_t world[] = "world";
-    EXPECT_SUCCESS(s2n_blob_slice(&g6, &g7, strlen((char *) hello), sizeof(world)));
-    EXPECT_EQUAL(memcmp(g7.data, world, sizeof(world)), 0);
-    EXPECT_EQUAL(g7.size, sizeof(world));
+    EXPECT_SUCCESS(s2n_blob_slice(&g7, &g8, strlen((char *) hello), sizeof(world)));
+    EXPECT_EQUAL(memcmp(g8.data, world, sizeof(world)), 0);
+    EXPECT_EQUAL(g8.size, sizeof(world));
 
     END_TEST();
 }

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -166,7 +166,7 @@ static int s2n_server_hello_parse(struct s2n_connection *conn)
             memset_check((uint8_t *)conn->secure.master_secret, 0, S2N_TLS_SECRET_LEN);
 
             /* Erase client session ticket which might have been set for session resumption */
-            conn->client_ticket.size = 0;
+            GUARD(s2n_free(&conn->client_ticket));
         }
     }
 

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -184,6 +184,9 @@ int s2n_realloc(struct s2n_blob *b, uint32_t size)
 
     if (b->size) {
         memcpy_check(new_memory.data, b->data, b->size);
+    }
+
+    if (b->allocated) {
         GUARD(s2n_free(b));
     }
 


### PR DESCRIPTION
Previously when we received ServerHello and session wasn't resumed, we set the conn->client_ticket.size to 0 instead of freeing the blob, later we reused this blob through calling s2n_realloc on it, which previously looked on size field instead of allocated to figure if blob needs to be released, causing memory leak.

This change fixes s2n_realloc and uses s2n_free on client_ticket instead of setting blob size to 0 directly, as the rest of codebase doesn't seem to follow this pattern.

_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 

**Description of changes:** 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
