### PR TITLE
Replace ServerHello extensions with new extensions module

### DIFF
--- a/tests/fuzz/s2n_server_extensions_recv_test.c
+++ b/tests/fuzz/s2n_server_extensions_recv_test.c
@@ -23,7 +23,7 @@
 #include <openssl/crypto.h>
 #include <openssl/err.h>
 
-#include "tls/s2n_tls.h"
+#include "tls/s2n_server_extensions.h"
 
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
@@ -76,7 +76,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     /* Run Test
      * Do not use GUARD macro here since the connection memory hasn't been freed.
      */
-    s2n_server_extensions_recv(client_conn, &(fuzz_stuffer.blob));
+    s2n_server_extensions_recv(client_conn, &fuzz_stuffer);
 
     /* Cleanup */
     GUARD(s2n_connection_free(client_conn));

--- a/tls/s2n_server_extensions.c
+++ b/tls/s2n_server_extensions.c
@@ -13,186 +13,57 @@
  * permissions and limitations under the License.
  */
 
-#include <stdint.h>
-#include <string.h>
+#include "tls/s2n_server_extensions.h"
 
-#include "error/s2n_errno.h"
-
-#include "tls/s2n_tls_parameters.h"
-#include "tls/s2n_connection.h"
-#include "tls/s2n_tls.h"
-#include "tls/s2n_tls13.h"
-#include "tls/s2n_kex.h"
-#include "tls/s2n_cipher_suites.h"
-
-#include "tls/extensions/s2n_cookie.h"
-#include "tls/extensions/s2n_ec_point_format.h"
-#include "tls/extensions/s2n_server_renegotiation_info.h"
-#include "tls/extensions/s2n_server_alpn.h"
-#include "tls/extensions/s2n_server_status_request.h"
-#include "tls/extensions/s2n_server_sct_list.h"
-#include "tls/extensions/s2n_server_max_fragment_length.h"
-#include "tls/extensions/s2n_server_session_ticket.h"
-#include "tls/extensions/s2n_server_server_name.h"
+#include "tls/extensions/s2n_extension_list.h"
 #include "tls/extensions/s2n_server_supported_versions.h"
-#include "tls/extensions/s2n_server_key_share.h"
-
+#include "tls/s2n_connection.h"
 #include "stuffer/s2n_stuffer.h"
-
 #include "utils/s2n_safety.h"
-#include "utils/s2n_blob.h"
 
-/* Guards against errors and non uint16s, then increments size */
-#define GUARD_UINT16_AND_INCREMENT( x, size ) do { \
-    GUARD_UINT16(x); \
-    size += x; \
-} while (0)
 
-#define GUARD_UINT16( x ) do { \
-    GUARD(x); \
-    lte_check(x, 65535); \
-} while (0)
-
-/* compute size server extensions send requires */
-int s2n_server_extensions_send_size(struct s2n_connection *conn)
-{
-    int total_size = 0;
-    const bool is_tls13_conn = conn->actual_protocol_version == S2N_TLS13;
-
-    if (is_tls13_conn) {
-        GUARD_UINT16_AND_INCREMENT(s2n_extensions_server_supported_versions_size(conn), total_size);
-        GUARD_UINT16_AND_INCREMENT(s2n_extensions_server_key_share_send_size(conn), total_size);
-        GUARD_UINT16_AND_INCREMENT(s2n_extensions_cookie_size(conn), total_size);
-        return total_size;
-    }
-
-    GUARD_UINT16_AND_INCREMENT(s2n_server_extensions_server_name_send_size(conn), total_size);
-    GUARD_UINT16_AND_INCREMENT(s2n_server_extensions_alpn_send_size(conn), total_size);
-    GUARD_UINT16_AND_INCREMENT(s2n_server_renegotiation_info_ext_size(conn), total_size);
-    GUARD_UINT16_AND_INCREMENT(s2n_server_ecc_point_format_extension_size(conn), total_size);
-    GUARD_UINT16_AND_INCREMENT(s2n_server_extensions_max_fragment_length_send_size(conn), total_size);
-    GUARD_UINT16_AND_INCREMENT(s2n_server_session_ticket_ext_size(conn), total_size);
-    GUARD_UINT16_AND_INCREMENT(s2n_server_extensions_status_request_send_size(conn), total_size);
-    GUARD_UINT16_AND_INCREMENT(s2n_server_extensions_sct_list_send_size(conn), total_size);
-
-    return total_size;
-}
+/* An empty list will just contain the uint16_t list size */
+#define S2N_EMPTY_EXTENSION_LIST_SIZE sizeof(uint16_t)
 
 int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    int total_size = s2n_server_extensions_send_size(conn);
