### PR TITLE
tests: lower self nonblocking iov_payload_size to improve test reliability

### DIFF
--- a/tests/unit/s2n_self_talk_nonblocking_test.c
+++ b/tests/unit/s2n_self_talk_nonblocking_test.c
@@ -190,7 +190,21 @@ int test_send(int use_tls13, int use_iov, int prefer_throughput)
     /* Get some random data to send/receive */
     uint32_t data_size = 0;
     DEFER_CLEANUP(struct s2n_blob blob = {0}, s2n_free);
-    int iov_payload_size = 65536, iov_size = 4;
+
+    /* These numbers are chosen so the last payload is 65,536 bytes,
+     * which is needed to validate TLS1.3 record sizing is handled.
+     *  (see https://github.com/awslabs/s2n/pull/1780).
+     *
+     * Note that for each iov in the list, the payload size is doubled
+     * to ensure the implementation handles various lengths.
+     *
+     * With the current values, it will include
+     * * 8192 bytes
+     * * 16384 bytes
+     * * 32768 bytes
+     * * 65536 bytes */
+    int iov_payload_size = 8192, iov_size = 4;
+
     struct iovec* iov = NULL;
     if (!use_iov) {
         data_size = 10000000;


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Description of changes:** 
The previous values caused a significant amount more bytes to be allocated:
* 65536 bytes
* 131072 bytes
* 262144 bytes
* 524288 bytes

This causes some issues on test reliability on smaller machines. Lowering the initial value to 8192 still exercises the "interesting" 65536 value, while writing much less.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
