### PR TITLE
Refactor third set of extension structs

### DIFF
--- a/tests/unit/s2n_choose_supported_group_test.c
+++ b/tests/unit/s2n_choose_supported_group_test.c
@@ -19,6 +19,9 @@
 #include "tls/extensions/s2n_client_supported_groups.h"
 #include "tls/s2n_security_policies.h"
 
+int s2n_choose_supported_group(struct s2n_connection *conn, const struct s2n_ecc_named_curve **group_options,
+        struct s2n_ecc_evp_params *chosen_group);
+
 int main(int argc, char **argv) 
 {
     struct s2n_connection *server_conn;

--- a/tests/unit/s2n_client_ecc_point_format_extension_test.c
+++ b/tests/unit/s2n_client_ecc_point_format_extension_test.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "tls/extensions/s2n_client_ec_point_format.h"
+#include "tls/s2n_resume.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    struct s2n_config *config;
+    EXPECT_NOT_NULL(config = s2n_config_new());
+
+    /* Test send */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        EXPECT_SUCCESS(s2n_client_ec_point_format_extension.send(conn, &stuffer));
+
+        uint8_t length;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint8(&stuffer, &length));
+        EXPECT_EQUAL(length, s2n_stuffer_data_available(&stuffer));
+
+        uint8_t point_format;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint8(&stuffer, &point_format));
+        EXPECT_EQUAL(point_format, TLS_EC_POINT_FORMAT_UNCOMPRESSED);
+
+        EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test recv */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        EXPECT_SUCCESS(s2n_client_ec_point_format_extension.send(conn, &stuffer));
+
+        EXPECT_FALSE(conn->ec_point_formats);
+        EXPECT_SUCCESS(s2n_client_ec_point_format_extension.recv(conn, &stuffer));
+        EXPECT_TRUE(conn->ec_point_formats);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    EXPECT_SUCCESS(s2n_config_free(config));
+
+    END_TEST();
+    return 0;
+}

--- a/tests/unit/s2n_client_status_request_extension_test.c
+++ b/tests/unit/s2n_client_status_request_extension_test.c
@@ -1,0 +1,136 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "tls/extensions/s2n_client_status_request.h"
+#include "tls/s2n_resume.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    struct s2n_config *config;
+    EXPECT_NOT_NULL(config = s2n_config_new());
+
+    /* Test should_send */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        /* status request should be sent by default */
+        EXPECT_FALSE(s2n_client_status_request_extension.should_send(conn));
+
+        /* status request should be sent if ocsp requested */
+        conn->config->status_request_type = S2N_STATUS_REQUEST_OCSP;
+        EXPECT_TRUE(s2n_client_status_request_extension.should_send(conn));
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test send */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        EXPECT_SUCCESS(s2n_client_status_request_extension.send(conn, &stuffer));
+
+        uint8_t request_type;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint8(&stuffer, &request_type));
+        EXPECT_EQUAL(request_type, S2N_STATUS_REQUEST_OCSP);
+
+        uint32_t unused_values;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint32(&stuffer, &unused_values));
+        EXPECT_EQUAL(unused_values, 0);
+
+        EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test recv */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        EXPECT_SUCCESS(s2n_client_status_request_extension.send(conn, &stuffer));
+
+        EXPECT_EQUAL(conn->status_type, S2N_STATUS_REQUEST_NONE);
+        EXPECT_SUCCESS(s2n_client_status_request_extension.recv(conn, &stuffer));
+        EXPECT_EQUAL(conn->status_type, S2N_STATUS_REQUEST_OCSP);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test recv - malformed length, ignore */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        EXPECT_SUCCESS(s2n_client_status_request_extension.send(conn, &stuffer));
+        EXPECT_SUCCESS(s2n_stuffer_wipe_n(&stuffer, sizeof(uint16_t)));
+
+        EXPECT_EQUAL(conn->status_type, S2N_STATUS_REQUEST_NONE);
+        EXPECT_SUCCESS(s2n_client_status_request_extension.recv(conn, &stuffer));
+        EXPECT_EQUAL(conn->status_type, S2N_STATUS_REQUEST_NONE);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test recv - not ocsp request, ignore */
+    {
+        struct s2n_config *bad_config;
+        EXPECT_NOT_NULL(bad_config = s2n_config_new());
+        bad_config->status_request_type = UINT8_MAX;
+
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, bad_config));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        EXPECT_SUCCESS(s2n_client_status_request_extension.send(conn, &stuffer));
+
+        EXPECT_EQUAL(conn->status_type, S2N_STATUS_REQUEST_NONE);
+        EXPECT_SUCCESS(s2n_client_status_request_extension.recv(conn, &stuffer));
+        EXPECT_EQUAL(conn->status_type, S2N_STATUS_REQUEST_NONE);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(bad_config));
+    }
+
+    EXPECT_SUCCESS(s2n_config_free(config));
+
+    END_TEST();
+    return 0;
+}

