### PR TITLE
Adds a proof harness for the s2n_blob_is_growable

### DIFF
--- a/tests/cbmc/proofs/s2n_blob_is_growable/Makefile
+++ b/tests/cbmc/proofs/s2n_blob_is_growable/Makefile
@@ -1,0 +1,26 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/error/s2n_errno.c
+
+ENTRY = s2n_blob_is_growable_harness
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_blob_is_growable/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_blob_is_growable/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--conversion-check;--div-by-zero-check;--enum-range-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_blob_is_growable_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_blob_is_growable/s2n_blob_is_growable_harness.c
+++ b/tests/cbmc/proofs/s2n_blob_is_growable/s2n_blob_is_growable_harness.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "error/s2n_errno.h"
+#include "utils/s2n_blob.h"
+
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_blob_is_growable_harness() {
+    /* Non-deterministic inputs. */
+    struct s2n_blob *blob = cbmc_allocate_s2n_blob();
+    __CPROVER_assume(S2N_IMPLIES(blob!= NULL, s2n_blob_is_valid(blob)));
+
+    /* Operation under verification. */
+    if(s2n_blob_is_growable(blob)) {
+        assert(blob->growable ||
+		           (blob->data == NULL &&
+		            blob->size == 0 &&
+		            blob->allocated == 0));
+    }
+
+    /* Post-condition. */
+    if(blob != NULL) assert(s2n_blob_is_valid(blob));
+}

--- a/tests/cbmc/source/make_common_datastructures.c
+++ b/tests/cbmc/source/make_common_datastructures.c
@@ -25,7 +25,7 @@ void ensure_s2n_blob_has_allocated_fields(struct s2n_blob* blob) {
 struct s2n_blob* cbmc_allocate_s2n_blob() {
     struct s2n_blob* blob = can_fail_malloc(sizeof(*blob));
     if (blob !=  NULL) {
-	ensure_s2n_blob_has_allocated_fields(blob);
+	      ensure_s2n_blob_has_allocated_fields(blob);
     }
     return blob;
 }

--- a/tests/cbmc/source/make_common_datastructures.c
+++ b/tests/cbmc/source/make_common_datastructures.c
@@ -15,12 +15,16 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 void ensure_s2n_blob_has_allocated_fields(struct s2n_blob* blob) {
-    blob->data = blob->growable ? bounded_malloc(blob->allocated) : bounded_malloc(blob->size);
+    if(blob->growable) {
+        blob->data = (blob->allocated == 0) ? NULL : bounded_malloc(blob->allocated);
+    } else {
+        blob->data = (blob->size == 0) ? NULL : bounded_malloc(blob->size);
+    }
 }
 
 struct s2n_blob* cbmc_allocate_s2n_blob() {
     struct s2n_blob* blob = can_fail_malloc(sizeof(*blob));
-    if (blob) {
+    if (blob !=  NULL) {
 	ensure_s2n_blob_has_allocated_fields(blob);
     }
     return blob;

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -153,7 +153,7 @@ int s2n_alloc(struct s2n_blob *b, uint32_t size)
 /* A blob is growable if it is either explicitly marked as such, or if it contains no data */
 bool s2n_blob_is_growable(const struct s2n_blob* b)
 {
-  return b && (b->growable || (b->data == NULL && b->size == 0 && b->allocated == 0));
+    return b && (b->growable || (b->data == NULL && b->size == 0 && b->allocated == 0));
 }
 
 /* Tries to realloc the requested bytes.


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A.

### Description of changes: 

- Adds predicates to `s2n_blob`structure (for CBMC proofs only);
- Adds a proof harness for the `s2n_blob_is_growable` function;
- Adds a precondition to the `s2n_blob_is_growable` function;

### Call-outs:

This PR depends on [PR #1918](https://github.com/awslabs/s2n/pull/1918).

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
