### PR TITLE
Add extension list send functionality

### DIFF
--- a/tests/unit/s2n_extension_list_send_test.c
+++ b/tests/unit/s2n_extension_list_send_test.c
@@ -1,0 +1,130 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+
+#include "tls/extensions/s2n_extension_list.h"
+#include "tls/extensions/s2n_extension_type_lists.h"
+#include "tls/extensions/s2n_client_supported_versions.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+    EXPECT_SUCCESS(s2n_enable_tls13());
+
+    /* Safety checks */
+    {
+        struct s2n_connection conn = { 0 };
+        struct s2n_stuffer stuffer = { 0 };
+
+        EXPECT_FAILURE(s2n_extension_list_send(0, NULL, &stuffer));
+        EXPECT_FAILURE(s2n_extension_list_send(0, &conn, NULL));
+        EXPECT_FAILURE(s2n_extension_list_send(-1, &conn, &stuffer));
+    }
+
+    /* Writes just size if extension type list empty */
+    {
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_extension_list_send(S2N_EXTENSION_LIST_EMPTY, conn, &stuffer));
+
+        uint16_t extension_list_size;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &extension_list_size));
+        EXPECT_EQUAL(extension_list_size, s2n_stuffer_data_available(&stuffer));
+        EXPECT_EQUAL(extension_list_size, 0);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Send performs basic, non-zero write */
+    {
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_extension_list_send(S2N_EXTENSION_LIST_CLIENT_HELLO, conn, &stuffer));
+
+        uint16_t extension_list_size;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &extension_list_size));
+        EXPECT_EQUAL(extension_list_size, s2n_stuffer_data_available(&stuffer));
+        EXPECT_NOT_EQUAL(extension_list_size, 0);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Write empty list */
+    {
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+        /* S2N_EXTENSION_LIST_CERTIFICATE only sends responses, and we haven't received any requests.
+         * Therefore, it should write an empty extensions list. */
+        EXPECT_SUCCESS(s2n_extension_list_send(S2N_EXTENSION_LIST_CERTIFICATE, conn, &stuffer));
+
+        uint16_t extension_list_size;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &extension_list_size));
+        EXPECT_EQUAL(extension_list_size, s2n_stuffer_data_available(&stuffer));
+        EXPECT_EQUAL(extension_list_size, 0);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Send writes valid supported_versions extension */
+    {
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        struct s2n_connection *client_conn;
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_extension_list_send(S2N_EXTENSION_LIST_CLIENT_HELLO, client_conn, &stuffer));
+
+        /* Skip list size - already tested */
+        EXPECT_SUCCESS(s2n_stuffer_skip_read(&stuffer, sizeof(uint16_t)));
+
+        uint16_t first_extension_type;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &first_extension_type));
+        EXPECT_EQUAL(first_extension_type, TLS_EXTENSION_SUPPORTED_VERSIONS);
+
+        uint16_t first_extension_size;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &first_extension_size));
+        EXPECT_NOT_EQUAL(first_extension_size, 0);
+
+        struct s2n_stuffer extensions_stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&extensions_stuffer, 0));
+        EXPECT_SUCCESS(s2n_stuffer_copy(&stuffer, &extensions_stuffer, first_extension_size));
+
+        struct s2n_connection *server_conn;
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_extension_recv(&s2n_client_supported_versions_extension, server_conn, &extensions_stuffer));
+
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_stuffer_free(&extensions_stuffer));
+    }
+
+    END_TEST();
+}

--- a/tls/extensions/s2n_extension_list.c
+++ b/tls/extensions/s2n_extension_list.c
@@ -24,7 +24,18 @@
 
 int s2n_extension_list_send(s2n_extension_list_id list_type, struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    S2N_ERROR(S2N_ERR_UNIMPLEMENTED);
+    s2n_extension_type_list *extension_type_list;
+    GUARD(s2n_extension_type_list_get(list_type, &extension_type_list));
+
+    struct s2n_stuffer_reservation total_extensions_size;
+    GUARD(s2n_stuffer_reserve_uint16(out, &total_extensions_size));
+
+    for (int i = 0; i < extension_type_list->count; i++) {
+        GUARD(s2n_extension_send(extension_type_list->extension_types[i], conn, out));
+    }
+
+    GUARD(s2n_stuffer_write_vector_size(total_extensions_size));
+    return S2N_SUCCESS;
 }
 
 int s2n_extension_list_recv(s2n_extension_list_id list_type, struct s2n_connection *conn, struct s2n_stuffer *in)


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:
resolves https://github.com/awslabs/s2n/issues/1915

### Description of changes: 

The simplest of the extension list operations! Send all extensions in a given list.

### Call-outs:

**Is writing the size even for an empty list the correct behavior?** All of our message types currently write empty extension lists **except** for ServerHello. The TLS1.3 RFC [makes no mention of omitting empty lists](https://tools.ietf.org/html/rfc8446#appendix-B.3.1), although the TLS1.2 RFC [does allow for not writing empty lists](https://tools.ietf.org/html/rfc5246#appendix-A.4.1). Because the ClientHello and all the new message types write empty lists, upgrading ServerHello's behavior seems reasonable. However, if there are concerns that we need to maintain the old behavior, we can add some special casing for ServerHello.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
