### PR TITLE
ci: Combined some tests under a new ENV variable - Part1

### DIFF
--- a/codebuild/bin/install_saw.sh
+++ b/codebuild/bin/install_saw.sh
@@ -28,6 +28,11 @@ fi
 DOWNLOAD_DIR=$1
 INSTALL_DIR=$2
 
+if [ -x "$INSTALL_DIR/bin/saw" ]; then
+	echo "Saw already installed at $INSTALL_DIR/bin/saw";
+	exit 0;
+fi
+
 mkdir -p "$DOWNLOAD_DIR"
 cd "$DOWNLOAD_DIR"
 

--- a/codebuild/bin/install_ubuntu_dependencies.sh
+++ b/codebuild/bin/install_ubuntu_dependencies.sh
@@ -18,10 +18,6 @@
 
 set -ex
 
-apt-key list
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 6B05F25D762E3157
-apt-key list
-
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 sudo apt-get update -o Acquire::CompressionTypes::Order::=gz
 

--- a/codebuild/bin/s2n_codebuild.sh
+++ b/codebuild/bin/s2n_codebuild.sh
@@ -63,16 +63,20 @@ if [[ "$OS_NAME" == "osx" && "$TESTS" == "integration" ]]; then
     scan-build --status-bugs -o /tmp/scan-build make -j$JOBS; STATUS=$?; test $STATUS -ne 0 && cat /tmp/scan-build/*/* ; [ "$STATUS" -eq "0" ];
 fi
 
+# Run Multiple tests on one flag.
+if [[ "$TESTS" == "ALL" || "$TESTS" == "sawHMACPlus" ]] && [[ "$OS_NAME" == "linux" ]]; then make -C tests/saw tmp/verify_HMAC.log tmp/verify_drbg.log sike failure-tests; fi
+
+# Run Individual tests
 if [[ "$TESTS" == "ALL" || "$TESTS" == "asan" ]]; then make clean; S2N_ADDRESS_SANITIZER=1 make -j $JOBS ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "integration" ]]; then make clean; make integration ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "integrationv2" ]]; then make clean; make integrationv2 ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "fuzz" ]]; then (make clean && make fuzz) ; fi
-if [[ "$TESTS" == "ALL" || "$TESTS" == "sawHMAC" ]] && [[ "$OS_NAME" == "linux" ]]; then make -C tests/saw/ tmp/verify_HMAC.log ; fi
-if [[ "$TESTS" == "ALL" || "$TESTS" == "sawDRBG" ]]; then make -C tests/saw tmp/verify_drbg.log ; fi
+if [[ "$TESTS" == "sawHMAC" ]] && [[ "$OS_NAME" == "linux" ]]; then make -C tests/saw/ tmp/verify_HMAC.log ; fi
+if [[ "$TESTS" == "sawDRBG" ]]; then make -C tests/saw tmp/verify_drbg.log ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "tls" ]]; then make -C tests/saw tmp/verify_handshake.log ; fi
-if [[ "$TESTS" == "ALL" || "$TESTS" == "sawHMACFailure" ]]; then make -C tests/saw failure-tests ; fi
+if [[ "$TESTS" == "sawHMACFailure" ]]; then make -C tests/saw failure-tests ; fi
 # Below runs sike r_1 r_2 and x86
-if [[ "$TESTS" == "ALL" || "$TESTS" == "sawSIKE" ]]; then make -C tests/saw sike ; fi
+if [[ "$TESTS" == "sawSIKE" ]]; then make -C tests/saw sike ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "sawBIKE" ]]; then make -C tests/saw bike ; fi
 
 # Generate *.gcov files that can be picked up by the CodeCov.io Bash helper script. Don't run lcov or genhtml 

--- a/codebuild/codebuild.config
+++ b/codebuild/codebuild.config
@@ -74,17 +74,9 @@ snippet: UbuntuBoilerplate2XL
 env: S2N_LIBCRYPTO=openssl-1.0.2-fips BUILD_S2N=true TESTS=valgrind GCC_VERSION=6
 
 # SAW tests
-[CodeBuild:s2nSawHmac]
-snippet: UbuntuBoilerplate2XL
-env: TESTS=sawHMAC SAW=true GCC_VERSION=NONE
-
-[CodeBuild:s2nSawDrbg]
-snippet: UbuntuBoilerplate2XL
-env: TESTS=sawDRBG SAW=true GCC_VERSION=NONE
-
-[CodeBuild:s2nSawSike]
-snippet: UbuntuBoilerplate2XL
-env: TESTS=sawSIKE SAW=true GCC_VERSION=NONE
+[CodeBuild:s2nSawHmacPlus]
+snippet: UbuntuBoilerplateLarge
+env: TESTS=sawHMACPlus SAW=true GCC_VERSION=NONE
 
 [CodeBuild:s2nSawBike]
 snippet: UbuntuBoilerplate2XL
@@ -93,10 +85,6 @@ env: TESTS=sawBIKE SAW=true GCC_VERSION=NONE S2N_LIBCRYPTO=openssl-1.0.2
 [CodeBuild:s2nSawTls]
 snippet: UbuntuBoilerplate2XL
 env: TESTS=tls SAW=true GCC_VERSION=NONE
-
-[CodeBuild:s2nSawHmacFailure]
-snippet: UbuntuBoilerplate2XL
-env: TESTS=sawHMACFailure SAW=true
 
 # Sidetrail - Run both tests in one job
 [CodeBuild:s2nSidetrail]


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
#1854 

**Description of changes:** 
Run four tests (sawHMAC, sawDRBG, sawSike, sawHMACFailure) under one flag/CodeBuild job.
This is being done to free up some webhooks.
The original flags for these tests still exist, so one-off runs can still be performed locally.

Once merged, the above CodeBuild jobs will be cleaned up by a CloudFormation run.

Testing on my fork, the runtime for SawHMAC job went from 6 minutes to 11 minutes (with all 4 tests).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
