### PR TITLE
Add key share extension structs

### DIFF
--- a/tests/unit/s2n_client_key_share_extension_test.c
+++ b/tests/unit/s2n_client_key_share_extension_test.c
@@ -164,6 +164,14 @@ int main(int argc, char **argv)
 
     /* Test s2n_client_key_share_extension.recv */
     {
+        /* Test that s2n_client_key_share_extension.recv is a no-op
+         * if tls1.3 not enabled */
+        {
+            EXPECT_SUCCESS(s2n_disable_tls13());
+            EXPECT_SUCCESS(s2n_client_key_share_extension.recv(NULL, NULL));
+            EXPECT_SUCCESS(s2n_enable_tls13());
+        }
+
         /* Test that s2n_client_key_share_extension.recv can read and parse
          * the result of s2n_client_key_share_extension.send */
         {

--- a/tests/unit/s2n_server_key_share_extension_test.c
+++ b/tests/unit/s2n_server_key_share_extension_test.c
@@ -386,7 +386,7 @@ int main(int argc, char **argv)
         /* Explicitly set the ecc_preferences list to NOT contain x25519 */
         EXPECT_SUCCESS(s2n_config_set_cipher_preferences(conn->config, "20140601"));
 
-        /* Fails because curve is supported, but not in ecc preferences */
+        /* Fails because curve is supported by s2n, but not supported by ecc preferences */
         conn->secure.server_ecc_evp_params.negotiated_curve = test_curve;
         conn->secure.client_ecc_evp_params[0].negotiated_curve = test_curve;
         EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.send(conn, &conn->handshake.io),
@@ -411,7 +411,7 @@ int main(int argc, char **argv)
         /* Write the iana id of x25519 as the group */
         EXPECT_SUCCESS(s2n_stuffer_write_uint16(extension_stuffer, test_curve->iana_id));
 
-        /* Fails because curve is supported, but not in ecc preferences */
+        /* Fails because curve is supported by s2n, but not supported by ecc preferences */
         EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.recv(conn, extension_stuffer),
                 S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
 

--- a/tests/unit/s2n_server_key_share_extension_test.c
+++ b/tests/unit/s2n_server_key_share_extension_test.c
@@ -32,6 +32,8 @@
         s2n_stuffer_data_available(stuffer)));         \
 } while (0)
 
+int s2n_extensions_server_key_share_send_check(struct s2n_connection *conn);
+
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
@@ -91,7 +93,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
-    /* Test s2n_extensions_server_key_share_send */
+    /* Test s2n_server_key_share_extension.send */
     {
         struct s2n_connection *conn;
 
@@ -104,7 +106,7 @@ int main(int argc, char **argv)
         struct s2n_stuffer* extension_stuffer = &conn->handshake.io;
 
         /* Error if no curve have been selected */
-        EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_server_key_share_send(conn, extension_stuffer), S2N_ERR_NULL);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.send(conn, extension_stuffer), S2N_ERR_NULL);
 
         S2N_STUFFER_READ_SKIP_TILL_END(extension_stuffer);
 
@@ -112,10 +114,8 @@ int main(int argc, char **argv)
             conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[i];
             conn->secure.client_ecc_evp_params[i].negotiated_curve = ecc_pref->ecc_curves[i];
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[i]));
-            EXPECT_SUCCESS(s2n_extensions_server_key_share_send(conn, extension_stuffer));
+            EXPECT_SUCCESS(s2n_server_key_share_extension.send(conn, extension_stuffer));
 
-            S2N_STUFFER_READ_EXPECT_EQUAL(extension_stuffer, TLS_EXTENSION_KEY_SHARE, uint16);
-            S2N_STUFFER_READ_EXPECT_EQUAL(extension_stuffer, ecc_pref->ecc_curves[i]->share_size + 4, uint16); /* 4 = iana_id + share_size */
             S2N_STUFFER_READ_EXPECT_EQUAL(extension_stuffer, ecc_pref->ecc_curves[i]->iana_id, uint16);
             S2N_STUFFER_READ_EXPECT_EQUAL(extension_stuffer, ecc_pref->ecc_curves[i]->share_size, uint16);
             S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(extension_stuffer, ecc_pref->ecc_curves[i]->share_size);
