### PR TITLE
ci: capture sidetrail image and buildspec

### DIFF
--- a/codebuild/codebuild.config
+++ b/codebuild/codebuild.config
@@ -82,8 +82,16 @@ snippet: UbuntuBoilerplate2XL
 env: TESTS=tls SAW=true GCC_VERSION=NONE
 
 # Sidetrail - Run both tests in one job
-[CodeBuild:s2nSidetrail]
-snippet: UbuntuBoilerplate2XL
+[CodeBuild:s2nSidetrail]]
+image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/linux-docker-images:sidetrail
+env_type: LINUX_CONTAINER
+compute_type: BUILD_GENERAL1_2XLARGE
+timeout_in_min: 90
+buildspec: codebuild/spec/buildspec_sidetrail.yml
+source_location: https://github.com/awslabs/s2n.git
+source_type : GITHUB
+source_clonedepth: 1
+source_version:
 env: TESTS=sidetrail
 
 # GitHub Actions Codebuild Shim Job


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

 resolves #1895 

### Description of changes: 

The SideTrail CodeBuild job uses a custom docker image and buildspec, which need to be captured in config files to avoid breaking the job with future changes.

### Call-outs:

N/A

### Testing:

Ran `create_project.py --noop --config codebuild.config`, then fed the resulting yml into CloudFormation and reviewed the changeset w/o applying.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
