### PR TITLE
ci: Codebuild consolidation with Integ tests

### DIFF
--- a/codebuild/README.md
+++ b/codebuild/README.md
@@ -19,7 +19,6 @@ General flow of the CodeBuild Test Projects
         - codebuild/install_openssl_1_1_1.sh
         - codebuild/install_openssl_1_0_2.sh
         - codebuild/install_openssl_1_0_2_fips.sh
-        - codebuild/install_cppcheck.sh
         - codebuild/install_libressl.sh
         - codebuild/install_python.sh
         - codebuild/install_gnutls.sh
@@ -28,7 +27,6 @@ General flow of the CodeBuild Test Projects
         - codebuild/install_sslyze.sh
     - codebuild/s2n_codebuild.sh
         - codebuild/s2n_override_paths.sh
-        - codebuild/run_cppcheck.sh
         - codebuild/copyright_mistake_scanner.sh
         - codebuild/run_kwstyle.sh
         - codebuild/cpp_style_comment_linter.sh

--- a/codebuild/bin/install_default_dependencies.sh
+++ b/codebuild/bin/install_default_dependencies.sh
@@ -31,12 +31,14 @@ fi
 
 # Download and Install Openssl 1.1.1
 if [[ ("$S2N_LIBCRYPTO" == "openssl-1.1.1") || ("$TESTS" == "integration" || "$TESTS" == "integrationv2" || "$TESTS" == "ALL" ) ]]; then
-    mkdir -p "$OPENSSL_1_1_1_INSTALL_DIR"||true
-    codebuild/bin/install_openssl_1_1_1.sh "$(mktemp -d)" "$OPENSSL_1_1_1_INSTALL_DIR" "$OS_NAME" > /dev/null ;
+    if [[ ! -x "$OPENSSL_1_1_1_INSTALL_DIR/bin/openssl" ]]; then
+      mkdir -p "$OPENSSL_1_1_1_INSTALL_DIR"||true
+      codebuild/bin/install_openssl_1_1_1.sh "$(mktemp -d)" "$OPENSSL_1_1_1_INSTALL_DIR" "$OS_NAME" > /dev/null ;
+    fi
 fi
 
 # Download and Install Openssl 1.0.2
-if [[ "$S2N_LIBCRYPTO" == "openssl-1.0.2" ]]; then
+if [[ "$S2N_LIBCRYPTO" == "openssl-1.0.2" && ! -d "$OPENSSL_1_0_2_INSTALL_DIR" ]]; then
     mkdir -p "$OPENSSL_1_0_2_INSTALL_DIR"||true
     codebuild/bin/install_openssl_1_0_2.sh "$(mktemp -d)" "$OPENSSL_1_0_2_INSTALL_DIR" "$OS_NAME" > /dev/null ;
 fi
@@ -45,40 +47,34 @@ fi
 if [[ "$S2N_LIBCRYPTO" == "openssl-1.0.2-fips" ]] && [[ ! -d "$OPENSSL_1_0_2_FIPS_INSTALL_DIR" ]]; then
     codebuild/bin/install_openssl_1_0_2_fips.sh "$(mktemp -d)" "$OPENSSL_1_0_2_FIPS_INSTALL_DIR" "$OS_NAME" ; fi
 
-# Download and Install CppCheck
-if [[ "$BUILD_S2N" == "true" ]]; then
-    mkdir -p "$CPPCHECK_INSTALL_DIR"||true
-    codebuild/bin/install_cppcheck.sh "$CPPCHECK_INSTALL_DIR" > /dev/null ;
-fi
-
 # Download and Install LibreSSL
-if [[ "$S2N_LIBCRYPTO" == "libressl" ]]; then
+if [[ "$S2N_LIBCRYPTO" == "libressl" && ! -d "$LIBRESSL_INSTALL_DIR" ]]; then
     mkdir -p "$LIBRESSL_INSTALL_DIR"||true
     codebuild/bin/install_libressl.sh "$(mktemp -d)" "$LIBRESSL_INSTALL_DIR" > /dev/null ;
 fi
 
 # Download and Install BoringSSL