@@ -127,7 +127,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
-    /* Test s2n_extensions_server_key_share_send for failures */
+    /* Test s2n_server_key_share_extension.send for failures */
     {
         struct s2n_connection *conn;
 
@@ -138,25 +138,25 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
         EXPECT_NOT_NULL(ecc_pref);
 
-        EXPECT_FAILURE(s2n_extensions_server_key_share_send(conn, extension_stuffer));
+        EXPECT_FAILURE(s2n_server_key_share_extension.send(conn, extension_stuffer));
 
         conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
-        EXPECT_FAILURE(s2n_extensions_server_key_share_send(conn, extension_stuffer));
+        EXPECT_FAILURE(s2n_server_key_share_extension.send(conn, extension_stuffer));
 
         conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
-        EXPECT_FAILURE(s2n_extensions_server_key_share_send(conn, extension_stuffer));
+        EXPECT_FAILURE(s2n_server_key_share_extension.send(conn, extension_stuffer));
 
         EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
-        EXPECT_SUCCESS(s2n_extensions_server_key_share_send(conn, extension_stuffer));
+        EXPECT_SUCCESS(s2n_server_key_share_extension.send(conn, extension_stuffer));
 
         conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[1];
-        EXPECT_FAILURE(s2n_extensions_server_key_share_send(conn, extension_stuffer));
+        EXPECT_FAILURE(s2n_server_key_share_extension.send(conn, extension_stuffer));
 
         EXPECT_SUCCESS(s2n_ecc_evp_params_free(&conn->secure.server_ecc_evp_params));
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
-    /* Test s2n_extensions_server_key_share_recv with supported curves */
+    /* Test s2n_server_key_share_extension.recv with supported curves */
     {
         const struct s2n_ecc_preferences *ecc_pref = NULL;
 
@@ -175,16 +175,13 @@ int main(int argc, char **argv)
             server_send_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[i];
             server_send_conn->secure.client_ecc_evp_params[i].negotiated_curve = ecc_pref->ecc_curves[i];
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_send_conn->secure.client_ecc_evp_params[i]));
-            EXPECT_SUCCESS(s2n_extensions_server_key_share_send(server_send_conn, extension_stuffer));
-
-            S2N_STUFFER_READ_EXPECT_EQUAL(extension_stuffer, TLS_EXTENSION_KEY_SHARE, uint16);
-            S2N_STUFFER_READ_EXPECT_EQUAL(extension_stuffer, s2n_extensions_server_key_share_send_size(server_send_conn) - 4, uint16); /* 4 = S2N_SIZE_OF_EXTENSION_TYPE + S2N_SIZE_OF_EXTENSION_DATA_SIZE */
+            EXPECT_SUCCESS(s2n_server_key_share_extension.send(server_send_conn, extension_stuffer));
 
             client_recv_conn->secure.client_ecc_evp_params[i].negotiated_curve = ecc_pref->ecc_curves[i];
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_recv_conn->secure.client_ecc_evp_params[i]));
 
             /* Parse key share */
-            EXPECT_SUCCESS(s2n_extensions_server_key_share_recv(client_recv_conn, extension_stuffer));
+            EXPECT_SUCCESS(s2n_server_key_share_extension.recv(client_recv_conn, extension_stuffer));
             EXPECT_EQUAL(s2n_stuffer_data_available(extension_stuffer), 0);
 
             EXPECT_EQUAL(server_send_conn->secure.server_ecc_evp_params.negotiated_curve->iana_id, client_recv_conn->secure.server_ecc_evp_params.negotiated_curve->iana_id);
@@ -197,7 +194,7 @@ int main(int argc, char **argv)
         } while (i<ecc_pref->count);
     }
 
-    /* Test s2n_extensions_server_key_share_recv with various sample payloads */
+    /* Test s2n_server_key_share_extension.recv with various sample payloads */
     {
         /* valid extension payloads */
         if (s2n_is_evp_apis_supported())
@@ -230,7 +227,7 @@ int main(int argc, char **argv)
                 client_conn->secure.client_ecc_evp_params[i].negotiated_curve = ecc_pref->ecc_curves[i];
                 EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.client_ecc_evp_params[i]));
 
-                EXPECT_SUCCESS(s2n_extensions_server_key_share_recv(client_conn, &extension_stuffer));
+                EXPECT_SUCCESS(s2n_server_key_share_extension.recv(client_conn, &extension_stuffer));
                 EXPECT_EQUAL(client_conn->secure.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[i]);
                 EXPECT_EQUAL(s2n_stuffer_data_available(&extension_stuffer), 0);
 
@@ -250,7 +247,7 @@ int main(int argc, char **argv)
             EXPECT_NULL(client_conn->secure.server_ecc_evp_params.negotiated_curve);
             EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&extension_stuffer, p256));
 
-            EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_server_key_share_recv(client_conn, &extension_stuffer), S2N_ERR_BAD_KEY_SHARE);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.recv(client_conn, &extension_stuffer), S2N_ERR_BAD_KEY_SHARE);
 
             EXPECT_SUCCESS(s2n_stuffer_free(&extension_stuffer));
             EXPECT_SUCCESS(s2n_connection_free(client_conn));
