### PR TITLE
Add stuffer methods to handle vectors

### DIFF
--- a/stuffer/s2n_stuffer_network_order.c
+++ b/stuffer/s2n_stuffer_network_order.c
@@ -17,6 +17,7 @@
 
 #include "stuffer/s2n_stuffer.h"
 
+#include "utils/s2n_annotations.h"
 #include "utils/s2n_safety.h"
 
 #define SIZEOF_UINT24 3

--- a/stuffer/s2n_stuffer_network_order.c
+++ b/stuffer/s2n_stuffer_network_order.c
@@ -28,6 +28,7 @@ static int s2n_stuffer_write_network_order(struct s2n_stuffer *stuffer, uint32_t
     uint8_t *data = stuffer->blob.data + stuffer->write_cursor - length;
 
     for (int i = 0; i < length; i++) {
+        S2N_INVARIENT(i <= length);
         uint8_t shift = (length - i - 1) * 8;
         data[i] = (input >> (shift)) & 0xFF;
     }

--- a/stuffer/s2n_stuffer_network_order.c
+++ b/stuffer/s2n_stuffer_network_order.c
@@ -1,0 +1,186 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "error/s2n_errno.h"
+
+#include "stuffer/s2n_stuffer.h"
+
+#include "utils/s2n_safety.h"
+
+#define SIZEOF_UINT24 3
+
+static int s2n_stuffer_write_network_order(struct s2n_stuffer *stuffer, uint32_t input, uint8_t length)
+{
+    notnull_check(stuffer);
+    GUARD(s2n_stuffer_skip_write(stuffer, length));
+    uint8_t *data = stuffer->blob.data + stuffer->write_cursor - length;
+
+    uint8_t shift;
+    for (int i = 0; i < length; i++) {
+        shift = (length - i - 1) * 8;
+        data[i] = (input >> (shift)) & 0xFF;
+    }
+
+    return S2N_SUCCESS;
+}
+
+int s2n_stuffer_read_uint8(struct s2n_stuffer *stuffer, uint8_t * u)
+{
+    GUARD(s2n_stuffer_read_bytes(stuffer, u, 1));
+
+    return 0;
+}
+
+int s2n_stuffer_write_uint8(struct s2n_stuffer *stuffer, const uint8_t u)
+{
+    GUARD(s2n_stuffer_write_bytes(stuffer, &u, 1));
+
+    return 0;
+}
+
+int s2n_stuffer_read_uint16(struct s2n_stuffer *stuffer, uint16_t * u)
+{
+    uint8_t data[2];
+
+    GUARD(s2n_stuffer_read_bytes(stuffer, data, sizeof(data)));
+
+    *u = data[0] << 8;
+    *u |= data[1];
+
+    return 0;
+}
+
+int s2n_stuffer_write_uint16(struct s2n_stuffer *stuffer, const uint16_t u)
+{
+    return s2n_stuffer_write_network_order(stuffer, u, sizeof(u));
+}
+
+int s2n_stuffer_reserve_uint16(struct s2n_stuffer *stuffer, struct s2n_stuffer_reservation *reservation)
+{
+    notnull_check(stuffer);
+    notnull_check(reservation);
+
+    reservation->stuffer = stuffer;
+    reservation->write_cursor = stuffer->write_cursor;
+    reservation->length = sizeof(uint16_t);
+
+    GUARD(s2n_stuffer_skip_write(stuffer, reservation->length));
+    memset_check(stuffer->blob.data + reservation->write_cursor, S2N_WIPE_PATTERN, reservation->length);
+
+    return S2N_SUCCESS;
+}
+
+int s2n_stuffer_read_uint24(struct s2n_stuffer *stuffer, uint32_t * u)
+{
+    uint8_t data[3];
+
+    GUARD(s2n_stuffer_read_bytes(stuffer, data, sizeof(data)));
+
+    *u = data[0] << 16;
+    *u |= data[1] << 8;
+    *u |= data[2];
+
+    return 0;
+}
+
+int s2n_stuffer_write_uint24(struct s2n_stuffer *stuffer, const uint32_t u)
+{
+    return s2n_stuffer_write_network_order(stuffer, u, SIZEOF_UINT24);
+}
+
+int s2n_stuffer_read_uint32(struct s2n_stuffer *stuffer, uint32_t * u)
+{
+    uint8_t data[4];
+
+    GUARD(s2n_stuffer_read_bytes(stuffer, data, sizeof(data)));
+
+    *u = ((uint32_t) data[0]) << 24;
+    *u |= data[1] << 16;
+    *u |= data[2] << 8;
+    *u |= data[3];
+
+    return 0;
+}
+
+int s2n_stuffer_write_uint32(struct s2n_stuffer *stuffer, const uint32_t u)
+{
+    return s2n_stuffer_write_network_order(stuffer, u, sizeof(u));
+}
+
+int s2n_stuffer_read_uint64(struct s2n_stuffer *stuffer, uint64_t * u)
+{
+    uint8_t data[8];
+
+    GUARD(s2n_stuffer_read_bytes(stuffer, data, sizeof(data)));
+
+    *u = ((uint64_t) data[0]) << 56;
+    *u |= ((uint64_t) data[1]) << 48;
+    *u |= ((uint64_t) data[2]) << 40;
+    *u |= ((uint64_t) data[3]) << 32;
+    *u |= ((uint64_t) data[4]) << 24;
+    *u |= ((uint64_t) data[5]) << 16;
+    *u |= ((uint64_t) data[6]) << 8;
+    *u |= data[7];
+
+    return 0;
+}
+
+int s2n_stuffer_write_uint64(struct s2n_stuffer *stuffer, const uint64_t u)
+{
+    GUARD(s2n_stuffer_write_network_order(stuffer, u >> (sizeof(uint32_t) * 8), sizeof(uint32_t)));
+    GUARD(s2n_stuffer_write_network_order(stuffer, u & UINT32_MAX, sizeof(uint32_t)));
+
+    return 0;
+}
+
+static int length_matches_value_check(uint32_t value, uint8_t length)
+{
+    /* Value is represented as a uint32_t, so shouldn't be assumed larger */
+    S2N_ERROR_IF(length > sizeof(uint32_t), S2N_ERR_SIZE_MISMATCH);
+
+    if (length < sizeof(uint32_t)) {
+        /* Value should be less than the maximum for its length */
+        S2N_ERROR_IF(value >= (0x01 << (length * 8)), S2N_ERR_SIZE_MISMATCH);
+    }
+
+    return S2N_SUCCESS;
+}
+
+static int s2n_stuffer_write_reservation(struct s2n_stuffer_reservation reservation, uint32_t u)
+{
+    notnull_check(reservation.stuffer);
+    uint32_t old_write_cursor = reservation.stuffer->write_cursor;
+    reservation.stuffer->write_cursor = reservation.write_cursor;
+
+    if (!s2n_stuffer_is_valid(reservation.stuffer)) {
+        reservation.stuffer->write_cursor = old_write_cursor;
+        S2N_ERROR(S2N_ERR_SAFETY);
+    }
+
+    if (length_matches_value_check(u, reservation.length) != S2N_SUCCESS
+            || s2n_stuffer_write_network_order(reservation.stuffer, u, reservation.length) != S2N_SUCCESS) {
+        reservation.stuffer->write_cursor = old_write_cursor;
+        S2N_ERROR_PRESERVE_ERRNO();
+    }
+
+    reservation.stuffer->write_cursor = old_write_cursor;
+    return S2N_SUCCESS;
+}
+
+int s2n_stuffer_write_vector_size(struct s2n_stuffer_reservation reservation)
+{
+    uint32_t size = reservation.stuffer->write_cursor - reservation.write_cursor - reservation.length;
+    return s2n_stuffer_write_reservation(reservation, size);
+}

--- a/stuffer/s2n_stuffer_network_order.c
+++ b/stuffer/s2n_stuffer_network_order.c
@@ -27,9 +27,8 @@ static int s2n_stuffer_write_network_order(struct s2n_stuffer *stuffer, uint32_t
     GUARD(s2n_stuffer_skip_write(stuffer, length));
     uint8_t *data = stuffer->blob.data + stuffer->write_cursor - length;
 
-    uint8_t shift;
     for (int i = 0; i < length; i++) {
-        shift = (length - i - 1) * 8;
+        uint8_t shift = (length - i - 1) * 8;
         data[i] = (input >> (shift)) & 0xFF;
     }
 

--- a/tests/sidetrail/working/s2n-record-read-aead/Makefile
+++ b/tests/sidetrail/working/s2n-record-read-aead/Makefile
@@ -12,6 +12,7 @@ extras += crypto/s2n_hash.c
 extras += crypto/s2n_hmac.c
 extras += error/s2n_errno.c
 extras += stuffer/s2n_stuffer.c
+extras += stuffer/s2n_stuffer_network_order.c
 extras += tls/s2n_aead.c
 extras += tls/s2n_cbc.c
 extras += tls/s2n_record_read_aead.c

--- a/tests/sidetrail/working/s2n-record-read-aead/copy_as_needed.sh
+++ b/tests/sidetrail/working/s2n-record-read-aead/copy_as_needed.sh
@@ -36,6 +36,7 @@ cp ../stubs/s2n_errno.c error/
 
 mkdir -p stuffer
 cp $S2N_BASE/stuffer/s2n_stuffer.c stuffer/
+cp $S2N_BASE/stuffer/s2n_stuffer_network_order.c stuffer/
 
 mkdir -p tls
 #add invariants etc needed for the proof to the s2n_cbc code

--- a/tests/sidetrail/working/s2n-record-read-cbc/Makefile
+++ b/tests/sidetrail/working/s2n-record-read-cbc/Makefile
@@ -12,6 +12,7 @@ extras += crypto/s2n_hash.c
 extras += crypto/s2n_hmac.c
 extras += error/s2n_errno.c
 extras += stuffer/s2n_stuffer.c
+extras += stuffer/s2n_stuffer_network_order.c
 extras += tls/s2n_cbc.c
 extras += tls/s2n_record_read_cbc.c
 extras += utils/s2n_mem.c

--- a/tests/sidetrail/working/s2n-record-read-cbc/copy_as_needed.sh
+++ b/tests/sidetrail/working/s2n-record-read-cbc/copy_as_needed.sh
@@ -37,6 +37,7 @@ cp ../stubs/s2n_errno.c error/
 
 mkdir -p stuffer
 cp $S2N_BASE/stuffer/s2n_stuffer.c stuffer/
+cp $S2N_BASE/stuffer/s2n_stuffer_network_order.c stuffer/
 
 mkdir -p tls
 #add invariants etc needed for the proof to the s2n_cbc code

--- a/tests/sidetrail/working/s2n-record-read-composite/Makefile
+++ b/tests/sidetrail/working/s2n-record-read-composite/Makefile
@@ -12,6 +12,7 @@ extras += crypto/s2n_hash.c
 extras += crypto/s2n_hmac.c
 extras += error/s2n_errno.c
 extras += stuffer/s2n_stuffer.c
+extras += stuffer/s2n_stuffer_network_order.c
 extras += tls/s2n_record_read_composite.c
 extras += utils/s2n_mem.c
 extras += utils/s2n_safety.c

--- a/tests/sidetrail/working/s2n-record-read-composite/copy_as_needed.sh
+++ b/tests/sidetrail/working/s2n-record-read-composite/copy_as_needed.sh
@@ -37,6 +37,7 @@ cp ../stubs/s2n_errno.c error/
 
 mkdir -p stuffer
 cp $S2N_BASE/stuffer/s2n_stuffer.c stuffer/
+cp $S2N_BASE/stuffer/s2n_stuffer_network_order.c stuffer/
 
 mkdir -p tls
 #add invariants etc needed for the proof to the s2n_cbc code

--- a/tests/sidetrail/working/s2n-record-read-stream/Makefile
+++ b/tests/sidetrail/working/s2n-record-read-stream/Makefile
@@ -12,6 +12,7 @@ extras += crypto/s2n_hash.c
 extras += crypto/s2n_hmac.c
 extras += error/s2n_errno.c
 extras += stuffer/s2n_stuffer.c
+extras += stuffer/s2n_stuffer_network_order.c
 extras += tls/s2n_cbc.c
 extras += tls/s2n_record_read_stream.c
 extras += utils/s2n_mem.c

--- a/tests/sidetrail/working/s2n-record-read-stream/copy_as_needed.sh
+++ b/tests/sidetrail/working/s2n-record-read-stream/copy_as_needed.sh
@@ -37,6 +37,7 @@ cp ../stubs/s2n_errno.c error/
 
 mkdir -p stuffer
 cp $S2N_BASE/stuffer/s2n_stuffer.c stuffer/
+cp $S2N_BASE/stuffer/s2n_stuffer_network_order.c stuffer/
 
 mkdir -p tls
 #add invariants etc needed for the proof to the s2n_cbc code

--- a/tests/unit/s2n_stuffer_network_order_test.c
+++ b/tests/unit/s2n_stuffer_network_order_test.c
@@ -1,0 +1,247 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <s2n.h>
+
+#include "s2n_test.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_mem.h"
+
+#include "stuffer/s2n_stuffer_network_order.c"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    struct s2n_stuffer stuffer;
+
+    /* s2n_stuffer_write_network_order */
+    {
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        /* Null checks */
+        EXPECT_FAILURE(s2n_stuffer_write_network_order(NULL, 0, 1));
+
+        /* No-op for zero length */
+        EXPECT_SUCCESS(s2n_stuffer_write_network_order(&stuffer, 0x00, 0));
+        EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
+
+        uint8_t byte_length;
+
+        /* uint8_t */
+        {
+            byte_length = sizeof(uint8_t);
+            uint8_t actual_value;
+
+            for (int i = 0; i <= UINT8_MAX; i++) {
+                EXPECT_SUCCESS(s2n_stuffer_write_network_order(&stuffer, i, byte_length));
+                EXPECT_SUCCESS(s2n_stuffer_read_uint8(&stuffer, &actual_value));
+                EXPECT_EQUAL(i, actual_value);
+            }
+        }
+
+        /* uint16_t */
+        {
+            byte_length = sizeof(uint16_t);
+            uint16_t actual_value;
+
+            for (int i = 0; i < UINT16_MAX; i++) {
+                EXPECT_SUCCESS(s2n_stuffer_write_network_order(&stuffer, i, byte_length));
+                EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &actual_value));
+                EXPECT_EQUAL(i, actual_value);
+            }
+        }
+
+        /* uint24 */
+        {
+            byte_length = 3;
+            uint32_t actual_value;
+            uint32_t test_values[] = { 0x000001, 0x0000FF, 0xABCDEF, 0xFFFFFF };
+
+            for (int i = 0; i < s2n_array_len(test_values); i++) {
+                EXPECT_SUCCESS(s2n_stuffer_write_network_order(&stuffer, test_values[i], byte_length));
+                EXPECT_SUCCESS(s2n_stuffer_read_uint24(&stuffer, &actual_value));
+                EXPECT_EQUAL(test_values[i], actual_value);
+            }
+
+            uint16_t prime = 257;
+            for (uint32_t i = 0; i < 0xFFFFFF - prime; i += prime) {
+                EXPECT_SUCCESS(s2n_stuffer_write_network_order(&stuffer, i, byte_length));
+                EXPECT_SUCCESS(s2n_stuffer_read_uint24(&stuffer, &actual_value));
+                EXPECT_EQUAL(i, actual_value);
+            }
+        }
+
+        /* uint32_t */
+        {
+            byte_length = sizeof(uint32_t);
+            uint32_t actual_value;
+            uint32_t test_values[] = { 0x00000001, 0x000000FF, 0xABCDEF12, UINT32_MAX };
+
+            for (int i = 0; i < s2n_array_len(test_values); i++) {
+                EXPECT_SUCCESS(s2n_stuffer_write_network_order(&stuffer, test_values[i], byte_length));
+                EXPECT_SUCCESS(s2n_stuffer_read_uint32(&stuffer, &actual_value));
+                EXPECT_EQUAL(test_values[i], actual_value);
+            }
+
+            uint32_t prime = 65537;
+            for (uint32_t i = 0; i < UINT32_MAX - prime; i += prime) {
+                EXPECT_SUCCESS(s2n_stuffer_write_network_order(&stuffer, i, byte_length));
+                EXPECT_SUCCESS(s2n_stuffer_read_uint32(&stuffer, &actual_value));
+                EXPECT_EQUAL(i, actual_value);
+            }
+        }
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+    }
+
+    /* s2n_stuffer_reserve_uint16 */
+    {
+        uint16_t actual_value;
+        struct s2n_stuffer_reservation reservation = { 0 };
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        /* Null checks */
+        EXPECT_FAILURE(s2n_stuffer_reserve_uint16(NULL, &reservation));
+        EXPECT_FAILURE(s2n_stuffer_reserve_uint16(&stuffer, NULL));
+
+        /* Happy case: successfully reserves space for a uint16_t */
+        {
+            /* Write some data. We want to verify it isn't overwritten. */
+            uint16_t data_before = 5;
+            EXPECT_SUCCESS(s2n_stuffer_write_uint16(&stuffer, data_before));
+
+            /* Reserve uint16 */
+            EXPECT_SUCCESS(s2n_stuffer_reserve_uint16(&stuffer, &reservation));
+            EXPECT_EQUAL(reservation.stuffer, &stuffer);
+            EXPECT_EQUAL(reservation.write_cursor, sizeof(uint16_t));
+            EXPECT_EQUAL(reservation.length, sizeof(uint16_t));
+
+            /* Reserve uint16 again */
+            EXPECT_SUCCESS(s2n_stuffer_reserve_uint16(&stuffer, &reservation));
+            EXPECT_EQUAL(reservation.stuffer, &stuffer);
+            EXPECT_EQUAL(reservation.write_cursor, sizeof(uint16_t) * 2);
+            EXPECT_EQUAL(reservation.length, sizeof(uint16_t));
+
+            /* Write some more data. We want to verify it isn't overwritten. */
+            uint16_t data_after = -1;
+            EXPECT_SUCCESS(s2n_stuffer_write_uint16(&stuffer, data_after));
+
+            /* Make sure expected values read back */
+            uint8_t actual_bytes[sizeof(uint16_t)], expected_bytes[] = { S2N_WIPE_PATTERN, S2N_WIPE_PATTERN };
+            EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &actual_value));
+            EXPECT_EQUAL(actual_value, data_before);
+            EXPECT_SUCCESS(s2n_stuffer_read_bytes(&stuffer, actual_bytes, sizeof(uint16_t)));
+            EXPECT_BYTEARRAY_EQUAL(actual_bytes, expected_bytes, sizeof(uint16_t));
+            EXPECT_SUCCESS(s2n_stuffer_read_bytes(&stuffer, actual_bytes, sizeof(uint16_t)));
+            EXPECT_BYTEARRAY_EQUAL(actual_bytes, expected_bytes, sizeof(uint16_t));
+            EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &actual_value));
+            EXPECT_EQUAL(actual_value, data_after);
+        }
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+    }
+
+    /* s2n_stuffer_write_reservation */
+    {
+        uint16_t actual_value;
+        struct s2n_stuffer_reservation reservation = { 0 };
+        struct s2n_stuffer_reservation other_reservation = { 0 };
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+        uint32_t expected_write_cursor = stuffer.write_cursor;
+
+        /* Null checks */
+        reservation.stuffer = NULL;
+        EXPECT_FAILURE(s2n_stuffer_write_reservation(reservation, 0));
+        EXPECT_EQUAL(stuffer.write_cursor, expected_write_cursor);
+        reservation.stuffer = &stuffer;
+
+        /* Should throw an error if reservation has wrong size */
+        reservation.length = sizeof(uint64_t);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_stuffer_write_reservation(reservation, 0), S2N_ERR_SIZE_MISMATCH);
+        EXPECT_EQUAL(stuffer.write_cursor, expected_write_cursor);
+        reservation.length = sizeof(uint16_t);
+
+        /* Should throw an error if value length does not match reservation length */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_stuffer_write_reservation(reservation, UINT32_MAX), S2N_ERR_SIZE_MISMATCH);
+        EXPECT_EQUAL(stuffer.write_cursor, expected_write_cursor);
+
+        /* Should throw an error if rewriting would require an invalid stuffer state.
+         * ( A write cursor being greater than the high water mark is an invalid stuffer state.) */
+        reservation.write_cursor = stuffer.high_water_mark + 1;
+        EXPECT_FAILURE_WITH_ERRNO(s2n_stuffer_write_reservation(reservation, 0), S2N_ERR_SAFETY);
+        EXPECT_EQUAL(stuffer.write_cursor, expected_write_cursor);
+
+        /* Happy case: successfully rewrites a uint16_t */
+        {
+            /* Write some data. We want to verify it isn't overwritten. */
+            uint16_t data_before = 5;
+            EXPECT_SUCCESS(s2n_stuffer_write_uint16(&stuffer, data_before));
+
+            /* Reserve uint16s */
+            EXPECT_SUCCESS(s2n_stuffer_reserve_uint16(&stuffer, &reservation));
+            EXPECT_SUCCESS(s2n_stuffer_reserve_uint16(&stuffer, &other_reservation));
+
+            /* Write some more data. We want to verify it isn't overwritten. */
+            uint16_t data_after = -1;
+            EXPECT_SUCCESS(s2n_stuffer_write_uint16(&stuffer, data_after));
+
+            /* Rewrite reserved uint16s */
+            uint16_t expected_value = 0xabcd;
+            expected_write_cursor = stuffer.write_cursor;
+            EXPECT_SUCCESS(s2n_stuffer_write_reservation(reservation, expected_value));
+            EXPECT_EQUAL(stuffer.write_cursor, expected_write_cursor);
+            EXPECT_SUCCESS(s2n_stuffer_write_reservation(other_reservation, expected_value));
+            EXPECT_EQUAL(stuffer.write_cursor, expected_write_cursor);
+
+            /* Make sure expected values read back */
+            EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &actual_value));
+            EXPECT_EQUAL(actual_value, data_before);
+            EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &actual_value));
+            EXPECT_EQUAL(actual_value, expected_value);
+            EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &actual_value));
+            EXPECT_EQUAL(actual_value, expected_value);
+            EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &actual_value));
+            EXPECT_EQUAL(actual_value, data_after);
+        }
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+    }
+
+    /* s2n_stuffer_write_vector_size */
+    {
+        uint16_t actual_value;
+        struct s2n_stuffer_reservation reservation = { 0 };
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        /* Happy cases */
+        uint16_t test_sizes[] = { 0, 1, 5, 0x88, 0xF0, 0xFF };
+        for( int i = 0; i < s2n_array_len(test_sizes); i++) {
+            EXPECT_SUCCESS(s2n_stuffer_reserve_uint16(&stuffer, &reservation));
+
+            EXPECT_SUCCESS(s2n_stuffer_skip_write(&stuffer, test_sizes[i]));
+            EXPECT_SUCCESS(s2n_stuffer_write_vector_size(reservation));
+
+            EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &actual_value));
+            EXPECT_EQUAL(actual_value, test_sizes[i]);
+
+            EXPECT_SUCCESS(s2n_stuffer_skip_read(&stuffer, test_sizes[i]));
+        }
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+    }
+
+    END_TEST();
+}