-if [[ "$S2N_LIBCRYPTO" == "boringssl" ]]; then
+if [[ "$S2N_LIBCRYPTO" == "boringssl" && ! -d "$BORINGSSL_INSTALL_DIR" ]]; then
     codebuild/bin/install_boringssl.sh "$(mktemp -d)" "$BORINGSSL_INSTALL_DIR" > /dev/null ;
 fi
 
 if [[ "$TESTS" == "integration" || "$TESTS" == "integrationv2" || "$TESTS" == "ALL" ]]; then
     # Install tox if running on Ubuntu(only supported Linux at this time)
-    if [[ "$OS_NAME" == "linux" ]]; then
+    if [[ "$OS_NAME" == "linux" && ! -x `which tox` ]]; then
         apt-get -y install tox
     fi
 
-    # Install python linked with the latest Openssl for integration tests
-    mkdir -p "$PYTHON_INSTALL_DIR"||true
-    codebuild/bin/install_python.sh "$OPENSSL_1_1_1_INSTALL_DIR" "$(mktemp -d)" "$PYTHON_INSTALL_DIR" > /dev/null ;
+    if [[ ! -x "$OPENSSL_0_9_8_INSTALL_DIR/bin/openssl" ]]; then
+      # Download and Install Openssl 0.9.8
+      mkdir -p "$OPENSSL_0_9_8_INSTALL_DIR"||true
+      codebuild/bin/install_openssl_0_9_8.sh "$(mktemp -d)" "$OPENSSL_0_9_8_INSTALL_DIR" "$OS_NAME" > /dev/null ;
+    fi
 
-    # Download and Install Openssl 0.9.8
-    mkdir -p "$OPENSSL_0_9_8_INSTALL_DIR"||true
-    codebuild/bin/install_openssl_0_9_8.sh "$(mktemp -d)" "$OPENSSL_0_9_8_INSTALL_DIR" "$OS_NAME" > /dev/null ;
-
-    # Download and Install GnuTLS for integration tests
-    mkdir -p "$GNUTLS_INSTALL_DIR"||true
-    codebuild/bin/install_gnutls.sh "$(mktemp -d)" "$GNUTLS_INSTALL_DIR" "$OS_NAME" > /dev/null ;
+    if [[ ! -x "$GNUTLS_INSTALL_DIR/bin/gnutls-cli" ]]; then
+      # Download and Install GnuTLS for integration tests
+      mkdir -p "$GNUTLS_INSTALL_DIR"||true
+      codebuild/bin/install_gnutls.sh "$(mktemp -d)" "$GNUTLS_INSTALL_DIR" "$OS_NAME" > /dev/null ;
+    fi
 
     # Install SSLyze for all Integration Tests
     codebuild/bin/install_sslyze.sh

