### PR TITLE
Add stricter verifications for when to send a Hello Retry.

### DIFF
--- a/tests/integration/common/s2n_test_scenario.py
+++ b/tests/integration/common/s2n_test_scenario.py
@@ -223,7 +223,6 @@ def scenario_runner(test_func, scenario):
     return runner
 
 def run_scenarios(test_func, scenarios):
-    failed = 0
     threadpool = __create_thread_pool()
     results = {}
 
@@ -239,12 +238,13 @@ def run_scenarios(test_func, scenarios):
     # get results, applying a 5 seconds limit for each task
     results.update((k, v.get(5000)) for k,v in results.items())
 
+    failed = 0
     print("\tScenarios ran. Reprinting failed tasks if any...")
     # Sort the results so that failures appear at the end
     sorted_results = sorted(results.items(), key=lambda x: not x[1].is_success())
     for scenario, result in sorted_results:
         if not result.is_success():
-            fail += 1
+            failed += 1
             print("%s %s" % (str(scenario), str(result).rstrip()))
 
     print("\tDone")

--- a/tests/integration/s2n_tls13_handshake_tests.py
+++ b/tests/integration/s2n_tls13_handshake_tests.py
@@ -41,14 +41,26 @@ def verify_hrr_random_data(server, client):
 
     # Start of HRR random data which will be printed in the
     # client process output
+    marker_found = False
+    hello_count = 0
+    finished_count = 0
     marker = b"cf 21 ad 74 e5 9a 61 11 be 1d"
+
     for line in client.stdout:
         if marker in line:
+            marker_found = True
+        if b'ClientHello' in line:
+            hello_count += 1
+        if b'], Finished' in line:
+            finished_count += 1
+        if marker_found and hello_count == 2 and finished_count == 2:
             result.status = Status.PASSED
             break
 
+
     return result
-    
+
+
 def key_update_recv(server, client):
     '''
     This test checks that a key update can be processed by s2n. It runs three times to prove that s2n can

--- a/tests/unit/s2n_extensions_server_key_share_select_test.c
+++ b/tests/unit/s2n_extensions_server_key_share_select_test.c
@@ -96,8 +96,9 @@ int main(int argc, char **argv)
 
         EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[0]);
 
-        EXPECT_EQUAL(s2n_is_hello_retry_required(server_conn), 1);
-        EXPECT_SUCCESS(s2n_connection_free(server_conn)); 
+        /* Verify that the handshake type was updated correctly */
+        EXPECT_EQUAL(s2n_is_hello_retry_handshake(server_conn), 1);
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
     }
 
     {

--- a/tests/unit/s2n_server_hello_retry_test.c
+++ b/tests/unit/s2n_server_hello_retry_test.c
@@ -103,8 +103,8 @@ int main(int argc, char **argv)
         total += 2 + s2n_extensions_server_supported_versions_size(server_conn)
                 + s2n_extensions_server_key_share_send_size(server_conn);
 
-        EXPECT_SUCCESS(s2n_server_hello_retry_send(server_conn));
         EXPECT_EQUAL(s2n_is_hello_retry_required(server_conn), 1);
+        EXPECT_SUCCESS(s2n_server_hello_retry_send(server_conn));
 
         EXPECT_EQUAL(s2n_stuffer_data_available(server_stuffer), total);
 
@@ -140,9 +140,8 @@ int main(int argc, char **argv)
 
         s2n_set_connection_hello_retry_flags(conn);
 
-        EXPECT_SUCCESS(s2n_server_hello_retry_send(conn));
-
         EXPECT_EQUAL(s2n_is_hello_retry_required(conn), 1);
+        EXPECT_SUCCESS(s2n_server_hello_retry_send(conn));
 
         EXPECT_SUCCESS(s2n_config_free(conf));
         EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -251,7 +250,11 @@ int main(int argc, char **argv)
         /* Setup the client to receive a HelloRetryRequest */
         memcpy_check(client_conn->secure.server_random, hello_retry_request_random_test_buffer, S2N_TLS_RANDOM_DATA_LEN);
         client_conn->server_protocol_version = S2N_TLS13;
+
+        /* Setup the handshake type and message number to simulate a condition where a HelloRetry should be sent */
+        client_conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
         EXPECT_SUCCESS(s2n_set_hello_retry_required(client_conn));
+        client_conn->handshake.message_number = 1;
 
         /* Parse the key share */
         EXPECT_SUCCESS(s2n_extensions_server_key_share_recv(client_conn, extension_stuffer));

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -518,6 +518,11 @@ int s2n_set_hello_retry_required(struct s2n_connection *conn)
  * A retry is only possible after the first ClientHello (HELLO_RETRY_MSG). */
 bool s2n_is_hello_retry_required(struct s2n_connection *conn)
 {
+    return ACTIVE_MESSAGE(conn) == HELLO_RETRY_MSG;
+}
+
+bool s2n_is_hello_retry_handshake(struct s2n_connection *conn)
+{
     return conn->handshake.handshake_type & HELLO_RETRY_REQUEST;
 }
 

--- a/tls/s2n_server_hello_retry.c
+++ b/tls/s2n_server_hello_retry.c
@@ -37,7 +37,6 @@ static int s2n_conn_reset_retry_values(struct s2n_connection *conn)
     notnull_check(conn);
 
     /* Reset handshake values */
-    conn->handshake.handshake_type = INITIAL | HELLO_RETRY_REQUEST;
     conn->handshake.client_hello_received = 0;
 
     /* Reset client hello state */

--- a/tls/s2n_tls13.h
+++ b/tls/s2n_tls13.h
@@ -27,4 +27,5 @@ int s2n_disable_tls13();
 bool s2n_is_valid_tls13_cipher(const uint8_t version[2]);
 
 bool s2n_is_hello_retry_required(struct s2n_connection *conn);
+bool s2n_is_hello_retry_handshake(struct s2n_connection *conn);
 int s2n_set_hello_retry_required(struct s2n_connection *conn);


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Description of changes: 

This change fixes a bug that caused the handshake to think it was a reader when it should have been a writer during the CCS messages. To do this we don't reset the handshake type after determining we need a retry. We also only allow sending an HRR if the current message is a HELLO_RETRY_MSG.

The change to the integ test verifies multiple handshake finished messages as well as the HRR random data. This verifies the handshake has completed.

### Testing:

Tested manually, and then in the integration test system after the test was updated.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
