### PR TITLE
Derive Application Keys correctly for TLS 1.3 Mutual Auth

### DIFF
--- a/crypto/s2n_tls13_keys.c
+++ b/crypto/s2n_tls13_keys.c
@@ -207,6 +207,9 @@ int s2n_tls13_derive_application_secrets(struct s2n_tls13_keys *keys, struct s2n
     notnull_check(client_secret);
     notnull_check(server_secret);
 
+    /* Sanity check that input hash is of expected type */
+    S2N_ERROR_IF(keys->hash_algorithm != hashes->alg, S2N_ERR_HASH_INVALID_ALGORITHM);
+
     s2n_tls13_key_blob(empty_key, keys->size);
     GUARD(s2n_hkdf_extract(&keys->hmac, keys->hmac_algorithm, &keys->derive_secret, &empty_key, &keys->extract_secret));
 

--- a/crypto/s2n_tls13_keys.c
+++ b/crypto/s2n_tls13_keys.c
@@ -267,16 +267,16 @@ int s2n_tls13_derive_finished_key(struct s2n_tls13_keys *keys, struct s2n_blob *
 int s2n_tls13_calculate_finished_mac(struct s2n_tls13_keys *keys, struct s2n_blob *finished_key, struct s2n_hash_state *hash_state, struct s2n_blob *finished_verify)
 {
     /* Set up a blob to contain hash */
-    s2n_tls13_key_blob(transcribe_hash, keys->size);
+    s2n_tls13_key_blob(transcript_hash, keys->size);
 
     /* Make a copy of the hash state */
     struct s2n_hash_state hash_state_copy;
     GUARD(s2n_hash_new(&hash_state_copy));
     GUARD(s2n_hash_copy(&hash_state_copy, hash_state));
-    GUARD(s2n_hash_digest(&hash_state_copy, transcribe_hash.data, transcribe_hash.size));
+    GUARD(s2n_hash_digest(&hash_state_copy, transcript_hash.data, transcript_hash.size));
     GUARD(s2n_hash_free(&hash_state_copy));
 
-    GUARD(s2n_hkdf_extract(&keys->hmac, keys->hmac_algorithm, finished_key, &transcribe_hash, finished_verify));
+    GUARD(s2n_hkdf_extract(&keys->hmac, keys->hmac_algorithm, finished_key, &transcript_hash, finished_verify));
 
     return 0;
 }

--- a/tests/unit/s2n_tls13_handshake_test.c
+++ b/tests/unit/s2n_tls13_handshake_test.c
@@ -37,9 +37,9 @@
 /* Just to get access to the static functions / variables we need to test */
 #include "tls/s2n_handshake_io.c"
 #include "tls/s2n_tls13_handshake.c"
+#include "tls/s2n_handshake_transcript.c"
 
 static int s2n_tls13_conn_copy_server_finished_hash(struct s2n_connection *conn);
-#include "tls/s2n_handshake_transcript.c"
 
 int main(int argc, char **argv)
 {

--- a/tests/unit/s2n_tls13_handshake_test.c
+++ b/tests/unit/s2n_tls13_handshake_test.c
@@ -38,6 +38,9 @@
 #include "tls/s2n_handshake_io.c"
 #include "tls/s2n_tls13_handshake.c"
 
+static int s2n_tls13_conn_copy_server_finished_hash(struct s2n_connection *conn);
+#include "tls/s2n_handshake_transcript.c"
+
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
@@ -165,6 +168,10 @@ int main(int argc, char **argv)
         S2N_STUFFER_READ_EXPECT_EQUAL(&server_conn->in, 0xCAFED00D, uint32);
         S2N_STUFFER_READ_EXPECT_EQUAL(&server_conn->in, TLS_APPLICATION_DATA, uint8);
 
+        /* populating server finished hash is now a requirement for s2n_tls13_handle_application_secrets */
+        EXPECT_SUCCESS(s2n_tls13_conn_copy_server_finished_hash(server_conn));
+        EXPECT_SUCCESS(s2n_tls13_conn_copy_server_finished_hash(client_conn));
+
         EXPECT_SUCCESS(s2n_tls13_handle_application_secrets(server_conn));
         EXPECT_SUCCESS(s2n_tls13_handle_application_secrets(client_conn));
 
@@ -228,6 +235,8 @@ int main(int argc, char **argv)
 
                 conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
                 conn->handshake.message_number = i;
+
+                EXPECT_SUCCESS(s2n_tls13_conn_copy_server_finished_hash(conn));
 
                 /* trigger s2n_conn_pre_handshake_hashes_update */
                 EXPECT_SUCCESS(s2n_conn_pre_handshake_hashes_update(conn));

--- a/tests/unit/s2n_tls13_keys_test.c
+++ b/tests/unit/s2n_tls13_keys_test.c
@@ -188,7 +188,7 @@ int main(int argc, char **argv)
     s2n_tls13_key_blob(client_application_secret, secrets.size);
     s2n_tls13_key_blob(server_application_secret, secrets.size);
 
-    /* Update handshake transcribe hashes */
+    /* Update handshake transcript hashes */
     EXPECT_SUCCESS(s2n_hash_update(&hash_state, encrypted_extensions.data, encrypted_extensions.size));
     EXPECT_SUCCESS(s2n_hash_update(&hash_state, certificate.data, certificate.size));
     EXPECT_SUCCESS(s2n_hash_update(&hash_state, certificate_verify.data, certificate_verify.size));

--- a/tls/s2n_client_finished.c
+++ b/tls/s2n_client_finished.c
@@ -70,7 +70,7 @@ int s2n_tls13_client_finished_recv(struct s2n_connection *conn) {
     /* get tls13 keys */
     s2n_tls13_connection_keys(keys, conn);
 
-    /* get transcribe hash */
+    /* get transcript hash */
     struct s2n_hash_state hash_state = {0};
     GUARD(s2n_handshake_get_hash_state(conn, keys.hash_algorithm, &hash_state));
 
@@ -91,7 +91,7 @@ int s2n_tls13_client_finished_send(struct s2n_connection *conn) {
     /* get tls13 keys */
     s2n_tls13_connection_keys(keys, conn);
 
-    /* get transcribe hash */
+    /* get transcript hash */
     struct s2n_hash_state hash_state = {0};
     GUARD(s2n_handshake_get_hash_state(conn, keys.hash_algorithm, &hash_state));
 

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -67,6 +67,7 @@ static int s2n_connection_new_hashes(struct s2n_connection *conn)
     GUARD(s2n_hash_new(&conn->handshake.prf_md5_hash_copy));
     GUARD(s2n_hash_new(&conn->handshake.prf_sha1_hash_copy));
     GUARD(s2n_hash_new(&conn->handshake.prf_tls12_hash_copy));
+    GUARD(s2n_hash_new(&conn->handshake.server_finished_copy));
     GUARD(s2n_hash_new(&conn->prf_space.ssl3.md5));
     GUARD(s2n_hash_new(&conn->prf_space.ssl3.sha1));
     GUARD(s2n_hash_new(&conn->initial.signature_hash));
@@ -111,6 +112,7 @@ static int s2n_connection_init_hashes(struct s2n_connection *conn)
     GUARD(s2n_hash_init(&conn->handshake.sha512, S2N_HASH_SHA512));
     GUARD(s2n_hash_init(&conn->handshake.ccv_hash_copy, S2N_HASH_NONE));
     GUARD(s2n_hash_init(&conn->handshake.prf_tls12_hash_copy, S2N_HASH_NONE));
+    GUARD(s2n_hash_init(&conn->handshake.server_finished_copy, S2N_HASH_NONE));
     GUARD(s2n_hash_init(&conn->handshake.prf_sha1_hash_copy, S2N_HASH_SHA1));
     GUARD(s2n_hash_init(&conn->prf_space.ssl3.sha1, S2N_HASH_SHA1));
     GUARD(s2n_hash_init(&conn->initial.signature_hash, S2N_HASH_NONE));
@@ -316,6 +318,7 @@ static int s2n_connection_reset_hashes(struct s2n_connection *conn)
     GUARD(s2n_hash_reset(&conn->handshake.prf_md5_hash_copy));
     GUARD(s2n_hash_reset(&conn->handshake.prf_sha1_hash_copy));
     GUARD(s2n_hash_reset(&conn->handshake.prf_tls12_hash_copy));
+    GUARD(s2n_hash_reset(&conn->handshake.server_finished_copy));
     GUARD(s2n_hash_reset(&conn->prf_space.ssl3.md5));
     GUARD(s2n_hash_reset(&conn->prf_space.ssl3.sha1));
     GUARD(s2n_hash_reset(&conn->initial.signature_hash));
@@ -382,6 +385,7 @@ static int s2n_connection_free_hashes(struct s2n_connection *conn)
     GUARD(s2n_hash_free(&conn->handshake.prf_md5_hash_copy));
     GUARD(s2n_hash_free(&conn->handshake.prf_sha1_hash_copy));
     GUARD(s2n_hash_free(&conn->handshake.prf_tls12_hash_copy));
+    GUARD(s2n_hash_free(&conn->handshake.server_finished_copy));
     GUARD(s2n_hash_free(&conn->prf_space.ssl3.md5));
     GUARD(s2n_hash_free(&conn->prf_space.ssl3.sha1));
     GUARD(s2n_hash_free(&conn->initial.signature_hash));
@@ -547,6 +551,8 @@ int s2n_connection_free_handshake(struct s2n_connection *conn)
     GUARD(s2n_hash_reset(&conn->handshake.prf_md5_hash_copy));
     GUARD(s2n_hash_reset(&conn->handshake.prf_sha1_hash_copy));
     GUARD(s2n_hash_reset(&conn->handshake.prf_tls12_hash_copy));
+    GUARD(s2n_hash_reset(&conn->handshake.server_finished_copy));
+    
 
     /* Wipe the buffers we are going to free */
     GUARD(s2n_stuffer_wipe(&conn->handshake.io));

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -93,14 +93,14 @@ static int s2n_connection_init_hashes(struct s2n_connection *conn)
     if (s2n_is_in_fips_mode()) {
         GUARD(s2n_hash_allow_md5_for_fips(&conn->handshake.md5));
         GUARD(s2n_hash_allow_md5_for_fips(&conn->handshake.prf_md5_hash_copy));
-        
-        /* Do not check s2n_hash_is_available before initialization. Allow MD5 and 
+
+        /* Do not check s2n_hash_is_available before initialization. Allow MD5 and
          * SHA-1 for both fips and non-fips mode. This is required to perform the
-         * signature checks in the CertificateVerify message in TLS 1.0 and TLS 1.1. 
+         * signature checks in the CertificateVerify message in TLS 1.0 and TLS 1.1.
          * This is approved per Nist SP 800-52r1.*/
         GUARD(s2n_hash_allow_md5_for_fips(&conn->handshake.md5_sha1));
     }
-    
+
     GUARD(s2n_hash_init(&conn->handshake.md5, S2N_HASH_MD5));
     GUARD(s2n_hash_init(&conn->handshake.prf_md5_hash_copy, S2N_HASH_MD5));
     GUARD(s2n_hash_init(&conn->handshake.md5_sha1, S2N_HASH_MD5_SHA1));
@@ -552,7 +552,6 @@ int s2n_connection_free_handshake(struct s2n_connection *conn)
     GUARD(s2n_hash_reset(&conn->handshake.prf_sha1_hash_copy));
     GUARD(s2n_hash_reset(&conn->handshake.prf_tls12_hash_copy));
     GUARD(s2n_hash_reset(&conn->handshake.server_finished_copy));
-    
 
     /* Wipe the buffers we are going to free */
     GUARD(s2n_stuffer_wipe(&conn->handshake.io));

--- a/tls/s2n_connection_evp_digests.c
+++ b/tls/s2n_connection_evp_digests.c
@@ -48,6 +48,7 @@ int s2n_connection_save_hash_state(struct s2n_connection_hash_handles *hash_hand
     hash_handles->prf_md5_hash_copy = conn->handshake.prf_md5_hash_copy.digest.high_level;
     hash_handles->prf_sha1_hash_copy = conn->handshake.prf_sha1_hash_copy.digest.high_level;
     hash_handles->prf_tls12_hash_copy = conn->handshake.prf_tls12_hash_copy.digest.high_level;
+    hash_handles->server_finished_copy = conn->handshake.server_finished_copy.digest.high_level;
 
     /* Preserve only the handlers for SSLv3 PRF hash state pointers to avoid re-allocation */
     hash_handles->prf_md5 = conn->prf_space.ssl3.md5.digest.high_level;
@@ -108,6 +109,7 @@ int s2n_connection_restore_hash_state(struct s2n_connection *conn, struct s2n_co
     conn->handshake.prf_md5_hash_copy.digest.high_level = hash_handles->prf_md5_hash_copy;
     conn->handshake.prf_sha1_hash_copy.digest.high_level = hash_handles->prf_sha1_hash_copy;
     conn->handshake.prf_tls12_hash_copy.digest.high_level = hash_handles->prf_tls12_hash_copy;
+    conn->handshake.server_finished_copy.digest.high_level = hash_handles->server_finished_copy;
 
     /* Restore s2n_connection handlers for SSLv3 PRF hash states */
     conn->prf_space.ssl3.md5.digest.high_level = hash_handles->prf_md5;

--- a/tls/s2n_connection_evp_digests.h
+++ b/tls/s2n_connection_evp_digests.h
@@ -41,6 +41,7 @@ struct s2n_connection_hash_handles {
     struct s2n_hash_evp_digest prf_md5_hash_copy;
     struct s2n_hash_evp_digest prf_sha1_hash_copy;
     struct s2n_hash_evp_digest prf_tls12_hash_copy;
+    struct s2n_hash_evp_digest server_finished_copy;
     struct s2n_hash_evp_digest prf_md5;
 
     /* SSLv3 PRF hash states */

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -127,6 +127,7 @@ struct s2n_handshake {
     struct s2n_hash_state prf_sha1_hash_copy;
     /*Used for TLS 1.2 PRF */
     struct s2n_hash_state prf_tls12_hash_copy;
+    struct s2n_hash_state server_finished_copy;
 
     /* Hash algorithms required for this handshake. The set of required hashes can be reduced as session parameters are
      * negotiated, i.e. cipher suite and protocol version.

--- a/tls/s2n_handshake_transcript.c
+++ b/tls/s2n_handshake_transcript.c
@@ -25,6 +25,7 @@
 #define MESSAGE_HASH_HEADER_LENGTH  4
 
 static int s2n_tls13_conn_copy_server_finished_hash(struct s2n_connection *conn) {
+    notnull_check(conn);
     s2n_tls13_connection_keys(keys, conn);
     struct s2n_hash_state hash_state = {0};
 

--- a/tls/s2n_server_finished.c
+++ b/tls/s2n_server_finished.c
@@ -88,7 +88,7 @@ int s2n_tls13_server_finished_recv(struct s2n_connection *conn) {
     /* get tls13 keys */
     s2n_tls13_connection_keys(keys, conn);
 
-    /* get transcribe hash */
+    /* get transcript hash */
     struct s2n_hash_state hash_state = {0};
     GUARD(s2n_handshake_get_hash_state(conn, keys.hash_algorithm, &hash_state));
 
@@ -112,7 +112,7 @@ int s2n_tls13_server_finished_send(struct s2n_connection *conn) {
     /* get tls13 keys */
     s2n_tls13_connection_keys(keys, conn);
 
-    /* get transcribe hash */
+    /* get transcript hash */
     struct s2n_hash_state hash_state = {0};
     GUARD(s2n_handshake_get_hash_state(conn, keys.hash_algorithm, &hash_state));
 

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -161,8 +161,8 @@ int s2n_tls13_handle_application_secrets(struct s2n_connection *conn)
     s2n_stack_blob(server_app_secret, keys.size, S2N_TLS13_SECRET_MAX_LEN);
 
     /* use frozen hashes during the server finished state */
-    struct s2n_hash_state hash_state = conn->handshake.server_finished_copy;
-    GUARD(s2n_tls13_derive_application_secrets(&keys, &hash_state, &client_app_secret, &server_app_secret));
+    struct s2n_hash_state *hash_state = &conn->handshake.server_finished_copy;
+    GUARD(s2n_tls13_derive_application_secrets(&keys, hash_state, &client_app_secret, &server_app_secret));
 
     s2n_tls13_key_blob(s_app_key, conn->secure.cipher_suite->record_alg->cipher->key_material_size);
     struct s2n_blob s_app_iv = { .data = conn->secure.server_implicit_iv, .size = S2N_TLS13_FIXED_IV_LEN };

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -160,8 +160,11 @@ int s2n_tls13_handle_application_secrets(struct s2n_connection *conn)
     s2n_stack_blob(client_app_secret, keys.size, S2N_TLS13_SECRET_MAX_LEN);
     s2n_stack_blob(server_app_secret, keys.size, S2N_TLS13_SECRET_MAX_LEN);
 
+    /*
     struct s2n_hash_state hash_state = {0};
     GUARD(s2n_handshake_get_hash_state(conn, keys.hash_algorithm, &hash_state));
+    */
+    struct s2n_hash_state hash_state = conn->handshake.server_finished_copy;
     GUARD(s2n_tls13_derive_application_secrets(&keys, &hash_state, &client_app_secret, &server_app_secret));
 
     s2n_tls13_key_blob(s_app_key, conn->secure.cipher_suite->record_alg->cipher->key_material_size);

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -161,7 +161,8 @@ int s2n_tls13_handle_application_secrets(struct s2n_connection *conn)
     s2n_stack_blob(server_app_secret, keys.size, S2N_TLS13_SECRET_MAX_LEN);
 
     /* use frozen hashes during the server finished state */
-    struct s2n_hash_state *hash_state = &conn->handshake.server_finished_copy;
+    struct s2n_hash_state *hash_state;
+    GUARD_NONNULL(hash_state = &conn->handshake.server_finished_copy);
     GUARD(s2n_tls13_derive_application_secrets(&keys, hash_state, &client_app_secret, &server_app_secret));
 
     s2n_tls13_key_blob(s_app_key, conn->secure.cipher_suite->record_alg->cipher->key_material_size);

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -160,10 +160,7 @@ int s2n_tls13_handle_application_secrets(struct s2n_connection *conn)
     s2n_stack_blob(client_app_secret, keys.size, S2N_TLS13_SECRET_MAX_LEN);
     s2n_stack_blob(server_app_secret, keys.size, S2N_TLS13_SECRET_MAX_LEN);
 
-    /*
-    struct s2n_hash_state hash_state = {0};
-    GUARD(s2n_handshake_get_hash_state(conn, keys.hash_algorithm, &hash_state));
-    */
+    /* use frozen hashes during the server finished state */
     struct s2n_hash_state hash_state = conn->handshake.server_finished_copy;
     GUARD(s2n_tls13_derive_application_secrets(&keys, &hash_state, &client_app_secret, &server_app_secret));
 


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
TLS 1.3 computes handshake hashes, derive application keys and update encryption right before client finished. This works for the usual TLS 1.3 handshake. Due to different state flows for mutual auth, this is no longer true.

There are possible solutions

1. we calculate the keys after server_finished, but not swap the keys until client_finished is received
2. make a copy of the hash after server_finished, update the app keys calculation to use the copy

**Description of changes:** 
This fix uses the 2nd approach. `server_finished_copy` is used to make a copy of the hash from server finished and derive the application keys after client finish. Madeline keyupdate's change will 1st approach by keeping the app secret for later use. Either ways it can refactored after.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
