### PR TITLE
Refactor first set of extensions into structs

### DIFF
--- a/tests/unit/s2n_client_alpn_extension_test.c
+++ b/tests/unit/s2n_client_alpn_extension_test.c
@@ -21,12 +21,11 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
-    const char *protocols[] = { "protocol1", "protocol2", "protocol2" };
+    const char *protocols[] = { "protocol1", "protocol2", "protocol3" };
     const uint8_t protocols_count = s2n_array_len(protocols);
 
     struct s2n_connection *conn;
     EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
-    EXPECT_NULL(s2n_get_application_protocol(conn));
 
     /* Test should_send */
     {

--- a/tests/unit/s2n_client_alpn_extension_test.c
+++ b/tests/unit/s2n_client_alpn_extension_test.c
@@ -1,0 +1,109 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "tls/extensions/s2n_client_alpn.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    const char *protocols[] = { "protocol1", "protocol2", "protocol2" };
+    const uint8_t protocols_count = s2n_array_len(protocols);
+
+    struct s2n_connection *conn;
+    EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+    EXPECT_NULL(s2n_get_application_protocol(conn));
+
+    /* Test should_send */
+    {
+        EXPECT_SUCCESS(s2n_connection_set_protocol_preferences(conn, NULL, 0));
+        EXPECT_FALSE(s2n_client_alpn_extension.should_send(conn));
+
+        EXPECT_SUCCESS(s2n_connection_set_protocol_preferences(conn, protocols, protocols_count));
+        EXPECT_TRUE(s2n_client_alpn_extension.should_send(conn));
+    }
+
+    /* Test send */
+    {
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+        EXPECT_SUCCESS(s2n_connection_set_protocol_preferences(conn, protocols, protocols_count));
+
+        EXPECT_SUCCESS(s2n_client_alpn_extension.send(conn, &stuffer));
+
+        /* Should have correct size */
+        uint16_t actual_size;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &actual_size));
+        EXPECT_EQUAL(actual_size, s2n_stuffer_data_available(&stuffer));
+        EXPECT_EQUAL(actual_size, conn->application_protocols_overridden.size);
+
+        /* Should have correct data */
+        uint8_t actual_data[256];
+        EXPECT_SUCCESS(s2n_stuffer_read_bytes(&stuffer, actual_data, actual_size));
+        EXPECT_BYTEARRAY_EQUAL(actual_data, conn->application_protocols_overridden.data, actual_size);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+    }
+
+    /* Test receive empty */
+    {
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        EXPECT_NULL(s2n_get_application_protocol(conn));
+        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&stuffer, 0));
+        EXPECT_SUCCESS(s2n_client_alpn_extension.recv(conn, &stuffer));
+        EXPECT_NULL(s2n_get_application_protocol(conn));
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+    }
+
+    /* Test receive can accept the output of send */
+    {
+        struct s2n_connection *conn_without_protocols;
+        EXPECT_NOT_NULL(conn_without_protocols = s2n_connection_new(S2N_CLIENT));
+
+        struct s2n_connection *conn_with_protocols;
+        EXPECT_NOT_NULL(conn_with_protocols = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_protocol_preferences(conn_with_protocols, protocols, protocols_count));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        EXPECT_SUCCESS(s2n_client_alpn_extension.send(conn_with_protocols, &stuffer));
+
+        /* If no protocols supported, do not set protocol */
+        EXPECT_NULL(s2n_get_application_protocol(conn_without_protocols));
+        EXPECT_SUCCESS(s2n_client_alpn_extension.recv(conn_without_protocols, &stuffer));
+        EXPECT_NULL(s2n_get_application_protocol(conn_without_protocols));
+
+        /* If matching protocol supported, set protocol */
+        EXPECT_NULL(s2n_get_application_protocol(conn_with_protocols));
+        EXPECT_SUCCESS(s2n_client_alpn_extension.recv(conn_with_protocols, &stuffer));
+        EXPECT_NOT_NULL(s2n_get_application_protocol(conn_with_protocols));
+        EXPECT_STRING_EQUAL(s2n_get_application_protocol(conn_with_protocols), protocols[0]);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn_with_protocols));
+        EXPECT_SUCCESS(s2n_connection_free(conn_without_protocols));
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+    }
+
+    EXPECT_SUCCESS(s2n_connection_free(conn));
+
+    END_TEST();
+    return 0;
+}

