### PR TITLE
Verify that the ServerHello message contains a cipher that was originally offered in the ClientHello.

### DIFF
--- a/tests/unit/s2n_cipher_suite_match_test.c
+++ b/tests/unit/s2n_cipher_suite_match_test.c
@@ -620,15 +620,15 @@ int main(int argc, char **argv)
             conn->server_protocol_version = S2N_TLS13;
 
             /* The client will offer the default tls13 ciphersuites */
-            s2n_connection_set_cipher_preferences(conn, "default_tls13");
+            s2n_connection_set_cipher_preferences(conn, "test_all_tls13");
 
             /* The server will send a TLS12 cipher over the wire */
             uint8_t invalid_wire_ciphers[] = {
-                TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+                TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
             };
 
             /* We expect to fail because the cipher was not offered by the client */
-            EXPECT_SUCCESS(s2n_set_cipher_as_client(conn, invalid_wire_ciphers));
+            EXPECT_FAILURE_WITH_ERRNO(s2n_set_cipher_as_client(conn, invalid_wire_ciphers), S2N_ERR_CIPHER_NOT_SUPPORTED);
 
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
             EXPECT_SUCCESS(s2n_disable_tls13());

--- a/tests/unit/s2n_cipher_suite_match_test.c
+++ b/tests/unit/s2n_cipher_suite_match_test.c
@@ -46,7 +46,8 @@ int main(int argc, char **argv)
             wire[0] = (i >> 8);
             wire[1] = i & 0xff;
 
-            if (s2n_set_cipher_as_client(conn, wire) == 0) {
+            struct s2n_cipher_suite *s = s2n_cipher_suite_from_wire(wire);
+            if (s != NULL) {
                 count++;
             }
         }
@@ -585,6 +586,50 @@ int main(int argc, char **argv)
             conn->client_protocol_version = S2N_TLS13;
             conn->actual_protocol_version = S2N_TLS13;
             EXPECT_FAILURE_WITH_ERRNO(s2n_set_cipher_as_tls_server(conn, invalid_cipher_pref, invalid_cipher_count), S2N_ERR_CIPHER_NOT_SUPPORTED);
+            EXPECT_SUCCESS(s2n_connection_wipe(conn));
+            EXPECT_SUCCESS(s2n_disable_tls13());
+        }
+
+        /* Test that the client allows the server to select ciphers that were offered in ClientHello */
+        {
+            EXPECT_SUCCESS(s2n_enable_tls13());
+            conn->client_protocol_version = S2N_TLS13;
+            conn->actual_protocol_version = S2N_TLS13;
+            conn->server_protocol_version = S2N_TLS13;
+
+            /* The client will offer the default tls13 ciphersuites */
+            s2n_connection_set_cipher_preferences(conn, "default_tls13");
+
+            /* The server will send a TLS13 cipher over the wire */
+            uint8_t valid_wire_ciphers[] = {
+                TLS_AES_128_GCM_SHA256
+            };
+
+            /* We expect to succeed because the cipher was offered by the client */
+            EXPECT_SUCCESS(s2n_set_cipher_as_client(conn, valid_wire_ciphers));
+
+            EXPECT_SUCCESS(s2n_connection_wipe(conn));
+            EXPECT_SUCCESS(s2n_disable_tls13());
+        }
+
+        /* Test that the client rejects a cipher that was not originally offered in ClientHello */
+        {
+            EXPECT_SUCCESS(s2n_enable_tls13());
+            conn->client_protocol_version = S2N_TLS13;
+            conn->actual_protocol_version = S2N_TLS13;
+            conn->server_protocol_version = S2N_TLS13;
+
+            /* The client will offer the default tls13 ciphersuites */
+            s2n_connection_set_cipher_preferences(conn, "default_tls13");
+
+            /* The server will send a TLS12 cipher over the wire */
+            uint8_t invalid_wire_ciphers[] = {
+                TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+            };
+
+            /* We expect to fail because the cipher was not offered by the client */
+            EXPECT_SUCCESS(s2n_set_cipher_as_client(conn, invalid_wire_ciphers));
+
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
             EXPECT_SUCCESS(s2n_disable_tls13());
         }

--- a/tests/unit/s2n_fragmentation_coalescing_test.c
+++ b/tests/unit/s2n_fragmentation_coalescing_test.c
@@ -406,6 +406,9 @@ int main(int argc, char **argv)
     EXPECT_NOT_NULL(config = s2n_config_new());
     EXPECT_SUCCESS(s2n_config_disable_x509_verification(config));
     EXPECT_SUCCESS(s2n_config_set_check_stapled_ocsp_response(config, 0));
