### PR TITLE
Refactor fifth set of extension structs

### DIFF
--- a/tests/unit/s2n_encrypted_extensions_test.c
+++ b/tests/unit/s2n_encrypted_extensions_test.c
@@ -74,6 +74,7 @@ int main(int argc, char **argv)
         const uint8_t ENCRYPTED_EXTENSIONS_HEADER_SIZE = 2;
         struct s2n_connection *server_conn;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(server_conn));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
         server_conn->actual_protocol_version = S2N_TLS13;
         EXPECT_EQUAL(s2n_encrypted_extensions_send_size(server_conn), 0);
@@ -130,6 +131,7 @@ int main(int argc, char **argv)
     {
         struct s2n_connection *client_conn;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(client_conn));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
         client_conn->actual_protocol_version = S2N_TLS13;
 

--- a/tests/unit/s2n_server_extensions_test.c
+++ b/tests/unit/s2n_server_extensions_test.c
@@ -85,6 +85,7 @@ int main(int argc, char **argv)
         {
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(conn));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
             struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
 

--- a/tests/unit/s2n_server_extensions_test.c
+++ b/tests/unit/s2n_server_extensions_test.c
@@ -259,6 +259,7 @@ int main(int argc, char **argv)
         {
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(conn));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
             struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
 

--- a/tests/unit/s2n_server_server_name_extension_test.c
+++ b/tests/unit/s2n_server_server_name_extension_test.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "tls/extensions/s2n_server_server_name.h"
+
+#define S2N_TEST_RESUMPTION_HANDSHAKE (NEGOTIATED)
+#define S2N_TEST_NOT_RESUMPTION_HANDSHAKE (NEGOTIATED | FULL_HANDSHAKE)
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    EXPECT_TRUE(IS_RESUMPTION_HANDSHAKE(S2N_TEST_RESUMPTION_HANDSHAKE));
+    EXPECT_FALSE(IS_RESUMPTION_HANDSHAKE(S2N_TEST_NOT_RESUMPTION_HANDSHAKE));
+
+    /* should_send */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+        /* By default, do not send */
+        EXPECT_FALSE(s2n_server_server_name_extension.should_send(conn));
+
+        /* server_name not used and resumption handshake -> do not send */
+        conn->server_name_used = false;
+        conn->handshake.handshake_type = S2N_TEST_RESUMPTION_HANDSHAKE;
+        EXPECT_FALSE(s2n_server_server_name_extension.should_send(conn));
+
+        /* server_name used and resumption handshake -> do not send */
+        conn->server_name_used = true;
+        conn->handshake.handshake_type = S2N_TEST_RESUMPTION_HANDSHAKE;
+        EXPECT_FALSE(s2n_server_server_name_extension.should_send(conn));
+
+        /* server_name not used and not resumption handshake -> do not send */
+        conn->server_name_used = false;
+        conn->handshake.handshake_type = S2N_TEST_NOT_RESUMPTION_HANDSHAKE;
+        EXPECT_FALSE(s2n_server_server_name_extension.should_send(conn));
+
+        /* server_name used and not resumption handshake -> send */
+        conn->server_name_used = true;
+        conn->handshake.handshake_type = S2N_TEST_NOT_RESUMPTION_HANDSHAKE;
+        EXPECT_TRUE(s2n_server_server_name_extension.should_send(conn));
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* send */
+    {
+        /* Send writes nothing and always succeeds. */
+        EXPECT_SUCCESS(s2n_server_server_name_extension.send(NULL, NULL));
+    }
+
+    /* recv */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+        /* Recv reads nothing and always succeeds */
+        EXPECT_FALSE(conn->server_name_used);
+        EXPECT_SUCCESS(s2n_server_server_name_extension.recv(conn, NULL));
+        EXPECT_TRUE(conn->server_name_used);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    END_TEST();
+    return 0;
+}

--- a/tests/unit/s2n_server_session_ticket_extension_test.c
+++ b/tests/unit/s2n_server_session_ticket_extension_test.c
@@ -64,6 +64,11 @@ int main(int argc, char **argv)
         conn->session_ticket_status = S2N_DECRYPT_TICKET;
         EXPECT_FALSE(s2n_server_session_ticket_extension.should_send(conn));
 
