### PR TITLE
S2N Stuffer Proofs

### DIFF
--- a/tests/cbmc/proofs/s2n_stuffer_free/s2n_stuffer_free_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_free/s2n_stuffer_free_harness.c
@@ -21,13 +21,6 @@
 #include <cbmc_proof/cbmc_utils.h>
 
 void s2n_calculate_stacktrace() {}
-int munlock(const void *addr, size_t len) {
-    int rval;
-
-    assert(__CPROVER_r_ok(addr, len));
-
-    return rval;
-}
 
 void s2n_stuffer_free_harness() {
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();

--- a/tests/cbmc/proofs/s2n_stuffer_peek_char/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_peek_char/Makefile
@@ -1,0 +1,31 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+
+ENTRY = s2n_stuffer_peek_char_harness
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_peek_char/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_peek_char/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;6"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_peek_char_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_peek_char/s2n_stuffer_peek_char_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_peek_char/s2n_stuffer_peek_char_harness.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_calculate_stacktrace() {}
+
+void s2n_stuffer_peek_char_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+
+    struct s2n_stuffer old_stuffer = *stuffer;
+    uint8_t dest;
+
+    /* Store a byte from the stuffer to compare after the read */
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    if (s2n_stuffer_peek_char(stuffer, &dest) == S2N_SUCCESS) {
+        /* If successful, ensure uint was assembled correctly from stuffer */
+        assert(stuffer->blob.data[old_stuffer.read_cursor] == dest);
+    }
+
+    assert(stuffer->read_cursor == old_stuffer.read_cursor);
+    assert(stuffer->write_cursor == old_stuffer.write_cursor);
+    assert(stuffer->blob.data == old_stuffer.blob.data);
+    assert(stuffer->blob.size == old_stuffer.blob.size);
+    assert(stuffer->write_cursor == old_stuffer.write_cursor);
+    assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+    assert(stuffer->alloced == old_stuffer.alloced);
+    assert(stuffer->growable == old_stuffer.growable);
+    assert(stuffer->tainted == old_stuffer.tainted);
+    assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_raw_write/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_raw_write/Makefile
@@ -1,0 +1,32 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+
+ENTRY = s2n_stuffer_raw_write_harness
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_raw_write/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_raw_write/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;6"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_raw_write_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_raw_write/s2n_stuffer_raw_write_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_raw_write/s2n_stuffer_raw_write_harness.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <sys/param.h>
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_calculate_stacktrace() {}
+
+void s2n_stuffer_raw_write_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    uint32_t data_len;
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct store_byte_from_buffer old_byte_from_stuffer;
+
+    /* Store a byte from the stuffer to compare */
+    if (stuffer->blob.size > 0) {
+        save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+    }
+
+    void *retval = s2n_stuffer_raw_write(stuffer, data_len);
+
+    if (retval != NULL) {
+        assert(stuffer->write_cursor == old_stuffer.write_cursor + data_len);
+        assert(retval == stuffer->blob.data + old_stuffer.write_cursor);
+        assert(stuffer->high_water_mark == MAX(old_stuffer.write_cursor + data_len, old_stuffer.high_water_mark));
+        assert(stuffer->tainted == 1);
+    } else {
+        assert(stuffer->write_cursor == old_stuffer.write_cursor);
+        assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+        assert(stuffer->tainted == old_stuffer.tainted);
+    }
+
+    if(old_stuffer.blob.size > 0) {
+        assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+    }
+
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_rewind_read/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_rewind_read/Makefile
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+
+ENTRY = s2n_stuffer_rewind_read_harness
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_rewind_read/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_rewind_read/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;6"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_rewind_read_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_rewind_read/s2n_stuffer_rewind_read_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_rewind_read/s2n_stuffer_rewind_read_harness.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_calculate_stacktrace() {}
+
+void s2n_stuffer_rewind_read_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    uint32_t size;
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+
+    struct s2n_stuffer old_stuffer = *stuffer;
+
+    /* Store a byte from the stuffer to compare after the read */
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    if(s2n_stuffer_rewind_read(stuffer, size) == S2N_SUCCESS) {
+        assert(old_stuffer.read_cursor >= size);
+        assert(stuffer->read_cursor == old_stuffer.read_cursor - size);
+    }
+    else {
+        assert(old_stuffer.read_cursor < size);
+        assert(stuffer->read_cursor == old_stuffer.read_cursor);
+    }
+
+    assert(stuffer->blob.data == old_stuffer.blob.data);
+    assert(stuffer->blob.size == old_stuffer.blob.size);
+    assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+    assert(stuffer->alloced == old_stuffer.alloced);
+    assert(stuffer->growable == old_stuffer.growable);
+    assert(stuffer->tainted == old_stuffer.tainted);
+    assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_rewrite/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_rewrite/Makefile
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+
+ENTRY = s2n_stuffer_rewrite_harness
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_rewrite/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_rewrite/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;6"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_rewrite_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_rewrite/s2n_stuffer_rewrite_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_rewrite/s2n_stuffer_rewrite_harness.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_calculate_stacktrace() {}
+
+void s2n_stuffer_rewrite_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+
+    struct s2n_stuffer old_stuffer = *stuffer;
+
+    /* Store a byte from the stuffer to compare after the read */
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    s2n_stuffer_rewrite(stuffer);
+
+    assert(stuffer->write_cursor == 0);
+    assert(stuffer->read_cursor == 0);
+    assert(stuffer->blob.data == old_stuffer.blob.data);
+    assert(stuffer->blob.size == old_stuffer.blob.size);
+    assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+    assert(stuffer->alloced == old_stuffer.alloced);
+    assert(stuffer->growable == old_stuffer.growable);
+    assert(stuffer->tainted == old_stuffer.tainted);
+    assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_skip_write/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_write/Makefile
@@ -1,0 +1,32 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+
+ENTRY = s2n_stuffer_skip_write_harness
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_skip_write/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_write/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;6"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_skip_write_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_skip_write/s2n_stuffer_skip_write_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_write/s2n_stuffer_skip_write_harness.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <sys/param.h>
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_calculate_stacktrace() {}
+
+void s2n_stuffer_skip_write_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    uint32_t data_len;
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct store_byte_from_buffer old_byte_from_stuffer;
+
+    /* Store a byte from the stuffer to compare */
+    if (stuffer->blob.size > 0) {
+        save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+    }
+
+    if (s2n_stuffer_skip_write(stuffer, data_len) == S2N_SUCCESS) {
+        assert(stuffer->write_cursor == old_stuffer.write_cursor + data_len);
+        assert(stuffer->high_water_mark == MAX(old_stuffer.write_cursor + data_len, old_stuffer.high_water_mark));
+    } else {
+        assert(stuffer->write_cursor == old_stuffer.write_cursor);
+        assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+    }
+
+    if(old_stuffer.blob.size > 0) {
+        assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+    }
+
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_write/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write/Makefile
@@ -1,0 +1,32 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+
+ENTRY = s2n_stuffer_write_harness
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_write/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;6"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_write_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_write/s2n_stuffer_write_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write/s2n_stuffer_write_harness.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+#include <sys/param.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_calculate_stacktrace() {}
+
+void s2n_stuffer_write_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    struct s2n_blob *blob = cbmc_allocate_s2n_blob();
+    uint32_t index;
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    __CPROVER_assume(s2n_blob_is_valid(blob));
+    __CPROVER_assume(blob->size <= UINT32_MAX - stuffer->write_cursor);
+
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct s2n_blob old_blob = *blob;
+
+
+    /* Store a byte from the stuffer that wont be overwritten to compare if the write succeeds */
+    __CPROVER_assume(index < stuffer->blob.size && (index < old_stuffer.write_cursor || index >= old_stuffer.write_cursor + blob->size));
+    uint8_t untouched_byte = stuffer->blob.data[index];
+
+    /* Store a byte from the stuffer to compare if the write fails */
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    /* Store a byte from the blob to compare */
+    struct store_byte_from_buffer old_byte_from_blob;
+    save_byte_from_blob(blob, &old_byte_from_blob);
+
+    if (s2n_stuffer_write(stuffer, blob) == S2N_SUCCESS) {
+        assert(stuffer->write_cursor == old_stuffer.write_cursor + blob->size);
+        assert(stuffer->blob.data[index] == untouched_byte);
+        assert(stuffer->high_water_mark == MAX(old_stuffer.write_cursor + blob->size, old_stuffer.high_water_mark));
+    } else {
+	assert(stuffer->write_cursor == old_stuffer.write_cursor);
+        assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+        assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+    }
+
+    assert(stuffer->read_cursor == old_stuffer.read_cursor);
+    assert_byte_from_blob_matches(blob, &old_byte_from_blob);
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_write_bytes/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_bytes/Makefile
@@ -1,0 +1,32 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+
+ENTRY = s2n_stuffer_write_bytes_harness
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_bytes/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_write_bytes/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;6"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_write_bytes_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_write_bytes/s2n_stuffer_write_bytes_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_bytes/s2n_stuffer_write_bytes_harness.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+#include <sys/param.h>
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_calculate_stacktrace() {}
+
+void s2n_stuffer_write_bytes_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    struct s2n_blob *blob = cbmc_allocate_s2n_blob();
+    uint32_t size;
+    uint32_t index;
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    __CPROVER_assume(s2n_blob_is_valid(blob));
+    __CPROVER_assume(size <= UINT32_MAX - stuffer->write_cursor && size <= blob->size);
+
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct s2n_blob old_blob = *blob;
+
+
+    /* Store a byte from the stuffer that wont be overwritten to compare if the write succeeds */
+    __CPROVER_assume(index < stuffer->blob.size && (index < old_stuffer.write_cursor || index >= old_stuffer.write_cursor + size));
+    uint8_t untouched_byte = stuffer->blob.data[index];
+
+    /* Store a byte from the stuffer to compare if the write fails */
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    /* Store a byte from the blob to compare if the write succeeds */
+    struct store_byte_from_buffer old_byte_from_blob;
+    save_byte_from_blob(blob, &old_byte_from_blob);
+
+    if (s2n_stuffer_write_bytes(stuffer, blob->data, size) == S2N_SUCCESS) {
+        assert(stuffer->write_cursor == old_stuffer.write_cursor + size);
+        assert(stuffer->blob.data[index] == untouched_byte);
+        assert(stuffer->high_water_mark == MAX(old_stuffer.write_cursor + size, old_stuffer.high_water_mark));
+    } else {
+        assert(stuffer->write_cursor == old_stuffer.write_cursor);
+        assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+        assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+    }
+
+    assert(stuffer->read_cursor == old_stuffer.read_cursor);
+    assert_byte_from_blob_matches(blob, &old_byte_from_blob);
+    assert(s2n_stuffer_is_valid(stuffer));
+}


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Description of changes:** This PR adds proofs for a variety of s2n_stuffer functions. After the s2n_mem.c refactor their coverage is reported as lower due to not touching certain s2n_mem.c functions, but they still cover all relevant functions.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