--- a/tests/unit/s2n_stuffer_network_order_test.c
+++ b/tests/unit/s2n_stuffer_network_order_test.c
@@ -181,7 +181,7 @@ int main(int argc, char **argv)
         /* Should throw an error if rewriting would require an invalid stuffer state.
          * ( A write cursor being greater than the high water mark is an invalid stuffer state.) */
         reservation.write_cursor = stuffer.high_water_mark + 1;
-        EXPECT_FAILURE_WITH_ERRNO(s2n_stuffer_write_reservation(reservation, 0), S2N_ERR_SAFETY);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_stuffer_write_reservation(reservation, 0), S2N_ERR_PRECONDITION_VIOLATION);
         EXPECT_EQUAL(stuffer.write_cursor, expected_write_cursor);
 
         /* Happy case: successfully rewrites a uint16_t */


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 

**Description of changes:** 
Many places in S2N, we need to write a "vector", which means writing
the size of some data, then writing that data. This change makes this
easier, letting us go back and write the size after we've figured
out what that size is.

We can't just duplicate the stuffer to handle this because if the
stuffer resizes, it will contain different memory than the duplicate.
We can't just use raw_write, because that handles the resize problem
by erroring on resize.

I considered requiring the stuffer to be "locked" for writing when these
methods are used, but I'm not sure that really provides any protection.
The caller could still unlock the stuffer without writing the reservation.
Also, we don't do any kind of locking to prevent someone from reading
memory used by a raw write. It looks like we largely rely on our informal
write-then-read pattern, which is fair.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
