### PR TITLE
ci: Move coverage flags to ASAN, remove unit test as a CodeBuild job.

### DIFF
--- a/codebuild/bin/s2n_codebuild.sh
+++ b/codebuild/bin/s2n_codebuild.sh
@@ -54,12 +54,12 @@ if [[ "$OS_NAME" == "linux" && "$TESTS" == "valgrind" ]]; then
     kill %1
 fi
 
-if [[ "$OS_NAME" == "linux" && (("$TESTS" == "integration") || ("$TESTS" == "integrationv2") || ("$TESTS" == "unit")) ]]; then
+if [[ "$OS_NAME" == "linux" && ( ("$TESTS" == "integration") || ("$TESTS" == "integrationv2") ) ]]; then
     make -j $JOBS
 fi
 
 # Build and run unit tests with scan-build for osx. scan-build bundle isn't available for linux
-if [[ "$OS_NAME" == "osx" && "$TESTS" == "integration" ]]; then  
+if [[ "$OS_NAME" == "osx" && "$TESTS" == "integration" ]]; then
     scan-build --status-bugs -o /tmp/scan-build make -j$JOBS; STATUS=$?; test $STATUS -ne 0 && cat /tmp/scan-build/*/* ; [ "$STATUS" -eq "0" ];
 fi
 

--- a/codebuild/codebuild.config
+++ b/codebuild/codebuild.config
@@ -50,15 +50,10 @@ env: S2N_LIBCRYPTO=openssl-1.1.1 OPENSSL_ia32cap="~0x200000200000000" BUILD_S2N=
 snippet: UbuntuBoilerplate2XL
 env: S2N_LIBCRYPTO=boringssl BUILD_S2N=true TESTS=integration GCC_VERSION=9
 
-# Unit Test
-[CodeBuild:s2nUnitOpenSSL111Gcc6]
-snippet: UbuntuBoilerplateLarge
-env: S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=unit GCC_VERSION=6 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true
-
 # Asan Test
-[CodeBuild:s2nAsanOpenSSL102Gcc6]
+[CodeBuild:s2nAsanOpenSSL111Gcc6]
 snippet: UbuntuBoilerplateLarge
-env: S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=asan GCC_VERSION=6
+env: S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=asan GCC_VERSION=6 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true
 
 #Valgrind Test
 [CodeBuild:s2nValgrindOpenSSL111Gcc9]


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
#1854

** Description. of changes: **
The unit tests run under multiple jobs (including the integration test), move the Codecov.io flags to the Asan test and get rid of the standalone unit test CodeBuild Job.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
