### PR TITLE
ci: Improve s2n_setup_env

### DIFF
--- a/codebuild/bin/install_clang.sh
+++ b/codebuild/bin/install_clang.sh
@@ -54,7 +54,7 @@ echo "Installed Clang Version: "
 "$CLANG_DOWNLOAD_DIR"/third_party/llvm-build/Release+Asserts/bin/clang --version
 
 # Install matching LLVM if FUZZ_COVERAGE is enabled
-if [[ -v FUZZ_COVERAGE ]]; then
+if [[ ! -z "$FUZZ_COVERAGE" ]]; then
 	LLVM_INSTALL_DIR="$CLANG_INSTALL_DIR"/../llvm
 	mkdir -p "$LLVM_INSTALL_DIR"
 	python3 "$CLANG_DOWNLOAD_DIR"/clang/scripts/update.py --package="coverage_tools" --output-dir="$LLVM_INSTALL_DIR"

--- a/codebuild/bin/s2n_setup_env.sh
+++ b/codebuild/bin/s2n_setup_env.sh
@@ -78,7 +78,7 @@ export OS_NAME
 export S2N_CORKED_IO
 
 # S2N_COVERAGE should not be used with fuzz tests, use FUZZ_COVERAGE instead
-if [[ -v S2N_COVERAGE && "$TESTS" == "fuzz" ]]; then
+if [[ ! -z "$S2N_COVERAGE" && "$TESTS" == "fuzz" ]]; then
     unset S2N_COVERAGE
     export FUZZ_COVERAGE=true
 fi

--- a/tests/fuzz/calcTotalCov.sh
+++ b/tests/fuzz/calcTotalCov.sh
@@ -24,7 +24,7 @@ if [ "$#" -ne "0" ]; then
     usage
 fi
 
-if [[ ! -v S2N_ROOT ]]; then
+if [[ -z "$S2N_ROOT" ]]; then
     S2N_ROOT=../..
 fi
 
@@ -35,7 +35,7 @@ FUZZCOV_SOURCES="${S2N_ROOT}/api ${S2N_ROOT}/bin ${S2N_ROOT}/crypto ${S2N_ROOT}/
 # Total coverage is overlayed on source code in s2n_cov.html and coverage statistics are available in s2n_cov.txt
 # If using LLVM version 9 or greater, coverage is output in LCOV format instead of HTML
 # All files are stored in the s2n coverage directory
-if [[ -v FUZZ_COVERAGE ]]; then
+if [[ ! -z "$FUZZ_COVERAGE" ]]; then
 
     printf "Calculating total s2n coverage... "
 

--- a/tests/fuzz/runFuzzTest.sh
+++ b/tests/fuzz/runFuzzTest.sh
@@ -78,7 +78,7 @@ cp -r ./corpus/${TEST_NAME}/. "${TEMP_CORPUS_DIR}"
 printf "Running %-s %-40s for %5d sec with %2d threads... " "${FIPS_TEST_MSG}" ${TEST_NAME} ${FUZZ_TIMEOUT_SEC} ${NUM_CPU_THREADS}
 
 # Setup and clean profile structure if FUZZ_COVERAGE is enabled, otherwise run as normal
-if [[ -v FUZZ_COVERAGE ]]; then
+if [[ ! -z "$FUZZ_COVERAGE" ]]; then
     mkdir -p "./profiles/${TEST_NAME}"
     rm -f ./profiles/${TEST_NAME}/*.profraw
     LLVM_PROFILE_FILE="./profiles/${TEST_NAME}/${TEST_NAME}.%p.profraw" ./${TEST_NAME} ${LIBFUZZER_ARGS} ${TEMP_CORPUS_DIR} > ${TEST_NAME}_output.txt 2>&1 || ACTUAL_TEST_FAILURE=1
@@ -98,7 +98,7 @@ declare -i TARGET_COV=0
 # Coverage is overlayed on source code in ${TEST_NAME}_cov.html, and coverage statistics are available in ${TEST_NAME}_cov.txt
 # If using LLVM version 9 or greater, coverage is output in LCOV format instead of HTML
 # All files are stored in the s2n coverage directory
-if [[ -v FUZZ_COVERAGE ]]; then
+if [[ ! -z "$FUZZ_COVERAGE" ]]; then
     mkdir -p ${COVERAGE_DIR}/fuzz
     llvm-profdata merge -sparse ./profiles/${TEST_NAME}/*.profraw -o ./profiles/${TEST_NAME}/${TEST_NAME}.profdata
     llvm-cov report -instr-profile=./profiles/${TEST_NAME}/${TEST_NAME}.profdata ${S2N_ROOT}/lib/libs2n.so ${FUZZCOV_SOURCES} -show-functions > ${COVERAGE_DIR}/fuzz/${TEST_NAME}_cov.txt
@@ -115,7 +115,7 @@ if [[ -v FUZZ_COVERAGE ]]; then
     TARGET_FUNCS=`grep -Pzo "(?<=/\* Target Functions: )[\w\s]*" ${TEST_NAME}.c | tr -d "\0"`
 
     # Find line coverage statistics for target functions
-    if [[ ! -z TARGET_FUNCS ]];
+    if [[ ! -z "$TARGET_FUNCS" ]];
     then
         for TARGET in ${TARGET_FUNCS}
         do
@@ -131,7 +131,7 @@ then
 
     # Output target function coverage percentage if target functions are defined and fuzzing coverage is enabled
     # Otherwise, print number of features covered
-    if [[ -v FUZZ_COVERAGE && ! -z TARGET_FUNCS && $EXPECTED_TEST_FAILURE != 1 && $TARGET_TOTAL != 0 ]];
+    if [[ ! -z "$FUZZ_COVERAGE" && ! -z "$TARGET_FUNCS" && "$EXPECTED_TEST_FAILURE" != 1 && "$TARGET_TOTAL" != 0 ]];
     then
         printf ", %6.2f%% target coverage" "$(( 10000 * ($TARGET_TOTAL - $TARGET_COV) / $TARGET_TOTAL ))e-2"
     else


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

 resolves #1801 

### Description of changes: 

Fix to allow older shells with s2n_setup_env.sh

### Call-outs:

### Testing:

```
sh-3.2$ export S2N_COVERAGE=true TESTS=fuzz; if [[ ! -z "$S2N_COVERAGE" && "$TESTS" == "fuzz" ]]; then echo foo;fi
foo
sh-3.2$ unset S2N_COVERAGE; if [[ ! -z "$S2N_COVERAGE" && "$TESTS" == "fuzz" ]]; then echo foo;fi
sh-3.2$
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
