### PR TITLE
Implements abstracted send/recv functions for KEM public keys and ciphertexts

### DIFF
--- a/tests/fuzz/s2n_bike_r1_fuzz_test.c
+++ b/tests/fuzz/s2n_bike_r1_fuzz_test.c
@@ -28,11 +28,11 @@
 /* This fuzz test uses the first private key from tests/unit/kats/bike_r1.kat, the valid ciphertext generated with the
  * public key was copied to corpus/s2n_bike_r1_fuzz_test/valid_ciphertext */
 
-static struct s2n_kem_keypair server_kem_keys = {.negotiated_kem = &s2n_bike1_l1_r1};
+static struct s2n_kem_params server_kem_params = {.kem = &s2n_bike1_l1_r1};
 
 static void s2n_fuzz_atexit()
 {
-    s2n_free(&server_kem_keys.private_key);
+    s2n_free(&server_kem_params.private_key);
     s2n_cleanup();
 }
 
@@ -41,11 +41,11 @@ int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
     GUARD(s2n_init());
     GUARD_STRICT(atexit(s2n_fuzz_atexit));
 
-    GUARD(s2n_alloc(&server_kem_keys.private_key, s2n_bike1_l1_r1.private_key_length));
+    GUARD(s2n_alloc(&server_kem_params.private_key, s2n_bike1_l1_r1.private_key_length));
 
     FILE *kat_file = fopen(RSP_FILE_NAME, "r");
     notnull_check(kat_file);
-    GUARD(ReadHex(kat_file, server_kem_keys.private_key.data, s2n_bike1_l1_r1.private_key_length, "sk = "));
+    GUARD(ReadHex(kat_file, server_kem_params.private_key.data, s2n_bike1_l1_r1.private_key_length, "sk = "));
 
     fclose(kat_file);
 
@@ -62,7 +62,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     memcpy_check(ciphertext.data, buf, len);
 
     /* Run the test, don't use GUARD since the memory needs to be cleaned up and decapsulate will most likely fail */
-    s2n_kem_decapsulate(&server_kem_keys, &server_shared_secret, &ciphertext);
+    s2n_kem_decapsulate(&server_kem_params, &server_shared_secret, &ciphertext);
 
     GUARD(s2n_free(&ciphertext));
 

--- a/tests/fuzz/s2n_bike_r2_fuzz_test.c
+++ b/tests/fuzz/s2n_bike_r2_fuzz_test.c
@@ -32,7 +32,7 @@ static struct s2n_kem_params server_kem_params = {.kem = &s2n_bike1_l1_r2};
 
 static void s2n_fuzz_atexit()
 {
-    s2n_free(&server_kem_params.private_key);
+    s2n_kem_free(&server_kem_params);
     s2n_cleanup();
 }
 
@@ -54,7 +54,6 @@ int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
 
 int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
 {
-    struct s2n_blob server_shared_secret = {0};
     struct s2n_blob ciphertext = {0};
     GUARD(s2n_alloc(&ciphertext, len));
 
@@ -62,13 +61,13 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     memcpy_check(ciphertext.data, buf, len);
 
     /* Run the test, don't use GUARD since the memory needs to be cleaned up and decapsulate will most likely fail */
-    s2n_kem_decapsulate(&server_kem_params, &server_shared_secret, &ciphertext);
+    s2n_kem_decapsulate(&server_kem_params, &ciphertext);
 
     GUARD(s2n_free(&ciphertext));
 
     /* The above s2n_kem_decapsulate could fail before ever allocating the server_shared_secret */
-    if (server_shared_secret.allocated) {
-        GUARD(s2n_free(&server_shared_secret));
+    if (server_kem_params.shared_secret.allocated) {
+        GUARD(s2n_free(&(server_kem_params.shared_secret)));
     }
     return 0;
 }

--- a/tests/fuzz/s2n_bike_r2_fuzz_test.c
+++ b/tests/fuzz/s2n_bike_r2_fuzz_test.c
@@ -28,11 +28,11 @@
 /* This fuzz test uses the first private key from tests/unit/kats/bike_r2.kat, the valid ciphertext generated with the
  * public key was copied to corpus/s2n_bike_r2_fuzz_test/valid_ciphertext */
 
-static struct s2n_kem_keypair server_kem_keys = {.negotiated_kem = &s2n_bike1_l1_r2};
+static struct s2n_kem_params server_kem_params = {.kem = &s2n_bike1_l1_r2};
 
 static void s2n_fuzz_atexit()
 {
-    s2n_free(&server_kem_keys.private_key);
+    s2n_free(&server_kem_params.private_key);
     s2n_cleanup();
 }
 
@@ -41,11 +41,11 @@ int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
     GUARD(s2n_init());
     GUARD_STRICT(atexit(s2n_fuzz_atexit));
 
-    GUARD(s2n_alloc(&server_kem_keys.private_key, s2n_bike1_l1_r2.private_key_length));
+    GUARD(s2n_alloc(&server_kem_params.private_key, s2n_bike1_l1_r2.private_key_length));
 
     FILE *kat_file = fopen(RSP_FILE_NAME, "r");
     notnull_check(kat_file);
-    GUARD(ReadHex(kat_file, server_kem_keys.private_key.data, s2n_bike1_l1_r2.private_key_length, "sk = "));
+    GUARD(ReadHex(kat_file, server_kem_params.private_key.data, s2n_bike1_l1_r2.private_key_length, "sk = "));
 
     fclose(kat_file);
 
@@ -62,7 +62,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     memcpy_check(ciphertext.data, buf, len);
 
     /* Run the test, don't use GUARD since the memory needs to be cleaned up and decapsulate will most likely fail */
-    s2n_kem_decapsulate(&server_kem_keys, &server_shared_secret, &ciphertext);
+    s2n_kem_decapsulate(&server_kem_params, &server_shared_secret, &ciphertext);
 
     GUARD(s2n_free(&ciphertext));
 

--- a/tests/fuzz/s2n_client_key_recv_fuzz_test.c
+++ b/tests/fuzz/s2n_client_key_recv_fuzz_test.c
@@ -209,7 +209,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     }
 
     if (server_conn->secure.cipher_suite->key_exchange_alg->client_key_recv == s2n_kem_client_key_recv || server_conn->secure.cipher_suite->key_exchange_alg->client_key_recv == s2n_hybrid_client_key_recv) {
-        server_conn->secure.s2n_kem_keys.negotiated_kem = &s2n_sike_p503_r1;
+        server_conn->secure.kem_params.kem = &s2n_sike_p503_r1;
     }
 
     /* Run Test

--- a/tests/fuzz/s2n_hybrid_ecdhe_bike_r1_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_bike_r1_fuzz_test.c
@@ -35,7 +35,7 @@
 #include "tls/s2n_cipher_suites.h"
 #include "tls/s2n_security_policies.h"
 
-static struct s2n_kem_keypair server_kem_keys = {.negotiated_kem = &s2n_bike1_l1_r1};
+static struct s2n_kem_params server_kem_params = {.kem = &s2n_bike1_l1_r1};
 
 /* Setup the connection in a state for a fuzz test run, s2n_client_key_recv modifies the state of the connection
  * along the way and gets cleaned up at the end of each fuzz test.
@@ -54,11 +54,11 @@ static int setup_connection(struct s2n_connection *server_conn)
 
     server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
     server_conn->secure.server_ecc_evp_params.evp_pkey = NULL;
-    server_conn->secure.s2n_kem_keys.negotiated_kem = &s2n_bike1_l1_r1;
+    server_conn->secure.kem_params.kem = &s2n_bike1_l1_r1;
     server_conn->secure.cipher_suite = &s2n_ecdhe_bike_rsa_with_aes_256_gcm_sha384;
     server_conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
 
-    GUARD(s2n_dup(&server_kem_keys.private_key, &server_conn->secure.s2n_kem_keys.private_key));
+    GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->secure.kem_params.private_key));
     GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.server_ecc_evp_params));
 
     return 0;
@@ -67,7 +67,7 @@ static int setup_connection(struct s2n_connection *server_conn)
 static void s2n_fuzz_atexit()
 {
     s2n_cleanup();
-    s2n_kem_free(&server_kem_keys);
+    s2n_kem_free(&server_kem_params);
 }
 
 int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
@@ -75,9 +75,9 @@ int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
     GUARD(s2n_init());
     GUARD_STRICT(atexit(s2n_fuzz_atexit));
 
-    struct s2n_blob *public_key = &server_kem_keys.public_key;
+    struct s2n_blob *public_key = &server_kem_params.public_key;
     GUARD(s2n_alloc(public_key, BIKE1_L1_R1_PUBLIC_KEY_BYTES));
-    GUARD(s2n_kem_generate_keypair(&server_kem_keys));
+    GUARD(s2n_kem_generate_keypair(&server_kem_params));
     GUARD(s2n_free(public_key));
 
     return 0;

--- a/tests/fuzz/s2n_hybrid_ecdhe_bike_r2_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_bike_r2_fuzz_test.c
@@ -35,7 +35,7 @@
 #include "tls/s2n_security_policies.h"
 #include "pq-crypto/bike_r2/bike_r2_kem.h"
 
-static struct s2n_kem_keypair server_kem_keys = {.negotiated_kem = &s2n_bike1_l1_r2};
+static struct s2n_kem_params server_kem_params = {.kem = &s2n_bike1_l1_r2};
 
 /* Setup the connection in a state for a fuzz test run, s2n_client_key_recv modifies the state of the connection
  * along the way and gets cleaned up at the end of each fuzz test.
@@ -54,11 +54,11 @@ static int setup_connection(struct s2n_connection *server_conn)
 
     server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
     server_conn->secure.server_ecc_evp_params.evp_pkey = NULL;
-    server_conn->secure.s2n_kem_keys.negotiated_kem = &s2n_bike1_l1_r2;
+    server_conn->secure.kem_params.kem = &s2n_bike1_l1_r2;
     server_conn->secure.cipher_suite = &s2n_ecdhe_bike_rsa_with_aes_256_gcm_sha384;
     server_conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
 
-    GUARD(s2n_dup(&server_kem_keys.private_key, &server_conn->secure.s2n_kem_keys.private_key));
+    GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->secure.kem_params.private_key));
     GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.server_ecc_evp_params));
 
     return 0;
@@ -67,7 +67,7 @@ static int setup_connection(struct s2n_connection *server_conn)
 static void s2n_fuzz_atexit()
 {
     s2n_cleanup();
-    s2n_kem_free(&server_kem_keys);
+    s2n_kem_free(&server_kem_params);
 }
 
 int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
@@ -75,9 +75,9 @@ int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
     GUARD(s2n_init());
     GUARD_STRICT(atexit(s2n_fuzz_atexit));
 
-    struct s2n_blob *public_key = &server_kem_keys.public_key;
+    struct s2n_blob *public_key = &server_kem_params.public_key;
     GUARD(s2n_alloc(public_key, BIKE1_L1_R2_PUBLIC_KEY_BYTES));
-    GUARD(s2n_kem_generate_keypair(&server_kem_keys));
+    GUARD(s2n_kem_generate_keypair(&server_kem_params));
     GUARD(s2n_free(public_key));
 
     return 0;

--- a/tests/fuzz/s2n_hybrid_ecdhe_sike_r1_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_sike_r1_fuzz_test.c
@@ -35,7 +35,7 @@
 #include "tls/s2n_cipher_suites.h"
 #include "tls/s2n_security_policies.h"
 
-static struct s2n_kem_keypair server_kem_keys = {.negotiated_kem = &s2n_sike_p503_r1};
+static struct s2n_kem_params server_kem_params = {.kem = &s2n_sike_p503_r1};
 
 /* Setup the connection in a state for a fuzz test run, s2n_client_key_recv modifies the state of the connection
  * along the way and gets cleaned up at the end of each fuzz test.
@@ -54,11 +54,11 @@ static int setup_connection(struct s2n_connection *server_conn)
 
     server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
     server_conn->secure.server_ecc_evp_params.evp_pkey = NULL;
-    server_conn->secure.s2n_kem_keys.negotiated_kem = &s2n_sike_p503_r1;
+    server_conn->secure.kem_params.kem = &s2n_sike_p503_r1;
     server_conn->secure.cipher_suite = &s2n_ecdhe_sike_rsa_with_aes_256_gcm_sha384;
     server_conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
 
-    GUARD(s2n_dup(&server_kem_keys.private_key, &server_conn->secure.s2n_kem_keys.private_key));
+    GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->secure.kem_params.private_key));
     GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.server_ecc_evp_params));
 
     return 0;
@@ -67,7 +67,7 @@ static int setup_connection(struct s2n_connection *server_conn)
 static void s2n_fuzz_atexit()
 {
     s2n_cleanup();
-    s2n_kem_free(&server_kem_keys);
+    s2n_kem_free(&server_kem_params);
 }
 
 int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
@@ -75,9 +75,9 @@ int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
     GUARD(s2n_init());
     GUARD_STRICT(atexit(s2n_fuzz_atexit));
 
-    struct s2n_blob *public_key = &server_kem_keys.public_key;
+    struct s2n_blob *public_key = &server_kem_params.public_key;
     GUARD(s2n_alloc(public_key, SIKE_P503_R1_PUBLIC_KEY_BYTES));
-    GUARD(s2n_kem_generate_keypair(&server_kem_keys));
+    GUARD(s2n_kem_generate_keypair(&server_kem_params));
     GUARD(s2n_free(public_key));
 
     return 0;

--- a/tests/fuzz/s2n_hybrid_ecdhe_sike_r2_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_sike_r2_fuzz_test.c
@@ -35,7 +35,7 @@
 #include "tls/s2n_cipher_suites.h"
 #include "tls/s2n_security_policies.h"
 
-static struct s2n_kem_keypair server_kem_keys = {.negotiated_kem = &s2n_sike_p434_r2};
+static struct s2n_kem_params server_kem_params = {.kem = &s2n_sike_p434_r2};
 
 /* Setup the connection in a state for a fuzz test run, s2n_client_key_recv modifies the state of the connection
  * along the way and gets cleaned up at the end of each fuzz test.
@@ -54,11 +54,11 @@ static int setup_connection(struct s2n_connection *server_conn)
 
     server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
     server_conn->secure.server_ecc_evp_params.evp_pkey = NULL;
-    server_conn->secure.s2n_kem_keys.negotiated_kem = &s2n_sike_p434_r2;
+    server_conn->secure.kem_params.kem = &s2n_sike_p434_r2;
     server_conn->secure.cipher_suite = &s2n_ecdhe_sike_rsa_with_aes_256_gcm_sha384;
     server_conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
 
-    GUARD(s2n_dup(&server_kem_keys.private_key, &server_conn->secure.s2n_kem_keys.private_key));
+    GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->secure.kem_params.private_key));
     GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.server_ecc_evp_params));
 
     return 0;
@@ -67,7 +67,7 @@ static int setup_connection(struct s2n_connection *server_conn)
 static void s2n_fuzz_atexit()
 {
     s2n_cleanup();
-    s2n_kem_free(&server_kem_keys);
+    s2n_kem_free(&server_kem_params);
 }
 
 int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
@@ -75,9 +75,9 @@ int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
     GUARD(s2n_init());
     GUARD(atexit(s2n_fuzz_atexit));
 
-    struct s2n_blob *public_key = &server_kem_keys.public_key;
+    struct s2n_blob *public_key = &server_kem_params.public_key;
     GUARD(s2n_alloc(public_key, SIKE_P434_R2_PUBLIC_KEY_BYTES));
-    GUARD(s2n_kem_generate_keypair(&server_kem_keys));
+    GUARD(s2n_kem_generate_keypair(&server_kem_params));
     GUARD(s2n_free(public_key));
 
     return 0;

--- a/tests/fuzz/s2n_sike_r1_fuzz_test.c
+++ b/tests/fuzz/s2n_sike_r1_fuzz_test.c
@@ -30,7 +30,7 @@
  * ciphertext generated with the public key was copied to corpus/s2n_sike_r1_fuzz_test/valid_ciphertext */
 static const char valid_private_key[] = "7C9935A0B07694AA0C6D10E4DB6B1ADD2FD81A25CCB148038626ED79D451140800E03B59B956F8210E556067407D13DC90FA9E8B872BFB0F0999A0BB085F85FDA70D04B8FCAE5A30989947F1E32E4BC4675C834CA22CBA08AE692935EC1C8AF2B5BF377EC17E79D09D57DB5828C6F6E1C1A64D0F30AF3D2F76D9D329108E01D027D856EC44B23A437872D538F2C26E48723E2F8E46A2E7A364C92D997C7B801ADA199EEFFBAB1161B29EC7CB4440DA0E75407F4CE02E37BDFB23154C513BD30CFA5F04D2E253357CBDEBCF6F539965C8B8B5F350A50526AD1B350A0220394AA33B18EB3E765F059FA7CB5585A9D18C8B198A07DA0E9CCEC61D6F43A4661CA6D8175C23A8C86DD30409607D6EBFA3639CDFD12599F9BB073AAEA9A1CC95FF0D50839049EDFAE95FD10DD4F27EC3C6921FA96DCB0366D9C086A8E8ED15390C4827E5672D167EE238229B188C0590E1FA38E8A74D34B6D17ECA1A64EA76AD65413F147DC43A762D69D072DADF573C13A7C983F9362D59DC6E37704BA0F15637CF6BEDBBD8C1051366FE4C21E03CC55964C0E24F6F8D738DC763B7E443122C63751F6D8130EADA4203A9671865F8D459035EAC2E";
 
