### PR TITLE
Refactor sixth set of extension structs

### DIFF
--- a/tests/fuzz/s2n_certificate_extensions_parse_test.c
+++ b/tests/fuzz/s2n_certificate_extensions_parse_test.c
@@ -14,7 +14,7 @@
  */
 
 /* Target Functions: s2n_certificate_extensions_parse
-                     s2n_recv_server_sct_list s2n_server_certificate_status_parse
+                     s2n_recv_server_sct_list s2n_server_certificate_status_recv
                      s2n_x509_validator_validate_cert_stapled_ocsp_response */
 
 #include <stdint.h>

--- a/tests/unit/s2n_certificate_extensions_test.c
+++ b/tests/unit/s2n_certificate_extensions_test.c
@@ -372,6 +372,7 @@ int main(int argc, char **argv)
     {
         struct s2n_connection *server_conn;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(server_conn));
 
         s2n_stack_blob(sct_list, SCT_LIST_SIZE, SCT_LIST_SIZE);
         s2n_stack_blob(raw, RAW_CERT_SIZE, RAW_CERT_SIZE);
@@ -460,6 +461,7 @@ int main(int argc, char **argv)
     {
         struct s2n_connection *server_conn;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(server_conn));
 
         s2n_stack_blob(ocsp_status, OCSP_SIZE, OCSP_SIZE);
         s2n_stack_blob(sct_list, SCT_LIST_SIZE, SCT_LIST_SIZE);

--- a/tests/unit/s2n_certificate_extensions_test.c
+++ b/tests/unit/s2n_certificate_extensions_test.c
@@ -34,6 +34,7 @@
 /* with invalid certificate extension (supported version) on the end */
 const char tls13_cert_invalid_ext_hex[] =
     "000001bb0001b03082" /* without 0b0001b9 header */
+/*  x000001bb == message size (443)                 */
     "01ac30820115a003020102020102300d06092a8648"
     "86f70d01010b0500300e310c300a06035504031303"
     "727361301e170d3136303733303031323335395a17"
@@ -54,12 +55,18 @@ const char tls13_cert_invalid_ext_hex[] =
     "5156726096fd335e5e67f2dbf102702e608ccae6be"
     "c1fc63a42a99be5c3eb7107c3c54e9b9eb2bd5203b"
     "1c3b84e0a8b2f759409ba3eac9d91d402dcc0cc8f8"
-    "961229ac9187b42b4de10006002b00020103";
+    "961229ac9187b42b4de10006002b00020304";
+/*   Extensions:        x0006 == total extension list size (6)
+ *                          x002b == extension type (supported_versions)
+ *                              x0002 == extension size (2)
+ *                                  x0304 == protocol version (1.3)
+ */
 
 /* with single extension sent */
 /* server can send empty status request extension from https://tools.ietf.org/html/rfc8446#section-4.4.2.1 */
 const char tls13_cert_single_ext_hex[] =
     "000001ba0001b03082" /* without 0b0001b9 header */
+/*  x000001ba == message size (442)                 */
     "01ac30820115a003020102020102300d06092a8648"
     "86f70d01010b0500300e310c300a06035504031303"
     "727361301e170d3136303733303031323335395a17"
@@ -81,6 +88,11 @@ const char tls13_cert_single_ext_hex[] =
     "c1fc63a42a99be5c3eb7107c3c54e9b9eb2bd5203b"
     "1c3b84e0a8b2f759409ba3eac9d91d402dcc0cc8f8"
     "961229ac9187b42b4de100050005000100";
+/*   Extensions:        x0005 == total extension list size (5)
+ *                          x0005 == extension type (status_request)
+ *                              x0001 == extension size (1)
+ *                                  x00   == status request type (no status request)
+ */
 
 
 int main(int argc, char **argv)

--- a/tests/unit/s2n_certificate_extensions_test.c
+++ b/tests/unit/s2n_certificate_extensions_test.c
@@ -59,7 +59,7 @@ const char tls13_cert_invalid_ext_hex[] =
 /* with single extension sent */
 /* server can send empty status request extension from https://tools.ietf.org/html/rfc8446#section-4.4.2.1 */
 const char tls13_cert_single_ext_hex[] =