+    /* The server hello has TLS_RSA_WITH_AES_256_CBC_SHA256 hardcoded,
+       so we need to set a cipher preference that will accept that value */
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20170328"));
     EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
     EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 

--- a/tests/unit/s2n_malformed_handshake_test.c
+++ b/tests/unit/s2n_malformed_handshake_test.c
@@ -241,6 +241,7 @@ int main(int argc, char **argv)
     EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
     EXPECT_NOT_NULL(config = s2n_config_new());
     EXPECT_SUCCESS(s2n_config_disable_x509_verification(config));
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "test_all"));
     EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
     /* Test a good certificate list */

--- a/tests/unit/s2n_server_hello_test.c
+++ b/tests/unit/s2n_server_hello_test.c
@@ -124,22 +124,13 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
 
-        struct s2n_stuffer *server_stuffer = &server_conn->handshake.io;
-
-        const uint32_t total = S2N_TLS_PROTOCOL_VERSION_LEN
-            + S2N_TLS_RANDOM_DATA_LEN
-            + SESSION_ID_SIZE
-            + server_conn->session_id_len
-            + S2N_TLS_CIPHER_SUITE_LEN
-            + COMPRESSION_METHOD_SIZE;
-
         server_conn->actual_protocol_version = S2N_TLS12;
-        server_conn->secure.cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
+        server_conn->secure.cipher_suite = &s2n_ecdhe_rsa_with_aes_256_gcm_sha384;
 
         EXPECT_SUCCESS(s2n_server_hello_send(server_conn));
-        EXPECT_EQUAL(s2n_stuffer_data_available(server_stuffer), total);
 
         /* Copy server stuffer to client stuffer */
+        const uint32_t total = s2n_stuffer_data_available(&server_conn->handshake.io);
         EXPECT_SUCCESS(s2n_stuffer_copy(&server_conn->handshake.io, &client_conn->handshake.io, total));
 
         /* Test s2n_server_hello_recv() */
@@ -150,6 +141,32 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_config_free(client_config));
         EXPECT_SUCCESS(s2n_config_free(server_config));
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+    }
+
+    /* Test Server Hello Recv with invalid cipher */
+    {
+        struct s2n_connection *server_conn;
+        struct s2n_connection *client_conn;
+
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+
+        server_conn->actual_protocol_version = S2N_TLS12;
+
+        /* This cipher is not in the client's default selection */
+        server_conn->secure.cipher_suite = &s2n_tls13_chacha20_poly1305_sha256;
+
+        EXPECT_SUCCESS(s2n_server_hello_send(server_conn));
+
+        /* Copy server stuffer to client stuffer */
+        const uint32_t total = s2n_stuffer_data_available(&server_conn->handshake.io);
+        EXPECT_SUCCESS(s2n_stuffer_copy(&server_conn->handshake.io, &client_conn->handshake.io, total));
+
+        /* The client should fail the handshake because an invalid cipher was offered */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_server_hello_recv(client_conn), S2N_ERR_CIPHER_NOT_SUPPORTED);
+
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
     }
@@ -236,24 +253,15 @@ int main(int argc, char **argv)
         /* The client will request TLS1.3 */
         client_conn->client_protocol_version = S2N_TLS13;
 
-        struct s2n_stuffer *server_stuffer = &server_conn->handshake.io;
-
-        const uint32_t total = S2N_TLS_PROTOCOL_VERSION_LEN
-            + S2N_TLS_RANDOM_DATA_LEN
-            + SESSION_ID_SIZE
-            + server_conn->session_id_len
-            + S2N_TLS_CIPHER_SUITE_LEN
-            + COMPRESSION_METHOD_SIZE;
-
         /* Set the negotiated curve, otherwise the server might try to respond with a retry */
         server_conn->secure.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
 
         /* The server will respond with TLS1.1 even though it supports TLS1.3 */
         server_conn->actual_protocol_version = S2N_TLS11;
         EXPECT_SUCCESS(s2n_server_hello_send(server_conn));
-        EXPECT_EQUAL(s2n_stuffer_data_available(server_stuffer), total);
 
         /* Copy server stuffer to client stuffer */
+        const uint32_t total = s2n_stuffer_data_available(&server_conn->handshake.io);
         EXPECT_SUCCESS(s2n_stuffer_copy(&server_conn->handshake.io, &client_conn->handshake.io, total));
 
         /* Verify that the downgrade is detected */
@@ -289,24 +297,15 @@ int main(int argc, char **argv)
         /* The client will request TLS1.3 */
         client_conn->client_protocol_version = S2N_TLS13;
 