--- a/tests/unit/s2n_client_max_frag_len_extension_test.c
+++ b/tests/unit/s2n_client_max_frag_len_extension_test.c
@@ -1,0 +1,152 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "tls/extensions/s2n_client_max_frag_len.h"
+#include "tls/s2n_tls.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Test should_send */
+    {
+        struct s2n_config *config;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        EXPECT_SUCCESS(s2n_config_send_max_fragment_length(config, S2N_TLS_MAX_FRAG_LEN_EXT_NONE));
+        EXPECT_FALSE(s2n_client_max_frag_len_extension.should_send(conn));
+
+        EXPECT_SUCCESS(s2n_config_send_max_fragment_length(config, S2N_TLS_MAX_FRAG_LEN_512));
+        EXPECT_TRUE(s2n_client_max_frag_len_extension.should_send(conn));
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
+    /* Test send */
+    {
+        struct s2n_config *config;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        EXPECT_SUCCESS(s2n_config_send_max_fragment_length(config, S2N_TLS_MAX_FRAG_LEN_512));
+        EXPECT_SUCCESS(s2n_client_max_frag_len_extension.send(conn, &stuffer));
+
+        /* Should have correct fragment length */
+        uint8_t actual_frag_len;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint8(&stuffer, &actual_frag_len));
+        EXPECT_EQUAL(actual_frag_len, S2N_TLS_MAX_FRAG_LEN_512);
+        EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
+    /* Test receive - accept_mfl not set */
+    {
+        struct s2n_config *config;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        EXPECT_SUCCESS(s2n_config_send_max_fragment_length(config, S2N_TLS_MAX_FRAG_LEN_512));
+        EXPECT_SUCCESS(s2n_client_max_frag_len_extension.send(conn, &stuffer));
+
+        /* Ignore fragment length if not accepting max fragment length */
+        EXPECT_FALSE(config->accept_mfl);
+        EXPECT_SUCCESS(s2n_client_max_frag_len_extension.recv(conn, &stuffer));
+        EXPECT_EQUAL(conn->mfl_code, S2N_TLS_MAX_FRAG_LEN_EXT_NONE);
+        EXPECT_EQUAL(conn->max_outgoing_fragment_length, S2N_DEFAULT_FRAGMENT_LENGTH);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
+    /* Test receive - invalid mfl code */
+    {
+        struct s2n_config *config;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+        EXPECT_SUCCESS(s2n_config_accept_max_fragment_length(config));
+
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        /* Send invalid mfl code */
+        conn->config->mfl_code = UINT8_MAX;
+        EXPECT_SUCCESS(s2n_client_max_frag_len_extension.send(conn, &stuffer));
+
+        /* Ignore invalid mfl code */
+        EXPECT_SUCCESS(s2n_client_max_frag_len_extension.recv(conn, &stuffer));
+        EXPECT_EQUAL(conn->mfl_code, S2N_TLS_MAX_FRAG_LEN_EXT_NONE);
+        EXPECT_EQUAL(conn->max_outgoing_fragment_length, S2N_DEFAULT_FRAGMENT_LENGTH);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
+    /* Test receive */
+    {
+        struct s2n_config *config;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+        EXPECT_SUCCESS(s2n_config_accept_max_fragment_length(config));
+
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        EXPECT_SUCCESS(s2n_config_send_max_fragment_length(conn->config, S2N_TLS_MAX_FRAG_LEN_512));
+        EXPECT_SUCCESS(s2n_client_max_frag_len_extension.send(conn, &stuffer));
+
+        /* Accept valid mfl code */
+        EXPECT_SUCCESS(s2n_client_max_frag_len_extension.recv(conn, &stuffer));
+        EXPECT_EQUAL(conn->mfl_code, S2N_TLS_MAX_FRAG_LEN_512);
+        EXPECT_EQUAL(conn->max_outgoing_fragment_length, mfl_code_to_length[S2N_TLS_MAX_FRAG_LEN_512]);
+        EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
+    END_TEST();
+    return 0;
+}

--- a/tests/unit/s2n_client_pq_kem_extension_test.c
+++ b/tests/unit/s2n_client_pq_kem_extension_test.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "tls/extensions/s2n_client_pq_kem.h"
+#include "tls/s2n_security_policies.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    const char *pq_security_policy = "KMS-PQ-TLS-1-0-2020-02";
+    const struct s2n_security_policy *security_policy;
+    EXPECT_SUCCESS(s2n_find_security_policy_from_version(pq_security_policy, &security_policy));
+    const struct s2n_kem_preferences *kem_preferences = security_policy->kem_preferences;
+
+    /* Test should_send */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+        /* Default cipher preferences do not include PQ, so extension not sent */
+        EXPECT_FALSE(s2n_client_pq_kem_extension.should_send(conn));
+
+        /* Use cipher preferences that do include PQ */
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, pq_security_policy));
+        EXPECT_TRUE(s2n_client_pq_kem_extension.should_send(conn));
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test send */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, pq_security_policy));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        EXPECT_SUCCESS(s2n_client_pq_kem_extension.send(conn, &stuffer));
+
+        /* Should write correct size */
+        uint16_t size;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &size));
+        EXPECT_EQUAL(size, s2n_stuffer_data_available(&stuffer));
+        EXPECT_EQUAL(size, kem_preferences->count * sizeof(kem_extension_size));
+
+        /* Should write ids */
+        uint16_t actual_id;
+        for (int i = 0; i < kem_preferences->count; i++) {
+            GUARD(s2n_stuffer_read_uint16(&stuffer, &actual_id));
+            EXPECT_EQUAL(actual_id, kem_preferences->kems[i]->kem_extension_id);
+        }
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test receive - malformed length */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, pq_security_policy));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        EXPECT_SUCCESS(s2n_client_pq_kem_extension.send(conn, &stuffer));
+        EXPECT_SUCCESS(s2n_stuffer_wipe_n(&stuffer, 1));
+
+        EXPECT_SUCCESS(s2n_client_pq_kem_extension.recv(conn, &stuffer));
+        EXPECT_EQUAL(conn->secure.client_pq_kem_extension.size, 0);
+        EXPECT_NULL(conn->secure.client_pq_kem_extension.data);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test receive */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, pq_security_policy));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        EXPECT_SUCCESS(s2n_client_pq_kem_extension.send(conn, &stuffer));
+
+        EXPECT_SUCCESS(s2n_client_pq_kem_extension.recv(conn, &stuffer));
+        EXPECT_EQUAL(conn->secure.client_pq_kem_extension.size, kem_preferences->count * sizeof(kem_extension_size));
+        EXPECT_NOT_NULL(conn->secure.client_pq_kem_extension.data);
+        EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    END_TEST();
+}

