### PR TITLE
Adds a proof harness for the s2n_blob_init function

### DIFF
--- a/error/s2n_errno.c
+++ b/error/s2n_errno.c
@@ -156,6 +156,7 @@ static const char *no_such_error = "Internal s2n error";
     ERR_ENTRY(S2N_ERR_RECV_STUFFER_FROM_CONN, "Error receiving stuffer from connection") \
     ERR_ENTRY(S2N_ERR_SEND_STUFFER_TO_CONN, "Error sending stuffer to connection") \
     ERR_ENTRY(S2N_ERR_PRECONDITION_VIOLATION, "Precondition violation") \
+    ERR_ENTRY(S2N_ERR_POSTCONDITION_VIOLATION, "Postcondition violation") \
     ERR_ENTRY(S2N_ERR_INTEGER_OVERFLOW, "Integer overflow violation") \
     ERR_ENTRY(S2N_ERR_ARRAY_INDEX_OOB, "Array index out of bounds") \
     ERR_ENTRY(S2N_ERR_FREE_STATIC_BLOB, "Cannot free a static blob") \

--- a/error/s2n_errno.h
+++ b/error/s2n_errno.h
@@ -185,6 +185,7 @@ typedef enum {
     S2N_ERR_RECV_STUFFER_FROM_CONN,
     S2N_ERR_SEND_STUFFER_TO_CONN,
     S2N_ERR_PRECONDITION_VIOLATION,
+    S2N_ERR_POSTCONDITION_VIOLATION,
     S2N_ERR_INTEGER_OVERFLOW,
     S2N_ERR_ARRAY_INDEX_OOB,
     S2N_ERR_FREE_STATIC_BLOB,
@@ -265,14 +266,6 @@ extern __thread const char *s2n_debug_str;
 #define S2N_ERROR_IF( cond , x ) do { if ( cond ) { S2N_ERROR( x ); }} while (0)
 #define S2N_ERROR_IF_PTR( cond , x ) do { if ( cond ) { S2N_ERROR_PTR( x ); }} while (0)
 #define S2N_ERROR_IS_BLOCKING( x )    ( s2n_error_get_type(x) == S2N_ERR_T_BLOCKED )
-
-#ifdef __TIMING_CONTRACTS__
-#    define S2N_PRECONDITION( cond ) (void) 0
-#    define S2N_PRECONDITION_PTR( cond ) (void) 0
-#else
-#    define S2N_PRECONDITION( cond ) S2N_ERROR_IF(!(cond), S2N_ERR_PRECONDITION_VIOLATION)
-#    define S2N_PRECONDITION_PTR( cond ) S2N_ERROR_IF_PTR(!(cond), S2N_ERR_PRECONDITION_VIOLATION)
-#endif /* __TIMING_CONTRACTS__ */
 
 /**
  * Define function contracts.

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -27,7 +27,7 @@ bool s2n_stuffer_is_valid(const struct s2n_stuffer* stuffer)
 {
     /* Note that we do not assert any properties on the alloced, growable, and tainted fields,
      * as all possible combinations of boolean values in those fields are valid */
-    return S2N_OBJECT_PTR_IS_READABLE(stuffer) && 
+    return S2N_OBJECT_PTR_IS_READABLE(stuffer) &&
         s2n_blob_is_valid(&stuffer->blob) &&
         /* <= is valid because we can have a fully written/read stuffer */
         stuffer->high_water_mark <= stuffer->blob.size &&
@@ -37,8 +37,8 @@ bool s2n_stuffer_is_valid(const struct s2n_stuffer* stuffer)
 
 int s2n_stuffer_init(struct s2n_stuffer *stuffer, struct s2n_blob *in)
 {
-    S2N_PRECONDITION(S2N_OBJECT_PTR_IS_WRITABLE(stuffer));
-    S2N_PRECONDITION(s2n_blob_is_valid(in));
+    PRECONDITION_POSIX(S2N_OBJECT_PTR_IS_WRITABLE(stuffer));
+    PRECONDITION_POSIX(s2n_blob_is_valid(in));
     stuffer->blob = *in;
     stuffer->read_cursor = 0;
     stuffer->write_cursor = 0;
@@ -123,7 +123,7 @@ int s2n_stuffer_rewind_read(struct s2n_stuffer *stuffer, const uint32_t size)
 
 int s2n_stuffer_reread(struct s2n_stuffer *stuffer)
 {
-    S2N_PRECONDITION(s2n_stuffer_is_valid(stuffer));
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     stuffer->read_cursor = 0;
     return 0;
 }
@@ -138,7 +138,7 @@ int s2n_stuffer_wipe_n(struct s2n_stuffer *stuffer, const uint32_t size)
     stuffer->write_cursor -= size;
     memset_check(stuffer->blob.data + stuffer->write_cursor, S2N_WIPE_PATTERN, size);
     stuffer->read_cursor = MIN(stuffer->read_cursor, stuffer->write_cursor);
-    
+
     return 0;
 }
 
@@ -172,7 +172,7 @@ int s2n_stuffer_wipe(struct s2n_stuffer *stuffer)
 
 int s2n_stuffer_skip_read(struct s2n_stuffer *stuffer, uint32_t n)
 {
-    S2N_PRECONDITION(s2n_stuffer_is_valid(stuffer));
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     S2N_ERROR_IF(s2n_stuffer_data_available(stuffer) < n, S2N_ERR_STUFFER_OUT_OF_DATA);
 
     stuffer->read_cursor += n;
@@ -341,7 +341,7 @@ int s2n_stuffer_copy(struct s2n_stuffer *from, struct s2n_stuffer *to, const uin
 
 int s2n_stuffer_extract_blob(struct s2n_stuffer *stuffer, struct s2n_blob *out)
 {
-    S2N_PRECONDITION(s2n_stuffer_is_valid(stuffer));
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     notnull_check(out);
     GUARD(s2n_free(out));
     GUARD(s2n_alloc(out, s2n_stuffer_data_available(stuffer)));

--- a/tests/cbmc/proofs/Makefile.common
+++ b/tests/cbmc/proofs/Makefile.common
@@ -80,7 +80,7 @@ DO_GOTO_INSTRUMENT = $(call DO_AND_LOG_COMMAND,$(GOTO_INSTRUMENT),$(CBMC_VERBOSI
 #1: flags, 2: source, 3: logfile
 DO_CBMC =  $(call DO_AND_LOG_IGNORING_ERROR_10,$(CBMC),$(CBMC_VERBOSITY) $(1) $(2), $(3))
 
-#1: message 2: source 3: dest 
+#1: message 2: source 3: dest
 DO_NOOP_COPY = cp $(2) $(3); echo $(1) | tee $(call LOG_FROM_ENTRY,$(3))
 
 
@@ -133,7 +133,7 @@ CBMCFLAGS += $(CBMC_UNWINDSET)
 
 ################################################################
 # Set C compiler defines
-CBMC_OBJECT_BITS ?= 6
+CBMC_OBJECT_BITS ?= 8
 CBMCFLAGS +=  --object-bits $(CBMC_OBJECT_BITS)
 DEFINES += -DCBMC_OBJECT_BITS=$(CBMC_OBJECT_BITS)
 DEFINES += -DCBMC=1
@@ -148,13 +148,13 @@ INC += -I$(SRCDIR)/api
 
 ################################################################
 # Enables costly checks (e.g. ones that contain loops)
-# Whether a proof needs these checks should be decided on a proof by proof basis.  
+# Whether a proof needs these checks should be decided on a proof by proof basis.
 # Checks can be enabled by setting AWS_DEEP_CHECKS to 1 in the makefile of the proof that requires them
 AWS_DEEP_CHECKS ?= 0
 DEFINES += -DAWS_DEEP_CHECKS=$(AWS_DEEP_CHECKS)
 
 ################################################################
-# Remove function bodies that are not used in the proofs. 
+# Remove function bodies that are not used in the proofs.
 # Removing the function from the goto program helps CBMC's
 # function pointer analysis
 

--- a/tests/cbmc/proofs/s2n_blob_init/Makefile
+++ b/tests/cbmc/proofs/s2n_blob_init/Makefile
@@ -1,0 +1,25 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use the default set of CBMC flags.
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+
+ENTRY = s2n_blob_init_harness
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_blob_init/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_blob_init/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--conversion-check;--div-by-zero-check;--enum-range-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_blob_init_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_blob_init/s2n_blob_init_harness.c
+++ b/tests/cbmc/proofs/s2n_blob_init/s2n_blob_init_harness.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "utils/s2n_blob.h"
+#include "error/s2n_errno.h"
+
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_blob_init_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_blob * blob = can_fail_malloc( sizeof( *blob ) );
+    uint32_t size;
+    uint8_t * data = can_fail_malloc( size );
+
+    /* Pre-conditions. */
+    __CPROVER_assume(S2N_IMPLIES(size != 0, data != NULL));
+
+    /* Operation under verification. */
+    if( s2n_blob_init( blob, data, size ) == S2N_SUCCESS )
+    {
+        assert( s2n_blob_is_valid( blob ) );
+    }
+}

--- a/tests/sidetrail/working/stubs/s2n_ensure.h
+++ b/tests/sidetrail/working/stubs/s2n_ensure.h
@@ -27,6 +27,8 @@ void *s2n_sidetrail_memset(void * ptr, int value, size_t num);
 
 #define __S2N_ENSURE( cond, action )                       __VERIFIER_assume((cond))
 
+#define __S2N_ENSURE_CONDITION( cond, action )             (void) 0
+
 #define __S2N_ENSURE_SAFE_MEMCPY( d , s , n , guard )      do { memcpy((d), (s), (n)); } while(0)
 
 #define __S2N_ENSURE_SAFE_MEMSET( d , c , n , guard )      \

--- a/utils/s2n_blob.c
+++ b/utils/s2n_blob.c
@@ -37,9 +37,9 @@ bool s2n_blob_is_valid(const struct s2n_blob* b)
 int s2n_blob_init(struct s2n_blob *b, uint8_t * data, uint32_t size)
 {
     notnull_check(b);
-    if(size != 0) { notnull_check(data); }
+    S2N_PRECONDITION(S2N_MEM_IS_READABLE(data,size));
     *b = (struct s2n_blob) {.data = data, .size = size, .allocated = 0, .growable = 0};
-    ENSURE_POSTCONDITION(s2n_blob_is_valid(b));
+    ENSURE_POSIX_POSTCONDITION(s2n_blob_is_valid(b));
     return S2N_SUCCESS;
 }
 

--- a/utils/s2n_blob.c
+++ b/utils/s2n_blob.c
@@ -28,17 +28,19 @@ bool s2n_blob_is_valid(const struct s2n_blob* b)
     return
         b != NULL &&
         S2N_OBJECT_PTR_IS_READABLE(b) &&
-        S2N_IMPLIES(!b->growable, b->allocated == 0) &&
-        S2N_IMPLIES(b->growable, b->size <= b->allocated) &&
-        S2N_IMPLIES(b->growable, S2N_MEM_IS_READABLE(b->data, b->allocated)) &&
+        S2N_IMPLIES(b->growable == 0, b->allocated == 0) &&
+        S2N_IMPLIES(b->growable != 0, S2N_MEM_IS_READABLE(b->data, b->allocated)) &&
+        S2N_IMPLIES(b->growable != 0, b->size <= b->allocated) &&
         S2N_MEM_IS_READABLE(b->data,b->size);
 }
 
 int s2n_blob_init(struct s2n_blob *b, uint8_t * data, uint32_t size)
 {
     notnull_check(b);
+    if(size != 0) { notnull_check(data); }
     *b = (struct s2n_blob) {.data = data, .size = size, .allocated = 0, .growable = 0};
-    return 0;
+    ENSURE_POSTCONDITION(s2n_blob_is_valid(b));
+    return S2N_SUCCESS;
 }
 
 int s2n_blob_zero(struct s2n_blob *b)

--- a/utils/s2n_blob.c
+++ b/utils/s2n_blob.c
@@ -25,13 +25,11 @@
 
 bool s2n_blob_is_valid(const struct s2n_blob* b)
 {
-    return
-        b != NULL &&
-        S2N_OBJECT_PTR_IS_READABLE(b) &&
-        S2N_IMPLIES(b->growable == 0, b->allocated == 0) &&
-        S2N_IMPLIES(b->growable != 0, S2N_MEM_IS_READABLE(b->data, b->allocated)) &&
-        S2N_IMPLIES(b->growable != 0, b->size <= b->allocated) &&
-        S2N_MEM_IS_READABLE(b->data,b->size);
+    return S2N_OBJECT_PTR_IS_READABLE(b) &&
+           S2N_IMPLIES(b->growable == 0, b->allocated == 0) &&
+           S2N_IMPLIES(b->growable != 0, S2N_MEM_IS_READABLE(b->data, b->allocated)) &&
+           S2N_IMPLIES(b->growable != 0, b->size <= b->allocated) &&
+           S2N_MEM_IS_READABLE(b->data,b->size);
 }
 
 int s2n_blob_init(struct s2n_blob *b, uint8_t * data, uint32_t size)

--- a/utils/s2n_blob.c
+++ b/utils/s2n_blob.c
@@ -37,9 +37,9 @@ bool s2n_blob_is_valid(const struct s2n_blob* b)
 int s2n_blob_init(struct s2n_blob *b, uint8_t * data, uint32_t size)
 {
     notnull_check(b);
-    S2N_PRECONDITION(S2N_MEM_IS_READABLE(data,size));
+    PRECONDITION_POSIX(S2N_MEM_IS_READABLE(data,size));
     *b = (struct s2n_blob) {.data = data, .size = size, .allocated = 0, .growable = 0};
-    ENSURE_POSIX_POSTCONDITION(s2n_blob_is_valid(b));
+    POSTCONDITION_POSIX(s2n_blob_is_valid(b));
     return S2N_SUCCESS;
 }
 

--- a/utils/s2n_ensure.h
+++ b/utils/s2n_ensure.h
@@ -29,6 +29,8 @@
  */
 #define __S2N_ENSURE( cond, action ) do {if ( !(cond) ) { action; }} while (0)
 
+#define __S2N_ENSURE_CONDITION( cond, action ) __S2N_ENSURE( cond, action )
+
 #define __S2N_ENSURE_SAFE_MEMCPY( d , s , n , guard )                            \
   do {                                                                           \
     __typeof( n ) __tmp_n = ( n );                                               \

--- a/utils/s2n_safety.c
+++ b/utils/s2n_safety.c
@@ -174,10 +174,10 @@ int s2n_mul_overflow(uint32_t a, uint32_t b, uint32_t* out)
 
 int s2n_align_to(uint32_t initial, uint32_t alignment, uint32_t* out)
 {
-    S2N_PRECONDITION(alignment != 0);
+    PRECONDITION_POSIX(alignment != 0);
     if (initial == 0) {
-	*out = 0;
-	return S2N_SUCCESS;
+        *out = 0;
+        return S2N_SUCCESS;
     }
     const uint64_t i = initial;
     const uint64_t a = alignment;
@@ -194,4 +194,3 @@ int s2n_add_overflow(uint32_t a, uint32_t b, uint32_t* out)
     *out = (uint32_t) result;
     return S2N_SUCCESS;
 }
-

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -96,12 +96,22 @@
 /**
  * Ensures the `condition` is `true`, otherwise the function will `BAIL` with a `S2N_ERR_SAFETY` error
  */
-#define ENSURE_POSTCONDITION( condition )            ENSURE((condition), S2N_ERR_SAFETY)
+#    define PRECONDITION( condition )                 ENSURE((condition), S2N_ERR_PRECONDITION_VIOLATION)
+
+/**
+ * Ensures the `condition` is `true`, otherwise the function will `BAIL` with a `S2N_ERR_SAFETY` error
+ */
+#    define POSTCONDITION( condition )                ENSURE((condition), S2N_ERR_POSTCONDITION_VIOLATION)
 
 /**
  * Ensures the `condition` is `true`, otherwise the function will `BAIL_POSIX` with a `S2N_ERR_SAFETY` error
  */
-#define ENSURE_POSIX_POSTCONDITION( condition )            ENSURE_POSIX((condition), S2N_ERR_SAFETY)
+#    define PRECONDITION_POSIX( condition )           ENSURE_POSIX((condition), S2N_ERR_PRECONDITION_VIOLATION)
+
+/**
+ * Ensures the `condition` is `true`, otherwise the function will `BAIL_POSIX` with a `S2N_ERR_SAFETY` error
+ */
+#    define POSTCONDITION_POSIX( condition )          ENSURE_POSIX((condition), S2N_ERR_POSTCONDITION_VIOLATION)
 
 /**
  * Ensures `min <= n <= max`

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -94,26 +94,6 @@
 #define ENSURE_NONNULL( x )                          ENSURE((x) != NULL, S2N_ERR_NULL)
 
 /**
- * Ensures the `condition` is `true`, otherwise the function will `BAIL` with a `S2N_ERR_SAFETY` error
- */
-#    define PRECONDITION( condition )                 ENSURE((condition), S2N_ERR_PRECONDITION_VIOLATION)
-
-/**
- * Ensures the `condition` is `true`, otherwise the function will `BAIL` with a `S2N_ERR_SAFETY` error
- */
-#    define POSTCONDITION( condition )                ENSURE((condition), S2N_ERR_POSTCONDITION_VIOLATION)
-
-/**
- * Ensures the `condition` is `true`, otherwise the function will `BAIL_POSIX` with a `S2N_ERR_SAFETY` error
- */
-#    define PRECONDITION_POSIX( condition )           ENSURE_POSIX((condition), S2N_ERR_PRECONDITION_VIOLATION)
-
-/**
- * Ensures the `condition` is `true`, otherwise the function will `BAIL_POSIX` with a `S2N_ERR_SAFETY` error
- */
-#    define POSTCONDITION_POSIX( condition )          ENSURE_POSIX((condition), S2N_ERR_POSTCONDITION_VIOLATION)
-
-/**
  * Ensures `min <= n <= max`
  */
 #define ENSURE_INCLUSIVE_RANGE( min , n , max )      \
@@ -152,6 +132,26 @@
  * Ensures `x` is not `NULL`, otherwise the function will `BAIL_PTR` with an `error`
  */
 #define ENSURE_PTR_NONNULL( x )                     ENSURE_PTR((x) != NULL, S2N_ERR_NULL)
+
+/**
+ * Ensures the `condition` is `true`, otherwise the function will `BAIL` with a `S2N_ERR_SAFETY` error
+ */
+#define PRECONDITION( condition )                 ENSURE((condition), S2N_ERR_PRECONDITION_VIOLATION)
+
+/**
+ * Ensures the `condition` is `true`, otherwise the function will `BAIL` with a `S2N_ERR_SAFETY` error
+ */
+#define POSTCONDITION( condition )                ENSURE((condition), S2N_ERR_POSTCONDITION_VIOLATION)
+
+/**
+ * Ensures the `condition` is `true`, otherwise the function will `BAIL_POSIX` with a `S2N_ERR_SAFETY` error
+ */
+#define PRECONDITION_POSIX( condition )           ENSURE_POSIX((condition), S2N_ERR_PRECONDITION_VIOLATION)
+
+/**
+ * Ensures the `condition` is `true`, otherwise the function will `BAIL_POSIX` with a `S2N_ERR_SAFETY` error
+ */
+#define POSTCONDITION_POSIX( condition )          ENSURE_POSIX((condition), S2N_ERR_POSTCONDITION_VIOLATION)
 
 /**
  * Ensures `x` is not an error, otherwise the function will return an error signal

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -134,24 +134,24 @@
 #define ENSURE_PTR_NONNULL( x )                     ENSURE_PTR((x) != NULL, S2N_ERR_NULL)
 
 /**
- * Ensures the `condition` is `true`, otherwise the function will `BAIL` with a `S2N_ERR_SAFETY` error
+ * Ensures the `condition` is `true`, otherwise the function will `BAIL` with a `S2N_ERR_PRECONDITION_VIOLATION` error
  */
-#define PRECONDITION( condition )                 ENSURE((condition), S2N_ERR_PRECONDITION_VIOLATION)
+#define PRECONDITION( condition )                   __S2N_ENSURE_CONDITION((condition), BAIL(S2N_ERR_PRECONDITION_VIOLATION))
 
 /**
- * Ensures the `condition` is `true`, otherwise the function will `BAIL` with a `S2N_ERR_SAFETY` error
+ * Ensures the `condition` is `true`, otherwise the function will `BAIL` with a `S2N_ERR_POSTCONDITION_VIOLATION` error
  */
-#define POSTCONDITION( condition )                ENSURE((condition), S2N_ERR_POSTCONDITION_VIOLATION)
+#define POSTCONDITION( condition )                  __S2N_ENSURE_CONDITION((condition), BAIL(S2N_ERR_POSTCONDITION_VIOLATION))
 
 /**
- * Ensures the `condition` is `true`, otherwise the function will `BAIL_POSIX` with a `S2N_ERR_SAFETY` error
+ * Ensures the `condition` is `true`, otherwise the function will `BAIL_POSIX` with a `S2N_ERR_PRECONDITION_VIOLATION` error
  */
-#define PRECONDITION_POSIX( condition )           ENSURE_POSIX((condition), S2N_ERR_PRECONDITION_VIOLATION)
+#define PRECONDITION_POSIX( condition )             __S2N_ENSURE_CONDITION((condition), BAIL_POSIX(S2N_ERR_PRECONDITION_VIOLATION))
 
 /**
- * Ensures the `condition` is `true`, otherwise the function will `BAIL_POSIX` with a `S2N_ERR_SAFETY` error
+ * Ensures the `condition` is `true`, otherwise the function will `BAIL_POSIX` with a `S2N_ERR_POSTCONDITION_VIOLATION` error
  */
-#define POSTCONDITION_POSIX( condition )          ENSURE_POSIX((condition), S2N_ERR_POSTCONDITION_VIOLATION)
+#define POSTCONDITION_POSIX( condition )            __S2N_ENSURE_CONDITION((condition), BAIL_POSIX(S2N_ERR_POSTCONDITION_VIOLATION))
 
 /**
  * Ensures `x` is not an error, otherwise the function will return an error signal

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -94,6 +94,11 @@
 #define ENSURE_NONNULL( x )                          ENSURE((x) != NULL, S2N_ERR_NULL)
 
 /**
+ * Ensures the `condition` is `true`, otherwise the function will `BAIL_POSIX` with a `S2N_ERR_SAFETY` error
+ */
+#define ENSURE_POSTCONDITION( condition )            __S2N_ENSURE((condition), BAIL_POSIX(S2N_ERR_SAFETY))
+
+/**
  * Ensures `min <= n <= max`
  */
 #define ENSURE_INCLUSIVE_RANGE( min , n , max )      \

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -94,9 +94,14 @@
 #define ENSURE_NONNULL( x )                          ENSURE((x) != NULL, S2N_ERR_NULL)
 
 /**
+ * Ensures the `condition` is `true`, otherwise the function will `BAIL` with a `S2N_ERR_SAFETY` error
+ */
+#define ENSURE_POSTCONDITION( condition )            ENSURE((condition), S2N_ERR_SAFETY)
+
+/**
  * Ensures the `condition` is `true`, otherwise the function will `BAIL_POSIX` with a `S2N_ERR_SAFETY` error
  */
-#define ENSURE_POSTCONDITION( condition )            __S2N_ENSURE((condition), BAIL_POSIX(S2N_ERR_SAFETY))
+#define ENSURE_POSIX_POSTCONDITION( condition )            ENSURE_POSIX((condition), S2N_ERR_SAFETY)
 
 /**
  * Ensures `min <= n <= max`


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A.

### Description of changes: 

- Updates the `s2n_blob_is_valid` function to consider the case `.data == NULL`;
- Updates the `s2n_blob_init` function to set `.size == 0` if `.data == NULL`;
- Adds a CBMC-proof harness for the `s2n_blob_init` function;

### Call-outs:

This PR depends on [PR #1959](https://github.com/awslabs/s2n/pull/1959).

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