@@ -277,7 +274,7 @@ int main(int argc, char **argv)
             client_conn->secure.client_ecc_evp_params[p_384_index].negotiated_curve = ecc_pref->ecc_curves[p_384_index];
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.client_ecc_evp_params[p_384_index]));
 
-            EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_server_key_share_recv(client_conn, &extension_stuffer), S2N_ERR_BAD_KEY_SHARE);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.recv(client_conn, &extension_stuffer), S2N_ERR_BAD_KEY_SHARE);
 
             EXPECT_SUCCESS(s2n_stuffer_free(&extension_stuffer));
             EXPECT_SUCCESS(s2n_connection_free(client_conn));
@@ -334,12 +331,10 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve->iana_id, ecc_pref->ecc_curves[i]->iana_id);
 
             /* Server sends ServerHello key_share */
-            EXPECT_SUCCESS(s2n_extensions_server_key_share_send(server_conn, &server_hello_key_share));
+            EXPECT_SUCCESS(s2n_server_key_share_extension.send(server_conn, &server_hello_key_share));
 
             /* Client receives ServerHello key_share */
-            S2N_STUFFER_READ_EXPECT_EQUAL(&server_hello_key_share, TLS_EXTENSION_KEY_SHARE, uint16);
-            S2N_STUFFER_READ_EXPECT_EQUAL(&server_hello_key_share, s2n_extensions_server_key_share_send_size(server_conn) - 4, uint16);
-            EXPECT_SUCCESS(s2n_extensions_server_key_share_recv(client_conn, &server_hello_key_share));
+            EXPECT_SUCCESS(s2n_server_key_share_extension.recv(client_conn, &server_hello_key_share));
             EXPECT_EQUAL(s2n_stuffer_data_available(&server_hello_key_share), 0);
 
             EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, client_conn->secure.server_ecc_evp_params.negotiated_curve);
@@ -379,69 +374,48 @@ int main(int argc, char **argv)
         } while (i < ecc_pref->count);
     }
 
-    /* Test s2n_extensions_server_key_share_send with supported curve not in s2n_ecc_preferences list selected */
+    /* Test s2n_server_key_share_extension.send with supported curve not in s2n_ecc_preferences list selected */
     if (s2n_is_evp_apis_supported()) {
         struct s2n_connection *conn;
-
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         EXPECT_NOT_NULL(conn->config);
-        /* Explicitly set the ecc_preferences list to contain the curves p-256 and p-384 */
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(conn->config, "20140601"));
 
-        const struct s2n_ecc_preferences *ecc_pref = NULL;
-        EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
-        EXPECT_NOT_NULL(ecc_pref);
-
-        /* x25519 is present in s2n_all_supported_curves_list but not in the "default" list */
+        /* x25519 is supported, but not present in all curve preference lists */
         const struct s2n_ecc_named_curve *test_curve = &s2n_ecc_curve_x25519;
 
-        conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
-        conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
+        /* Explicitly set the ecc_preferences list to NOT contain x25519 */
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(conn->config, "20140601"));
 
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
-
-        struct s2n_stuffer *extension_stuffer = &conn->handshake.io;
-        EXPECT_SUCCESS(s2n_extensions_server_key_share_send(conn, extension_stuffer));
-
+        /* Fails because curve is supported, but not in ecc preferences */
+        conn->secure.server_ecc_evp_params.negotiated_curve = test_curve;
         conn->secure.client_ecc_evp_params[0].negotiated_curve = test_curve;
-        EXPECT_FAILURE(s2n_extensions_server_key_share_send(conn, extension_stuffer));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.send(conn, &conn->handshake.io),
+                S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
 
         EXPECT_SUCCESS(s2n_ecc_evp_params_free(&conn->secure.server_ecc_evp_params));
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
-    /* Test s2n_extensions_server_key_share_recv with supported curve not in s2n_ecc_preferences list selected  */
+    /* Test s2n_server_key_share_extension.recv with supported curve not in s2n_ecc_preferences list selected  */
     if (s2n_is_evp_apis_supported()) {
-        struct s2n_connection *server_send_conn;
-        struct s2n_connection *client_recv_conn;
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        struct s2n_stuffer *extension_stuffer = &conn->handshake.io;
 
-        EXPECT_NOT_NULL(server_send_conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_NOT_NULL(client_recv_conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_NOT_NULL(server_send_conn->config);
-        /* Explicitly set the ecc_preferences list to contain the curves p-256 and p-384 */
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_send_conn->config, "20140601"));
-
-        const struct s2n_ecc_preferences *ecc_pref = NULL;
-        EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(server_send_conn, &ecc_pref));
-        EXPECT_NOT_NULL(ecc_pref);
-
-        /* x25519 is present in s2n_all_supported_curves_list but not in the "default" list */
+        /* x25519 is supported, but not present in all curve preference lists */
         const struct s2n_ecc_named_curve *test_curve = &s2n_ecc_curve_x25519;
 
