### PR TITLE
Cookie extension fixes

### DIFF
--- a/tests/unit/s2n_extension_type_test.c
+++ b/tests/unit/s2n_extension_type_test.c
@@ -55,9 +55,11 @@ int main()
     {
         /* Test common implementations for send */
         EXPECT_FAILURE_WITH_ERRNO(s2n_extension_send_unimplemented(NULL, NULL), S2N_ERR_UNIMPLEMENTED);
+        EXPECT_SUCCESS(s2n_extension_send_noop(NULL, NULL));
 
         /* Test common implementations for recv */
         EXPECT_FAILURE_WITH_ERRNO(s2n_extension_recv_unimplemented(NULL, NULL), S2N_ERR_UNIMPLEMENTED);
+        EXPECT_SUCCESS(s2n_extension_recv_noop(NULL, NULL));
 
         /* Test common implementations for should_send */
         {

--- a/tls/extensions/s2n_client_sct_list.c
+++ b/tls/extensions/s2n_client_sct_list.c
@@ -23,13 +23,12 @@
 #include "utils/s2n_safety.h"
 
 static bool s2n_client_sct_list_should_send(struct s2n_connection *conn);
-static int s2n_client_sct_list_send(struct s2n_connection *conn, struct s2n_stuffer *out);
 static int s2n_client_sct_list_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
 
 const s2n_extension_type s2n_client_sct_list_extension = {
     .iana_value = TLS_EXTENSION_SCT_LIST,
     .is_response = false,
-    .send = s2n_client_sct_list_send,
+    .send = s2n_extension_send_noop,
     .recv = s2n_client_sct_list_recv,
     .should_send = s2n_client_sct_list_should_send,
     .if_missing = s2n_extension_noop_if_missing,
@@ -38,12 +37,6 @@ const s2n_extension_type s2n_client_sct_list_extension = {
 static bool s2n_client_sct_list_should_send(struct s2n_connection *conn)
 {
     return conn->config->ct_type != S2N_CT_SUPPORT_NONE;
-}
-
-static int s2n_client_sct_list_send(struct s2n_connection *conn, struct s2n_stuffer *out)
-{
-    /* This extension is empty */
-    return S2N_SUCCESS;
 }
 
 static int s2n_client_sct_list_recv(struct s2n_connection *conn, struct s2n_stuffer *out)

--- a/tls/extensions/s2n_cookie.c
+++ b/tls/extensions/s2n_cookie.c
@@ -20,6 +20,15 @@
 #define S2N_SIZE_OF_EXTENSION_DATA_SIZE     2
 #define S2N_SIZE_OF_COOKIE_DATA_SIZE        2
 
+const s2n_extension_type s2n_client_cookie_extension = {
+    .iana_value = TLS_EXTENSION_COOKIE,
+    .is_response = true,
+    .send = s2n_extension_send_noop,
+    .recv = s2n_extension_recv_noop,
+    .should_send = s2n_extension_never_send,
+    .if_missing = s2n_extension_noop_if_missing,
+};
+
 static bool s2n_cookie_should_send(struct s2n_connection *conn);
 static int s2n_cookie_send(struct s2n_connection *conn, struct s2n_stuffer *out);
 static int s2n_cookie_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_cookie.h
+++ b/tls/extensions/s2n_cookie.h
@@ -20,6 +20,7 @@
 #include "tls/s2n_connection.h"
 #include "stuffer/s2n_stuffer.h"
 
+extern const s2n_extension_type s2n_client_cookie_extension;
 extern const s2n_extension_type s2n_server_cookie_extension;
 
 /* Old-style extension functions -- remove after extensions refactor is complete */

--- a/tls/extensions/s2n_ec_point_format.c
+++ b/tls/extensions/s2n_ec_point_format.c
@@ -40,7 +40,7 @@ const s2n_extension_type s2n_server_ec_point_format_extension = {
     .iana_value = TLS_EXTENSION_EC_POINT_FORMATS,
     .is_response = true,
     .send = s2n_ec_point_format_send,
-    .recv = s2n_ec_point_format_recv,
+    .recv = s2n_extension_recv_noop,
     .should_send = s2n_server_ec_point_format_should_send,
     .if_missing = s2n_extension_noop_if_missing,
 };

--- a/tls/extensions/s2n_extension_type.c
+++ b/tls/extensions/s2n_extension_type.c
@@ -151,6 +151,16 @@ int s2n_extension_recv_unimplemented(struct s2n_connection *conn, struct s2n_stu
     S2N_ERROR(S2N_ERR_UNIMPLEMENTED);
 }
 
+int s2n_extension_send_noop(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    return S2N_SUCCESS;
+}
+
+int s2n_extension_recv_noop(struct s2n_connection *conn, struct s2n_stuffer *in)
+{
+    return S2N_SUCCESS;
+}
+
 bool s2n_extension_always_send(struct s2n_connection *conn)
 {
     return true;

--- a/tls/extensions/s2n_extension_type.h
+++ b/tls/extensions/s2n_extension_type.h
@@ -59,6 +59,7 @@ static const uint16_t s2n_supported_extensions[] = {
     TLS_EXTENSION_SESSION_TICKET,
     TLS_EXTENSION_SUPPORTED_VERSIONS,
     TLS_EXTENSION_KEY_SHARE,
+    TLS_EXTENSION_COOKIE,
 };
 
 typedef char s2n_extension_bitfield[S2N_SUPPORTED_EXTENSIONS_BITFIELD_LEN];

--- a/tls/extensions/s2n_extension_type.h
+++ b/tls/extensions/s2n_extension_type.h
@@ -74,9 +74,11 @@ int s2n_extension_type_init();
 
 /* Common implementations for send */
 int s2n_extension_send_unimplemented(struct s2n_connection *conn, struct s2n_stuffer *out);
+int s2n_extension_send_noop(struct s2n_connection *conn, struct s2n_stuffer *out);
 
 /* Common implementations for recv */
 int s2n_extension_recv_unimplemented(struct s2n_connection *conn, struct s2n_stuffer *in);
+int s2n_extension_recv_noop(struct s2n_connection *conn, struct s2n_stuffer *out);
 
 /* Common implementations for should_send */
 bool s2n_extension_always_send(struct s2n_connection *conn);

--- a/tls/extensions/s2n_extension_type_lists.c
+++ b/tls/extensions/s2n_extension_type_lists.c
@@ -58,6 +58,7 @@ static const s2n_extension_type *const client_hello_extensions[] = {
         &s2n_client_ec_point_format_extension,
         &s2n_client_pq_kem_extension,
         &s2n_client_renegotiation_info_extension,
+        &s2n_client_cookie_extension,
 };
 
 static const s2n_extension_type *const tls12_server_hello_extensions[] = {

--- a/tls/extensions/s2n_server_session_ticket.c
+++ b/tls/extensions/s2n_server_session_ticket.c
@@ -21,13 +21,12 @@
 #include "tls/extensions/s2n_server_session_ticket.h"
 
 static bool s2n_session_ticket_should_send(struct s2n_connection *conn);
-static int s2n_session_ticket_send(struct s2n_connection *conn, struct s2n_stuffer *out);
 static int s2n_session_ticket_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
 
 const s2n_extension_type s2n_server_session_ticket_extension = {
     .iana_value = TLS_EXTENSION_SESSION_TICKET,
     .is_response = true,
-    .send = s2n_session_ticket_send,
+    .send = s2n_extension_send_noop,
     .recv = s2n_session_ticket_recv,
     .should_send = s2n_session_ticket_should_send,
     .if_missing = s2n_extension_noop_if_missing,
@@ -36,12 +35,6 @@ const s2n_extension_type s2n_server_session_ticket_extension = {
 static bool s2n_session_ticket_should_send(struct s2n_connection *conn)
 {
     return s2n_server_sending_nst(conn) && s2n_connection_get_protocol_version(conn) < S2N_TLS13;
-}
-
-static int s2n_session_ticket_send(struct s2n_connection *conn, struct s2n_stuffer *out)
-{
-    /* Write nothing. The extension just needs to exist. */
-    return S2N_SUCCESS;
 }
 
 static int s2n_session_ticket_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)

--- a/tls/extensions/s2n_server_status_request.c
+++ b/tls/extensions/s2n_server_status_request.c
@@ -20,13 +20,12 @@
 #include "tls/extensions/s2n_server_status_request.h"
 
 static bool s2n_server_status_request_should_send(struct s2n_connection *conn);
-static int s2n_server_status_request_send(struct s2n_connection *conn, struct s2n_stuffer *out);
 static int s2n_server_status_request_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
 
 const s2n_extension_type s2n_server_status_request_extension = {
     .iana_value = TLS_EXTENSION_STATUS_REQUEST,
     .is_response = true,
-    .send = s2n_server_status_request_send,
+    .send = s2n_extension_send_noop,
     .recv = s2n_server_status_request_recv,
     .should_send = s2n_server_status_request_should_send,
     .if_missing = s2n_extension_noop_if_missing,
@@ -35,11 +34,6 @@ const s2n_extension_type s2n_server_status_request_extension = {
 static bool s2n_server_status_request_should_send(struct s2n_connection *conn)
 {
     return s2n_server_can_send_ocsp(conn);
-}
-
-int s2n_server_status_request_send(struct s2n_connection *conn, struct s2n_stuffer *out) {
-    /* Write nothing. The extension just needs to exist. */
-    return S2N_SUCCESS;
 }
 
 int s2n_server_status_request_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)

--- a/tls/s2n_server_extensions.c
+++ b/tls/s2n_server_extensions.c
@@ -52,7 +52,7 @@ int s2n_server_extensions_send_size(struct s2n_connection *conn)
     if (is_tls13_conn) {
         GUARD_UINT16_AND_INCREMENT(s2n_extensions_server_supported_versions_size(conn), total_size);
         GUARD_UINT16_AND_INCREMENT(s2n_extensions_server_key_share_send_size(conn), total_size);
-
+        GUARD_UINT16_AND_INCREMENT(s2n_extensions_cookie_size(conn), total_size);
         return total_size;
     }
 


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

### Description of changes: 

While testing the new extensions logic, I found a bug with the cookie implementation: the server cookie size isn't currently included in the extensions list size, even if sent. So if the server sends a cookie, the size of the extensions list is wrong. A sane client would probably just ignore the cookie extension, since it's the last one in the list.

I also added the cookie to the list of extensions we support and created a no-op client extension for it (so we don't consider it an "unexpected extension" if it appears on the client). The other changes are just me taking advantage of the new no-op methods.

### Call-outs:

**Why was the server_ec_point_format recv replaced with a no-op? It sets a flag!** It doesn't have to set that flag, I just originally reused the client recv. The extension works like this:
- When s2n is the server: The server receives an extension with the ClientHello listing all the point formats that the client supports. However, s2n only supports "uncompressed", so we ignore all the client's formats. We just set a flag to indicate we need to respond. The server then sends an extension that just says "TLS_EC_POINT_FORMAT_UNCOMPRESSED" with the ServerHello.
- When s2n is the client: Since s2n only supports "uncompressed", we send that with the ClientHello. We ignore whatever the server responds with, because we only support the one format. This is the method that previously set the flag, but is now a true no-op.

### Testing:
I left all the existing tests in place to verify no behavior changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
