### PR TITLE
Refactor fourth set of extension structs

### DIFF
--- a/tests/unit/s2n_encrypted_extensions_test.c
+++ b/tests/unit/s2n_encrypted_extensions_test.c
@@ -74,6 +74,7 @@ int main(int argc, char **argv)
         const uint8_t ENCRYPTED_EXTENSIONS_HEADER_SIZE = 2;
         struct s2n_connection *server_conn;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(server_conn));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
         server_conn->actual_protocol_version = S2N_TLS13;
         EXPECT_EQUAL(s2n_encrypted_extensions_send_size(server_conn), 0);
@@ -130,6 +131,7 @@ int main(int argc, char **argv)
     {
         struct s2n_connection *client_conn;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(client_conn));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
         client_conn->actual_protocol_version = S2N_TLS13;
 
@@ -152,6 +154,7 @@ int main(int argc, char **argv)
     {
         struct s2n_connection *client_conn;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(client_conn));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
         client_conn->actual_protocol_version = S2N_TLS13;;
 

--- a/tests/unit/s2n_server_alpn_extension_test.c
+++ b/tests/unit/s2n_server_alpn_extension_test.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "tls/extensions/s2n_server_alpn.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    const char *test_protocol_name = "chosen_protocol";
+    const uint8_t test_protocol_name_size = strlen(test_protocol_name);
+
+    /* Test should_send */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+
+        /* Should not send if protocol not set. Protocol not set by default. */
+        EXPECT_FALSE(s2n_server_alpn_extension.should_send(conn));
+
+        /* Should send if protocol set. */
+        EXPECT_MEMCPY_SUCCESS(conn->application_protocol, test_protocol_name, test_protocol_name_size);
+        EXPECT_TRUE(s2n_server_alpn_extension.should_send(conn));
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test send */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_MEMCPY_SUCCESS(conn->application_protocol, test_protocol_name, test_protocol_name_size);
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        EXPECT_SUCCESS(s2n_server_alpn_extension.send(conn, &stuffer));
+
+        /* Should have correct total size */
+        uint16_t total_size;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &total_size));
+        EXPECT_EQUAL(total_size, s2n_stuffer_data_available(&stuffer));
+
+        /* Should have correct protocol name size */
+        uint8_t protocol_name_size;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint8(&stuffer, &protocol_name_size));
+        EXPECT_EQUAL(protocol_name_size, s2n_stuffer_data_available(&stuffer));
+        EXPECT_EQUAL(protocol_name_size, test_protocol_name_size);
+
+        /* Should have correct protocol name */
+        uint8_t protocol_name[protocol_name_size];
+        EXPECT_SUCCESS(s2n_stuffer_read_bytes(&stuffer, protocol_name, protocol_name_size));
+        EXPECT_BYTEARRAY_EQUAL(protocol_name, test_protocol_name, test_protocol_name_size);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test recv */
+    {
+        struct s2n_connection *server_conn;
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_MEMCPY_SUCCESS(server_conn->application_protocol, test_protocol_name, test_protocol_name_size);
+
+        /* Should accept extension written by send */
+        {
+            struct s2n_connection *client_conn;
+            EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+
+            struct s2n_stuffer stuffer;
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+            EXPECT_SUCCESS(s2n_server_alpn_extension.send(server_conn, &stuffer));
+
+            EXPECT_NULL(s2n_get_application_protocol(client_conn));
+            EXPECT_SUCCESS(s2n_server_alpn_extension.recv(client_conn, &stuffer));
+            EXPECT_NOT_NULL(s2n_get_application_protocol(client_conn));
+            EXPECT_STRING_EQUAL(s2n_get_application_protocol(client_conn), test_protocol_name);
+
+            EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
+
+            EXPECT_SUCCESS(s2n_connection_free(client_conn));
+            EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        }
+
+        /* Should ignore extension if protocol name list size incorrect */
+        {
+            struct s2n_connection *client_conn;
+            EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+
+            struct s2n_stuffer stuffer;
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+            EXPECT_SUCCESS(s2n_server_alpn_extension.send(server_conn, &stuffer));
+            EXPECT_SUCCESS(s2n_stuffer_wipe_n(&stuffer, 1));
+
+            EXPECT_NULL(s2n_get_application_protocol(client_conn));
+            EXPECT_SUCCESS(s2n_server_alpn_extension.recv(client_conn, &stuffer));
+            EXPECT_NULL(s2n_get_application_protocol(client_conn));
+
+            EXPECT_SUCCESS(s2n_connection_free(client_conn));
+            EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        }
+
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+    }
+
+    END_TEST();
+    return 0;
+}