--- a/tests/unit/s2n_client_renegotiation_info_extension_test.c
+++ b/tests/unit/s2n_client_renegotiation_info_extension_test.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "tls/extensions/s2n_client_renegotiation_info.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Test receive - too much data */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&stuffer, 0));
+
+        EXPECT_FAILURE_WITH_ERRNO(s2n_client_renegotiation_info_extension.recv(conn, &stuffer),
+                S2N_ERR_NON_EMPTY_RENEGOTIATION_INFO);
+        EXPECT_FALSE(conn->secure_renegotiation);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test receive - value not 0 */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, 1));
+
+        EXPECT_FAILURE_WITH_ERRNO(s2n_client_renegotiation_info_extension.recv(conn, &stuffer),
+                S2N_ERR_NON_EMPTY_RENEGOTIATION_INFO);
+        EXPECT_FALSE(conn->secure_renegotiation);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test receive */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, 0));
+
+        EXPECT_SUCCESS(s2n_client_renegotiation_info_extension.recv(conn, &stuffer));
+        EXPECT_TRUE(conn->secure_renegotiation);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    END_TEST();
+}

--- a/tests/unit/s2n_client_sct_list_extension_test.c
+++ b/tests/unit/s2n_client_sct_list_extension_test.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "tls/extensions/s2n_client_sct_list.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Test should_send */
+    {
+        struct s2n_config *config;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        /* Default configs use S2N_CT_SUPPORT_NONE */
+        EXPECT_FALSE(s2n_client_sct_list_extension.should_send(conn));
+
+        /* Use cipher preferences that do include PQ */
+        EXPECT_SUCCESS(s2n_config_set_ct_support_level(config, S2N_CT_SUPPORT_REQUEST));
+        EXPECT_TRUE(s2n_client_sct_list_extension.should_send(conn));
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
+    /* Test send */
+    {
+        struct s2n_config *config;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        EXPECT_SUCCESS(s2n_client_sct_list_extension.send(conn, &stuffer));
+        EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
+    /* Test receive */
+    {
+        struct s2n_config *config;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        EXPECT_SUCCESS(s2n_client_sct_list_extension.send(conn, &stuffer));
+
+        EXPECT_NOT_EQUAL(conn->ct_level_requested, S2N_CT_SUPPORT_REQUEST);
+        EXPECT_SUCCESS(s2n_client_sct_list_extension.recv(conn, &stuffer));
+        EXPECT_EQUAL(conn->ct_level_requested, S2N_CT_SUPPORT_REQUEST);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
+    END_TEST();
+}

--- a/tls/extensions/s2n_client_alpn.c
+++ b/tls/extensions/s2n_client_alpn.c
@@ -17,26 +17,46 @@
 #include <stdint.h>
 
 #include "tls/extensions/s2n_client_alpn.h"
+
+#include "tls/extensions/s2n_extension_type.h"
 #include "tls/s2n_tls.h"
 #include "tls/s2n_tls_parameters.h"
 
 #include "utils/s2n_safety.h"
 
-int s2n_extensions_client_alpn_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+static int s2n_client_alpn_should_send(struct s2n_connection *conn);
+static int s2n_client_alpn_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+static int s2n_client_alpn_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
+
+const s2n_extension_type s2n_client_alpn_extension = {
+    .iana_value = TLS_EXTENSION_ALPN,
+    .is_response = false,
+    .send = s2n_client_alpn_send,
+    .recv = s2n_client_alpn_recv,
+    .should_send = s2n_client_alpn_should_send,
+    .if_missing = s2n_extension_noop_if_missing,
+};
+
+static int s2n_client_alpn_should_send(struct s2n_connection *conn)
+{
+    struct s2n_blob *client_app_protocols;
+
+    return s2n_connection_get_protocol_preferences(conn, &client_app_protocols) == S2N_SUCCESS
+            && client_app_protocols->size != 0;
+}
+
+static int s2n_client_alpn_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
     struct s2n_blob *client_app_protocols;
     GUARD(s2n_connection_get_protocol_preferences(conn, &client_app_protocols));
-    uint16_t application_protocols_len = client_app_protocols->size;
 
-    GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_ALPN));
-    GUARD(s2n_stuffer_write_uint16(out, application_protocols_len + 2));
-    GUARD(s2n_stuffer_write_uint16(out, application_protocols_len));
+    GUARD(s2n_stuffer_write_uint16(out, client_app_protocols->size));
     GUARD(s2n_stuffer_write(out, client_app_protocols));
 
     return 0;
 }
 