-        struct s2n_stuffer *server_stuffer = &server_conn->handshake.io;
-
-        const uint32_t total = S2N_TLS_PROTOCOL_VERSION_LEN
-            + S2N_TLS_RANDOM_DATA_LEN
-            + SESSION_ID_SIZE
-            + server_conn->session_id_len
-            + S2N_TLS_CIPHER_SUITE_LEN
-            + COMPRESSION_METHOD_SIZE;
-
         /* Set the negotiated curve, otherwise the server might try to respond with a retry */
         server_conn->secure.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
 
         /* The server will respond with TLS1.2 even though it supports TLS1.3 */
         server_conn->actual_protocol_version = S2N_TLS12;
         EXPECT_SUCCESS(s2n_server_hello_send(server_conn));
-        EXPECT_EQUAL(s2n_stuffer_data_available(server_stuffer), total);
 
         /* Copy server stuffer to client stuffer */
+        const uint32_t total = s2n_stuffer_data_available(&server_conn->handshake.io);
         EXPECT_SUCCESS(s2n_stuffer_copy(&server_conn->handshake.io, &client_conn->handshake.io, total));
 
         /* Verify that the downgrade is detected */
@@ -341,25 +340,16 @@ int main(int argc, char **argv)
         /* The client will request TLS1.2 */
         client_conn->client_protocol_version = S2N_TLS12;
 
-        struct s2n_stuffer *server_stuffer = &server_conn->handshake.io;
-
-        const uint32_t total = S2N_TLS_PROTOCOL_VERSION_LEN
-            + S2N_TLS_RANDOM_DATA_LEN
-            + SESSION_ID_SIZE
-            + server_conn->session_id_len
-            + S2N_TLS_CIPHER_SUITE_LEN
-            + COMPRESSION_METHOD_SIZE;
-
         /* The server will respond with TLS1.2 even though it support TLS1.3. This is expected because */
         /* the client only support TLS1.2 */
         EXPECT_SUCCESS(s2n_enable_tls13());
         server_conn->actual_protocol_version = S2N_TLS12;
-        server_conn->secure.cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
+        server_conn->secure.cipher_suite = &s2n_ecdhe_rsa_with_aes_256_gcm_sha384;
         EXPECT_SUCCESS(s2n_server_hello_send(server_conn));
         EXPECT_SUCCESS(s2n_disable_tls13());
-        EXPECT_EQUAL(s2n_stuffer_data_available(server_stuffer), total);
 
         /* Copy server stuffer to client stuffer */
+        const uint32_t total = s2n_stuffer_data_available(&server_conn->handshake.io);
         EXPECT_SUCCESS(s2n_stuffer_copy(&server_conn->handshake.io, &client_conn->handshake.io, total));
 
         /* Verify that a TLS12 client does not error due to the downgrade */
@@ -392,23 +382,15 @@ int main(int argc, char **argv)
         /* The client will request TLS1.3 */
         client_conn->client_protocol_version = S2N_TLS13;
 
-        struct s2n_stuffer *server_stuffer = &server_conn->handshake.io;
-
-        const uint32_t total = S2N_TLS_PROTOCOL_VERSION_LEN
-            + S2N_TLS_RANDOM_DATA_LEN
-            + SESSION_ID_SIZE
-            + server_conn->session_id_len
-            + S2N_TLS_CIPHER_SUITE_LEN
-            + COMPRESSION_METHOD_SIZE;
-
         /* The server will respond with TLS1.2 */
         server_conn->server_protocol_version = S2N_TLS12;
         server_conn->actual_protocol_version = S2N_TLS12;
-        server_conn->secure.cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
+
+        server_conn->secure.cipher_suite = &s2n_ecdhe_rsa_with_aes_256_gcm_sha384;
         EXPECT_SUCCESS(s2n_server_hello_send(server_conn));
-        EXPECT_EQUAL(s2n_stuffer_data_available(server_stuffer), total);
 
         /* Copy server stuffer to client stuffer */
+        const uint32_t total = s2n_stuffer_data_available(&server_conn->handshake.io);
         EXPECT_SUCCESS(s2n_stuffer_copy(&server_conn->handshake.io, &client_conn->handshake.io, total));
 
         /* Verify that a TLS13 client does not error due to the downgrade */
@@ -442,25 +424,17 @@ int main(int argc, char **argv)
         /* The client will request TLS1.2 */
         client_conn->client_protocol_version = S2N_TLS12;
 
