### PR TITLE
Changes the name of struct s2n_kem_keypair -> s2n_kem_params

### DIFF
--- a/tests/fuzz/s2n_bike_r1_fuzz_test.c
+++ b/tests/fuzz/s2n_bike_r1_fuzz_test.c
@@ -28,11 +28,11 @@
 /* This fuzz test uses the first private key from tests/unit/kats/bike_r1.kat, the valid ciphertext generated with the
  * public key was copied to corpus/s2n_bike_r1_fuzz_test/valid_ciphertext */
 
-static struct s2n_kem_keypair server_kem_keys = {.negotiated_kem = &s2n_bike1_l1_r1};
+static struct s2n_kem_params server_kem_params = {.kem = &s2n_bike1_l1_r1};
 
 static void s2n_fuzz_atexit()
 {
-    s2n_free(&server_kem_keys.private_key);
+    s2n_free(&server_kem_params.private_key);
     s2n_cleanup();
 }
 
@@ -41,11 +41,11 @@ int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
     GUARD(s2n_init());
     GUARD_STRICT(atexit(s2n_fuzz_atexit));
 
-    GUARD(s2n_alloc(&server_kem_keys.private_key, s2n_bike1_l1_r1.private_key_length));
+    GUARD(s2n_alloc(&server_kem_params.private_key, s2n_bike1_l1_r1.private_key_length));
 
     FILE *kat_file = fopen(RSP_FILE_NAME, "r");
     notnull_check(kat_file);
-    GUARD(ReadHex(kat_file, server_kem_keys.private_key.data, s2n_bike1_l1_r1.private_key_length, "sk = "));
+    GUARD(ReadHex(kat_file, server_kem_params.private_key.data, s2n_bike1_l1_r1.private_key_length, "sk = "));
 
     fclose(kat_file);
 
@@ -62,7 +62,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     memcpy_check(ciphertext.data, buf, len);
 
     /* Run the test, don't use GUARD since the memory needs to be cleaned up and decapsulate will most likely fail */
-    s2n_kem_decapsulate(&server_kem_keys, &server_shared_secret, &ciphertext);
+    s2n_kem_decapsulate(&server_kem_params, &server_shared_secret, &ciphertext);
 
     GUARD(s2n_free(&ciphertext));
 

--- a/tests/fuzz/s2n_bike_r2_fuzz_test.c
+++ b/tests/fuzz/s2n_bike_r2_fuzz_test.c
@@ -28,11 +28,11 @@
 /* This fuzz test uses the first private key from tests/unit/kats/bike_r2.kat, the valid ciphertext generated with the
  * public key was copied to corpus/s2n_bike_r2_fuzz_test/valid_ciphertext */
 
-static struct s2n_kem_keypair server_kem_keys = {.negotiated_kem = &s2n_bike1_l1_r2};
+static struct s2n_kem_params server_kem_params = {.kem = &s2n_bike1_l1_r2};
 
 static void s2n_fuzz_atexit()
 {
-    s2n_free(&server_kem_keys.private_key);
+    s2n_free(&server_kem_params.private_key);
     s2n_cleanup();
 }
 
@@ -41,11 +41,11 @@ int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
     GUARD(s2n_init());
     GUARD_STRICT(atexit(s2n_fuzz_atexit));
 
-    GUARD(s2n_alloc(&server_kem_keys.private_key, s2n_bike1_l1_r2.private_key_length));
+    GUARD(s2n_alloc(&server_kem_params.private_key, s2n_bike1_l1_r2.private_key_length));
 
     FILE *kat_file = fopen(RSP_FILE_NAME, "r");
     notnull_check(kat_file);
-    GUARD(ReadHex(kat_file, server_kem_keys.private_key.data, s2n_bike1_l1_r2.private_key_length, "sk = "));
+    GUARD(ReadHex(kat_file, server_kem_params.private_key.data, s2n_bike1_l1_r2.private_key_length, "sk = "));
 
     fclose(kat_file);
 
@@ -62,7 +62,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     memcpy_check(ciphertext.data, buf, len);
 
     /* Run the test, don't use GUARD since the memory needs to be cleaned up and decapsulate will most likely fail */
-    s2n_kem_decapsulate(&server_kem_keys, &server_shared_secret, &ciphertext);
+    s2n_kem_decapsulate(&server_kem_params, &server_shared_secret, &ciphertext);
 
     GUARD(s2n_free(&ciphertext));
 