-int s2n_recv_client_alpn(struct s2n_connection *conn, struct s2n_stuffer *extension)
+static int s2n_client_alpn_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
     uint16_t size_of_all;
     struct s2n_stuffer client_protos = {0};
@@ -93,4 +113,16 @@ int s2n_recv_client_alpn(struct s2n_connection *conn, struct s2n_stuffer *extens
         GUARD(s2n_stuffer_reread(&client_protos));
     }
     return 0;
+}
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
+
+int s2n_extensions_client_alpn_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    return s2n_extension_send(&s2n_client_alpn_extension, conn, out);
+}
+
+int s2n_recv_client_alpn(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    return s2n_extension_recv(&s2n_client_alpn_extension, conn, extension);
 }

--- a/tls/extensions/s2n_client_alpn.c
+++ b/tls/extensions/s2n_client_alpn.c
@@ -53,7 +53,7 @@ static int s2n_client_alpn_send(struct s2n_connection *conn, struct s2n_stuffer 
     GUARD(s2n_stuffer_write_uint16(out, client_app_protocols->size));
     GUARD(s2n_stuffer_write(out, client_app_protocols));
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 static int s2n_client_alpn_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
@@ -67,13 +67,13 @@ static int s2n_client_alpn_recv(struct s2n_connection *conn, struct s2n_stuffer 
 
     if (!server_app_protocols->size) {
         /* No protocols configured, nothing to do */
-        return 0;
+        return S2N_SUCCESS;
     }
 
     GUARD(s2n_stuffer_read_uint16(extension, &size_of_all));
     if (size_of_all > s2n_stuffer_data_available(extension) || size_of_all < 3) {
         /* Malformed length, ignore the extension */
-        return 0;
+        return S2N_SUCCESS;
     }
 
     struct s2n_blob client_app_protocols = { 0 };
@@ -105,14 +105,14 @@ static int s2n_client_alpn_recv(struct s2n_connection *conn, struct s2n_stuffer 
                 if (memcmp(client_protocol, server_protocol, client_length) == 0) {
                     memcpy_check(conn->application_protocol, client_protocol, client_length);
                     conn->application_protocol[client_length] = '\0';
-                    return 0;
+                    return S2N_SUCCESS;
                 }
             }
         }
 
         GUARD(s2n_stuffer_reread(&client_protos));
     }
-    return 0;
+    return S2N_SUCCESS;
 }
 
 /* Old-style extension functions -- remove after extensions refactor is complete */

--- a/tls/extensions/s2n_client_alpn.c
+++ b/tls/extensions/s2n_client_alpn.c
@@ -24,7 +24,7 @@
 
 #include "utils/s2n_safety.h"
 
-static int s2n_client_alpn_should_send(struct s2n_connection *conn);
+static bool s2n_client_alpn_should_send(struct s2n_connection *conn);
 static int s2n_client_alpn_send(struct s2n_connection *conn, struct s2n_stuffer *out);
 static int s2n_client_alpn_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
 
@@ -37,7 +37,7 @@ const s2n_extension_type s2n_client_alpn_extension = {
     .if_missing = s2n_extension_noop_if_missing,
 };
 
-static int s2n_client_alpn_should_send(struct s2n_connection *conn)
+static bool s2n_client_alpn_should_send(struct s2n_connection *conn)
 {
     struct s2n_blob *client_app_protocols;
 

--- a/tls/extensions/s2n_client_alpn.c
+++ b/tls/extensions/s2n_client_alpn.c
@@ -42,13 +42,14 @@ static bool s2n_client_alpn_should_send(struct s2n_connection *conn)
     struct s2n_blob *client_app_protocols;
 
     return s2n_connection_get_protocol_preferences(conn, &client_app_protocols) == S2N_SUCCESS
-            && client_app_protocols->size != 0;
+            && client_app_protocols->size != 0 && client_app_protocols->data != NULL;
 }
 
 static int s2n_client_alpn_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
     struct s2n_blob *client_app_protocols;
     GUARD(s2n_connection_get_protocol_preferences(conn, &client_app_protocols));
