### PR TITLE
Add extension type lists for each message type

### DIFF
--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -38,6 +38,9 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_set_test_protocol_versions(server_conn));
 
+        /* Handle null */
+        EXPECT_EQUAL(s2n_connection_get_protocol_version(NULL), S2N_UNKNOWN_PROTOCOL_VERSION);
+
         /* Return actual if set */
         EXPECT_EQUAL(s2n_connection_get_protocol_version(client_conn), actual_version);
         EXPECT_EQUAL(s2n_connection_get_protocol_version(server_conn), actual_version);

--- a/tests/unit/s2n_extension_type_lists_test.c
+++ b/tests/unit/s2n_extension_type_lists_test.c
@@ -17,6 +17,7 @@
 
 #include "tls/extensions/s2n_extension_type_lists.h"
 #include "tls/s2n_connection.h"
+#include "tls/s2n_tls.h"
 
 #define LIST_TYPE_SAME_IN_TLS13         S2N_EXTENSION_LIST_CLIENT_HELLO
 #define LIST_TYPE_DIFFERENT_IN_TLS13    S2N_EXTENSION_LIST_SERVER_HELLO
@@ -30,87 +31,93 @@
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
+    EXPECT_SUCCESS(s2n_enable_tls13());
 
     /* Test s2n_extension_type_list_get */
     {
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
-        const s2n_extension_type_list *list;
+        s2n_extension_type_list *list;
 
         /* Handles nulls */
         EXPECT_FAILURE(s2n_extension_type_list_get(0, conn, NULL));
-        EXPECT_SUCCESS(s2n_extension_type_list_get(0, NULL, &list));
+        EXPECT_FAILURE(s2n_extension_type_list_get(0, NULL, &list));
 
         /* Should fail for a bad list type */
         EXPECT_FAILURE(s2n_extension_type_list_get(-1, conn, &list));
 
         /* Can retrieve the same list for tls1.2 and tls1.3 */
         {
-            const s2n_extension_type_list *tls12_list, *tls13_list;
+            s2n_extension_type_list *default_list, *tls13_list;
 
             conn->actual_protocol_version = S2N_TLS12;
-            EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_SAME_IN_TLS13, conn, &tls12_list));
-            EXPECT_NOT_EMPTY_LIST(tls12_list);
+            EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_SAME_IN_TLS13, conn, &default_list));
+            EXPECT_NOT_EMPTY_LIST(default_list);
 
             conn->actual_protocol_version = S2N_TLS13;
             EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_SAME_IN_TLS13, conn, &tls13_list));
             EXPECT_NOT_EMPTY_LIST(tls13_list);
 
-            EXPECT_EQUAL(tls12_list->extension_types, tls13_list->extension_types);
+            EXPECT_EQUAL(default_list->extension_types, tls13_list->extension_types);
         }
 
         /* Can retrieve different lists for tls1.2 and tls1.3 */
         {
-            const s2n_extension_type_list *tls12_list, *tls13_list;
+            s2n_extension_type_list *default_list, *tls13_list;
 
             conn->actual_protocol_version = S2N_TLS12;
-            EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_DIFFERENT_IN_TLS13, conn, &tls12_list));
-            EXPECT_NOT_EMPTY_LIST(tls12_list);
+            EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_DIFFERENT_IN_TLS13, conn, &default_list));
+            EXPECT_NOT_EMPTY_LIST(default_list);
 
             conn->actual_protocol_version = S2N_TLS13;
             EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_DIFFERENT_IN_TLS13, conn, &tls13_list));
             EXPECT_NOT_EMPTY_LIST(tls13_list);
 
-            EXPECT_NOT_EQUAL(tls12_list->extension_types, tls13_list->extension_types);
+            EXPECT_NOT_EQUAL(default_list->extension_types, tls13_list->extension_types);
         }
 
