### PR TITLE
Add dynamic record size test.

### DIFF
--- a/tests/integrationv2/fixtures.py
+++ b/tests/integrationv2/fixtures.py
@@ -1,6 +1,9 @@
-import time
+import os
 import pytest
+import subprocess
 import threading
+import time
+
 from processes import ManagedProcess
 from providers import Provider
 from common import ProviderOptions
@@ -11,19 +14,28 @@ def managed_process():
     """
     Generic process manager. This could be used to launch any process as a background
     task and cleanup when finished.
+
+    The reason a fixture is used, instead of creating a ManagedProcess() directly
+    from the test, is to control the life of the process. Using the fixture
+    allows cleanup after a test, even if a failure occurred.
     """
     processes = []
 
     def _fn(provider_class: Provider, options: ProviderOptions, timeout=5):
         provider = provider_class(options)
         cmd_line = provider.get_cmd_line()
-        p = ManagedProcess(cmd_line, provider.set_provider_ready, ready_to_send=provider.ready_to_send_marker, data_source=options.data_to_send, timeout=timeout)
+        p = ManagedProcess(cmd_line,
+                provider.set_provider_ready,
+                wait_for_marker=provider.ready_to_test,
+                ready_to_send=provider.ready_to_send_marker,
+                data_source=options.data_to_send,
+                timeout=timeout)
 
         processes.append(p)
         with p.ready_condition:
             p.start()
             with provider._provider_ready_condition:
-                provider._provider_ready_condition.wait_for(provider.is_provider_ready, 1)
+                provider._provider_ready_condition.wait_for(provider.is_provider_ready, timeout)
         return p
 
     try:
@@ -36,3 +48,43 @@ def managed_process():
         # Whether the processes succeeded or not, clean then up.
         for p in processes:
             p.join()
+
+
+def _swap_mtu(device, new_mtu):
+    """
+    Swap the device's current MTU for the requested MTU.
+    Return the original MTU so it can be reset later.
+    """
+    cmd = ["ip", "link", "show", device]
+    p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    mtu = 65536
+    for line in p.stdout.readlines():
+        s = line.decode("utf-8")
+        pieces = s.split(' ')
+        if len(pieces) >= 4 and pieces[3] == 'mtu':
+            mtu = int(pieces[4])
+
+    p.wait()
+
+    subprocess.call(["ip", "link", "set", device, "mtu", str(new_mtu)])
+
+    return int(mtu)
+
+
+@pytest.fixture(scope='module')
+def custom_mtu():
+    """
+    This fixture will swap the loopback's MTU from the default
+    to 1500, which is more reasonable for a network device.
+    Using a fixture allows us to reset the MTU even if the test
+    fails.
+
+    These values are all hardcoded because they are only used
+    from a single test. This simplifies the use of the fixture.
+    """
+    if os.geteuid() != 0:
+        pytest.skip("Test needs root privileges to modify lo MTU")
+
+    original_mtu = _swap_mtu('lo', 1500)
+    yield
+    _swap_mtu('lo', original_mtu)

--- a/tests/integrationv2/processes.py
+++ b/tests/integrationv2/processes.py
@@ -1,4 +1,3 @@
-import io
 import os
 import select
 import selectors

--- a/tests/integrationv2/test_dynamic_record_sizes.py
+++ b/tests/integrationv2/test_dynamic_record_sizes.py
@@ -1,0 +1,75 @@
+import copy
+import os
+import pytest
+import subprocess
+import time
+
+from configuration import available_ports, CIPHERSUITES, CURVES, PROVIDERS
+from common import ProviderOptions, data_bytes
+from fixtures import managed_process, custom_mtu
+from providers import S2N, OpenSSL, Tcpdump
+
+
+def find_fragmented_packet(results):
+    """
+    This function searches Tcpdump's standard output and looks for packets
+    that have a length larger than the MTU(hardcoded to 1500) of the device.
+    """
+    for line in results.decode('utf-8').split('\n'):
+        pieces = line.split(' ')
+        if len(pieces) < 2:
+            continue
+
+        if pieces[-2] == 'length':
+            if int(pieces[-1]) > 1500:
+                return True
+
+    return False
+
+
+@pytest.mark.parametrize("cipher", CIPHERSUITES)
+@pytest.mark.parametrize("curve", CURVES)
+def test_s2n_client_dynamic_record(custom_mtu, managed_process, cipher, curve):
+    host = "localhost"
+    port = next(available_ports)
+
+    # 16384 bytes is enough to reliably get a packet that will exceed the MTU
+    bytes_to_send = data_bytes(16384)
+    client_options = ProviderOptions(
+        mode="client",
+        host="localhost",
+        port=port,
+        cipher=cipher,
+        data_to_send=bytes_to_send,
+        insecure=True,
+        tls13=True)
+
+    server_options = copy.copy(client_options)
+    server_options.data_to_send = None
+    server_options.mode = "server"
+    server_options.key = "../pems/ecdsa_p384_pkcs1_key.pem"
+    server_options.cert = "../pems/ecdsa_p384_pkcs1_cert.pem"
+
+    # This test shouldn't last longer than 5 seconds, even though
+    # Tcpdump tends to take a second to startup.
+    tcpdump = managed_process(Tcpdump, client_options, timeout=5)
+    server = managed_process(OpenSSL, server_options, timeout=5)
+    client = managed_process(S2N, client_options, timeout=5)
+
+    for results in client.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+        assert b"Actual protocol version: 34" in results.stdout
+
+    for results in server.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+
+    # The Tcpdump provider only captures 12 packets. This is enough
+    # to detect a packet larger than the MTU, but less than the
+    # total packets sent. This is important because it lets Tcpdump
+    # exit cleanly, which means all the output is available for us
+    # to examine.
+    for results in tcpdump.get_results():
+        assert results.exit_code == 0
+        assert find_fragmented_packet(results.stdout) is True


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
Fixes #1537 
Fixes #1838 

**Description of changes:**
Add a dynamic record size test. This test required a few other changes:

 * Add Tcpdump provider to monitor packets in the background.
 * Enable process stdout monitor to know when a process is ready
   to start working.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