-    "000001b90001b03082" /* without 0b0001b9 header */
+    "000001ba0001b03082" /* without 0b0001b9 header */
     "01ac30820115a003020102020102300d06092a8648"
     "86f70d01010b0500300e310c300a06035504031303"
     "727361301e170d3136303733303031323335395a17"
@@ -80,7 +80,7 @@ const char tls13_cert_single_ext_hex[] =
     "5156726096fd335e5e67f2dbf102702e608ccae6be"
     "c1fc63a42a99be5c3eb7107c3c54e9b9eb2bd5203b"
     "1c3b84e0a8b2f759409ba3eac9d91d402dcc0cc8f8"
-    "961229ac9187b42b4de1000400050000";
+    "961229ac9187b42b4de100050005000100";
 
 
 int main(int argc, char **argv)
@@ -239,10 +239,11 @@ int main(int argc, char **argv)
     {
         struct s2n_connection *client_conn;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(client_conn));
 
         S2N_BLOB_FROM_HEX(tls13_cert, tls13_cert_single_ext_hex);
         EXPECT_SUCCESS(s2n_stuffer_write(&client_conn->handshake.io, &tls13_cert));
-        EXPECT_EQUAL(s2n_stuffer_data_available(&client_conn->handshake.io), 445);
+        EXPECT_EQUAL(s2n_stuffer_data_available(&client_conn->handshake.io), 446);
 
         client_conn->x509_validator.skip_cert_validation = 1;
         EXPECT_SUCCESS(s2n_server_cert_recv(client_conn));
@@ -280,6 +281,7 @@ int main(int argc, char **argv)
     {
         struct s2n_connection *server_conn;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(server_conn));
 
         s2n_stack_blob(ocsp_status, OCSP_SIZE, OCSP_SIZE);
         s2n_stack_blob(raw, RAW_CERT_SIZE, RAW_CERT_SIZE);
@@ -347,6 +349,7 @@ int main(int argc, char **argv)
         /* The current behaviour does not send OCSP stapling in client mode */
         struct s2n_connection *client_conn;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(client_conn));
         client_conn->status_type = S2N_STATUS_REQUEST_OCSP;
         client_conn->handshake_params.our_chain_and_key = &chain_and_key;
 

--- a/tests/unit/s2n_server_certificate_status_test.c
+++ b/tests/unit/s2n_server_certificate_status_test.c
@@ -1,0 +1,152 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+
+#include "tls/extensions/s2n_server_certificate_status.h"
+
+const uint8_t ocsp_data[] = "OCSP DATA";
+struct s2n_cert_chain_and_key *chain_and_key;
+
+int s2n_test_enable_sending_extension(struct s2n_connection *conn)
+{
+    conn->mode = S2N_SERVER;
+    conn->status_type = S2N_STATUS_REQUEST_OCSP;
+    conn->handshake_params.our_chain_and_key = chain_and_key;
+    EXPECT_SUCCESS(s2n_cert_chain_and_key_set_ocsp_data(chain_and_key, ocsp_data, s2n_array_len(ocsp_data)));
+    return S2N_SUCCESS;
+}
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
+            S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
+
+    /* should_send */
+    {
+        struct s2n_config *config;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        /* Don't send by default */
+        EXPECT_FALSE(s2n_tls13_server_status_request_extension.should_send(conn));
+
+        /* Send if all prerequisites met */
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_TRUE(s2n_tls13_server_status_request_extension.should_send(conn));
+
+        /* Don't send if client */
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        conn->mode = S2N_CLIENT;
+        EXPECT_FALSE(s2n_tls13_server_status_request_extension.should_send(conn));
+
+        /* Don't send if no status request configured */
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        conn->status_type = S2N_STATUS_REQUEST_NONE;
+        EXPECT_FALSE(s2n_tls13_server_status_request_extension.should_send(conn));
+
+        /* Don't send if no certificate set */
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        conn->handshake_params.our_chain_and_key = NULL;
+        EXPECT_FALSE(s2n_tls13_server_status_request_extension.should_send(conn));
+
+        /* Don't send if no ocsp data */
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_SUCCESS(s2n_free(&conn->handshake_params.our_chain_and_key->ocsp_status));
+        EXPECT_FALSE(s2n_tls13_server_status_request_extension.should_send(conn));
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
+    /* Test send */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        EXPECT_SUCCESS(s2n_tls13_server_status_request_extension.send(conn, &stuffer));
+
+        uint8_t request_type;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint8(&stuffer, &request_type));
+        EXPECT_EQUAL(request_type, S2N_STATUS_REQUEST_OCSP);
+
+        uint32_t ocsp_size;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint24(&stuffer, &ocsp_size));
+        EXPECT_EQUAL(ocsp_size, s2n_stuffer_data_available(&stuffer));
+        EXPECT_EQUAL(ocsp_size, s2n_array_len(ocsp_data));
+
+        uint8_t *actual_ocsp_data;
+        EXPECT_NOT_NULL(actual_ocsp_data = s2n_stuffer_raw_read(&stuffer, ocsp_size));
+        EXPECT_BYTEARRAY_EQUAL(actual_ocsp_data, ocsp_data, ocsp_size);
+
+        EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test recv */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        EXPECT_SUCCESS(s2n_tls13_server_status_request_extension.send(conn, &stuffer));
+
+        EXPECT_EQUAL(conn->status_response.size, 0);
+        EXPECT_SUCCESS(s2n_tls13_server_status_request_extension.recv(conn, &stuffer));
+        EXPECT_BYTEARRAY_EQUAL(conn->status_response.data, ocsp_data, s2n_array_len(ocsp_data));
+
+        EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test recv - not ocsp */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, S2N_STATUS_REQUEST_NONE));
+
+        EXPECT_EQUAL(conn->status_response.size, 0);
+        EXPECT_SUCCESS(s2n_tls13_server_status_request_extension.recv(conn, &stuffer));
+        EXPECT_EQUAL(conn->status_response.size, 0);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    END_TEST();
+    return 0;
+}