-        /* Retrieves tls1.2 list when protocol version earlier than tls1.2 */
+        /* Retrieves default list when protocol version earlier than tls1.2 */
         {
-            const s2n_extension_type_list *tls12_list, *tls10_list;
+            s2n_extension_type_list *default_list, *tls10_list;
             conn->actual_protocol_version = S2N_TLS12;
-            EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_DIFFERENT_IN_TLS13, conn, &tls12_list));
-            EXPECT_NOT_EMPTY_LIST(tls12_list);
+            EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_DIFFERENT_IN_TLS13, conn, &default_list));
+            EXPECT_NOT_EMPTY_LIST(default_list);
 
             conn->actual_protocol_version = S2N_TLS10;
             EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_DIFFERENT_IN_TLS13, conn, &tls10_list));
             EXPECT_NOT_EMPTY_LIST(tls10_list);
 
-            EXPECT_EQUAL(tls12_list->extension_types, tls10_list->extension_types);
-        }
-
-        /* Retrieves tls1.2 list when protocol version unknown */
-        {
-            const s2n_extension_type_list *tls12_list, *unknown_version_list;
-            conn->actual_protocol_version = S2N_TLS12;
-            EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_DIFFERENT_IN_TLS13, conn, &tls12_list));
-            EXPECT_NOT_EMPTY_LIST(tls12_list);
-
-            conn->actual_protocol_version = S2N_UNKNOWN_PROTOCOL_VERSION;
-            EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_DIFFERENT_IN_TLS13, conn, &unknown_version_list));
-            EXPECT_NOT_EMPTY_LIST(unknown_version_list);
-
-            EXPECT_EQUAL(tls12_list->extension_types, unknown_version_list->extension_types);
+            EXPECT_EQUAL(default_list->extension_types, tls10_list->extension_types);
         }
 
         /* Can retrieve an empty list */
         {
-            const s2n_extension_type_list *tls12_list;
+            s2n_extension_type_list *empty_list;
             conn->actual_protocol_version = S2N_TLS12;
-            EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_EMPTY_IN_TLS12, conn, &tls12_list));
-            EXPECT_NOT_NULL(tls12_list);
-            EXPECT_EQUAL(tls12_list->count, 0);
-            EXPECT_NULL(tls12_list->extension_types);
+            EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_EMPTY_IN_TLS12, conn, &empty_list));
+            EXPECT_NOT_NULL(empty_list);
+            EXPECT_EQUAL(empty_list->count, 0);
+            EXPECT_NULL(empty_list->extension_types);
+        }
+
+        /* Fails to retrieve an invalid list id */
+        {
+            conn->actual_protocol_version = S2N_TLS12;
+            EXPECT_FAILURE(s2n_extension_type_list_get(S2N_EXTENSION_LIST_IDS_COUNT, conn, &list));
+        }
+
+        /* Can retrieve a list for every id + protocol version */
+        {
+            for (int i = 0; i < S2N_EXTENSION_LIST_IDS_COUNT; i++) {
+                for (int j = 0; j <= s2n_highest_protocol_version; j++) {
+                    conn->actual_protocol_version = j;
+
+                    list = NULL;
+                    EXPECT_SUCCESS(s2n_extension_type_list_get(i, conn, &list));
+                    EXPECT_NOT_NULL(list);
+                }
+            }
         }
 
         EXPECT_SUCCESS(s2n_connection_free(conn));

--- a/tests/unit/s2n_extension_type_lists_test.c
+++ b/tests/unit/s2n_extension_type_lists_test.c
@@ -49,7 +49,7 @@ int main(int argc, char **argv)
 
         /* Can retrieve the same list for tls1.2 and tls1.3 */
         {
-            s2n_extension_type_list *default_list, *tls13_list;
+            s2n_extension_type_list *default_list = NULL, *tls13_list = NULL;
 
             conn->actual_protocol_version = S2N_TLS12;
             EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_SAME_IN_TLS13, conn, &default_list));