--- a/codebuild/integ_codebuild.config
+++ b/codebuild/integ_codebuild.config
@@ -1,0 +1,81 @@
+# Config file consumed by create_project
+# Helpful reminder about CodeBuild provided docker images:
+#  https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html
+[Global]
+stack_name: s2nIntegrationScheduled
+
+#Reusable templates - use the snippet:NAME
+[IntegUbuntuBoilerplateLarge]
+image : aws/codebuild/standard:2.0
+env_type: LINUX_CONTAINER
+compute_type: BUILD_GENERAL1_LARGE
+timeout_in_min: 90
+buildspec: codebuild/spec/buildspec_ubuntu_integ_openssl102.yml
+source_location: https://github.com/awslabs/s2n.git
+source_type : GITHUB
+source_clonedepth: 1
+source_version:
+
+# Boring + GCC9, Libre + GCC6
+[CodeBuild:s2nIntegrationBoringLibre]
+image : aws/codebuild/standard:2.0
+env_type: LINUX_CONTAINER
+compute_type: BUILD_GENERAL1_LARGE
+timeout_in_min: 90
+buildspec: codebuild/spec/buildspec_ubuntu_integ_boringlibre.yml
+source_location: https://github.com/awslabs/s2n.git
+source_type : GITHUB
+source_clonedepth: 1
+source_version:
+env: TESTS=integration BUILD_S2N=true
+
+# OpenSSL111 + GCC6 + Corked and notCorked + Gcc4.8
+[CodeBuild:s2nIntegrationOpenSSL111Plus]
+image : aws/codebuild/standard:2.0
+env_type: LINUX_CONTAINER
+compute_type: BUILD_GENERAL1_LARGE
+timeout_in_min: 90
+buildspec: codebuild/spec/buildspec_ubuntu_integ_openssl111.yml
+source_location: https://github.com/awslabs/s2n.git
+source_type : GITHUB
+source_clonedepth: 1
+source_version:
+env: TESTS=integration BUILD_S2N=true
+
+# OpenSSL102 Fips and notFips + GCC6
+[CodeBuild:s2nIntegrationOpenSSL102Plus]
+image : aws/codebuild/standard:2.0
+env_type: LINUX_CONTAINER
+compute_type: BUILD_GENERAL1_LARGE
+timeout_in_min: 90
+buildspec: codebuild/spec/buildspec_ubuntu_integ_openssl102.yml
+source_location: https://github.com/awslabs/s2n.git
+source_type : GITHUB
+source_clonedepth: 1
+source_version:
+env: TESTS=integration BUILD_S2N=true
+
+# OpenSSL102 + GCC6 + Asan and Valgrind
+[CodeBuild:s2nIntegrationOpenSSL102AsanValgrind]
+image : aws/codebuild/standard:2.0
+env_type: LINUX_CONTAINER
+compute_type: BUILD_GENERAL1_LARGE
+timeout_in_min: 90
+buildspec: codebuild/spec/buildspec_ubuntu_integ_openssl102_asanvalgrind.yml
+source_location: https://github.com/awslabs/s2n.git
+source_type : GITHUB
+source_clonedepth: 1
+source_version:
+env: TESTS=integration BUILD_S2N=true
+
+#{"environmentVariablesOverride": [{"name": "S2N_NO_PQ","value": "true"}]}
+
+#[CodeBuild:s2nIntegrationScheduled]
+#snippet: IntegUbuntuBoilerplateLarge
+#env: TESTS=integration BUILD_S2N=true
+
+# Disabled Scheduled job (example) for tests not needing webhooks.
+#[CloudWatchEvent:s2n_Integration_Openssl111_Gcc48_test]
+#start_time: 13
+#build_job_name: s2nIntegrationScheduled
+#input: {"environmentVariablesOverride": [{"name": "S2N_LIBCRYPTO","value": "openssl-1.1.1"},{"name": "GCC_VERSION", "value":"4.8"}]}

--- a/codebuild/spec/buildspec_ubuntu_integ_boringlibre.yml
+++ b/codebuild/spec/buildspec_ubuntu_integ_boringlibre.yml
@@ -1,0 +1,46 @@
+---
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      python: 3.7
+    commands:
+      - echo Entered the install phase...
+      - echo "We need a test PPA for gcc-9."
+      - add-apt-repository ppa:ubuntu-toolchain-r/test -y
+      - apt-get update -o Acquire::CompressionTypes::Order::=gz
+      - apt-get update -y
+      - apt-get install -y --no-install-recommends gcc-6 g++-6 gcc g++ gcc-9 g++-9
+      # Don't install old clang and llvm if LATEST_CLANG is enabled, handle it in install_clang.sh instead
+      - |
+        if expr "${LATEST_CLANG}" != "true" >/dev/null; then
+          apt-get install -y --no-install-recommends clang-3.9 llvm-3.9;
+        fi
+      - apt-get install -y --no-install-recommends indent kwstyle lcov libssl-dev m4 make net-tools nettle-bin nettle-dev pkg-config psmisc python3-pip shellcheck sudo tcpdump unzip valgrind zlib1g-dev zlibc cmake tox
+  pre_build:
+    commands:
+      - S2N_LIBCRYPTO=libressl GCC_VERSION=6 codebuild/bin/install_default_dependencies.sh
+      - S2N_LIBCRYPTO=boringssl GCC_VERSION=9 codebuild/bin/install_default_dependencies.sh
+  build:
+    commands:
+      - printenv
+      - S2N_LIBCRYPTO=libressl GCC_VERSION=6 TESTS=integration codebuild/bin/s2n_codebuild.sh
+      - S2N_LIBCRYPTO=boringssl GCC_VERSION=9 TESTS=integration codebuild/bin/s2n_codebuild.sh
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      - echo Uploading CodeCov.io artifacts
+      - codebuild/bin/s2n_after_codebuild.sh