--- a/tests/unit/s2n_server_extensions_test.c
+++ b/tests/unit/s2n_server_extensions_test.c
@@ -208,6 +208,7 @@ int main(int argc, char **argv)
         {
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(conn));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
             struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
 

--- a/tests/unit/s2n_server_extensions_test.c
+++ b/tests/unit/s2n_server_extensions_test.c
@@ -179,6 +179,7 @@ int main(int argc, char **argv)
         {
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(conn));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
             struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
 

--- a/tests/unit/s2n_server_sct_list_extension_test.c
+++ b/tests/unit/s2n_server_sct_list_extension_test.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+
+#include "tls/extensions/s2n_server_sct_list.h"
+
+const uint8_t sct_list_data[] = "SCT LIST DATA";
+struct s2n_cert_chain_and_key *chain_and_key;
+
+int s2n_test_enable_sending_extension(struct s2n_connection *conn)
+{
+    conn->mode = S2N_SERVER;
+    conn->ct_level_requested = S2N_CT_SUPPORT_REQUEST;
+    conn->handshake_params.our_chain_and_key = chain_and_key;
+    EXPECT_SUCCESS(s2n_cert_chain_and_key_set_sct_list(chain_and_key, sct_list_data, s2n_array_len(sct_list_data)));
+    return S2N_SUCCESS;
+}
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
+            S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
+
+    /* should_send */
+    {
+        struct s2n_config *config;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        /* Don't send by default */
+        EXPECT_FALSE(s2n_server_sct_list_extension.should_send(conn));
+
+        /* Send if all prerequisites met */
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_TRUE(s2n_server_sct_list_extension.should_send(conn));
+
+        /* Don't send if client */
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        conn->mode = S2N_CLIENT;
+        EXPECT_FALSE(s2n_server_sct_list_extension.should_send(conn));
+
+        /* Don't send if certificate transparency not requested */
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        conn->ct_level_requested = S2N_CT_SUPPORT_NONE;
+        EXPECT_FALSE(s2n_server_sct_list_extension.should_send(conn));
+
+        /* Don't send if no certificate set */
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        conn->handshake_params.our_chain_and_key = NULL;
+        EXPECT_FALSE(s2n_server_sct_list_extension.should_send(conn));
+
+        /* Don't send if no ocsp data */
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_SUCCESS(s2n_free(&conn->handshake_params.our_chain_and_key->sct_list));
+        EXPECT_FALSE(s2n_server_sct_list_extension.should_send(conn));
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
+    /* Test send */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        EXPECT_SUCCESS(s2n_server_sct_list_extension.send(conn, &stuffer));
+
+        EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), s2n_array_len(sct_list_data));
+        EXPECT_BYTEARRAY_EQUAL(stuffer.blob.data, sct_list_data, s2n_array_len(sct_list_data));
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test recv */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        EXPECT_SUCCESS(s2n_server_sct_list_extension.send(conn, &stuffer));
+
+        EXPECT_EQUAL(conn->ct_response.size, 0);
+        EXPECT_SUCCESS(s2n_server_sct_list_extension.recv(conn, &stuffer));
+        EXPECT_EQUAL(conn->ct_response.size, s2n_array_len(sct_list_data));
+        EXPECT_BYTEARRAY_EQUAL(conn->ct_response.data, sct_list_data, s2n_array_len(sct_list_data));
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    END_TEST();
+    return 0;
+}