--- a/tests/fuzz/s2n_client_key_recv_fuzz_test.c
+++ b/tests/fuzz/s2n_client_key_recv_fuzz_test.c
@@ -209,7 +209,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     }
 
     if (server_conn->secure.cipher_suite->key_exchange_alg->client_key_recv == s2n_kem_client_key_recv || server_conn->secure.cipher_suite->key_exchange_alg->client_key_recv == s2n_hybrid_client_key_recv) {
-        server_conn->secure.s2n_kem_keys.negotiated_kem = &s2n_sike_p503_r1;
+        server_conn->secure.kem_params.kem = &s2n_sike_p503_r1;
     }
 
     /* Run Test

--- a/tests/fuzz/s2n_hybrid_ecdhe_bike_r1_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_bike_r1_fuzz_test.c
@@ -35,7 +35,7 @@
 #include "tls/s2n_cipher_suites.h"
 #include "tls/s2n_security_policies.h"
 
-static struct s2n_kem_keypair server_kem_keys = {.negotiated_kem = &s2n_bike1_l1_r1};
+static struct s2n_kem_params server_kem_params = {.kem = &s2n_bike1_l1_r1};
 
 /* Setup the connection in a state for a fuzz test run, s2n_client_key_recv modifies the state of the connection
  * along the way and gets cleaned up at the end of each fuzz test.
@@ -54,11 +54,11 @@ static int setup_connection(struct s2n_connection *server_conn)
 
     server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
     server_conn->secure.server_ecc_evp_params.evp_pkey = NULL;
-    server_conn->secure.s2n_kem_keys.negotiated_kem = &s2n_bike1_l1_r1;
+    server_conn->secure.kem_params.kem = &s2n_bike1_l1_r1;
     server_conn->secure.cipher_suite = &s2n_ecdhe_bike_rsa_with_aes_256_gcm_sha384;
     server_conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
 
-    GUARD(s2n_dup(&server_kem_keys.private_key, &server_conn->secure.s2n_kem_keys.private_key));
+    GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->secure.kem_params.private_key));
     GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.server_ecc_evp_params));
 
     return 0;
@@ -67,7 +67,7 @@ static int setup_connection(struct s2n_connection *server_conn)
 static void s2n_fuzz_atexit()
 {
     s2n_cleanup();
-    s2n_kem_free(&server_kem_keys);
+    s2n_kem_free(&server_kem_params);
 }
 
 int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
@@ -75,9 +75,9 @@ int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
     GUARD(s2n_init());
     GUARD_STRICT(atexit(s2n_fuzz_atexit));
 
-    struct s2n_blob *public_key = &server_kem_keys.public_key;
+    struct s2n_blob *public_key = &server_kem_params.public_key;
     GUARD(s2n_alloc(public_key, BIKE1_L1_R1_PUBLIC_KEY_BYTES));
-    GUARD(s2n_kem_generate_keypair(&server_kem_keys));
+    GUARD(s2n_kem_generate_keypair(&server_kem_params));
     GUARD(s2n_free(public_key));
 
     return 0;

--- a/tests/fuzz/s2n_hybrid_ecdhe_bike_r2_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_bike_r2_fuzz_test.c
@@ -35,7 +35,7 @@
 #include "tls/s2n_security_policies.h"
 #include "pq-crypto/bike_r2/bike_r2_kem.h"
 
-static struct s2n_kem_keypair server_kem_keys = {.negotiated_kem = &s2n_bike1_l1_r2};
+static struct s2n_kem_params server_kem_params = {.kem = &s2n_bike1_l1_r2};
 
 /* Setup the connection in a state for a fuzz test run, s2n_client_key_recv modifies the state of the connection
  * along the way and gets cleaned up at the end of each fuzz test.
@@ -54,11 +54,11 @@ static int setup_connection(struct s2n_connection *server_conn)
 
     server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
     server_conn->secure.server_ecc_evp_params.evp_pkey = NULL;
-    server_conn->secure.s2n_kem_keys.negotiated_kem = &s2n_bike1_l1_r2;
+    server_conn->secure.kem_params.kem = &s2n_bike1_l1_r2;
     server_conn->secure.cipher_suite = &s2n_ecdhe_bike_rsa_with_aes_256_gcm_sha384;
     server_conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
 
-    GUARD(s2n_dup(&server_kem_keys.private_key, &server_conn->secure.s2n_kem_keys.private_key));
+    GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->secure.kem_params.private_key));
     GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.server_ecc_evp_params));
 
     return 0;
@@ -67,7 +67,7 @@ static int setup_connection(struct s2n_connection *server_conn)
 static void s2n_fuzz_atexit()
 {
     s2n_cleanup();
-    s2n_kem_free(&server_kem_keys);
+    s2n_kem_free(&server_kem_params);
 }
 
 int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
@@ -75,9 +75,9 @@ int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
     GUARD(s2n_init());
     GUARD_STRICT(atexit(s2n_fuzz_atexit));
 
-    struct s2n_blob *public_key = &server_kem_keys.public_key;
+    struct s2n_blob *public_key = &server_kem_params.public_key;
     GUARD(s2n_alloc(public_key, BIKE1_L1_R2_PUBLIC_KEY_BYTES));
-    GUARD(s2n_kem_generate_keypair(&server_kem_keys));
+    GUARD(s2n_kem_generate_keypair(&server_kem_params));
     GUARD(s2n_free(public_key));
 
     return 0;

--- a/tests/fuzz/s2n_hybrid_ecdhe_sike_r1_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_sike_r1_fuzz_test.c
@@ -35,7 +35,7 @@
 #include "tls/s2n_cipher_suites.h"
 #include "tls/s2n_security_policies.h"
 
-static struct s2n_kem_keypair server_kem_keys = {.negotiated_kem = &s2n_sike_p503_r1};
+static struct s2n_kem_params server_kem_params = {.kem = &s2n_sike_p503_r1};
 
 /* Setup the connection in a state for a fuzz test run, s2n_client_key_recv modifies the state of the connection
  * along the way and gets cleaned up at the end of each fuzz test.
@@ -54,11 +54,11 @@ static int setup_connection(struct s2n_connection *server_conn)
 
     server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
     server_conn->secure.server_ecc_evp_params.evp_pkey = NULL;
-    server_conn->secure.s2n_kem_keys.negotiated_kem = &s2n_sike_p503_r1;
+    server_conn->secure.kem_params.kem = &s2n_sike_p503_r1;
     server_conn->secure.cipher_suite = &s2n_ecdhe_sike_rsa_with_aes_256_gcm_sha384;
     server_conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
 
-    GUARD(s2n_dup(&server_kem_keys.private_key, &server_conn->secure.s2n_kem_keys.private_key));
+    GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->secure.kem_params.private_key));
     GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.server_ecc_evp_params));
 
     return 0;
@@ -67,7 +67,7 @@ static int setup_connection(struct s2n_connection *server_conn)
 static void s2n_fuzz_atexit()
 {
     s2n_cleanup();
-    s2n_kem_free(&server_kem_keys);
+    s2n_kem_free(&server_kem_params);
 }
 
 int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
@@ -75,9 +75,9 @@ int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
     GUARD(s2n_init());
     GUARD_STRICT(atexit(s2n_fuzz_atexit));
 
-    struct s2n_blob *public_key = &server_kem_keys.public_key;
+    struct s2n_blob *public_key = &server_kem_params.public_key;
     GUARD(s2n_alloc(public_key, SIKE_P503_R1_PUBLIC_KEY_BYTES));
-    GUARD(s2n_kem_generate_keypair(&server_kem_keys));
+    GUARD(s2n_kem_generate_keypair(&server_kem_params));
     GUARD(s2n_free(public_key));
 
     return 0;

--- a/tests/fuzz/s2n_hybrid_ecdhe_sike_r2_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_sike_r2_fuzz_test.c
@@ -35,7 +35,7 @@
 #include "tls/s2n_cipher_suites.h"
 #include "tls/s2n_security_policies.h"
 
-static struct s2n_kem_keypair server_kem_keys = {.negotiated_kem = &s2n_sike_p434_r2};
+static struct s2n_kem_params server_kem_params = {.kem = &s2n_sike_p434_r2};
 
 /* Setup the connection in a state for a fuzz test run, s2n_client_key_recv modifies the state of the connection
  * along the way and gets cleaned up at the end of each fuzz test.
@@ -54,11 +54,11 @@ static int setup_connection(struct s2n_connection *server_conn)
 
     server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
     server_conn->secure.server_ecc_evp_params.evp_pkey = NULL;
-    server_conn->secure.s2n_kem_keys.negotiated_kem = &s2n_sike_p434_r2;
+    server_conn->secure.kem_params.kem = &s2n_sike_p434_r2;
     server_conn->secure.cipher_suite = &s2n_ecdhe_sike_rsa_with_aes_256_gcm_sha384;
     server_conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
 
-    GUARD(s2n_dup(&server_kem_keys.private_key, &server_conn->secure.s2n_kem_keys.private_key));
+    GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->secure.kem_params.private_key));
     GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.server_ecc_evp_params));
 
     return 0;
@@ -67,7 +67,7 @@ static int setup_connection(struct s2n_connection *server_conn)
 static void s2n_fuzz_atexit()
 {
     s2n_cleanup();
-    s2n_kem_free(&server_kem_keys);
+    s2n_kem_free(&server_kem_params);
 }
 
 int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
@@ -75,9 +75,9 @@ int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
     GUARD(s2n_init());
     GUARD(atexit(s2n_fuzz_atexit));
 
-    struct s2n_blob *public_key = &server_kem_keys.public_key;
+    struct s2n_blob *public_key = &server_kem_params.public_key;
     GUARD(s2n_alloc(public_key, SIKE_P434_R2_PUBLIC_KEY_BYTES));
-    GUARD(s2n_kem_generate_keypair(&server_kem_keys));
+    GUARD(s2n_kem_generate_keypair(&server_kem_params));
     GUARD(s2n_free(public_key));
 
     return 0;

--- a/tests/fuzz/s2n_sike_r1_fuzz_test.c
+++ b/tests/fuzz/s2n_sike_r1_fuzz_test.c
@@ -30,7 +30,7 @@
  * ciphertext generated with the public key was copied to corpus/s2n_sike_r1_fuzz_test/valid_ciphertext */
 static const char valid_private_key[] = "7C9935A0B07694AA0C6D10E4DB6B1ADD2FD81A25CCB148038626ED79D451140800E03B59B956F8210E556067407D13DC90FA9E8B872BFB0F0999A0BB085F85FDA70D04B8FCAE5A30989947F1E32E4BC4675C834CA22CBA08AE692935EC1C8AF2B5BF377EC17E79D09D57DB5828C6F6E1C1A64D0F30AF3D2F76D9D329108E01D027D856EC44B23A437872D538F2C26E48723E2F8E46A2E7A364C92D997C7B801ADA199EEFFBAB1161B29EC7CB4440DA0E75407F4CE02E37BDFB23154C513BD30CFA5F04D2E253357CBDEBCF6F539965C8B8B5F350A50526AD1B350A0220394AA33B18EB3E765F059FA7CB5585A9D18C8B198A07DA0E9CCEC61D6F43A4661CA6D8175C23A8C86DD30409607D6EBFA3639CDFD12599F9BB073AAEA9A1CC95FF0D50839049EDFAE95FD10DD4F27EC3C6921FA96DCB0366D9C086A8E8ED15390C4827E5672D167EE238229B188C0590E1FA38E8A74D34B6D17ECA1A64EA76AD65413F147DC43A762D69D072DADF573C13A7C983F9362D59DC6E37704BA0F15637CF6BEDBBD8C1051366FE4C21E03CC55964C0E24F6F8D738DC763B7E443122C63751F6D8130EADA4203A9671865F8D459035EAC2E";
 