+    notnull_check(client_app_protocols);
 
     GUARD(s2n_stuffer_write_uint16(out, client_app_protocols->size));
     GUARD(s2n_stuffer_write(out, client_app_protocols));

--- a/tls/extensions/s2n_client_alpn.h
+++ b/tls/extensions/s2n_client_alpn.h
@@ -15,8 +15,13 @@
 
 #pragma once
 
+#include "tls/extensions/s2n_extension_type.h"
 #include "tls/s2n_connection.h"
 #include "stuffer/s2n_stuffer.h"
+
+extern const s2n_extension_type s2n_client_alpn_extension;
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
 
 extern int s2n_extensions_client_alpn_send(struct s2n_connection *conn, struct s2n_stuffer *out);
 extern int s2n_recv_client_alpn(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_client_max_frag_len.c
+++ b/tls/extensions/s2n_client_max_frag_len.c
@@ -48,18 +48,18 @@ static int s2n_client_max_frag_len_send(struct s2n_connection *conn, struct s2n_
 static int s2n_client_max_frag_len_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
     if (!conn->config->accept_mfl) {
-        return 0;
+        return S2N_SUCCESS;
     }
 
     uint8_t mfl_code;
     GUARD(s2n_stuffer_read_uint8(extension, &mfl_code));
     if (mfl_code > S2N_TLS_MAX_FRAG_LEN_4096 || mfl_code_to_length[mfl_code] > S2N_TLS_MAXIMUM_FRAGMENT_LENGTH) {
-        return 0;
+        return S2N_SUCCESS;
     }
 
     conn->mfl_code = mfl_code;
     conn->max_outgoing_fragment_length = mfl_code_to_length[mfl_code];
-    return 0;
+    return S2N_SUCCESS;
 }
 
 /* Old-style extension functions -- remove after extensions refactor is complete */

--- a/tls/extensions/s2n_client_max_frag_len.c
+++ b/tls/extensions/s2n_client_max_frag_len.c
@@ -22,7 +22,7 @@
 
 #include "utils/s2n_safety.h"
 
-static int s2n_client_max_frag_len_should_send(struct s2n_connection *conn);
+static bool s2n_client_max_frag_len_should_send(struct s2n_connection *conn);
 static int s2n_client_max_frag_len_send(struct s2n_connection *conn, struct s2n_stuffer *out);
 static int s2n_client_max_frag_len_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
 
@@ -35,7 +35,7 @@ const s2n_extension_type s2n_client_max_frag_len_extension = {
     .if_missing = s2n_extension_noop_if_missing,
 };
 
-static int s2n_client_max_frag_len_should_send(struct s2n_connection *conn)
+static bool s2n_client_max_frag_len_should_send(struct s2n_connection *conn)
 {
     return conn->config->mfl_code != S2N_TLS_MAX_FRAG_LEN_EXT_NONE;
 }

--- a/tls/extensions/s2n_client_max_frag_len.c
+++ b/tls/extensions/s2n_client_max_frag_len.c
@@ -22,18 +22,30 @@
 
 #include "utils/s2n_safety.h"
 
-int s2n_extensions_client_max_frag_len_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+static int s2n_client_max_frag_len_should_send(struct s2n_connection *conn);
+static int s2n_client_max_frag_len_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+static int s2n_client_max_frag_len_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
+
+const s2n_extension_type s2n_client_max_frag_len_extension = {
+    .iana_value = TLS_EXTENSION_MAX_FRAG_LEN,
+    .is_response = false,
+    .send = s2n_client_max_frag_len_send,
+    .recv = s2n_client_max_frag_len_recv,
+    .should_send = s2n_client_max_frag_len_should_send,
+    .if_missing = s2n_extension_noop_if_missing,
+};
+
+static int s2n_client_max_frag_len_should_send(struct s2n_connection *conn)
 {
-    uint16_t mfl_code_len = sizeof(conn->config->mfl_code);
-
-    GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_MAX_FRAG_LEN));
-    GUARD(s2n_stuffer_write_uint16(out, mfl_code_len));
-    GUARD(s2n_stuffer_write_uint8(out, conn->config->mfl_code));
-
-    return 0;
+    return conn->config->mfl_code != S2N_TLS_MAX_FRAG_LEN_EXT_NONE;
 }
 