-        server_send_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
-        server_send_conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
+        /* Explicitly set the ecc_preferences list to NOT contain x25519 */
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(conn->config, "20140601"));
 
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_send_conn->secure.client_ecc_evp_params[0]));
+        /* Write the iana id of x25519 as the group */
+        EXPECT_SUCCESS(s2n_stuffer_write_uint16(extension_stuffer, test_curve->iana_id));
 
-        struct s2n_stuffer *extension_stuffer = &server_send_conn->handshake.io;
-        EXPECT_SUCCESS(s2n_extensions_server_key_share_send(server_send_conn, extension_stuffer));
-        client_recv_conn->secure.client_ecc_evp_params[0].negotiated_curve = test_curve;
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_recv_conn->secure.client_ecc_evp_params[0]));
+        /* Fails because curve is supported, but not in ecc preferences */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.recv(conn, extension_stuffer),
+                S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
 
-        EXPECT_FAILURE(s2n_extensions_server_key_share_recv(client_recv_conn, extension_stuffer));
-
-        EXPECT_SUCCESS(s2n_connection_free(server_send_conn));
-        EXPECT_SUCCESS(s2n_connection_free(client_recv_conn));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
     END_TEST();

--- a/tests/unit/s2n_tls13_handshake_test.c
+++ b/tests/unit/s2n_tls13_handshake_test.c
@@ -44,6 +44,7 @@ static int s2n_tls13_conn_copy_server_finished_hash(struct s2n_connection *conn)
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
+    EXPECT_SUCCESS(s2n_enable_tls13());
 
     /* Test: TLS 1.3 key and secrets generation is symmetrical */
     {
@@ -392,8 +393,6 @@ int main(int argc, char **argv)
 
     /* Test: Handshake self-talks using s2n_handshake_write_io and s2n_handshake_read_io */
     {
-        EXPECT_SUCCESS(s2n_enable_tls13());
-
         struct s2n_connection *client_conn;
         struct s2n_connection *server_conn;
 

--- a/tls/extensions/s2n_client_key_share.c
+++ b/tls/extensions/s2n_client_key_share.c
@@ -44,10 +44,60 @@
  * - Key shares for named groups not in the client's supported_groups extension.
  **/
 
-static int s2n_ecdhe_supported_curves_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+static int s2n_client_key_share_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+static int s2n_client_key_share_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
 
-int s2n_extensions_client_key_share_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
+const s2n_extension_type s2n_client_key_share_extension = {
+    .iana_value = TLS_EXTENSION_KEY_SHARE,
+    .is_response = false,
+    .send = s2n_client_key_share_send,
+    .recv = s2n_client_key_share_recv,
+    .should_send = s2n_extension_send_if_tls13_enabled,
+    .if_missing = s2n_extension_noop_if_missing,
+};
+
+static int s2n_ecdhe_supported_curves_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
+    notnull_check(conn);
+    notnull_check(conn->config);
+
+    const struct s2n_ecc_preferences *ecc_pref = NULL;
+    GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+    notnull_check(ecc_pref);
+
+    const struct s2n_ecc_named_curve *named_curve = NULL;
+    struct s2n_ecc_evp_params *ecc_evp_params = NULL;
+
+    for (uint32_t i = 0; i < ecc_pref->count; i++) {
+        ecc_evp_params = &conn->secure.client_ecc_evp_params[i];
+        named_curve = ecc_pref->ecc_curves[i];
+
+        ecc_evp_params->negotiated_curve = named_curve;
+        ecc_evp_params->evp_pkey = NULL;
+        GUARD(s2n_ecdhe_parameters_send(ecc_evp_params, out));
+    }
+
+    return S2N_SUCCESS;
+}
+
+static int s2n_client_key_share_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    struct s2n_stuffer_reservation shares_size;
+    GUARD(s2n_stuffer_reserve_uint16(out, &shares_size));
+
+    GUARD(s2n_ecdhe_supported_curves_send(conn, out));
+
+    GUARD(s2n_stuffer_write_vector_size(shares_size));
+
+    return S2N_SUCCESS;
+}
+
+static int s2n_client_key_share_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    if (!s2n_is_tls13_enabled()) {
+        return S2N_SUCCESS;
+    }
+
     notnull_check(conn);
     notnull_check(extension);
 
@@ -122,8 +172,10 @@ int s2n_extensions_client_key_share_recv(struct s2n_connection *conn, struct s2n
         GUARD(s2n_set_hello_retry_required(conn));
     }
 
