### PR TITLE
Create simple reseed drbg testlib method

### DIFF
--- a/tests/testlib/s2n_hybrid_kem_tests.c
+++ b/tests/testlib/s2n_hybrid_kem_tests.c
@@ -113,7 +113,7 @@ int s2n_test_hybrid_ecdhe_kem_with_kat(const struct s2n_kem *kem, struct s2n_cip
     GUARD_NONNULL(kat_file);
     GUARD(s2n_alloc(&hybrid_kat_entropy_blob, 48));
     GUARD(ReadHex(kat_file, hybrid_kat_entropy_blob.data, 48, "seed = "));
-    GUARD(s2n_unsafe_drbg_reseed(hybrid_kat_entropy_blob.data, hybrid_kat_entropy_blob.size));
+    GUARD(s2n_unsafe_set_drbg_seed(&hybrid_kat_entropy_blob));
 #endif
 
     /* Part 2 server sends key first */

--- a/tests/testlib/s2n_kem_tests.c
+++ b/tests/testlib/s2n_kem_tests.c
@@ -60,7 +60,10 @@ int s2n_test_kem_with_kat(const struct s2n_kem *kem, const char *kat_file_name)
 
         /* Set the NIST rng to the same state the response file was created with */
         GUARD(ReadHex(kat_file, kat_entropy_buff, SEED_LENGTH, "seed = "));
-        GUARD(s2n_unsafe_drbg_reseed(kat_entropy_buff, SEED_LENGTH));
+
+        struct s2n_blob seed;
+        GUARD(s2n_blob_init(&seed, kat_entropy_buff, SEED_LENGTH));
+        GUARD(s2n_unsafe_set_drbg_seed(&seed));
 
         /* Generate the public/private key pair */
         GUARD(kem->generate_keypair(pk, sk));

--- a/tests/testlib/s2n_random_test_utils.c
+++ b/tests/testlib/s2n_random_test_utils.c
@@ -21,6 +21,8 @@
 #include "crypto/s2n_drbg.h"
 #include "tests/testlib/s2n_testlib.h"
 
+#if S2N_LIBCRYPTO_SUPPORTS_CUSTOM_RAND
+
 static uint8_t seed_buffer[S2N_DRBG_MAX_SEED_SIZE] = { 0 };
 
 S2N_RESULT s2n_fixed_entropy_generator(struct s2n_blob *blob)
@@ -31,8 +33,6 @@ S2N_RESULT s2n_fixed_entropy_generator(struct s2n_blob *blob)
 }
 
 static struct s2n_drbg fixed_drbg = { .entropy_generator = &s2n_fixed_entropy_generator };