-static struct s2n_kem_keypair server_kem_keys = {.negotiated_kem = &s2n_sike_p503_r1};
+static struct s2n_kem_params server_kem_params = {.kem = &s2n_sike_p503_r1};
 static struct s2n_stuffer private_key_stuffer = {{0}};
 
 static void s2n_fuzz_atexit()
@@ -45,8 +45,8 @@ int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
     GUARD(s2n_stuffer_alloc_ro_from_hex_string(&private_key_stuffer, valid_private_key));
     GUARD_STRICT(atexit(s2n_fuzz_atexit));
 
-    server_kem_keys.private_key.size = s2n_sike_p503_r1.private_key_length;
-    server_kem_keys.private_key.data = s2n_stuffer_raw_read(&private_key_stuffer, s2n_sike_p503_r1.public_key_length);
+    server_kem_params.private_key.size = s2n_sike_p503_r1.private_key_length;
+    server_kem_params.private_key.data = s2n_stuffer_raw_read(&private_key_stuffer, s2n_sike_p503_r1.public_key_length);
     return 0;
 }
 
@@ -60,7 +60,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     memcpy_check(ciphertext.data, buf, len);
 
     /* Run the test, don't use GUARD since the memory needs to be cleaned up and decapsulate will most likely fail */
-    s2n_kem_decapsulate(&server_kem_keys, &server_shared_secret, &ciphertext);
+    s2n_kem_decapsulate(&server_kem_params, &server_shared_secret, &ciphertext);
 
     GUARD(s2n_free(&ciphertext));
 

--- a/tests/fuzz/s2n_sike_r1_fuzz_test.c
+++ b/tests/fuzz/s2n_sike_r1_fuzz_test.c
@@ -15,44 +15,45 @@
 
 /* Target Functions: s2n_kem_decapsulate SIKE_P503_r1_crypto_kem_dec */
 
-#include "stuffer/s2n_stuffer.h"
-
 #include "tests/s2n_test.h"
+#include "tests/testlib/s2n_nist_kats.h"
 #include "tests/testlib/s2n_testlib.h"
-
 #include "tls/s2n_kem.h"
-
 #include "utils/s2n_safety.h"
 #include "utils/s2n_mem.h"
 #include "utils/s2n_blob.h"
 
-/* This fuzz test uses the below private key which is the first key from tests/unit/kats/sike_r1.kat, the valid
+#define RSP_FILE_NAME "../unit/kats/sike_r1.kat"
+
+/* This fuzz test uses the the first key from tests/unit/kats/sike_r1.kat, the valid
  * ciphertext generated with the public key was copied to corpus/s2n_sike_r1_fuzz_test/valid_ciphertext */
-static const char valid_private_key[] = "7C9935A0B07694AA0C6D10E4DB6B1ADD2FD81A25CCB148038626ED79D451140800E03B59B956F8210E556067407D13DC90FA9E8B872BFB0F0999A0BB085F85FDA70D04B8FCAE5A30989947F1E32E4BC4675C834CA22CBA08AE692935EC1C8AF2B5BF377EC17E79D09D57DB5828C6F6E1C1A64D0F30AF3D2F76D9D329108E01D027D856EC44B23A437872D538F2C26E48723E2F8E46A2E7A364C92D997C7B801ADA199EEFFBAB1161B29EC7CB4440DA0E75407F4CE02E37BDFB23154C513BD30CFA5F04D2E253357CBDEBCF6F539965C8B8B5F350A50526AD1B350A0220394AA33B18EB3E765F059FA7CB5585A9D18C8B198A07DA0E9CCEC61D6F43A4661CA6D8175C23A8C86DD30409607D6EBFA3639CDFD12599F9BB073AAEA9A1CC95FF0D50839049EDFAE95FD10DD4F27EC3C6921FA96DCB0366D9C086A8E8ED15390C4827E5672D167EE238229B188C0590E1FA38E8A74D34B6D17ECA1A64EA76AD65413F147DC43A762D69D072DADF573C13A7C983F9362D59DC6E37704BA0F15637CF6BEDBBD8C1051366FE4C21E03CC55964C0E24F6F8D738DC763B7E443122C63751F6D8130EADA4203A9671865F8D459035EAC2E";
 
 static struct s2n_kem_params server_kem_params = {.kem = &s2n_sike_p503_r1};