-    return 0;
+    return S2N_SUCCESS;
 }
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
 
 uint32_t s2n_extensions_client_key_share_size(struct s2n_connection *conn)
 {
@@ -147,43 +199,10 @@ uint32_t s2n_extensions_client_key_share_size(struct s2n_connection *conn)
 
 int s2n_extensions_client_key_share_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    notnull_check(out);
-    notnull_check(conn);
-    
-    const uint16_t extension_type = TLS_EXTENSION_KEY_SHARE;
-    const uint16_t extension_data_size =
-            s2n_extensions_client_key_share_size(conn) - S2N_SIZE_OF_EXTENSION_TYPE - S2N_SIZE_OF_EXTENSION_DATA_SIZE;
-    const uint16_t client_shares_size =
-            extension_data_size - S2N_SIZE_OF_CLIENT_SHARES_SIZE;
-
-    GUARD(s2n_stuffer_write_uint16(out, extension_type));
-    GUARD(s2n_stuffer_write_uint16(out, extension_data_size));
-    GUARD(s2n_stuffer_write_uint16(out, client_shares_size));
-
-    GUARD(s2n_ecdhe_supported_curves_send(conn, out));
-
-    return 0;
+    return s2n_extension_send(&s2n_client_key_share_extension, conn, out);
 }
 
-static int s2n_ecdhe_supported_curves_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+int s2n_extensions_client_key_share_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
-    notnull_check(conn);
-
-    const struct s2n_ecc_preferences *ecc_pref = NULL;
-    GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
-    notnull_check(ecc_pref);
-
-    const struct s2n_ecc_named_curve *named_curve = NULL;
-    struct s2n_ecc_evp_params *ecc_evp_params = NULL;
-
-    for (uint32_t i = 0; i < ecc_pref->count; i++) {
-        ecc_evp_params = &conn->secure.client_ecc_evp_params[i];
-        named_curve = ecc_pref->ecc_curves[i];
-
-        ecc_evp_params->negotiated_curve = named_curve;
-        ecc_evp_params->evp_pkey = NULL;
-        GUARD(s2n_ecdhe_parameters_send(ecc_evp_params, out));
-    }
-
-    return 0;
+    return s2n_extension_recv(&s2n_client_key_share_extension, conn, extension);
 }

--- a/tls/extensions/s2n_client_key_share.c
+++ b/tls/extensions/s2n_client_key_share.c
@@ -52,7 +52,7 @@ const s2n_extension_type s2n_client_key_share_extension = {
     .is_response = false,
     .send = s2n_client_key_share_send,
     .recv = s2n_client_key_share_recv,
-    .should_send = s2n_extension_send_if_tls13_enabled,
+    .should_send = s2n_extension_send_if_tls13_connection,
     .if_missing = s2n_extension_noop_if_missing,
 };
 

--- a/tls/extensions/s2n_client_key_share.h
+++ b/tls/extensions/s2n_client_key_share.h
@@ -18,6 +18,9 @@
 #include "tls/s2n_connection.h"
 #include "stuffer/s2n_stuffer.h"
 
+extern const s2n_extension_type s2n_client_key_share_extension;
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
 extern int s2n_extensions_client_key_share_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
 extern uint32_t s2n_extensions_client_key_share_size(struct s2n_connection *conn);
 extern int s2n_extensions_client_key_share_send(struct s2n_connection *conn, struct s2n_stuffer *out);

--- a/tls/extensions/s2n_server_key_share.c
+++ b/tls/extensions/s2n_server_key_share.c
@@ -30,7 +30,7 @@ const s2n_extension_type s2n_server_key_share_extension = {
     .is_response = false,
     .send = s2n_server_key_share_send,
     .recv = s2n_server_key_share_recv,
-    .should_send = s2n_extension_send_if_tls13_enabled,
+    .should_send = s2n_extension_send_if_tls13_connection,
     .if_missing = s2n_extension_noop_if_missing,
 };
 

