### PR TITLE
Don't error for unexpected extensions

### DIFF
--- a/tests/unit/s2n_certificate_extensions_test.c
+++ b/tests/unit/s2n_certificate_extensions_test.c
@@ -324,8 +324,8 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(s2n_stuffer_data_available(&client_conn->handshake.io), 447);
 
         client_conn->x509_validator.skip_cert_validation = 1;
-        /* Verified it fails inside of extension parsing, but the error is masked by cert_untrusted */
-        EXPECT_FAILURE_WITH_ERRNO(s2n_server_cert_recv(client_conn), S2N_ERR_CERT_UNTRUSTED);
+        /* Verified it succeeds */
+        EXPECT_SUCCESS(s2n_server_cert_recv(client_conn));
         EXPECT_EQUAL(s2n_stuffer_data_available(&client_conn->handshake.io), 0);
 
         EXPECT_SUCCESS(s2n_connection_free(client_conn));

--- a/tests/unit/s2n_extension_list_process_test.c
+++ b/tests/unit/s2n_extension_list_process_test.c
@@ -33,6 +33,8 @@ s2n_parsed_extension empty_parsed_extensions[S2N_PARSED_EXTENSIONS_COUNT] = { 0 
 
 #define EXPECT_PARSED_EXTENSION_LIST_EMPTY(list) \
     EXPECT_BYTEARRAY_EQUAL(list.parsed_extensions, empty_parsed_extensions, sizeof(empty_parsed_extensions))
+#define EXPECT_PARSED_EXTENSION_LIST_NOT_EMPTY(list) \
+    EXPECT_BYTEARRAY_NOT_EQUAL(list.parsed_extensions, empty_parsed_extensions, sizeof(empty_parsed_extensions))
 
 static int s2n_setup_test_parsed_extension(const s2n_extension_type *extension_type,
         s2n_parsed_extension *parsed_extension, struct s2n_connection *conn, struct s2n_stuffer *stuffer)
@@ -276,7 +278,7 @@ int main()
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }
 
-        /* Fails on unexpected parsed_extension */
+        /* Skips on unexpected parsed_extension */
         {
             s2n_parsed_extensions_list parsed_extension_list = { 0 };
 
@@ -287,8 +289,9 @@ int main()
             SET_PARSED_EXTENSION(parsed_extension_list, test_empty_parsed_extension);
 
             conn->server_name_used = false;
-            EXPECT_FAILURE_WITH_ERRNO(s2n_extension_list_process(S2N_EXTENSION_LIST_EMPTY,
-                    conn, &parsed_extension_list), S2N_ERR_UNSUPPORTED_EXTENSION);
+            EXPECT_SUCCESS(s2n_extension_list_process(S2N_EXTENSION_LIST_EMPTY, conn, &parsed_extension_list));
+
+            EXPECT_PARSED_EXTENSION_LIST_NOT_EMPTY(parsed_extension_list);
             EXPECT_FALSE(conn->server_name_used);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));

--- a/tests/unit/s2n_server_extensions_test.c
+++ b/tests/unit/s2n_server_extensions_test.c
@@ -550,9 +550,10 @@ int main(int argc, char **argv)
                     server_conn, &stuffer));
             EXPECT_SUCCESS(s2n_stuffer_write_vector_size(extension_list_size));
 
+            EXPECT_EQUAL(client_conn->status_type, S2N_STATUS_REQUEST_NONE);
             EXPECT_EQUAL(client_conn->server_protocol_version, S2N_UNKNOWN_PROTOCOL_VERSION);
-            EXPECT_FAILURE_WITH_ERRNO(s2n_server_extensions_recv(client_conn, &stuffer),
-                    S2N_ERR_UNSUPPORTED_EXTENSION);
+            EXPECT_SUCCESS(s2n_server_extensions_recv(client_conn, &stuffer));
+            EXPECT_EQUAL(client_conn->status_type, S2N_STATUS_REQUEST_NONE);
             EXPECT_EQUAL(client_conn->server_protocol_version, S2N_TLS13);
 
             EXPECT_SUCCESS(s2n_connection_free(client_conn));

--- a/tls/extensions/s2n_extension_list.c
+++ b/tls/extensions/s2n_extension_list.c
@@ -104,6 +104,19 @@ int s2n_extension_list_process(s2n_extension_list_id list_type, struct s2n_conne
                 conn, parsed_extension_list));
     }
 
+    /* If parsed_extension_list.parsed_extensions is not completely wiped at this point,
+     * then we have received an extension not allowed on this message type.
+     *
+     * According to the RFC, we should alert and close the connection.
+     * From https://tools.ietf.org/html/rfc8446#section-4.2:
+     *    If an implementation receives an extension which it recognizes and which is not
+     *    specified for the message in which it appears, it MUST abort the handshake with an
+     *    "illegal_parameter" alert.
+     *
+     * However, to be more tolerant of non-compliant peers, we will just ignore and not
+     * process the illegal extensions, treating them as if they are unsupported.
+     */
+
     return S2N_SUCCESS;
 }
 

--- a/tls/extensions/s2n_extension_list.c
+++ b/tls/extensions/s2n_extension_list.c
@@ -104,10 +104,6 @@ int s2n_extension_list_process(s2n_extension_list_id list_type, struct s2n_conne
                 conn, parsed_extension_list));
     }
 
-    /* If we did not process an extension, than that extension is not allowed on this message type. */
-    ENSURE_POSIX(memcmp(parsed_extension_list->parsed_extensions, empty_parsed_extensions, sizeof(empty_parsed_extensions)) == 0,
-            S2N_ERR_UNSUPPORTED_EXTENSION);
-
     return S2N_SUCCESS;
 }
 


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

### Description of changes: 

With the latest changes, S2N will error if it receives an known extension on a message that extension doesn't belong on. But that doesn't provide any extra security, and definitely makes S2N more brittle. We should just ignore unexpected extensions.

### Callouts

**Is it a problem that s2n_extension_list_process might not clear the parsed extension list now?** No. Only the ClientHello parsed extension list has the potential to be used again after process is called, and [parse ensures that the list is cleared before reuse](https://github.com/awslabs/s2n/blob/master/tls/extensions/s2n_extension_list.c#L153-L154).

### Testing:
Updated existing tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
