### PR TITLE
Add session resumption integ test

### DIFF
--- a/tests/integrationv2/Makefile
+++ b/tests/integrationv2/Makefile
@@ -19,8 +19,6 @@ ifndef S2N_LIBCRYPTO
 	export S2N_LIBCRYPTO="openssl-1.1.1"
 endif
 
-LIBCRYPTO_ROOT:=/home/ubuntu/development/s2n/test-deps/openssl-1.1.1/
-
 HANDSHAKE_TEST_PARAMS:=--libcrypto $(S2N_LIBCRYPTO) $(S2ND_HOST) $(S2ND_PORT)
 
 ifeq ($(S2N_CORKED_IO),true)

--- a/tests/integrationv2/README.md
+++ b/tests/integrationv2/README.md
@@ -88,11 +88,26 @@ def test_example(managed_process, cipher, provider, protocol, certificate):
 # Testing a new feature
 
 If you are testing a new feature you need to determine how to use that feature with all supported
-providers. You may have to add a flag to s2nc/s2nd to allow that feature from the command line.
+providers.
 
-Next, add a flag to the ProviderOptions object. For example, add a `require_client_auth` flag
-which will be a boolean. In the toy example above, you can set `require_client_auth` in the `client_options`
-and `server_options`.
+## s2nd / s2nc
+
+You may have to add a flag to s2nc/s2nd to allow that feature from the command line. If at all possible
+use long options, and use the same option in s2nc as s2nd. This attempts to limit the differences
+between the two. If you are able to setup the option similar to how an OpenSSL derivitive works, that
+will make things easier in the long run. An example of this is '-reconnect' in OpenSSL and '-r' in S2N.
+Both have a hardcoded value of 5 reconnects. The point is to remove logic from the test, and make the
+providers act as similar as possible.
+
+## Control the provider from the test
+
+To tell the provider you want to excersize some functionality you can add an option to the ProviderOptions
+object, or you can pass extra_flags data. If multiple providers need to know about your option, choose
+the ProviderOptions method. If your option is specific to one provider, just pass extra_flags.
+
+For example, during session resumption we need to tell various clients and server to resume a session
+multiple times. To do this we added the 'reconnect' and 'reconnects_before_exit' options to the ProviderOptions
+object. But with dynamic thresholds we simply pass the '-D' argument as an extra flag to s2n.
 
 In each provider that supports client authentication, you need to check if the flag is set, and
 create a command line option for that particular provider. You can also add logic checks, e.g with

--- a/tests/integrationv2/common.py
+++ b/tests/integrationv2/common.py
@@ -265,6 +265,8 @@ class ProviderOptions(object):
             client_certificate_file=None,
             extra_flags=None,
             client_trust_store=None,
+            reconnects_before_exit=None,
+            reconnect=None,
             protocol=None):
 
         # Client or server
@@ -306,4 +308,11 @@ class ProviderOptions(object):
         self.client_trust_store = client_trust_store
         self.client_key_file = client_key_file
 
+        # Reconnects on the server side (includes first connection)
+        self.reconnects_before_exit = reconnects_before_exit
+
+        # Tell the client to reconnect
+        self.reconnect = reconnect
+
+        # Extra flags to pass to the provider
         self.extra_flags = extra_flags

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -121,6 +121,13 @@ class S2N(Provider):
             cmd_line.append('--insecure')
         elif options.client_trust_store is not None:
             cmd_line.extend(['-f', options.client_trust_store])
+        else:
+            if options.cert is not None:
+                cmd_line.extend(['-f', options.cert])
+
+        if options.reconnect is True:
+            cmd_line.append('-r')
+
         if options.protocol == Protocols.TLS13:
             cmd_line.append('--tls13')
 
@@ -159,6 +166,12 @@ class S2N(Provider):
         if options.use_client_auth is True:
             cmd_line.append('-m')
             cmd_line.extend(['-t', options.client_certificate_file])
+
+        if options.reconnects_before_exit is not None:
+            cmd_line.append('--max-conns={}'.format(options.reconnects_before_exit))
+
+        if options.extra_flags is not None:
+            cmd_line.extend(options.extra_flags)
 
         cmd_line.extend([options.host, options.port])
 
@@ -226,6 +239,12 @@ class OpenSSL(Provider):
             cmd_line.extend(['-key', options.client_key_file])
             cmd_line.extend(['-cert', options.client_certificate_file])
 
+        if options.reconnect is True:
+            cmd_line.append('-reconnect')
+
+        if options.extra_flags is not None:
+            cmd_line.extend(options.extra_flags)
+
         # Clients are always ready to connect
         self.set_provider_ready()
 