+    uint32_t data_available_before_extensions = s2n_stuffer_data_available(out);
 
-    if (total_size == 0) {
-        return 0;
-    }
-    GUARD_UINT16(total_size);
-
-    GUARD(s2n_stuffer_write_uint16(out, total_size));
-
-    const bool is_tls13_conn = conn->actual_protocol_version == S2N_TLS13;
-
-    /* TLS 1.3 ServerHello extensions */
-    if (is_tls13_conn) {
-        /* Write supported versions extension */
-        GUARD(s2n_extensions_server_supported_versions_send(conn, out));
-        /* Write key share extension */
-        GUARD(s2n_extensions_server_key_share_send(conn, out));
-        /* Write cookie extension */
-        GUARD(s2n_extensions_cookie_send(conn, out));
-
-        return 0;
+    if (conn->actual_protocol_version >= S2N_TLS13) {
+        GUARD(s2n_extension_list_send(S2N_EXTENSION_LIST_SERVER_HELLO_TLS13, conn, out));
+    } else {
+        GUARD(s2n_extension_list_send(S2N_EXTENSION_LIST_SERVER_HELLO_DEFAULT, conn, out));
     }
 
-    /* TLS 1.2 Extensions */
+    /* The ServerHello extension list size (uint16_t) is NOT written if the list is empty.
+     * This is to support older clients written before extensions existed that might fail
+     * on any unexpected bytes at the end of the ServerHello.
+     *
+     * This behavior is outlined in the TLS1.2 RFC: https://tools.ietf.org/html/rfc5246#appendix-A.4.1
+     *
+     * We COULD write the size if using TLS1.3, but let's prefer consistency and avoid
+     * altering existing behavior.
+     */
+    if(s2n_stuffer_data_available(out) - data_available_before_extensions == S2N_EMPTY_EXTENSION_LIST_SIZE) {
+        GUARD(s2n_stuffer_wipe_n(out, sizeof(uint16_t)));
+    }
 
-    /* Write server name extension */
-    GUARD(s2n_server_extensions_server_name_send(conn, out));
-
-    /* Write kex extension */
-    GUARD(s2n_extension_send(&s2n_server_ec_point_format_extension, conn, out));
-    
-    /* Write the renegotiation_info extension */
-    GUARD(s2n_send_server_renegotiation_info_ext(conn, out));
-
-    /* Write ALPN extension */
-    GUARD(s2n_server_extensions_alpn_send(conn, out));
-
-    /* Write OCSP extension */
-    GUARD(s2n_server_extensions_status_request_send(conn, out));
-
-    /* Write Signed Certificate Timestamp extension */
-    GUARD(s2n_server_extensions_sct_list_send(conn, out));
-
-    /* Write max fragment length extension */
-    GUARD(s2n_server_extensions_max_fragment_length_send(conn, out));
-
-    /* Write session ticket extension */
-    GUARD(s2n_send_server_session_ticket_ext(conn, out));
-
-    return 0;
+    return S2N_SUCCESS;
 }
 