@@ -64,7 +64,7 @@ int main(int argc, char **argv)
 
         /* Can retrieve different lists for tls1.2 and tls1.3 */
         {
-            s2n_extension_type_list *default_list, *tls13_list;
+            s2n_extension_type_list *default_list = NULL, *tls13_list = NULL;
 
             conn->actual_protocol_version = S2N_TLS12;
             EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_DIFFERENT_IN_TLS13, conn, &default_list));
@@ -79,7 +79,7 @@ int main(int argc, char **argv)
 
         /* Retrieves default list when protocol version earlier than tls1.2 */
         {
-            s2n_extension_type_list *default_list, *tls10_list;
+            s2n_extension_type_list *default_list = NULL, *tls10_list = NULL;
             conn->actual_protocol_version = S2N_TLS12;
             EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_DIFFERENT_IN_TLS13, conn, &default_list));
             EXPECT_NOT_EMPTY_LIST(default_list);
@@ -93,7 +93,7 @@ int main(int argc, char **argv)
 
         /* Can retrieve an empty list */
         {
-            s2n_extension_type_list *empty_list;
+            s2n_extension_type_list *empty_list = NULL;
             conn->actual_protocol_version = S2N_TLS12;
             EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_EMPTY_IN_TLS12, conn, &empty_list));
             EXPECT_NOT_NULL(empty_list);

--- a/tests/unit/s2n_extension_type_lists_test.c
+++ b/tests/unit/s2n_extension_type_lists_test.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "tls/extensions/s2n_extension_type_lists.h"
+#include "tls/s2n_connection.h"
+
+#define LIST_TYPE_SAME_IN_TLS13         S2N_EXTENSION_LIST_CLIENT_HELLO
+#define LIST_TYPE_DIFFERENT_IN_TLS13    S2N_EXTENSION_LIST_SERVER_HELLO
+#define LIST_TYPE_EMPTY_IN_TLS12        S2N_EXTENSION_LIST_ENCRYPTED_EXTENSIONS
+
+#define EXPECT_NOT_EMPTY_LIST(list) \
+        EXPECT_NOT_NULL(list); \
+        EXPECT_NOT_EQUAL((list)->count, 0); \
+        EXPECT_NOT_NULL((list)->extension_types) \
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Test s2n_extension_type_list_get */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+        const s2n_extension_type_list *list;
+
+        /* Handles nulls */
+        EXPECT_FAILURE(s2n_extension_type_list_get(0, conn, NULL));
+        EXPECT_SUCCESS(s2n_extension_type_list_get(0, NULL, &list));
+
+        /* Should fail for a bad list type */
+        EXPECT_FAILURE(s2n_extension_type_list_get(-1, conn, &list));
+
+        /* Can retrieve the same list for tls1.2 and tls1.3 */
+        {
+            const s2n_extension_type_list *tls12_list, *tls13_list;
+
+            conn->actual_protocol_version = S2N_TLS12;
+            EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_SAME_IN_TLS13, conn, &tls12_list));
+            EXPECT_NOT_EMPTY_LIST(tls12_list);
+
+            conn->actual_protocol_version = S2N_TLS13;
+            EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_SAME_IN_TLS13, conn, &tls13_list));
+            EXPECT_NOT_EMPTY_LIST(tls13_list);
+
+            EXPECT_EQUAL(tls12_list->extension_types, tls13_list->extension_types);
+        }
+
+        /* Can retrieve different lists for tls1.2 and tls1.3 */
+        {
+            const s2n_extension_type_list *tls12_list, *tls13_list;
+
+            conn->actual_protocol_version = S2N_TLS12;
+            EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_DIFFERENT_IN_TLS13, conn, &tls12_list));
+            EXPECT_NOT_EMPTY_LIST(tls12_list);
+
+            conn->actual_protocol_version = S2N_TLS13;
+            EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_DIFFERENT_IN_TLS13, conn, &tls13_list));
+            EXPECT_NOT_EMPTY_LIST(tls13_list);
+
+            EXPECT_NOT_EQUAL(tls12_list->extension_types, tls13_list->extension_types);
+        }
+
+        /* Retrieves tls1.2 list when protocol version earlier than tls1.2 */
+        {
+            const s2n_extension_type_list *tls12_list, *tls10_list;
+            conn->actual_protocol_version = S2N_TLS12;
+            EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_DIFFERENT_IN_TLS13, conn, &tls12_list));
+            EXPECT_NOT_EMPTY_LIST(tls12_list);
+
+            conn->actual_protocol_version = S2N_TLS10;
+            EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_DIFFERENT_IN_TLS13, conn, &tls10_list));
+            EXPECT_NOT_EMPTY_LIST(tls10_list);
+
+            EXPECT_EQUAL(tls12_list->extension_types, tls10_list->extension_types);
+        }
+
+        /* Retrieves tls1.2 list when protocol version unknown */
+        {
+            const s2n_extension_type_list *tls12_list, *unknown_version_list;
+            conn->actual_protocol_version = S2N_TLS12;
+            EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_DIFFERENT_IN_TLS13, conn, &tls12_list));
+            EXPECT_NOT_EMPTY_LIST(tls12_list);
+
+            conn->actual_protocol_version = S2N_UNKNOWN_PROTOCOL_VERSION;
+            EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_DIFFERENT_IN_TLS13, conn, &unknown_version_list));
+            EXPECT_NOT_EMPTY_LIST(unknown_version_list);
+
+            EXPECT_EQUAL(tls12_list->extension_types, unknown_version_list->extension_types);
+        }
+
+        /* Can retrieve an empty list */
+        {
+            const s2n_extension_type_list *tls12_list;
+            conn->actual_protocol_version = S2N_TLS12;
+            EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_EMPTY_IN_TLS12, conn, &tls12_list));
+            EXPECT_NOT_NULL(tls12_list);
+            EXPECT_EQUAL(tls12_list->count, 0);
+            EXPECT_NULL(tls12_list->extension_types);
+        }
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    END_TEST();
+}

