### PR TITLE
Adds proof harnesses for s2n_stuffer_read_uint*

### DIFF
--- a/tests/cbmc/proofs/s2n_stuffer_read_uint16/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint16/Makefile
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+
+ENTRY = s2n_stuffer_read_uint16_harness
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint16/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint16/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;6"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_read_uint16_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint16/s2n_stuffer_read_uint16_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint16/s2n_stuffer_read_uint16_harness.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_calculate_stacktrace() {}
+
+void s2n_stuffer_read_uint16_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+
+    struct s2n_stuffer old_stuffer = *stuffer;
+    uint16_t dest;
+
+    /* Store a byte from the stuffer to compare after the read */
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    if (s2n_stuffer_read_uint16(stuffer, &dest) == S2N_SUCCESS) {
+        assert(stuffer->read_cursor == old_stuffer.read_cursor + sizeof(uint16_t));
+
+        /* If successful, ensure uint was assembled correctly from stuffer */
+        assert(((uint16_t) stuffer->blob.data[old_stuffer.read_cursor]) << 8
+             | ((uint16_t) stuffer->blob.data[old_stuffer.read_cursor + 1]) == dest);
+    } else {
+	assert(stuffer->read_cursor == old_stuffer.read_cursor);
+    }
+
+    assert(stuffer->blob.data == old_stuffer.blob.data);
+    assert(stuffer->blob.size == old_stuffer.blob.size);
+    assert(stuffer->write_cursor == old_stuffer.write_cursor);
+    assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+    assert(stuffer->alloced == old_stuffer.alloced);
+    assert(stuffer->growable == old_stuffer.growable);
+    assert(stuffer->tainted == old_stuffer.tainted);
+    assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint24/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint24/Makefile
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+
+ENTRY = s2n_stuffer_read_uint24_harness
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint24/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint24/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;6"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_read_uint24_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint24/s2n_stuffer_read_uint24_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint24/s2n_stuffer_read_uint24_harness.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_calculate_stacktrace() {}
+
+void s2n_stuffer_read_uint24_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+
+    struct s2n_stuffer old_stuffer = *stuffer;
+    uint32_t dest;
+
+    /* Store a byte from the stuffer to compare after the read */
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    if (s2n_stuffer_read_uint24(stuffer, &dest) == S2N_SUCCESS) {
+        assert(stuffer->read_cursor == old_stuffer.read_cursor + sizeof(uint32_t) - 1);
+
+        /* If successful, ensure uint was assembled correctly from stuffer */
+        assert(((uint32_t) stuffer->blob.data[old_stuffer.read_cursor]) << 16
+             | ((uint32_t) stuffer->blob.data[old_stuffer.read_cursor + 1]) << 8
+             | ((uint32_t) stuffer->blob.data[old_stuffer.read_cursor + 2]) == dest);
+    } else {
+	assert(stuffer->read_cursor == old_stuffer.read_cursor);
+    }
+
+    assert(stuffer->blob.data == old_stuffer.blob.data);
+    assert(stuffer->blob.size == old_stuffer.blob.size);
+    assert(stuffer->write_cursor == old_stuffer.write_cursor);
+    assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+    assert(stuffer->alloced == old_stuffer.alloced);
+    assert(stuffer->growable == old_stuffer.growable);
+    assert(stuffer->tainted == old_stuffer.tainted);
+    assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint32/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint32/Makefile
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+
+ENTRY = s2n_stuffer_read_uint32_harness
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint32/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint32/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;6"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_read_uint32_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint32/s2n_stuffer_read_uint32_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint32/s2n_stuffer_read_uint32_harness.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_calculate_stacktrace() {}
+
+void s2n_stuffer_read_uint32_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+
+    struct s2n_stuffer old_stuffer = *stuffer;
+    uint32_t dest;
+
+    /* Store a byte from the stuffer to compare after the read */
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    if (s2n_stuffer_read_uint32(stuffer, &dest) == S2N_SUCCESS) {
+        assert(stuffer->read_cursor == old_stuffer.read_cursor + sizeof(uint32_t));
+
+        /* If successful, ensure uint was assembled correctly from stuffer */
+        assert(((uint32_t) stuffer->blob.data[old_stuffer.read_cursor]) << 24
+             | ((uint32_t) stuffer->blob.data[old_stuffer.read_cursor + 1]) << 16
+             | ((uint32_t) stuffer->blob.data[old_stuffer.read_cursor + 2]) << 8
+             | ((uint32_t) stuffer->blob.data[old_stuffer.read_cursor + 3]) == dest);
+    } else {
+	assert(stuffer->read_cursor == old_stuffer.read_cursor);
+    }
+
+    assert(stuffer->blob.data == old_stuffer.blob.data);
+    assert(stuffer->blob.size == old_stuffer.blob.size);
+    assert(stuffer->write_cursor == old_stuffer.write_cursor);
+    assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+    assert(stuffer->alloced == old_stuffer.alloced);
+    assert(stuffer->growable == old_stuffer.growable);
+    assert(stuffer->tainted == old_stuffer.tainted);
+    assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint64/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint64/Makefile
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+
+ENTRY = s2n_stuffer_read_uint64_harness
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint64/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint64/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;6"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_read_uint64_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint64/s2n_stuffer_read_uint64_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint64/s2n_stuffer_read_uint64_harness.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_calculate_stacktrace() {}
+
+void s2n_stuffer_read_uint64_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+
+    struct s2n_stuffer old_stuffer = *stuffer;
+    uint64_t dest;
+
+    /* Store a byte from the stuffer to compare after the read */
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    if (s2n_stuffer_read_uint64(stuffer, &dest) == S2N_SUCCESS) {
+        assert(stuffer->read_cursor == old_stuffer.read_cursor + sizeof(uint64_t));
+
+        /* If successful, ensure uint was assembled correctly from stuffer */
+        assert(((uint64_t) stuffer->blob.data[old_stuffer.read_cursor]) << 56
+             | ((uint64_t) stuffer->blob.data[old_stuffer.read_cursor + 1]) << 48
+             | ((uint64_t) stuffer->blob.data[old_stuffer.read_cursor + 2]) << 40
+             | ((uint64_t) stuffer->blob.data[old_stuffer.read_cursor + 3]) << 32
+             | ((uint64_t) stuffer->blob.data[old_stuffer.read_cursor + 4]) << 24
+             | ((uint64_t) stuffer->blob.data[old_stuffer.read_cursor + 5]) << 16
+             | ((uint64_t) stuffer->blob.data[old_stuffer.read_cursor + 6]) << 8
+             | ((uint64_t) stuffer->blob.data[old_stuffer.read_cursor + 7]) == dest);
+    } else {
+	assert(stuffer->read_cursor == old_stuffer.read_cursor);
+    }
+
+    assert(stuffer->blob.data == old_stuffer.blob.data);
+    assert(stuffer->blob.size == old_stuffer.blob.size);
+    assert(stuffer->write_cursor == old_stuffer.write_cursor);
+    assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+    assert(stuffer->alloced == old_stuffer.alloced);
+    assert(stuffer->growable == old_stuffer.growable);
+    assert(stuffer->tainted == old_stuffer.tainted);
+    assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint8/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint8/Makefile
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+
+ENTRY = s2n_stuffer_read_uint8_harness
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint8/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint8/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;6"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_read_uint8_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint8/s2n_stuffer_read_uint8_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint8/s2n_stuffer_read_uint8_harness.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_calculate_stacktrace() {}
+
+void s2n_stuffer_read_uint8_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+
+    struct s2n_stuffer old_stuffer = *stuffer;
+    uint8_t dest;
+
+    /* Store a byte from the stuffer to compare after the read */
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    if (s2n_stuffer_read_uint8(stuffer, &dest) == S2N_SUCCESS) {
+        assert(stuffer->read_cursor == old_stuffer.read_cursor + sizeof(uint8_t));
+
+        /* If successful, ensure uint was assembled correctly from stuffer */
+        assert(stuffer->blob.data[old_stuffer.read_cursor] == dest);
+    } else {
+	assert(stuffer->read_cursor == old_stuffer.read_cursor);
+    }
+
+    assert(stuffer->blob.data == old_stuffer.blob.data);
+    assert(stuffer->blob.size == old_stuffer.blob.size);
+    assert(stuffer->write_cursor == old_stuffer.write_cursor);
+    assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+    assert(stuffer->alloced == old_stuffer.alloced);
+    assert(stuffer->growable == old_stuffer.growable);
+    assert(stuffer->tainted == old_stuffer.tainted);
+    assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint16/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint16/Makefile
@@ -1,0 +1,32 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+
+ENTRY = s2n_stuffer_write_uint16_harness
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint16/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint16/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;6"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_write_uint16_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint16/s2n_stuffer_write_uint16_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint16/s2n_stuffer_write_uint16_harness.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_calculate_stacktrace() {}
+
+void s2n_stuffer_write_uint16_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+
+    uint16_t src;
+    uint32_t index;
+    uint32_t old_write_cursor = stuffer->write_cursor;
+
+    /* Store a byte from the stuffer that wont be overwritten to compare if the write succeeds */
+    __CPROVER_assume(index < stuffer->blob.size && (index < old_write_cursor || index >= old_write_cursor + sizeof(uint16_t)));
+    uint8_t untouched_byte = stuffer->blob.data[index];
+
+    /* Store a byte from the stuffer to compare if the write fails */
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    /* Store src to compare after the write */
+    uint16_t old_src = src;
+
+    if (s2n_stuffer_write_uint16(stuffer, src) == S2N_SUCCESS) {
+        assert(stuffer->write_cursor == old_write_cursor + sizeof(uint16_t));
+        assert(stuffer->blob.data[index] == untouched_byte);
+
+        /* Ensure uint was correctly written to the stuffer */
+        assert(((uint16_t) stuffer->blob.data[old_write_cursor]) << 8
+             | ((uint16_t) stuffer->blob.data[old_write_cursor + 1]) == src);
+    } else {
+        assert(stuffer->write_cursor == old_write_cursor);
+        assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+    }
+
+    assert(old_src == src);
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint24/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint24/Makefile
@@ -1,0 +1,32 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+
+ENTRY = s2n_stuffer_write_uint24_harness
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint24/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint24/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;6"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_write_uint24_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint24/s2n_stuffer_write_uint24_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint24/s2n_stuffer_write_uint24_harness.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_calculate_stacktrace() {}
+
+void s2n_stuffer_write_uint24_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+
+    uint32_t src;
+    uint32_t index;
+    uint32_t old_write_cursor = stuffer->write_cursor;
+
+    /* Store a byte from the stuffer that wont be overwritten to compare if the write succeeds */
+    __CPROVER_assume(index < stuffer->blob.size && (index < old_write_cursor || index >= old_write_cursor + sizeof(uint32_t) - 1));
+    uint8_t untouched_byte = stuffer->blob.data[index];
+
+    /* Store a byte from the stuffer to compare if the write fails */
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    /* Store src to compare after the write */
+    uint32_t old_src = src;
+
+    if (s2n_stuffer_write_uint24(stuffer, src) == S2N_SUCCESS) {
+        assert(stuffer->write_cursor == old_write_cursor + sizeof(uint32_t) - 1);
+        assert(stuffer->blob.data[index] == untouched_byte);
+
+        /* Ensure uint was correctly written to the stuffer */
+        assert(((uint32_t) stuffer->blob.data[old_write_cursor]) << 16
+             | ((uint32_t) stuffer->blob.data[old_write_cursor + 1]) << 8
+             | ((uint32_t) stuffer->blob.data[old_write_cursor + 2]) == (src & 0xFFFFFF));
+    } else {
+        assert(stuffer->write_cursor == old_write_cursor);
+        assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+    }
+
+    assert(old_src == src);
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint32/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint32/Makefile
@@ -1,0 +1,32 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+
+ENTRY = s2n_stuffer_write_uint32_harness
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint32/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint32/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;6"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_write_uint32_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint32/s2n_stuffer_write_uint32_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint32/s2n_stuffer_write_uint32_harness.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_calculate_stacktrace() {}
+
+void s2n_stuffer_write_uint32_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+
+    uint32_t src;
+    uint32_t index;
+    uint32_t old_write_cursor = stuffer->write_cursor;
+
+    /* Store a byte from the stuffer that wont be overwritten to compare if the write succeeds */
+    __CPROVER_assume(index < stuffer->blob.size && (index < old_write_cursor || index >= old_write_cursor + sizeof(uint32_t)));
+    uint8_t untouched_byte = stuffer->blob.data[index];
+
+    /* Store a byte from the stuffer to compare if the write fails */
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    /* Store src to compare after the write */
+    uint32_t old_src = src;
+
+    if (s2n_stuffer_write_uint32(stuffer, src) == S2N_SUCCESS) {
+        assert(stuffer->write_cursor == old_write_cursor + sizeof(uint32_t));
+        assert(stuffer->blob.data[index] == untouched_byte);
+
+        /* Ensure uint was correctly written to the stuffer */
+        assert(((uint32_t) stuffer->blob.data[old_write_cursor]) << 24
+             | ((uint32_t) stuffer->blob.data[old_write_cursor + 1]) << 16
+             | ((uint32_t) stuffer->blob.data[old_write_cursor + 2]) << 8
+             | ((uint32_t) stuffer->blob.data[old_write_cursor + 3]) == src);
+    } else {
+        assert(stuffer->write_cursor == old_write_cursor);
+        assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+    }
+
+    assert(old_src == src);
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint64/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint64/Makefile
@@ -1,0 +1,32 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+
+ENTRY = s2n_stuffer_write_uint64_harness
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint64/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint64/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;6"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_write_uint64_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint64/s2n_stuffer_write_uint64_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint64/s2n_stuffer_write_uint64_harness.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_calculate_stacktrace() {}
+
+void s2n_stuffer_write_uint64_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+
+    uint64_t src;
+    uint32_t index;
+    uint32_t old_write_cursor = stuffer->write_cursor;
+
+    /* Store a byte from the stuffer that wont be overwritten to compare if the write succeeds */
+    __CPROVER_assume(index < stuffer->blob.size && (index < old_write_cursor || index >= old_write_cursor + sizeof(uint64_t)));
+    uint8_t untouched_byte = stuffer->blob.data[index];
+
+    /* Store a byte from the stuffer to compare if the write fails */
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    /* Store src to compare after the write */
+    uint64_t old_src = src;
+
+    if (s2n_stuffer_write_uint64(stuffer, src) == S2N_SUCCESS) {
+        assert(stuffer->write_cursor == old_write_cursor + sizeof(uint64_t));
+        assert(stuffer->blob.data[index] == untouched_byte);
+
+        /* Ensure uint was correctly written to the stuffer */
+        assert(((uint64_t) stuffer->blob.data[old_write_cursor]) << 56
+             | ((uint64_t) stuffer->blob.data[old_write_cursor + 1]) << 48
+             | ((uint64_t) stuffer->blob.data[old_write_cursor + 2]) << 40
+             | ((uint64_t) stuffer->blob.data[old_write_cursor + 3]) << 32
+             | ((uint64_t) stuffer->blob.data[old_write_cursor + 4]) << 24
+             | ((uint64_t) stuffer->blob.data[old_write_cursor + 5]) << 16
+             | ((uint64_t) stuffer->blob.data[old_write_cursor + 6]) << 8
+             | ((uint64_t) stuffer->blob.data[old_write_cursor + 7]) == src);
+    } else {
+        assert(stuffer->write_cursor == old_write_cursor);
+        assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+    }
+
+    assert(old_src == src);
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint8/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint8/Makefile
@@ -1,0 +1,32 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+
+ENTRY = s2n_stuffer_write_uint8_harness
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint8/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint8/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;6"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_write_uint8_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint8/s2n_stuffer_write_uint8_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint8/s2n_stuffer_write_uint8_harness.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_calculate_stacktrace() {}
+
+void s2n_stuffer_write_uint8_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+
+    uint8_t src;
+    uint32_t index;
+    uint32_t old_write_cursor = stuffer->write_cursor;
+
+    /* Store a byte from the stuffer that wont be overwritten to compare if the write succeeds */
+    __CPROVER_assume(index < stuffer->blob.size && (index < old_write_cursor || index >= old_write_cursor + sizeof(uint8_t)));
+    uint8_t untouched_byte = stuffer->blob.data[index];
+
+    /* Store a byte from the stuffer to compare if the write fails */
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    /* Store src to compare after the write */
+    uint8_t old_src = src;
+
+    if (s2n_stuffer_write_uint8(stuffer, src) == S2N_SUCCESS) {
+        assert(stuffer->write_cursor == old_write_cursor + sizeof(uint8_t));
+        assert(stuffer->blob.data[index] == untouched_byte);
+
+        /* Ensure uint was correctly written to the stuffer */
+        assert(stuffer->blob.data[old_write_cursor] == src);
+    } else {
+        assert(stuffer->write_cursor == old_write_cursor);
+        assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+    }
+
+    assert(old_src == src);
+    assert(s2n_stuffer_is_valid(stuffer));
+}


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Description of changes:** This PR adds ten new proofs for the read and write uint functions for s2n_stuffers. The write functions report lower coverage now after the s2n_mem.c refactoring, but cover the same core functions. The lower coverage seems to come from s2n_mem.c functions that aren't used by the read or write functions. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