--- a/tests/unit/s2n_server_alpn_extension_test.c
+++ b/tests/unit/s2n_server_alpn_extension_test.c
@@ -51,9 +51,9 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_server_alpn_extension.send(conn, &stuffer));
 
         /* Should have correct total size */
-        uint16_t total_size;
-        EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &total_size));
-        EXPECT_EQUAL(total_size, s2n_stuffer_data_available(&stuffer));
+        uint16_t protocol_name_list_size;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &protocol_name_list_size));
+        EXPECT_EQUAL(protocol_name_list_size, s2n_stuffer_data_available(&stuffer));
 
         /* Should have correct protocol name size */
         uint8_t protocol_name_size;

--- a/tests/unit/s2n_server_extensions_test.c
+++ b/tests/unit/s2n_server_extensions_test.c
@@ -151,6 +151,7 @@ int main(int argc, char **argv)
         {
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(conn));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
             struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
 

--- a/tests/unit/s2n_server_extensions_test.c
+++ b/tests/unit/s2n_server_extensions_test.c
@@ -119,6 +119,7 @@ int main(int argc, char **argv)
         {
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(conn));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
             struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
             strcpy(conn->application_protocol, "h2");

--- a/tests/unit/s2n_server_max_frag_len_extension_test.c
+++ b/tests/unit/s2n_server_max_frag_len_extension_test.c
@@ -1,0 +1,123 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "tls/extensions/s2n_server_max_fragment_length.h"
+#include "tls/s2n_tls.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Test should_send */
+    {
+        struct s2n_config *config;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        /* Should not send by default */
+        EXPECT_FALSE(s2n_server_max_fragment_length_extension.should_send(conn));
+
+        /* Should send if mfl code set. It is set by the client version of this extension. */
+        conn->mfl_code = S2N_TLS_MAX_FRAG_LEN_512;
+        EXPECT_TRUE(s2n_server_max_fragment_length_extension.should_send(conn));
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
+    /* Test send */
+    {
+        struct s2n_config *config;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+        EXPECT_SUCCESS(s2n_config_send_max_fragment_length(config, S2N_TLS_MAX_FRAG_LEN_512));
+
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        conn->mfl_code = S2N_TLS_MAX_FRAG_LEN_512;
+        EXPECT_SUCCESS(s2n_server_max_fragment_length_extension.send(conn, &stuffer));
+
+        /* Should have correct fragment length */
+        uint8_t actual_fragment_length;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint8(&stuffer, &actual_fragment_length));
+        EXPECT_EQUAL(actual_fragment_length, S2N_TLS_MAX_FRAG_LEN_512);
+
+        EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
+    /* Test receive - does not match requested value */
+    {
+        struct s2n_config *config;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+        EXPECT_SUCCESS(s2n_config_send_max_fragment_length(config, S2N_TLS_MAX_FRAG_LEN_512));
+
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        conn->mfl_code = S2N_TLS_MAX_FRAG_LEN_1024;
+        EXPECT_SUCCESS(s2n_server_max_fragment_length_extension.send(conn, &stuffer));
+
+        EXPECT_FAILURE_WITH_ERRNO(s2n_server_max_fragment_length_extension.recv(conn, &stuffer),
+                S2N_ERR_MAX_FRAG_LEN_MISMATCH);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
+    /* Test receive */
+    {
+        struct s2n_config *config;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+        EXPECT_SUCCESS(s2n_config_send_max_fragment_length(config, S2N_TLS_MAX_FRAG_LEN_512));
+
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        conn->mfl_code = S2N_TLS_MAX_FRAG_LEN_512;
+        EXPECT_SUCCESS(s2n_server_max_fragment_length_extension.send(conn, &stuffer));
+        EXPECT_NOT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
+        EXPECT_SUCCESS(s2n_server_max_fragment_length_extension.recv(conn, &stuffer));
+        EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
+    END_TEST();
+    return 0;
+}

--- a/tests/unit/s2n_server_renegotiation_info_test.c
+++ b/tests/unit/s2n_server_renegotiation_info_test.c
@@ -50,7 +50,7 @@ int main(int argc, char **argv)
         conn->secure_renegotiation = true;
         EXPECT_FALSE(s2n_server_renegotiation_info_extension.should_send(conn));
 
-        /* TLS1.2 and secure renegotiation enabled -> send! */
+        /* TLS1.2 and secure renegotiation enabled -> send */
         conn->actual_protocol_version = S2N_TLS12;
         conn->secure_renegotiation = true;
         EXPECT_TRUE(s2n_server_renegotiation_info_extension.should_send(conn));

--- a/tests/unit/s2n_server_renegotiation_info_test.c
+++ b/tests/unit/s2n_server_renegotiation_info_test.c
@@ -30,49 +30,99 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
-    struct s2n_config *config;
-    EXPECT_NOT_NULL(config = s2n_config_new());
+    /* Test should_send */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+
+        /* TLS1.2 and secure renegotiation not enabled -> DON'T send */
+        conn->actual_protocol_version = S2N_TLS12;
+        conn->secure_renegotiation = false;
+        EXPECT_FALSE(s2n_server_renegotiation_info_extension.should_send(conn));
+
+        /* TLS1.3 and secure renegotiation not enabled -> DON'T send */
+        conn->actual_protocol_version = S2N_TLS13;
+        conn->secure_renegotiation = false;
+        EXPECT_FALSE(s2n_server_renegotiation_info_extension.should_send(conn));
+
+        /* TLS1.3 and secure renegotiation enabled -> DON'T send */
+        conn->actual_protocol_version = S2N_TLS13;
+        conn->secure_renegotiation = true;
+        EXPECT_FALSE(s2n_server_renegotiation_info_extension.should_send(conn));
+
+        /* TLS1.2 and secure renegotiation enabled -> send! */
+        conn->actual_protocol_version = S2N_TLS12;
+        conn->secure_renegotiation = true;
+        EXPECT_TRUE(s2n_server_renegotiation_info_extension.should_send(conn));
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
 
     /* Test server_renegotiation_info send and recv */
     {
         struct s2n_connection *server_conn, *client_conn;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
-        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
-       /* Zero length extension expected as conn cannot send ext */
-        EXPECT_EQUAL(0, s2n_server_renegotiation_info_ext_size(server_conn));
-
-        /* Set connection to be able to send extension and verify size */
-        uint16_t expected_ext_length = 5;
+        struct s2n_stuffer extension;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&extension, 0));
 
         server_conn->actual_protocol_version = S2N_TLS12;
         server_conn->secure_renegotiation = 1;
-        EXPECT_EQUAL(expected_ext_length, s2n_server_renegotiation_info_ext_size(server_conn));
 
-        struct s2n_stuffer extension;
-        s2n_stuffer_alloc(&extension, s2n_server_renegotiation_info_ext_size(server_conn));
+        EXPECT_SUCCESS(s2n_server_renegotiation_info_extension.send(server_conn, &extension));
+        EXPECT_NOT_EQUAL(s2n_stuffer_data_available(&extension), 0);
 
-        EXPECT_SUCCESS(s2n_send_server_renegotiation_info_ext(server_conn, &extension));
-        EXPECT_EQUAL(s2n_stuffer_data_available(&extension), s2n_server_renegotiation_info_ext_size(server_conn));
-
-        uint16_t extension_type, extension_length;
-        s2n_stuffer_read_uint16(&extension, &extension_type);
-        s2n_stuffer_read_uint16(&extension, &extension_length);
-        EXPECT_EQUAL(extension_type, TLS_EXTENSION_RENEGOTIATION_INFO);
-        EXPECT_EQUAL(extension_length, 1);
-        EXPECT_EQUAL(s2n_stuffer_data_available(&extension), extension_length);
-
-        EXPECT_SUCCESS(s2n_recv_server_renegotiation_info_ext(client_conn, &extension));
+        EXPECT_SUCCESS(s2n_server_renegotiation_info_extension.recv(client_conn, &extension));
         EXPECT_EQUAL(client_conn->secure_renegotiation, 1);
+        EXPECT_EQUAL(s2n_stuffer_data_available(&extension), 0);
 
         EXPECT_SUCCESS(s2n_stuffer_free(&extension));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
     }
 
