### PR TITLE
Do not include features.h on MACs

### DIFF
--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -14,7 +14,9 @@
  */
 
 #define  _DEFAULT_SOURCE 1
+#if !defined(__APPLE__)
 #include <features.h>
+#endif
 
 #include <stdint.h>
 #include <unistd.h>


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
```
s2n_mem.c:17:10: fatal error: 'features.h' file not found
#include <features.h>
         ^~~~~~~~~~~~
```
**Description of changes:** 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