-int s2n_recv_client_max_frag_len(struct s2n_connection *conn, struct s2n_stuffer *extension)
+static int s2n_client_max_frag_len_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    return s2n_stuffer_write_uint8(out, conn->config->mfl_code);
+}
+
+static int s2n_client_max_frag_len_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
     if (!conn->config->accept_mfl) {
         return 0;
@@ -48,4 +60,16 @@ int s2n_recv_client_max_frag_len(struct s2n_connection *conn, struct s2n_stuffer
     conn->mfl_code = mfl_code;
     conn->max_outgoing_fragment_length = mfl_code_to_length[mfl_code];
     return 0;
+}
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
+
+int s2n_extensions_client_max_frag_len_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    return s2n_extension_send(&s2n_client_max_frag_len_extension, conn, out);
+}
+
+int s2n_recv_client_max_frag_len(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    return s2n_extension_recv(&s2n_client_max_frag_len_extension, conn, extension);
 }

--- a/tls/extensions/s2n_client_max_frag_len.h
+++ b/tls/extensions/s2n_client_max_frag_len.h
@@ -18,5 +18,9 @@
 #include "tls/s2n_connection.h"
 #include "stuffer/s2n_stuffer.h"
 
+extern const s2n_extension_type s2n_client_max_frag_len_extension;
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
+
 extern int s2n_extensions_client_max_frag_len_send(struct s2n_connection *conn, struct s2n_stuffer *out);
 extern int s2n_recv_client_max_frag_len(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_client_pq_kem.c
+++ b/tls/extensions/s2n_client_pq_kem.c
@@ -24,7 +24,7 @@
 
 #include "utils/s2n_safety.h"
 
-static int s2n_client_pq_kem_should_send(struct s2n_connection *conn);
+static bool s2n_client_pq_kem_should_send(struct s2n_connection *conn);
 static int s2n_client_pq_kem_send(struct s2n_connection *conn, struct s2n_stuffer *out);
 static int s2n_client_pq_kem_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
 
@@ -37,7 +37,7 @@ const s2n_extension_type s2n_client_pq_kem_extension = {
     .if_missing = s2n_extension_noop_if_missing,
 };
 
-static int s2n_client_pq_kem_should_send(struct s2n_connection *conn)
+static bool s2n_client_pq_kem_should_send(struct s2n_connection *conn)
 {
     const struct s2n_security_policy *security_policy;
     return s2n_connection_get_security_policy(conn, &security_policy) == S2N_SUCCESS

--- a/tls/extensions/s2n_client_pq_kem.c
+++ b/tls/extensions/s2n_client_pq_kem.c
@@ -24,17 +24,33 @@
 
 #include "utils/s2n_safety.h"
 
-int s2n_extensions_client_pq_kem_send(struct s2n_connection *conn, struct s2n_stuffer *out, uint16_t pq_kem_list_size)
+static int s2n_client_pq_kem_should_send(struct s2n_connection *conn);
+static int s2n_client_pq_kem_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+static int s2n_client_pq_kem_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
+
+const s2n_extension_type s2n_client_pq_kem_extension = {
+    .iana_value = TLS_EXTENSION_PQ_KEM_PARAMETERS,
+    .is_response = false,
+    .send = s2n_client_pq_kem_send,
+    .recv = s2n_client_pq_kem_recv,
+    .should_send = s2n_client_pq_kem_should_send,
+    .if_missing = s2n_extension_noop_if_missing,
+};
+
+static int s2n_client_pq_kem_should_send(struct s2n_connection *conn)
 {
-    GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_PQ_KEM_PARAMETERS));
-    /* Overall extension length */
-    GUARD(s2n_stuffer_write_uint16(out, 2 + pq_kem_list_size));
-    /* Length of parameters in bytes */
-    GUARD(s2n_stuffer_write_uint16(out, pq_kem_list_size));
-    /* Each supported kem id is 2 bytes */
+    const struct s2n_security_policy *security_policy;
+    return s2n_connection_get_security_policy(conn, &security_policy) == S2N_SUCCESS
+            && s2n_pq_kem_is_extension_required(security_policy);
+}
+
+static int s2n_client_pq_kem_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
     const struct s2n_kem_preferences *kem_preferences = NULL;
     GUARD(s2n_connection_get_kem_preferences(conn, &kem_preferences));
     notnull_check(kem_preferences);
+
+    GUARD(s2n_stuffer_write_uint16(out, kem_preferences->count * sizeof(kem_extension_size)));
     for (int i = 0; i < kem_preferences->count; i++) {
         GUARD(s2n_stuffer_write_uint16(out, kem_preferences->kems[i]->kem_extension_id));
     }
@@ -42,13 +58,13 @@ int s2n_extensions_client_pq_kem_send(struct s2n_connection *conn, struct s2n_st
     return 0;
 }
 
-int s2n_recv_pq_kem_extension(struct s2n_connection *conn, struct s2n_stuffer *extension)
+static int s2n_client_pq_kem_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
     uint16_t size_of_all;
     struct s2n_blob *proposed_kems = &conn->secure.client_pq_kem_extension;
 
     GUARD(s2n_stuffer_read_uint16(extension, &size_of_all));