--- a/tests/unit/s2n_server_status_request_extension_test.c
+++ b/tests/unit/s2n_server_status_request_extension_test.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+
+#include "tls/extensions/s2n_server_status_request.h"
+
+const uint8_t ocsp_data[] = "OCSP DATA";
+struct s2n_cert_chain_and_key *chain_and_key;
+
+int s2n_test_enable_sending_extension(struct s2n_connection *conn)
+{
+    conn->mode = S2N_SERVER;
+    conn->status_type = S2N_STATUS_REQUEST_OCSP;
+    conn->handshake_params.our_chain_and_key = chain_and_key;
+    EXPECT_SUCCESS(s2n_cert_chain_and_key_set_ocsp_data(chain_and_key, ocsp_data, s2n_array_len(ocsp_data)));
+    return S2N_SUCCESS;
+}
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
+            S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
+
+    /* should_send */
+    {
+        struct s2n_config *config;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        /* Don't send by default */
+        EXPECT_FALSE(s2n_server_status_request_extension.should_send(conn));
+
+        /* Send if all prerequisites met */
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_TRUE(s2n_server_status_request_extension.should_send(conn));
+
+        /* Don't send if client */
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        conn->mode = S2N_CLIENT;
+        EXPECT_FALSE(s2n_server_status_request_extension.should_send(conn));
+
+        /* Don't send if no status request configured */
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        conn->status_type = S2N_STATUS_REQUEST_NONE;
+        EXPECT_FALSE(s2n_server_status_request_extension.should_send(conn));
+
+        /* Don't send if no certificate set */
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        conn->handshake_params.our_chain_and_key = NULL;
+        EXPECT_FALSE(s2n_server_status_request_extension.should_send(conn));
+
+        /* Don't send if no ocsp data */
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_SUCCESS(s2n_free(&conn->handshake_params.our_chain_and_key->ocsp_status));
+        EXPECT_FALSE(s2n_server_status_request_extension.should_send(conn));
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
+    /* Set oscp data */
+    EXPECT_SUCCESS(s2n_cert_chain_and_key_set_ocsp_data(chain_and_key, ocsp_data, s2n_array_len(ocsp_data)));
+
+    /* Test send and recv */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+
+        EXPECT_SUCCESS(s2n_server_status_request_extension.send(conn, NULL));
+
+        EXPECT_EQUAL(conn->status_type, S2N_STATUS_REQUEST_NONE);
+        EXPECT_SUCCESS(s2n_server_status_request_extension.recv(conn, NULL));
+        EXPECT_EQUAL(conn->status_type, S2N_STATUS_REQUEST_OCSP);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    END_TEST();
+    return 0;
+}

--- a/tls/extensions/s2n_certificate_extensions.c
+++ b/tls/extensions/s2n_certificate_extensions.c
@@ -66,7 +66,7 @@ int s2n_certificate_extensions_parse(struct s2n_connection *conn, struct s2n_blo
             }
             break;
         case TLS_EXTENSION_STATUS_REQUEST:
-            GUARD(s2n_server_certificate_status_parse(conn, &ext));
+            GUARD(s2n_tls13_ocsp_extension_recv(conn, &ext));
             break;
         /* Error on known extensions that are not supposed to appear in EE
          * https://tools.ietf.org/html/rfc8446#page-37

--- a/tls/extensions/s2n_server_certificate_status.c
+++ b/tls/extensions/s2n_server_certificate_status.c
@@ -33,7 +33,7 @@ const s2n_extension_type s2n_tls13_server_status_request_extension = {
     .iana_value = TLS_EXTENSION_STATUS_REQUEST,
     .is_response = true,
     .send = s2n_server_certificate_status_send,
-    .recv = s2n_server_certificate_status_parse,
+    .recv = s2n_server_certificate_status_recv,
     .should_send = s2n_tls13_server_status_request_should_send,
     .if_missing = s2n_extension_noop_if_missing,
 };
@@ -53,16 +53,16 @@ int s2n_server_certificate_status_send(struct s2n_connection *conn, struct s2n_s
     GUARD(s2n_stuffer_write_uint24(out, ocsp_status->size));
     GUARD(s2n_stuffer_write(out, ocsp_status));
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
-int s2n_server_certificate_status_parse(struct s2n_connection *conn, struct s2n_stuffer *in)
+int s2n_server_certificate_status_recv(struct s2n_connection *conn, struct s2n_stuffer *in)
 {
     notnull_check(conn);
 
     uint8_t type;
     GUARD(s2n_stuffer_read_uint8(in, &type));
-    if (type != S2N_STATUS_REQUEST_OCSP ) {
+    if (type != S2N_STATUS_REQUEST_OCSP) {
         /* We only support OCSP */
         return S2N_SUCCESS;
     }

--- a/tls/extensions/s2n_server_certificate_status.h
+++ b/tls/extensions/s2n_server_certificate_status.h
@@ -15,7 +15,16 @@
 
 #pragma once
 
+#include "tls/extensions/s2n_extension_type.h"
+#include "tls/s2n_connection.h"
+#include "stuffer/s2n_stuffer.h"
+
+extern const s2n_extension_type s2n_tls13_server_status_request_extension;
+
+int s2n_server_certificate_status_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+int s2n_server_certificate_status_parse(struct s2n_connection *conn, struct s2n_stuffer *in);
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
 int s2n_tls13_ocsp_extension_send_size(struct s2n_connection *conn);
 int s2n_tls13_ocsp_extension_send(struct s2n_connection *conn, struct s2n_stuffer *out);
-int s2n_server_certificate_status_send(struct s2n_connection *conn, struct s2n_stuffer *out);
-int s2n_server_certificate_status_parse(struct s2n_connection *conn, struct s2n_blob *status);
+int s2n_tls13_ocsp_extension_recv(struct s2n_connection *conn, struct s2n_blob *extension);

--- a/tls/extensions/s2n_server_certificate_status.h
+++ b/tls/extensions/s2n_server_certificate_status.h
@@ -22,7 +22,7 @@
 extern const s2n_extension_type s2n_tls13_server_status_request_extension;
 
 int s2n_server_certificate_status_send(struct s2n_connection *conn, struct s2n_stuffer *out);
-int s2n_server_certificate_status_parse(struct s2n_connection *conn, struct s2n_stuffer *in);
+int s2n_server_certificate_status_recv(struct s2n_connection *conn, struct s2n_stuffer *in);
 
 /* Old-style extension functions -- remove after extensions refactor is complete */
 int s2n_tls13_ocsp_extension_send_size(struct s2n_connection *conn);