--- a/tls/extensions/s2n_extension_type_lists.c
+++ b/tls/extensions/s2n_extension_type_lists.c
@@ -94,46 +94,46 @@ static const s2n_extension_type *const certificate_extensions[] = {
 };
 
 #define S2N_EXTENSION_LIST(list) { .extension_types = (list), .count = s2n_array_len(list) }
-
-static const s2n_extension_type_list empty_extension_type_list = { .extension_types = NULL, .count = 0 };
+#define S2N_EMPTY_EXTENSION_LIST { .extension_types = NULL, .count = 0 }
 
 static struct {
-    const s2n_extension_type_list tls12_list;
-    const s2n_extension_type_list tls13_list; /* TLS1.3 moved some extensions to different extension lists */
+    s2n_extension_type_list default_list;
+    s2n_extension_type_list tls13_list; /* TLS1.3 moved some extensions to different extension lists */
 } extension_lists[] = {
         [S2N_EXTENSION_LIST_CLIENT_HELLO] = {
-                .tls12_list = S2N_EXTENSION_LIST(client_hello_extensions),
+                .default_list = S2N_EXTENSION_LIST(client_hello_extensions),
                 .tls13_list = S2N_EXTENSION_LIST(client_hello_extensions),
         },
         [S2N_EXTENSION_LIST_SERVER_HELLO] = {
-                .tls12_list = S2N_EXTENSION_LIST(tls12_server_hello_extensions),
+                .default_list = S2N_EXTENSION_LIST(tls12_server_hello_extensions),
                 .tls13_list = S2N_EXTENSION_LIST(tls13_server_hello_extensions),
         },
         [S2N_EXTENSION_LIST_ENCRYPTED_EXTENSIONS] = {
+                .default_list = S2N_EMPTY_EXTENSION_LIST,
                 .tls13_list = S2N_EXTENSION_LIST(encrypted_extensions),
         },
         [S2N_EXTENSION_LIST_CERT_REQ] = {
+                .default_list = S2N_EMPTY_EXTENSION_LIST,
                 .tls13_list = S2N_EXTENSION_LIST(cert_req_extensions),
         },
         [S2N_EXTENSION_LIST_CERTIFICATE] = {
+                .default_list = S2N_EMPTY_EXTENSION_LIST,
                 .tls13_list = S2N_EXTENSION_LIST(certificate_extensions),
         },
 };
 