--- a/tests/unit/s2n_client_status_request_extension_test.c
+++ b/tests/unit/s2n_client_status_request_extension_test.c
@@ -31,15 +31,18 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
-        /* status request should be sent by default */
+        /* status request should NOT be sent by default */
         EXPECT_FALSE(s2n_client_status_request_extension.should_send(conn));
 
         /* status request should be sent if ocsp requested */
-        conn->config->status_request_type = S2N_STATUS_REQUEST_OCSP;
+        config->status_request_type = S2N_STATUS_REQUEST_OCSP;
         EXPECT_TRUE(s2n_client_status_request_extension.should_send(conn));
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
+
+    /* Enable status requests */
+    config->status_request_type = S2N_STATUS_REQUEST_OCSP;
 
     /* Test send */
     {

--- a/tests/unit/s2n_client_supported_groups_extension_test.c
+++ b/tests/unit/s2n_client_supported_groups_extension_test.c
@@ -17,13 +17,11 @@
 
 #include <stdint.h>
 
-#include "tls/s2n_alerts.h"
+#include "tls/extensions/s2n_client_supported_groups.h"
 #include "tls/s2n_config.h"
 #include "tls/s2n_connection.h"
 #include "tls/s2n_client_extensions.h"
 #include "tls/s2n_tls.h"
-#include "tls/extensions/s2n_client_key_share.h"
-#include "tls/extensions/s2n_key_share.h"
 
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_safety.h"
@@ -31,6 +29,112 @@
 int main()
 {
     BEGIN_TEST();
+
+    /* Test s2n_extension_should_send_if_ecc_enabled */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+        /* ecc extensions are required for the default config */
+        EXPECT_TRUE(s2n_client_supported_groups_extension.should_send(conn));
+
+        /* ecc extensions are NOT required for 20140601 */
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "20140601"));
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test send */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        const struct s2n_ecc_preferences *ecc_pref = NULL;
+        EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+
+        EXPECT_SUCCESS(s2n_client_supported_groups_extension.send(conn, &stuffer));
+
+        uint16_t length;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &length));
+        EXPECT_EQUAL(length, s2n_stuffer_data_available(&stuffer));
+
+        uint16_t curve_id;
+        for (int i = 0; i < ecc_pref->count; i++) {
+            EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &curve_id));
+            EXPECT_EQUAL(curve_id, ecc_pref->ecc_curves[i]->iana_id);
+        }
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test recv */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        const struct s2n_ecc_preferences *ecc_pref = NULL;
+        EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+
+        EXPECT_SUCCESS(s2n_client_supported_groups_extension.send(conn, &stuffer));
+
+        EXPECT_NULL(conn->secure.server_ecc_evp_params.negotiated_curve);
+        EXPECT_SUCCESS(s2n_client_supported_groups_extension.recv(conn, &stuffer));
+        EXPECT_EQUAL(conn->secure.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[0]);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test recv - no common curve */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        const struct s2n_ecc_preferences *ecc_pref = NULL;
+        EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+
+        EXPECT_SUCCESS(s2n_client_supported_groups_extension.send(conn, &stuffer));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "null"));
+
+        EXPECT_NULL(conn->secure.server_ecc_evp_params.negotiated_curve);
+        EXPECT_SUCCESS(s2n_client_supported_groups_extension.recv(conn, &stuffer));
+        EXPECT_NULL(conn->secure.server_ecc_evp_params.negotiated_curve);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test recv - malformed extension */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        const struct s2n_ecc_preferences *ecc_pref = NULL;
+        EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+
+        EXPECT_SUCCESS(s2n_client_supported_groups_extension.send(conn, &stuffer));
+        EXPECT_SUCCESS(s2n_stuffer_wipe_n(&stuffer, 1));
+
+        EXPECT_NULL(conn->secure.server_ecc_evp_params.negotiated_curve);
+        EXPECT_SUCCESS(s2n_client_supported_groups_extension.recv(conn, &stuffer));
+        EXPECT_NULL(conn->secure.server_ecc_evp_params.negotiated_curve);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
 
     {
         /* Test that unknown TLS_EXTENSION_SUPPORTED_GROUPS values are ignored */

--- a/tests/unit/s2n_parse_client_supported_groups_list_test.c
+++ b/tests/unit/s2n_parse_client_supported_groups_list_test.c
@@ -21,6 +21,9 @@
 #include "tls/extensions/s2n_client_supported_groups.h"
 #include "tls/s2n_security_policies.h"
 
+int s2n_parse_client_supported_groups_list(struct s2n_connection *conn, struct s2n_blob *iana_ids,
+        const struct s2n_ecc_named_curve **supported_groups);
+
 int main(int argc, char **argv)
 {
     struct s2n_connection *server_conn;

--- a/tls/extensions/s2n_client_ec_point_format.h
+++ b/tls/extensions/s2n_client_ec_point_format.h
@@ -15,7 +15,13 @@
 
 #pragma once
 
+#include "tls/extensions/s2n_extension_type.h"
 #include "tls/s2n_connection.h"
 #include "stuffer/s2n_stuffer.h"
 
+#define TLS_EC_POINT_FORMAT_UNCOMPRESSED 0
+
+extern const s2n_extension_type s2n_client_ec_point_format_extension;
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
 extern int s2n_recv_client_ec_point_formats(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_client_status_request.c
+++ b/tls/extensions/s2n_client_status_request.c
@@ -22,29 +22,70 @@
 
 #include "utils/s2n_safety.h"
 
-int s2n_extensions_client_status_request_send(struct s2n_connection *conn, struct s2n_stuffer *out)
-{
-    GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_STATUS_REQUEST));
-    GUARD(s2n_stuffer_write_uint16(out, 5));
-    GUARD(s2n_stuffer_write_uint8(out, (uint8_t) conn->config->status_request_type));
-    GUARD(s2n_stuffer_write_uint16(out, 0));
-    GUARD(s2n_stuffer_write_uint16(out, 0));
+static bool s2n_client_status_request_should_send(struct s2n_connection *conn);
+static int s2n_client_status_request_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+static int s2n_client_status_request_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
 
-    return 0;
+const s2n_extension_type s2n_client_status_request_extension = {
+    .iana_value = TLS_EXTENSION_STATUS_REQUEST,
+    .is_response = false,
+    .send = s2n_client_status_request_send,
+    .recv = s2n_client_status_request_recv,
+    .should_send = s2n_client_status_request_should_send,
+    .if_missing = s2n_extension_noop_if_missing,
+};
+
+static bool s2n_client_status_request_should_send(struct s2n_connection *conn)
+{
+    return conn->config->status_request_type != S2N_STATUS_REQUEST_NONE;
 }
 
-int s2n_recv_client_status_request(struct s2n_connection *conn, struct s2n_stuffer *extension)
+static int s2n_client_status_request_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    GUARD(s2n_stuffer_write_uint8(out, (uint8_t) conn->config->status_request_type));
+
+    /* responder_id_list
+     *
+     * From https://tools.ietf.org/html/rfc6066#section-8:
+     * A zero-length "responder_id_list" sequence has the special meaning that the responders are implicitly
+     * known to the server, e.g., by prior arrangement */
+    GUARD(s2n_stuffer_write_uint16(out, 0));
+
+    /* request_extensions
+     *
+     * From https://tools.ietf.org/html/rfc6066#section-8:
+     * A zero-length "request_extensions" value means that there are no extensions. */
+    GUARD(s2n_stuffer_write_uint16(out, 0));
+
+    return S2N_SUCCESS;
+}
+
+static int s2n_client_status_request_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
     if (s2n_stuffer_data_available(extension) < 5) {
         /* Malformed length, ignore the extension */
-        return 0;
+        return S2N_SUCCESS;
     }
+
     uint8_t type;
     GUARD(s2n_stuffer_read_uint8(extension, &type));
     if (type != (uint8_t) S2N_STATUS_REQUEST_OCSP) {
         /* We only support OCSP (type 1), ignore the extension */
-        return 0;
+        return S2N_SUCCESS;
     }
+
     conn->status_type = (s2n_status_request_type) type;
-    return 0;
+    return S2N_SUCCESS;
+}
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
+
+int s2n_extensions_client_status_request_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    return s2n_extension_send(&s2n_client_status_request_extension, conn, out);
+}
+
+int s2n_recv_client_status_request(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    return s2n_extension_recv(&s2n_client_status_request_extension, conn, extension);
 }