-static struct s2n_kem_keypair server_kem_keys = {.negotiated_kem = &s2n_sike_p503_r1};
+static struct s2n_kem_params server_kem_params = {.kem = &s2n_sike_p503_r1};
 static struct s2n_stuffer private_key_stuffer = {{0}};
 
 static void s2n_fuzz_atexit()
@@ -45,8 +45,8 @@ int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
     GUARD(s2n_stuffer_alloc_ro_from_hex_string(&private_key_stuffer, valid_private_key));
     GUARD_STRICT(atexit(s2n_fuzz_atexit));
 
-    server_kem_keys.private_key.size = s2n_sike_p503_r1.private_key_length;
-    server_kem_keys.private_key.data = s2n_stuffer_raw_read(&private_key_stuffer, s2n_sike_p503_r1.public_key_length);
+    server_kem_params.private_key.size = s2n_sike_p503_r1.private_key_length;
+    server_kem_params.private_key.data = s2n_stuffer_raw_read(&private_key_stuffer, s2n_sike_p503_r1.public_key_length);
     return 0;
 }
 
@@ -60,7 +60,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     memcpy_check(ciphertext.data, buf, len);
 
     /* Run the test, don't use GUARD since the memory needs to be cleaned up and decapsulate will most likely fail */
-    s2n_kem_decapsulate(&server_kem_keys, &server_shared_secret, &ciphertext);
+    s2n_kem_decapsulate(&server_kem_params, &server_shared_secret, &ciphertext);
 
     GUARD(s2n_free(&ciphertext));
 

