### PR TITLE
Add types for integration tests 

### DIFF
--- a/tests/integrationv2/Makefile
+++ b/tests/integrationv2/Makefile
@@ -19,6 +19,8 @@ ifndef S2N_LIBCRYPTO
 	export S2N_LIBCRYPTO="openssl-1.1.1"
 endif
 
+LIBCRYPTO_ROOT:=/home/ubuntu/development/s2n/test-deps/openssl-1.1.1/
+
 HANDSHAKE_TEST_PARAMS:=--libcrypto $(S2N_LIBCRYPTO) $(S2ND_HOST) $(S2ND_PORT)
 
 ifeq ($(S2N_CORKED_IO),true)

--- a/tests/integrationv2/configuration.py
+++ b/tests/integrationv2/configuration.py
@@ -1,6 +1,4 @@
-import threading
-
-from common import Cert, Ciphers, Curves, Protocols, AvailablePorts, TLS_CURVES, TLS13_CURVES
+from common import Certificates, Ciphers, Curves, Protocols, AvailablePorts
 from providers import S2N, OpenSSL, BoringSSL
 
 
@@ -27,31 +25,33 @@ TLS13 = [True, False]
 
 
 # List of all curves that will be tested.
-ALL_CURVES = TLS13_CURVES[:]
-ALL_CURVES.extend(TLS_CURVES)
-ALL_CURVES.append(None)
-
-
-ALL_CERTS = [
-    # PKCS1 will only work with older OpenSSL versions
-    # Cert("RSA_2048_PKCS1", "rsa_2048_pkcs1"),
-    Cert("RSA_1024_SHA256", "rsa_1024_sha256_client"),
-    Cert("RSA_1024_SHA384", "rsa_1024_sha384_client"),
-    Cert("RSA_1024_SHA512", "rsa_1024_sha512_client"),
-    Cert("RSA_2048_SHA256", "rsa_2048_sha256_client"),
-    Cert("RSA_2048_SHA384", "rsa_2048_sha384_client"),
-    Cert("RSA_2048_SHA512", "rsa_2048_sha512_client"),
-    Cert("RSA_3072_SHA256", "rsa_3072_sha256_client"),
-    Cert("RSA_3072_SHA384", "rsa_3072_sha384_client"),
-    Cert("RSA_3072_SHA512", "rsa_3072_sha512_client"),
-    Cert("RSA_4096_SHA256", "rsa_4096_sha256_client"),
-    Cert("RSA_4096_SHA384", "rsa_4096_sha384_client"),
-    Cert("RSA_4096_SHA512", "rsa_4096_sha512_client"),
-    Cert("ECDSA_256", "ecdsa_p256_pkcs1"),
-    Cert("ECDSA_384", "ecdsa_p384_pkcs1"),
+ALL_TEST_CURVES = [
+    Curves.X25519,
+    Curves.P256,
+    Curves.P384,
 ]
 
 
+# List of all certificates that will be tested.
+ALL_TEST_CERTS = [
+    Certificates.RSA_1024_SHA256,
+    Certificates.RSA_1024_SHA384,
+    Certificates.RSA_1024_SHA512,
+    Certificates.RSA_2048_SHA256,
+    Certificates.RSA_2048_SHA384,
+    Certificates.RSA_2048_SHA512,
+    Certificates.RSA_3072_SHA256,
+    Certificates.RSA_3072_SHA384,
+    Certificates.RSA_3072_SHA512,
+    Certificates.RSA_4096_SHA256,
+    Certificates.RSA_4096_SHA384,
+    Certificates.RSA_4096_SHA512,
+    Certificates.ECDSA_256,
+    Certificates.ECDSA_384,
+]
+
+
+# List of all ciphers that will be tested.
 ALL_TEST_CIPHERS = [
     Ciphers.DHE_RSA_AES128_SHA,
     Ciphers.DHE_RSA_AES256_SHA,

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -13,46 +13,6 @@ class Provider(object):
     ClientMode = "client"
     ServerMode = "server"
 
-    # These are the ciphers that we will test, and the parameters S2N needs in order to
-    # test them. Other providers may need to override this list if they have different
-    # names for the ciphers.
-    supported_ciphers = {
-        Ciphers.CHACHA20_POLY1305_SHA256: 'test_all_tls13',
-        Ciphers.ECDHE_RSA_CHACHA20_POLY1305: 'test_all',
-        Ciphers.ECDHE_ECDSA_CHACHA20_POLY1305: 'test_all',
-        Ciphers.DHE_RSA_CHACHA20_POLY1305: 'test_all',
-
-        Ciphers.DHE_RSA_AES128_SHA: 'test_all',
-        Ciphers.DHE_RSA_AES256_SHA: 'test_all',
-        Ciphers.DHE_RSA_AES128_SHA256: 'test_all',
-        Ciphers.DHE_RSA_AES256_SHA256: 'test_all',
-        Ciphers.DHE_RSA_AES128_GCM_SHA256: 'test_all',
-        Ciphers.DHE_RSA_AES256_GCM_SHA384: 'test_all',
-        Ciphers.DHE_RSA_CHACHA20_POLY1305: 'test_all',
-
-        Ciphers.AES128_GCM_SHA256: 'test_all_tls13',
-        Ciphers.AES256_GCM_SHA384: 'test_all_tls13',
-        Ciphers.AES128_SHA256: 'test_all',
-        Ciphers.AES256_SHA256: 'test_all',
-        Ciphers.AES128_SHA: 'test_all',
-        Ciphers.AES256_SHA: 'test_all',
-
-        Ciphers.ECDHE_ECDSA_AES128_GCM_SHA256: 'test_all',
-        Ciphers.ECDHE_ECDSA_AES256_GCM_SHA384: 'test_all',
-        Ciphers.ECDHE_ECDSA_AES128_SHA256: 'test_all',
-        Ciphers.ECDHE_ECDSA_AES256_SHA384: 'test_all',
-        Ciphers.ECDHE_ECDSA_AES128_SHA: 'test_all',
-        Ciphers.ECDHE_ECDSA_AES256_SHA: 'test_all',
-
-        Ciphers.ECDHE_RSA_AES128_GCM_SHA256: 'test_all',
-        Ciphers.ECDHE_RSA_AES256_GCM_SHA384: 'test_all',
-        Ciphers.ECDHE_RSA_DES_CBC3_SHA: 'test_all',
-        Ciphers.ECDHE_RSA_AES128_SHA: 'test_all',
-        Ciphers.ECDHE_RSA_AES256_SHA: 'test_all',
-        Ciphers.ECDHE_RSA_AES128_SHA256: 'test_all',
-        Ciphers.ECDHE_RSA_AES256_SHA384: 'test_all',
-    }
-
     def __init__(self, options: ProviderOptions):
         # If the test should wait for a specific output message before beginning,
         # put that message in ready_to_test_marker
@@ -165,9 +125,8 @@ class S2N(Provider):
 
         if options.protocol == Protocols.TLS13:
             cmd_line.append('--tls13')
-            cmd_line.extend(['-c', 'test_all_tls13'])
-        else:
-            cmd_line.extend(['-c', 'test_all'])
+
+        cmd_line.extend(['-c', 'test_all'])
 
         cmd_line.extend([options.host, options.port])
 
@@ -192,9 +151,8 @@ class S2N(Provider):
 
         if options.protocol == Protocols.TLS13:
             cmd_line.append('--tls13')
-            cmd_line.extend(['-c', 'test_all_tls13'])
-        else:
-            cmd_line.extend(['-c', 'test_all'])
+
+        cmd_line.extend(['-c', 'test_all'])
         if options.use_client_auth is True:
             cmd_line.append('-m')
             cmd_line.extend(['-t', options.client_certificate_file])
@@ -206,42 +164,6 @@ class S2N(Provider):
 
 class OpenSSL(Provider):
 
-    supported_ciphers = {
-        Ciphers.CHACHA20_POLY1305_SHA256: 'TLS_CHACHA20_POLY1305_SHA256',
-
-        Ciphers.DHE_RSA_CHACHA20_POLY1305: 'DHE-RSA-CHACHA20-POLY1305',
-        Ciphers.DHE_RSA_AES128_SHA: 'DHE-RSA-AES128-SHA',
-        Ciphers.DHE_RSA_AES256_SHA: 'DHE-RSA-AES128-SHA',
-        Ciphers.DHE_RSA_AES128_SHA256: 'DHE-RSA-AES128-SHA256',
-        Ciphers.DHE_RSA_AES256_SHA256: 'DHE-RSA-AES256-SHA256',
-        Ciphers.DHE_RSA_AES128_GCM_SHA256: 'DHE-RSA-AES128-GCM-SHA256',
-        Ciphers.DHE_RSA_AES256_GCM_SHA384: 'DHE-RSA-AES256-GCM-SHA384',
-
-        Ciphers.AES128_GCM_SHA256: 'TLS_AES_128_GCM_SHA256',
-        Ciphers.AES256_GCM_SHA384: 'TLS_AES_256_GCM_SHA384',
-        Ciphers.AES128_SHA256: 'AES128-SHA256',
-        Ciphers.AES256_SHA256: 'AES256-SHA256',
-        Ciphers.AES128_SHA: 'AES128-SHA',
-        Ciphers.AES256_SHA: 'AES256-SHA',
-
-        Ciphers.ECDHE_ECDSA_AES128_GCM_SHA256: 'ECDHE-ECDSA-AES128-GCM-SHA256',
-        Ciphers.ECDHE_ECDSA_AES256_GCM_SHA384: 'ECDHE-ECDSA-AES256-GCM-SHA384',
-        Ciphers.ECDHE_ECDSA_AES128_SHA256: 'ECDHE-ECDSA-AES128-SHA256',
-        Ciphers.ECDHE_ECDSA_AES256_SHA384: 'ECDHE-ECDSA-AES256-SHA384',
-        Ciphers.ECDHE_ECDSA_AES128_SHA: 'ECDHE-ECDSA-AES128-SHA',
-        Ciphers.ECDHE_ECDSA_AES256_SHA: 'ECDHE-ECDSA-AES256-SHA',
-        Ciphers.ECDHE_ECDSA_CHACHA20_POLY1305: 'ECDHE-ECDSA-CHACHA20-POLY1305',
-
-        Ciphers.ECDHE_RSA_AES128_GCM_SHA256: 'ECDHE-RSA-AES128-GCM-SHA256',
-        Ciphers.ECDHE_RSA_AES256_GCM_SHA384: 'ECDHE-RSA-AES256-GCM-SHA384',
-        Ciphers.ECDHE_RSA_CHACHA20_POLY1305: 'ECDHE-RSA-CHACHA20-POLY1305',
-        Ciphers.ECDHE_RSA_DES_CBC3_SHA: 'ECDHE-RSA-DES-CBC3-SHA',
-        Ciphers.ECDHE_RSA_AES128_SHA: 'ECDHE-RSA-AES128-SHA',
-        Ciphers.ECDHE_RSA_AES256_SHA: 'ECDHE-RSA-AES256-SHA',
-        Ciphers.ECDHE_RSA_AES128_SHA256: 'ECDHE-RSA-AES128-SHA256',
-        Ciphers.ECDHE_RSA_AES256_SHA384: 'ECDHE-RSA-AES256-SHA384',
-    }
-
     def __init__(self, options: ProviderOptions):
         self.ready_to_send_input_marker = None
         Provider.__init__(self, options)
@@ -251,13 +173,16 @@ class OpenSSL(Provider):
 
         # Prior to TLS13 the -cipher flag is used
         if cipher.min_version == Protocols.TLS13:
+            supported_ciphers = {
+                Ciphers.AES128_GCM_SHA256: 'TLS_AES_128_GCM_SHA256',
+                Ciphers.AES256_GCM_SHA384: 'TLS_AES_256_GCM_SHA384',
+                Ciphers.CHACHA20_POLY1305_SHA256: 'TLS_CHACHA20_POLY1305_SHA256',
+            }
+
             cmdline.append('-ciphersuites')
+            cmdline.append(supported_ciphers[cipher])
         else:
             cmdline.append('-cipher')
-
-        if cipher in OpenSSL.supported_ciphers:
-            cmdline.append(OpenSSL.supported_ciphers[cipher])
-        else:
             cmdline.append(cipher.name.replace("_", "-"))
 
         return cmdline
@@ -292,7 +217,8 @@ class OpenSSL(Provider):
             cmd_line.extend(self.cipher_to_cmdline(options.protocol, options.cipher))
 
         if options.curve is not None:
-            cmd_line.extend(['-curves', options.curve])
+            cmd_line.extend(['-curves', str(options.curve)])
+
         if options.use_client_auth is True:
             cmd_line.extend(['-key', options.client_key_file])
             cmd_line.extend(['-cert', options.client_certificate_file])
@@ -305,10 +231,6 @@ class OpenSSL(Provider):
     def setup_server(self, options: ProviderOptions):
         # s_server prints this message before it is ready to send/receive data
         self.ready_to_test_marker = 'ACCEPT'
-
-        # NOTE: At this time I can't get S2N to connect when the server uses this cipher
-        if options.cipher == Ciphers.DHE_RSA_CHACHA20_POLY1305:
-            pytest.skip('S2N can not connect to a server using DHE_RSA_CHACHA20_POLY1305')
 
         cmd_line = ['openssl', 's_server']
         cmd_line.extend(['-accept', '{}:{}'.format(options.host, options.port)])
@@ -337,9 +259,11 @@ class OpenSSL(Provider):
 
         if options.cipher is not None:
             cmd_line.extend(self.cipher_to_cmdline(options.protocol, options.cipher))
+            if options.cipher.parameters is not None:
+                cmd_line.extend(['-dhparam', options.cipher.parameters])
 
         if options.curve is not None:
-            cmd_line.extend(['-curves', options.curve])
+            cmd_line.extend(['-curves', str(options.curve)])
 
         return cmd_line
 

--- a/tests/integrationv2/test_dynamic_record_sizes.py
+++ b/tests/integrationv2/test_dynamic_record_sizes.py
@@ -4,7 +4,7 @@ import pytest
 import subprocess
 import time
 
-from configuration import available_ports, ALL_TEST_CIPHERS, ALL_CURVES, ALL_CERTS, PROVIDERS, PROTOCOLS
+from configuration import available_ports, ALL_TEST_CIPHERS, ALL_TEST_CURVES, ALL_TEST_CERTS, PROVIDERS, PROTOCOLS
 from common import ProviderOptions, data_bytes, Protocols
 from fixtures import managed_process, custom_mtu
 from providers import Provider, S2N, OpenSSL, Tcpdump
@@ -40,10 +40,10 @@ def find_fragmented_packet(results):
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
-@pytest.mark.parametrize("curve", ALL_CURVES)
+@pytest.mark.parametrize("curve", ALL_TEST_CURVES)
 @pytest.mark.parametrize("provider", [OpenSSL])
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
-@pytest.mark.parametrize("certificate", ALL_CERTS, ids=get_parameter_name)
+@pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
 def test_s2n_client_dynamic_record(custom_mtu, managed_process, cipher, curve, provider, protocol, certificate):
     host = "localhost"
     port = next(available_ports)

--- a/tests/integrationv2/test_happy_path.py
+++ b/tests/integrationv2/test_happy_path.py
@@ -1,19 +1,19 @@
 import copy
 import pytest
 
-from configuration import available_ports, ALL_TEST_CIPHERS, ALL_CURVES, ALL_CERTS, PROVIDERS, PROTOCOLS
+from configuration import available_ports, ALL_TEST_CIPHERS, ALL_TEST_CURVES, ALL_TEST_CERTS, PROVIDERS, PROTOCOLS
 from common import ProviderOptions, Protocols, data_bytes
 from fixtures import managed_process
-from providers import Provider, S2N
+from providers import Provider, S2N, OpenSSL
 from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version
 
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
-@pytest.mark.parametrize("cipher", [cipher for cipher in ALL_TEST_CIPHERS if cipher.name is not 'DHE_RSA_CHACHA20_POLY1305'], ids=get_parameter_name)
+@pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", PROVIDERS)
-@pytest.mark.parametrize("curve", ALL_CURVES)
+@pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
-@pytest.mark.parametrize("certificate", ALL_CERTS, ids=get_parameter_name)
+@pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
 def test_s2n_server_happy_path(managed_process, cipher, provider, curve, protocol, certificate):
     host = "localhost"
     port = next(available_ports)
@@ -21,9 +21,9 @@ def test_s2n_server_happy_path(managed_process, cipher, provider, curve, protoco
     # s2nd can receive large amounts of data because all the data is
     # echo'd to stdout unmodified. This lets us compare received to
     # expected easily.
-    # The downside here is that, should the test fail, all 4 mbs will
-    # be dumped in the exception.
-    random_bytes = data_bytes(4096)
+    # We purposefully send a non block aligned number to make sure
+    # nothing blocks waiting for more data.
+    random_bytes = data_bytes(65519)
     client_options = ProviderOptions(
         mode=Provider.ClientMode,
         host="localhost",
@@ -66,9 +66,10 @@ def test_s2n_server_happy_path(managed_process, cipher, provider, curve, protoco
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", PROVIDERS)
+@pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
-@pytest.mark.parametrize("certificate", ALL_CERTS, ids=get_parameter_name)
-def test_s2n_client_happy_path(managed_process, cipher, provider, protocol, certificate):
+@pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
+def test_s2n_client_happy_path(managed_process, cipher, provider, curve, protocol, certificate):
     host = "localhost"
     port = next(available_ports)
 
@@ -83,6 +84,7 @@ def test_s2n_client_happy_path(managed_process, cipher, provider, protocol, cert
         host="localhost",
         port=port,
         cipher=cipher,
+        curve=curve,
         data_to_send=random_bytes,
         insecure=True,
         protocol=protocol)

--- a/tests/integrationv2/tox.ini
+++ b/tests/integrationv2/tox.ini
@@ -12,4 +12,3 @@ deps =
     pytest-xdist
 commands =
     pytest -rpfsq
-


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

 resolves #1758, resolves #1613 

### Description of changes: 
Add types for integration tests and validate type combinations to reduce test explosion.

 * Cipher, certificates, curves, protocols, etc.
 * Update test combinations logic to deselect tests that don't make sense.
 * Update s2nc test suite so we can test each cipher.

Describe s2n’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.
### Call-outs:

Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 

### Testing:
Using a related change, #1906, ran the full test suite.

```
=================================================================================================================================== 8408 passed, 18144 deselected in 4603.48s (1:16:43) ====================================================================================================================================
_________________________________________________________________________________________________________________________________________________________ summary __________________________________________________________________________________________________________________________________________________________
  py38: commands succeeded
  congratulations :)
```
Testing for #1613 shows 3024 tests using TLS1.3 with various sized RSA certificates and ciphers:

```
$ cat happy.log | grep RSA | grep TLS1.3 | wc -l
3024
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