+        /* If no ticket, do not send */
+        EXPECT_SUCCESS(s2n_test_enable_extension(conn));
+        conn->session_ticket_status = S2N_NO_TICKET;
+        EXPECT_FALSE(s2n_server_session_ticket_extension.should_send(conn));
+
         /* If protocol version too high, do not send */
         EXPECT_SUCCESS(s2n_test_enable_extension(conn));
         conn->actual_protocol_version = S2N_TLS13;

--- a/tests/unit/s2n_server_signature_algorithms_extension_test.c
+++ b/tests/unit/s2n_server_signature_algorithms_extension_test.c
@@ -41,17 +41,9 @@ int main(int argc, char **argv)
 
         struct s2n_stuffer io;
         s2n_stuffer_alloc(&io, s2n_extensions_server_signature_algorithms_size(server_conn));
-        EXPECT_SUCCESS(s2n_extensions_server_signature_algorithms_send(server_conn, &io));
+        EXPECT_SUCCESS(s2n_server_signature_algorithms_extension.send(server_conn, &io));
 
-        uint16_t extension_type;
-        EXPECT_SUCCESS(s2n_stuffer_read_uint16(&io, &extension_type));
-        EXPECT_EQUAL(extension_type, TLS_EXTENSION_SIGNATURE_ALGORITHMS);
-
-        uint16_t extension_size;
-        EXPECT_SUCCESS(s2n_stuffer_read_uint16(&io, &extension_size));
-        EXPECT_EQUAL(extension_size, s2n_stuffer_data_available(&io));
-
-        EXPECT_SUCCESS(s2n_extensions_server_signature_algorithms_recv(client_conn, &io));
+        EXPECT_SUCCESS(s2n_server_signature_algorithms_extension.recv(client_conn, &io));
         EXPECT_EQUAL(s2n_stuffer_data_available(&io), 0);
 
         EXPECT_EQUAL(client_conn->handshake_params.server_sig_hash_algs.len, s2n_supported_sig_schemes_count(server_conn));

--- a/tls/extensions/s2n_server_server_name.c
+++ b/tls/extensions/s2n_server_server_name.c
@@ -18,11 +18,42 @@
 #include "tls/s2n_connection.h"
 #include "tls/extensions/s2n_server_server_name.h"
 
-#define s2n_server_can_send_server_name(conn) ((conn)->server_name_used && \
-        !s2n_connection_is_session_resumed((conn)))
+static bool s2n_server_name_should_send(struct s2n_connection *conn);
+static int s2n_server_name_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+static int s2n_server_name_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
+
+const s2n_extension_type s2n_server_server_name_extension = {
+    .iana_value = TLS_EXTENSION_SERVER_NAME,
+    .is_response = true,
+    .send = s2n_server_name_send,
+    .recv = s2n_server_name_recv,
+    .should_send = s2n_server_name_should_send,
+    .if_missing = s2n_extension_noop_if_missing,
+};
+
+static bool s2n_server_name_should_send(struct s2n_connection *conn)
+{
+    return conn && conn->server_name_used && !s2n_connection_is_session_resumed(conn);
+}
+
+int s2n_server_name_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    /* Write nothing. The extension just needs to exist. */
+    return S2N_SUCCESS;
+}
+
+int s2n_server_name_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    notnull_check(conn);
+    /* Read nothing. The extension just needs to exist. */
+    conn->server_name_used = 1;
+    return S2N_SUCCESS;
+}
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
 
 int s2n_server_extensions_server_name_send_size(struct s2n_connection *conn) {
-    if (!s2n_server_can_send_server_name(conn)) {
+    if (!s2n_server_name_should_send(conn)) {
         return 0;
     }
 
@@ -31,18 +62,10 @@ int s2n_server_extensions_server_name_send_size(struct s2n_connection *conn) {
 
 int s2n_server_extensions_server_name_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    if (!s2n_server_can_send_server_name(conn)) {
-        return 0;
-    }
-
-    GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_SERVER_NAME));
-    GUARD(s2n_stuffer_write_uint16(out, 0));
-
-    return 0;
+    return s2n_extension_send(&s2n_server_server_name_extension, conn, out);
 }
 
 int s2n_recv_server_server_name(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
-    conn->server_name_used = 1;
-    return 0;
+    return s2n_extension_recv(&s2n_server_server_name_extension, conn, extension);
 }

