### PR TITLE
ci: Update CodeBuild to use latest ubuntu image.

### DIFF
--- a/codebuild/codebuild.config
+++ b/codebuild/codebuild.config
@@ -96,7 +96,7 @@ env: TESTS=sidetrail
 
 # GitHub Actions Codebuild Shim Job
 [CodeBuild:s2nGithubCodebuild]
-image : aws/codebuild/standard:2.0
+image : aws/codebuild/standard:4.0
 env_type: LINUX_CONTAINER
 compute_type: BUILD_GENERAL1_LARGE
 timeout_in_min: 480

--- a/codebuild/common.config
+++ b/codebuild/common.config
@@ -10,7 +10,7 @@ account_number: 024603541914
 
 #Reusable templates - use the snippet:NAME
 [UbuntuBoilerplate2XL]
-image : aws/codebuild/standard:2.0
+image : aws/codebuild/standard:4.0
 env_type: LINUX_CONTAINER
 compute_type: BUILD_GENERAL1_2XLARGE
 timeout_in_min: 90
@@ -21,7 +21,7 @@ source_clonedepth: 1
 source_version:
 
 [UbuntuBoilerplateLarge]
-image : aws/codebuild/standard:2.0
+image : aws/codebuild/standard:4.0
 env_type: LINUX_CONTAINER
 compute_type: BUILD_GENERAL1_LARGE
 timeout_in_min: 90

--- a/codebuild/fuzz_codebuild.config
+++ b/codebuild/fuzz_codebuild.config
@@ -6,7 +6,7 @@ stack_name: s2nScheduledFuzz
 
 # CodeBuild Scheduled Fuzz
 [CodeBuild:s2nFuzzScheduled]
-image : aws/codebuild/standard:2.0
+image : aws/codebuild/standard:4.0
 env_type: LINUX_CONTAINER
 compute_type: BUILD_GENERAL1_LARGE
 timeout_in_min: 480

--- a/codebuild/integ_codebuild.config
+++ b/codebuild/integ_codebuild.config
@@ -6,7 +6,7 @@ stack_name: s2nIntegrationScheduled
 
 #Reusable templates - use the snippet:NAME
 [IntegUbuntuBoilerplateLarge]
-image : aws/codebuild/standard:2.0
+image : aws/codebuild/standard:4.0
 env_type: LINUX_CONTAINER
 compute_type: BUILD_GENERAL1_LARGE
 timeout_in_min: 90
@@ -18,7 +18,7 @@ source_version:
 
 # Boring + GCC9, Libre + GCC6
 [CodeBuild:s2nIntegrationBoringLibre]
-image : aws/codebuild/standard:2.0
+image : aws/codebuild/standard:4.0
 env_type: LINUX_CONTAINER
 compute_type: BUILD_GENERAL1_LARGE
 timeout_in_min: 90
@@ -31,7 +31,7 @@ env: TESTS=integration BUILD_S2N=true
 
 # OpenSSL111 + GCC6 + Corked and notCorked + Gcc4.8
 [CodeBuild:s2nIntegrationOpenSSL111PlusCoverage]
-image : aws/codebuild/standard:2.0
+image : aws/codebuild/standard:4.0
 env_type: LINUX_CONTAINER
 compute_type: BUILD_GENERAL1_LARGE
 timeout_in_min: 90
@@ -44,7 +44,7 @@ env: TESTS=integration BUILD_S2N=true
 
 # OpenSSL102 Fips and notFips + GCC6
 [CodeBuild:s2nIntegrationOpenSSL102Plus]
-image : aws/codebuild/standard:2.0
+image : aws/codebuild/standard:4.0
 env_type: LINUX_CONTAINER
 compute_type: BUILD_GENERAL1_LARGE
 timeout_in_min: 90
@@ -57,7 +57,7 @@ env: TESTS=integration BUILD_S2N=true
 
 # OpenSSL102 + GCC6 + Asan and Valgrind
 [CodeBuild:s2nIntegrationOpenSSL102AsanValgrind]
-image : aws/codebuild/standard:2.0
+image : aws/codebuild/standard:4.0
 env_type: LINUX_CONTAINER
 compute_type: BUILD_GENERAL1_LARGE
 timeout_in_min: 90


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:
None
### Description of changes: 

Notice went out about CodeBuild vended images EOS (s2n uses 2.0).
```
Starting on June 29, 2020, AWS CodeBuild will no longer maintain the following images:

* Platform: Ubuntu 18.04 - Image: aws/codebuild/standard:1.0 - Definition: ubuntu/standard/1.0
* Platform: Ubuntu 18.04 - Image: aws/codebuild/standard:2.0 - Definition: ubuntu/standard/2.0
* Platform: Amazon Linux 2 - Image: aws/codebuild/amazonlinux2-x86_64-standard:1.0 - Definition: al2/standard/1.0

You can continue using these images, but could see increased build latency. These images will not get any further updates. You are encouraged to update your Build Projects to use the latest build images in order to get the latest language runtimes and tools.

```
### Call-outs:

Jobs need ad-hoc test runs against the new images first.

### Testing:

- [x]  s2nIntegrationOpenSSL102Plus
- [x]  s2nIntegrationOpenSSL102AsanValgrind
- [x]  s2nIntegrationBoringLibre
- [x]  s2nIntegrationOpenSSL111Plus
- [x]  s2nAsanOpenSSL111Gcc6
- [x]  s2nSidetrail
- [x]  s2nIntegrationOpenSSL111Gcc6SoftCrypto
- [x]  s2nSawHmacPlus
- [x]  s2nSawTls
- [x]  s2nIntegrationOpenSSL102Gcc6FIPS
- [x]  s2nValgrindOpenSSL102Gcc6
- [x]  s2nfuzzerOpenSSL111Coverage
- [x]  s2nIntegrationOpenSSL111Gcc6
- [x]  s2nValgrindOpenSSL102Gcc6Fips
- [x]  s2nIntegrationLibreSSLGcc9
- [x]  s2nSawBike
- [x]  s2nIntegrationOpenSSL111Gcc6Corked
- [x]  s2nIntegrationBoringSSLGcc9
- [x]  s2nIntegrationOpenSSL111Gcc9
- [x]  s2nfuzzerOpenSSL102FIPS
- [x]  s2nValgrindOpenSSL111Gcc9
- [x]  s2nIntegrationOpenSSL102Gcc6
- [ ]  s2nFuzzScheduled

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