--- a/tls/extensions/s2n_server_key_share.c
+++ b/tls/extensions/s2n_server_key_share.c
@@ -68,6 +68,10 @@ static int s2n_server_key_share_send(struct s2n_connection *conn, struct s2n_stu
  */
 static int s2n_server_key_share_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
+    if (!s2n_is_tls13_enabled()) {
+        return S2N_SUCCESS;
+    }
+
     notnull_check(conn);
     notnull_check(extension);
 

--- a/tls/extensions/s2n_server_key_share.c
+++ b/tls/extensions/s2n_server_key_share.c
@@ -22,16 +22,104 @@
 #include "utils/s2n_safety.h"
 #include "tls/s2n_tls13.h"
 
+static int s2n_server_key_share_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+static int s2n_server_key_share_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
+
+const s2n_extension_type s2n_server_key_share_extension = {
+    .iana_value = TLS_EXTENSION_KEY_SHARE,
+    .is_response = false,
+    .send = s2n_server_key_share_send,
+    .recv = s2n_server_key_share_recv,
+    .should_send = s2n_extension_send_if_tls13_enabled,
+    .if_missing = s2n_extension_noop_if_missing,
+};
+
+int s2n_extensions_server_key_share_send_check(struct s2n_connection *conn);
+
+static int s2n_server_key_share_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    GUARD(s2n_extensions_server_key_share_send_check(conn));
+    notnull_check(conn);
+    notnull_check(out);
+
+    /* Retry requests only require the selected named group, not an actual share.
+     * https://tools.ietf.org/html/rfc8446#section-4.2.8 */
+    if (s2n_is_hello_retry_required(conn)) {
+        notnull_check(conn->secure.server_ecc_evp_params.negotiated_curve);
+
+        /* There was a mutually supported group, so that is the group we will select */
+        uint16_t curve = conn->secure.server_ecc_evp_params.negotiated_curve->iana_id;
+        GUARD(s2n_stuffer_write_uint16(out, curve));
+        return 0;
+    }
+
+    GUARD(s2n_ecdhe_parameters_send(&conn->secure.server_ecc_evp_params, out));
+
+    return S2N_SUCCESS;
+}
+
+/*
+ * From https://tools.ietf.org/html/rfc8446#section-4.2.8
+ *
+ * If using (EC)DHE key establishment, servers offer exactly one
+ * KeyShareEntry in the ServerHello.  This value MUST be in the same
+ * group as the KeyShareEntry value offered by the client that the
+ * server has selected for the negotiated key exchange.
+ */
+static int s2n_server_key_share_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    notnull_check(conn);
+    notnull_check(extension);
+
+    /* If this is a HelloRetryRequest, we won't have a key share. We just have the selected group.
+     * Exit early so a proper keyshare can be generated. */
+    if (s2n_is_hello_retry_required(conn)) {
+        return 0;
+    }
+
+    uint16_t named_group;
+    S2N_ERROR_IF(s2n_stuffer_data_available(extension) < sizeof(named_group), S2N_ERR_BAD_KEY_SHARE);
+    GUARD(s2n_stuffer_read_uint16(extension, &named_group));
+
+    const struct s2n_ecc_preferences *ecc_pref = NULL;
+    GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+    notnull_check(ecc_pref);
+
+    int supported_curve_index = -1;
+    for (int i = 0; i < ecc_pref->count; i++) {
+        if (named_group == ecc_pref->ecc_curves[i]->iana_id) {
+            supported_curve_index = i;
+            break;
+        }
+    }
+
+    S2N_ERROR_IF(supported_curve_index < 0, S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
+
+    /* Key share not sent by client */
+    S2N_ERROR_IF(conn->secure.client_ecc_evp_params[supported_curve_index].evp_pkey == NULL, S2N_ERR_BAD_KEY_SHARE);
+
+    struct s2n_ecc_evp_params* server_ecc_evp_params = &conn->secure.server_ecc_evp_params;
+    server_ecc_evp_params->negotiated_curve = ecc_pref->ecc_curves[supported_curve_index];
+
+    uint16_t share_size;
+    S2N_ERROR_IF(s2n_stuffer_data_available(extension) < sizeof(share_size), S2N_ERR_BAD_KEY_SHARE);
+    GUARD(s2n_stuffer_read_uint16(extension, &share_size));
+    S2N_ERROR_IF(s2n_stuffer_data_available(extension) < share_size, S2N_ERR_BAD_KEY_SHARE);
+
+    /* Proceed to parse share */
+    struct s2n_blob point_blob;
+    S2N_ERROR_IF(s2n_ecc_evp_read_params_point(extension, share_size,  &point_blob) < 0, S2N_ERR_BAD_KEY_SHARE);
+    S2N_ERROR_IF(s2n_ecc_evp_parse_params_point(&point_blob, server_ecc_evp_params) < 0, S2N_ERR_BAD_KEY_SHARE);
+
+    return S2N_SUCCESS;
+}
+
 /*
  * Check whether client has sent a corresponding curve and key_share
  */
 int s2n_extensions_server_key_share_send_check(struct s2n_connection *conn)
 {
     notnull_check(conn);
-
-    const struct s2n_ecc_preferences *ecc_pref = NULL;
-    GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
-    notnull_check(ecc_pref);
 
     /* If we are responding to a retry request then we don't have a valid
      * curve from the client. Just return 0 so a selected group will be
@@ -40,9 +128,13 @@ int s2n_extensions_server_key_share_send_check(struct s2n_connection *conn)
         return 0;
     }
 
-    const struct s2n_ecc_named_curve *server_curve, *client_curve;
+    const struct s2n_ecc_named_curve *server_curve;
     server_curve = conn->secure.server_ecc_evp_params.negotiated_curve;
     notnull_check(server_curve);
+
+    const struct s2n_ecc_preferences *ecc_pref = NULL;
+    GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+    notnull_check(ecc_pref);
 
     int curve_index = -1;
     for (int i = 0; i < ecc_pref->count; i++) {
@@ -52,10 +144,10 @@ int s2n_extensions_server_key_share_send_check(struct s2n_connection *conn)
         }
     }
 
-    gt_check(curve_index, -1);
+    S2N_ERROR_IF(curve_index < 0, S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
 
     const struct s2n_ecc_evp_params client_ecc_evp = conn->secure.client_ecc_evp_params[curve_index];
-    client_curve = client_ecc_evp.negotiated_curve;
+    const struct s2n_ecc_named_curve *client_curve = client_ecc_evp.negotiated_curve;
 
     S2N_ERROR_IF(client_curve == NULL, S2N_ERR_BAD_KEY_SHARE);
     S2N_ERROR_IF(client_curve != server_curve, S2N_ERR_BAD_KEY_SHARE);
@@ -92,6 +184,8 @@ int s2n_extensions_server_key_share_select(struct s2n_connection *conn)
 
     S2N_ERROR(S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
 }
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
 
 /*
  * Calculate the data length for Server Key Share extension
@@ -131,30 +225,7 @@ int s2n_extensions_server_key_share_send_size(struct s2n_connection *conn)
  */
 int s2n_extensions_server_key_share_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    GUARD(s2n_extensions_server_key_share_send_check(conn));
-
-    notnull_check(out);
-
-    GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_KEY_SHARE));
-    GUARD(s2n_stuffer_write_uint16(out, s2n_extensions_server_key_share_send_size(conn)
-        - S2N_SIZE_OF_EXTENSION_TYPE
-        - S2N_SIZE_OF_EXTENSION_DATA_SIZE
-    ));
-
-    /* Retry requests only require the selected named group, not an actual share.
-     * https://tools.ietf.org/html/rfc8446#section-4.2.8 */
-    if (s2n_is_hello_retry_required(conn)) {
-        notnull_check(conn->secure.server_ecc_evp_params.negotiated_curve);
-
-        /* There was a mutually supported group, so that is the group we will select */
-        uint16_t curve = conn->secure.server_ecc_evp_params.negotiated_curve->iana_id;
-        GUARD(s2n_stuffer_write_uint16(out, curve));
-        return 0;
-    }
-
-    GUARD(s2n_ecdhe_parameters_send(&conn->secure.server_ecc_evp_params, out));
-
-    return 0;
+    return s2n_extension_send(&s2n_server_key_share_extension, conn, out);
 }
 
 /*
@@ -164,66 +235,5 @@ int s2n_extensions_server_key_share_send(struct s2n_connection *conn, struct s2n
  */
 int s2n_extensions_server_key_share_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
