### PR TITLE
dev: add s2n-dev Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ bitcode :
 	${MAKE} -C tests/saw bitcode
 
 .PHONY : bc
-bc: 
+bc:
 	${MAKE} -C crypto bc
 	${MAKE} -C stuffer bc
 	${MAKE} -C tls bc
@@ -57,7 +57,7 @@ bike_r2_bc: bc
 	${MAKE} -C pq-crypto bike_r2_bc
 
 .PHONY : saw
-saw : bc 
+saw : bc
 	$(MAKE) -C tests/saw
 
 include s2n.mk
@@ -96,7 +96,7 @@ fuzz : fuzz-osx
 endif
 
 .PHONY : fuzz-osx
-fuzz-osx : 
+fuzz-osx :
 	@echo "\033[33;1mSKIPPED\033[0m Fuzzing is not supported on \"$$(uname -mprs)\" at this time."
 
 .PHONY : fuzz-linux
@@ -148,6 +148,13 @@ indent:
 
 .PHONY : pre_commit_check
 pre_commit_check: all indent clean
+
+# TODO use awslabs instead
+DEV_IMAGE ?= camshaft/s2n-dev
+DEV_VERSION ?= ubuntu_18.04_openssl-1.1.1_gcc9
+
+dev:
+	@docker run -it --rm --ulimit memlock=-1 -v `pwd`:/home/s2n-dev/s2n $(DEV_IMAGE):$(DEV_VERSION)
 
 .PHONY : clean
 clean:

--- a/codebuild/bin/install_ubuntu_dependencies.sh
+++ b/codebuild/bin/install_ubuntu_dependencies.sh
@@ -23,24 +23,22 @@ sudo apt-get update -o Acquire::CompressionTypes::Order::=gz
 
 DEPENDENCIES="unzip make indent kwstyle libssl-dev tcpdump valgrind lcov m4 nettle-dev nettle-bin pkg-config gcc g++ zlibc zlib1g-dev python3-pip llvm curl git tox"
 
-sudo apt-get install -y ${DEPENDENCIES}
 
 if [[ -n "$GCC_VERSION" ]] && [[ "$GCC_VERSION" != "NONE" ]]; then
-    sudo apt-get -y install gcc-$GCC_VERSION g++-$GCC_VERSION;
+    DEPENDENCIES+=" gcc-$GCC_VERSION g++-$GCC_VERSION";
 fi
 
 if [[ "$S2N_LIBCRYPTO" == "boringssl" ]]; then
-    sudo apt-get -y install cmake;
+    DEPENDENCIES+=" cmake";
 fi
+
+sudo apt-get -y install --no-install-recommends ${DEPENDENCIES}
 
 # If prlimit is not on our current PATH, download and compile prlimit manually. s2n needs prlimit to memlock pages
 if ! type prlimit > /dev/null && [[ ! -d "$PRLIMIT_INSTALL_DIR" ]]; then
     mkdir -p "$PRLIMIT_INSTALL_DIR";
     sudo codebuild/bin/install_prlimit.sh "$(mktemp -d)" "$PRLIMIT_INSTALL_DIR";
 fi
-
-if [[ "$TESTS" == "ctverif" || "$TESTS" == "ALL" ]] ; then
-    codebuild/bin/install_ctverif_dependencies.sh ; fi
 
 if [[ "$TESTS" == "ctverif" || "$TESTS" == "ALL" ]] && [[ ! -d "$CTVERIF_INSTALL_DIR" ]]; then
     mkdir -p "$CTVERIF_INSTALL_DIR" && codebuild/bin/install_ctverif.sh "$CTVERIF_INSTALL_DIR" > /dev/null ; fi

--- a/codebuild/bin/s2n_install_test_dependencies.sh
+++ b/codebuild/bin/s2n_install_test_dependencies.sh
@@ -19,8 +19,8 @@ set -ex
 # Install missing test dependencies. If the install directory already exists, cached artifacts will be used
 # for that dependency.
 
-if [[ ! -d test-deps ]]; then 
-    mkdir test-deps ; 
+if [[ ! -d test-deps ]]; then
+    mkdir test-deps ;
 fi
 
 #Install & Run shell check before installing dependencies

--- a/codebuild/bin/s2n_setup_env.sh
+++ b/codebuild/bin/s2n_setup_env.sh
@@ -25,23 +25,24 @@
 # Setup the cache directory paths.
 # Set Env Variables with defaults if they aren't already set
 : "${BASE_S2N_DIR:=$(pwd)}"
