### PR TITLE
Add generalized KEM public_key/ciphertext send/receive functions

### DIFF
--- a/tests/unit/s2n_kem_test.c
+++ b/tests/unit/s2n_kem_test.c
@@ -496,25 +496,9 @@ int main(int argc, char **argv)
         kem_params.kem = &s2n_test_kem;
         EXPECT_FAILURE_WITH_ERRNO(s2n_kem_recv_ciphertext(&io_stuffer, &kem_params), S2N_ERR_NULL);
 
-        /* Not enough data available in the stuffer to read the ciphertext length */
+        /* The given ciphertext length doesn't match the KEM's actual ciphertext length */
         EXPECT_SUCCESS(s2n_alloc(&(kem_params.private_key), TEST_PRIVATE_KEY_LENGTH));
         memcpy_check(kem_params.private_key.data, TEST_PRIVATE_KEY, TEST_PRIVATE_KEY_LENGTH);
-        uint8_t bad_ct_input_1[] = { 5 };
-        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&io_stuffer, bad_ct_input_1, 1));
-        EXPECT_SUCCESS(s2n_stuffer_reread(&io_stuffer));
-        EXPECT_FAILURE_WITH_ERRNO(s2n_kem_recv_ciphertext(&io_stuffer, &kem_params), S2N_ERR_BAD_MESSAGE);
-
-        /* The given ciphertext length is larger than the remaining data in the stuffer */
-        DEFER_CLEANUP(struct s2n_blob io_blob_2 = { 0 }, s2n_free);
-        EXPECT_SUCCESS(s2n_alloc(&io_blob_2, TEST_CIPHERTEXT_LENGTH + 2));
-        struct s2n_stuffer io_stuffer_2 = { 0 };
-        EXPECT_SUCCESS(s2n_stuffer_init(&io_stuffer_2, &io_blob_2));
-        uint8_t bad_ct_input_2[] = { 0, 5, 5 };
-        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&io_stuffer_2, bad_ct_input_2, 3));
-        EXPECT_SUCCESS(s2n_stuffer_reread(&io_stuffer_2));
-        EXPECT_FAILURE_WITH_ERRNO(s2n_kem_recv_ciphertext(&io_stuffer_2, &kem_params), S2N_ERR_BAD_MESSAGE);
-
-        /* The given ciphertext length doesn't match the KEM's actual ciphertext length */
         DEFER_CLEANUP(struct s2n_blob io_blob_3 = { 0 }, s2n_free);
         EXPECT_SUCCESS(s2n_alloc(&io_blob_3, TEST_CIPHERTEXT_LENGTH + 2));
         struct s2n_stuffer io_stuffer_3 = { 0 };
@@ -571,22 +555,6 @@ int main(int argc, char **argv)
         EXPECT_FAILURE_WITH_ERRNO(s2n_kem_recv_public_key(&io_stuffer, &kem_params), S2N_ERR_NULL);
 
         kem_params.kem = &s2n_test_kem;
-
-        /* Not enough data available in the stuffer to read the public key length */
-        uint8_t bad_pk_input_1[] = { 2 };
-        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&io_stuffer, bad_pk_input_1, 1));
-        EXPECT_SUCCESS(s2n_stuffer_reread(&io_stuffer));
-        EXPECT_FAILURE_WITH_ERRNO(s2n_kem_recv_public_key(&io_stuffer, &kem_params), S2N_ERR_BAD_MESSAGE);
-
-        /* The given public key length is larger than the remaining data in the stuffer */
-        DEFER_CLEANUP(struct s2n_blob io_blob_2 = {0}, s2n_free);
-        EXPECT_SUCCESS(s2n_alloc(&io_blob_2, TEST_PUBLIC_KEY_LENGTH + 2));
-        struct s2n_stuffer io_stuffer_2 = {0};
-        EXPECT_SUCCESS(s2n_stuffer_init(&io_stuffer_2, &io_blob_2));
-        uint8_t bad_pk_input_2[] = {0, 2, 2 };
-        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&io_stuffer_2, bad_pk_input_2, 3));
-        EXPECT_SUCCESS(s2n_stuffer_reread(&io_stuffer_2));
-        EXPECT_FAILURE_WITH_ERRNO(s2n_kem_recv_public_key(&io_stuffer_2, &kem_params), S2N_ERR_BAD_MESSAGE);
 
         /* The given public key length doesn't match the KEM's actual public key length */
         DEFER_CLEANUP(struct s2n_blob io_blob_3 = {0}, s2n_free);