--- a/tests/fuzz/s2n_sike_r2_fuzz_test.c
+++ b/tests/fuzz/s2n_sike_r2_fuzz_test.c
@@ -30,7 +30,7 @@
  * ciphertext generated with the public key was copied to corpus/s2n_sike_r2_fuzz_test/valid_ciphertext */
 static const char valid_private_key[] = "7C9935A0B07694AA0C6D10E4DB6B1ADD91282214654CB55E7C2CACD53919604D5BAC7B23EEF4B315FEEF5E014484D7AADB44B40CC180DC568B2C142A60E6E2863F5988614A6215254B2F5F6F79B48F329AD1A2DED20B7ABAB10F7DBF59C3E20B59A700093060D2A44ACDC0083A53CF0808E0B3A827C45176BEE0DC6EC7CC16461E38461C12451BB95191407C1E942BB50D4C7B25A49C644B630159E6C403653838E689FBF4A7ADEA693ED0657BA4A724786AF7953F7BA6E15F9BBF9F5007FB711569E72ACAB05D3463A458536CAB647F00C205D27D5311B2A5113D4B26548000DB237515931A040804E769361F94FF0167C78353D2630A1E6F595A1F80E87F6A5BCD679D7A64C5006F6191D4ADEFA1EA67F6388B7017D453F4FE2DFE80CCC709000B52175BFC3ADE52ECCB0CEBE1654F89D39131C357EACB61E5F13C80AB0165B7714D6BE6DF65F8DE73FF47B7F3304639F0903653ECCFA252F6E2104C4ABAD3C33AF24FD0E56F58DB92CC66859766035419AB2DF600";
 
-static struct s2n_kem_keypair server_kem_keys = {.negotiated_kem = &s2n_sike_p434_r2};
+static struct s2n_kem_params server_kem_params = {.kem = &s2n_sike_p434_r2};
 static struct s2n_stuffer private_key_stuffer = {{0}};
 
 static void s2n_fuzz_atexit()
@@ -45,8 +45,8 @@ int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
     GUARD(s2n_stuffer_alloc_ro_from_hex_string(&private_key_stuffer, valid_private_key));
     GUARD_STRICT(atexit(s2n_fuzz_atexit));
 
-    server_kem_keys.private_key.size = s2n_sike_p434_r2.private_key_length;
-    server_kem_keys.private_key.data = s2n_stuffer_raw_read(&private_key_stuffer, s2n_sike_p434_r2.public_key_length);
+    server_kem_params.private_key.size = s2n_sike_p434_r2.private_key_length;
+    server_kem_params.private_key.data = s2n_stuffer_raw_read(&private_key_stuffer, s2n_sike_p434_r2.public_key_length);
     return 0;
 }
 