-        struct s2n_stuffer *server_stuffer = &server_conn->handshake.io;
-
-        const uint32_t total = S2N_TLS_PROTOCOL_VERSION_LEN
-            + S2N_TLS_RANDOM_DATA_LEN
-            + SESSION_ID_SIZE
-            + server_conn->session_id_len
-            + S2N_TLS_CIPHER_SUITE_LEN
-            + COMPRESSION_METHOD_SIZE;
-
         /* The server will respond with TLS1.2 even though it support TLS1.3. This is expected because */
         /* the client only support TLS1.2 */
         EXPECT_SUCCESS(s2n_enable_tls13());
         server_conn->actual_protocol_version = S2N_TLS12;
-        server_conn->secure.cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
+
+        server_conn->secure.cipher_suite = &s2n_ecdhe_rsa_with_aes_256_gcm_sha384;
         EXPECT_SUCCESS(s2n_server_hello_send(server_conn));
         EXPECT_SUCCESS(s2n_disable_tls13());
-        EXPECT_EQUAL(s2n_stuffer_data_available(server_stuffer), total);
 
         /* Copy server stuffer to client stuffer */
+        const uint32_t total = s2n_stuffer_data_available(&server_conn->handshake.io);
         EXPECT_SUCCESS(s2n_stuffer_copy(&server_conn->handshake.io, &client_conn->handshake.io, total));
 
         /* Verify that a TLS12 client does not error due to the downgrade */

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -1054,9 +1054,33 @@ struct s2n_cipher_suite *s2n_cipher_suite_from_wire(const uint8_t cipher_suite[S
 
 int s2n_set_cipher_as_client(struct s2n_connection *conn, uint8_t wire[S2N_TLS_CIPHER_SUITE_LEN])
 {
+    notnull_check(conn);
+
     /* See if the cipher is one we support */
     conn->secure.cipher_suite = s2n_cipher_suite_from_wire(wire);
     S2N_ERROR_IF(conn->secure.cipher_suite == NULL, S2N_ERR_CIPHER_NOT_SUPPORTED);
+
+    /* Verify the cipher was part of the originally offered list */
+    const struct s2n_cipher_preferences *cipher_prefs;
+    GUARD(s2n_connection_get_cipher_preferences(conn, &cipher_prefs));
+
+    uint8_t found = 0;
+
+    for (int i = 0; i < cipher_prefs->count; i++ ) {
+        /* The client sends all "available" ciphers in the preference list to the server.
+           The server must pick one of the ciphers offered by the client. */
+        if (cipher_prefs->suites[i]->available) {
+            const uint8_t *server_iana_value = conn->secure.cipher_suite->iana_value;
+            const uint8_t *client_iana_value = cipher_prefs->suites[i]->iana_value;
+
+            if (memcmp(server_iana_value, client_iana_value, S2N_TLS_CIPHER_SUITE_LEN) == 0) {
+                found = 1;
+                break;
+            }
+        }
+    }
+
+    S2N_ERROR_IF(found != 1, S2N_ERR_CIPHER_NOT_SUPPORTED);
 
     /* For SSLv3 use SSLv3-specific ciphers */
     if (conn->actual_protocol_version == S2N_SSLv3) {

--- a/tls/s2n_cipher_suites.h
+++ b/tls/s2n_cipher_suites.h
@@ -37,7 +37,8 @@
 #define S2N_PQ_CIPHER_SUITE_COUNT       0
 #endif
 
-#define S2N_CIPHER_SUITE_COUNT          (36 + S2N_PQ_CIPHER_SUITE_COUNT) /* Kept up-to-date by s2n_cipher_suite_match_test */
+/* Kept up-to-date by s2n_cipher_suite_match_test */
+#define S2N_CIPHER_SUITE_COUNT          (36 + S2N_PQ_CIPHER_SUITE_COUNT)
 
 
 /* Record algorithm flags that can be OR'ed */


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

related to #1729

### Description of changes: 

Verify the cipher provided by the server was originally offered by
the client in s2n_set_cipher_as_client.

Update the cipher match test to verify s2n_cipher_suite_from_wire
instead of s2n_set_cipher_as_client. 

### Call-outs:

The intent of the previously failing cipher suite match test is to be sure
we don't accept unknown cipher values off the wire. It is more appropriate
to test the `s2n_cipher_suite_from_wire` function for this, as that function
is used by `s2n_set_cipher_as_client` and `s2n_set_cipher_as_server`.

The `s2n_set_cipher_as_client` introduces additional checks which allow
different ciphers based on the linked TLS library. Trying to verify these
exact counts in the cipher suite match test is very fragile and beyond the
scope of the test.

### Testing:

Unit tests with all the supported libraries.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