@@ -238,8 +257,12 @@ class OpenSSL(Provider):
         cmd_line = ['openssl', 's_server']
         cmd_line.extend(['-accept', '{}:{}'.format(options.host, options.port)])
 
-        # Exit after the first connection
-        cmd_line.extend(['-naccept', '1'])
+        if options.reconnects_before_exit is not None:
+            # If the user request a specific reconnection count, set it here
+            cmd_line.extend(['-naccept', str(options.reconnects_before_exit)])
+        else:
+            # Exit after the first connection by default
+            cmd_line.extend(['-naccept', '1'])
 
         # Additional debugging that will be captured incase of failure
         cmd_line.extend(['-debug', '-tlsextdebug'])

--- a/tests/integrationv2/test_session_resumption.py
+++ b/tests/integrationv2/test_session_resumption.py
@@ -1,0 +1,55 @@
+import copy
+import os
+import pytest
+import time
+
+from configuration import available_ports, ALL_TEST_CIPHERS, ALL_TEST_CURVES, ALL_TEST_CERTS, PROTOCOLS
+from common import ProviderOptions, Protocols
+from fixtures import managed_process
+from providers import Provider, S2N, OpenSSL
+from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version
+
+
+@pytest.mark.uncollect_if(func=invalid_test_parameters)
+@pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
+@pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
+@pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
+@pytest.mark.parametrize("protocol", [p for p in PROTOCOLS if p != Protocols.TLS13], ids=get_parameter_name)
+def test_session_resumption_s2n_server(managed_process, cipher, curve, protocol, certificate):
+    host = "localhost"
+    port = next(available_ports)
+
+    client_options = ProviderOptions(
+        mode=Provider.ClientMode,
+        host="localhost",
+        port=port,
+        cipher=cipher,
+        curve=curve,
+        insecure=True,
+        reconnect=True,
+        protocol=protocol)
+
+    server_options = copy.copy(client_options)
+    server_options.reconnects_before_exit = 6
+    server_options.mode = Provider.ServerMode
+    server_options.key = certificate.key
+    server_options.cert = certificate.cert
+
+    # Passing the type of client and server as a parameter will
+    # allow us to use a fixture to enumerate all possibilities.
+    server = managed_process(S2N, server_options, timeout=5)
+    client = managed_process(OpenSSL, client_options, timeout=5)
+
+    # The client should connect and return without error
+    for results in client.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+        assert results.stdout.count(bytes("Session-ID:".encode('utf-8'))) == 6
+
+    expected_version = get_expected_s2n_version(protocol, OpenSSL)
+
+    # S2N should indicate the procotol version in a successful connection.
+    for results in server.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+        assert results.stdout.count(bytes("Actual protocol version: {}".format(expected_version).encode('utf-8'))) == 6

--- a/tests/integrationv2/utils.py
+++ b/tests/integrationv2/utils.py
@@ -34,14 +34,15 @@ def invalid_test_parameters(*args, **kwargs):
     cipher = kwargs.get('cipher')
     curve = kwargs.get('curve')
 
-    # If the selected protocol doesn't allow the cipher, don't test
-    if cipher.min_version > protocol:
-        return True
+    if cipher is not None:
+        # If the selected protocol doesn't allow the cipher, don't test
+        if protocol is not None and cipher.min_version > protocol:
+            return True
 
-    # NOTE: We don't detect the version of OpenSSL at the moment,
-    # so we will deselect these tests.
-    if cipher.openssl1_1_1 is False:
-        return True
+        # NOTE: We don't detect the version of OpenSSL at the moment,
+        # so we will deselect these tests.
+        if cipher.openssl1_1_1 is False:
+            return True
 
     # If we are using a cipher that depends on a specific certificate algorithm
     # deselect the test of the wrong certificate is used.


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

 resolves #1869 

### Description of changes: 

    Add session resumption integ test.

     * Update s2nd to accept variable number of max connections (maintain backwards compat).
     * Slight updates to providers to support max conns.
     * README updates.

### Call-outs:

s2nd needed to accept a "max-conn" parameter which would shutdown s2nd after a certain amount of connections. This matches openssl's hardcoded '5' reconnect attempts for session resumption. This parameters allows s2nd to cleanly shutdown without timing out.

### Testing:

```
platform linux -- Python 3.6.9, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /home/ubuntu/development/s2n/tests/integrationv2
plugins: xdist-1.32.0, forked-1.1.3
collected 3654 items / 2934 deselected / 720 selected

test_session_resumption.py ......................................................................................................................................................................................................................................................................................... [ 39%]
.................................................................................................................................................................................................................................................................................................................... [ 81%]
...................................................................................................................................                                                                                                                                                                                  [100%]

===================================================================================================================================== 720 passed, 2934 deselected in 82.91s (0:01:22) ======================================================================================================================================
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
