### PR TITLE
Do not check CBMC properties during coverage check

### DIFF
--- a/tests/cbmc/proofs/Makefile.cbmc_batch
+++ b/tests/cbmc/proofs/Makefile.cbmc_batch
@@ -21,7 +21,7 @@ BATCHFLAGS ?= \
 	--batchpkg $(BATCHPKG) \
 	--blddir $(SRCDIR) \
 	--bucket $(BUCKET) \
-	--cbmcflags $(call encode_options,$(CBMCFLAGS)) \
+	--cbmcflags $(call encode_options,$(CHECKFLAGS)) \
 	--cbmcpkg $(CBMCPKG) \
 	--coverage-memory $(COVMEM) \
 	--goto gotos/$(ENTRY).goto \
@@ -53,7 +53,7 @@ endef
 $(ENTRY).yaml: 
 	echo 'batchpkg: $(BATCHPKG)' > $@
 	echo 'build: true' >> $@
-	echo 'cbmcflags: $(call yaml_encode_options,$(CBMCFLAGS))' >> $@
+	echo 'cbmcflags: $(call yaml_encode_options,$(CHECKFLAGS) $(CBMCFLAGS))' >> $@
 	echo 'cbmcpkg: $(CBMCPKG)' >> $@
 	echo 'coverage_memory: $(COVMEM)' >> $@
 	echo 'expected: "SUCCESSFUL"' >> $@
@@ -65,7 +65,7 @@ $(ENTRY).yaml:
 batch-yaml: $(ENTRY).yaml Makefile
 
 cbmc-batch.yaml: 
-	echo 'cbmcflags: $(strip $(call yaml_encode_options,$(CBMCFLAGS)))' > $@
+	echo 'cbmcflags: $(strip $(call yaml_encode_options,$(CHECKFLAGS) $(CBMCFLAGS)))' > $@
 	echo 'expected: "SUCCESSFUL"' >> $@
 	echo 'goto: gotos/$(ENTRY).goto' >> $@
 	echo 'jobos: ubuntu16' >> $@

--- a/tests/cbmc/proofs/Makefile.common
+++ b/tests/cbmc/proofs/Makefile.common
@@ -14,7 +14,7 @@
 ################################################################
 # This Makefile is the base makefile for CBMC proofs in this repository
 # Consumers of this makefile are expected to set the relevant variables
-# e.g. ENTRY, CBMCFLAGS, UNWINDSET etc
+# e.g. ENTRY, CHECKFLAGS, UNWINDSET etc
 # and then include this makefile.  To see how to use this makefile, take a look
 # at any of the existing proofs in this repository.
 #
@@ -92,19 +92,22 @@ LOG_FROM_ENTRY = $(LOGDIR)/$(notdir $(1:.goto=.log))
 LOG_FROM_GOTO = $(patsubst $(GOTODIR)%,$(LOGDIR)%,$(1:.goto=.log))
 
 ################################################################
-# Default CBMC flags
-CBMCFLAGS += --bounds-check
-CBMCFLAGS += --conversion-check
-CBMCFLAGS += --div-by-zero-check
-CBMCFLAGS += --float-overflow-check
-CBMCFLAGS += --nan-check
-CBMCFLAGS += --pointer-check
-CBMCFLAGS += --pointer-overflow-check
-CBMCFLAGS += --signed-overflow-check
-CBMCFLAGS += --undefined-shift-check
-CBMCFLAGS += --unsigned-overflow-check
+# CBMC flags used when performing safety checks
+CHECKFLAGS += --bounds-check
+CHECKFLAGS += --conversion-check
+CHECKFLAGS += --div-by-zero-check
+CHECKFLAGS += --float-overflow-check
+CHECKFLAGS += --nan-check
+CHECKFLAGS += --pointer-check
+CHECKFLAGS += --pointer-overflow-check
+CHECKFLAGS += --signed-overflow-check
+CHECKFLAGS += --undefined-shift-check
+CHECKFLAGS += --unsigned-overflow-check
+CHECKFLAGS += --unwinding-assertions
+
+################################################################
+# CBMC flags used for all CBMC invocations, even coverage checking
 CBMCFLAGS += --unwind 1
-CBMCFLAGS += --unwinding-assertions
 
 ################################################################
 # Verbosity
@@ -247,13 +250,15 @@ goto: $(ENTRY_GOTO).goto
 ################################################################
 # Targets to run the analysis commands
 logs/cbmc.log: $(ENTRY_GOTO).goto
-	$(call DO_CBMC,$(CBMCFLAGS) --trace,$<,$@)
+	$(call DO_CBMC,$(CBMCFLAGS) $(CHECKFLAGS) --trace,$<,$@)
 
 logs/property.xml: $(ENTRY_GOTO).goto
