### PR TITLE
Add s2n_server_ec_point_format_extension struct

### DIFF
--- a/tests/unit/s2n_kex_test.c
+++ b/tests/unit/s2n_kex_test.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "tests/s2n_test.h"
+
+#include "tls/s2n_kex.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Test s2n_kex_includes */
+    {
+        /* True if same kex */
+        EXPECT_TRUE(s2n_kex_includes(NULL, NULL));
+        EXPECT_TRUE(s2n_kex_includes(&s2n_rsa, &s2n_rsa));
+        EXPECT_TRUE(s2n_kex_includes(&s2n_hybrid_ecdhe_kem, &s2n_hybrid_ecdhe_kem));
+
+        /* False if different kex */
+        EXPECT_FALSE(s2n_kex_includes(&s2n_rsa, &s2n_dhe));
+        EXPECT_FALSE(s2n_kex_includes(&s2n_kem, &s2n_ecdhe));
+
+        /* True if hybrid that contains */
+        EXPECT_TRUE(s2n_kex_includes(&s2n_hybrid_ecdhe_kem, &s2n_ecdhe));
+        EXPECT_TRUE(s2n_kex_includes(&s2n_hybrid_ecdhe_kem, &s2n_kem));
+
+        /* False if hybrid "contains" relationship reversed */
+        EXPECT_FALSE(s2n_kex_includes(&s2n_ecdhe, &s2n_hybrid_ecdhe_kem));
+        EXPECT_FALSE(s2n_kex_includes(&s2n_kem, &s2n_hybrid_ecdhe_kem));
+
+        /* False if hybrid that does not contain */
+        EXPECT_FALSE(s2n_kex_includes(&s2n_hybrid_ecdhe_kem, &s2n_rsa));
+        EXPECT_FALSE(s2n_kex_includes(&s2n_hybrid_ecdhe_kem, &s2n_dhe));
+
+        /* False if one kex null */
+        EXPECT_FALSE(s2n_kex_includes(&s2n_rsa, NULL));
+        EXPECT_FALSE(s2n_kex_includes(NULL, &s2n_rsa));
+    }
+
+    END_TEST();
+}

--- a/tests/unit/s2n_server_extensions_test.c
+++ b/tests/unit/s2n_server_extensions_test.c
@@ -23,6 +23,7 @@
 #include "tls/s2n_tls13.h"
 #include "tls/extensions/s2n_server_supported_versions.h"
 #include "tls/extensions/s2n_server_key_share.h"
+#include "tls/extensions/s2n_ec_point_format.h"
 #include "tls/s2n_cipher_preferences.h"
 #include "tls/s2n_security_policies.h"
 
@@ -480,6 +481,40 @@ int main(int argc, char **argv)
         }
 
         EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
+    /* Test ec_point_format extension */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(conn));
+        conn->secure.cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha;
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        conn->ec_point_formats = false;
+        EXPECT_SUCCESS(s2n_server_extensions_send(conn, &stuffer));
+        EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
+
+        conn->ec_point_formats = true;
+        EXPECT_SUCCESS(s2n_server_extensions_send(conn, &stuffer));
+        EXPECT_NOT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
+
+        uint16_t extensions_size;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &extensions_size));
+        EXPECT_EQUAL(extensions_size, s2n_stuffer_data_available(&stuffer));
+        EXPECT_EQUAL(extensions_size, s2n_server_ecc_point_format_extension_size(conn));
+        EXPECT_NOT_EQUAL(extensions_size, 0);
+
+        struct s2n_blob extension_data;
+        EXPECT_SUCCESS(s2n_blob_init(&extension_data,
+                s2n_stuffer_raw_read(&stuffer, extensions_size), extensions_size));
+        EXPECT_SUCCESS(s2n_server_extensions_recv(conn, &extension_data));
+        EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
     EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));

--- a/tls/extensions/s2n_client_supported_groups.c
+++ b/tls/extensions/s2n_client_supported_groups.c
@@ -16,8 +16,9 @@
 #include <sys/param.h>
 #include <stdint.h>
 
-#include "tls/extensions/s2n_client_ec_point_format.h"
 #include "tls/extensions/s2n_client_supported_groups.h"
+#include "tls/extensions/s2n_ec_point_format.h"
+
 #include "tls/s2n_tls.h"
 #include "tls/s2n_tls_parameters.h"
 #include "tls/s2n_security_policies.h"

