### PR TITLE
Extend s2n_handle_retry_state to support write handlers

### DIFF
--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -141,7 +141,7 @@ struct s2n_handshake {
     /* Indicates the CLIENT_HELLO message has been completely received */
     unsigned client_hello_received:1;
 
-    /* Indicates the handshake blocked while trying to read data, and has been paused */
+    /* Indicates the handshake blocked while trying to read or write data, and has been paused */
     unsigned paused:1;
 
     /* Handshake type is a bitset, with the following

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1007,7 +1007,7 @@ static int s2n_handle_retry_state(struct s2n_connection *conn)
      * The handler will know how to continue, so we should call the handler right away.
      * We aren't going to read more handshake data yet because the current message has
      * not finished processing. */
-    s2n_errno = S2N_ERR_T_OK;
+    s2n_errno = S2N_ERR_OK;
     const int r = ACTIVE_STATE(conn).handler[conn->mode] (conn);
 
     if (r < 0) {
@@ -1047,7 +1047,7 @@ int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status * blocked)
     }
 
     while (ACTIVE_STATE(conn).writer != 'B') {
-        s2n_errno = S2N_ERR_T_OK;
+        s2n_errno = S2N_ERR_OK;
 
         /* Flush any pending I/O or alert messages */
         GUARD(s2n_flush(conn, blocked));

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1015,7 +1015,7 @@ static int s2n_handle_retry_state(struct s2n_connection *conn)
         S2N_ERROR_PRESERVE_ERRNO();
     }
 
-    char this = conn->mode == S2N_CLIENT ? 'C' : 'S';
+    const char this = conn->mode == S2N_CLIENT ? 'C' : 'S';
 
     if (ACTIVE_STATE(conn).writer != this) {
         /* We're done parsing the record, reset everything */
@@ -1041,8 +1041,8 @@ static int s2n_handle_retry_state(struct s2n_connection *conn)
             GUARD(s2n_handshake_finish_header(&conn->handshake.io));
         }
     } else {
-        /* The handler completed successfully, we are done with this record. */
-        /* Advance the state machine and wipe the record. */
+        /* The read handler processed the record successfully, we are done with this
+         * record. Advance the state machine. */
         GUARD(s2n_advance_message(conn));
     }
 
@@ -1073,7 +1073,8 @@ int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status * blocked)
 
         if (ACTIVE_STATE(conn).writer == this) {
             *blocked = S2N_BLOCKED_ON_WRITE;
-            int r = s2n_handshake_write_io(conn);
+            const int r = s2n_handshake_write_io(conn);
+
             if (r < 0) {
                 if (!S2N_ERROR_IS_BLOCKING(s2n_errno)) {
                     /* Non-retryable write error. The peer might have sent an alert. Try and read it. */
@@ -1101,7 +1102,7 @@ int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status * blocked)
             }
         } else {
             *blocked = S2N_BLOCKED_ON_READ;
-            int r = s2n_handshake_read_io(conn);
+            const int r = s2n_handshake_read_io(conn);
 
             if (r < 0) {
                 /* One blocking condition is waiting on the session resumption cache. */


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

Alternative approach for #1955 

No issue opened, prerequisite for async pkey operations changes.

### Description of changes: 
    
Previously s2n_handle_retry_state supported only read handlers. Attempt to use it for write handlers resulted in record not being written, while state machine proceeded to the next record.

With this change s2n_handle_retry_state will finish writing tls record and won't advance state machine for write handlers, allowing s2n_handshake_write_io to write the record to the socket before advancing state machine.
### Testing:

Right now this is not tested, as there are no handlers using pause during write handlers, however it'll be used and tested in subsequent PR for async pkey operations changes, where paused is used in ServerKeyExchange and CertVerify for TLS1.3

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