-    EXPECT_SUCCESS(s2n_config_free(config));
+    /* Test server_renegotiation_info recv - extension too long */
+    {
+        struct s2n_connection *server_conn, *client_conn;
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+
+        struct s2n_stuffer extension;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&extension, 0));
+
+        server_conn->actual_protocol_version = S2N_TLS12;
+        server_conn->secure_renegotiation = 1;
+
+        EXPECT_SUCCESS(s2n_server_renegotiation_info_extension.send(server_conn, &extension));
+        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&extension, 0));
+
+        EXPECT_FAILURE_WITH_ERRNO(s2n_server_renegotiation_info_extension.recv(client_conn, &extension),
+                S2N_ERR_NON_EMPTY_RENEGOTIATION_INFO);
+        EXPECT_EQUAL(client_conn->secure_renegotiation, 0);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&extension));
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+    }
+
+    /* Test server_renegotiation_info recv - extension length wrong */
+    {
+        struct s2n_connection *client_conn;
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+
+        struct s2n_stuffer extension;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&extension, 0));
+
+        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&extension, 5));
+
+        EXPECT_FAILURE_WITH_ERRNO(s2n_server_renegotiation_info_extension.recv(client_conn, &extension),
+                S2N_ERR_NON_EMPTY_RENEGOTIATION_INFO);
+        EXPECT_EQUAL(client_conn->secure_renegotiation, 0);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&extension));
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+    }
 
     END_TEST();
     return 0;

