### PR TITLE
Add S2N_NO_PQ guards to tests that should be skipped if PQ is disabled.

### DIFF
--- a/tests/unit/s2n_client_pq_kem_extension_test.c
+++ b/tests/unit/s2n_client_pq_kem_extension_test.c
@@ -22,6 +22,8 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
+#if !defined(S2N_NO_PQ)
+
     const char *pq_security_policy = "KMS-PQ-TLS-1-0-2020-02";
     const struct s2n_security_policy *security_policy;
     EXPECT_SUCCESS(s2n_find_security_policy_from_version(pq_security_policy, &security_policy));
@@ -109,6 +111,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
+
+#endif
 
     END_TEST();
 }

--- a/tests/unit/s2n_tls_hybrid_prf_test.c
+++ b/tests/unit/s2n_tls_hybrid_prf_test.c
@@ -43,6 +43,8 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
+#if !defined(S2N_NO_PQ)
+
     if (s2n_is_in_fips_mode()) {
         /* There is no support for PQ KEMs while in FIPS mode */
         END_TEST();
@@ -124,6 +126,8 @@ int main(int argc, char **argv)
     if (FindMarker(kat_file, "count = ") == 0) {
         FAIL_MSG("Found unexpected test vectors in the KAT file. Has the KAT file been changed? Did you update NUM_TEST_VECTORS?");
     }
+
+#endif
 
     END_TEST();
 }

--- a/tls/extensions/s2n_server_sct_list.c
+++ b/tls/extensions/s2n_server_sct_list.c
@@ -55,9 +55,10 @@ int s2n_server_sct_list_recv(struct s2n_connection *conn, struct s2n_stuffer *ex
     notnull_check(conn);
 
     struct s2n_blob sct_list;
+    size_t data_available = s2n_stuffer_data_available(extension);
     GUARD(s2n_blob_init(&sct_list,
-            s2n_stuffer_raw_read(extension, s2n_stuffer_data_available(extension)),
-            s2n_stuffer_data_available(extension)));
+            s2n_stuffer_raw_read(extension, data_available),
+            data_available));
     notnull_check(sct_list.data);
 
     GUARD(s2n_dup(&sct_list, &conn->ct_response));


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

 related to #1949

### Description of changes: 

Adds guards to two tests which were failing when S2N_NO_PQ was defined.

### Call-outs:

### Testing:

Tested in Brazil, Ubuntu ARM.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