--- a/tls/extensions/s2n_client_status_request.h
+++ b/tls/extensions/s2n_client_status_request.h
@@ -15,8 +15,12 @@
 
 #pragma once
 
+#include "tls/extensions/s2n_extension_type.h"
 #include "tls/s2n_connection.h"
 #include "stuffer/s2n_stuffer.h"
 
+extern const s2n_extension_type s2n_client_status_request_extension;
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
 extern int s2n_extensions_client_status_request_send(struct s2n_connection *conn, struct s2n_stuffer *out);
 extern int s2n_recv_client_status_request(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_client_supported_groups.h
+++ b/tls/extensions/s2n_client_supported_groups.h
@@ -15,10 +15,13 @@
 
 #pragma once
 
+#include "tls/extensions/s2n_extension_type.h"
 #include "tls/s2n_connection.h"
 #include "stuffer/s2n_stuffer.h"
 
-extern int s2n_extensions_client_supported_groups_send(struct s2n_connection *conn, struct s2n_stuffer *out);
-extern int s2n_recv_client_supported_groups(struct s2n_connection *conn, struct s2n_stuffer *extension);
-int s2n_parse_client_supported_groups_list(struct s2n_connection *conn, struct s2n_blob *iana_ids, const struct s2n_ecc_named_curve **supported_groups);
-int s2n_choose_supported_group(struct s2n_connection *conn, const struct s2n_ecc_named_curve **group_options, struct s2n_ecc_evp_params *chosen_group);
+extern const s2n_extension_type s2n_client_supported_groups_extension;
+bool s2n_extension_should_send_if_ecc_enabled(struct s2n_connection *conn);
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
+int s2n_extensions_client_supported_groups_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+int s2n_recv_client_supported_groups(struct s2n_connection *conn, struct s2n_stuffer *extension);


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

### Description of changes: 
Move the next 3 extensions into the new structures. For each extension, I:
- create the struct
- move current send and receive logic into static methods linked to the struct
- write static should_send method based on the existing logic in s2n_client_extensions
- replace current send and receive methods with calls to s2n_extension_send/recv
- remove type + size from what the send method sends

### Call-outs:
This is part of a larger task: https://github.com/awslabs/s2n/issues/1817

The existing send/receive methods are left for now, but reference the new methods.

We were sending the ecc_points_format extension from the supported_curves extension's send method. To maintain backwards compatibility with minimal changes, I just continued to send the ecc_points_format from the legacy supported_curves send function.

### Testing:

I add unit tests for extensions that didn't already have them. My unit tests for supported groups don't look sufficient, but most of the logic is already tested by s2n_choose_supported_group_test.c and s2n_parse_client_supported_groups_list_test.c.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
