### PR TITLE
Adds a proof harness for s2n_blob_char_to_lower

### DIFF
--- a/error/s2n_errno.h
+++ b/error/s2n_errno.h
@@ -297,6 +297,11 @@ extern __thread const char *s2n_debug_str;
 #endif /* CBMC */
 
 #define S2N_IMPLIES(a, b) (!(a) || (b))
+/**
+ * If and only if (iff) is a biconditional logical connective between statements a and b.
+ * Equivalent to (S2N_IMPLIES(a, b) && S2N_IMPLIES(b, a)).
+ */
+#define S2N_IFF(a, b) (!!(a) == !!(b))
 
 /** Calculate and print stacktraces */
 struct s2n_stacktrace {

--- a/tests/cbmc/include/cbmc_proof/make_common_datastructures.h
+++ b/tests/cbmc/include/cbmc_proof/make_common_datastructures.h
@@ -19,13 +19,33 @@
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
 
+/*
+ * Checks whether s2n_blob is bounded by max_size.
+ */
+bool s2n_blob_is_bounded(const struct s2n_blob* blob, const size_t max_size);
+
+/*
+ * Ensures s2n_blob has a proper allocated data member.
+ */
 void ensure_s2n_blob_has_allocated_fields(struct s2n_blob* blob);
+
+/*
+ * Properly allocates s2n_blob for CBMC proofs.
+ */
 struct s2n_blob* cbmc_allocate_s2n_blob();
+
+/*
+ * Ensures s2n_stuffer has a proper allocated blob member.
+ */
 void ensure_s2n_stuffer_has_allocated_fields(struct s2n_stuffer* stuffer);
+
+/*
+ * Properly allocates s2n_stuffer for CBMC proofs.
+ */
 struct s2n_stuffer* cbmc_allocate_s2n_stuffer();
 
-/**
+/*
  * Ensures a valid const string is allocated,
- * with as much nondet as possible, len < max_size
+ * with as much nondet as possible, len < max_size.
  */
 const char *ensure_c_str_is_allocated(size_t max_size);

--- a/tests/cbmc/proofs/Makefile.common
+++ b/tests/cbmc/proofs/Makefile.common
@@ -83,6 +83,8 @@ DO_CBMC =  $(call DO_AND_LOG_IGNORING_ERROR_10,$(CBMC),$(CBMC_VERBOSITY) $(1) $(
 #1: message 2: source 3: dest
 DO_NOOP_COPY = cp $(2) $(3); echo $(1) | tee $(call LOG_FROM_ENTRY,$(3))
 
+# +1 bound
+addone = $(shell echo $$(( $(1) + 1)))
 
 ################################################################
 # Useful macros translating filenames

--- a/tests/cbmc/proofs/s2n_blob_char_to_lower/Makefile
+++ b/tests/cbmc/proofs/s2n_blob_char_to_lower/Makefile
@@ -1,0 +1,36 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+ABSTRACTIONS += $(HELPERDIR)/stubs/__tolower.c
+
+# Enough to get full coverage with 10 seconds of runtime.
+BLOB_SIZE = 10
+DEFINES += -DBLOB_SIZE=$(BLOB_SIZE)
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+DEPENDENCIES += $(SRCDIR)/error/s2n_errno.c
+
+ENTRY = s2n_blob_char_to_lower_harness
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_calculate_stacktrace
+
+UNWINDSET += s2n_blob_char_to_lower.3:$(call addone,$(BLOB_SIZE))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_blob_char_to_lower/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_blob_char_to_lower/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_blob_char_to_lower/s2n_blob_char_to_lower_harness.c
+++ b/tests/cbmc/proofs/s2n_blob_char_to_lower/s2n_blob_char_to_lower_harness.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "utils/s2n_blob.h"
+
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_blob_char_to_lower_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_blob *blob = cbmc_allocate_s2n_blob();
+    __CPROVER_assume(s2n_blob_is_valid(blob));
+    __CPROVER_assume(s2n_blob_is_bounded(blob, BLOB_SIZE));
+
+    /* Save previous state. */
+    struct s2n_blob old_blob = *blob;
+    struct store_byte_from_buffer old_byte_from_blob;
+    save_byte_from_blob(blob, &old_byte_from_blob);
+
+    /* Operation under verification. */
+    if(s2n_blob_char_to_lower(blob) == S2N_SUCCESS && blob->size != 0) {
+        if(old_byte_from_blob.byte >= 'A' && old_byte_from_blob.byte <= 'Z')
+        {
+            assert(blob->data[old_byte_from_blob.index] == (old_byte_from_blob.byte + ('a' - 'A')));
+        }
+    }
+    /* s2n_blob_char_to_lower will always modify blob->data. */
+    assert(blob->size == old_blob.size);
+    assert(blob->allocated == old_blob.allocated);
+    assert(blob->growable == old_blob.growable);
+    assert(s2n_blob_is_valid(blob));
+}

--- a/tests/cbmc/proofs/s2n_blob_char_to_lower/s2n_blob_char_to_lower_harness.c
+++ b/tests/cbmc/proofs/s2n_blob_char_to_lower/s2n_blob_char_to_lower_harness.c
@@ -34,10 +34,12 @@ void s2n_blob_char_to_lower_harness()
     save_byte_from_blob(blob, &old_byte_from_blob);
 
     /* Operation under verification. */
-    if(s2n_blob_char_to_lower(blob) == S2N_SUCCESS && blob->size != 0) {
-        if(old_byte_from_blob.byte >= 'A' && old_byte_from_blob.byte <= 'Z')
-        {
-            assert(blob->data[old_byte_from_blob.index] == (old_byte_from_blob.byte + ('a' - 'A')));
+    if(s2n_blob_char_to_lower(blob) == S2N_SUCCESS) {
+        if (blob->size != 0){
+            if(old_byte_from_blob.byte >= 'A' && old_byte_from_blob.byte <= 'Z')
+            {
+                assert(blob->data[old_byte_from_blob.index] == (old_byte_from_blob.byte + ('a' - 'A')));
+            }
         }
     }
     /* s2n_blob_char_to_lower will always modify blob->data. */

--- a/tests/cbmc/source/make_common_datastructures.c
+++ b/tests/cbmc/source/make_common_datastructures.c
@@ -14,6 +14,11 @@
  */
 
 #include <cbmc_proof/make_common_datastructures.h>
+
+bool s2n_blob_is_bounded(const struct s2n_blob* blob, const size_t max_size) {
+    return (blob->size <= max_size);
+}
+
 void ensure_s2n_blob_has_allocated_fields(struct s2n_blob* blob) {
     if(blob->growable) {
         blob->data = (blob->allocated == 0) ? NULL : bounded_malloc(blob->allocated);

--- a/tests/cbmc/stubs/__tolower.c
+++ b/tests/cbmc/stubs/__tolower.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * FUNCTION: __tolower
+ *
+ * CBMC doesn't implement tolower yet, so we use this stub instead.
+ */
+
+#include <assert.h>
+
+int __tolower(int c)
+{
+    if(c >= 'A' && c <= 'Z')
+    {
+        c = c + ('a' - 'A');
+    }
+    return c;
+}

--- a/tests/cbmc/stubs/s2n_calculate_stacktrace.c
+++ b/tests/cbmc/stubs/s2n_calculate_stacktrace.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include <cbmc_proof/nondet.h>
+
+int s2n_calculate_stacktrace()
+{
+    return nondet_bool() ? S2N_SUCCESS : S2N_FAILURE;
+}

--- a/utils/s2n_blob.c
+++ b/utils/s2n_blob.c
@@ -28,6 +28,7 @@ bool s2n_blob_is_valid(const struct s2n_blob* b)
 {
     return S2N_OBJECT_PTR_IS_READABLE(b) &&
            S2N_IMPLIES(b->data == NULL, b->size == 0) &&
+           S2N_IMPLIES(b->data == NULL, b->allocated == 0) &&
            S2N_IMPLIES(b->growable == 0, b->allocated == 0) &&
            S2N_IMPLIES(b->growable != 0, b->size <= b->allocated) &&
            S2N_MEM_IS_READABLE(b->data, b->allocated) &&
@@ -70,12 +71,11 @@ int s2n_blob_slice(const struct s2n_blob *b, struct s2n_blob *slice, uint32_t of
 
 int s2n_blob_char_to_lower(struct s2n_blob *b)
 {
-    uint8_t *ptr = b->data;
-    for (int i = 0; i < b->size; i++ ) {
-        *ptr = tolower(*ptr);
-        ptr++;
+    PRECONDITION_POSIX(s2n_blob_is_valid(b));
+    for (size_t i = 0; i < b->size; i++) {
+        b->data[i] = tolower(b->data[i]);
     }
-
+    POSTCONDITION_POSIX(s2n_blob_is_valid(b));
     return S2N_SUCCESS;
 }
 


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A.

### Description of changes: 

- Adds `s2n_blob_is_bounded` predicate (for CBMC proofs only);
- Adds a proof harness for the `s2n_blob_char_to_lower` function;
- Adds a precondition to the `s2n_blob_char_to_lower` function;
- Adds a stub for `__tolower`;
- Improves documentation for CBMC predicates.

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