--- a/tls/extensions/s2n_cookie.h
+++ b/tls/extensions/s2n_cookie.h
@@ -16,14 +16,13 @@
 
 #pragma once
 
+#include "tls/extensions/s2n_extension_type.h"
 #include "tls/s2n_connection.h"
 #include "stuffer/s2n_stuffer.h"
 
-/* Return the length of cookie data in the connection */
+extern const s2n_extension_type s2n_server_cookie_extension;
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
 int s2n_extensions_cookie_size(struct s2n_connection *conn);
-
-/* Write the connection's cookie data to the output stuffer */
 int s2n_extensions_cookie_send(struct s2n_connection *conn, struct s2n_stuffer *out);
-
-/* Read cookie data out of the received extension, and save it in the connection */
 int s2n_extensions_cookie_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_server_alpn.c
+++ b/tls/extensions/s2n_server_alpn.c
@@ -68,6 +68,7 @@ static int s2n_alpn_recv(struct s2n_connection *conn, struct s2n_stuffer *extens
 
     uint8_t protocol_len;
     GUARD(s2n_stuffer_read_uint8(extension, &protocol_len));
+    lt_check(protocol_len, s2n_array_len(conn->application_protocol));
 
     uint8_t *protocol = s2n_stuffer_raw_read(extension, protocol_len);
     notnull_check(protocol);

--- a/tls/extensions/s2n_server_alpn.h
+++ b/tls/extensions/s2n_server_alpn.h
@@ -15,6 +15,13 @@
 
 #pragma once
 
+#include "tls/extensions/s2n_extension_type.h"
+#include "tls/s2n_connection.h"
+#include "stuffer/s2n_stuffer.h"
+
+extern const s2n_extension_type s2n_server_alpn_extension;
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
 int s2n_server_extensions_alpn_send_size(struct s2n_connection *conn);
 int s2n_server_extensions_alpn_send(struct s2n_connection *conn, struct s2n_stuffer *out);
 int s2n_recv_server_alpn(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_server_max_fragment_length.c
+++ b/tls/extensions/s2n_server_max_fragment_length.c
@@ -39,7 +39,7 @@ const s2n_extension_type s2n_server_max_fragment_length_extension = {
 
 static bool s2n_max_fragment_length_should_send(struct s2n_connection *conn)
 {
-    return conn && conn->mfl_code;
+    return conn && conn->mfl_code != S2N_TLS_MAX_FRAG_LEN_EXT_NONE;
 }
 
 static int s2n_max_fragment_length_send(struct s2n_connection *conn, struct s2n_stuffer *out)

--- a/tls/extensions/s2n_server_max_fragment_length.c
+++ b/tls/extensions/s2n_server_max_fragment_length.c
@@ -24,7 +24,44 @@
 
 #include "tls/extensions/s2n_server_max_fragment_length.h"
 
-/* Precalculate size of extension */
+static bool s2n_max_fragment_length_should_send(struct s2n_connection *conn);
+static int s2n_max_fragment_length_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+static int s2n_max_fragment_length_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
+
+const s2n_extension_type s2n_server_max_fragment_length_extension = {
+    .iana_value = TLS_EXTENSION_MAX_FRAG_LEN,
+    .is_response = true,
+    .send = s2n_max_fragment_length_send,
+    .recv = s2n_max_fragment_length_recv,
+    .should_send = s2n_max_fragment_length_should_send,
+    .if_missing = s2n_extension_noop_if_missing,
+};
+
+static bool s2n_max_fragment_length_should_send(struct s2n_connection *conn)
+{
+    return conn && conn->mfl_code;
+}
+
+static int s2n_max_fragment_length_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    notnull_check(conn);
+    GUARD(s2n_stuffer_write_uint8(out, conn->mfl_code));
+    return S2N_SUCCESS;
+}
+
+static int s2n_max_fragment_length_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    notnull_check(conn);
+    notnull_check(conn->config);
+
+    uint8_t mfl_code;
+    GUARD(s2n_stuffer_read_uint8(extension, &mfl_code));
+    S2N_ERROR_IF(mfl_code != conn->config->mfl_code, S2N_ERR_MAX_FRAG_LEN_MISMATCH);
+    return S2N_SUCCESS;
+}
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
+
 int s2n_server_extensions_max_fragment_length_send_size(struct s2n_connection *conn)
 {
     if (!conn->mfl_code) {
@@ -33,24 +70,12 @@ int s2n_server_extensions_max_fragment_length_send_size(struct s2n_connection *c
     return 2 * sizeof(uint16_t) + 1 * sizeof(uint8_t);
 }
 
-/* Write MFL extension */
 int s2n_server_extensions_max_fragment_length_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    if (!conn->mfl_code) {
-        return 0;
-    }
-    GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_MAX_FRAG_LEN));
-    GUARD(s2n_stuffer_write_uint16(out, sizeof(uint8_t)));
-    GUARD(s2n_stuffer_write_uint8(out, conn->mfl_code));
-
-    return 0;
+    return s2n_extension_send(&s2n_server_max_fragment_length_extension, conn, out);
 }
 
 int s2n_recv_server_max_fragment_length(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
-    uint8_t mfl_code;
-    GUARD(s2n_stuffer_read_uint8(extension, &mfl_code));
-    S2N_ERROR_IF(mfl_code != conn->config->mfl_code, S2N_ERR_MAX_FRAG_LEN_MISMATCH);
-
-    return 0;
+    return s2n_extension_recv(&s2n_server_max_fragment_length_extension, conn, extension);
 }