-int s2n_extension_type_list_get(s2n_extension_list_id list_type, struct s2n_connection *conn,
-        const s2n_extension_type_list **extension_list)
+int s2n_extension_type_list_get(s2n_extension_list_id list_type, const struct s2n_connection *conn,
+        s2n_extension_type_list **extension_list)
 {
     notnull_check(extension_list);
+    notnull_check(conn);
     lt_check(list_type, s2n_array_len(extension_lists));
 
     if (s2n_connection_get_protocol_version(conn) >= S2N_TLS13) {
         *extension_list = &extension_lists[list_type].tls13_list;
     } else {
-        *extension_list = &extension_lists[list_type].tls12_list;
+        *extension_list = &extension_lists[list_type].default_list;
     }
 
-    if (*extension_list == NULL) {
-        *extension_list = &empty_extension_type_list;
-    }
     return S2N_SUCCESS;
 }

--- a/tls/extensions/s2n_extension_type_lists.c
+++ b/tls/extensions/s2n_extension_type_lists.c
@@ -1,0 +1,139 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <s2n.h>
+
+#include "tls/extensions/s2n_extension_type_lists.h"
+#include "tls/s2n_connection.h"
+
+#include "tls/extensions/s2n_cookie.h"
+#include "tls/extensions/s2n_client_supported_versions.h"
+#include "tls/extensions/s2n_client_signature_algorithms.h"
+#include "tls/extensions/s2n_client_max_frag_len.h"
+#include "tls/extensions/s2n_client_session_ticket.h"
+#include "tls/extensions/s2n_client_server_name.h"
+#include "tls/extensions/s2n_client_alpn.h"
+#include "tls/extensions/s2n_client_status_request.h"
+#include "tls/extensions/s2n_client_key_share.h"
+#include "tls/extensions/s2n_client_sct_list.h"
+#include "tls/extensions/s2n_client_supported_groups.h"
+#include "tls/extensions/s2n_client_pq_kem.h"
+#include "tls/extensions/s2n_client_renegotiation_info.h"
+#include "tls/extensions/s2n_ec_point_format.h"
+#include "tls/extensions/s2n_server_certificate_status.h"
+#include "tls/extensions/s2n_server_renegotiation_info.h"
+#include "tls/extensions/s2n_server_alpn.h"
+#include "tls/extensions/s2n_server_status_request.h"
+#include "tls/extensions/s2n_server_sct_list.h"
+#include "tls/extensions/s2n_server_max_fragment_length.h"
+#include "tls/extensions/s2n_server_session_ticket.h"
+#include "tls/extensions/s2n_server_server_name.h"
+#include "tls/extensions/s2n_server_signature_algorithms.h"
+#include "tls/extensions/s2n_server_supported_versions.h"
+#include "tls/extensions/s2n_server_key_share.h"
+
+static const s2n_extension_type *const client_hello_extensions[] = {
+        &s2n_client_supported_versions_extension,
+        &s2n_client_key_share_extension,
+        &s2n_client_signature_algorithms_extension,
+        &s2n_client_server_name_extension,
+        &s2n_client_alpn_extension,
+        &s2n_client_status_request_extension,
+        &s2n_client_sct_list_extension,
+        &s2n_client_max_frag_len_extension,
+        &s2n_client_session_ticket_extension,
+        &s2n_client_supported_groups_extension,
+        &s2n_client_ec_point_format_extension,
+        &s2n_client_pq_kem_extension,
+        &s2n_client_renegotiation_info_extension,
+};
+
+static const s2n_extension_type *const tls12_server_hello_extensions[] = {
+        &s2n_server_supported_versions_extension,
+        &s2n_server_server_name_extension,
+        &s2n_server_ec_point_format_extension,
+        &s2n_server_renegotiation_info_extension,
+        &s2n_server_alpn_extension,
+        &s2n_server_status_request_extension,
+        &s2n_server_sct_list_extension,
+        &s2n_server_max_fragment_length_extension,
+        &s2n_server_session_ticket_extension,
+};
+
+static const s2n_extension_type *const tls13_server_hello_extensions[] = {
+        &s2n_server_supported_versions_extension,
+        &s2n_server_key_share_extension,
+        &s2n_server_cookie_extension,
+};
+
+static const s2n_extension_type *const encrypted_extensions[] = {
+        &s2n_server_server_name_extension,
+        &s2n_server_max_fragment_length_extension,
+        &s2n_server_alpn_extension,
+};
+
+static const s2n_extension_type *const cert_req_extensions[] = {
+        &s2n_server_signature_algorithms_extension,
+};
+
+static const s2n_extension_type *const certificate_extensions[] = {
+        &s2n_tls13_server_status_request_extension,
+        &s2n_server_sct_list_extension,
+};
+
+#define S2N_EXTENSION_LIST(list) { .extension_types = (list), .count = s2n_array_len(list) }
+
+static const s2n_extension_type_list empty_extension_type_list = { .extension_types = NULL, .count = 0 };
+
+static struct {
+    const s2n_extension_type_list tls12_list;
+    const s2n_extension_type_list tls13_list; /* TLS1.3 moved some extensions to different extension lists */
+} extension_lists[] = {
+        [S2N_EXTENSION_LIST_CLIENT_HELLO] = {
+                .tls12_list = S2N_EXTENSION_LIST(client_hello_extensions),
+                .tls13_list = S2N_EXTENSION_LIST(client_hello_extensions),
+        },
+        [S2N_EXTENSION_LIST_SERVER_HELLO] = {
+                .tls12_list = S2N_EXTENSION_LIST(tls12_server_hello_extensions),
+                .tls13_list = S2N_EXTENSION_LIST(tls13_server_hello_extensions),
+        },
+        [S2N_EXTENSION_LIST_ENCRYPTED_EXTENSIONS] = {
+                .tls13_list = S2N_EXTENSION_LIST(encrypted_extensions),
+        },
+        [S2N_EXTENSION_LIST_CERT_REQ] = {
+                .tls13_list = S2N_EXTENSION_LIST(cert_req_extensions),
+        },
+        [S2N_EXTENSION_LIST_CERTIFICATE] = {
+                .tls13_list = S2N_EXTENSION_LIST(certificate_extensions),
+        },
+};
+
+int s2n_extension_type_list_get(s2n_extension_list_id list_type, struct s2n_connection *conn,
+        const s2n_extension_type_list **extension_list)
+{
+    notnull_check(extension_list);
+    lt_check(list_type, s2n_array_len(extension_lists));
+
+    if (s2n_connection_get_protocol_version(conn) >= S2N_TLS13) {
+        *extension_list = &extension_lists[list_type].tls13_list;
+    } else {
+        *extension_list = &extension_lists[list_type].tls12_list;
+    }
+
+    if (*extension_list == NULL) {
+        *extension_list = &empty_extension_type_list;
+    }
+    return S2N_SUCCESS;
+}