-    if (size_of_all > s2n_stuffer_data_available(extension) || size_of_all % 2) {
+    if (size_of_all > s2n_stuffer_data_available(extension) || size_of_all % sizeof(kem_extension_size)) {
         /* Malformed length, ignore the extension */
         return 0;
     }
@@ -58,4 +74,16 @@ int s2n_recv_pq_kem_extension(struct s2n_connection *conn, struct s2n_stuffer *e
     notnull_check(proposed_kems->data);
 
     return 0;
+}
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
+
+int s2n_extensions_client_pq_kem_send(struct s2n_connection *conn, struct s2n_stuffer *out, uint16_t pq_kem_list_size)
+{
+    return s2n_extension_send(&s2n_client_pq_kem_extension, conn, out);
+}
+
+int s2n_recv_pq_kem_extension(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    return s2n_extension_recv(&s2n_client_pq_kem_extension, conn, extension);
 }

--- a/tls/extensions/s2n_client_pq_kem.c
+++ b/tls/extensions/s2n_client_pq_kem.c
@@ -55,7 +55,7 @@ static int s2n_client_pq_kem_send(struct s2n_connection *conn, struct s2n_stuffe
         GUARD(s2n_stuffer_write_uint16(out, kem_preferences->kems[i]->kem_extension_id));
     }
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 static int s2n_client_pq_kem_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
@@ -66,14 +66,14 @@ static int s2n_client_pq_kem_recv(struct s2n_connection *conn, struct s2n_stuffe
     GUARD(s2n_stuffer_read_uint16(extension, &size_of_all));
     if (size_of_all > s2n_stuffer_data_available(extension) || size_of_all % sizeof(kem_extension_size)) {
         /* Malformed length, ignore the extension */
-        return 0;
+        return S2N_SUCCESS;
     }
 
     proposed_kems->size = size_of_all;
     proposed_kems->data = s2n_stuffer_raw_read(extension, proposed_kems->size);
     notnull_check(proposed_kems->data);
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 /* Old-style extension functions -- remove after extensions refactor is complete */

--- a/tls/extensions/s2n_client_pq_kem.h
+++ b/tls/extensions/s2n_client_pq_kem.h
@@ -15,8 +15,13 @@
 
 #pragma once
 
+#include "tls/extensions/s2n_extension_type.h"
 #include "tls/s2n_connection.h"
 #include "stuffer/s2n_stuffer.h"
+
+extern const s2n_extension_type s2n_client_pq_kem_extension;
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
 
 extern int s2n_extensions_client_pq_kem_send(struct s2n_connection *conn, struct s2n_stuffer *out, uint16_t pq_kem_list_size);
 extern int s2n_recv_pq_kem_extension(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_client_renegotiation_info.c
+++ b/tls/extensions/s2n_client_renegotiation_info.c
@@ -21,7 +21,18 @@
 
 #include "utils/s2n_safety.h"
 
-int s2n_recv_client_renegotiation_info(struct s2n_connection *conn, struct s2n_stuffer *extension)
+static int s2n_client_renegotiation_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
+
+const s2n_extension_type s2n_client_renegotiation_info_extension = {
+    .iana_value = TLS_EXTENSION_RENEGOTIATION_INFO,
+    .is_response = false,
+    .send = s2n_extension_send_unimplemented,
+    .recv = s2n_client_renegotiation_recv,
+    .should_send = s2n_extension_never_send,
+    .if_missing = s2n_extension_noop_if_missing,
+};
+
+static int s2n_client_renegotiation_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
     /* RFC5746 Section 3.2: The renegotiated_connection field is of zero length for the initial handshake. */
     uint8_t renegotiated_connection_len;
@@ -30,4 +41,11 @@ int s2n_recv_client_renegotiation_info(struct s2n_connection *conn, struct s2n_s
 
     conn->secure_renegotiation = 1;
     return 0;
+}
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
+
+int s2n_recv_client_renegotiation_info(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    return s2n_extension_recv(&s2n_client_renegotiation_info_extension, conn, extension);
 }

--- a/tls/extensions/s2n_client_renegotiation_info.c
+++ b/tls/extensions/s2n_client_renegotiation_info.c
@@ -40,7 +40,7 @@ static int s2n_client_renegotiation_recv(struct s2n_connection *conn, struct s2n
     S2N_ERROR_IF(s2n_stuffer_data_available(extension) || renegotiated_connection_len, S2N_ERR_NON_EMPTY_RENEGOTIATION_INFO);
 
     conn->secure_renegotiation = 1;
-    return 0;
+    return S2N_SUCCESS;
 }
 
 /* Old-style extension functions -- remove after extensions refactor is complete */

--- a/tls/extensions/s2n_client_renegotiation_info.h
+++ b/tls/extensions/s2n_client_renegotiation_info.h
@@ -18,4 +18,8 @@
 #include "tls/s2n_connection.h"
 #include "stuffer/s2n_stuffer.h"
 
-extern int s2n_recv_client_renegotiation_info(struct s2n_connection *conn, struct s2n_stuffer *extension);
+extern const s2n_extension_type s2n_client_renegotiation_info_extension;
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
+
+int s2n_recv_client_renegotiation_info(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_client_sct_list.c
+++ b/tls/extensions/s2n_client_sct_list.c
@@ -22,17 +22,45 @@
 
 #include "utils/s2n_safety.h"
 
+static int s2n_client_sct_list_should_send(struct s2n_connection *conn);
+static int s2n_client_sct_list_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+static int s2n_client_sct_list_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
+
+const s2n_extension_type s2n_client_sct_list_extension = {
+    .iana_value = TLS_EXTENSION_SCT_LIST,
+    .is_response = false,
+    .send = s2n_client_sct_list_send,
+    .recv = s2n_client_sct_list_recv,
+    .should_send = s2n_client_sct_list_should_send,
+    .if_missing = s2n_extension_noop_if_missing,
+};
+
+static int s2n_client_sct_list_should_send(struct s2n_connection *conn)
+{
+    return conn->config->ct_type != S2N_CT_SUPPORT_NONE;
+}
+
+static int s2n_client_sct_list_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    /* This extension is empty */
+    return S2N_SUCCESS;
+}
+
+static int s2n_client_sct_list_recv(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    conn->ct_level_requested = S2N_CT_SUPPORT_REQUEST;
+    /* Skip reading the extension, per RFC6962 (3.1.1) it SHOULD be empty anyway  */
+    return S2N_SUCCESS;
+}
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
+
 int s2n_extensions_client_sct_list_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_SCT_LIST));
-    GUARD(s2n_stuffer_write_uint16(out, 0));
-
-    return 0;
+    return s2n_extension_send(&s2n_client_sct_list_extension, conn, out);
 }
 
 int s2n_recv_client_sct_list(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
-    conn->ct_level_requested = S2N_CT_SUPPORT_REQUEST;
-    /* Skip reading the extension, per RFC6962 (3.1.1) it SHOULD be empty anyway  */
-    return 0;
+    return s2n_extension_recv(&s2n_client_sct_list_extension, conn, extension);
 }