--- a/tls/extensions/s2n_server_sct_list.c
+++ b/tls/extensions/s2n_server_sct_list.c
@@ -52,10 +52,12 @@ int s2n_server_sct_list_send(struct s2n_connection *conn, struct s2n_stuffer *ou
 
 int s2n_server_sct_list_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
-    struct s2n_blob sct_list = { .data = NULL, .size = 0 };
+    notnull_check(conn);
 
-    sct_list.size = s2n_stuffer_data_available(extension);
-    sct_list.data = s2n_stuffer_raw_read(extension, sct_list.size);
+    struct s2n_blob sct_list;
+    GUARD(s2n_blob_init(&sct_list,
+            s2n_stuffer_raw_read(extension, s2n_stuffer_data_available(extension)),
+            s2n_stuffer_data_available(extension)));
     notnull_check(sct_list.data);
 
     GUARD(s2n_dup(&sct_list, &conn->ct_response));

--- a/tls/extensions/s2n_server_sct_list.c
+++ b/tls/extensions/s2n_server_sct_list.c
@@ -21,6 +21,50 @@
 #include "utils/s2n_safety.h"
 #include "utils/s2n_blob.h"
 
+static bool s2n_server_sct_list_should_send(struct s2n_connection *conn);
+static int s2n_server_sct_list_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+static int s2n_server_sct_list_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
+
+const s2n_extension_type s2n_server_sct_list_extension = {
+    .iana_value = TLS_EXTENSION_SCT_LIST,
+    .is_response = true,
+    .send = s2n_server_sct_list_send,
+    .recv = s2n_server_sct_list_recv,
+    .should_send = s2n_server_sct_list_should_send,
+    .if_missing = s2n_extension_noop_if_missing,
+};
+
+static bool s2n_server_sct_list_should_send(struct s2n_connection *conn)
+{
+    return s2n_server_can_send_sct_list(conn);
+}
+
+int s2n_server_sct_list_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    notnull_check(conn);
+    struct s2n_blob *sct_list = &conn->handshake_params.our_chain_and_key->sct_list;
+
+    notnull_check(sct_list);
+    GUARD(s2n_stuffer_write(out, sct_list));
+
+    return S2N_SUCCESS;
+}
+
+int s2n_server_sct_list_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    struct s2n_blob sct_list = { .data = NULL, .size = 0 };
+
+    sct_list.size = s2n_stuffer_data_available(extension);
+    sct_list.data = s2n_stuffer_raw_read(extension, sct_list.size);
+    notnull_check(sct_list.data);
+
+    GUARD(s2n_dup(&sct_list, &conn->ct_response));
+
+    return S2N_SUCCESS;
+}
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
+
 int s2n_server_extensions_sct_list_send_size(struct s2n_connection *conn)
 {
     if (s2n_server_can_send_sct_list(conn)) {
@@ -31,31 +75,12 @@ int s2n_server_extensions_sct_list_send_size(struct s2n_connection *conn)
     return 0;
 }
 
-/* Write Signed Certificate Timestamp extension */
 int s2n_server_extensions_sct_list_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    notnull_check(conn);
-
-    if (s2n_server_can_send_sct_list(conn)) {
-        struct s2n_blob *sct_list = &conn->handshake_params.our_chain_and_key->sct_list;
-
-        GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_SCT_LIST));
-        GUARD(s2n_stuffer_write_uint16(out, sct_list->size));
-        GUARD(s2n_stuffer_write(out, sct_list));
-    }
-
-    return 0;
+    return s2n_extension_send(&s2n_server_sct_list_extension, conn, out);
 }
 
 int s2n_recv_server_sct_list(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
-    struct s2n_blob sct_list = { .data = NULL, .size = 0 };
-
-    sct_list.size = s2n_stuffer_data_available(extension);
-    sct_list.data = s2n_stuffer_raw_read(extension, sct_list.size);
-    notnull_check(sct_list.data);
-
-    GUARD(s2n_dup(&sct_list, &conn->ct_response));
-
-    return 0;
+    return s2n_extension_recv(&s2n_server_sct_list_extension, conn, extension);
 }

--- a/tls/extensions/s2n_server_sct_list.h
+++ b/tls/extensions/s2n_server_sct_list.h
@@ -15,6 +15,13 @@
 
 #pragma once
 
