### PR TITLE
Remove variable-sized arrays in tests

### DIFF
--- a/tests/unit/s2n_server_alpn_extension_test.c
+++ b/tests/unit/s2n_server_alpn_extension_test.c
@@ -62,8 +62,8 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(protocol_name_size, test_protocol_name_size);
 
         /* Should have correct protocol name */
-        uint8_t protocol_name[protocol_name_size];
-        EXPECT_SUCCESS(s2n_stuffer_read_bytes(&stuffer, protocol_name, protocol_name_size));
+        uint8_t *protocol_name;
+        EXPECT_NOT_NULL(protocol_name = s2n_stuffer_raw_read(&stuffer, protocol_name_size));
         EXPECT_BYTEARRAY_EQUAL(protocol_name, test_protocol_name, test_protocol_name_size);
 
         EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));

--- a/tests/unit/s2n_tls13_cookie_test.c
+++ b/tests/unit/s2n_tls13_cookie_test.c
@@ -80,8 +80,8 @@ int main(int argc, char *argv[])
         EXPECT_EQUAL(cookie_size, s2n_stuffer_data_available(&stuffer));
         EXPECT_EQUAL(cookie_size, test_cookie_size);
 
-        uint8_t cookie_data[cookie_size];
-        EXPECT_SUCCESS(s2n_stuffer_read_bytes(&stuffer, cookie_data, cookie_size));
+        uint8_t *cookie_data;
+        EXPECT_NOT_NULL(cookie_data = s2n_stuffer_raw_read(&stuffer, cookie_size));
         EXPECT_BYTEARRAY_EQUAL(cookie_data, test_cookie_data, test_cookie_size);
 
         EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

### Description of changes: 

I used variable-length arrays in some tests :(

I don't know why the stack protector didn't catch this originally, but the tests started periodically failing to build because of it.

### Testing:

The stack protector stopped erroring on any builds. I also checked all uses of s2n_stuffer_read_bytes in the unit tests, and all the others looked fine.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