-static struct s2n_stuffer private_key_stuffer = {{0}};
 
 static void s2n_fuzz_atexit()
 {
-    s2n_stuffer_free(&private_key_stuffer);
+    s2n_kem_free(&server_kem_params);
     s2n_cleanup();
 }
 
 int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
 {
     GUARD(s2n_init());
-    GUARD(s2n_stuffer_alloc_ro_from_hex_string(&private_key_stuffer, valid_private_key));
     GUARD_STRICT(atexit(s2n_fuzz_atexit));
 
-    server_kem_params.private_key.size = s2n_sike_p503_r1.private_key_length;
-    server_kem_params.private_key.data = s2n_stuffer_raw_read(&private_key_stuffer, s2n_sike_p503_r1.public_key_length);
+    GUARD(s2n_alloc(&server_kem_params.private_key, s2n_sike_p503_r1.private_key_length));
+
+    FILE *kat_file = fopen(RSP_FILE_NAME, "r");
+    notnull_check(kat_file);
+    GUARD(ReadHex(kat_file, server_kem_params.private_key.data, s2n_sike_p503_r1.private_key_length, "sk = "));
+
+    fclose(kat_file);
+
     return 0;
 }
 
 int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
 {
-    struct s2n_blob server_shared_secret = {0};
     struct s2n_blob ciphertext = {0};
     GUARD(s2n_alloc(&ciphertext, len));
 
@@ -60,13 +61,13 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     memcpy_check(ciphertext.data, buf, len);
 
     /* Run the test, don't use GUARD since the memory needs to be cleaned up and decapsulate will most likely fail */
-    s2n_kem_decapsulate(&server_kem_params, &server_shared_secret, &ciphertext);
+    s2n_kem_decapsulate(&server_kem_params, &ciphertext);
 
     GUARD(s2n_free(&ciphertext));
 
     /* The above s2n_kem_decapsulate could fail before ever allocating the server_shared_secret */
-    if (server_shared_secret.allocated) {
-        GUARD(s2n_free(&server_shared_secret));
+    if (server_kem_params.shared_secret.allocated) {
+        GUARD(s2n_free(&(server_kem_params.shared_secret)));
     }
     return 0;
 }

--- a/tests/fuzz/s2n_sike_r2_fuzz_test.c
+++ b/tests/fuzz/s2n_sike_r2_fuzz_test.c
@@ -30,7 +30,7 @@
  * ciphertext generated with the public key was copied to corpus/s2n_sike_r2_fuzz_test/valid_ciphertext */
 static const char valid_private_key[] = "7C9935A0B07694AA0C6D10E4DB6B1ADD91282214654CB55E7C2CACD53919604D5BAC7B23EEF4B315FEEF5E014484D7AADB44B40CC180DC568B2C142A60E6E2863F5988614A6215254B2F5F6F79B48F329AD1A2DED20B7ABAB10F7DBF59C3E20B59A700093060D2A44ACDC0083A53CF0808E0B3A827C45176BEE0DC6EC7CC16461E38461C12451BB95191407C1E942BB50D4C7B25A49C644B630159E6C403653838E689FBF4A7ADEA693ED0657BA4A724786AF7953F7BA6E15F9BBF9F5007FB711569E72ACAB05D3463A458536CAB647F00C205D27D5311B2A5113D4B26548000DB237515931A040804E769361F94FF0167C78353D2630A1E6F595A1F80E87F6A5BCD679D7A64C5006F6191D4ADEFA1EA67F6388B7017D453F4FE2DFE80CCC709000B52175BFC3ADE52ECCB0CEBE1654F89D39131C357EACB61E5F13C80AB0165B7714D6BE6DF65F8DE73FF47B7F3304639F0903653ECCFA252F6E2104C4ABAD3C33AF24FD0E56F58DB92CC66859766035419AB2DF600";
 
-static struct s2n_kem_keypair server_kem_keys = {.negotiated_kem = &s2n_sike_p434_r2};
+static struct s2n_kem_params server_kem_params = {.kem = &s2n_sike_p434_r2};
 static struct s2n_stuffer private_key_stuffer = {{0}};
 
 static void s2n_fuzz_atexit()
@@ -45,8 +45,8 @@ int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
     GUARD(s2n_stuffer_alloc_ro_from_hex_string(&private_key_stuffer, valid_private_key));
     GUARD_STRICT(atexit(s2n_fuzz_atexit));
 
-    server_kem_keys.private_key.size = s2n_sike_p434_r2.private_key_length;
-    server_kem_keys.private_key.data = s2n_stuffer_raw_read(&private_key_stuffer, s2n_sike_p434_r2.public_key_length);
+    server_kem_params.private_key.size = s2n_sike_p434_r2.private_key_length;
+    server_kem_params.private_key.data = s2n_stuffer_raw_read(&private_key_stuffer, s2n_sike_p434_r2.public_key_length);
     return 0;
 }
 
@@ -60,7 +60,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     memcpy_check(ciphertext.data, buf, len);
 
     /* Run the test, don't use GUARD since the memory needs to be cleaned up and decapsulate will most likely fail */
-    s2n_kem_decapsulate(&server_kem_keys, &server_shared_secret, &ciphertext);
+    s2n_kem_decapsulate(&server_kem_params, &server_shared_secret, &ciphertext);
 
     GUARD(s2n_free(&ciphertext));
 

--- a/tests/fuzz/s2n_sike_r2_fuzz_test.c
+++ b/tests/fuzz/s2n_sike_r2_fuzz_test.c
@@ -15,44 +15,45 @@
 
 /* Target Functions: s2n_kem_decapsulate SIKE_P434_r2_crypto_kem_dec */
 
-#include "stuffer/s2n_stuffer.h"
-
 #include "tests/s2n_test.h"
+#include "tests/testlib/s2n_nist_kats.h"
 #include "tests/testlib/s2n_testlib.h"
-
 #include "tls/s2n_kem.h"
-
 #include "utils/s2n_safety.h"
 #include "utils/s2n_mem.h"
 #include "utils/s2n_blob.h"
 
-/* This fuzz test uses the below private key which is the first key from tests/unit/kats/sike_r2.kat, the valid
+#define RSP_FILE_NAME "../unit/kats/sike_r2.kat"
+
+/* This fuzz test uses the the first key from tests/unit/kats/sike_r2.kat, the valid
  * ciphertext generated with the public key was copied to corpus/s2n_sike_r2_fuzz_test/valid_ciphertext */
-static const char valid_private_key[] = "7C9935A0B07694AA0C6D10E4DB6B1ADD91282214654CB55E7C2CACD53919604D5BAC7B23EEF4B315FEEF5E014484D7AADB44B40CC180DC568B2C142A60E6E2863F5988614A6215254B2F5F6F79B48F329AD1A2DED20B7ABAB10F7DBF59C3E20B59A700093060D2A44ACDC0083A53CF0808E0B3A827C45176BEE0DC6EC7CC16461E38461C12451BB95191407C1E942BB50D4C7B25A49C644B630159E6C403653838E689FBF4A7ADEA693ED0657BA4A724786AF7953F7BA6E15F9BBF9F5007FB711569E72ACAB05D3463A458536CAB647F00C205D27D5311B2A5113D4B26548000DB237515931A040804E769361F94FF0167C78353D2630A1E6F595A1F80E87F6A5BCD679D7A64C5006F6191D4ADEFA1EA67F6388B7017D453F4FE2DFE80CCC709000B52175BFC3ADE52ECCB0CEBE1654F89D39131C357EACB61E5F13C80AB0165B7714D6BE6DF65F8DE73FF47B7F3304639F0903653ECCFA252F6E2104C4ABAD3C33AF24FD0E56F58DB92CC66859766035419AB2DF600";
 
 static struct s2n_kem_params server_kem_params = {.kem = &s2n_sike_p434_r2};