-    notnull_check(conn);
-    notnull_check(extension);
-
-    const struct s2n_ecc_preferences *ecc_pref = NULL;
-    GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
-    notnull_check(ecc_pref);
-
-    uint16_t named_group, share_size;
-
-    /* Make sure we can read the 2 byte named group */
-    S2N_ERROR_IF(s2n_stuffer_data_available(extension) < 2, S2N_ERR_BAD_KEY_SHARE);
-    GUARD(s2n_stuffer_read_uint16(extension, &named_group));
-
-    /* If this is a HelloRetryRequest, we won't have a key share. We just have the selected group.
-     * Exit early so a proper keyshare can be generated. */
-    if (s2n_is_hello_retry_required(conn)) {
-        return 0;
-    }
-
-    /* Make sure we can read the 2 byte key share size */
-    S2N_ERROR_IF(s2n_stuffer_data_available(extension) < 2, S2N_ERR_BAD_KEY_SHARE);
-    GUARD(s2n_stuffer_read_uint16(extension, &share_size));
-
-    /* Verify that *share_size* bytes are available in the stuffer */
-    S2N_ERROR_IF(s2n_stuffer_data_available(extension) < share_size, S2N_ERR_BAD_KEY_SHARE);
-
-    int supported_curve_index = -1;
-    const struct s2n_ecc_named_curve *supported_curve = NULL;
-    for (int i = 0; i < ecc_pref->count; i++) {
-        if (named_group == ecc_pref->ecc_curves[i]->iana_id) {
-            supported_curve_index = i;
-            supported_curve = ecc_pref->ecc_curves[i];
-            break;
-        }
-    }
-
-    /*
-     * From https://tools.ietf.org/html/rfc8446#section-4.2.8
-     *
-     * If using (EC)DHE key establishment, servers offer exactly one
-     * KeyShareEntry in the ServerHello.  This value MUST be in the same
-     * group as the KeyShareEntry value offered by the client that the
-     * server has selected for the negotiated key exchange.
-     */
-
-    /* Key share unsupported by s2n */
-    S2N_ERROR_IF(supported_curve == NULL, S2N_ERR_BAD_KEY_SHARE);
-    S2N_ERROR_IF(supported_curve_index == -1, S2N_ERR_BAD_KEY_SHARE);
-
-    /* Key share not sent by client */
-    S2N_ERROR_IF(conn->secure.client_ecc_evp_params[supported_curve_index].evp_pkey == NULL, S2N_ERR_BAD_KEY_SHARE);
-
-    struct s2n_ecc_evp_params* server_ecc_evp_params = &conn->secure.server_ecc_evp_params;
-    server_ecc_evp_params->negotiated_curve = supported_curve;
-
-    /* Proceed to parse curve */
-    struct s2n_blob point_blob;
-
-    S2N_ERROR_IF(s2n_ecc_evp_read_params_point(extension, share_size,  &point_blob) < 0, S2N_ERR_BAD_KEY_SHARE);
-    S2N_ERROR_IF(s2n_ecc_evp_parse_params_point(&point_blob, server_ecc_evp_params) < 0, S2N_ERR_BAD_KEY_SHARE);
-
-    return 0;
+    return s2n_extension_recv(&s2n_server_key_share_extension, conn, extension);
 }