@@ -60,7 +60,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     memcpy_check(ciphertext.data, buf, len);
 
     /* Run the test, don't use GUARD since the memory needs to be cleaned up and decapsulate will most likely fail */
-    s2n_kem_decapsulate(&server_kem_keys, &server_shared_secret, &ciphertext);
+    s2n_kem_decapsulate(&server_kem_params, &server_shared_secret, &ciphertext);
 
     GUARD(s2n_free(&ciphertext));
 

--- a/tests/testlib/s2n_hybrid_kem_tests.c
+++ b/tests/testlib/s2n_hybrid_kem_tests.c
@@ -54,7 +54,7 @@ int setup_connection(struct s2n_connection *conn, const struct s2n_kem *kem, str
     GUARD_NONNULL(ecc_preferences = security_policy->ecc_preferences);
 
     conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
-    conn->secure.s2n_kem_keys.negotiated_kem = kem;
+    conn->secure.kem_params.kem = kem;
     conn->secure.cipher_suite = cipher_suite;
     conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
     GUARD(s2n_connection_set_cipher_preferences(conn, cipher_pref_version));

--- a/tests/unit/s2n_client_extensions_test.c
+++ b/tests/unit/s2n_client_extensions_test.c
@@ -115,7 +115,7 @@ static int negotiate_kem(const uint8_t client_extensions[], const size_t client_
     GUARD(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
     GUARD(s2n_config_set_cipher_preferences(server_config, cipher_pref_version));
     GUARD(s2n_connection_set_config(server_conn, server_config));
-    server_conn->secure.s2n_kem_keys.negotiated_kem = NULL;
+    server_conn->secure.kem_params.kem = NULL;
 
     /* Send the client hello */
     eq_check(write(piped_io->client_write, record_header, record_header_len),record_header_len);
@@ -132,8 +132,8 @@ static int negotiate_kem(const uint8_t client_extensions[], const size_t client_
 
     int negotiated_kem_id;
 
-    if (server_conn->secure.s2n_kem_keys.negotiated_kem != NULL) {
-        negotiated_kem_id = server_conn->secure.s2n_kem_keys.negotiated_kem->kem_extension_id;
+    if (server_conn->secure.kem_params.kem != NULL) {
+        negotiated_kem_id = server_conn->secure.kem_params.kem->kem_extension_id;
     } else {
         negotiated_kem_id = -1;
     }

--- a/tests/unit/s2n_kem_test.c
+++ b/tests/unit/s2n_kem_test.c
@@ -106,8 +106,8 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(sizeof(kem_ciphertext_key_size), 2);
     }
     {
-        struct s2n_kem_keypair server_kem_keypair = { 0 };
-        server_kem_keypair.negotiated_kem = &s2n_test_kem;
+        struct s2n_kem_params server_kem_keypair = { 0 };
+        server_kem_keypair.kem = &s2n_test_kem;
         EXPECT_SUCCESS(s2n_alloc(&server_kem_keypair.public_key, TEST_PUBLIC_KEY_LENGTH));
         EXPECT_SUCCESS(s2n_kem_generate_keypair(&server_kem_keypair));
         EXPECT_EQUAL(TEST_PUBLIC_KEY_LENGTH, server_kem_keypair.public_key.size);
@@ -115,8 +115,8 @@ int main(int argc, char **argv)
         EXPECT_BYTEARRAY_EQUAL(TEST_PUBLIC_KEY, server_kem_keypair.public_key.data, TEST_PUBLIC_KEY_LENGTH);
         EXPECT_BYTEARRAY_EQUAL(TEST_PRIVATE_KEY, server_kem_keypair.private_key.data, TEST_PRIVATE_KEY_LENGTH);
 
-        struct s2n_kem_keypair client_kem_keypair = { 0 };
-        client_kem_keypair.negotiated_kem = &s2n_test_kem;
+        struct s2n_kem_params client_kem_keypair = { 0 };
+        client_kem_keypair.kem = &s2n_test_kem;
         /* This would be handled by client/server key exchange methods which isn't being tested */
         GUARD(s2n_alloc(&client_kem_keypair.public_key, TEST_PUBLIC_KEY_LENGTH));
         memset(client_kem_keypair.public_key.data, TEST_PUBLIC_KEY_LENGTH, TEST_PUBLIC_KEY_LENGTH);

--- a/tests/unit/s2n_kex_with_kem_test.c
+++ b/tests/unit/s2n_kex_with_kem_test.c
@@ -58,11 +58,11 @@ static int do_kex_with_kem(struct s2n_cipher_suite *cipher_suite, const char *se
     GUARD(s2n_find_security_policy_from_version(security_policy_version, &security_policy));
     GUARD_NONNULL(security_policy);
 
-    client_conn->secure.s2n_kem_keys.negotiated_kem = negotiated_kem;
+    client_conn->secure.kem_params.kem = negotiated_kem;
     client_conn->secure.cipher_suite = cipher_suite;
     client_conn->security_policy_override = security_policy;
 
-    server_conn->secure.s2n_kem_keys.negotiated_kem = negotiated_kem;
+    server_conn->secure.kem_params.kem = negotiated_kem;
     server_conn->secure.cipher_suite = cipher_suite;
     server_conn->security_policy_override = security_policy;
 
@@ -73,7 +73,7 @@ static int do_kex_with_kem(struct s2n_cipher_suite *cipher_suite, const char *se
     const uint32_t KEM_PUBLIC_KEY_MESSAGE_SIZE = (*negotiated_kem).public_key_length + 4;
     eq_check(data_to_sign.size, KEM_PUBLIC_KEY_MESSAGE_SIZE);
 
-    eq_check((*negotiated_kem).private_key_length, server_conn->secure.s2n_kem_keys.private_key.size);
+    eq_check((*negotiated_kem).private_key_length, server_conn->secure.kem_params.private_key.size);
     struct s2n_blob server_key_message = {.size = KEM_PUBLIC_KEY_MESSAGE_SIZE, .data = s2n_stuffer_raw_read(&server_conn->handshake.io,
             KEM_PUBLIC_KEY_MESSAGE_SIZE)};
     GUARD_NONNULL(server_key_message.data);
@@ -95,7 +95,7 @@ static int do_kex_with_kem(struct s2n_cipher_suite *cipher_suite, const char *se
         S2N_ERROR_PRESERVE_ERRNO();
     }
 
-    eq_check((*negotiated_kem).public_key_length, client_conn->secure.s2n_kem_keys.public_key.size);
+    eq_check((*negotiated_kem).public_key_length, client_conn->secure.kem_params.public_key.size);
 
     /* Part 3: Client calls send_key. The additional 2 bytes are for the ciphertext length sent over the wire */
     const uint32_t KEM_CIPHERTEXT_MESSAGE_SIZE = (*negotiated_kem).ciphertext_length + 2;
@@ -130,7 +130,7 @@ static int assert_kex_fips_checks(struct s2n_cipher_suite *cipher_suite, const c
     const struct s2n_security_policy *security_policy = NULL;
     GUARD(s2n_find_security_policy_from_version(security_policy_version, &security_policy));
     GUARD_NONNULL(security_policy);
-    server_conn->secure.s2n_kem_keys.negotiated_kem = negotiated_kem;
+    server_conn->secure.kem_params.kem = negotiated_kem;
     server_conn->secure.cipher_suite = cipher_suite;
     server_conn->security_policy_override = security_policy;
 

--- a/tls/s2n_client_key_exchange.c
+++ b/tls/s2n_client_key_exchange.c
@@ -167,9 +167,9 @@ int s2n_kem_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared
     const struct s2n_blob ciphertext = {.size = ciphertext_length, .data = s2n_stuffer_raw_read(in, ciphertext_length)};
     notnull_check(ciphertext.data);
 
-    GUARD(s2n_kem_decapsulate(&conn->secure.s2n_kem_keys, shared_key, &ciphertext));
+    GUARD(s2n_kem_decapsulate(&conn->secure.kem_params, shared_key, &ciphertext));
 
-    GUARD(s2n_kem_free(&conn->secure.s2n_kem_keys));
+    GUARD(s2n_kem_free(&conn->secure.kem_params));
     return 0;
 }
 
@@ -251,7 +251,7 @@ int s2n_rsa_client_key_send(struct s2n_connection *conn, struct s2n_blob *shared
 int s2n_kem_client_key_send(struct s2n_connection *conn, struct s2n_blob *shared_key)
 {
     struct s2n_stuffer *out = &conn->handshake.io;
-    const struct s2n_kem *kem = conn->secure.s2n_kem_keys.negotiated_kem;
+    const struct s2n_kem *kem = conn->secure.kem_params.kem;
 
     GUARD(s2n_stuffer_write_uint16(out, kem->ciphertext_length));
 
@@ -259,8 +259,8 @@ int s2n_kem_client_key_send(struct s2n_connection *conn, struct s2n_blob *shared
     struct s2n_blob ciphertext = {.data = s2n_stuffer_raw_write(out, kem->ciphertext_length), .size = kem->ciphertext_length};
     notnull_check(ciphertext.data);
 
-    GUARD(s2n_kem_encapsulate(&conn->secure.s2n_kem_keys, shared_key, &ciphertext));
-    GUARD(s2n_kem_free(&conn->secure.s2n_kem_keys));
+    GUARD(s2n_kem_encapsulate(&conn->secure.kem_params, shared_key, &ciphertext));
+    GUARD(s2n_kem_free(&conn->secure.kem_params));
     return 0;
 }
 

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -257,8 +257,8 @@ static int s2n_connection_zero(struct s2n_connection *conn, int mode, struct s2n
     conn->current_user_data_consumed = 0;
     conn->initial.cipher_suite = &s2n_null_cipher_suite;
     conn->secure.cipher_suite = &s2n_null_cipher_suite;
-    conn->initial.s2n_kem_keys.negotiated_kem = NULL;
-    conn->secure.s2n_kem_keys.negotiated_kem = NULL;
+    conn->initial.kem_params.kem = NULL;
+    conn->secure.kem_params.kem = NULL;
     conn->server = &conn->initial;
     conn->client = &conn->initial;
     conn->max_outgoing_fragment_length = S2N_DEFAULT_FRAGMENT_LENGTH;
@@ -297,7 +297,7 @@ static int s2n_connection_wipe_keys(struct s2n_connection *conn)
     for (int i=0; i < S2N_ECC_EVP_SUPPORTED_CURVES_COUNT; i++) {
         GUARD(s2n_ecc_evp_params_free(&conn->secure.client_ecc_evp_params[i]));
     }
-    GUARD(s2n_kem_free(&conn->secure.s2n_kem_keys));
+    GUARD(s2n_kem_free(&conn->secure.kem_params));
     GUARD(s2n_free(&conn->secure.client_cert_chain));
     GUARD(s2n_free(&conn->ct_response));
 
@@ -911,11 +911,11 @@ const char *s2n_connection_get_kem_name(struct s2n_connection *conn)
 {
     notnull_check_ptr(conn);
 
-    if (!conn->secure.s2n_kem_keys.negotiated_kem) {
+    if (!conn->secure.kem_params.kem) {
         return "NONE";
     }
 
-    return conn->secure.s2n_kem_keys.negotiated_kem->name;
+    return conn->secure.kem_params.kem->name;
 }
 
 int s2n_connection_get_client_protocol_version(struct s2n_connection *conn)

--- a/tls/s2n_crypto.h
+++ b/tls/s2n_crypto.h
@@ -59,8 +59,8 @@
 /* RFC 5246 7.4.1.2 */
 #define S2N_TLS_SESSION_ID_MAX_LEN     32
 
-struct s2n_kem_keypair {
-    const struct s2n_kem *negotiated_kem;
+struct s2n_kem_params {
+    const struct s2n_kem *kem;
     struct s2n_blob public_key;
     struct s2n_blob private_key;
 };
@@ -72,7 +72,7 @@ struct s2n_crypto_parameters {
     struct s2n_ecc_evp_params server_ecc_evp_params;
     const struct s2n_ecc_named_curve * mutually_supported_groups[S2N_ECC_EVP_SUPPORTED_CURVES_COUNT];
     struct s2n_ecc_evp_params client_ecc_evp_params[S2N_ECC_EVP_SUPPORTED_CURVES_COUNT];
-    struct s2n_kem_keypair s2n_kem_keys;
+    struct s2n_kem_params kem_params;
     struct s2n_blob client_key_exchange_message;
     struct s2n_blob client_pq_kem_extension;
 

--- a/tls/s2n_kem.c
+++ b/tls/s2n_kem.c
@@ -110,57 +110,57 @@ const struct s2n_iana_to_kem *kem_mapping = NULL;
 
 #endif
 
-int s2n_kem_generate_keypair(struct s2n_kem_keypair *kem_keys)
+int s2n_kem_generate_keypair(struct s2n_kem_params *kem_params)
 {
-    notnull_check(kem_keys);
-    const struct s2n_kem *kem = kem_keys->negotiated_kem;
+    notnull_check(kem_params);
+    const struct s2n_kem *kem = kem_params->kem;
     notnull_check(kem->generate_keypair);
 
-    eq_check(kem_keys->public_key.size, kem->public_key_length);
-    notnull_check(kem_keys->public_key.data);
+    eq_check(kem_params->public_key.size, kem->public_key_length);
+    notnull_check(kem_params->public_key.data);
 
     /* The private key is needed for client_key_recv and must be saved */
-    GUARD(s2n_alloc(&kem_keys->private_key, kem->private_key_length));
+    GUARD(s2n_alloc(&kem_params->private_key, kem->private_key_length));
 
-    GUARD(kem->generate_keypair(kem_keys->public_key.data, kem_keys->private_key.data));
+    GUARD(kem->generate_keypair(kem_params->public_key.data, kem_params->private_key.data));
     return 0;
 }
 
-int s2n_kem_encapsulate(const struct s2n_kem_keypair *kem_keys, struct s2n_blob *shared_secret,
+int s2n_kem_encapsulate(const struct s2n_kem_params *kem_params, struct s2n_blob *shared_secret,
                         struct s2n_blob *ciphertext)
 {
-    notnull_check(kem_keys);
-    const struct s2n_kem *kem = kem_keys->negotiated_kem;
+    notnull_check(kem_params);
+    const struct s2n_kem *kem = kem_params->kem;
     notnull_check(kem->encapsulate);
 
-    eq_check(kem_keys->public_key.size, kem->public_key_length);
-    notnull_check(kem_keys->public_key.data);
+    eq_check(kem_params->public_key.size, kem->public_key_length);
+    notnull_check(kem_params->public_key.data);
 
     eq_check(ciphertext->size, kem->ciphertext_length);
     notnull_check(ciphertext->data);
 
     GUARD(s2n_alloc(shared_secret, kem->shared_secret_key_length));
 
-    GUARD(kem->encapsulate(ciphertext->data, shared_secret->data, kem_keys->public_key.data));
+    GUARD(kem->encapsulate(ciphertext->data, shared_secret->data, kem_params->public_key.data));
     return 0;
 }
 
-int s2n_kem_decapsulate(const struct s2n_kem_keypair *kem_keys, struct s2n_blob *shared_secret,
+int s2n_kem_decapsulate(const struct s2n_kem_params *kem_params, struct s2n_blob *shared_secret,
                         const struct s2n_blob *ciphertext)
 {
-    notnull_check(kem_keys);
-    const struct s2n_kem *kem = kem_keys->negotiated_kem;
+    notnull_check(kem_params);
+    const struct s2n_kem *kem = kem_params->kem;
     notnull_check(kem->decapsulate);
 
-    eq_check(kem_keys->private_key.size, kem->private_key_length);
-    notnull_check(kem_keys->private_key.data);
+    eq_check(kem_params->private_key.size, kem->private_key_length);
+    notnull_check(kem_params->private_key.data);
 
     eq_check(ciphertext->size, kem->ciphertext_length);
     notnull_check(ciphertext->data);
 
-    GUARD(s2n_alloc(shared_secret, kem_keys->negotiated_kem->shared_secret_key_length));
+    GUARD(s2n_alloc(shared_secret, kem_params->kem->shared_secret_key_length));
 
-    GUARD(kem->decapsulate(shared_secret->data, ciphertext->data, kem_keys->private_key.data));
+    GUARD(kem->decapsulate(shared_secret->data, ciphertext->data, kem_params->private_key.data));
     return 0;
 }
 
@@ -230,15 +230,15 @@ int s2n_choose_kem_without_peer_pref_list(const uint8_t iana_value[S2N_TLS_CIPHE
     S2N_ERROR(S2N_ERR_KEM_UNSUPPORTED_PARAMS);
 }
 
-int s2n_kem_free(struct s2n_kem_keypair *kem_keys)
+int s2n_kem_free(struct s2n_kem_params *kem_params)
 {
-    if (kem_keys != NULL){
-        GUARD(s2n_blob_zero(&kem_keys->private_key));
-        if (kem_keys->private_key.allocated) {
-            GUARD(s2n_free(&kem_keys->private_key));
+    if (kem_params != NULL){
+        GUARD(s2n_blob_zero(&kem_params->private_key));
+        if (kem_params->private_key.allocated) {
+            GUARD(s2n_free(&kem_params->private_key));
         }
-        if (kem_keys->public_key.allocated) {
-            GUARD(s2n_free(&kem_keys->public_key));
+        if (kem_params->public_key.allocated) {
+            GUARD(s2n_free(&kem_params->public_key));
         }
     }
     return 0;

--- a/tls/s2n_kem.h
+++ b/tls/s2n_kem.h
@@ -53,12 +53,12 @@ extern const struct s2n_kem s2n_sike_p434_r2;
 
 #endif
 
-extern int s2n_kem_generate_keypair(struct s2n_kem_keypair *kem_keys);
+extern int s2n_kem_generate_keypair(struct s2n_kem_params *kem_params);
 
-extern int s2n_kem_encapsulate(const struct s2n_kem_keypair *kem_keys, struct s2n_blob *shared_secret,
+extern int s2n_kem_encapsulate(const struct s2n_kem_params *kem_params, struct s2n_blob *shared_secret,
                                struct s2n_blob *ciphertext);
 
-extern int s2n_kem_decapsulate(const struct s2n_kem_keypair *kem_params, struct s2n_blob *shared_secret,
+extern int s2n_kem_decapsulate(const struct s2n_kem_params *kem_params, struct s2n_blob *shared_secret,
                                const struct s2n_blob *ciphertext);
 
 extern int s2n_choose_kem_with_peer_pref_list(const uint8_t iana_value[S2N_TLS_CIPHER_SUITE_LEN], struct s2n_blob *client_kem_ids,
@@ -68,6 +68,6 @@ extern int s2n_choose_kem_with_peer_pref_list(const uint8_t iana_value[S2N_TLS_C
 extern int s2n_choose_kem_without_peer_pref_list(const uint8_t iana_value[S2N_TLS_CIPHER_SUITE_LEN], const struct s2n_kem *server_kem_pref_list[],
                                         const uint8_t num_server_supported_kems, const struct s2n_kem **chosen_kem);
 
-extern int s2n_kem_free(struct s2n_kem_keypair *kem_keys);
+extern int s2n_kem_free(struct s2n_kem_params *kem_params);
 
 extern int s2n_cipher_suite_to_kem(const uint8_t iana_value[S2N_TLS_CIPHER_SUITE_LEN], const struct s2n_iana_to_kem **supported_params);

--- a/tls/s2n_kex.c
+++ b/tls/s2n_kex.c
@@ -145,7 +145,7 @@ static int s2n_configure_kem(const struct s2n_cipher_suite *cipher_suite, struct
             security_policy->kem_preferences->count, &chosen_kem));
     }
 
-    conn->secure.s2n_kem_keys.negotiated_kem = chosen_kem;
+    conn->secure.kem_params.kem = chosen_kem;
     return 0;
 }
 


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 

**Description of changes:** 
Straightforward naming refactor:
* `struct s2n_kem_keypair` -> `struct s2n_kem_params`
* `s2n_kem_params.negotiated_kem` -> `s2n_kem_params.kem`

These changes are being made to logically accommodate future additions for PQ-TLS 1.3. In particular, the `struct` will augmented to store the shared secret (thus `params` makes more sense than `keypair`), and the associated KEM may not necessarily be the final KEM that gets negotiated in the handshake.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