-static struct s2n_stuffer private_key_stuffer = {{0}};
 
 static void s2n_fuzz_atexit()
 {
-    s2n_stuffer_free(&private_key_stuffer);
+    s2n_kem_free(&server_kem_params);
     s2n_cleanup();
 }
 
 int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
 {
     GUARD(s2n_init());
-    GUARD(s2n_stuffer_alloc_ro_from_hex_string(&private_key_stuffer, valid_private_key));
     GUARD_STRICT(atexit(s2n_fuzz_atexit));
 
-    server_kem_params.private_key.size = s2n_sike_p434_r2.private_key_length;
-    server_kem_params.private_key.data = s2n_stuffer_raw_read(&private_key_stuffer, s2n_sike_p434_r2.public_key_length);
+    GUARD(s2n_alloc(&server_kem_params.private_key, s2n_sike_p434_r2.private_key_length));
+
+    FILE *kat_file = fopen(RSP_FILE_NAME, "r");
+    notnull_check(kat_file);
+    GUARD(ReadHex(kat_file, server_kem_params.private_key.data, s2n_sike_p434_r2.private_key_length, "sk = "));
+
+    fclose(kat_file);
+
     return 0;
 }
 
 int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
 {
-    struct s2n_blob server_shared_secret = {0};
     struct s2n_blob ciphertext = {0};
     GUARD(s2n_alloc(&ciphertext, len));
 
@@ -60,13 +61,13 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     memcpy_check(ciphertext.data, buf, len);
 
     /* Run the test, don't use GUARD since the memory needs to be cleaned up and decapsulate will most likely fail */
-    s2n_kem_decapsulate(&server_kem_params, &server_shared_secret, &ciphertext);
+    s2n_kem_decapsulate(&server_kem_params, &ciphertext);
 
     GUARD(s2n_free(&ciphertext));
 
     /* The above s2n_kem_decapsulate could fail before ever allocating the server_shared_secret */
-    if (server_shared_secret.allocated) {
-        GUARD(s2n_free(&server_shared_secret));
+    if (server_kem_params.shared_secret.allocated) {
+        GUARD(s2n_free(&(server_kem_params.shared_secret)));
     }
     return 0;
 }

--- a/tests/testlib/s2n_hybrid_kem_tests.c
+++ b/tests/testlib/s2n_hybrid_kem_tests.c
@@ -54,7 +54,7 @@ int setup_connection(struct s2n_connection *conn, const struct s2n_kem *kem, str
     GUARD_NONNULL(ecc_preferences = security_policy->ecc_preferences);
 
     conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
-    conn->secure.s2n_kem_keys.negotiated_kem = kem;
+    conn->secure.kem_params.kem = kem;
     conn->secure.cipher_suite = cipher_suite;
     conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
     GUARD(s2n_connection_set_cipher_preferences(conn, cipher_pref_version));

--- a/tests/unit/s2n_client_extensions_test.c
+++ b/tests/unit/s2n_client_extensions_test.c
@@ -115,7 +115,7 @@ static int negotiate_kem(const uint8_t client_extensions[], const size_t client_
     GUARD(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
     GUARD(s2n_config_set_cipher_preferences(server_config, cipher_pref_version));
     GUARD(s2n_connection_set_config(server_conn, server_config));
-    server_conn->secure.s2n_kem_keys.negotiated_kem = NULL;
+    server_conn->secure.kem_params.kem = NULL;
 
     /* Send the client hello */
     eq_check(write(piped_io->client_write, record_header, record_header_len),record_header_len);
@@ -132,8 +132,8 @@ static int negotiate_kem(const uint8_t client_extensions[], const size_t client_
 
     int negotiated_kem_id;
 
-    if (server_conn->secure.s2n_kem_keys.negotiated_kem != NULL) {
-        negotiated_kem_id = server_conn->secure.s2n_kem_keys.negotiated_kem->kem_extension_id;
+    if (server_conn->secure.kem_params.kem != NULL) {
+        negotiated_kem_id = server_conn->secure.kem_params.kem->kem_extension_id;
     } else {
         negotiated_kem_id = -1;
     }

--- a/tests/unit/s2n_kem_test.c
+++ b/tests/unit/s2n_kem_test.c
@@ -337,6 +337,9 @@ int main(int argc, char **argv)
         EXPECT_BYTEARRAY_EQUAL(kem_params.public_key.data, TEST_PUBLIC_KEY, TEST_PUBLIC_KEY_LENGTH);
         EXPECT_EQUAL(kem_params.shared_secret.size, 0);
         EXPECT_NULL(kem_params.shared_secret.data);
+
+        /* This free would normally happen in s2n_connection_free() */
+        EXPECT_SUCCESS(s2n_kem_free(&kem_params));
     }
     {
         /* Failure cases for s2n_kem_send_public_key() */
@@ -380,6 +383,9 @@ int main(int argc, char **argv)
         EXPECT_BYTEARRAY_EQUAL(kem_params.public_key.data, TEST_PUBLIC_KEY, TEST_PUBLIC_KEY_LENGTH);
         EXPECT_EQUAL(kem_params.private_key.size, 0);
         EXPECT_NULL(kem_params.private_key.data);
+
+        /* This free would normally happen in s2n_connection_free() */
+        EXPECT_SUCCESS(s2n_kem_free(&kem_params));
     }
     {
         /* Failure cases for s2n_kem_send_ciphertext() */
@@ -423,6 +429,9 @@ int main(int argc, char **argv)
 
         EXPECT_EQUAL(kem_params.shared_secret.size, TEST_SHARED_SECRET_LENGTH);
         EXPECT_BYTEARRAY_EQUAL(kem_params.shared_secret.data, TEST_SHARED_SECRET, TEST_SHARED_SECRET_LENGTH);
+
+        /* This free would normally happen in s2n_connection_free() */
+        EXPECT_SUCCESS(s2n_kem_free(&kem_params));
     }
     {
         /* Failure cases for s2n_kem_recv_ciphertext() */

--- a/tests/unit/s2n_kem_test.c
+++ b/tests/unit/s2n_kem_test.c
@@ -25,13 +25,13 @@
 #include "crypto/s2n_fips.h"
 
 #define TEST_PUBLIC_KEY_LENGTH 2
-const char TEST_PUBLIC_KEY[] = { 2, 2 };
+const uint8_t TEST_PUBLIC_KEY[] = { 2, 2 };
 #define TEST_PRIVATE_KEY_LENGTH 3
-const char TEST_PRIVATE_KEY[] = { 3, 3, 3 };
+const uint8_t TEST_PRIVATE_KEY[] = { 3, 3, 3 };
 #define TEST_SHARED_SECRET_LENGTH 4
-const char TEST_SHARED_SECRET[] = { 4, 4, 4, 4 };
+const uint8_t TEST_SHARED_SECRET[] = { 4, 4, 4, 4 };
 #define TEST_CIPHERTEXT_LENGTH 5
-const char TEST_CIPHERTEXT[] = { 5, 5, 5, 5, 5 };
+const uint8_t TEST_CIPHERTEXT[] = { 5, 5, 5, 5, 5 };
 
 static const uint8_t bike_iana[S2N_TLS_CIPHER_SUITE_LEN] = { TLS_ECDHE_BIKE_RSA_WITH_AES_256_GCM_SHA384 };
 static const uint8_t sike_iana[S2N_TLS_CIPHER_SUITE_LEN] = { TLS_ECDHE_SIKE_RSA_WITH_AES_256_GCM_SHA384 };
@@ -62,6 +62,7 @@ int s2n_test_decrypt(unsigned char *shared_secret, const unsigned char *cipherte
 }
 
 const struct s2n_kem s2n_test_kem = {
+    .name = "Test-Kem",
     .public_key_length = TEST_PUBLIC_KEY_LENGTH,
     .private_key_length = TEST_PRIVATE_KEY_LENGTH,
     .shared_secret_key_length = TEST_SHARED_SECRET_LENGTH,
@@ -106,38 +107,49 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(sizeof(kem_ciphertext_key_size), 2);
     }
     {
-        struct s2n_kem_keypair server_kem_keypair = { 0 };
-        server_kem_keypair.negotiated_kem = &s2n_test_kem;
-        EXPECT_SUCCESS(s2n_alloc(&server_kem_keypair.public_key, TEST_PUBLIC_KEY_LENGTH));
-        EXPECT_SUCCESS(s2n_kem_generate_keypair(&server_kem_keypair));
-        EXPECT_EQUAL(TEST_PUBLIC_KEY_LENGTH, server_kem_keypair.public_key.size);
-        EXPECT_EQUAL(TEST_PRIVATE_KEY_LENGTH, server_kem_keypair.private_key.size);
-        EXPECT_BYTEARRAY_EQUAL(TEST_PUBLIC_KEY, server_kem_keypair.public_key.data, TEST_PUBLIC_KEY_LENGTH);
-        EXPECT_BYTEARRAY_EQUAL(TEST_PRIVATE_KEY, server_kem_keypair.private_key.data, TEST_PRIVATE_KEY_LENGTH);
+        struct s2n_kem_params server_kem_params = { 0 };
+        server_kem_params.kem = &s2n_test_kem;
+        EXPECT_SUCCESS(s2n_alloc(&server_kem_params.public_key, TEST_PUBLIC_KEY_LENGTH));
+        EXPECT_SUCCESS(s2n_kem_generate_keypair(&server_kem_params));
+        EXPECT_EQUAL(TEST_PUBLIC_KEY_LENGTH, server_kem_params.public_key.size);
+        EXPECT_EQUAL(TEST_PRIVATE_KEY_LENGTH, server_kem_params.private_key.size);
+        EXPECT_BYTEARRAY_EQUAL(TEST_PUBLIC_KEY, server_kem_params.public_key.data, TEST_PUBLIC_KEY_LENGTH);
+        EXPECT_BYTEARRAY_EQUAL(TEST_PRIVATE_KEY, server_kem_params.private_key.data, TEST_PRIVATE_KEY_LENGTH);
+        /* KeyGen shouldn't modify the shared secret */
+        EXPECT_EQUAL(0, server_kem_params.shared_secret.size);
+        EXPECT_NULL(server_kem_params.shared_secret.data);
 
-        struct s2n_kem_keypair client_kem_keypair = { 0 };
-        client_kem_keypair.negotiated_kem = &s2n_test_kem;
+        struct s2n_kem_params client_kem_params = { 0 };
+        client_kem_params.kem = &s2n_test_kem;
         /* This would be handled by client/server key exchange methods which isn't being tested */
-        GUARD(s2n_alloc(&client_kem_keypair.public_key, TEST_PUBLIC_KEY_LENGTH));
-        memset(client_kem_keypair.public_key.data, TEST_PUBLIC_KEY_LENGTH, TEST_PUBLIC_KEY_LENGTH);
+        GUARD(s2n_alloc(&client_kem_params.public_key, TEST_PUBLIC_KEY_LENGTH));
+        memset(client_kem_params.public_key.data, TEST_PUBLIC_KEY_LENGTH, TEST_PUBLIC_KEY_LENGTH);
 
-        DEFER_CLEANUP(struct s2n_blob client_shared_secret = { 0 }, s2n_free);
         DEFER_CLEANUP(struct s2n_blob ciphertext = { 0 }, s2n_free);
         GUARD(s2n_alloc(&ciphertext, TEST_CIPHERTEXT_LENGTH));
 
-        EXPECT_SUCCESS(s2n_kem_encapsulate(&client_kem_keypair, &client_shared_secret, &ciphertext));
-        EXPECT_EQUAL(TEST_SHARED_SECRET_LENGTH, client_shared_secret.size);
+        EXPECT_SUCCESS(s2n_kem_encapsulate(&client_kem_params, &ciphertext));
+        EXPECT_EQUAL(TEST_SHARED_SECRET_LENGTH, client_kem_params.shared_secret.size);
         EXPECT_EQUAL(TEST_CIPHERTEXT_LENGTH, ciphertext.size);
-        EXPECT_BYTEARRAY_EQUAL(TEST_SHARED_SECRET, client_shared_secret.data, TEST_SHARED_SECRET_LENGTH);
+        EXPECT_BYTEARRAY_EQUAL(TEST_SHARED_SECRET, client_kem_params.shared_secret.data, TEST_SHARED_SECRET_LENGTH);
         EXPECT_BYTEARRAY_EQUAL(TEST_CIPHERTEXT, ciphertext.data, TEST_CIPHERTEXT_LENGTH);
+        /* Encaps shouldn't modify the public or private keys */
+        EXPECT_EQUAL(TEST_PUBLIC_KEY_LENGTH, client_kem_params.public_key.size);
+        EXPECT_BYTEARRAY_EQUAL(TEST_PUBLIC_KEY, client_kem_params.public_key.data, TEST_PUBLIC_KEY_LENGTH);
+        EXPECT_EQUAL(0, client_kem_params.private_key.size);
+        EXPECT_NULL(client_kem_params.private_key.data);
 
-        DEFER_CLEANUP(struct s2n_blob server_shared_secret = { 0 }, s2n_free);
-        EXPECT_SUCCESS(s2n_kem_decapsulate(&server_kem_keypair, &server_shared_secret, &ciphertext));
-        EXPECT_EQUAL(TEST_SHARED_SECRET_LENGTH, server_shared_secret.size);
-        EXPECT_BYTEARRAY_EQUAL(TEST_SHARED_SECRET, server_shared_secret.data, TEST_SHARED_SECRET_LENGTH);
+        EXPECT_SUCCESS(s2n_kem_decapsulate(&server_kem_params, &ciphertext));
+        EXPECT_EQUAL(TEST_SHARED_SECRET_LENGTH, server_kem_params.shared_secret.size);
+        EXPECT_BYTEARRAY_EQUAL(TEST_SHARED_SECRET, server_kem_params.shared_secret.data, TEST_SHARED_SECRET_LENGTH);
+        /* Decaps shouldn't modify the public or private keys */
+        EXPECT_EQUAL(TEST_PUBLIC_KEY_LENGTH, server_kem_params.public_key.size);
+        EXPECT_EQUAL(TEST_PRIVATE_KEY_LENGTH, server_kem_params.private_key.size);
+        EXPECT_BYTEARRAY_EQUAL(TEST_PUBLIC_KEY, server_kem_params.public_key.data, TEST_PUBLIC_KEY_LENGTH);
+        EXPECT_BYTEARRAY_EQUAL(TEST_PRIVATE_KEY, server_kem_params.private_key.data, TEST_PRIVATE_KEY_LENGTH);
 
-        EXPECT_SUCCESS(s2n_kem_free(&server_kem_keypair));
-        EXPECT_SUCCESS(s2n_kem_free(&client_kem_keypair));
+        EXPECT_SUCCESS(s2n_kem_free(&server_kem_params));
+        EXPECT_SUCCESS(s2n_kem_free(&client_kem_params));
     }
     {
         /* The order of the client kem list should always be ignored; the server chooses based on the
@@ -301,6 +313,302 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(compatible_params->kem_count, 2);
         EXPECT_EQUAL(compatible_params->kems[0]->kem_extension_id, s2n_sike_p503_r1.kem_extension_id);
         EXPECT_EQUAL(compatible_params->kems[1]->kem_extension_id, s2n_sike_p434_r2.kem_extension_id);
+    }
+    {
+        /* Happy case for s2n_kem_send_public_key() */
+        struct s2n_kem_params kem_params = {0};
+        kem_params.kem = &s2n_test_kem;
+
+        DEFER_CLEANUP(struct s2n_blob io_blob = {0}, s2n_free);
+        EXPECT_SUCCESS(s2n_alloc(&io_blob, TEST_PUBLIC_KEY_LENGTH + 2));
+        struct s2n_stuffer io_stuffer = {0};
+        EXPECT_SUCCESS(s2n_stuffer_init(&io_stuffer, &io_blob));
+
+        EXPECT_SUCCESS(s2n_kem_send_public_key(&io_stuffer, &kem_params));
+
+        /* {0, 2} = length of public key to follow
+         * {2, 2} = test public key */
+        const uint8_t expected_output[] = {0, 2, 2, 2};
+        EXPECT_BYTEARRAY_EQUAL(io_stuffer.blob.data, expected_output, TEST_PUBLIC_KEY_LENGTH + 2);
+
+        EXPECT_EQUAL(kem_params.private_key.size, TEST_PRIVATE_KEY_LENGTH);
+        EXPECT_BYTEARRAY_EQUAL(kem_params.private_key.data, TEST_PRIVATE_KEY, TEST_PRIVATE_KEY_LENGTH);
+        EXPECT_EQUAL(kem_params.public_key.size, TEST_PUBLIC_KEY_LENGTH);
+        EXPECT_BYTEARRAY_EQUAL(kem_params.public_key.data, TEST_PUBLIC_KEY, TEST_PUBLIC_KEY_LENGTH);
+        EXPECT_EQUAL(kem_params.shared_secret.size, 0);
+        EXPECT_NULL(kem_params.shared_secret.data);
+    }
+    {
+        /* Failure cases for s2n_kem_send_public_key() */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_kem_send_public_key(NULL, NULL), S2N_ERR_NULL);
+
+        DEFER_CLEANUP(struct s2n_blob io_blob = {0}, s2n_free);
+        EXPECT_SUCCESS(s2n_alloc(&io_blob, 1));
+        struct s2n_stuffer io_stuffer = {0};
+        EXPECT_SUCCESS(s2n_stuffer_init(&io_stuffer, &io_blob));
+
+        EXPECT_FAILURE_WITH_ERRNO(s2n_kem_send_public_key(&io_stuffer, NULL), S2N_ERR_NULL);
+
+        struct s2n_kem_params kem_params = {0};
+        EXPECT_FAILURE_WITH_ERRNO(s2n_kem_send_public_key(&io_stuffer, &kem_params), S2N_ERR_NULL);
+    }
+    {
+        /* Happy case for s2n_kem_send_ciphertext() */
+        struct s2n_kem_params kem_params = {0};
+        kem_params.kem = &s2n_test_kem;
+
+        DEFER_CLEANUP(struct s2n_blob io_blob = {0}, s2n_free);
+        EXPECT_SUCCESS(s2n_alloc(&io_blob, TEST_CIPHERTEXT_LENGTH + 2));
+        struct s2n_stuffer io_stuffer = {0};
+        EXPECT_SUCCESS(s2n_stuffer_init(&io_stuffer, &io_blob));
+
+        DEFER_CLEANUP(struct s2n_blob public_key = {0}, s2n_free);
+        EXPECT_SUCCESS(s2n_alloc(&public_key, TEST_PUBLIC_KEY_LENGTH));
+        memcpy_check(public_key.data, TEST_PUBLIC_KEY, TEST_PUBLIC_KEY_LENGTH);
+        kem_params.public_key = public_key;
+
+        EXPECT_SUCCESS(s2n_kem_send_ciphertext(&io_stuffer, &kem_params));
+
+        /* {0, 5} = length of ciphertext to follow
+         * {5, 5, 5, 5, 5} = test ciphertext */
+        const uint8_t expected_output[] = {0, 5, 5, 5, 5, 5, 5};
+        EXPECT_BYTEARRAY_EQUAL(io_stuffer.blob.data, expected_output, TEST_CIPHERTEXT_LENGTH + 2);
+
+        EXPECT_EQUAL(kem_params.shared_secret.size, TEST_SHARED_SECRET_LENGTH);
+        EXPECT_BYTEARRAY_EQUAL(kem_params.shared_secret.data, TEST_SHARED_SECRET, TEST_SHARED_SECRET_LENGTH);
+        EXPECT_EQUAL(kem_params.public_key.size, TEST_PUBLIC_KEY_LENGTH);
+        EXPECT_BYTEARRAY_EQUAL(kem_params.public_key.data, TEST_PUBLIC_KEY, TEST_PUBLIC_KEY_LENGTH);
+        EXPECT_EQUAL(kem_params.private_key.size, 0);
+        EXPECT_NULL(kem_params.private_key.data);
+    }
+    {
+        /* Failure cases for s2n_kem_send_ciphertext() */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_kem_send_ciphertext(NULL, NULL), S2N_ERR_NULL);
+
+        DEFER_CLEANUP(struct s2n_blob io_blob = {0}, s2n_free);
+        EXPECT_SUCCESS(s2n_alloc(&io_blob, 1));
+        struct s2n_stuffer io_stuffer = {0};
+        EXPECT_SUCCESS(s2n_stuffer_init(&io_stuffer, &io_blob));
+
+        EXPECT_FAILURE_WITH_ERRNO(s2n_kem_send_ciphertext(&io_stuffer, NULL), S2N_ERR_NULL);
+
+        struct s2n_kem_params kem_params = {0};
+        EXPECT_FAILURE_WITH_ERRNO(s2n_kem_send_ciphertext(&io_stuffer, &kem_params), S2N_ERR_NULL);
+
+        kem_params.kem = &s2n_test_kem;
+        EXPECT_FAILURE_WITH_ERRNO(s2n_kem_send_ciphertext(&io_stuffer, &kem_params), S2N_ERR_NULL);
+    }
+    {
+        /* Happy case for s2n_kem_recv_ciphertext() */
+        struct s2n_kem_params kem_params = {0};
+        kem_params.kem = &s2n_test_kem;
+
+        DEFER_CLEANUP(struct s2n_blob io_blob = {0}, s2n_free);
+        EXPECT_SUCCESS(s2n_alloc(&io_blob, TEST_CIPHERTEXT_LENGTH + 2));
+        struct s2n_stuffer io_stuffer = {0};
+        EXPECT_SUCCESS(s2n_stuffer_init(&io_stuffer, &io_blob));
+
+        DEFER_CLEANUP(struct s2n_blob private_key = {0}, s2n_free);
+        s2n_alloc(&private_key, TEST_PRIVATE_KEY_LENGTH);
+        memcpy_check(private_key.data, TEST_PRIVATE_KEY, TEST_PRIVATE_KEY_LENGTH);
+        kem_params.private_key = private_key;
+
+        /* {0, 5} = length of ciphertext to follow
+         * {5, 5, 5, 5, 5} = test ciphertext */
+        uint8_t input[] = {0, 5, 5, 5, 5, 5, 5};
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&io_stuffer, input, TEST_CIPHERTEXT_LENGTH + 2));
+        EXPECT_SUCCESS(s2n_stuffer_reread(&io_stuffer));
+
+        EXPECT_SUCCESS(s2n_kem_recv_ciphertext(&io_stuffer, &kem_params));
+
+        EXPECT_EQUAL(kem_params.shared_secret.size, TEST_SHARED_SECRET_LENGTH);
+        EXPECT_BYTEARRAY_EQUAL(kem_params.shared_secret.data, TEST_SHARED_SECRET, TEST_SHARED_SECRET_LENGTH);
+    }
+    {
+        /* Failure cases for s2n_kem_recv_ciphertext() */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_kem_recv_ciphertext(NULL, NULL), S2N_ERR_NULL);
+
+        DEFER_CLEANUP(struct s2n_blob io_blob = {0}, s2n_free);
+        EXPECT_SUCCESS(s2n_alloc(&io_blob, 1));
+        struct s2n_stuffer io_stuffer = {0};
+        EXPECT_SUCCESS(s2n_stuffer_init(&io_stuffer, &io_blob));
+
+        EXPECT_FAILURE_WITH_ERRNO(s2n_kem_recv_ciphertext(&io_stuffer, NULL), S2N_ERR_NULL);
+
+        struct s2n_kem_params kem_params = {0};
+        EXPECT_FAILURE_WITH_ERRNO(s2n_kem_recv_ciphertext(&io_stuffer, &kem_params), S2N_ERR_NULL);
+
+        kem_params.kem = &s2n_test_kem;
+        EXPECT_FAILURE_WITH_ERRNO(s2n_kem_recv_ciphertext(&io_stuffer, &kem_params), S2N_ERR_NULL);
+
+        /* Not enough data available in the stuffer to read the ciphertext length */
+        DEFER_CLEANUP(struct s2n_blob private_key = {0}, s2n_free);
+        s2n_alloc(&private_key, TEST_PRIVATE_KEY_LENGTH);
+        memcpy_check(private_key.data, TEST_PRIVATE_KEY, TEST_PRIVATE_KEY_LENGTH);
+        kem_params.private_key = private_key;
+        uint8_t bad_ct_input_1[] = { 5 };
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&io_stuffer, bad_ct_input_1, 1));
+        EXPECT_SUCCESS(s2n_stuffer_reread(&io_stuffer));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_kem_recv_ciphertext(&io_stuffer, &kem_params), S2N_ERR_BAD_MESSAGE);
+
+        /* The given ciphertext length is larger than the remaining data in the stuffer */
+        DEFER_CLEANUP(struct s2n_blob io_blob_2 = {0}, s2n_free);
+        EXPECT_SUCCESS(s2n_alloc(&io_blob_2, TEST_CIPHERTEXT_LENGTH + 2));
+        struct s2n_stuffer io_stuffer_2 = {0};
+        EXPECT_SUCCESS(s2n_stuffer_init(&io_stuffer_2, &io_blob_2));
+        uint8_t bad_ct_input_2[] = {0, 5, 5, };
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&io_stuffer_2, bad_ct_input_2, 3));
+        EXPECT_SUCCESS(s2n_stuffer_reread(&io_stuffer_2));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_kem_recv_ciphertext(&io_stuffer_2, &kem_params), S2N_ERR_BAD_MESSAGE);
+
+        /* The given ciphertext length doesn't match the KEM's actual ciphertext length */
+        DEFER_CLEANUP(struct s2n_blob io_blob_3 = {0}, s2n_free);
+        EXPECT_SUCCESS(s2n_alloc(&io_blob_3, TEST_CIPHERTEXT_LENGTH + 2));
+        struct s2n_stuffer io_stuffer_3 = {0};
+        EXPECT_SUCCESS(s2n_stuffer_init(&io_stuffer_3, &io_blob_3));
+        uint8_t bad_ct_input_3[] = {0, 2, 2, 2};
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&io_stuffer_3, bad_ct_input_3, 4));
+        EXPECT_SUCCESS(s2n_stuffer_reread(&io_stuffer_3));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_kem_recv_ciphertext(&io_stuffer_3, &kem_params), S2N_ERR_BAD_MESSAGE);
+    }
+    {
+        /* Happy case for s2n_kem_recv_public_key() */
+        struct s2n_kem_params kem_params = {0};
+        kem_params.kem = &s2n_test_kem;
+
+        DEFER_CLEANUP(struct s2n_blob io_blob = {0}, s2n_free);
+        EXPECT_SUCCESS(s2n_alloc(&io_blob, TEST_PUBLIC_KEY_LENGTH + 2));
+        struct s2n_stuffer io_stuffer = {0};
+        EXPECT_SUCCESS(s2n_stuffer_init(&io_stuffer, &io_blob));
+
+        /* {0, 2} = length of public key to follow
+         * {2, 2} = test public key */
+        const uint8_t input[] = {0, 2, 2, 2};
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&io_stuffer, input, TEST_PUBLIC_KEY_LENGTH + 2));
+        EXPECT_SUCCESS(s2n_stuffer_reread(&io_stuffer));
+
+        EXPECT_SUCCESS(s2n_kem_recv_public_key(&io_stuffer, &kem_params));
+
+        EXPECT_EQUAL(kem_params.public_key.size, TEST_PUBLIC_KEY_LENGTH);
+        EXPECT_BYTEARRAY_EQUAL(kem_params.public_key.data, TEST_PUBLIC_KEY, TEST_PUBLIC_KEY_LENGTH);
+    }
+    {
+        /* Failure cases for s2n_kem_recv_public_key() */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_kem_recv_public_key(NULL, NULL), S2N_ERR_NULL);
+
+        DEFER_CLEANUP(struct s2n_blob io_blob = {0}, s2n_free);
+        EXPECT_SUCCESS(s2n_alloc(&io_blob, 1));
+        struct s2n_stuffer io_stuffer = {0};
+        EXPECT_SUCCESS(s2n_stuffer_init(&io_stuffer, &io_blob));
+
+        EXPECT_FAILURE_WITH_ERRNO(s2n_kem_recv_public_key(&io_stuffer, NULL), S2N_ERR_NULL);
+
+        struct s2n_kem_params kem_params = {0};
+        EXPECT_FAILURE_WITH_ERRNO(s2n_kem_recv_public_key(&io_stuffer, &kem_params), S2N_ERR_NULL);
+
+        kem_params.kem = &s2n_test_kem;
+
+        /* Not enough data available in the stuffer to read the public key length */
+        uint8_t bad_pk_input_1[] = { 2 };
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&io_stuffer, bad_pk_input_1, 1));
+        EXPECT_SUCCESS(s2n_stuffer_reread(&io_stuffer));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_kem_recv_public_key(&io_stuffer, &kem_params), S2N_ERR_BAD_MESSAGE);
+
+        /* The given public key length is larger than the remaining data in the stuffer */
+        DEFER_CLEANUP(struct s2n_blob io_blob_2 = {0}, s2n_free);
+        EXPECT_SUCCESS(s2n_alloc(&io_blob_2, TEST_PUBLIC_KEY_LENGTH + 2));
+        struct s2n_stuffer io_stuffer_2 = {0};
+        EXPECT_SUCCESS(s2n_stuffer_init(&io_stuffer_2, &io_blob_2));
+        uint8_t bad_pk_input_2[] = {0, 2, 2 };
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&io_stuffer_2, bad_pk_input_2, 3));
+        EXPECT_SUCCESS(s2n_stuffer_reread(&io_stuffer_2));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_kem_recv_public_key(&io_stuffer_2, &kem_params), S2N_ERR_BAD_MESSAGE);
+
+        /* The given public key length doesn't match the KEM's actual public key length */
+        DEFER_CLEANUP(struct s2n_blob io_blob_3 = {0}, s2n_free);
+        EXPECT_SUCCESS(s2n_alloc(&io_blob_3, 5));
+        struct s2n_stuffer io_stuffer_3 = {0};
+        EXPECT_SUCCESS(s2n_stuffer_init(&io_stuffer_3, &io_blob_3));
+        uint8_t bad_pk_input_3[] = {0, 3, 3, 3, 3};
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&io_stuffer_3, bad_pk_input_3, 5));
+        EXPECT_SUCCESS(s2n_stuffer_reread(&io_stuffer_3));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_kem_recv_public_key(&io_stuffer_3, &kem_params), S2N_ERR_BAD_MESSAGE);
+    }
+    {
+        /* Happy case(s) for s2n_get_kem_from_extension_id() */
+
+        /* The kem_extensions and kems arrays should be kept in sync with each other */
+        uint8_t kem_extensions[4][2] = {
+                {0, 1},  /* TLS_PQ_KEM_EXTENSION_ID_BIKE1_L1_R1 */
+                {0, 13}, /* TLS_PQ_KEM_EXTENSION_ID_BIKE1_L1_R2 */
+                {0, 10}, /* TLS_PQ_KEM_EXTENSION_ID_SIKE_P503_R1 */
+                {0, 19}, /* TLS_PQ_KEM_EXTENSION_ID_SIKE_P434_R2 */
+        };
+        const struct s2n_kem *kems[] = {
+                &s2n_bike1_l1_r1,
+                &s2n_bike1_l1_r2,
+                &s2n_sike_p503_r1,
+                &s2n_sike_p434_r2,
+        };
+
+        for (int i = 0; i < 4; i++) {
+            uint8_t *extension_id_bytes = kem_extensions[i]; /* TLS_PQ_KEM_EXTENSION_ID_SIKE_P434_R2 */
+            struct s2n_blob kem_id = {.data = extension_id_bytes, .size = 2};
+            const struct s2n_kem *returned_kem = NULL;
+
+            EXPECT_SUCCESS(s2n_get_kem_from_extension_id(&kem_id, &returned_kem));
+            EXPECT_NOT_NULL(returned_kem);
+            EXPECT_EQUAL(kems[i], returned_kem);
+        }
+    }
+    {
+        /* Failure cases for s2n_get_kem_from_extension_id() */
+        const struct s2n_kem *returned_kem = NULL;
+        EXPECT_FAILURE_WITH_ERRNO(s2n_get_kem_from_extension_id(NULL, &returned_kem), S2N_ERR_NULL);
+
+        struct s2n_blob kem_id = { 0 };
+        EXPECT_FAILURE_WITH_ERRNO(s2n_get_kem_from_extension_id(&kem_id, &returned_kem), S2N_ERR_NULL);
+
+        uint8_t bad_kem_id[] = { 0, 1, 1 };
+        kem_id.data = bad_kem_id;
+        kem_id.size = 3;
+        EXPECT_FAILURE_WITH_ERRNO(s2n_get_kem_from_extension_id(&kem_id, &returned_kem), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+
+        uint8_t non_existant_kem_id[] = { 255, 255 };
+        kem_id.data = non_existant_kem_id;
+        kem_id.size = 2;
+        EXPECT_FAILURE_WITH_ERRNO(s2n_get_kem_from_extension_id(&kem_id, &returned_kem), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+    }
+    {
+        /* Tests for s2n_kem_free() */
+        EXPECT_SUCCESS(s2n_kem_free(NULL));
+
+        struct s2n_kem_params kem_params = { 0 };
+        EXPECT_SUCCESS(s2n_kem_free(&kem_params));
+
+        EXPECT_SUCCESS(s2n_alloc(&(kem_params.private_key), TEST_PRIVATE_KEY_LENGTH));
+        struct s2n_stuffer private_key_stuffer = {0};
+        EXPECT_SUCCESS(s2n_stuffer_init(&private_key_stuffer, &(kem_params.private_key)));
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&private_key_stuffer, TEST_PRIVATE_KEY, TEST_PRIVATE_KEY_LENGTH));
+
+        EXPECT_SUCCESS(s2n_alloc(&(kem_params.public_key), TEST_PUBLIC_KEY_LENGTH));
+        struct s2n_stuffer public_key_stuffer = {0};
+        EXPECT_SUCCESS(s2n_stuffer_init(&public_key_stuffer, &(kem_params.public_key)));
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&public_key_stuffer, TEST_PUBLIC_KEY, TEST_PUBLIC_KEY_LENGTH));
+
+        EXPECT_SUCCESS(s2n_alloc(&(kem_params.shared_secret), TEST_SHARED_SECRET_LENGTH));
+        struct s2n_stuffer shared_secret_stuffer = {0};
+        EXPECT_SUCCESS(s2n_stuffer_init(&shared_secret_stuffer, &(kem_params.shared_secret)));
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&shared_secret_stuffer, TEST_SHARED_SECRET, TEST_SHARED_SECRET_LENGTH));
+
+        EXPECT_SUCCESS(s2n_kem_free(&kem_params));
+
+        EXPECT_NULL(kem_params.private_key.data);
+        EXPECT_EQUAL(kem_params.private_key.size, 0);
+        EXPECT_NULL(kem_params.public_key.data);
+        EXPECT_EQUAL(kem_params.public_key.size, 0);
+        EXPECT_NULL(kem_params.shared_secret.data);
+        EXPECT_EQUAL(kem_params.shared_secret.size, 0);
     }
 
 #endif