-
-#if S2N_LIBCRYPTO_SUPPORTS_CUSTOM_RAND
 
 int s2n_unsafe_drbg_reseed(uint8_t *seed, uint8_t seed_size)
 {

--- a/tests/testlib/s2n_random_test_utils.c
+++ b/tests/testlib/s2n_random_test_utils.c
@@ -34,6 +34,8 @@ static struct s2n_drbg fixed_drbg = { .entropy_generator = &s2n_fixed_entropy_ge
 
 int s2n_unsafe_drbg_reseed(uint8_t *seed, uint8_t seed_size)
 {
+    S2N_ERROR_IF(!s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
+
     memset(seed_buffer, 0, S2N_DRBG_MAX_SEED_SIZE);
     memcpy_check(seed_buffer, seed, MIN(seed_size, S2N_DRBG_MAX_SEED_SIZE));
 

--- a/tests/testlib/s2n_random_test_utils.c
+++ b/tests/testlib/s2n_random_test_utils.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <sys/param.h>
+
+#include "utils/s2n_mem.h"
+#include "utils/s2n_random.h"
+#include "utils/s2n_safety.h"
+#include "crypto/s2n_drbg.h"
+#include "tests/testlib/s2n_testlib.h"
+
+static uint8_t seed_buffer[S2N_DRBG_MAX_SEED_SIZE] = { 0 };
+
+S2N_RESULT s2n_fixed_entropy_generator(struct s2n_blob *blob)
+{
+    ENSURE_LTE(blob->size, S2N_DRBG_MAX_SEED_SIZE);
+    blob->data = seed_buffer;
+    return S2N_RESULT_OK;
+}
+
+static struct s2n_drbg fixed_drbg = { .entropy_generator = &s2n_fixed_entropy_generator };
+
+#if S2N_LIBCRYPTO_SUPPORTS_CUSTOM_RAND
+
+int s2n_unsafe_drbg_reseed(uint8_t *seed, uint8_t seed_size)
+{
+    memset(seed_buffer, 0, S2N_DRBG_MAX_SEED_SIZE);
+    memcpy_check(seed_buffer, seed, MIN(seed_size, S2N_DRBG_MAX_SEED_SIZE));
+
+    uint8_t data[48] = { 0 };
+    struct s2n_blob ps;
+    GUARD(s2n_blob_init(&ps, data, sizeof(data)));
+
+    GUARD(s2n_drbg_instantiate(&fixed_drbg, &ps, S2N_DANGEROUS_AES_256_CTR_NO_DF_NO_PR));
+    GUARD_AS_POSIX(s2n_set_private_drbg_for_test(fixed_drbg));
+
+    return S2N_SUCCESS;
+}
+
+#else
+
+int s2n_unsafe_drbg_reseed(uint8_t *seed, uint8_t seed_size)
+{
+    S2N_ERROR(S2N_ERR_UNIMPLEMENTED);
+}
+
+#endif

--- a/tests/testlib/s2n_random_test_utils.c
+++ b/tests/testlib/s2n_random_test_utils.c
@@ -21,8 +21,6 @@
 #include "crypto/s2n_drbg.h"
 #include "tests/testlib/s2n_testlib.h"
 
-#if S2N_LIBCRYPTO_SUPPORTS_CUSTOM_RAND
-
 static uint8_t seed_buffer[S2N_DRBG_MAX_SEED_SIZE] = { 0 };
 
 S2N_RESULT s2n_fixed_entropy_generator(struct s2n_blob *blob)
@@ -48,12 +46,3 @@ int s2n_unsafe_drbg_reseed(uint8_t *seed, uint8_t seed_size)
 
     return S2N_SUCCESS;
 }
-
-#else
-
-int s2n_unsafe_drbg_reseed(uint8_t *seed, uint8_t seed_size)
-{
-    S2N_ERROR(S2N_ERR_UNIMPLEMENTED);
-}
-
-#endif

--- a/tests/testlib/s2n_random_test_utils.c
+++ b/tests/testlib/s2n_random_test_utils.c
@@ -32,12 +32,12 @@ S2N_RESULT s2n_fixed_entropy_generator(struct s2n_blob *blob)
 
 static struct s2n_drbg fixed_drbg = { .entropy_generator = &s2n_fixed_entropy_generator };
 
-int s2n_unsafe_drbg_reseed(uint8_t *seed, uint8_t seed_size)
+int s2n_unsafe_set_drbg_seed(const struct s2n_blob *seed)
 {
     S2N_ERROR_IF(!s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
 
-    memset(seed_buffer, 0, S2N_DRBG_MAX_SEED_SIZE);
-    memcpy_check(seed_buffer, seed, MIN(seed_size, S2N_DRBG_MAX_SEED_SIZE));
+    memset_check((uint8_t*) seed_buffer, 0, sizeof(seed_buffer));
+    memcpy_check(seed_buffer, seed->data, MIN(seed->size, S2N_DRBG_MAX_SEED_SIZE));
 
     uint8_t data[48] = { 0 };
     struct s2n_blob ps;

--- a/tests/testlib/s2n_testlib.h
+++ b/tests/testlib/s2n_testlib.h
@@ -58,7 +58,7 @@ int s2n_fd_set_non_blocking(int fd);
 int s2n_set_connection_hello_retry_flags(struct s2n_connection *conn);
 int s2n_connection_allow_all_response_extensions(struct s2n_connection *conn);
 
-int s2n_unsafe_drbg_reseed(uint8_t *seed, uint8_t seed_size);
+int s2n_unsafe_set_drbg_seed(const struct s2n_blob *seed);
 
 #define S2N_MAX_TEST_PEM_SIZE 4096
 

--- a/tests/testlib/s2n_testlib.h
+++ b/tests/testlib/s2n_testlib.h
@@ -58,6 +58,8 @@ int s2n_fd_set_non_blocking(int fd);
 int s2n_set_connection_hello_retry_flags(struct s2n_connection *conn);
 int s2n_connection_allow_all_response_extensions(struct s2n_connection *conn);
 
+int s2n_unsafe_drbg_reseed(uint8_t *seed, uint8_t seed_size);
+
 #define S2N_MAX_TEST_PEM_SIZE 4096
 
 /* These paths assume that the unit tests are run from inside the unit/ directory.

--- a/tests/unit/s2n_override_openssl_random_test.c
+++ b/tests/unit/s2n_override_openssl_random_test.c
@@ -111,13 +111,7 @@ int main(int argc, char **argv)
 
     /* Set s2n_random to use a new fixed DRBG to test that other known answer tests with s2n_random and OpenSSL are deterministic */
     EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&test_entropy, reference_entropy_hex));
-    struct s2n_drbg drbg = {.entropy_generator = &s2n_entropy_generator};
-    s2n_stack_blob(personalization_string, 32, 32);
-    EXPECT_SUCCESS(s2n_drbg_instantiate(&drbg, &personalization_string, S2N_DANGEROUS_AES_256_CTR_NO_DF_NO_PR));
-    EXPECT_OK(s2n_set_private_drbg_for_test(drbg));
-    /* Verify we switched to a new DRBG */
-    EXPECT_OK(s2n_get_private_random_bytes_used(&bytes_used));
-    EXPECT_EQUAL(bytes_used, 0);
+    EXPECT_SUCCESS(s2n_unsafe_drbg_reseed(test_entropy.blob.data, test_entropy.blob.size));
 
     DEFER_CLEANUP(struct s2n_stuffer out_stuffer = {0}, s2n_stuffer_free);
     struct s2n_blob out_blob = {0};

--- a/tests/unit/s2n_override_openssl_random_test.c
+++ b/tests/unit/s2n_override_openssl_random_test.c
@@ -111,7 +111,7 @@ int main(int argc, char **argv)
 
     /* Set s2n_random to use a new fixed DRBG to test that other known answer tests with s2n_random and OpenSSL are deterministic */
     EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&test_entropy, reference_entropy_hex));
-    EXPECT_SUCCESS(s2n_unsafe_drbg_reseed(test_entropy.blob.data, test_entropy.blob.size));
+    EXPECT_SUCCESS(s2n_unsafe_set_drbg_seed(&test_entropy.blob));
 
     DEFER_CLEANUP(struct s2n_stuffer out_stuffer = {0}, s2n_stuffer_free);
     struct s2n_blob out_blob = {0};


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Description of changes: 

I wanted to use `s2n_set_private_drbg_for_test` in another test, but found its interface tricky to understand. So I've created a simpler utility function that handles the most basic case of reseeding the drbg for testing. It doesn't allow variable personalization strings or modes, but none of our tests used those arguments.

### Testing:
Just the existing tests continuing to pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
