### PR TITLE
Setup for extension list functionality

### DIFF
--- a/tests/unit/s2n_extension_type_lists_test.c
+++ b/tests/unit/s2n_extension_type_lists_test.c
@@ -19,15 +19,6 @@
 #include "tls/s2n_connection.h"
 #include "tls/s2n_tls.h"
 
-#define LIST_TYPE_SAME_IN_TLS13         S2N_EXTENSION_LIST_CLIENT_HELLO
-#define LIST_TYPE_DIFFERENT_IN_TLS13    S2N_EXTENSION_LIST_SERVER_HELLO
-#define LIST_TYPE_EMPTY_IN_TLS12        S2N_EXTENSION_LIST_ENCRYPTED_EXTENSIONS
-
-#define EXPECT_NOT_EMPTY_LIST(list) \
-        EXPECT_NOT_NULL(list); \
-        EXPECT_NOT_EQUAL((list)->count, 0); \
-        EXPECT_NOT_NULL((list)->extension_types) \
-
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
@@ -35,92 +26,25 @@ int main(int argc, char **argv)
 
     /* Test s2n_extension_type_list_get */
     {
-        struct s2n_connection *conn;
-        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        s2n_extension_type_list *list = NULL;
 
-        s2n_extension_type_list *list;
-
-        /* Handles nulls */
-        EXPECT_FAILURE(s2n_extension_type_list_get(0, conn, NULL));
-        EXPECT_FAILURE(s2n_extension_type_list_get(0, NULL, &list));
-
-        /* Should fail for a bad list type */
-        EXPECT_FAILURE(s2n_extension_type_list_get(-1, conn, &list));
-
-        /* Can retrieve the same list for tls1.2 and tls1.3 */
+        /* Safety checks */
         {
-            s2n_extension_type_list *default_list = NULL, *tls13_list = NULL;
+            EXPECT_FAILURE(s2n_extension_type_list_get(0, NULL));
 
-            conn->actual_protocol_version = S2N_TLS12;
-            EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_SAME_IN_TLS13, conn, &default_list));
-            EXPECT_NOT_EMPTY_LIST(default_list);
-
-            conn->actual_protocol_version = S2N_TLS13;
-            EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_SAME_IN_TLS13, conn, &tls13_list));
-            EXPECT_NOT_EMPTY_LIST(tls13_list);
-
-            EXPECT_EQUAL(default_list->extension_types, tls13_list->extension_types);
+            /* Should fail for a bad list type */
+            EXPECT_FAILURE(s2n_extension_type_list_get(-1, &list));
+            EXPECT_FAILURE(s2n_extension_type_list_get(S2N_EXTENSION_LIST_IDS_COUNT, &list));
         }
 