--- a/tls/extensions/s2n_server_server_name.c
+++ b/tls/extensions/s2n_server_server_name.c
@@ -36,13 +36,13 @@ static bool s2n_server_name_should_send(struct s2n_connection *conn)
     return conn && conn->server_name_used && !s2n_connection_is_session_resumed(conn);
 }
 
-int s2n_server_name_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+static int s2n_server_name_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
     /* Write nothing. The extension just needs to exist. */
     return S2N_SUCCESS;
 }
 
-int s2n_server_name_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
+static int s2n_server_name_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
     notnull_check(conn);
     /* Read nothing. The extension just needs to exist. */

--- a/tls/extensions/s2n_server_server_name.h
+++ b/tls/extensions/s2n_server_server_name.h
@@ -15,6 +15,13 @@
 
 #pragma once
 
+#include "tls/extensions/s2n_extension_type.h"
+#include "tls/s2n_connection.h"
+#include "stuffer/s2n_stuffer.h"
+
+extern const s2n_extension_type s2n_server_server_name_extension;
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
 int s2n_server_extensions_server_name_send_size(struct s2n_connection *conn);
 int s2n_server_extensions_server_name_send(struct s2n_connection *conn, struct s2n_stuffer *out);
 int s2n_recv_server_server_name(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_server_session_ticket.c
+++ b/tls/extensions/s2n_server_session_ticket.c
@@ -38,13 +38,13 @@ static bool s2n_session_ticket_should_send(struct s2n_connection *conn)
     return s2n_server_sending_nst(conn) && s2n_connection_get_protocol_version(conn) < S2N_TLS13;
 }
 
-int s2n_session_ticket_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+static int s2n_session_ticket_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
     /* Write nothing. The extension just needs to exist. */
     return S2N_SUCCESS;
 }
 
-int s2n_session_ticket_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
+static int s2n_session_ticket_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
     /* Read nothing. The extension just needs to exist. */
     notnull_check(conn);

--- a/tls/extensions/s2n_server_session_ticket.h
+++ b/tls/extensions/s2n_server_session_ticket.h
@@ -15,6 +15,13 @@
 
 #pragma once
 
+#include "tls/extensions/s2n_extension_type.h"
+#include "tls/s2n_connection.h"
+#include "stuffer/s2n_stuffer.h"
+
+extern const s2n_extension_type s2n_server_session_ticket_extension;
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
 int s2n_recv_server_session_ticket_ext(struct s2n_connection *conn, struct s2n_stuffer *extension);
 int s2n_send_server_session_ticket_ext(struct s2n_connection *conn, struct s2n_stuffer *out);
 int s2n_server_session_ticket_ext_size(struct s2n_connection *conn);

--- a/tls/extensions/s2n_server_signature_algorithms.h
+++ b/tls/extensions/s2n_server_signature_algorithms.h
@@ -15,9 +15,13 @@
 
 #pragma once
 
+#include "tls/extensions/s2n_extension_type.h"
 #include "tls/s2n_connection.h"
 #include "stuffer/s2n_stuffer.h"
 
+extern const s2n_extension_type s2n_server_signature_algorithms_extension;
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
 int s2n_extensions_server_signature_algorithms_send(struct s2n_connection *conn, struct s2n_stuffer *out);
 int s2n_extensions_server_signature_algorithms_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
 int s2n_extensions_server_signature_algorithms_size(struct s2n_connection *conn);


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

### Description of changes: 

Move the next 3 extensions into the new structures. For each extension, I:
- create the struct
- move current send and receive logic into static methods linked to the struct
- remove type + size from what the send method sends
- write static should_send method based on the existing logic in s2n_server_extensions/s2n_encrypted_extensions/where the extension is sent from
- replace current send and receive methods with calls to s2n_extension_send/recv

### Call-outs:

This is part of a larger task: #1817

The server session ticket and server name extensions are marked as "responses." This means that we won't receive / send them unless we have sent / received the corresponding request extensions.

The server signature algorithms extension has its "is_missing" function pointer set to s2n_extension_error_if_missing. This isn't new behavior: it matches [the logic currently in the cert request message](https://github.com/awslabs/s2n/blob/master/tls/extensions/s2n_server_certificate_request_extensions.c#L68-L71).

### Testing:

I add missing unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