-int s2n_server_extensions_recv(struct s2n_connection *conn, struct s2n_blob *extensions)
+int s2n_server_extensions_recv(struct s2n_connection *conn, struct s2n_stuffer *in)
 {
-    struct s2n_stuffer in = {0};
+    s2n_parsed_extensions_list parsed_extension_list = { 0 };
+    GUARD(s2n_extension_list_parse(in, &parsed_extension_list));
 
-    GUARD(s2n_stuffer_init(&in, extensions));
-    GUARD(s2n_stuffer_write(&in, extensions));
+    /* Process supported_versions first so that we know which extensions list to use */
+    GUARD(s2n_extension_process(&s2n_server_supported_versions_extension, conn, &parsed_extension_list));
 
-    while (s2n_stuffer_data_available(&in)) {
-        struct s2n_blob ext = {0};
-        uint16_t extension_type, extension_size;
-        struct s2n_stuffer extension = {0};
-
-        GUARD(s2n_stuffer_read_uint16(&in, &extension_type));
-        GUARD(s2n_stuffer_read_uint16(&in, &extension_size));
-
-        ext.size = extension_size;
-        ext.data = s2n_stuffer_raw_read(&in, ext.size);
-        notnull_check(ext.data);
-
-        GUARD(s2n_stuffer_init(&extension, &ext));
-        GUARD(s2n_stuffer_write(&extension, &ext));
-
-        switch (extension_type) {
-        case TLS_EXTENSION_SERVER_NAME:
-            GUARD(s2n_recv_server_server_name(conn, &extension));
-            break;
-        case TLS_EXTENSION_RENEGOTIATION_INFO:
-            GUARD(s2n_recv_server_renegotiation_info_ext(conn, &extension));
-            break;
-        case TLS_EXTENSION_ALPN:
-            GUARD(s2n_recv_server_alpn(conn, &extension));
-            break;
-        case TLS_EXTENSION_STATUS_REQUEST:
-            GUARD(s2n_recv_server_status_request(conn, &extension));
-            break;
-        case TLS_EXTENSION_SCT_LIST:
-            GUARD(s2n_recv_server_sct_list(conn, &extension));
-            break;
-        case TLS_EXTENSION_MAX_FRAG_LEN:
-            GUARD(s2n_recv_server_max_fragment_length(conn, &extension));
-            break;
-        case TLS_EXTENSION_SESSION_TICKET:
-            GUARD(s2n_recv_server_session_ticket_ext(conn, &extension));
-            break;
-        case TLS_EXTENSION_SUPPORTED_VERSIONS:
-            if (s2n_is_tls13_enabled()) {
-                GUARD(s2n_extensions_server_supported_versions_recv(conn, &extension));
-            }
-            break;
-        case TLS_EXTENSION_KEY_SHARE:
-            if (s2n_is_tls13_enabled()) {
-                GUARD(s2n_extensions_server_key_share_recv(conn, &extension));
-            }
-            break;
-        case TLS_EXTENSION_COOKIE:
-            if (s2n_is_tls13_enabled()) {
-                GUARD(s2n_extensions_cookie_recv(conn, &extension));
-            }
-            break;
-        }
+    if (conn->server_protocol_version >= S2N_TLS13) {
+        GUARD(s2n_extension_list_process(S2N_EXTENSION_LIST_SERVER_HELLO_TLS13, conn, &parsed_extension_list));
+    } else {
+        GUARD(s2n_extension_list_process(S2N_EXTENSION_LIST_SERVER_HELLO_DEFAULT, conn, &parsed_extension_list));
     }
 
-    return 0;
+    return S2N_SUCCESS;
 }

--- a/tls/s2n_server_extensions.h
+++ b/tls/s2n_server_extensions.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include "tls/s2n_connection.h"
+#include "stuffer/s2n_stuffer.h"
+
+int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+int s2n_server_extensions_recv(struct s2n_connection *conn, struct s2n_stuffer *in);

--- a/tls/s2n_server_hello_retry.c
+++ b/tls/s2n_server_hello_retry.c
@@ -16,8 +16,8 @@
 
 #include "error/s2n_errno.h"
 #include "utils/s2n_blob.h"
-#include "tls/extensions/s2n_cookie.h"
 #include "tls/s2n_cipher_suites.h"
+#include "tls/s2n_server_extensions.h"
 #include "tls/s2n_tls.h"
 #include "tls/s2n_tls13.h"
 #include "tls/s2n_tls13_handshake.h"

--- a/tls/s2n_tls.h
+++ b/tls/s2n_tls.h
@@ -77,9 +77,6 @@ extern int s2n_read_full_record(struct s2n_connection *conn, uint8_t * record_ty
 extern int s2n_recv_close_notify(struct s2n_connection *conn, s2n_blocked_status * blocked);
 extern int s2n_client_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *out);
 extern int s2n_client_extensions_recv(struct s2n_connection *conn, struct s2n_array *parsed_extensions);
-extern int s2n_server_extensions_send_size(struct s2n_connection *conn);
-extern int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *out);
-extern int s2n_server_extensions_recv(struct s2n_connection *conn, struct s2n_blob *extensions);
 
 extern uint16_t mfl_code_to_length[5];
 


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

https://github.com/awslabs/s2n/issues/1751

### Description of changes: 

Swap out the old ServerHello send/parse/recv logic for the new [s2n_extension_list](https://github.com/awslabs/s2n/blob/master/tls/extensions/s2n_extension_list.h) module. No behavior should change.

### Testing:

Updated the existing testing. I also added a new test to verify we're swapping extension lists properly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