--- a/tls/extensions/s2n_client_sct_list.c
+++ b/tls/extensions/s2n_client_sct_list.c
@@ -22,7 +22,7 @@
 
 #include "utils/s2n_safety.h"
 
-static int s2n_client_sct_list_should_send(struct s2n_connection *conn);
+static bool s2n_client_sct_list_should_send(struct s2n_connection *conn);
 static int s2n_client_sct_list_send(struct s2n_connection *conn, struct s2n_stuffer *out);
 static int s2n_client_sct_list_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
 
@@ -35,7 +35,7 @@ const s2n_extension_type s2n_client_sct_list_extension = {
     .if_missing = s2n_extension_noop_if_missing,
 };
 
-static int s2n_client_sct_list_should_send(struct s2n_connection *conn)
+static bool s2n_client_sct_list_should_send(struct s2n_connection *conn)
 {
     return conn->config->ct_type != S2N_CT_SUPPORT_NONE;
 }

--- a/tls/extensions/s2n_client_sct_list.h
+++ b/tls/extensions/s2n_client_sct_list.h
@@ -18,5 +18,9 @@
 #include "tls/s2n_connection.h"
 #include "stuffer/s2n_stuffer.h"
 
+extern const s2n_extension_type s2n_client_sct_list_extension;
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
+
 extern int s2n_extensions_client_sct_list_send(struct s2n_connection *conn, struct s2n_stuffer *out);
 extern int s2n_recv_client_sct_list(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_extension_type.h
+++ b/tls/extensions/s2n_extension_type.h
@@ -30,6 +30,7 @@
  * The +1 is necessary to handle any remainder left over when dividing. */
 #define S2N_SUPPORTED_EXTENSIONS_BITFIELD_LEN   ((S2N_SUPPORTED_EXTENSIONS_COUNT / sizeof(char)) + 1)
 
+struct s2n_connection;
 typedef struct {
     uint16_t iana_value;
     unsigned is_response:1;


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** https://github.com/awslabs/s2n/issues/1817

**Description of changes:** 
Move the first 5 extensions into the new structures. This batch is mostly currently tested through the shared s2n_client_extensions_test, so I also added individual unit tests.

For each extension, I:
- create the struct
- move current send and receive logic into static methods linked to the struct
- write static should_send method based on the existing logic in s2n_client_extensions
- replace current send and receive methods with calls to s2n_extension_send/recv
- remove type + size from what the send method sends


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
