### PR TITLE
Integv2 Happy Path

### DIFF
--- a/tests/integrationv2/certificate.py
+++ b/tests/integrationv2/certificate.py
@@ -1,0 +1,11 @@
+from constants import TEST_CERT_DIRECTORY
+
+
+class Cert():
+    def __init__(self, name, prefix, location=TEST_CERT_DIRECTORY):
+        self.name = name
+        self.cert = location + prefix + "_cert.pem"
+        self.key = location + prefix + "_key.pem"
+
+    def __str__(self):
+        return self.name

--- a/tests/integrationv2/configuration.py
+++ b/tests/integrationv2/configuration.py
@@ -1,44 +1,56 @@
 import threading
-from contextlib import contextmanager
-from common import Ciphersuites, Curves
+
+from certificate import Cert
+from common import Ciphersuites, Curves, Protocols, AvailablePorts, TLS_CIPHERSUITES, TLS13_CIPHERSUITES, TLS_CURVES, TLS13_CURVES
 from providers import S2N, OpenSSL, BoringSSL
 
 
-# List of ciphersuites that will be tested.
-CIPHERSUITES = [
-    Ciphersuites.TLS_CHACHA20_POLY1305_SHA256,
-    Ciphersuites.TLS_AES_128_GCM_256,
-    Ciphersuites.TLS_AES_256_GCM_384
+# The boolean configuration will let a test run for True and False
+# for some value. For example, using the insecure flag.
+BOOLEAN = [True, False]
+
+
+# List of all protocols to be tested
+PROTOCOLS = [
+    Protocols.TLS13,
+    Protocols.TLS12,
+    Protocols.TLS11,
+    Protocols.TLS10,
 ]
 
 
-# List of curves that will be tested.
-CURVES = [
-    Curves.P256,
-    Curves.P384
+# List of all ciphersuites that will be tested.
+ALL_CIPHERSUITES = TLS13_CIPHERSUITES[:]
+ALL_CIPHERSUITES.extend(TLS_CIPHERSUITES)
+
+
+# List of all curves that will be tested.
+ALL_CURVES = TLS13_CURVES[:]
+ALL_CURVES.extend(TLS_CURVES)
+
+
+ALL_CERTS = [
+    # PKCS1 will only work with older OpenSSL versions
+    # Cert("RSA_2048_PKCS1", "rsa_2048_pkcs1"),
+    Cert("RSA_1024_SHA256", "rsa_1024_sha256_client"),
+    Cert("RSA_1024_SHA384", "rsa_1024_sha384_client"),
+    Cert("RSA_1024_SHA512", "rsa_1024_sha512_client"),
+    Cert("RSA_2048_SHA256", "rsa_2048_sha256_client"),
+    Cert("RSA_2048_SHA384", "rsa_2048_sha384_client"),
+    Cert("RSA_2048_SHA512", "rsa_2048_sha512_client"),
+    Cert("RSA_3072_SHA256", "rsa_3072_sha256_client"),
+    Cert("RSA_3072_SHA384", "rsa_3072_sha384_client"),
+    Cert("RSA_3072_SHA512", "rsa_3072_sha512_client"),
+    Cert("RSA_4096_SHA256", "rsa_4096_sha256_client"),
+    Cert("RSA_4096_SHA384", "rsa_4096_sha384_client"),
+    Cert("RSA_4096_SHA512", "rsa_4096_sha512_client"),
+    Cert("ECDSA_256", "ecdsa_p256_pkcs1"),
+    Cert("ECDSA_384", "ecdsa_p384_pkcs1"),
 ]
 
 
 # List of providers that will be tested.
-PROVIDERS = [S2N, OpenSSL, BoringSSL]
-
-
-class AvailablePorts():
-    """
-    NOTE: This is not where this belongs, refactor needed.
-    An iterator that atomically returns the next available port.
-    """
-
-    def __init__(self):
-        self.ports = iter(range(8000, 9000))
-        self.lock = threading.Lock()
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        with self.lock:
-            return next(self.ports)
+PROVIDERS = [S2N, OpenSSL]
 
 
 available_ports = AvailablePorts()

--- a/tests/integrationv2/constants.py
+++ b/tests/integrationv2/constants.py
@@ -1,0 +1,1 @@
+TEST_CERT_DIRECTORY="../pems/"

--- a/tests/integrationv2/fixtures.py
+++ b/tests/integrationv2/fixtures.py
@@ -6,7 +6,8 @@ import time
 
 from processes import ManagedProcess
 from providers import Provider
-from common import ProviderOptions
+from common import ProviderOptions, Protocols
+from configuration import TLS13_CURVES, TLS13_CIPHERSUITES
 
 
 @pytest.fixture
@@ -26,8 +27,8 @@ def managed_process():
         cmd_line = provider.get_cmd_line()
         p = ManagedProcess(cmd_line,
                 provider.set_provider_ready,
-                wait_for_marker=provider.ready_to_test,
-                ready_to_send=provider.ready_to_send_marker,
+                wait_for_marker=provider.ready_to_test_marker,
+                ready_to_send=provider.ready_to_send_input_marker,
                 data_source=options.data_to_send,
                 timeout=timeout)
 
@@ -35,6 +36,7 @@ def managed_process():
         with p.ready_condition:
             p.start()
             with provider._provider_ready_condition:
+                # Don't continue processing until the provider has indicated it is ready.
                 provider._provider_ready_condition.wait_for(provider.is_provider_ready, timeout)
         return p
 

--- a/tests/integrationv2/test_dynamic_record_sizes.py
+++ b/tests/integrationv2/test_dynamic_record_sizes.py
@@ -4,51 +4,73 @@ import pytest
 import subprocess
 import time
 
-from configuration import available_ports, CIPHERSUITES, CURVES, PROVIDERS
-from common import ProviderOptions, data_bytes
+from configuration import available_ports, ALL_CIPHERSUITES, ALL_CURVES, ALL_CERTS, PROVIDERS, PROTOCOLS
+from common import ProviderOptions, data_bytes, Protocols, invalid_test_parameters
 from fixtures import managed_process, custom_mtu
-from providers import S2N, OpenSSL, Tcpdump
+from providers import Provider, S2N, OpenSSL, Tcpdump
 
 
 def find_fragmented_packet(results):
     """
     This function searches Tcpdump's standard output and looks for packets
     that have a length larger than the MTU(hardcoded to 1500) of the device.
+
+    When traffic goes over a known port, such as 8080, the protocol is appended
+    to the output line. This happens even when using `-nn` on the command line.
+    That is why we need two ways to detect the length of the packet.
     """
     for line in results.decode('utf-8').split('\n'):
         pieces = line.split(' ')
-        if len(pieces) < 2:
+        if len(pieces) < 3:
             continue
 
+        packet_len = 0
         if pieces[-2] == 'length':
-            if int(pieces[-1]) > 1500:
-                return True
+            packet_len = int(pieces[-1])
+        elif pieces[-3] == 'length':
+            # In this case the length has a colon `1234:`, so we must trim it.
+            packet_len = int(pieces[-2][:-1])
+
+        if packet_len > 1500:
+            return True
 
     return False
 
 
-@pytest.mark.parametrize("cipher", CIPHERSUITES)
-@pytest.mark.parametrize("curve", CURVES)
-def test_s2n_client_dynamic_record(custom_mtu, managed_process, cipher, curve):
+@pytest.mark.uncollect_if(func=invalid_test_parameters)
+@pytest.mark.parametrize("cipher", ALL_CIPHERSUITES)
+@pytest.mark.parametrize("curve", ALL_CURVES)
+@pytest.mark.parametrize("protocol", PROTOCOLS)
+@pytest.mark.parametrize("certificate", ALL_CERTS, ids=str)
+def test_s2n_client_dynamic_record(custom_mtu, managed_process, cipher, curve, protocol, certificate):
     host = "localhost"
     port = next(available_ports)
 
     # 16384 bytes is enough to reliably get a packet that will exceed the MTU
     bytes_to_send = data_bytes(16384)
     client_options = ProviderOptions(
-        mode="client",
+        mode=Provider.ClientMode,
         host="localhost",
         port=port,
         cipher=cipher,
         data_to_send=bytes_to_send,
         insecure=True,
-        tls13=True)
+        protocol=protocol)
 
     server_options = copy.copy(client_options)
     server_options.data_to_send = None
-    server_options.mode = "server"
-    server_options.key = "../pems/ecdsa_p384_pkcs1_key.pem"
-    server_options.cert = "../pems/ecdsa_p384_pkcs1_cert.pem"
+    server_options.mode = Provider.ServerMode
+    server_options.key = certificate.key
+    server_options.cert = certificate.cert
+
+    if protocol == Protocols.TLS13:
+        version = '34'
+    elif protocol == Protocols.TLS12:
+        version = '33'
+    elif protocol == Protocols.TLS11:
+        version = '32'
+    elif protocol == Protocols.TLS10:
+        version = '31'
 
     # This test shouldn't last longer than 5 seconds, even though
     # Tcpdump tends to take a second to startup.
@@ -59,7 +81,7 @@ def test_s2n_client_dynamic_record(custom_mtu, managed_process, cipher, curve):
     for results in client.get_results():
         assert results.exception is None
         assert results.exit_code == 0
-        assert b"Actual protocol version: 34" in results.stdout
+        assert bytes(f"Actual protocol version: {version}".encode('utf-8')) in results.stdout
 
     for results in server.get_results():
         assert results.exception is None
@@ -71,5 +93,5 @@ def test_s2n_client_dynamic_record(custom_mtu, managed_process, cipher, curve):
     # exit cleanly, which means all the output is available for us
     # to examine.
     for results in tcpdump.get_results():
-        assert results.exit_code == 0
+        assert results.exit_code == 0 # or results.exit_code == -9
         assert find_fragmented_packet(results.stdout) is True

--- a/tests/integrationv2/tox.ini
+++ b/tests/integrationv2/tox.ini
@@ -6,6 +6,8 @@ skipsdist = True
 # install pytest in the virtualenv where commands will be executed
 setenv = S2N_INTEG_TEST = 1
 passenv = LD_LIBRARY_PATH
-deps = pytest
+deps =
+    pytest==5.3.5
 commands =
     pytest -rpfsq
+


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
Fixes #1839 

**Description of changes:** 
Move the existing integ test happy path functions into the new framework.

* Add ciphers, curves, certs, that needs to be tested
* Add method to deselect tests with nonsensical parameters
* Change packets to collect in dynamic record size test
* Refactor variable names to make wait conditions easier to understand
* Refactor locations of classes to make configuration of tests easier

**Sample Output**
```
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.3-S2N-X25519-TLS_CHACHA20_POLY1305_SHA256]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.3-S2N-X25519-TLS_AES_128_GCM_256]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.3-S2N-X25519-TLS_AES_256_GCM_384]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.3-S2N-P-256-TLS_CHACHA20_POLY1305_SHA256]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.3-S2N-P-256-TLS_AES_128_GCM_256]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.3-S2N-P-256-TLS_AES_256_GCM_384]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.3-S2N-P-384-TLS_CHACHA20_POLY1305_SHA256]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.3-S2N-P-384-TLS_AES_128_GCM_256]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.3-S2N-P-384-TLS_AES_256_GCM_384]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.3-OpenSSL-X25519-TLS_CHACHA20_POLY1305_SHA256]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.3-OpenSSL-X25519-TLS_AES_128_GCM_256]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.3-OpenSSL-X25519-TLS_AES_256_GCM_384]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.3-OpenSSL-P-256-TLS_CHACHA20_POLY1305_SHA256]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.3-OpenSSL-P-256-TLS_AES_128_GCM_256]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.3-OpenSSL-P-256-TLS_AES_256_GCM_384]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.3-OpenSSL-P-384-TLS_CHACHA20_POLY1305_SHA256]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.3-OpenSSL-P-384-TLS_AES_128_GCM_256]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.3-OpenSSL-P-384-TLS_AES_256_GCM_384]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.2-S2N-P-256-TLS_AES_128_GCM_256]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.2-S2N-P-256-TLS_AES_256_GCM_384]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.2-S2N-P-384-TLS_AES_128_GCM_256]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.2-S2N-P-384-TLS_AES_256_GCM_384]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.2-OpenSSL-P-256-TLS_AES_128_GCM_256]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.2-OpenSSL-P-256-TLS_AES_256_GCM_384]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.2-OpenSSL-P-384-TLS_AES_128_GCM_256]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.2-OpenSSL-P-384-TLS_AES_256_GCM_384]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.1-S2N-P-256-TLS_AES_128_GCM_256]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.1-S2N-P-256-TLS_AES_256_GCM_384]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.1-S2N-P-384-TLS_AES_128_GCM_256]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.1-S2N-P-384-TLS_AES_256_GCM_384]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.1-OpenSSL-P-256-TLS_AES_128_GCM_256]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.1-OpenSSL-P-256-TLS_AES_256_GCM_384]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.1-OpenSSL-P-384-TLS_AES_128_GCM_256]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.1-OpenSSL-P-384-TLS_AES_256_GCM_384]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.0-S2N-P-256-TLS_AES_128_GCM_256]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.0-S2N-P-256-TLS_AES_256_GCM_384]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.0-S2N-P-384-TLS_AES_128_GCM_256]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.0-S2N-P-384-TLS_AES_256_GCM_384]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.0-OpenSSL-P-256-TLS_AES_128_GCM_256]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.0-OpenSSL-P-256-TLS_AES_256_GCM_384]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.0-OpenSSL-P-384-TLS_AES_128_GCM_256]
PASSED test_happy_path.py::test_s2n_client_happy_path[RSA_4096_SHA256-TLS1.0-OpenSSL-P-384-TLS_AES_256_GCM_384]

 1356 passed, 1173 deselected in 390.00s (0:06:29)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
