### PR TITLE
Adds a proof harness for s2n_blob_zero function

### DIFF
--- a/tests/cbmc/proofs/s2n_blob_zero/Makefile
+++ b/tests/cbmc/proofs/s2n_blob_zero/Makefile
@@ -15,6 +15,7 @@
 
 CBMCFLAGS +=
 
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
 DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
 DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c

--- a/tests/cbmc/proofs/s2n_blob_zero/Makefile
+++ b/tests/cbmc/proofs/s2n_blob_zero/Makefile
@@ -1,0 +1,24 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+
+ENTRY = s2n_blob_zero_harness
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_blob_zero/Makefile
+++ b/tests/cbmc/proofs/s2n_blob_zero/Makefile
@@ -11,11 +11,14 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Expected runtime is 10 seconds.
+
 CBMCFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
 DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
 
 ENTRY = s2n_blob_zero_harness
 

--- a/tests/cbmc/proofs/s2n_blob_zero/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_blob_zero/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--conversion-check;--div-by-zero-check;--enum-range-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_blob_zero_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_blob_zero/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_blob_zero/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwind;1;--object-bits;8"
-expected: "SUCCESSFUL"
-goto: gotos/s2n_blob_zero_harness.goto
-jobos: ubuntu16
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_blob_zero/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_blob_zero/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--bounds-check;--conversion-check;--div-by-zero-check;--enum-range-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+cbmcflags: "--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwind;1;--object-bits;8"
 expected: "SUCCESSFUL"
 goto: gotos/s2n_blob_zero_harness.goto
 jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_blob_zero/s2n_blob_zero_harness.c
+++ b/tests/cbmc/proofs/s2n_blob_zero/s2n_blob_zero_harness.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "utils/s2n_blob.h"
+
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_blob_zero_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_blob *blob = cbmc_allocate_s2n_blob();
+    __CPROVER_assume( s2n_blob_is_valid( blob ) );
+
+    /* Operation under verification. */
+    if( s2n_blob_zero( blob ) == S2N_SUCCESS ) {
+        size_t index;
+        __CPROVER_assume(index < blob->size);
+        assert(blob->data[index] == 0);
+    }
+    assert( s2n_blob_is_valid( blob ) );
+}

--- a/tests/cbmc/proofs/s2n_blob_zero/s2n_blob_zero_harness.c
+++ b/tests/cbmc/proofs/s2n_blob_zero/s2n_blob_zero_harness.c
@@ -17,6 +17,7 @@
 #include "utils/s2n_blob.h"
 
 #include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
@@ -29,9 +30,7 @@ void s2n_blob_zero_harness()
     /* Operation under verification. */
     if(s2n_blob_zero(blob) == S2N_SUCCESS && blob->size != 0)
     {
-        size_t index;
-        __CPROVER_assume(index < blob->size);
-        assert(blob->data[index] == 0);
+        assert_all_zeroes(blob->data, blob->size);
     }
     assert(s2n_blob_is_valid(blob));
 }

--- a/tests/cbmc/proofs/s2n_blob_zero/s2n_blob_zero_harness.c
+++ b/tests/cbmc/proofs/s2n_blob_zero/s2n_blob_zero_harness.c
@@ -27,7 +27,7 @@ void s2n_blob_zero_harness()
     __CPROVER_assume(s2n_blob_is_valid(blob));
 
     /* Operation under verification. */