-: "${PYTHON_INSTALL_DIR:=$(pwd)/test-deps/python}"
-: "${GNUTLS_INSTALL_DIR:=$(pwd)/test-deps/gnutls}"
-: "${PRLIMIT_INSTALL_DIR:=$(pwd)/test-deps/prlimit}"
-: "${SAW_INSTALL_DIR:=$(pwd)/test-deps/saw}"
-: "${Z3_INSTALL_DIR:=$(pwd)/test-deps/z3}"
-: "${LIBFUZZER_INSTALL_DIR:=$(pwd)/test-deps/libfuzzer}"
-: "${LATEST_CLANG_INSTALL_DIR:=$(pwd)/test-deps/clang}"
-: "${SCAN_BUILD_INSTALL_DIR:=$(pwd)/test-deps/scan-build}"
-: "${OPENSSL_0_9_8_INSTALL_DIR:=$(pwd)/test-deps/openssl-0.9.8}"
-: "${OPENSSL_1_1_1_INSTALL_DIR:=$(pwd)/test-deps/openssl-1.1.1}"
-: "${OPENSSL_1_0_2_INSTALL_DIR:=$(pwd)/test-deps/openssl-1.0.2}"
-: "${OPENSSL_1_0_2_FIPS_INSTALL_DIR:=$(pwd)/test-deps/openssl-1.0.2-fips}"
-: "${BORINGSSL_INSTALL_DIR:=$(pwd)/test-deps/boringssl}"
-: "${LIBRESSL_INSTALL_DIR:=$(pwd)/test-deps/libressl-2.6.4}"
-: "${CPPCHECK_INSTALL_DIR:=$(pwd)/test-deps/cppcheck}"
-: "${CTVERIF_INSTALL_DIR:=$(pwd)/test-deps/ctverif}"
-: "${SIDETRAIL_INSTALL_DIR:=$(pwd)/test-deps/sidetrail}"
+: "${TEST_DEPS_DIR:=$BASE_S2N_DIR/test-deps}"
+: "${PYTHON_INSTALL_DIR:=$TEST_DEPS_DIR/python}"
+: "${GNUTLS_INSTALL_DIR:=$TEST_DEPS_DIR/gnutls}"
+: "${PRLIMIT_INSTALL_DIR:=$TEST_DEPS_DIR/prlimit}"
+: "${SAW_INSTALL_DIR:=$TEST_DEPS_DIR/saw}"
+: "${Z3_INSTALL_DIR:=$TEST_DEPS_DIR/z3}"
+: "${LIBFUZZER_INSTALL_DIR:=$TEST_DEPS_DIR/libfuzzer}"
+: "${LATEST_CLANG_INSTALL_DIR:=$TEST_DEPS_DIR/clang}"
+: "${SCAN_BUILD_INSTALL_DIR:=$TEST_DEPS_DIR/scan-build}"
+: "${OPENSSL_0_9_8_INSTALL_DIR:=$TEST_DEPS_DIR/openssl-0.9.8}"
+: "${OPENSSL_1_1_1_INSTALL_DIR:=$TEST_DEPS_DIR/openssl-1.1.1}"
+: "${OPENSSL_1_0_2_INSTALL_DIR:=$TEST_DEPS_DIR/openssl-1.0.2}"
+: "${OPENSSL_1_0_2_FIPS_INSTALL_DIR:=$TEST_DEPS_DIR/openssl-1.0.2-fips}"
+: "${BORINGSSL_INSTALL_DIR:=$TEST_DEPS_DIR/boringssl}"
+: "${LIBRESSL_INSTALL_DIR:=$TEST_DEPS_DIR/libressl-2.6.4}"
+: "${CPPCHECK_INSTALL_DIR:=$TEST_DEPS_DIR/cppcheck}"
+: "${CTVERIF_INSTALL_DIR:=$TEST_DEPS_DIR/ctverif}"
+: "${SIDETRAIL_INSTALL_DIR:=$TEST_DEPS_DIR/sidetrail}"
 : "${FUZZ_TIMEOUT_SEC:=10}"
 
 # OS_NAME