--- a/codebuild/spec/buildspec_ubuntu_integ_openssl102.yml
+++ b/codebuild/spec/buildspec_ubuntu_integ_openssl102.yml
@@ -1,0 +1,46 @@
+---
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      python: 3.7
+    commands:
+      - echo Entered the install phase...
+      - echo "We need a test PPA for gcc-9."
+      - add-apt-repository ppa:ubuntu-toolchain-r/test -y
+      - apt-get update -o Acquire::CompressionTypes::Order::=gz
+      - apt-get update -y
+      - apt-get install -y --no-install-recommends gcc g++  gcc-6 g++-6 gcc-9 g++-9
+      # Don't install old clang and llvm if LATEST_CLANG is enabled, handle it in install_clang.sh instead
+      - |
+        if expr "${LATEST_CLANG}" != "true" >/dev/null; then
+          apt-get install -y --no-install-recommends clang-3.9 llvm-3.9;
+        fi
+      - apt-get install -y --no-install-recommends indent kwstyle lcov libssl-dev m4 make net-tools nettle-bin nettle-dev pkg-config psmisc python3-pip shellcheck sudo tcpdump unzip valgrind zlib1g-dev zlibc cmake tox
+  pre_build:
+    commands:
+      - S2N_LIBCRYPTO=openssl-1.0.2 codebuild/bin/install_default_dependencies.sh
+      - S2N_LIBCRYPTO=openssl-1.0.2-fips codebuild/bin/install_default_dependencies.sh
+  build:
+    commands:
+      - printenv
+      - S2N_LIBCRYPTO=openssl-1.0.2 TESTS=integration GCC_VERSION=6 codebuild/bin/s2n_codebuild.sh
+      - S2N_LIBCRYPTO=openssl-1.0.2-fips TESTS=integration GCC_VERSION=6 codebuild/bin/s2n_codebuild.sh
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      - echo Uploading CodeCov.io artifacts
+      - codebuild/bin/s2n_after_codebuild.sh

--- a/codebuild/spec/buildspec_ubuntu_integ_openssl102_asanvalgrind.yml
+++ b/codebuild/spec/buildspec_ubuntu_integ_openssl102_asanvalgrind.yml
@@ -1,0 +1,46 @@
+---
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      python: 3.7
+    commands:
+      - echo Entered the install phase...
+      - echo "We need a test PPA for gcc-9."
+      - add-apt-repository ppa:ubuntu-toolchain-r/test -y
+      - apt-get update -o Acquire::CompressionTypes::Order::=gz
+      - apt-get update -y
+      - apt-get install -y --no-install-recommends gcc g++  gcc-6 g++-6 gcc-9 g++-9
+      # Don't install old clang and llvm if LATEST_CLANG is enabled, handle it in install_clang.sh instead
+      - |
+        if expr "${LATEST_CLANG}" != "true" >/dev/null; then
+          apt-get install -y --no-install-recommends clang-3.9 llvm-3.9;
+        fi
+      - apt-get install -y --no-install-recommends indent kwstyle lcov libssl-dev m4 make net-tools nettle-bin nettle-dev pkg-config psmisc python3-pip shellcheck sudo tcpdump unzip valgrind zlib1g-dev zlibc cmake tox
+  pre_build:
+    commands:
+      - S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=asan GCC_VERSION=6 codebuild/bin/install_default_dependencies.sh
+      - S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=valgrind GCC_VERSION=6 codebuild/bin/install_default_dependencies.sh
+  build:
+    commands:
+      - printenv
+      - S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=asan GCC_VERSION=6 codebuild/bin/s2n_codebuild.sh
+      - S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=valgrind GCC_VERSION=6 codebuild/bin/s2n_codebuild.sh
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      - echo Uploading CodeCov.io artifacts
+      - codebuild/bin/s2n_after_codebuild.sh