--- a/tests/unit/s2n_kem_test.c
+++ b/tests/unit/s2n_kem_test.c
@@ -570,12 +570,13 @@ int main(int argc, char **argv)
         /* Happy case(s) for s2n_get_kem_from_extension_id() */
 
         /* The kem_extensions and kems arrays should be kept in sync with each other */
-        uint8_t kem_extensions[4][2] = {
-                {0, 1},  /* TLS_PQ_KEM_EXTENSION_ID_BIKE1_L1_R1 */
-                {0, 13}, /* TLS_PQ_KEM_EXTENSION_ID_BIKE1_L1_R2 */
-                {0, 10}, /* TLS_PQ_KEM_EXTENSION_ID_SIKE_P503_R1 */
-                {0, 19}, /* TLS_PQ_KEM_EXTENSION_ID_SIKE_P434_R2 */
+        kem_extension_size kem_extensions[] = {
+                TLS_PQ_KEM_EXTENSION_ID_BIKE1_L1_R1,
+                TLS_PQ_KEM_EXTENSION_ID_BIKE1_L1_R2,
+                TLS_PQ_KEM_EXTENSION_ID_SIKE_P503_R1,
+                TLS_PQ_KEM_EXTENSION_ID_SIKE_P434_R2
         };
+
         const struct s2n_kem *kems[] = {
                 &s2n_bike1_l1_r1,
                 &s2n_bike1_l1_r2,
@@ -584,11 +585,10 @@ int main(int argc, char **argv)
         };
 
         for (int i = 0; i < 4; i++) {
-            uint8_t *extension_id_bytes = kem_extensions[i]; /* TLS_PQ_KEM_EXTENSION_ID_SIKE_P434_R2 */
-            struct s2n_blob kem_id = {.data = extension_id_bytes, .size = 2};
+            kem_extension_size kem_id = kem_extensions[i];
             const struct s2n_kem *returned_kem = NULL;
 
-            EXPECT_SUCCESS(s2n_get_kem_from_extension_id(&kem_id, &returned_kem));
+            EXPECT_SUCCESS(s2n_get_kem_from_extension_id(kem_id, &returned_kem));
             EXPECT_NOT_NULL(returned_kem);
             EXPECT_EQUAL(kems[i], returned_kem);
         }
@@ -596,20 +596,8 @@ int main(int argc, char **argv)
     {
         /* Failure cases for s2n_get_kem_from_extension_id() */
         const struct s2n_kem *returned_kem = NULL;
-        EXPECT_FAILURE_WITH_ERRNO(s2n_get_kem_from_extension_id(NULL, &returned_kem), S2N_ERR_NULL);
-
-        struct s2n_blob kem_id = { 0 };
-        EXPECT_FAILURE_WITH_ERRNO(s2n_get_kem_from_extension_id(&kem_id, &returned_kem), S2N_ERR_NULL);
-
-        uint8_t bad_kem_id[] = { 0, 1, 1 };
-        kem_id.data = bad_kem_id;
-        kem_id.size = 3;
-        EXPECT_FAILURE_WITH_ERRNO(s2n_get_kem_from_extension_id(&kem_id, &returned_kem), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
-
-        uint8_t non_existant_kem_id[] = { 255, 255 };
-        kem_id.data = non_existant_kem_id;
-        kem_id.size = 2;
-        EXPECT_FAILURE_WITH_ERRNO(s2n_get_kem_from_extension_id(&kem_id, &returned_kem), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+        kem_extension_size non_existant_kem_id = 65535;
+        EXPECT_FAILURE_WITH_ERRNO(s2n_get_kem_from_extension_id(non_existant_kem_id, &returned_kem), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
     }
 
 #endif

--- a/tls/s2n_client_key_exchange.c
+++ b/tls/s2n_client_key_exchange.c
@@ -160,7 +160,7 @@ int s2n_ecdhe_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shar
 
 int s2n_kem_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared_key)
 {
-    /* s2n_kem_decapsulate() writes the KEM shared secret directly to
+    /* s2n_kem_recv_ciphertext() writes the KEM shared secret directly to
      * conn->secure.kem_params. However, the calling function
      * likely expects *shared_key to point to the shared secret. We 
      * can't reassign *shared_key to point to kem_params.shared_secret,
@@ -173,15 +173,7 @@ int s2n_kem_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared
     notnull_check(shared_key);
     S2N_ERROR_IF(shared_key != &(conn->secure.kem_params.shared_secret), S2N_ERR_SAFETY);
 
-    struct s2n_stuffer *in = &conn->handshake.io;
-    kem_ciphertext_key_size ciphertext_length;
-
-    GUARD(s2n_stuffer_read_uint16(in, &ciphertext_length));
-    S2N_ERROR_IF(ciphertext_length > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);
-
-    const struct s2n_blob ciphertext = {.size = ciphertext_length, .data = s2n_stuffer_raw_read(in, ciphertext_length)};
-    notnull_check(ciphertext.data);
-    GUARD(s2n_kem_decapsulate(&conn->secure.kem_params, &ciphertext));
+    GUARD(s2n_kem_recv_ciphertext(&(conn->handshake.io), &(conn->secure.kem_params)));
 
     return 0;
 }
@@ -263,7 +255,7 @@ int s2n_rsa_client_key_send(struct s2n_connection *conn, struct s2n_blob *shared
 
 int s2n_kem_client_key_send(struct s2n_connection *conn, struct s2n_blob *shared_key)
 {
-    /* s2n_kem_encapsulate() writes the KEM shared secret directly to
+    /* s2n_kem_send_ciphertext() writes the KEM shared secret directly to
      * conn->secure.kem_params. However, the calling function
      * likely expects *shared_key to point to the shared secret. We
      * can't reassign *shared_key to point to kem_params.shared_secret,
@@ -276,15 +268,7 @@ int s2n_kem_client_key_send(struct s2n_connection *conn, struct s2n_blob *shared
     notnull_check(shared_key);
     S2N_ERROR_IF(shared_key != &(conn->secure.kem_params.shared_secret), S2N_ERR_SAFETY);
 
-    struct s2n_stuffer *out = &conn->handshake.io;
-    const struct s2n_kem *kem = conn->secure.kem_params.kem;
-
-    GUARD(s2n_stuffer_write_uint16(out, kem->ciphertext_length));
-
-    /* The ciphertext is not needed after this method, write it straight to the stuffer */
-    struct s2n_blob ciphertext = {.data = s2n_stuffer_raw_write(out, kem->ciphertext_length), .size = kem->ciphertext_length};
-    notnull_check(ciphertext.data);
-    GUARD(s2n_kem_encapsulate(&conn->secure.kem_params, &ciphertext));
+    GUARD(s2n_kem_send_ciphertext(&(conn->handshake.io), &(conn->secure.kem_params)));
 
     return 0;
 }

--- a/tls/s2n_kem.c
+++ b/tls/s2n_kem.c
@@ -321,9 +321,7 @@ int s2n_kem_recv_public_key(struct s2n_stuffer *in, struct s2n_kem_params *kem_p
     const struct s2n_kem *kem = kem_params->kem;
     kem_public_key_size public_key_length;
 
-    S2N_ERROR_IF(s2n_stuffer_data_available(in) < sizeof(kem_public_key_size), S2N_ERR_BAD_MESSAGE);
     GUARD(s2n_stuffer_read_uint16(in, &public_key_length));
-    S2N_ERROR_IF(public_key_length > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);
     S2N_ERROR_IF(public_key_length != kem->public_key_length, S2N_ERR_BAD_MESSAGE);
 
     /* Alloc memory for the public key; the peer receiving it will need it
@@ -363,9 +361,7 @@ int s2n_kem_recv_ciphertext(struct s2n_stuffer *in, struct s2n_kem_params *kem_p
     const struct s2n_kem *kem = kem_params->kem;
     kem_ciphertext_key_size ciphertext_length;
 
-    S2N_ERROR_IF(s2n_stuffer_data_available(in) < sizeof(kem_ciphertext_key_size), S2N_ERR_BAD_MESSAGE);
     GUARD(s2n_stuffer_read_uint16(in, &ciphertext_length));
-    S2N_ERROR_IF(ciphertext_length > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);
     S2N_ERROR_IF(ciphertext_length != kem->ciphertext_length, S2N_ERR_BAD_MESSAGE);
 
     const struct s2n_blob ciphertext = {.data = s2n_stuffer_raw_read(in, ciphertext_length), .size = ciphertext_length};

--- a/tls/s2n_kem.c
+++ b/tls/s2n_kem.c
@@ -255,27 +255,16 @@ int s2n_cipher_suite_to_kem(const uint8_t iana_value[S2N_TLS_CIPHER_SUITE_LEN], 
     S2N_ERROR(S2N_ERR_KEM_UNSUPPORTED_PARAMS);
 }
 
-int s2n_get_kem_from_extension_id(struct s2n_blob *kem_id, const struct s2n_kem **kem) {
+int s2n_get_kem_from_extension_id(kem_extension_size kem_id, const struct s2n_kem **kem) {
     /* cppcheck-suppress knownConditionTrueFalse */
     S2N_ERROR_IF(kem_mapping == NULL, S2N_ERR_KEM_UNSUPPORTED_PARAMS);
-
-    notnull_check(kem_id);
-    notnull_check(kem_id->data);
-    S2N_ERROR_IF(kem_id->size != 2, S2N_ERR_KEM_UNSUPPORTED_PARAMS);
-
-    struct s2n_stuffer kem_id_stuffer = {0};
-    GUARD(s2n_stuffer_init(&kem_id_stuffer, kem_id));
-    GUARD(s2n_stuffer_write(&kem_id_stuffer, kem_id));
-
-    kem_extension_size kem_extension_id;
-    GUARD(s2n_stuffer_read_uint16(&kem_id_stuffer, &kem_extension_id));
 
     for (int i = 0; i < s2n_array_len(kem_mapping); i++) {
         const struct s2n_iana_to_kem *iana_to_kem = &kem_mapping[i];
 
         for (int j = 0; j < iana_to_kem->kem_count; j++) {
             const struct s2n_kem *candidate_kem = iana_to_kem->kems[j];
-            if (candidate_kem->kem_extension_id == kem_extension_id) {
+            if (candidate_kem->kem_extension_id == kem_id) {
                 *kem = candidate_kem;
                 return S2N_SUCCESS;
             }

--- a/tls/s2n_kem.c
+++ b/tls/s2n_kem.c
@@ -119,11 +119,11 @@ int s2n_kem_generate_keypair(struct s2n_kem_params *kem_params)
     eq_check(kem_params->public_key.size, kem->public_key_length);
     notnull_check(kem_params->public_key.data);
 
-    /* The private key is needed for client_key_recv and must be saved */
+    /* Need to save the private key for decapsulation */
     GUARD(s2n_alloc(&kem_params->private_key, kem->private_key_length));
 
     GUARD(kem->generate_keypair(kem_params->public_key.data, kem_params->private_key.data));
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_kem_encapsulate(struct s2n_kem_params *kem_params, struct s2n_blob *ciphertext)
@@ -142,7 +142,7 @@ int s2n_kem_encapsulate(struct s2n_kem_params *kem_params, struct s2n_blob *ciph
     GUARD(s2n_alloc(&(kem_params->shared_secret), kem->shared_secret_key_length));
 
     GUARD(kem->encapsulate(ciphertext->data, kem_params->shared_secret.data, kem_params->public_key.data));
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_kem_decapsulate(struct s2n_kem_params *kem_params, const struct s2n_blob *ciphertext)
@@ -161,7 +161,7 @@ int s2n_kem_decapsulate(struct s2n_kem_params *kem_params, const struct s2n_blob
     GUARD(s2n_alloc(&(kem_params->shared_secret), kem->shared_secret_key_length));
 
     GUARD(kem->decapsulate(kem_params->shared_secret.data, ciphertext->data, kem_params->private_key.data));
-    return 0;
+    return S2N_SUCCESS;
 }
 
 static int s2n_kem_check_kem_compatibility(const uint8_t iana_value[S2N_TLS_CIPHER_SUITE_LEN], const struct s2n_kem *candidate_kem,
@@ -172,12 +172,12 @@ static int s2n_kem_check_kem_compatibility(const uint8_t iana_value[S2N_TLS_CIPH
     for (uint8_t i = 0; i < compatible_kems->kem_count; i++) {
         if (candidate_kem->kem_extension_id == compatible_kems->kems[i]->kem_extension_id) {
             *kem_is_compatible = 1;
-            return 0;
+            return S2N_SUCCESS;
         }
     }
 
     *kem_is_compatible = 0;
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_choose_kem_with_peer_pref_list(const uint8_t iana_value[S2N_TLS_CIPHER_SUITE_LEN], struct s2n_blob *client_kem_ids,
@@ -205,7 +205,7 @@ int s2n_choose_kem_with_peer_pref_list(const uint8_t iana_value[S2N_TLS_CIPHER_S
 
             if (candidate_server_kem->kem_extension_id == candidate_client_kem_id) {
                 *chosen_kem = candidate_server_kem;
-                return 0;
+                return S2N_SUCCESS;
             }
         }
         GUARD(s2n_stuffer_reread(&client_kem_ids_stuffer));
@@ -222,7 +222,7 @@ int s2n_choose_kem_without_peer_pref_list(const uint8_t iana_value[S2N_TLS_CIPHE
         GUARD(s2n_kem_check_kem_compatibility(iana_value, server_kem_pref_list[i], &kem_is_compatible));
         if (kem_is_compatible) {
             *chosen_kem = server_kem_pref_list[i];
-            return 0;
+            return S2N_SUCCESS;
         }
     }
 
@@ -237,7 +237,7 @@ int s2n_kem_free(struct s2n_kem_params *kem_params)
         GUARD(s2n_blob_zeroize_free(&kem_params->public_key));
         GUARD(s2n_blob_zeroize_free(&kem_params->shared_secret));
     }
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_cipher_suite_to_kem(const uint8_t iana_value[S2N_TLS_CIPHER_SUITE_LEN], const struct s2n_iana_to_kem **compatible_params)
@@ -249,8 +249,130 @@ int s2n_cipher_suite_to_kem(const uint8_t iana_value[S2N_TLS_CIPHER_SUITE_LEN], 
         const struct s2n_iana_to_kem *candidate = &kem_mapping[i];
         if (memcmp(iana_value, candidate->iana_value, S2N_TLS_CIPHER_SUITE_LEN) == 0) {
             *compatible_params = candidate;
-            return 0;
+            return S2N_SUCCESS;
         }
     }
     S2N_ERROR(S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+}
+
+int s2n_get_kem_from_extension_id(struct s2n_blob *kem_id, const struct s2n_kem **kem) {
+    /* cppcheck-suppress knownConditionTrueFalse */
+    S2N_ERROR_IF(kem_mapping == NULL, S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+
+    notnull_check(kem_id);
+    notnull_check(kem_id->data);
+    S2N_ERROR_IF(kem_id->size != 2, S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+
+    struct s2n_stuffer kem_id_stuffer = {0};
+    GUARD(s2n_stuffer_init(&kem_id_stuffer, kem_id));
+    GUARD(s2n_stuffer_write(&kem_id_stuffer, kem_id));
+
+    kem_extension_size kem_extension_id;
+    GUARD(s2n_stuffer_read_uint16(&kem_id_stuffer, &kem_extension_id));
+
+    for (int i = 0; i < s2n_array_len(kem_mapping); i++) {
+        const struct s2n_iana_to_kem *iana_to_kem = &kem_mapping[i];
+
+        for (int j = 0; j < iana_to_kem->kem_count; j++) {
+            const struct s2n_kem *candidate_kem = iana_to_kem->kems[j];
+            if (candidate_kem->kem_extension_id == kem_extension_id) {
+                *kem = candidate_kem;
+                return S2N_SUCCESS;
+            }
+        }
+    }
+
+    S2N_ERROR(S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+}
+
+int s2n_kem_send_public_key(struct s2n_stuffer *out, struct s2n_kem_params *kem_params) {
+    notnull_check(out);
+    notnull_check(kem_params);
+    notnull_check(kem_params->kem);
+
+    const struct s2n_kem *kem = kem_params->kem;
+
+    GUARD(s2n_stuffer_write_uint16(out, kem->public_key_length));
+
+    /* We don't need to store the public key after sending it.
+     * We write it directly to *out. */
+    kem_params->public_key.data = s2n_stuffer_raw_write(out, kem->public_key_length);
+    notnull_check(kem_params->public_key.data);
+    kem_params->public_key.size = kem->public_key_length;
+
+    /* Saves the private key in kem_params */
+    GUARD(s2n_kem_generate_keypair(kem_params));
+
+    /* After using s2n_stuffer_raw_write() above to write the public
+     * key to the stuffer, we want to ensure that kem_params->public_key.data
+     * does not continue to point at *out, else we may unexpectedly
+     * overwrite part of the stuffer when s2n_kem_free() is called. */
+    kem_params->public_key.data = NULL;
+    kem_params->public_key.size = 0;
+
+    return S2N_SUCCESS;
+}
+
+int s2n_kem_recv_public_key(struct s2n_stuffer *in, struct s2n_kem_params *kem_params) {
+    notnull_check(in);
+    notnull_check(kem_params);
+    notnull_check(kem_params->kem);
+
+    const struct s2n_kem *kem = kem_params->kem;
+    kem_public_key_size public_key_length;
+
+    S2N_ERROR_IF(s2n_stuffer_data_available(in) < sizeof(kem_public_key_size), S2N_ERR_BAD_MESSAGE);
+    GUARD(s2n_stuffer_read_uint16(in, &public_key_length));
+    S2N_ERROR_IF(public_key_length > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);
+    S2N_ERROR_IF(public_key_length != kem->public_key_length, S2N_ERR_BAD_MESSAGE);
+
+    /* Alloc memory for the public key; the peer receiving it will need it
+     * later during the handshake to encapsulate the shared secret. */
+    GUARD(s2n_alloc(&(kem_params->public_key), public_key_length));
+    GUARD(s2n_stuffer_read_bytes(in, kem_params->public_key.data, public_key_length));
+
+    return S2N_SUCCESS;
+}
+
+int s2n_kem_send_ciphertext(struct s2n_stuffer *out, struct s2n_kem_params *kem_params) {
+    notnull_check(out);
+    notnull_check(kem_params);
+    notnull_check(kem_params->kem);
+    notnull_check(kem_params->public_key.data);
+
+    const struct s2n_kem *kem = kem_params->kem;
+
+    GUARD(s2n_stuffer_write_uint16(out, kem->ciphertext_length));
+
+    /* Ciphertext will get written to *out */
+    struct s2n_blob ciphertext = {.data = s2n_stuffer_raw_write(out, kem->ciphertext_length), .size = kem->ciphertext_length};
+    notnull_check(ciphertext.data);
+
+    /* Saves the shared secret in kem_params */
+    GUARD(s2n_kem_encapsulate(kem_params, &ciphertext));
+
+    return S2N_SUCCESS;
+}
+
+int s2n_kem_recv_ciphertext(struct s2n_stuffer *in, struct s2n_kem_params *kem_params) {
+    notnull_check(in);
+    notnull_check(kem_params);
+    notnull_check(kem_params->kem);
+    notnull_check(kem_params->private_key.data);
+
+    const struct s2n_kem *kem = kem_params->kem;
+    kem_ciphertext_key_size ciphertext_length;
+
+    S2N_ERROR_IF(s2n_stuffer_data_available(in) < sizeof(kem_ciphertext_key_size), S2N_ERR_BAD_MESSAGE);
+    GUARD(s2n_stuffer_read_uint16(in, &ciphertext_length));
+    S2N_ERROR_IF(ciphertext_length > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);
+    S2N_ERROR_IF(ciphertext_length != kem->ciphertext_length, S2N_ERR_BAD_MESSAGE);
+
+    const struct s2n_blob ciphertext = {.data = s2n_stuffer_raw_read(in, ciphertext_length), .size = ciphertext_length};
+    notnull_check(ciphertext.data);
+
+    /* Saves the shared secret in kem_params */
+    GUARD(s2n_kem_decapsulate(kem_params, &ciphertext));
+
+    return S2N_SUCCESS;
 }

--- a/tls/s2n_kem.h
+++ b/tls/s2n_kem.h
@@ -67,3 +67,8 @@ extern int s2n_choose_kem_without_peer_pref_list(const uint8_t iana_value[S2N_TL
 extern int s2n_kem_free(struct s2n_kem_params *kem_params);
 
 extern int s2n_cipher_suite_to_kem(const uint8_t iana_value[S2N_TLS_CIPHER_SUITE_LEN], const struct s2n_iana_to_kem **supported_params);
+extern int s2n_get_kem_from_extension_id(struct s2n_blob *client_kem_ids, const struct s2n_kem **kem);
+extern int s2n_kem_send_public_key(struct s2n_stuffer *out, struct s2n_kem_params *kem_params);
+extern int s2n_kem_recv_public_key(struct s2n_stuffer *in, struct s2n_kem_params *kem_params);
+extern int s2n_kem_send_ciphertext(struct s2n_stuffer *out, struct s2n_kem_params *kem_params);
+extern int s2n_kem_recv_ciphertext(struct s2n_stuffer *in, struct s2n_kem_params *kem_params);

--- a/tls/s2n_kem.h
+++ b/tls/s2n_kem.h
@@ -67,7 +67,7 @@ extern int s2n_choose_kem_without_peer_pref_list(const uint8_t iana_value[S2N_TL
 extern int s2n_kem_free(struct s2n_kem_params *kem_params);
 
 extern int s2n_cipher_suite_to_kem(const uint8_t iana_value[S2N_TLS_CIPHER_SUITE_LEN], const struct s2n_iana_to_kem **supported_params);
-extern int s2n_get_kem_from_extension_id(struct s2n_blob *client_kem_ids, const struct s2n_kem **kem);
+extern int s2n_get_kem_from_extension_id(kem_extension_size kem_id, const struct s2n_kem **kem);
 extern int s2n_kem_send_public_key(struct s2n_stuffer *out, struct s2n_kem_params *kem_params);
 extern int s2n_kem_recv_public_key(struct s2n_stuffer *in, struct s2n_kem_params *kem_params);
 extern int s2n_kem_send_ciphertext(struct s2n_stuffer *out, struct s2n_kem_params *kem_params);

--- a/tls/s2n_server_key_exchange.c
+++ b/tls/s2n_server_key_exchange.c
@@ -157,7 +157,15 @@ int s2n_kem_server_key_recv_read_data(struct s2n_connection *conn, struct s2n_bl
     notnull_check(kem_data->kem_name.data);
     kem_data->kem_name.size = 2;
 
-    GUARD(s2n_get_kem_from_extension_id(&(kem_data->kem_name), &(conn->secure.kem_params.kem)));
+    struct s2n_stuffer kem_id_stuffer = { 0 };
+    uint8_t kem_id_arr[2];
+    kem_extension_size kem_id;
+    struct s2n_blob kem_id_blob = { .data = kem_id_arr, .size = s2n_array_len(kem_id_arr) };
+    GUARD(s2n_stuffer_init(&kem_id_stuffer, &kem_id_blob));
+    GUARD(s2n_stuffer_write(&kem_id_stuffer, &(kem_data->kem_name)));
+    GUARD(s2n_stuffer_read_uint16(&kem_id_stuffer, &kem_id));
+
+    GUARD(s2n_get_kem_from_extension_id(kem_id, &(conn->secure.kem_params.kem)));
     GUARD(s2n_kem_recv_public_key(in, &(conn->secure.kem_params)));
 
     kem_data->raw_public_key.data = conn->secure.kem_params.public_key.data;

--- a/tls/s2n_server_key_exchange.c
+++ b/tls/s2n_server_key_exchange.c
@@ -147,7 +147,6 @@ int s2n_kem_server_key_recv_read_data(struct s2n_connection *conn, struct s2n_bl
 {
     struct s2n_kem_raw_server_params *kem_data = &raw_server_data->kem_data;
     struct s2n_stuffer *in = &conn->handshake.io;
-    kem_public_key_size key_length;
 
     /* Keep a copy to the start of the whole structure for the signature check */
     data_to_verify->data = s2n_stuffer_raw_read(in, 0);
@@ -158,14 +157,14 @@ int s2n_kem_server_key_recv_read_data(struct s2n_connection *conn, struct s2n_bl
     notnull_check(kem_data->kem_name.data);
     kem_data->kem_name.size = 2;
 
-    GUARD(s2n_stuffer_read_uint16(in, &key_length));
-    S2N_ERROR_IF(key_length > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);
+    GUARD(s2n_get_kem_from_extension_id(&(kem_data->kem_name), &(conn->secure.kem_params.kem)));
+    GUARD(s2n_kem_recv_public_key(in, &(conn->secure.kem_params)));
 
-    kem_data->raw_public_key.data = s2n_stuffer_raw_read(in, key_length);
-    notnull_check(kem_data->raw_public_key.data);
-    kem_data->raw_public_key.size = key_length;
+    kem_data->raw_public_key.data = conn->secure.kem_params.public_key.data;
+    kem_data->raw_public_key.size = conn->secure.kem_params.public_key.size;
 
-    data_to_verify->size = sizeof(kem_extension_size) + sizeof(kem_public_key_size) + key_length;
+    data_to_verify->size = sizeof(kem_extension_size) + sizeof(kem_public_key_size) + kem_data->raw_public_key.size;
+
     return 0;
 }
 
@@ -186,7 +185,6 @@ int s2n_kem_server_key_recv_parse_data(struct s2n_connection *conn, struct s2n_k
 
     S2N_ERROR_IF(kem_data->raw_public_key.size != conn->secure.kem_params.kem->public_key_length, S2N_ERR_BAD_MESSAGE);
 
-    s2n_dup(&kem_data->raw_public_key, &conn->secure.kem_params.public_key);
     return 0;
 }
 
@@ -290,24 +288,10 @@ int s2n_kem_server_key_send(struct s2n_connection *conn, struct s2n_blob *data_t
     notnull_check(data_to_sign->data);
 
     GUARD(s2n_stuffer_write_uint16(out, kem->kem_extension_id));
-    GUARD(s2n_stuffer_write_uint16(out, kem->public_key_length));
+    GUARD(s2n_kem_send_public_key(out, &(conn->secure.kem_params)));
 
-    /* Initialize the connection's KEM public key to point to the *out stuffer
-     * so that generate_keypair writes the public key directly to *out */
-    struct s2n_blob *public_key = &conn->secure.kem_params.public_key;
-    public_key->data = s2n_stuffer_raw_write(out, kem->public_key_length);
-    notnull_check(public_key->data);
-    public_key->size = kem->public_key_length;
+    data_to_sign->size = sizeof(kem_extension_size) + sizeof(kem_public_key_size) +  kem->public_key_length;
 
-    GUARD(s2n_kem_generate_keypair(&conn->secure.kem_params));
-
-    data_to_sign->size = sizeof(kem_extension_size) + sizeof(kem_public_key_size) +  public_key->size;
-
-    /* Now that we've written the public key to *out, we don't want public_key.data to
-     * point to *out anymore, otherwise calling s2n_kem_free() later will zero-ize
-     * parts of the handshake IO. */
-    conn->secure.kem_params.public_key.data = NULL;
-    conn->secure.kem_params.public_key.size = 0;
     return 0;
 }
 

--- a/tls/s2n_tls_parameters.h
+++ b/tls/s2n_tls_parameters.h
@@ -58,9 +58,7 @@
 #define TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256  0xCC, 0xA9
 #define TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256      0xCC, 0xAA
 
-/* TLS Hybrid post-quantum definitions from https://tools.ietf.org/html/draft-campagna-tls-bike-sike-hybrid-02
- * Note that the value for SIKE_P434_R2 (19) disagrees with the above spec. This value (19)
- * reflects an upcoming change that will be published in draft-campagna-tls-bike-sike-hybrid-03. */
+/* TLS Hybrid post-quantum definitions from https://tools.ietf.org/html/draft-campagna-tls-bike-sike-hybrid */
 #define TLS_ECDHE_BIKE_RSA_WITH_AES_256_GCM_SHA384 0xFF, 0x04
 #define TLS_ECDHE_SIKE_RSA_WITH_AES_256_GCM_SHA384 0xFF, 0x08
 #define TLS_EXTENSION_PQ_KEM_PARAMETERS 0xFE01


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A

### Description of changes: 
* Adds five new KEM functions to generalize the sending and receiving of PQ public keys and ciphertexts: 
  * `s2n_kem_send_public_key()`
  * `s2n_kem_recv_public_key()`
  * `s2n_kem_send_ciphertext()`
  * `s2n_kem_recv_ciphertext()`
  * `s2n_get_kem_from_extension_id()`
* Integrates these functions into the current PQ-TLS1.2 KEX code.

### Call-outs:
This is a forward-looking change; the intent is to easily reuse the new functions for PQ-TLS1.3. 

### Testing:
Unit tests (both happy and sad cases) added for all functions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