-        /* Can retrieve different lists for tls1.2 and tls1.3 */
-        {
-            s2n_extension_type_list *default_list = NULL, *tls13_list = NULL;
-
-            conn->actual_protocol_version = S2N_TLS12;
-            EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_DIFFERENT_IN_TLS13, conn, &default_list));
-            EXPECT_NOT_EMPTY_LIST(default_list);
-
-            conn->actual_protocol_version = S2N_TLS13;
-            EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_DIFFERENT_IN_TLS13, conn, &tls13_list));
-            EXPECT_NOT_EMPTY_LIST(tls13_list);
-
-            EXPECT_NOT_EQUAL(default_list->extension_types, tls13_list->extension_types);
-        }
-
-        /* Retrieves default list when protocol version earlier than tls1.2 */
-        {
-            s2n_extension_type_list *default_list = NULL, *tls10_list = NULL;
-            conn->actual_protocol_version = S2N_TLS12;
-            EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_DIFFERENT_IN_TLS13, conn, &default_list));
-            EXPECT_NOT_EMPTY_LIST(default_list);
-
-            conn->actual_protocol_version = S2N_TLS10;
-            EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_DIFFERENT_IN_TLS13, conn, &tls10_list));
-            EXPECT_NOT_EMPTY_LIST(tls10_list);
-
-            EXPECT_EQUAL(default_list->extension_types, tls10_list->extension_types);
-        }
-
-        /* Can retrieve an empty list */
-        {
-            s2n_extension_type_list *empty_list = NULL;
-            conn->actual_protocol_version = S2N_TLS12;
-            EXPECT_SUCCESS(s2n_extension_type_list_get(LIST_TYPE_EMPTY_IN_TLS12, conn, &empty_list));
-            EXPECT_NOT_NULL(empty_list);
-            EXPECT_EQUAL(empty_list->count, 0);
-            EXPECT_NULL(empty_list->extension_types);
-        }
-
-        /* Fails to retrieve an invalid list id */
-        {
-            conn->actual_protocol_version = S2N_TLS12;
-            EXPECT_FAILURE(s2n_extension_type_list_get(S2N_EXTENSION_LIST_IDS_COUNT, conn, &list));
-        }
-
-        /* Can retrieve a list for every id + protocol version */
+        /* Can retrieve a list for every id */
         {
             for (int i = 0; i < S2N_EXTENSION_LIST_IDS_COUNT; i++) {
-                for (int j = 0; j <= s2n_highest_protocol_version; j++) {
-                    conn->actual_protocol_version = j;
-
-                    list = NULL;
-                    EXPECT_SUCCESS(s2n_extension_type_list_get(i, conn, &list));
-                    EXPECT_NOT_NULL(list);
-                }
+                list = NULL;
+                EXPECT_SUCCESS(s2n_extension_type_list_get(i, &list));
+                EXPECT_NOT_NULL(list);
             }
         }
-
-        EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
     END_TEST();

--- a/tests/unit/s2n_extension_type_test.c
+++ b/tests/unit/s2n_extension_type_test.c
@@ -98,6 +98,20 @@ int main()
         }
     }
 
