### PR TITLE
Fix "comparison is always false..." warnings

### DIFF
--- a/tls/extensions/s2n_certificate_extensions.h
+++ b/tls/extensions/s2n_certificate_extensions.h
@@ -21,9 +21,13 @@
 
 /* Guards against errors and non uint16s, then increments size */
 #define GUARD_UINT16_AND_INCREMENT( x, size ) do { \
+    GUARD_UINT16(x); \
+    size += x; \
+} while (0)
+
+#define GUARD_UINT16( x ) do { \
     GUARD(x); \
     lte_check(x, 65535); \
-    size += x; \
 } while (0)
 
 int s2n_certificate_extensions_parse(struct s2n_connection *conn, struct s2n_blob *extensions);

--- a/tls/extensions/s2n_server_renegotiation_info.c
+++ b/tls/extensions/s2n_server_renegotiation_info.c
@@ -54,7 +54,7 @@ int s2n_send_server_renegotiation_info_ext(struct s2n_connection *conn, struct s
     return 0;
 }
 
-uint16_t s2n_server_renegotiation_info_ext_size(struct s2n_connection *conn)
+int s2n_server_renegotiation_info_ext_size(struct s2n_connection *conn)
 {
     if (s2n_server_can_send_secure_renegotiation(conn)) {
         /* 2 for ext type, 2 for extension length, 1 for value of 0 */

--- a/tls/extensions/s2n_server_renegotiation_info.h
+++ b/tls/extensions/s2n_server_renegotiation_info.h
@@ -17,4 +17,4 @@
 
 int s2n_recv_server_renegotiation_info_ext(struct s2n_connection *conn, struct s2n_stuffer *extension);
 int s2n_send_server_renegotiation_info_ext(struct s2n_connection *conn, struct s2n_stuffer *out);
-uint16_t s2n_server_renegotiation_info_ext_size(struct s2n_connection *conn);
+int s2n_server_renegotiation_info_ext_size(struct s2n_connection *conn);

--- a/tls/extensions/s2n_server_session_ticket.c
+++ b/tls/extensions/s2n_server_session_ticket.c
@@ -40,7 +40,7 @@ int s2n_send_server_session_ticket_ext(struct s2n_connection *conn, struct s2n_s
     return 0;
 }
 
-uint16_t s2n_server_session_ticket_ext_size(struct s2n_connection *conn)
+int s2n_server_session_ticket_ext_size(struct s2n_connection *conn)
 {
     if (s2n_server_can_send_nst(conn)) {
         /* 2 for extension type. 2 for extension length of 0 */

--- a/tls/extensions/s2n_server_session_ticket.h
+++ b/tls/extensions/s2n_server_session_ticket.h
@@ -17,4 +17,4 @@
 
 int s2n_recv_server_session_ticket_ext(struct s2n_connection *conn, struct s2n_stuffer *extension);
 int s2n_send_server_session_ticket_ext(struct s2n_connection *conn, struct s2n_stuffer *out);
-uint16_t s2n_server_session_ticket_ext_size(struct s2n_connection *conn);
+int s2n_server_session_ticket_ext_size(struct s2n_connection *conn);

--- a/tls/s2n_server_extensions.c
+++ b/tls/s2n_server_extensions.c
@@ -57,10 +57,10 @@ int s2n_server_extensions_send_size(struct s2n_connection *conn)
 
     GUARD_UINT16_AND_INCREMENT(s2n_server_extensions_server_name_send_size(conn), total_size);
     GUARD_UINT16_AND_INCREMENT(s2n_server_extensions_alpn_send_size(conn), total_size);
-    GUARD_UINT16_AND_INCREMENT(s2n_server_renegotiation_info_ext_size(conn), total_size);
+    total_size += s2n_server_renegotiation_info_ext_size(conn);
     GUARD_UINT16_AND_INCREMENT(s2n_kex_server_extension_size(conn->secure.cipher_suite->key_exchange_alg, conn), total_size);
     GUARD_UINT16_AND_INCREMENT(s2n_server_extensions_max_fragment_length_send_size(conn), total_size);
-    GUARD_UINT16_AND_INCREMENT(s2n_server_session_ticket_ext_size(conn), total_size);
+    total_size += s2n_server_session_ticket_ext_size(conn);
     GUARD_UINT16_AND_INCREMENT(s2n_server_extensions_status_request_send_size(conn), total_size);
     GUARD_UINT16_AND_INCREMENT(s2n_server_extensions_sct_list_send_size(conn), total_size);
 
@@ -74,7 +74,7 @@ int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *
     if (total_size == 0) {
         return 0;
     }
-    inclusive_range_check(0, total_size, 65535);
+    GUARD_UINT16(total_size);
 
     GUARD(s2n_stuffer_write_uint16(out, total_size));
 

--- a/tls/s2n_server_extensions.c
+++ b/tls/s2n_server_extensions.c
@@ -57,10 +57,10 @@ int s2n_server_extensions_send_size(struct s2n_connection *conn)
 
     GUARD_UINT16_AND_INCREMENT(s2n_server_extensions_server_name_send_size(conn), total_size);
     GUARD_UINT16_AND_INCREMENT(s2n_server_extensions_alpn_send_size(conn), total_size);
-    total_size += s2n_server_renegotiation_info_ext_size(conn);
+    GUARD_UINT16_AND_INCREMENT(s2n_server_renegotiation_info_ext_size(conn), total_size);
     GUARD_UINT16_AND_INCREMENT(s2n_kex_server_extension_size(conn->secure.cipher_suite->key_exchange_alg, conn), total_size);
     GUARD_UINT16_AND_INCREMENT(s2n_server_extensions_max_fragment_length_send_size(conn), total_size);
-    total_size += s2n_server_session_ticket_ext_size(conn);
+    GUARD_UINT16_AND_INCREMENT(s2n_server_session_ticket_ext_size(conn), total_size);
     GUARD_UINT16_AND_INCREMENT(s2n_server_extensions_status_request_send_size(conn), total_size);
     GUARD_UINT16_AND_INCREMENT(s2n_server_extensions_sct_list_send_size(conn), total_size);
 


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
```
/tls/s2n_server_extensions.c: In function 's2n_server_extensions_send_size':
/tls/s2n_server_extensions.c:60: warning: comparison is always false due to limited range of data type
/tls/s2n_server_extensions.c:60: warning: comparison is always false due to limited range of data type
/tls/s2n_server_extensions.c:63: warning: comparison is always false due to limited range of data type
/tls/s2n_server_extensions.c:63: warning: comparison is always false due to limited range of data type
```
**Description of changes:** 
~~Don't check uint16 ranges for uint16_t types.~~
keep int for _size() function signatures

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