@@ -86,9 +87,9 @@ fi
 if [[ -z $S2N_LIBCRYPTO ]]; then export LIBCRYPTO_ROOT=$OPENSSL_1_1_1_INSTALL_DIR ; fi
 if [[ "$S2N_LIBCRYPTO" == "openssl-1.1.1" ]]; then export LIBCRYPTO_ROOT=$OPENSSL_1_1_1_INSTALL_DIR ; fi
 if [[ "$S2N_LIBCRYPTO" == "openssl-1.0.2" ]]; then export LIBCRYPTO_ROOT=$OPENSSL_1_0_2_INSTALL_DIR ; fi
-if [[ "$S2N_LIBCRYPTO" == "openssl-1.0.2-fips" ]]; then 
-    export LIBCRYPTO_ROOT=$OPENSSL_1_0_2_FIPS_INSTALL_DIR ; 
-    export S2N_TEST_IN_FIPS_MODE=1 ; 
+if [[ "$S2N_LIBCRYPTO" == "openssl-1.0.2-fips" ]]; then
+    export LIBCRYPTO_ROOT=$OPENSSL_1_0_2_FIPS_INSTALL_DIR ;
+    export S2N_TEST_IN_FIPS_MODE=1 ;
 fi
 if [[ "$S2N_LIBCRYPTO" == "boringssl" ]]; then export LIBCRYPTO_ROOT=$BORINGSSL_INSTALL_DIR ; fi
 

--- a/docker-images/.gitignore
+++ b/docker-images/.gitignore
@@ -1,0 +1,1 @@
+codebuild

--- a/docker-images/Makefile
+++ b/docker-images/Makefile
@@ -1,0 +1,5 @@
+REPOSITORY_URI ?= awslabs/s2n-dev
+
+build:
+	@cp -R ../codebuild/ ./codebuild/
+	@REPOSITORY_URI=$(REPOSITORY_URI) docker-compose build

--- a/docker-images/docker-compose.yml
+++ b/docker-images/docker-compose.yml
@@ -11,28 +11,15 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-#
 
-set -e
-
-usage() {
-    echo "install_cppcheck.sh install_dir"
-    exit 1
-}
-
-if [ "$#" -ne "1" ]; then
-    usage
-fi
-
-INSTALL_DIR=$1
-source codebuild/bin/jobs.sh
-
-mkdir -p $INSTALL_DIR||true
-cd "$INSTALL_DIR"
-git clone https://github.com/danmar/cppcheck.git
-cd cppcheck
-git checkout 1.88
-
-make -j $JOBS
-
-rm -rf .git
+version: '3.8'
+services:
+  ubuntu_18.04_openssl-1.1.1_gcc9:
+    build:
+      args:
+        UBUNTU_VERSION: 18.04
+        OPENSSL_VERSION: openssl-1.1.1
+        GCC_VERSION: 9
+      context: ./
+      dockerfile: ./ubuntu/Dockerfile
+    image: ${REPOSITORY_URI}:ubuntu_18.04_openssl-1.1.1_gcc9