+#include "tls/extensions/s2n_extension_type.h"
+#include "tls/s2n_connection.h"
+#include "stuffer/s2n_stuffer.h"
+
+extern const s2n_extension_type s2n_server_sct_list_extension;
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
 int s2n_server_extensions_sct_list_send_size(struct s2n_connection *conn);
 int s2n_server_extensions_sct_list_send(struct s2n_connection *conn, struct s2n_stuffer *extension);
 int s2n_recv_server_sct_list(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_server_status_request.h
+++ b/tls/extensions/s2n_server_status_request.h
@@ -15,6 +15,13 @@
 
 #pragma once
 
+#include "tls/extensions/s2n_extension_type.h"
+#include "tls/s2n_connection.h"
+#include "stuffer/s2n_stuffer.h"
+
+extern const s2n_extension_type s2n_server_status_request_extension;
+
+/* Old-style extension functions -- remove after extensions refactor is complete */
 int s2n_server_extensions_status_request_send_size(struct s2n_connection *conn);
 int s2n_server_extensions_status_request_send(struct s2n_connection *conn, struct s2n_stuffer *out);
 int s2n_recv_server_status_request(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/s2n_ocsp_stapling.c
+++ b/tls/s2n_ocsp_stapling.c
@@ -36,5 +36,5 @@ int s2n_server_status_send(struct s2n_connection *conn)
 
 int s2n_server_status_recv(struct s2n_connection *conn)
 {
-    return s2n_server_certificate_status_parse(conn, &conn->handshake.io);
+    return s2n_server_certificate_status_recv(conn, &conn->handshake.io);
 }

--- a/tls/s2n_ocsp_stapling.c
+++ b/tls/s2n_ocsp_stapling.c
@@ -27,24 +27,14 @@
 
 int s2n_server_status_send(struct s2n_connection *conn)
 {
-    GUARD(s2n_server_certificate_status_send(conn, &conn->handshake.io));
+    if (s2n_server_can_send_ocsp(conn)) {
+        GUARD(s2n_server_certificate_status_send(conn, &conn->handshake.io));
+    }
 
     return 0;
 }
 
 int s2n_server_status_recv(struct s2n_connection *conn)
 {
-    uint8_t type;
-    struct s2n_blob status = {.data = NULL,.size = 0 };
-
-    GUARD(s2n_stuffer_read_uint8(&conn->handshake.io, &type));
-    GUARD(s2n_stuffer_read_uint24(&conn->handshake.io, &status.size));
-    status.data = s2n_stuffer_raw_read(&conn->handshake.io, status.size);
-    notnull_check(status.data);
-
-    if (type == S2N_STATUS_REQUEST_OCSP) {
-        GUARD(s2n_server_certificate_status_parse(conn, &status));
-    }
-
-    return 0;
+    return s2n_server_certificate_status_parse(conn, &conn->handshake.io);
 }


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

### Description of changes: 

Move the next 3 extensions into the new structures. For each extension, I:
- create the struct
- move current send and receive logic into static methods linked to the struct
- remove type + size from what the send method sends
- write static should_send method based on the existing logic in s2n_certificate_extensions etc
- replace current send and receive methods with calls to s2n_extension_send/recv

**IN ADDITION**, this PR makes a behavior change. The parse method for the tls1.3 status request response was wrong: https://github.com/lrstewart/s2n/blob/master/tls/extensions/s2n_server_certificate_status.c#L69-L70 It did not parse the status type, and interpreted the size of the extension as the size of the ocsp data. Recv could not parse the output of send.

From https://tools.ietf.org/html/rfc8446#section-4.4.2.1:
```
   In TLS 1.3, the server's OCSP information
   is carried in an extension in the CertificateEntry containing the
   associated certificate.  Specifically, the body of the
   "status_request" extension from the server MUST be a
   CertificateStatus structure as defined in [RFC6066]
```
The CertificateStatus structure, as defined in https://tools.ietf.org/html/rfc6066#section-8:
```
      struct {
          CertificateStatusType status_type;
          select (status_type) {
              case ocsp: OCSPResponse;
          } response;
      } CertificateStatus;

      opaque OCSPResponse<1..2^24-1>;
```

### Call-outs:

This is part of a larger task: #1817

The diff is particularly messed up for the two status request responses. I tried a couple function orders, but without much success getting github to recognize unchanged functions. The easiest way is probably just to compare current code to the old code:

s2n_server_status_request: [old](https://github.com/lrstewart/s2n/blob/master/tls/extensions/s2n_server_status_request.c) -> [new](https://github.com/lrstewart/s2n/blob/115b36e75a5734ec036e9ad7e5d8e4352a837113/tls/extensions/s2n_server_status_request.c)
s2n_tls13_server_status_request:  [old](https://github.com/lrstewart/s2n/blob/master/tls/extensions/s2n_server_certificate_status.c) -> [new](https://github.com/lrstewart/s2n/blob/115b36e75a5734ec036e9ad7e5d8e4352a837113/tls/extensions/s2n_server_certificate_status.c)

### Testing:

I added missing unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
