### PR TITLE
Adds a proof harness for s2n_stuffer_resize_if_empty

### DIFF
--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -99,8 +99,8 @@ int s2n_stuffer_resize_if_empty(struct s2n_stuffer *stuffer, const uint32_t size
 {
     PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     if (stuffer->blob.data == NULL) {
-        S2N_ERROR_IF(stuffer->tainted == 1, S2N_ERR_RESIZE_TAINTED_STUFFER);
-        S2N_ERROR_IF(stuffer->growable == 0, S2N_ERR_RESIZE_STATIC_STUFFER);
+        ENSURE_POSIX(!stuffer->tainted, S2N_ERR_RESIZE_TAINTED_STUFFER);
+        ENSURE_POSIX(stuffer->growable, S2N_ERR_RESIZE_STATIC_STUFFER);
         GUARD(s2n_realloc(&stuffer->blob, size));
     }
     POSTCONDITION_POSIX(s2n_stuffer_is_valid(stuffer));

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -26,13 +26,13 @@
 bool s2n_stuffer_is_valid(const struct s2n_stuffer* stuffer)
 {
     /* Note that we do not assert any properties on the alloced, growable, and tainted fields,
-     * as all possible combinations of boolean values in those fields are valid */
+    * as all possible combinations of boolean values in those fields are valid */
     return S2N_OBJECT_PTR_IS_READABLE(stuffer) &&
-        s2n_blob_is_valid(&stuffer->blob) &&
-        /* <= is valid because we can have a fully written/read stuffer */
-        stuffer->high_water_mark <= stuffer->blob.size &&
-        stuffer->write_cursor <= stuffer->high_water_mark &&
-        stuffer->read_cursor <= stuffer->write_cursor;
+           s2n_blob_is_valid(&stuffer->blob) &&
+           /* <= is valid because we can have a fully written/read stuffer */
+           stuffer->high_water_mark <= stuffer->blob.size &&
+           stuffer->write_cursor <= stuffer->high_water_mark &&
+           stuffer->read_cursor <= stuffer->write_cursor;
 }
 
 int s2n_stuffer_init(struct s2n_stuffer *stuffer, struct s2n_blob *in)
@@ -97,11 +97,14 @@ int s2n_stuffer_resize(struct s2n_stuffer *stuffer, const uint32_t size)
 
 int s2n_stuffer_resize_if_empty(struct s2n_stuffer *stuffer, const uint32_t size)
 {
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     if (stuffer->blob.data == NULL) {
-        GUARD(s2n_stuffer_resize(stuffer, size));
+        S2N_ERROR_IF(stuffer->tainted == 1, S2N_ERR_RESIZE_TAINTED_STUFFER);
+        S2N_ERROR_IF(stuffer->growable == 0, S2N_ERR_RESIZE_STATIC_STUFFER);
+        GUARD(s2n_realloc(&stuffer->blob, size));
     }
-
-    return 0;
+    POSTCONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
+    return S2N_SUCCESS;
 }
 
 int s2n_stuffer_rewrite(struct s2n_stuffer *stuffer)

--- a/tests/cbmc/proofs/Makefile.common
+++ b/tests/cbmc/proofs/Makefile.common
@@ -185,7 +185,7 @@ SIMPLIFY ?= 0
 $(ENTRY_GOTO)0.goto: $(ENTRY).c $(DEPENDENCIES)
 	mkdir -p $(dir $@)
 	mkdir -p $(dir $(call LOG_FROM_ENTRY,$@))
-	$(call DO_GOTO_CC,--export-function-local-symbols --function $(ENTRY) $(INC) $(DEFINES),$^,$@)
+	$(call DO_GOTO_CC,--export-file-local-symbols --function $(ENTRY) $(INC) $(DEFINES),$^,$@)
 
 # Removes specified function bodies. This allows us to replace
 # function definitions with ABSTRACTIONS.

--- a/tests/cbmc/proofs/s2n_stuffer_resize_if_empty/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_resize_if_empty/Makefile
@@ -1,0 +1,38 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 20 seconds.
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/error/s2n_errno.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+
+ENTRY = s2n_stuffer_resize_if_empty_harness
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_calculate_stacktrace
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_blob_slice
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_ensure_memcpy_trace
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_resize_if_empty/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_resize_if_empty/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_resize_if_empty_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_resize_if_empty/s2n_stuffer_resize_if_empty_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_resize_if_empty/s2n_stuffer_resize_if_empty_harness.c
@@ -30,13 +30,13 @@ void s2n_stuffer_resize_if_empty_harness() {
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
     uint32_t size;
 
-		/* Non-deterministically set initialized (in s2n_mem) to true. */
-		if(nondet_bool()) {
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
         s2n_mem_init();
-		}
+    }
 
-		/* Save previous state. */
-		struct s2n_stuffer old_stuffer = *stuffer;
+    /* Save previous state. */
+    struct s2n_stuffer old_stuffer = *stuffer;
 
     /* Operation under verification. */
     if (s2n_stuffer_resize_if_empty(stuffer, size) == S2N_SUCCESS) {
@@ -44,8 +44,8 @@ void s2n_stuffer_resize_if_empty_harness() {
             assert(stuffer->blob.growable == 1);
             assert(stuffer->blob.size == size);
             assert(stuffer->blob.allocated >= size);
-				}
-		} else {
+        }
+    } else {
         assert(stuffer->blob.size == old_stuffer.blob.size);
         assert(stuffer->write_cursor == old_stuffer.write_cursor);
         assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
@@ -54,6 +54,6 @@ void s2n_stuffer_resize_if_empty_harness() {
         assert(stuffer->tainted == old_stuffer.tainted);
     }
 
-		/* Post-conditions. */
-		assert(s2n_stuffer_is_valid(stuffer));
+    /* Post-conditions. */
+    assert(s2n_stuffer_is_valid(stuffer));
 }

--- a/tests/cbmc/proofs/s2n_stuffer_resize_if_empty/s2n_stuffer_resize_if_empty_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_resize_if_empty/s2n_stuffer_resize_if_empty_harness.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+/*
+ * The reason we don't have full coverage is that we only call s2n_realloc
+ * with blob-data == NULL.
+ */
+void s2n_stuffer_resize_if_empty_harness() {
+    /* Non-deterministic inputs. */
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    uint32_t size;
+
+		/* Non-deterministically set initialized (in s2n_mem) to true. */
+		if(nondet_bool()) {
+        s2n_mem_init();
+		}
+
+		/* Save previous state. */
+		struct s2n_stuffer old_stuffer = *stuffer;
+
+    /* Operation under verification. */
+    if (s2n_stuffer_resize_if_empty(stuffer, size) == S2N_SUCCESS) {
+        if(size != 0 && old_stuffer.blob.data == NULL) {
+            assert(stuffer->blob.growable == 1);
+            assert(stuffer->blob.size == size);
+            assert(stuffer->blob.allocated >= size);
+				}
+		} else {
+        assert(stuffer->blob.size == old_stuffer.blob.size);
+        assert(stuffer->write_cursor == old_stuffer.write_cursor);
+        assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+        assert(stuffer->alloced == old_stuffer.alloced);
+        assert(stuffer->growable == old_stuffer.growable);
+        assert(stuffer->tainted == old_stuffer.tainted);
+    }
+
+		/* Post-conditions. */
+		assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_resize_if_empty/s2n_stuffer_resize_if_empty_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_resize_if_empty/s2n_stuffer_resize_if_empty_harness.c
@@ -37,14 +37,15 @@ void s2n_stuffer_resize_if_empty_harness() {
 
     /* Save previous state. */
     struct s2n_stuffer old_stuffer = *stuffer;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_blob(&stuffer->blob, &old_byte);
 
     /* Operation under verification. */
-    if (s2n_stuffer_resize_if_empty(stuffer, size) == S2N_SUCCESS) {
-        if(size != 0 && old_stuffer.blob.data == NULL) {
-            assert(stuffer->blob.growable == 1);
-            assert(stuffer->blob.size == size);
-            assert(stuffer->blob.allocated >= size);
-        }
+    if (s2n_stuffer_resize_if_empty(stuffer, size) == S2N_SUCCESS &&
+        size != 0 && old_stuffer.blob.data == NULL) {
+        assert(stuffer->blob.growable);
+        assert(stuffer->blob.size == size);
+        assert(stuffer->blob.allocated >= size);
     } else {
         assert(stuffer->blob.size == old_stuffer.blob.size);
         assert(stuffer->write_cursor == old_stuffer.write_cursor);
@@ -52,6 +53,7 @@ void s2n_stuffer_resize_if_empty_harness() {
         assert(stuffer->alloced == old_stuffer.alloced);
         assert(stuffer->growable == old_stuffer.growable);
         assert(stuffer->tainted == old_stuffer.tainted);
+        assert_byte_from_blob_matches(&stuffer->blob, &old_byte);
     }
 
     /* Post-conditions. */

--- a/tests/cbmc/source/make_common_datastructures.c
+++ b/tests/cbmc/source/make_common_datastructures.c
@@ -37,8 +37,8 @@ void ensure_s2n_stuffer_has_allocated_fields(struct s2n_stuffer* stuffer)
 
 struct s2n_stuffer* cbmc_allocate_s2n_stuffer() {
     struct s2n_stuffer* stuffer = can_fail_malloc(sizeof(*stuffer));
-    if (stuffer) {
-	ensure_s2n_stuffer_has_allocated_fields(stuffer);
+    if (stuffer != NULL) {
+        ensure_s2n_stuffer_has_allocated_fields(stuffer);
     }
     return stuffer;
 }

--- a/utils/s2n_blob.c
+++ b/utils/s2n_blob.c
@@ -26,10 +26,11 @@
 bool s2n_blob_is_valid(const struct s2n_blob* b)
 {
     return S2N_OBJECT_PTR_IS_READABLE(b) &&
+           S2N_IMPLIES(b->data == NULL, b->size == 0) &&
            S2N_IMPLIES(b->growable == 0, b->allocated == 0) &&
-           S2N_IMPLIES(b->growable != 0, S2N_MEM_IS_READABLE(b->data, b->allocated)) &&
            S2N_IMPLIES(b->growable != 0, b->size <= b->allocated) &&
-           S2N_MEM_IS_READABLE(b->data,b->size);
+           S2N_MEM_IS_READABLE(b->data, b->allocated) &&
+           S2N_MEM_IS_READABLE(b->data, b->size);
 }
 
 int s2n_blob_init(struct s2n_blob *b, uint8_t * data, uint32_t size)
@@ -44,8 +45,7 @@ int s2n_blob_init(struct s2n_blob *b, uint8_t * data, uint32_t size)
 int s2n_blob_zero(struct s2n_blob *b)
 {
     memset_check(b->data, 0, b->size);
-
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_blob_slice(const struct s2n_blob *b, struct s2n_blob *slice, uint32_t offset, uint32_t size)

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -85,7 +85,11 @@ static int s2n_mem_malloc_mlock_impl(void **ptr, uint32_t requested, uint32_t *a
     /* Page aligned allocation required for mlock */
     uint32_t allocate;
 
+/* Avoids spurious alarms over signed to unsigned conversion in (uint32_t)page_size. */
+#pragma CPROVER check push
+#pragma CPROVER check disable "conversion"
     GUARD(s2n_align_to(requested, page_size, &allocate));
+#pragma CPROVER check pop
 
     *ptr = NULL;
     S2N_ERROR_IF(posix_memalign(ptr, page_size, allocate) != 0, S2N_ERR_ALLOC);

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -46,11 +46,10 @@ static s2n_mem_free_callback s2n_mem_free_cb = s2n_mem_free_mlock_impl;
 
 static int s2n_mem_init_impl(void)
 {
-/* Avoids spurious alarms over signed to unsigned conversion in (uint32_t)return_value_sysconf. */
-#pragma CPROVER check push
-#pragma CPROVER check disable "conversion"
-    GUARD(page_size = sysconf(_SC_PAGESIZE));
-#pragma CPROVER check pop
+    long sysconf_rc = sysconf(_SC_PAGESIZE);
+    GUARD(sysconf_rc);
+    ENSURE_POSIX(sysconf_rc <= UINT32_MAX, S2N_FAILURE);
+    page_size = (uint32_t)sysconf_rc;
 
     if (getenv("S2N_DONT_MLOCK")) {
         s2n_mem_malloc_cb = s2n_mem_malloc_no_mlock_impl;


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A.

### Description of changes: 

- Adds a proof harness for the `s2n_stuffer_resize_if_empty ` function;
- Adds a pre- and post-conditions to the `s2n_stuffer_resize_if_empty ` function;
- Updates the validity function for `s2n_blob`;
- Adds a pragma to `s2n_mem_malloc_mlock_impl` in order to avoid spurious alarms on CBMC proofs over signed to unsigned conversion in `(uint32_t)page_size`;

### Call-outs:

This PR depends on [PR #1918](https://github.com/awslabs/s2n/pull/1918).
This PR overrides [PR #1408](https://github.com/awslabs/s2n/pull/1408).

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.