--- a/tls/extensions/s2n_extension_type_lists.h
+++ b/tls/extensions/s2n_extension_type_lists.h
@@ -23,6 +23,7 @@ typedef enum {
     S2N_EXTENSION_LIST_ENCRYPTED_EXTENSIONS,
     S2N_EXTENSION_LIST_CERT_REQ,
     S2N_EXTENSION_LIST_CERTIFICATE,
+    S2N_EXTENSION_LIST_IDS_COUNT,
 } s2n_extension_list_id;
 
 typedef struct {
@@ -30,5 +31,5 @@ typedef struct {
     const uint8_t count;
 } s2n_extension_type_list;
 
-int s2n_extension_type_list_get(s2n_extension_list_id list_type, struct s2n_connection *conn,
-        const s2n_extension_type_list **extension_type_list);
+int s2n_extension_type_list_get(s2n_extension_list_id list_type, const struct s2n_connection *conn,
+        s2n_extension_type_list **extension_type_list);

--- a/tls/extensions/s2n_extension_type_lists.h
+++ b/tls/extensions/s2n_extension_type_lists.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include "tls/extensions/s2n_extension_type.h"
+
+typedef enum {
+    S2N_EXTENSION_LIST_CLIENT_HELLO = 0,
+    S2N_EXTENSION_LIST_SERVER_HELLO,
+    S2N_EXTENSION_LIST_ENCRYPTED_EXTENSIONS,
+    S2N_EXTENSION_LIST_CERT_REQ,
+    S2N_EXTENSION_LIST_CERTIFICATE,
+} s2n_extension_list_id;
+
+typedef struct {
+    const s2n_extension_type *const *extension_types;
+    const uint8_t count;
+} s2n_extension_type_list;
+
+int s2n_extension_type_list_get(s2n_extension_list_id list_type, struct s2n_connection *conn,
+        const s2n_extension_type_list **extension_type_list);

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1287,7 +1287,7 @@ struct s2n_cert_chain_and_key *s2n_connection_get_selected_cert(struct s2n_conne
     return conn->handshake_params.our_chain_and_key;
 }
 
-uint8_t s2n_connection_get_protocol_version(struct s2n_connection *conn)
+uint8_t s2n_connection_get_protocol_version(const struct s2n_connection *conn)
 {
     if (conn == NULL) {
         return S2N_UNKNOWN_PROTOCOL_VERSION;
@@ -1299,10 +1299,6 @@ uint8_t s2n_connection_get_protocol_version(struct s2n_connection *conn)
 
     if (conn->mode == S2N_CLIENT) {
         return conn->client_protocol_version;
-    } else if (conn->mode == S2N_SERVER) {
-        return conn->server_protocol_version;
     }
-
-    return S2N_UNKNOWN_PROTOCOL_VERSION;
+    return conn->server_protocol_version;
 }
-

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1289,6 +1289,10 @@ struct s2n_cert_chain_and_key *s2n_connection_get_selected_cert(struct s2n_conne
 
 uint8_t s2n_connection_get_protocol_version(struct s2n_connection *conn)
 {
+    if (conn == NULL) {
+        return S2N_UNKNOWN_PROTOCOL_VERSION;
+    }
+
     if (conn->actual_protocol_version != S2N_UNKNOWN_PROTOCOL_VERSION) {
         return conn->actual_protocol_version;
     }

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -326,4 +326,4 @@ int s2n_connection_get_protocol_preferences(struct s2n_connection *conn, struct 
 int s2n_connection_set_client_auth_type(struct s2n_connection *conn, s2n_cert_auth_type cert_auth_type);
 int s2n_connection_get_client_auth_type(struct s2n_connection *conn, s2n_cert_auth_type *client_cert_auth_type);
 int s2n_connection_get_client_cert_chain(struct s2n_connection *conn, uint8_t **der_cert_chain_out, uint32_t *cert_chain_len);
-uint8_t s2n_connection_get_protocol_version(struct s2n_connection *conn);
+uint8_t s2n_connection_get_protocol_version(const struct s2n_connection *conn);


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

 resolves https://github.com/awslabs/s2n/issues/1914

### Description of changes: 

The new extension structs will let us handle extensions using common logic and defined lists of extensions. To take advantage of that, we need lists of extensions!

### Call-outs:

**Why is supported_versions in the tls12_server_hello_extensions list?** When the client starts processing the ServerHello extensions, it potentially doesn't know whether the server wants to use 1.3 or 1.2. We need to make that decision after we process supported_versions, potentially switching which list we are using.

### Testing:

This change only includes basic unit tests. We will need to prove that these lists match current behavior, but that will minimally require the send method.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