--- a/codebuild/spec/buildspec_ubuntu_integ_openssl111.yml
+++ b/codebuild/spec/buildspec_ubuntu_integ_openssl111.yml
@@ -1,0 +1,46 @@
+---
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      python: 3.7
+    commands:
+      - echo Entered the install phase...
+      - echo "We need a test PPA for gcc-9."
+      - add-apt-repository ppa:ubuntu-toolchain-r/test -y
+      - apt-get update -o Acquire::CompressionTypes::Order::=gz
+      - apt-get update -y
+      - apt-get install -y --no-install-recommends gcc g++  gcc-6 g++-6 gcc-4.8 g++-4.8
+      # Don't install old clang and llvm if LATEST_CLANG is enabled, handle it in install_clang.sh instead
+      - |
+        if expr "${LATEST_CLANG}" != "true" >/dev/null; then
+          apt-get install -y --no-install-recommends clang-3.9 llvm-3.9;
+        fi
+      - apt-get install -y --no-install-recommends indent kwstyle lcov libssl-dev m4 make net-tools nettle-bin nettle-dev pkg-config psmisc python3-pip shellcheck sudo tcpdump unzip valgrind zlib1g-dev zlibc cmake tox
+  pre_build:
+    commands:
+      - S2N_LIBCRYPTO=openssl-1.1.1 GCC_VERSION=6 codebuild/bin/install_default_dependencies.sh
+  build:
+    commands:
+      - printenv
+      - S2N_LIBCRYPTO=openssl-1.1.1 GCC_VERSION=4.8 codebuild/bin/s2n_codebuild.sh
+      - S2N_LIBCRYPTO=openssl-1.1.1 TESTS=integration GCC_VERSION=6 codebuild/bin/s2n_codebuild.sh
+      - S2N_LIBCRYPTO=openssl-1.1.1 TESTS=integration GCC_VERSION=6 S2N_CORKED_IO=true codebuild/bin/s2n_codebuild.sh
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      - echo Uploading CodeCov.io artifacts
+      - codebuild/bin/s2n_after_codebuild.sh


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
#1854 

**Description of changes:** 
- Use a new buildspec setup to run multiple Integ tests together (group by libCrypto and runtime)
- Improve install_default_deps script to check before installing

### From the linked issue, these changes will:
- Combine s2nIntegrationLibreSSLGcc9 with s2nIntegrationBoring
- Combine s2nIntegrationOpenSSL111Gcc6Corked with s2nIntegrationOpenSSL111Gcc6
- Combine s2nIntegrationOpenSSL102Gcc6FIPS with s2nIntegrationOpenSSL102Gcc6
- Add Asan on OpenSSL102 to ValgrindOpenSSL102

### Job names and Runtimes (from private fork)
- s2nIntegrationBoringLibre - Runtime 22min
- s2nIntegrationOpenSSL111Plus - Runtime 37min
- s2nIntegrationOpenSSL102AsanValgrind - Runtime 29 min
- s2nIntegrationOpenSSL102Plus - Runtime 22min

### Rollout steps
- Merge #1864 
- Merge #1889 
- Run `./create_project.py --config integ_codebuild.config`
- Configure source repo and webhooks on four new jobs
- Remove `required` on travis test
- Cleanup travis (future PR)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