-    if(s2n_blob_zero(blob) == S2N_SUCCESS)
+    if(s2n_blob_zero(blob) == S2N_SUCCESS && blob->size != 0)
     {
         size_t index;
         __CPROVER_assume(index < blob->size);

--- a/tests/cbmc/proofs/s2n_blob_zero/s2n_blob_zero_harness.c
+++ b/tests/cbmc/proofs/s2n_blob_zero/s2n_blob_zero_harness.c
@@ -24,13 +24,14 @@ void s2n_blob_zero_harness()
 {
     /* Non-deterministic inputs. */
     struct s2n_blob *blob = cbmc_allocate_s2n_blob();
-    __CPROVER_assume( s2n_blob_is_valid( blob ) );
+    __CPROVER_assume(s2n_blob_is_valid(blob));
 
     /* Operation under verification. */
-    if( s2n_blob_zero( blob ) == S2N_SUCCESS ) {
+    if(s2n_blob_zero(blob) == S2N_SUCCESS)
+    {
         size_t index;
         __CPROVER_assume(index < blob->size);
         assert(blob->data[index] == 0);
     }
-    assert( s2n_blob_is_valid( blob ) );
+    assert(s2n_blob_is_valid(blob));
 }

--- a/tests/saw/spec/DRBG/DRBG.saw
+++ b/tests/saw/spec/DRBG/DRBG.saw
@@ -99,6 +99,8 @@ let alloc_blob n = do {
     datap <- alloc_bytes n;
     crucible_points_to (crucible_field p "data") datap;
     crucible_points_to (crucible_field p "size") (tm {{ `n : [32] }});
+    crucible_points_to (crucible_field p "allocated") (tm {{ 0 : [32] }});
+    crucible_points_to (crucible_field p "growable") (tm {{ 0 : [8] }});
     return (p, datap);
 };
 

--- a/utils/s2n_blob.c
+++ b/utils/s2n_blob.c
@@ -44,6 +44,7 @@ int s2n_blob_init(struct s2n_blob *b, uint8_t * data, uint32_t size)
 
 int s2n_blob_zero(struct s2n_blob *b)
 {
+    PRECONDITION_POSIX(s2n_blob_is_valid(b));
     memset_check(b->data, 0, b->size);
     return S2N_SUCCESS;
 }

--- a/utils/s2n_blob.c
+++ b/utils/s2n_blob.c
@@ -44,7 +44,6 @@ int s2n_blob_init(struct s2n_blob *b, uint8_t * data, uint32_t size)
 
 int s2n_blob_zero(struct s2n_blob *b)
 {
-    PRECONDITION_POSIX(s2n_blob_is_valid(b));
     memset_check(b->data, 0, b->size);
     return S2N_SUCCESS;
 }

--- a/utils/s2n_blob.c
+++ b/utils/s2n_blob.c
@@ -15,6 +15,7 @@
 
 #include <string.h>
 #include <ctype.h>
+#include <sys/param.h>
 
 #include "error/s2n_errno.h"
 
@@ -44,7 +45,9 @@ int s2n_blob_init(struct s2n_blob *b, uint8_t * data, uint32_t size)
 
 int s2n_blob_zero(struct s2n_blob *b)
 {
-    memset_check(b->data, 0, b->size);
+    PRECONDITION_POSIX(s2n_blob_is_valid(b));
+    memset_check(b->data, 0, MAX(b->allocated, b->size));
+    POSTCONDITION_POSIX(s2n_blob_is_valid(b));
     return S2N_SUCCESS;
 }
 

--- a/utils/s2n_blob.h
+++ b/utils/s2n_blob.h
@@ -19,8 +19,6 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-
-
 struct s2n_blob {
     /* The data for the s2n_blob */
     uint8_t *data;
@@ -29,9 +27,9 @@ struct s2n_blob {
     uint32_t size;
 
     /* The amount of memory allocated for this blob (i.e. the amount of memory
-     * which needs to be freed when the blob is cleaned up). If this blob was 
+     * which needs to be freed when the blob is cleaned up). If this blob was
      * created with s2n_blob_init(), this value is 0. If s2n_alloc() was called,
-     * this value will be greater than 0. 
+     * this value will be greater than 0.
      */
     uint32_t allocated;
 

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -215,7 +215,7 @@ int s2n_free_object(uint8_t **p_data, uint32_t size)
     if (*p_data == NULL) {
         return 0;
     }
-    struct s2n_blob b = {.data = *p_data, .size = size, .growable = 1};
+    struct s2n_blob b = {.data = *p_data, .allocated = size, .size = size, .growable = 1};
 
     /* s2n_free() will call free() even if it returns error (for a growable blob).
     ** This makes sure *p_data is not used after free() */


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A.

### Description of changes: 

- Adds a proof harness for the `s2n_blob_zero` function;
- Adds a precondition to the `s2n_blob_zero` function;

### Call-outs:

This PR depends on [PR #1923](https://github.com/awslabs/s2n/pull/1923).

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