+    /* Test s2n_extension_supported_iana_value_to_id */
+    {
+        s2n_extension_type_id id = s2n_unsupported_extension;
+
+        /* Supported extension id returned */
+        EXPECT_SUCCESS(s2n_extension_supported_iana_value_to_id(s2n_supported_extensions[5], &id));
+        EXPECT_EQUAL(id, 5);
+
+        /* Fail on unsupported iana value
+         * 15 == heartbeat, which s2n will probably never support :) */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_extension_supported_iana_value_to_id(15, &id),
+                S2N_ERR_UNRECOGNIZED_EXTENSION);
+    }
+
     /* Test bitfield behavior */
     {
         s2n_extension_bitfield test_bitfield = { 0 };

--- a/tests/unit/s2n_extension_type_test.c
+++ b/tests/unit/s2n_extension_type_test.c
@@ -103,8 +103,9 @@ int main()
         s2n_extension_type_id id = s2n_unsupported_extension;
 
         /* Supported extension id returned */
-        EXPECT_SUCCESS(s2n_extension_supported_iana_value_to_id(s2n_supported_extensions[5], &id));
-        EXPECT_EQUAL(id, 5);
+        const uint16_t supported_extension_id = 5;
+        EXPECT_SUCCESS(s2n_extension_supported_iana_value_to_id(s2n_supported_extensions[supported_extension_id], &id));
+        EXPECT_EQUAL(id, supported_extension_id);
 
         /* Fail on unsupported iana value
          * 15 == heartbeat, which s2n will probably never support :) */

--- a/tls/extensions/s2n_extension_list.c
+++ b/tls/extensions/s2n_extension_list.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_extension_list.h"
+#include "s2n_extension_type.h"
+#include "s2n_extension_type_lists.h"
+
+#include <s2n.h>
+
+#include "error/s2n_errno.h"
+#include "utils/s2n_safety.h"
+
+int s2n_extension_list_send(s2n_extension_list_id list_type, struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    S2N_ERROR(S2N_ERR_UNIMPLEMENTED);
+}
+
+int s2n_extension_list_recv(s2n_extension_list_id list_type, struct s2n_connection *conn, struct s2n_stuffer *in)
+{
+    s2n_parsed_extensions_list parsed_extension_list = { 0 };
+    GUARD(s2n_extension_list_parse(in, &parsed_extension_list));
+    GUARD(s2n_extension_list_process(list_type, conn, &parsed_extension_list));
+    return S2N_SUCCESS;
+}
+
+int s2n_extension_process(const s2n_extension_type *extension_type, struct s2n_connection *conn,
+        s2n_parsed_extensions_list *parsed_extension_list)
+{
+    S2N_ERROR(S2N_ERR_UNIMPLEMENTED);
+}
+
+int s2n_extension_list_process(s2n_extension_list_id list_type, struct s2n_connection *conn,
+        s2n_parsed_extensions_list *parsed_extension_list)
+{
+    S2N_ERROR(S2N_ERR_UNIMPLEMENTED);
+}
+
+int s2n_extension_list_parse(struct s2n_stuffer *in, s2n_parsed_extensions_list *parsed_extension_list)
+{
+    S2N_ERROR(S2N_ERR_UNIMPLEMENTED);
+}

--- a/tls/extensions/s2n_extension_list.h
+++ b/tls/extensions/s2n_extension_list.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include "stuffer/s2n_stuffer.h"
+#include "tls/extensions/s2n_extension_type.h"
+#include "tls/s2n_connection.h"
+
+#define S2N_PARSED_EXTENSIONS_COUNT S2N_SUPPORTED_EXTENSIONS_COUNT
+
+typedef struct {
+    uint16_t extension_type;
+    struct s2n_blob extension;
+} s2n_parsed_extension;
+
+typedef struct {
+    s2n_parsed_extension parsed_extensions[S2N_PARSED_EXTENSIONS_COUNT];
+    struct s2n_blob raw; /* Needed by some ClientHello APIs */
+} s2n_parsed_extensions_list;
+
+typedef enum {
+    S2N_EXTENSION_LIST_CLIENT_HELLO = 0,
+    S2N_EXTENSION_LIST_SERVER_HELLO_DEFAULT,
+    S2N_EXTENSION_LIST_SERVER_HELLO_TLS13,
+    S2N_EXTENSION_LIST_ENCRYPTED_EXTENSIONS,
+    S2N_EXTENSION_LIST_CERT_REQ,
+    S2N_EXTENSION_LIST_CERTIFICATE,
+    S2N_EXTENSION_LIST_EMPTY,
+    S2N_EXTENSION_LIST_IDS_COUNT,
+} s2n_extension_list_id;
+
+int s2n_extension_list_send(s2n_extension_list_id list_type, struct s2n_connection *conn, struct s2n_stuffer *out);
+int s2n_extension_list_recv(s2n_extension_list_id list_type, struct s2n_connection *conn, struct s2n_stuffer *in);
+
+int s2n_extension_process(const s2n_extension_type *extension_type, struct s2n_connection *conn,
+        s2n_parsed_extensions_list *parsed_extension_list);
+int s2n_extension_list_process(s2n_extension_list_id list_type, struct s2n_connection *conn,
+        s2n_parsed_extensions_list *parsed_extension_list);
+int s2n_extension_list_parse(struct s2n_stuffer *in, s2n_parsed_extensions_list *parsed_extension_list);

--- a/tls/extensions/s2n_extension_type.c
+++ b/tls/extensions/s2n_extension_type.c
@@ -77,6 +77,8 @@ s2n_extension_type_id s2n_extension_iana_value_to_id(const uint16_t iana_value)
 
 int s2n_extension_supported_iana_value_to_id(const uint16_t iana_value, s2n_extension_type_id *internal_id)
 {
+    notnull_check(internal_id);
+
     *internal_id = s2n_extension_iana_value_to_id(iana_value);
     S2N_ERROR_IF(*internal_id == s2n_unsupported_extension, S2N_ERR_UNRECOGNIZED_EXTENSION);
     return S2N_SUCCESS;

--- a/tls/extensions/s2n_extension_type.c
+++ b/tls/extensions/s2n_extension_type.c
@@ -75,9 +75,11 @@ s2n_extension_type_id s2n_extension_iana_value_to_id(const uint16_t iana_value)
     return s2n_unsupported_extension;
 }
 
-static s2n_extension_type_id s2n_extension_type_get_id(const s2n_extension_type *extension_type)
+int s2n_extension_supported_iana_value_to_id(const uint16_t iana_value, s2n_extension_type_id *internal_id)
 {
-    return s2n_extension_iana_value_to_id(extension_type->iana_value);
+    *internal_id = s2n_extension_iana_value_to_id(iana_value);
+    S2N_ERROR_IF(*internal_id == s2n_unsupported_extension, S2N_ERR_UNRECOGNIZED_EXTENSION);
+    return S2N_SUCCESS;
 }
 
 int s2n_extension_send(const s2n_extension_type *extension_type, struct s2n_connection *conn, struct s2n_stuffer *out)
@@ -87,9 +89,12 @@ int s2n_extension_send(const s2n_extension_type *extension_type, struct s2n_conn
     notnull_check(extension_type->send);
     notnull_check(conn);
 
+    s2n_extension_type_id extension_id;
+    GUARD(s2n_extension_supported_iana_value_to_id(extension_type->iana_value, &extension_id));
+
     /* Do not send response if request not received. */
     if (extension_type->is_response &&
-            !S2N_CBIT_TEST(conn->extension_requests_received, s2n_extension_type_get_id(extension_type))) {
+            !S2N_CBIT_TEST(conn->extension_requests_received, extension_id)) {
         return S2N_SUCCESS;
     }
 
@@ -113,7 +118,7 @@ int s2n_extension_send(const s2n_extension_type *extension_type, struct s2n_conn
 
     /* Set request bit flag */
     if (!extension_type->is_response) {
-        S2N_CBIT_SET(conn->extension_requests_sent, s2n_extension_type_get_id(extension_type));
+        S2N_CBIT_SET(conn->extension_requests_sent, extension_id);
     }
 
     return S2N_SUCCESS;
@@ -125,9 +130,12 @@ int s2n_extension_recv(const s2n_extension_type *extension_type, struct s2n_conn
     notnull_check(extension_type->recv);
     notnull_check(conn);
 
+    s2n_extension_type_id extension_id;
+    GUARD(s2n_extension_supported_iana_value_to_id(extension_type->iana_value, &extension_id));
+
     /* Do not accept a response if we did not send a request */
     if(extension_type->is_response &&
-            !S2N_CBIT_TEST(conn->extension_requests_sent, s2n_extension_type_get_id(extension_type))) {
+            !S2N_CBIT_TEST(conn->extension_requests_sent, extension_id)) {
         S2N_ERROR(S2N_ERR_UNSUPPORTED_EXTENSION);
     }
 
@@ -135,7 +143,7 @@ int s2n_extension_recv(const s2n_extension_type *extension_type, struct s2n_conn
 
     /* Set request bit flag */
     if (!extension_type->is_response) {
-        S2N_CBIT_SET(conn->extension_requests_received, s2n_extension_type_get_id(extension_type));
+        S2N_CBIT_SET(conn->extension_requests_received, extension_id);
     }
 
     return S2N_SUCCESS;

--- a/tls/extensions/s2n_extension_type.h
+++ b/tls/extensions/s2n_extension_type.h
@@ -59,6 +59,7 @@ static const uint16_t s2n_supported_extensions[] = {
     TLS_EXTENSION_SESSION_TICKET,
     TLS_EXTENSION_SUPPORTED_VERSIONS,
     TLS_EXTENSION_KEY_SHARE,
+    TLS_EXTENSION_COOKIE,
 };
 
 typedef char s2n_extension_bitfield[S2N_SUPPORTED_EXTENSIONS_BITFIELD_LEN];
@@ -68,6 +69,11 @@ extern const s2n_extension_type_id s2n_unsupported_extension;
 
 int s2n_extension_send(const s2n_extension_type *extension_type, struct s2n_connection *conn, struct s2n_stuffer *out);
 int s2n_extension_recv(const s2n_extension_type *extension_type, struct s2n_connection *conn, struct s2n_stuffer *in);
+
+/* Map from TLS IANA value to internal s2n id.
+ * All possible IANA values is a large space, so using an internal id gives us more
+ * flexibility when using arrays / bitfields / etc. */
+int s2n_extension_supported_iana_value_to_id(const uint16_t iana_value, s2n_extension_type_id *internal_id);
 
 /* Initializer */
 int s2n_extension_type_init();

--- a/tls/extensions/s2n_extension_type_lists.c
+++ b/tls/extensions/s2n_extension_type_lists.c
@@ -94,46 +94,22 @@ static const s2n_extension_type *const certificate_extensions[] = {
 };
 
 #define S2N_EXTENSION_LIST(list) { .extension_types = (list), .count = s2n_array_len(list) }
-#define S2N_EMPTY_EXTENSION_LIST { .extension_types = NULL, .count = 0 }
 
-static struct {
-    s2n_extension_type_list default_list;
-    s2n_extension_type_list tls13_list; /* TLS1.3 moved some extensions to different extension lists */
-} extension_lists[] = {
-        [S2N_EXTENSION_LIST_CLIENT_HELLO] = {
-                .default_list = S2N_EXTENSION_LIST(client_hello_extensions),
-                .tls13_list = S2N_EXTENSION_LIST(client_hello_extensions),
-        },
-        [S2N_EXTENSION_LIST_SERVER_HELLO] = {
-                .default_list = S2N_EXTENSION_LIST(tls12_server_hello_extensions),
-                .tls13_list = S2N_EXTENSION_LIST(tls13_server_hello_extensions),
-        },
-        [S2N_EXTENSION_LIST_ENCRYPTED_EXTENSIONS] = {
-                .default_list = S2N_EMPTY_EXTENSION_LIST,
-                .tls13_list = S2N_EXTENSION_LIST(encrypted_extensions),
-        },
-        [S2N_EXTENSION_LIST_CERT_REQ] = {
-                .default_list = S2N_EMPTY_EXTENSION_LIST,
-                .tls13_list = S2N_EXTENSION_LIST(cert_req_extensions),
-        },
-        [S2N_EXTENSION_LIST_CERTIFICATE] = {
-                .default_list = S2N_EMPTY_EXTENSION_LIST,
-                .tls13_list = S2N_EXTENSION_LIST(certificate_extensions),
-        },
+static s2n_extension_type_list extension_lists[] = {
+        [S2N_EXTENSION_LIST_CLIENT_HELLO] = S2N_EXTENSION_LIST(client_hello_extensions),
+        [S2N_EXTENSION_LIST_SERVER_HELLO_DEFAULT] = S2N_EXTENSION_LIST(tls12_server_hello_extensions),
+        [S2N_EXTENSION_LIST_SERVER_HELLO_TLS13] = S2N_EXTENSION_LIST(tls13_server_hello_extensions),
+        [S2N_EXTENSION_LIST_ENCRYPTED_EXTENSIONS] = S2N_EXTENSION_LIST(encrypted_extensions),
+        [S2N_EXTENSION_LIST_CERT_REQ] = S2N_EXTENSION_LIST(cert_req_extensions),
+        [S2N_EXTENSION_LIST_CERTIFICATE] = S2N_EXTENSION_LIST(certificate_extensions),
+        [S2N_EXTENSION_LIST_EMPTY] = { .extension_types = NULL, .count = 0 },
 };
 
-int s2n_extension_type_list_get(s2n_extension_list_id list_type, const struct s2n_connection *conn,
-        s2n_extension_type_list **extension_list)
+int s2n_extension_type_list_get(s2n_extension_list_id list_type, s2n_extension_type_list **extension_list)
 {
     notnull_check(extension_list);
-    notnull_check(conn);
     lt_check(list_type, s2n_array_len(extension_lists));
 
-    if (s2n_connection_get_protocol_version(conn) >= S2N_TLS13) {
-        *extension_list = &extension_lists[list_type].tls13_list;
-    } else {
-        *extension_list = &extension_lists[list_type].default_list;
-    }
-
+    *extension_list = &extension_lists[list_type];
     return S2N_SUCCESS;
 }

--- a/tls/extensions/s2n_extension_type_lists.h
+++ b/tls/extensions/s2n_extension_type_lists.h
@@ -19,10 +19,12 @@
 
 typedef enum {
     S2N_EXTENSION_LIST_CLIENT_HELLO = 0,
-    S2N_EXTENSION_LIST_SERVER_HELLO,
+    S2N_EXTENSION_LIST_SERVER_HELLO_DEFAULT,
+    S2N_EXTENSION_LIST_SERVER_HELLO_TLS13,
     S2N_EXTENSION_LIST_ENCRYPTED_EXTENSIONS,
     S2N_EXTENSION_LIST_CERT_REQ,
     S2N_EXTENSION_LIST_CERTIFICATE,
+    S2N_EXTENSION_LIST_EMPTY,
     S2N_EXTENSION_LIST_IDS_COUNT,
 } s2n_extension_list_id;
 
@@ -31,5 +33,4 @@ typedef struct {
     const uint8_t count;
 } s2n_extension_type_list;
 
-int s2n_extension_type_list_get(s2n_extension_list_id list_type, const struct s2n_connection *conn,
-        s2n_extension_type_list **extension_type_list);
+int s2n_extension_type_list_get(s2n_extension_list_id list_type, s2n_extension_type_list **extension_type_list);

--- a/tls/extensions/s2n_extension_type_lists.h
+++ b/tls/extensions/s2n_extension_type_lists.h
@@ -15,18 +15,8 @@
 
 #pragma once
 
+#include "tls/extensions/s2n_extension_list.h"
 #include "tls/extensions/s2n_extension_type.h"
-
-typedef enum {
-    S2N_EXTENSION_LIST_CLIENT_HELLO = 0,
-    S2N_EXTENSION_LIST_SERVER_HELLO_DEFAULT,
-    S2N_EXTENSION_LIST_SERVER_HELLO_TLS13,
-    S2N_EXTENSION_LIST_ENCRYPTED_EXTENSIONS,
-    S2N_EXTENSION_LIST_CERT_REQ,
-    S2N_EXTENSION_LIST_CERTIFICATE,
-    S2N_EXTENSION_LIST_EMPTY,
-    S2N_EXTENSION_LIST_IDS_COUNT,
-} s2n_extension_list_id;
 
 typedef struct {
     const s2n_extension_type *const *extension_types;


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

### Issue
https://github.com/awslabs/s2n/issues/1752

### Description of changes: 

Several changes necessary to enable the rest of the extensions refactor. They're all very small, so I bundled them together. You can view one commit at a time to see them one at a time.

- Add a method to convert extension IANA value -> internal id safely. For all use cases except parsing extensions, s2n_unsupported_extension_id should be an error.
- Stop choosing extension lists based on version. Only ServerHello has different versions, and it should own the logic to choose between them. 
- Add method stubs + shared objects for the extension list handling logic. This template will let me review and merge the different functions separately, to keep those PRs small and focused.

### Call-outs:

**Why does s2n_parsed_extensions_list include a `raw` field?** The ClientHello needs to keep track of the raw extensions because of several public APIs: https://github.com/awslabs/s2n/blob/master/api/s2n.h#L189-L190

**Why S2N_EXTENSION_LIST_EMPTY?** It's useful for testing, but also Certificate has a use case for it: https://github.com/awslabs/s2n/blob/master/tls/extensions/s2n_certificate_extensions.c#L89-L97 We send empty extensions (just the 2-byte length field set to 0) for every cert in the chain after the first.

### Testing:

Unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