--- a/docker-images/ubuntu/Dockerfile
+++ b/docker-images/ubuntu/Dockerfile
@@ -1,0 +1,71 @@
+ARG UBUNTU_VERSION=18.04
+
+FROM ubuntu:${UBUNTU_VERSION}
+
+WORKDIR /opt/s2n
+
+ARG OPENSSL_VERSION=openssl-1.1.1
+ARG GCC_VERSION=9
+ARG ZSH_THEME=cypher
+
+ENV S2N_LIBCRYPTO=${OPENSSL_VERSION} \
+    GCC_VERSION=${GCC_VERSION} \
+    BUILD_S2N=true \
+    TESTS=integration
+
+# The `s2n_setup_env` assumes bash, not sh
+SHELL ["/bin/bash", "-c"]
+
+# set up user account
+RUN set -eux; \
+  apt-get update; \
+  apt-get -y install --no-install-recommends\
+     curl sudo zsh unzip gnupg2 software-properties-common python-pip rubygems wget; \
+  gem install bundler; \
+  useradd -m s2n-dev; \
+  echo "s2n-dev ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/s2n-dev; \
+  chmod 0440 /etc/sudoers.d/s2n-dev; \
+  mkdir -p /home/s2n-dev/s2n; \
+  curl -L https://github.com/ohmyzsh/ohmyzsh/archive/master.zip -o /tmp/oh-my-zsh.zip; \
+  unzip /tmp/oh-my-zsh.zip -d /tmp; \
+  mkdir -p /home/s2n-dev/.zsh/plugins; \
+  mkdir -p /home/s2n-dev/.zsh/themes; \
+  cp /tmp/ohmyzsh-master/oh-my-zsh.sh /home/s2n-dev/.zsh/init.sh; \
+  cp -R /tmp/ohmyzsh-master/lib /home/s2n-dev/.zsh; \
+  cp /tmp/ohmyzsh-master/themes/${ZSH_THEME}.zsh-theme /home/s2n-dev/.zsh/themes/theme.zsh-theme; \
+  rm -rf /tmp/oh-my-zsh.zip /tmp/ohmyzsh-master; \
+  echo $'# ZSH setup\n\
+  export DISABLE_UPDATE_PROMPT=true\n\
+  export DISABLE_AUTO_UPDATE=true\n\
+  export ZSH="/home/s2n-dev/.zsh"\n\
+  export ZSH_THEME="theme"\n\
+  plugins=()\n\
+  source $ZSH/init.sh\n\
+  \n\
+  # s2n setup\n\
+  export S2N_LIBCRYPTO='"$S2N_LIBCRYPTO"$'\n\
+  export BUILD_S2N=true\n\
+  export GCC_VERSION='"$GCC_VERSION"$'\n\
+  export TESTS=integration\n\
+  export TEST_DEPS_DIR=/opt/s2n/test-deps\n\
+  cd /home/s2n-dev/s2n && source /opt/s2n/codebuild/bin/s2n_setup_env.sh\n\
+  ' > /home/s2n-dev/.zshrc; \
+  chown -R s2n-dev:s2n-dev /home/s2n-dev; \
+  rm -rf /var/lib/apt/lists/*; \
+  apt-get clean; \
+  echo done
+
+ADD codebuild codebuild
+
+# install dependencies
+RUN set -eux; \
+  export LD_LIBRARY_PATH=""; \
+  . codebuild/bin/s2n_setup_env.sh; \
+  codebuild/bin/s2n_install_test_dependencies.sh; \
+  rm -rf /var/lib/apt/lists/*; \
+  apt-get clean; \
+  echo done
+
+USER s2n-dev
+WORKDIR /home/s2n-dev/s2n
+CMD ["/bin/zsh","-l"]


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Description of changes:** 

### Docker development environment
Using a docker environment for development has some advantages:

* Consistency between machines and OSs - no globals or assumptions about installed software!
* Dependencies are prebuilt and ready to use
* Onboarding new developers is "Install docker, clone s2n, run `make dev`"
* Dependencies are kept up to date so your environment doesn't rot

#### Sample output
```sh
➜ make dev
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=18.04
DISTRIB_CODENAME=bionic
DISTRIB_DESCRIPTION="Ubuntu 18.04.4 LTS"
UID=1000
OS_NAME=linux
S2N_LIBCRYPTO=openssl-1.1.1
LIBCRYPTO_ROOT=/opt/s2n/test-deps/openssl-1.1.1
BUILD_S2N=true
GCC_VERSION=9
LATEST_CLANG=false
TESTS=integration
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
LD_LIBRARY_PATH=
51431e182675 :: ~/s2n » make
...
Running s2n_tls13_client_finished_test.c                   ... PASSED        360 tests
Running s2n_session_ticket_test.c                          ... PASSED        398 tests
Running s2n_optional_client_auth_test.c                    ... PASSED        771 tests
Running s2n_3des_test.c                                    ... PASSED     153558 tests
Running s2n_aes_test.c                                     ... PASSED     307115 tests
Running s2n_x509_validator_test.c                          ... PASSED        257 tests
Running s2n_stuffer_base64_test.c                          ... PASSED        464 tests
Running s2n_stuffer_test.c                                 ... PASSED       1035 tests
Running s2n_handshake_test.c                               ... PASSED        399 tests
Running s2n_utils_test.c                                   ... PASSED          4 tests
Running s2n_parse_client_supported_groups_list_test.c      ... PASSED         38 tests
Running s2n_server_key_share_extension_test.c              ... PASSED        344 tests
Running s2n_tls12_handshake_test.c                         ... PASSED      69312 tests
Running s2n_handshake_errno_test.c                         ... PASSED         12 tests
Running s2n_tls13_zero_length_payload_test.c               ... PASSED         53 tests
...
```

### Future Improvements

* We should automatically publish image updates to https://hub.docker.com/u/awslabs instead of https://hub.docker.com/u/camshaft
* SAW support
* CMBC support
* Sidetrail support

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