--- a/tls/extensions/s2n_ec_point_format.c
+++ b/tls/extensions/s2n_ec_point_format.c
@@ -74,6 +74,14 @@ static int s2n_ec_point_format_recv(struct s2n_connection *conn, struct s2n_stuf
 
 /* Old-style extension functions -- remove after extensions refactor is complete */
 
+int s2n_server_ecc_point_format_extension_size(struct s2n_connection *conn)
+{
+    if (s2n_server_ec_point_format_extension.should_send(conn) && s2n_server_can_send_ec_point_formats(conn)) {
+        return 6;
+    }
+    return 0;
+}
+
 int s2n_recv_client_ec_point_formats(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
     return s2n_extension_recv(&s2n_client_ec_point_format_extension, conn, extension);

--- a/tls/extensions/s2n_ec_point_format.c
+++ b/tls/extensions/s2n_ec_point_format.c
@@ -47,9 +47,8 @@ const s2n_extension_type s2n_server_ec_point_format_extension = {
 
 static bool s2n_server_ec_point_format_should_send(struct s2n_connection *conn)
 {
-    return conn && conn->secure.cipher_suite &&
-            (conn->secure.cipher_suite->key_exchange_alg == &s2n_ecdhe
-             || conn->secure.cipher_suite->key_exchange_alg == &s2n_hybrid_ecdhe_kem);
+    return conn && conn->secure.cipher_suite
+            && s2n_kex_includes(conn->secure.cipher_suite->key_exchange_alg, &s2n_ecdhe);
 }
 
 static int s2n_ec_point_format_send(struct s2n_connection *conn, struct s2n_stuffer *out)

--- a/tls/extensions/s2n_ec_point_format.c
+++ b/tls/extensions/s2n_ec_point_format.c
@@ -17,24 +17,42 @@
 #include <stdint.h>
 
 #include "tls/extensions/s2n_client_supported_groups.h"
-#include "tls/extensions/s2n_client_ec_point_format.h"
+#include "tls/extensions/s2n_ec_point_format.h"
 #include "tls/s2n_tls.h"
 
 #include "utils/s2n_safety.h"
 
-static int s2n_client_ec_point_format_send(struct s2n_connection *conn, struct s2n_stuffer *out);
-static int s2n_client_ec_point_format_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
+static int s2n_ec_point_format_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+static int s2n_ec_point_format_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
 
 const s2n_extension_type s2n_client_ec_point_format_extension = {
     .iana_value = TLS_EXTENSION_EC_POINT_FORMATS,
     .is_response = false,
-    .send = s2n_client_ec_point_format_send,
-    .recv = s2n_client_ec_point_format_recv,
+    .send = s2n_ec_point_format_send,
+    .recv = s2n_ec_point_format_recv,
     .should_send = s2n_extension_should_send_if_ecc_enabled,
     .if_missing = s2n_extension_noop_if_missing,
 };
 
-static int s2n_client_ec_point_format_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+static bool s2n_server_ec_point_format_should_send(struct s2n_connection *conn);
+
+const s2n_extension_type s2n_server_ec_point_format_extension = {
+    .iana_value = TLS_EXTENSION_EC_POINT_FORMATS,
+    .is_response = true,
+    .send = s2n_ec_point_format_send,
+    .recv = s2n_ec_point_format_recv,
+    .should_send = s2n_server_ec_point_format_should_send,
+    .if_missing = s2n_extension_noop_if_missing,
+};
+
+static bool s2n_server_ec_point_format_should_send(struct s2n_connection *conn)
+{
+    return conn && conn->secure.cipher_suite &&
+            (conn->secure.cipher_suite->key_exchange_alg == &s2n_ecdhe
+             || conn->secure.cipher_suite->key_exchange_alg == &s2n_hybrid_ecdhe_kem);
+}
+
+static int s2n_ec_point_format_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
     /* Point format list len. We only support one. */
     GUARD(s2n_stuffer_write_uint8(out, 1));
@@ -45,7 +63,7 @@ static int s2n_client_ec_point_format_send(struct s2n_connection *conn, struct s
     return S2N_SUCCESS;
 }
 
-static int s2n_client_ec_point_format_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
+static int s2n_ec_point_format_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
     /**
      * Only uncompressed points are supported by the server and the client must include it in

--- a/tls/extensions/s2n_ec_point_format.c
+++ b/tls/extensions/s2n_ec_point_format.c
@@ -77,7 +77,10 @@ static int s2n_ec_point_format_recv(struct s2n_connection *conn, struct s2n_stuf
 int s2n_server_ecc_point_format_extension_size(struct s2n_connection *conn)
 {
     if (s2n_server_ec_point_format_extension.should_send(conn) && s2n_server_can_send_ec_point_formats(conn)) {
-        return 6;
+        return sizeof(uint16_t)     /* extension type */
+                + sizeof(uint16_t)  /* extension size */
+                + sizeof(uint8_t)   /* point list size */
+                + sizeof(uint8_t);  /* point */
     }
     return 0;
 }

--- a/tls/extensions/s2n_ec_point_format.h
+++ b/tls/extensions/s2n_ec_point_format.h
@@ -22,6 +22,7 @@
 #define TLS_EC_POINT_FORMAT_UNCOMPRESSED 0
 
 extern const s2n_extension_type s2n_client_ec_point_format_extension;
+extern const s2n_extension_type s2n_server_ec_point_format_extension;
 
 /* Old-style extension functions -- remove after extensions refactor is complete */
 extern int s2n_recv_client_ec_point_formats(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_ec_point_format.h
+++ b/tls/extensions/s2n_ec_point_format.h
@@ -25,4 +25,5 @@ extern const s2n_extension_type s2n_client_ec_point_format_extension;
 extern const s2n_extension_type s2n_server_ec_point_format_extension;
 
 /* Old-style extension functions -- remove after extensions refactor is complete */
-extern int s2n_recv_client_ec_point_formats(struct s2n_connection *conn, struct s2n_stuffer *extension);
+int s2n_server_ecc_point_format_extension_size(struct s2n_connection *conn);
+int s2n_recv_client_ec_point_formats(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/s2n_client_extensions.c
+++ b/tls/s2n_client_extensions.c
@@ -38,8 +38,8 @@
 #include "extensions/s2n_client_sct_list.h"
 #include "extensions/s2n_client_supported_groups.h"
 #include "extensions/s2n_client_pq_kem.h"
-#include "extensions/s2n_client_ec_point_format.h"
 #include "extensions/s2n_client_renegotiation_info.h"
+#include "extensions/s2n_ec_point_format.h"
 
 #include "stuffer/s2n_stuffer.h"
 

--- a/tls/s2n_kex.c
+++ b/tls/s2n_kex.c
@@ -179,7 +179,7 @@ static int s2n_get_server_hybrid_extensions_size(const struct s2n_connection *co
     return s2n_kex_server_extension_size(hybrid_kex_0, conn) + s2n_kex_server_extension_size(hybrid_kex_1, conn);
 }
 
-static const struct s2n_kex s2n_kem = {
+const struct s2n_kex s2n_kem = {
     .is_ephemeral = 1,
     .get_server_extension_size = &s2n_get_no_extension_size,
     .write_server_extensions = &s2n_write_no_extension,
@@ -323,4 +323,17 @@ int s2n_kex_tls_prf(const struct s2n_kex *kex, struct s2n_connection *conn, stru
 {
     notnull_check(kex->prf);
     return kex->prf(conn, premaster_secret);
+}
+
+bool s2n_kex_includes(const struct s2n_kex *kex, const struct s2n_kex *query)
+{
+    if (kex == query) {
+        return true;
+    }
+
+    if (kex == NULL || query == NULL) {
+        return false;
+    }
+
+    return query == kex->hybrid[0] || query == kex->hybrid[1];
 }

--- a/tls/s2n_kex.c
+++ b/tls/s2n_kex.c
@@ -24,46 +24,6 @@
 #include "tls/s2n_tls.h"
 #include "utils/s2n_safety.h"
 
-static int s2n_get_server_ecc_extension_size(const struct s2n_connection *conn)
-{
-    if (s2n_server_can_send_ec_point_formats(conn)) {
-        return 6;
-    } else {
-        return 0;
-    }
-}
-
-static int s2n_get_no_extension_size(const struct s2n_connection *conn)
-{
-    return 0;
-}
-
-/* Write the Supported Points Format extension.
- * RFC 4492 section 5.2 states that the absence of this extension in the Server Hello
- * is equivalent to allowing only the uncompressed point format. Let's send the
- * extension in case clients(Openssl 1.0.0) don't honor the implied behavior.
- */
-static int s2n_write_server_ecc_extension(const struct s2n_connection *conn, struct s2n_stuffer *out)
-{
-    if (s2n_server_can_send_ec_point_formats(conn)) {
-        GUARD(s2n_stuffer_write_uint16(out, TLS_EXTENSION_EC_POINT_FORMATS));
-        /* Total extension length */
-        GUARD(s2n_stuffer_write_uint16(out, 2));
-        /* Format list length */
-        GUARD(s2n_stuffer_write_uint8(out, 1));
-        /* Only uncompressed format is supported. Interoperability shouldn't be an issue:
-         * RFC 4492 Section 5.1.2: Implementations must support it for all of their curves.
-         */
-        GUARD(s2n_stuffer_write_uint8(out, TLS_EC_FORMAT_UNCOMPRESSED));
-    }
-    return 0;
-}
-
-static int s2n_write_no_extension(const struct s2n_connection *conn, struct s2n_stuffer *out)
-{
-    return 0;
-}
-
 static int s2n_check_rsa_key(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn)
 {
     return s2n_get_compatible_cert_chain_and_key(conn, S2N_PKEY_TYPE_RSA) != NULL;
@@ -161,28 +121,8 @@ static int s2n_check_hybrid_echde_kem(const struct s2n_cipher_suite *cipher_suit
     return s2n_check_ecdhe(cipher_suite, conn) && s2n_check_kem(cipher_suite, conn);
 }
 
-static int s2n_write_server_hybrid_extensions(const struct s2n_connection *conn, struct s2n_stuffer *out)
-{
-    const struct s2n_kex *kex = conn->secure.cipher_suite->key_exchange_alg;
-    const struct s2n_kex *hybrid_kex_0 = kex->hybrid[0];
-    const struct s2n_kex *hybrid_kex_1 = kex->hybrid[1];
-    GUARD(s2n_kex_write_server_extension(hybrid_kex_0, conn, out));
-    GUARD(s2n_kex_write_server_extension(hybrid_kex_1, conn, out));
-    return 0;
-}
-
-static int s2n_get_server_hybrid_extensions_size(const struct s2n_connection *conn)
-{
-    const struct s2n_kex *kex = conn->secure.cipher_suite->key_exchange_alg;
-    const struct s2n_kex *hybrid_kex_0 = kex->hybrid[0];
-    const struct s2n_kex *hybrid_kex_1 = kex->hybrid[1];
-    return s2n_kex_server_extension_size(hybrid_kex_0, conn) + s2n_kex_server_extension_size(hybrid_kex_1, conn);
-}
-
 const struct s2n_kex s2n_kem = {
     .is_ephemeral = 1,
-    .get_server_extension_size = &s2n_get_no_extension_size,
-    .write_server_extensions = &s2n_write_no_extension,
     .connection_supported = &s2n_check_kem,
     .configure_connection = &s2n_configure_kem,
     .server_key_recv_read_data = &s2n_kem_server_key_recv_read_data,
@@ -194,8 +134,6 @@ const struct s2n_kex s2n_kem = {
 
 const struct s2n_kex s2n_rsa = {
     .is_ephemeral = 0,
-    .get_server_extension_size = &s2n_get_no_extension_size,
-    .write_server_extensions = &s2n_write_no_extension,
     .connection_supported = &s2n_check_rsa_key,
     .configure_connection = &s2n_no_op_configure,
     .server_key_recv_read_data = NULL,
@@ -208,8 +146,6 @@ const struct s2n_kex s2n_rsa = {
 
 const struct s2n_kex s2n_dhe = {
     .is_ephemeral = 1,
-    .get_server_extension_size = &s2n_get_no_extension_size,
-    .write_server_extensions = &s2n_write_no_extension,
     .connection_supported = &s2n_check_dhe,
     .configure_connection = &s2n_no_op_configure,
     .server_key_recv_read_data = &s2n_dhe_server_key_recv_read_data,
@@ -222,8 +158,6 @@ const struct s2n_kex s2n_dhe = {
 
 const struct s2n_kex s2n_ecdhe = {
     .is_ephemeral = 1,
-    .get_server_extension_size = &s2n_get_server_ecc_extension_size,
-    .write_server_extensions = &s2n_write_server_ecc_extension,
     .connection_supported = &s2n_check_ecdhe,
     .configure_connection = &s2n_no_op_configure,
     .server_key_recv_read_data = &s2n_ecdhe_server_key_recv_read_data,
@@ -237,8 +171,6 @@ const struct s2n_kex s2n_ecdhe = {
 const struct s2n_kex s2n_hybrid_ecdhe_kem = {
     .is_ephemeral = 1,
     .hybrid = { &s2n_ecdhe, &s2n_kem },
-    .get_server_extension_size = &s2n_get_server_hybrid_extensions_size,
-    .write_server_extensions = &s2n_write_server_hybrid_extensions,
     .connection_supported = &s2n_check_hybrid_echde_kem,
     .configure_connection = &s2n_configure_kem,
     .server_key_recv_read_data = &s2n_hybrid_server_key_recv_read_data,
@@ -248,28 +180,6 @@ const struct s2n_kex s2n_hybrid_ecdhe_kem = {
     .client_key_send = &s2n_hybrid_client_key_send,
     .prf = &s2n_hybrid_prf_master_secret,
 };
-
-int s2n_kex_server_extension_size(const struct s2n_kex *kex, const struct s2n_connection *conn)
-{
-    if (s2n_server_can_send_kex(conn)) {
-        notnull_check(kex);
-        notnull_check(kex->get_server_extension_size);
-        return kex->get_server_extension_size(conn);
-    }
-
-    return 0;
-}
-
-int s2n_kex_write_server_extension(const struct s2n_kex *kex, const struct s2n_connection *conn, struct s2n_stuffer *out)
-{
-    if (s2n_server_can_send_kex(conn)) {
-        notnull_check(kex);
-        notnull_check(kex->write_server_extensions);
-        return kex->write_server_extensions(conn, out);
-    }
-
-    return 0;
-}
 
 int s2n_kex_supported(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn)
 {

--- a/tls/s2n_kex.h
+++ b/tls/s2n_kex.h
@@ -23,8 +23,6 @@ struct s2n_kex {
     uint8_t is_ephemeral;
     const struct s2n_kex *hybrid[2];
 
-    int (*get_server_extension_size)(const struct s2n_connection *conn);
-    int (*write_server_extensions)(const struct s2n_connection *conn, struct s2n_stuffer *out);
     int (*connection_supported)(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn);
     int (*configure_connection)(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn);
     int (*server_key_recv_read_data)(struct s2n_connection *conn, struct s2n_blob *data_to_verify, struct s2n_kex_raw_server_data *kex_data);
@@ -41,8 +39,6 @@ extern const struct s2n_kex s2n_dhe;
 extern const struct s2n_kex s2n_ecdhe;
 extern const struct s2n_kex s2n_hybrid_ecdhe_kem;
 
-extern int s2n_kex_server_extension_size(const struct s2n_kex *kex, const struct s2n_connection *conn);
-extern int s2n_kex_write_server_extension(const struct s2n_kex *kex, const struct s2n_connection *conn, struct s2n_stuffer *out);
 extern int s2n_kex_supported(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn);
 extern int s2n_configure_kex(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn);
 extern int s2n_kex_is_ephemeral(const struct s2n_kex *kex);

--- a/tls/s2n_kex.h
+++ b/tls/s2n_kex.h
@@ -52,4 +52,4 @@ extern int s2n_kex_client_key_send(const struct s2n_kex *kex, struct s2n_connect
 
 extern int s2n_kex_tls_prf(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *premaster_secret);
 
-bool s2n_kex_includes(const struct s2n_kex *kex, const struct s2n_kex *query);
+extern bool s2n_kex_includes(const struct s2n_kex *kex, const struct s2n_kex *query);

--- a/tls/s2n_kex.h
+++ b/tls/s2n_kex.h
@@ -35,6 +35,7 @@ struct s2n_kex {
     int (*prf)(struct s2n_connection *conn, struct s2n_blob *premaster_secret);
 };
 
+extern const struct s2n_kex s2n_kem;
 extern const struct s2n_kex s2n_rsa;
 extern const struct s2n_kex s2n_dhe;
 extern const struct s2n_kex s2n_ecdhe;
@@ -54,3 +55,5 @@ extern int s2n_kex_client_key_recv(const struct s2n_kex *kex, struct s2n_connect
 extern int s2n_kex_client_key_send(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *shared_key);
 
 extern int s2n_kex_tls_prf(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *premaster_secret);
+
+bool s2n_kex_includes(const struct s2n_kex *kex, const struct s2n_kex *query);

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -568,11 +568,11 @@ int s2n_security_policies_init()
             S2N_ERROR_IF(s2n_is_valid_tls13_cipher(cipher->iana_value) ^
                 (cipher->minimum_required_tls_version >= S2N_TLS13), S2N_ERR_INVALID_SECURITY_POLICY);
 
-            if (cipher->key_exchange_alg == &s2n_ecdhe || cipher->key_exchange_alg == &s2n_hybrid_ecdhe_kem) {
+            if (s2n_kex_includes(cipher->key_exchange_alg, &s2n_ecdhe)) {
                 security_policy_selection[i].ecc_extension_required = 1;
             }
 
-            if (cipher->key_exchange_alg == &s2n_hybrid_ecdhe_kem) {
+            if (s2n_kex_includes(cipher->key_exchange_alg, &s2n_kem)) {
                 security_policy_selection[i].pq_kem_extension_required = 1;
             }
         }

--- a/tls/s2n_server_extensions.c
+++ b/tls/s2n_server_extensions.c
@@ -27,6 +27,7 @@
 
 #include "tls/extensions/s2n_certificate_extensions.h"
 #include "tls/extensions/s2n_cookie.h"
+#include "tls/extensions/s2n_ec_point_format.h"
 #include "tls/extensions/s2n_server_renegotiation_info.h"
 #include "tls/extensions/s2n_server_alpn.h"
 #include "tls/extensions/s2n_server_status_request.h"
@@ -58,7 +59,7 @@ int s2n_server_extensions_send_size(struct s2n_connection *conn)
     GUARD_UINT16_AND_INCREMENT(s2n_server_extensions_server_name_send_size(conn), total_size);
     GUARD_UINT16_AND_INCREMENT(s2n_server_extensions_alpn_send_size(conn), total_size);
     GUARD_UINT16_AND_INCREMENT(s2n_server_renegotiation_info_ext_size(conn), total_size);
-    GUARD_UINT16_AND_INCREMENT(s2n_kex_server_extension_size(conn->secure.cipher_suite->key_exchange_alg, conn), total_size);
+    GUARD_UINT16_AND_INCREMENT(s2n_server_ecc_point_format_extension_size(conn), total_size);
     GUARD_UINT16_AND_INCREMENT(s2n_server_extensions_max_fragment_length_send_size(conn), total_size);
     GUARD_UINT16_AND_INCREMENT(s2n_server_session_ticket_ext_size(conn), total_size);
     GUARD_UINT16_AND_INCREMENT(s2n_server_extensions_status_request_send_size(conn), total_size);
@@ -98,7 +99,7 @@ int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *
     GUARD(s2n_server_extensions_server_name_send(conn, out));
 
     /* Write kex extension */
-    GUARD(s2n_kex_write_server_extension(conn->secure.cipher_suite->key_exchange_alg, conn, out));
+    GUARD(s2n_extension_send(&s2n_server_ec_point_format_extension, conn, out));
     
     /* Write the renegotiation_info extension */
     GUARD(s2n_send_server_renegotiation_info_ext(conn, out));

--- a/tls/s2n_tls.h
+++ b/tls/s2n_tls.h
@@ -104,6 +104,3 @@ extern uint16_t mfl_code_to_length[5];
 
 #define s2n_server_sending_nst(conn) ((conn)->config->use_tickets && \
         (conn)->session_ticket_status == S2N_NEW_TICKET)
-
-#define s2n_server_can_send_kex(conn) \
-    ((conn)->secure.cipher_suite->key_exchange_alg)


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

### Description of changes: 

Moving one last extension into a structure! The server ec point format response extension was hiding in s2n_kex.

server_extensions.c [calls a kex method to write any kex-related extensions](https://github.com/awslabs/s2n/blob/master/tls/s2n_server_extensions.c#L101). Each kex [supports an extensions size and send method](https://github.com/awslabs/s2n/blob/master/tls/s2n_kex.h#L26-L27), but only s2n_ecdhe writes anything. s2n_ecdhe [writes the ec point format extension](https://github.com/awslabs/s2n/blob/master/tls/s2n_kex.c#L46-L60).

I created the necessary struct and removed the code from s2n_kex.c so I don't miss cleaning it up later.

This is part of this larger issue: https://github.com/awslabs/s2n/issues/1817

### Testing:

Added unit tests for the new functions. I also added another server_extension test to make sure I didn't break anything by moving the logic out of s2n_kex.c.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