--- a/tests/unit/s2n_kex_with_kem_test.c
+++ b/tests/unit/s2n_kex_with_kem_test.c
@@ -58,11 +58,11 @@ static int do_kex_with_kem(struct s2n_cipher_suite *cipher_suite, const char *se
     GUARD(s2n_find_security_policy_from_version(security_policy_version, &security_policy));
     GUARD_NONNULL(security_policy);
 
-    client_conn->secure.s2n_kem_keys.negotiated_kem = negotiated_kem;
+    client_conn->secure.kem_params.kem = negotiated_kem;
     client_conn->secure.cipher_suite = cipher_suite;
     client_conn->security_policy_override = security_policy;
 
-    server_conn->secure.s2n_kem_keys.negotiated_kem = negotiated_kem;
+    server_conn->secure.kem_params.kem = negotiated_kem;
     server_conn->secure.cipher_suite = cipher_suite;
     server_conn->security_policy_override = security_policy;
 
@@ -73,7 +73,7 @@ static int do_kex_with_kem(struct s2n_cipher_suite *cipher_suite, const char *se
     const uint32_t KEM_PUBLIC_KEY_MESSAGE_SIZE = (*negotiated_kem).public_key_length + 4;
     eq_check(data_to_sign.size, KEM_PUBLIC_KEY_MESSAGE_SIZE);
 
-    eq_check((*negotiated_kem).private_key_length, server_conn->secure.s2n_kem_keys.private_key.size);
+    eq_check((*negotiated_kem).private_key_length, server_conn->secure.kem_params.private_key.size);
     struct s2n_blob server_key_message = {.size = KEM_PUBLIC_KEY_MESSAGE_SIZE, .data = s2n_stuffer_raw_read(&server_conn->handshake.io,
             KEM_PUBLIC_KEY_MESSAGE_SIZE)};
     GUARD_NONNULL(server_key_message.data);
@@ -95,7 +95,7 @@ static int do_kex_with_kem(struct s2n_cipher_suite *cipher_suite, const char *se
         S2N_ERROR_PRESERVE_ERRNO();
     }
 
-    eq_check((*negotiated_kem).public_key_length, client_conn->secure.s2n_kem_keys.public_key.size);
+    eq_check((*negotiated_kem).public_key_length, client_conn->secure.kem_params.public_key.size);
 
     /* Part 3: Client calls send_key. The additional 2 bytes are for the ciphertext length sent over the wire */
     const uint32_t KEM_CIPHERTEXT_MESSAGE_SIZE = (*negotiated_kem).ciphertext_length + 2;
@@ -130,7 +130,7 @@ static int assert_kex_fips_checks(struct s2n_cipher_suite *cipher_suite, const c
     const struct s2n_security_policy *security_policy = NULL;
     GUARD(s2n_find_security_policy_from_version(security_policy_version, &security_policy));
     GUARD_NONNULL(security_policy);
-    server_conn->secure.s2n_kem_keys.negotiated_kem = negotiated_kem;
+    server_conn->secure.kem_params.kem = negotiated_kem;
     server_conn->secure.cipher_suite = cipher_suite;
     server_conn->security_policy_override = security_policy;
 

--- a/tls/s2n_client_key_exchange.c
+++ b/tls/s2n_client_key_exchange.c
@@ -158,18 +158,9 @@ int s2n_ecdhe_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shar
 
 int s2n_kem_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared_key)
 {
-    struct s2n_stuffer *in = &conn->handshake.io;
-    kem_ciphertext_key_size ciphertext_length;
-
-    GUARD(s2n_stuffer_read_uint16(in, &ciphertext_length));
-    S2N_ERROR_IF(ciphertext_length > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);
-
-    const struct s2n_blob ciphertext = {.size = ciphertext_length, .data = s2n_stuffer_raw_read(in, ciphertext_length)};
-    notnull_check(ciphertext.data);
-
-    GUARD(s2n_kem_decapsulate(&conn->secure.s2n_kem_keys, shared_key, &ciphertext));
-
-    GUARD(s2n_kem_free(&conn->secure.s2n_kem_keys));
+    GUARD(s2n_kem_recv_ciphertext(&(conn->handshake.io), &(conn->secure.kem_params)));
+    GUARD(s2n_dup(&(conn->secure.kem_params.shared_secret), shared_key));
+    GUARD(s2n_kem_free(&(conn->secure.kem_params)));
     return 0;
 }
 
@@ -250,17 +241,9 @@ int s2n_rsa_client_key_send(struct s2n_connection *conn, struct s2n_blob *shared
 
 int s2n_kem_client_key_send(struct s2n_connection *conn, struct s2n_blob *shared_key)
 {
-    struct s2n_stuffer *out = &conn->handshake.io;
-    const struct s2n_kem *kem = conn->secure.s2n_kem_keys.negotiated_kem;
-
-    GUARD(s2n_stuffer_write_uint16(out, kem->ciphertext_length));
-
-    /* The ciphertext is not needed after this method, write it straight to the stuffer */
-    struct s2n_blob ciphertext = {.data = s2n_stuffer_raw_write(out, kem->ciphertext_length), .size = kem->ciphertext_length};
-    notnull_check(ciphertext.data);
-
-    GUARD(s2n_kem_encapsulate(&conn->secure.s2n_kem_keys, shared_key, &ciphertext));
-    GUARD(s2n_kem_free(&conn->secure.s2n_kem_keys));
+    GUARD(s2n_kem_send_ciphertext(&(conn->handshake.io), &(conn->secure.kem_params)));
+    GUARD(s2n_dup(&(conn->secure.kem_params.shared_secret), shared_key));
+    GUARD(s2n_kem_free(&conn->secure.kem_params));
     return 0;
 }
 

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -255,8 +255,8 @@ static int s2n_connection_zero(struct s2n_connection *conn, int mode, struct s2n
     conn->current_user_data_consumed = 0;
     conn->initial.cipher_suite = &s2n_null_cipher_suite;
     conn->secure.cipher_suite = &s2n_null_cipher_suite;
-    conn->initial.s2n_kem_keys.negotiated_kem = NULL;
-    conn->secure.s2n_kem_keys.negotiated_kem = NULL;
+    conn->initial.kem_params.kem = NULL;
+    conn->secure.kem_params.kem = NULL;
     conn->server = &conn->initial;
     conn->client = &conn->initial;
     conn->max_outgoing_fragment_length = S2N_DEFAULT_FRAGMENT_LENGTH;
@@ -295,7 +295,7 @@ static int s2n_connection_wipe_keys(struct s2n_connection *conn)
     for (int i=0; i < S2N_ECC_EVP_SUPPORTED_CURVES_COUNT; i++) {
         GUARD(s2n_ecc_evp_params_free(&conn->secure.client_ecc_evp_params[i]));
     }
-    GUARD(s2n_kem_free(&conn->secure.s2n_kem_keys));
+    GUARD(s2n_kem_free(&conn->secure.kem_params));
     GUARD(s2n_free(&conn->secure.client_cert_chain));
     GUARD(s2n_free(&conn->ct_response));
 
@@ -906,11 +906,11 @@ const char *s2n_connection_get_kem_name(struct s2n_connection *conn)
 {
     notnull_check_ptr(conn);
 
-    if (!conn->secure.s2n_kem_keys.negotiated_kem) {
+    if (!conn->secure.kem_params.kem) {
         return "NONE";
     }
 
-    return conn->secure.s2n_kem_keys.negotiated_kem->name;
+    return conn->secure.kem_params.kem->name;
 }
 
 int s2n_connection_get_client_protocol_version(struct s2n_connection *conn)

--- a/tls/s2n_crypto.h
+++ b/tls/s2n_crypto.h
@@ -59,10 +59,11 @@
 /* RFC 5246 7.4.1.2 */
 #define S2N_TLS_SESSION_ID_MAX_LEN     32
 
-struct s2n_kem_keypair {
-    const struct s2n_kem *negotiated_kem;
+struct s2n_kem_params {
+    const struct s2n_kem *kem;
     struct s2n_blob public_key;
     struct s2n_blob private_key;
+    struct s2n_blob shared_secret;
 };
 
 struct s2n_crypto_parameters {
@@ -72,7 +73,7 @@ struct s2n_crypto_parameters {
     struct s2n_ecc_evp_params server_ecc_evp_params;
     const struct s2n_ecc_named_curve * mutually_supported_groups[S2N_ECC_EVP_SUPPORTED_CURVES_COUNT];
     struct s2n_ecc_evp_params client_ecc_evp_params[S2N_ECC_EVP_SUPPORTED_CURVES_COUNT];
-    struct s2n_kem_keypair s2n_kem_keys;
+    struct s2n_kem_params kem_params;
     struct s2n_blob client_key_exchange_message;
     struct s2n_blob client_pq_kem_extension;
 

--- a/tls/s2n_kem.c
+++ b/tls/s2n_kem.c
@@ -304,7 +304,7 @@ int s2n_kem_send_public_key(struct s2n_stuffer *out, struct s2n_kem_params *kem_
     GUARD(s2n_stuffer_write_uint16(out, kem->public_key_length));
 
     struct s2n_blob *public_key = &(kem_params->public_key);
-    /* Public key will get written to *out */
+    /* Public key will get written directly to *out */
     public_key->data = s2n_stuffer_raw_write(out, kem->public_key_length);
     notnull_check(public_key->data);
     public_key->size = kem->public_key_length;

--- a/tls/s2n_kem.c
+++ b/tls/s2n_kem.c
@@ -17,6 +17,7 @@
 
 #include "tls/s2n_tls_parameters.h"
 #include "tls/s2n_kem.h"
+#include "tls/s2n_connection.h"
 
 #include "utils/s2n_mem.h"
 #include "utils/s2n_safety.h"
@@ -110,58 +111,58 @@ const struct s2n_iana_to_kem *kem_mapping = NULL;
 
 #endif
 
-int s2n_kem_generate_keypair(struct s2n_kem_keypair *kem_keys)
+int s2n_kem_generate_keypair(struct s2n_kem_params *kem_params)
 {
-    notnull_check(kem_keys);
-    const struct s2n_kem *kem = kem_keys->negotiated_kem;
+    notnull_check(kem_params);
+    const struct s2n_kem *kem = kem_params->kem;
     notnull_check(kem->generate_keypair);
 
-    eq_check(kem_keys->public_key.size, kem->public_key_length);
-    notnull_check(kem_keys->public_key.data);
+    eq_check(kem_params->public_key.size, kem->public_key_length);
+    notnull_check(kem_params->public_key.data);
 
-    /* The private key is needed for client_key_recv and must be saved */
-    GUARD(s2n_alloc(&kem_keys->private_key, kem->private_key_length));
+    /* Need to save the private key for decapsulation */
+    GUARD(s2n_alloc(&(kem_params->private_key), kem->private_key_length));
 
-    GUARD(kem->generate_keypair(kem_keys->public_key.data, kem_keys->private_key.data));
-    return 0;
+    GUARD(kem->generate_keypair(kem_params->public_key.data, kem_params->private_key.data));
+    return S2N_SUCCESS;
 }
 
-int s2n_kem_encapsulate(const struct s2n_kem_keypair *kem_keys, struct s2n_blob *shared_secret,
-                        struct s2n_blob *ciphertext)
+int s2n_kem_encapsulate(struct s2n_kem_params *kem_params, struct s2n_blob *ciphertext)
 {
-    notnull_check(kem_keys);
-    const struct s2n_kem *kem = kem_keys->negotiated_kem;
+    notnull_check(kem_params);
+    const struct s2n_kem *kem = kem_params->kem;
     notnull_check(kem->encapsulate);
 
-    eq_check(kem_keys->public_key.size, kem->public_key_length);
-    notnull_check(kem_keys->public_key.data);
+    eq_check(kem_params->public_key.size, kem->public_key_length);
+    notnull_check(kem_params->public_key.data);
 
     eq_check(ciphertext->size, kem->ciphertext_length);
     notnull_check(ciphertext->data);
 
-    GUARD(s2n_alloc(shared_secret, kem->shared_secret_key_length));
+    /* Need to save the shared secret for key derivation */
+    GUARD(s2n_alloc(&(kem_params->shared_secret), kem->shared_secret_key_length));
 
-    GUARD(kem->encapsulate(ciphertext->data, shared_secret->data, kem_keys->public_key.data));
-    return 0;
+    GUARD(kem->encapsulate(ciphertext->data, kem_params->shared_secret.data, kem_params->public_key.data));
+    return S2N_SUCCESS;
 }
 
-int s2n_kem_decapsulate(const struct s2n_kem_keypair *kem_keys, struct s2n_blob *shared_secret,
-                        const struct s2n_blob *ciphertext)
+int s2n_kem_decapsulate(struct s2n_kem_params *kem_params, const struct s2n_blob *ciphertext)
 {
-    notnull_check(kem_keys);
-    const struct s2n_kem *kem = kem_keys->negotiated_kem;
+    notnull_check(kem_params);
+    const struct s2n_kem *kem = kem_params->kem;
     notnull_check(kem->decapsulate);
 
-    eq_check(kem_keys->private_key.size, kem->private_key_length);
-    notnull_check(kem_keys->private_key.data);
+    eq_check(kem_params->private_key.size, kem->private_key_length);
+    notnull_check(kem_params->private_key.data);
 
     eq_check(ciphertext->size, kem->ciphertext_length);
     notnull_check(ciphertext->data);
 
-    GUARD(s2n_alloc(shared_secret, kem_keys->negotiated_kem->shared_secret_key_length));
+    /* Need to save the shared secret for key derivation */
+    GUARD(s2n_alloc(&(kem_params->shared_secret), kem_params->kem->shared_secret_key_length));
 
-    GUARD(kem->decapsulate(shared_secret->data, ciphertext->data, kem_keys->private_key.data));
-    return 0;
+    GUARD(kem->decapsulate(kem_params->shared_secret.data, ciphertext->data, kem_params->private_key.data));
+    return S2N_SUCCESS;
 }
 
 static int s2n_kem_check_kem_compatibility(const uint8_t iana_value[S2N_TLS_CIPHER_SUITE_LEN], const struct s2n_kem *candidate_kem,
@@ -172,12 +173,12 @@ static int s2n_kem_check_kem_compatibility(const uint8_t iana_value[S2N_TLS_CIPH
     for (uint8_t i = 0; i < compatible_kems->kem_count; i++) {
         if (candidate_kem->kem_extension_id == compatible_kems->kems[i]->kem_extension_id) {
             *kem_is_compatible = 1;
-            return 0;
+            return S2N_SUCCESS;
         }
     }
 
     *kem_is_compatible = 0;
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_choose_kem_with_peer_pref_list(const uint8_t iana_value[S2N_TLS_CIPHER_SUITE_LEN], struct s2n_blob *client_kem_ids,
@@ -205,7 +206,7 @@ int s2n_choose_kem_with_peer_pref_list(const uint8_t iana_value[S2N_TLS_CIPHER_S
 
             if (candidate_server_kem->kem_extension_id == candidate_client_kem_id) {
                 *chosen_kem = candidate_server_kem;
-                return 0;
+                return S2N_SUCCESS;
             }
         }
         GUARD(s2n_stuffer_reread(&client_kem_ids_stuffer));
@@ -222,7 +223,7 @@ int s2n_choose_kem_without_peer_pref_list(const uint8_t iana_value[S2N_TLS_CIPHE
         GUARD(s2n_kem_check_kem_compatibility(iana_value, server_kem_pref_list[i], &kem_is_compatible));
         if (kem_is_compatible) {
             *chosen_kem = server_kem_pref_list[i];
-            return 0;
+            return S2N_SUCCESS;
         }
     }
 
@@ -230,18 +231,22 @@ int s2n_choose_kem_without_peer_pref_list(const uint8_t iana_value[S2N_TLS_CIPHE
     S2N_ERROR(S2N_ERR_KEM_UNSUPPORTED_PARAMS);
 }
 
-int s2n_kem_free(struct s2n_kem_keypair *kem_keys)
+int s2n_kem_free(struct s2n_kem_params *kem_params)
 {
-    if (kem_keys != NULL){
-        GUARD(s2n_blob_zero(&kem_keys->private_key));
-        if (kem_keys->private_key.allocated) {
-            GUARD(s2n_free(&kem_keys->private_key));
+    if (kem_params != NULL){
+        GUARD(s2n_blob_zero(&kem_params->private_key));
+        if (kem_params->private_key.allocated) {
+            GUARD(s2n_free(&kem_params->private_key));
         }
-        if (kem_keys->public_key.allocated) {
-            GUARD(s2n_free(&kem_keys->public_key));
+        GUARD(s2n_blob_zero(&kem_params->shared_secret));
+        if (kem_params->shared_secret.allocated) {
+            GUARD(s2n_free(&kem_params->shared_secret));
+        }
+        if (kem_params->public_key.allocated) {
+            GUARD(s2n_free(&kem_params->public_key));
         }
     }
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_cipher_suite_to_kem(const uint8_t iana_value[S2N_TLS_CIPHER_SUITE_LEN], const struct s2n_iana_to_kem **compatible_params)
@@ -253,8 +258,123 @@ int s2n_cipher_suite_to_kem(const uint8_t iana_value[S2N_TLS_CIPHER_SUITE_LEN], 
         const struct s2n_iana_to_kem *candidate = &kem_mapping[i];
         if (memcmp(iana_value, candidate->iana_value, S2N_TLS_CIPHER_SUITE_LEN) == 0) {
             *compatible_params = candidate;
-            return 0;
+            return S2N_SUCCESS;
         }
     }
     S2N_ERROR(S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+}
+
+int s2n_get_kem_from_extension_id(struct s2n_blob *kem_id, const struct s2n_kem **kem) {
+    /* cppcheck-suppress knownConditionTrueFalse */
+    S2N_ERROR_IF(kem_mapping == NULL, S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+
+    notnull_check(kem_id);
+    notnull_check(kem_id->data);
+    S2N_ERROR_IF(kem_id->size != 2, S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+
+    struct s2n_stuffer kem_id_stuffer = {0};
+    GUARD(s2n_stuffer_init(&kem_id_stuffer, kem_id));
+    GUARD(s2n_stuffer_write(&kem_id_stuffer, kem_id));
+
+    kem_extension_size kem_extension_id;
+    GUARD(s2n_stuffer_read_uint16(&kem_id_stuffer, &kem_extension_id));
+
+    for (int i = 0; i < s2n_array_len(kem_mapping); i++) {
+        const struct s2n_iana_to_kem *iana_to_kem = &kem_mapping[i];
+
+        for (int j = 0; j < iana_to_kem->kem_count; j++) {
+            const struct s2n_kem *candidate_kem = iana_to_kem->kems[j];
+            if (candidate_kem->kem_extension_id == kem_extension_id) {
+                *kem = candidate_kem;
+                return S2N_SUCCESS;
+            }
+        }
+    }
+
+    S2N_ERROR(S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+}
+
+int s2n_kem_send_public_key(struct s2n_stuffer *out, struct s2n_kem_params *kem_params) {
+    notnull_check(out);
+    notnull_check(kem_params);
+    notnull_check(kem_params->kem);
+
+    const struct s2n_kem *kem = kem_params->kem;
+
+    GUARD(s2n_stuffer_write_uint16(out, kem->public_key_length));
+
+    struct s2n_blob *public_key = &(kem_params->public_key);
+    /* Public key will get written to *out */
+    public_key->data = s2n_stuffer_raw_write(out, kem->public_key_length);
+    notnull_check(public_key->data);
+    public_key->size = kem->public_key_length;
+
+    /* Saves the key pair in kem_params */
+    GUARD(s2n_kem_generate_keypair(kem_params));
+
+    return S2N_SUCCESS;
+}
+
+int s2n_kem_recv_public_key(struct s2n_stuffer *in, struct s2n_kem_params *kem_params) {
+    notnull_check(in);
+    notnull_check(kem_params);
+    notnull_check(kem_params->kem);
+
+    const struct s2n_kem *kem = kem_params->kem;
+    kem_public_key_size public_key_length;
+
+    S2N_ERROR_IF(s2n_stuffer_data_available(in) < sizeof(kem_public_key_size), S2N_ERR_BAD_MESSAGE);
+    GUARD(s2n_stuffer_read_uint16(in, &public_key_length));
+    S2N_ERROR_IF(public_key_length > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);
+    S2N_ERROR_IF(public_key_length != kem->public_key_length, S2N_ERR_BAD_MESSAGE);
+
+    /* Save the public key in kem_params */
+    kem_params->public_key.data = s2n_stuffer_raw_read(in, public_key_length);
+    notnull_check(kem_params->public_key.data);
+    kem_params->public_key.size = public_key_length;
+
+    return S2N_SUCCESS;
+}
+
+int s2n_kem_send_ciphertext(struct s2n_stuffer *out, struct s2n_kem_params *kem_params) {
+    notnull_check(out);
+    notnull_check(kem_params);
+    notnull_check(kem_params->kem);
+    notnull_check(kem_params->public_key.data);
+
+    const struct s2n_kem *kem = kem_params->kem;
+
+    GUARD(s2n_stuffer_write_uint16(out, kem->ciphertext_length));
+
+    /* Ciphertext will get written to *out */
+    struct s2n_blob ciphertext = {.data = s2n_stuffer_raw_write(out, kem->ciphertext_length), .size = kem->ciphertext_length};
+    notnull_check(ciphertext.data);
+
+    /* Saves the shared secret in kem_params */
+    GUARD(s2n_kem_encapsulate(kem_params, &ciphertext));
+
+    return S2N_SUCCESS;
+}
+
+int s2n_kem_recv_ciphertext(struct s2n_stuffer *in, struct s2n_kem_params *kem_params) {
+    notnull_check(in);
+    notnull_check(kem_params);
+    notnull_check(kem_params->kem);
+    notnull_check(kem_params->private_key.data);
+
+    const struct s2n_kem *kem = kem_params->kem;
+    kem_ciphertext_key_size ciphertext_length;
+
+    S2N_ERROR_IF(s2n_stuffer_data_available(in) < sizeof(kem_ciphertext_key_size), S2N_ERR_BAD_MESSAGE);
+    GUARD(s2n_stuffer_read_uint16(in, &ciphertext_length));
+    S2N_ERROR_IF(ciphertext_length > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);
+    S2N_ERROR_IF(ciphertext_length != kem->ciphertext_length, S2N_ERR_BAD_MESSAGE);
+
+    const struct s2n_blob ciphertext = {.size = ciphertext_length, .data = s2n_stuffer_raw_read(in, ciphertext_length)};
+    notnull_check(ciphertext.data);
+
+    /* Saves the shared secret in kem_params */
+    GUARD(s2n_kem_decapsulate(kem_params, &ciphertext));
+
+    return S2N_SUCCESS;
 }

--- a/tls/s2n_kem.h
+++ b/tls/s2n_kem.h
@@ -53,14 +53,9 @@ extern const struct s2n_kem s2n_sike_p434_r2;
 
 #endif
 
-extern int s2n_kem_generate_keypair(struct s2n_kem_keypair *kem_keys);
-
-extern int s2n_kem_encapsulate(const struct s2n_kem_keypair *kem_keys, struct s2n_blob *shared_secret,
-                               struct s2n_blob *ciphertext);
-
-extern int s2n_kem_decapsulate(const struct s2n_kem_keypair *kem_params, struct s2n_blob *shared_secret,
-                               const struct s2n_blob *ciphertext);
-
+extern int s2n_kem_generate_keypair(struct s2n_kem_params *kem_params);
+extern int s2n_kem_encapsulate(struct s2n_kem_params *kem_params, struct s2n_blob *ciphertext);
+extern int s2n_kem_decapsulate(struct s2n_kem_params *kem_params, const struct s2n_blob *ciphertext);
 extern int s2n_choose_kem_with_peer_pref_list(const uint8_t iana_value[S2N_TLS_CIPHER_SUITE_LEN], struct s2n_blob *client_kem_ids,
                                       const struct s2n_kem *server_kem_pref_list[], const uint8_t num_server_supported_kems,
                                       const struct s2n_kem **chosen_kem);
@@ -68,6 +63,10 @@ extern int s2n_choose_kem_with_peer_pref_list(const uint8_t iana_value[S2N_TLS_C
 extern int s2n_choose_kem_without_peer_pref_list(const uint8_t iana_value[S2N_TLS_CIPHER_SUITE_LEN], const struct s2n_kem *server_kem_pref_list[],
                                         const uint8_t num_server_supported_kems, const struct s2n_kem **chosen_kem);
 
-extern int s2n_kem_free(struct s2n_kem_keypair *kem_keys);
-
+extern int s2n_kem_free(struct s2n_kem_params *kem_params);
 extern int s2n_cipher_suite_to_kem(const uint8_t iana_value[S2N_TLS_CIPHER_SUITE_LEN], const struct s2n_iana_to_kem **supported_params);
+extern int s2n_get_kem_from_extension_id(struct s2n_blob *client_kem_ids, const struct s2n_kem **kem);
+extern int s2n_kem_send_public_key(struct s2n_stuffer *out, struct s2n_kem_params *kem_params);
+extern int s2n_kem_recv_public_key(struct s2n_stuffer *in, struct s2n_kem_params *kem_params);
+extern int s2n_kem_send_ciphertext(struct s2n_stuffer *out, struct s2n_kem_params *kem_params);
+extern int s2n_kem_recv_ciphertext(struct s2n_stuffer *in, struct s2n_kem_params *kem_params);

--- a/tls/s2n_kex.c
+++ b/tls/s2n_kex.c
@@ -145,7 +145,7 @@ static int s2n_configure_kem(const struct s2n_cipher_suite *cipher_suite, struct
             security_policy->kem_preferences->count, &chosen_kem));
     }
 
-    conn->secure.s2n_kem_keys.negotiated_kem = chosen_kem;
+    conn->secure.kem_params.kem = chosen_kem;
     return 0;
 }
 

--- a/tls/s2n_tls_parameters.h
+++ b/tls/s2n_tls_parameters.h
@@ -58,9 +58,7 @@
 #define TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256  0xCC, 0xA9
 #define TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256      0xCC, 0xAA
 
-/* TLS Hybrid post-quantum definitions from https://tools.ietf.org/html/draft-campagna-tls-bike-sike-hybrid-02
- * Note that the value for SIKE_P434_R2 (19) disagrees with the above spec. This value (19)
- * reflects an upcoming change that will be published in draft-campagna-tls-bike-sike-hybrid-03. */
+/* TLS Hybrid post-quantum definitions from https://tools.ietf.org/html/draft-campagna-tls-bike-sike-hybrid */
 #define TLS_ECDHE_BIKE_RSA_WITH_AES_256_GCM_SHA384 0xFF, 0x04
 #define TLS_ECDHE_SIKE_RSA_WITH_AES_256_GCM_SHA384 0xFF, 0x08
 #define TLS_EXTENSION_PQ_KEM_PARAMETERS 0xFE01


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** N/A

**Description of changes:** 
This lays the preliminary groundwork for PQ-TLS 1.3.

* Adds `shared_secret` to the PQKEM structure in `s2n_crypto_parameters`
  * Also renames the struct: `s2n_kem_keypair` -> `s2n_kem_params`
* Adds generic send/receive functions for KEM public keys and ciphertexts
* Adds function to retrieve a KEM from an extension ID
* Integrates the generic KEM send/receive functions with the PQ-TLS 1.2 KEX functions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.