--- a/tls/extensions/s2n_server_max_fragment_length.h
+++ b/tls/extensions/s2n_server_max_fragment_length.h
@@ -15,6 +15,13 @@
 
 #pragma once
 
+#include "tls/extensions/s2n_extension_type.h"
+#include "tls/s2n_connection.h"
+#include "stuffer/s2n_stuffer.h"
+
+extern const s2n_extension_type s2n_server_max_fragment_length_extension;
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
 int s2n_server_extensions_max_fragment_length_send_size(struct s2n_connection *conn);
 int s2n_server_extensions_max_fragment_length_send(struct s2n_connection *conn, struct s2n_stuffer *out);
 int s2n_recv_server_max_fragment_length(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_server_renegotiation_info.h
+++ b/tls/extensions/s2n_server_renegotiation_info.h
@@ -15,6 +15,13 @@
 
 #pragma once
 
+#include "tls/extensions/s2n_extension_type.h"
+#include "tls/s2n_connection.h"
+#include "stuffer/s2n_stuffer.h"
+
+extern const s2n_extension_type s2n_server_renegotiation_info_extension;
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
 int s2n_recv_server_renegotiation_info_ext(struct s2n_connection *conn, struct s2n_stuffer *extension);
 int s2n_send_server_renegotiation_info_ext(struct s2n_connection *conn, struct s2n_stuffer *out);
 int s2n_server_renegotiation_info_ext_size(struct s2n_connection *conn);


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

### Description of changes: 
Move the next 4 extensions into the new structures. For each extension, I:

- create the struct
- move current send and receive logic into static methods linked to the struct
- remove type + size from what the send method sends
- write static should_send method based on the existing logic in s2n_server_extensions/s2n_encrypted_extensions
- replace current send and receive methods with calls to s2n_extension_send/recv

### Call-outs:
This is part of a larger task: #1817

The existing send/receive methods are left for now, but reference the new methods.

The alpn and max_frag extensions are marked as responses, meaning that they can only be sent/received if a corresponding request is sent/received.

### Testing:

I added unit tests for extensions that didn't already have them. I mostly rewrote the cookie tests, because they previously relied heavily on the size function and were doing some unnecessary blob manipulation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
