### PR TITLE
Additional CBMC flag, and fix CBMC warning

### DIFF
--- a/tests/cbmc/proofs/Makefile.common
+++ b/tests/cbmc/proofs/Makefile.common
@@ -100,6 +100,7 @@ CBMCFLAGS += --float-overflow-check
 CBMCFLAGS += --nan-check
 CBMCFLAGS += --pointer-check
 CBMCFLAGS += --pointer-overflow-check
+CBMCFLAGS += --pointer-primitive-check
 CBMCFLAGS += --signed-overflow-check
 CBMCFLAGS += --undefined-shift-check
 CBMCFLAGS += --unsigned-overflow-check

--- a/tests/cbmc/source/cbmc_utils.c
+++ b/tests/cbmc/source/cbmc_utils.c
@@ -68,6 +68,9 @@ int nondet_compare(const void *const a, const void *const b) {
 }
 
 int __CPROVER_uninterpreted_compare(const void *const a, const void *const b);
+bool __CPROVER_uninterpreted_equals(const void *const a, const void *const b);
+uint64_t __CPROVER_uninterpreted_hasher(const void *const a);
+
 int uninterpreted_compare(const void *const a, const void *const b) {
     assert(a != NULL);
     assert(b != NULL);
@@ -89,8 +92,6 @@ bool nondet_equals(const void *const a, const void *const b) {
     return nondet_bool();
 }
 
-bool __CPROVER_uninterpreted_equals(const void *const a, const void *const b);
-uint64_t __CPROVER_uninterpreted_hasher(const void *const a);
 /**
  * Add assumptions that equality is reflexive and symmetric. Don't bother with
  * transitivity because it doesn't cause any spurious proof failures on hash-table


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

 resolves #ISSUE-NUMBER1, resolves #ISSUE-NUMBER2, etc.

### Description of changes: 

1. Adds a new flag`--pointer-primitive-check` to CBMC proofs. This ensures that all pointers passed to CBMC primitive functions are valid.
1. Fix a warning due to a function being defined after use, instead of before.

### Call-outs:

Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