-	$(call DO_CBMC,$(CBMCFLAGS) --show-properties --xml-ui,$<,$@)
+	$(call DO_CBMC,$(CBMCFLAGS) $(CHECKFLAGS) --show-properties --xml-ui,$<,$@)
 
+# CHECKFLAGS intentionally omitted here---no need to perform safety
+# checks when computing coverage
 logs/coverage.xml: $(ENTRY_GOTO).goto
-	$(call DO_CBMC,$(filter-out --unwinding-assertions,$(CBMCFLAGS)) --cover location --xml-ui,$<,$@)
+	$(call DO_CBMC,$(CBMCFLAGS)               --cover location --xml-ui,$<,$@)
 
 cbmc: logs/cbmc.log
 

--- a/tests/cbmc/proofs/s2n_stuffer_alloc/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc/Makefile
@@ -13,7 +13,7 @@
 
 ###########
 #Use the default set of CBMC flags
-CBMCFLAGS +=
+CHECKFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c

--- a/tests/cbmc/proofs/s2n_stuffer_copy/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_copy/Makefile
@@ -13,7 +13,7 @@
 
 ###########
 #Use the default set of CBMC flags
-CBMCFLAGS +=
+CHECKFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
 DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c

--- a/tests/cbmc/proofs/s2n_stuffer_erase_and_read/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_erase_and_read/Makefile
@@ -13,7 +13,7 @@
 
 ###########
 #Use the default set of CBMC flags
-CBMCFLAGS +=
+CHECKFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
 DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c

--- a/tests/cbmc/proofs/s2n_stuffer_erase_and_read_bytes/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_erase_and_read_bytes/Makefile
@@ -13,7 +13,7 @@
 
 ###########
 #Use the default set of CBMC flags
-CBMCFLAGS +=
+CHECKFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
 DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c

--- a/tests/cbmc/proofs/s2n_stuffer_free/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_free/Makefile
@@ -13,7 +13,7 @@
 
 ###########
 #Use the default set of CBMC flags
-CBMCFLAGS +=
+CHECKFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c

--- a/tests/cbmc/proofs/s2n_stuffer_init/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_init/Makefile
@@ -13,7 +13,7 @@
 
 ###########
 #Use the default set of CBMC flags
-CBMCFLAGS +=
+CHECKFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c

--- a/tests/cbmc/proofs/s2n_stuffer_raw_read/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_raw_read/Makefile
@@ -13,7 +13,7 @@
 
 ###########
 #Use the default set of CBMC flags
-CBMCFLAGS +=
+CHECKFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
 DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c

--- a/tests/cbmc/proofs/s2n_stuffer_read/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read/Makefile
@@ -13,7 +13,7 @@
 
 ###########
 #Use the default set of CBMC flags
-CBMCFLAGS +=
+CHECKFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
 DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c

--- a/tests/cbmc/proofs/s2n_stuffer_read_bytes/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_bytes/Makefile
@@ -13,7 +13,7 @@
 
 ###########
 #Use the default set of CBMC flags
-CBMCFLAGS +=
+CHECKFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
 DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c

--- a/tests/cbmc/proofs/s2n_stuffer_reread/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_reread/Makefile
@@ -13,7 +13,7 @@
 
 ###########
 #Use the default set of CBMC flags
-CBMCFLAGS +=
+CHECKFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
 DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c

--- a/tests/cbmc/proofs/s2n_stuffer_skip_read/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_read/Makefile
@@ -13,7 +13,7 @@
 
 ###########
 #Use the default set of CBMC flags
-CBMCFLAGS +=
+CHECKFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
 DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c

--- a/tests/cbmc/proofs/s2n_stuffer_wipe/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_wipe/Makefile
@@ -13,7 +13,7 @@
 
 ###########
 #Use the default set of CBMC flags
-CBMCFLAGS +=
+CHECKFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c

--- a/tests/cbmc/proofs/s2n_stuffer_wipe_n/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_wipe_n/Makefile
@@ -13,7 +13,7 @@
 
 ###########
 #Use the default set of CBMC flags
-CBMCFLAGS +=
+CHECKFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c


### PR DESCRIPTION
This PR is an alternative implementation of #1939.

This commit removes the majority of CBMC checks from the invocation of
CBMC that checks coverage, which dramatically decreases the proofs' run
time.

Currently, we run CBMC three times---once to check the actual safety
properties like memory safety and arithmetic overflow, and once to
compute how much code CBMC has covered. The second check is important
because it allows us to see whether the first check has missed any code,
giving us a false sense of security about the code's safety. However, we
had previously been passing the safety check flags to the coverage
check, which vastly increases the coverage check's runtime.

This commit changes the CBMCFLAGS variable to only contain flags passed
to all three invocations of CBMC, and introduces the CHECKFLAGS
variable, which contains flags (including memory safety checks) that
should only be passed to the property check runs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