--- a/tls/extensions/s2n_server_key_share.c
+++ b/tls/extensions/s2n_server_key_share.c
@@ -71,12 +71,6 @@ static int s2n_server_key_share_recv(struct s2n_connection *conn, struct s2n_stu
     notnull_check(conn);
     notnull_check(extension);
 
-    /* If this is a HelloRetryRequest, we won't have a key share. We just have the selected group.
-     * Exit early so a proper keyshare can be generated. */
-    if (s2n_is_hello_retry_required(conn)) {
-        return 0;
-    }
-
     uint16_t named_group;
     S2N_ERROR_IF(s2n_stuffer_data_available(extension) < sizeof(named_group), S2N_ERR_BAD_KEY_SHARE);
     GUARD(s2n_stuffer_read_uint16(extension, &named_group));
@@ -94,6 +88,12 @@ static int s2n_server_key_share_recv(struct s2n_connection *conn, struct s2n_stu
     }
 
     S2N_ERROR_IF(supported_curve_index < 0, S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
+
+    /* If this is a HelloRetryRequest, we won't have a key share. We just have the selected group.
+     * Exit early so a proper keyshare can be generated. */
+    if (s2n_is_hello_retry_required(conn)) {
+        return 0;
+    }
 
     /* Key share not sent by client */
     S2N_ERROR_IF(conn->secure.client_ecc_evp_params[supported_curve_index].evp_pkey == NULL, S2N_ERR_BAD_KEY_SHARE);

--- a/tls/extensions/s2n_server_key_share.h
+++ b/tls/extensions/s2n_server_key_share.h
@@ -20,8 +20,11 @@
 
 #include "tls/extensions/s2n_key_share.h"
 
-extern int s2n_extensions_server_key_share_send_check(struct s2n_connection *conn);
-extern int s2n_extensions_server_key_share_send_size(struct s2n_connection *conn);
+extern const s2n_extension_type s2n_server_key_share_extension;
+
 extern int s2n_extensions_server_key_share_select(struct s2n_connection *conn);
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
+extern int s2n_extensions_server_key_share_send_size(struct s2n_connection *conn);
 extern int s2n_extensions_server_key_share_send(struct s2n_connection *conn, struct s2n_stuffer *out);
 extern int s2n_extensions_server_key_share_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** https://github.com/awslabs/s2n/issues/1817

**Description of changes:** 
I've split out the key share extension into its own refactor PR because I made non-trivial updates to the server side code. When I made send stop appending the extension_type + extension_size, an EXPECT_FAILURE in the s2n_server_key_share_extension_test.c unit tests started succeeding. The test was supposed to fail because a curve was unsupported, but it had actually been failing because TLS_EXTENSION_KEY_SHARE is not a valid group iana.

I ended up rewriting the two s2n_server_key_share_extension_test.c tests for unsupported curves to make them work. I added more explicit error handling for unsupported curves so I could use EXPECT_FAILURE_WITH_ERRNO. I also rearranged some of the send/recv logic, primarily moving variable initializations closer to where those variables are used to make it easier to follow.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
