### PR TITLE
Adds proof harnesses for s2n_stuffer_read_uint*

### DIFF
--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -214,6 +214,7 @@ int s2n_stuffer_erase_and_read(struct s2n_stuffer *stuffer, struct s2n_blob *out
 int s2n_stuffer_read_bytes(struct s2n_stuffer *stuffer, uint8_t * data, uint32_t size)
 {
     notnull_check(data);
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     GUARD(s2n_stuffer_skip_read(stuffer, size));
     notnull_check(stuffer->blob.data);
     void *ptr = stuffer->blob.data + stuffer->read_cursor - size;

--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -21,6 +21,8 @@
 
 #include "utils/s2n_blob.h"
 
+#define SIZEOF_UINT24 3
+
 /* Using a non-zero value
  * (a) makes wiped data easy to see in the debugger
  * (b) makes use of wiped data obvious since this is unlikely to be a valid bit pattern

--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -15,19 +15,22 @@
 
 #pragma once
 
+#include <limits.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <sys/uio.h>
 
 #include "utils/s2n_blob.h"
 
-#define SIZEOF_UINT24 3
-
 /* Using a non-zero value
  * (a) makes wiped data easy to see in the debugger
  * (b) makes use of wiped data obvious since this is unlikely to be a valid bit pattern
  */
 #define S2N_WIPE_PATTERN 'w'
+
+#define SIZEOF_IN_BITS( t ) (sizeof(t) * CHAR_BIT)
+
+#define SIZEOF_UINT24 3
 
 struct s2n_stuffer {
     /* The data for the s2n_stuffer */

--- a/stuffer/s2n_stuffer_network_order.c
+++ b/stuffer/s2n_stuffer_network_order.c
@@ -56,18 +56,19 @@ int s2n_stuffer_read_uint8(struct s2n_stuffer *stuffer, uint8_t * u)
 {
     GUARD(s2n_stuffer_read_bytes(stuffer, u, 1));
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_stuffer_write_uint8(struct s2n_stuffer *stuffer, const uint8_t u)
 {
     GUARD(s2n_stuffer_write_bytes(stuffer, &u, 1));
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_stuffer_read_uint16(struct s2n_stuffer *stuffer, uint16_t * u)
 {
+    notnull_check(u);
     uint8_t data[2];
 
     GUARD(s2n_stuffer_read_bytes(stuffer, data, sizeof(data)));
@@ -75,7 +76,7 @@ int s2n_stuffer_read_uint16(struct s2n_stuffer *stuffer, uint16_t * u)
     *u = data[0] << 8;
     *u |= data[1];
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_stuffer_write_uint16(struct s2n_stuffer *stuffer, const uint16_t u)
@@ -90,6 +91,7 @@ int s2n_stuffer_reserve_uint16(struct s2n_stuffer *stuffer, struct s2n_stuffer_r
 
 int s2n_stuffer_read_uint24(struct s2n_stuffer *stuffer, uint32_t * u)
 {
+    notnull_check(u);
     uint8_t data[3];
 
     GUARD(s2n_stuffer_read_bytes(stuffer, data, sizeof(data)));
@@ -98,7 +100,7 @@ int s2n_stuffer_read_uint24(struct s2n_stuffer *stuffer, uint32_t * u)
     *u |= data[1] << 8;
     *u |= data[2];
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_stuffer_write_uint24(struct s2n_stuffer *stuffer, const uint32_t u)
@@ -113,6 +115,7 @@ int s2n_stuffer_reserve_uint24(struct s2n_stuffer *stuffer, struct s2n_stuffer_r
 
 int s2n_stuffer_read_uint32(struct s2n_stuffer *stuffer, uint32_t * u)
 {
+    notnull_check(u);
     uint8_t data[4];
 
     GUARD(s2n_stuffer_read_bytes(stuffer, data, sizeof(data)));
@@ -122,7 +125,7 @@ int s2n_stuffer_read_uint32(struct s2n_stuffer *stuffer, uint32_t * u)
     *u |= data[2] << 8;
     *u |= data[3];
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_stuffer_write_uint32(struct s2n_stuffer *stuffer, const uint32_t u)
@@ -132,6 +135,7 @@ int s2n_stuffer_write_uint32(struct s2n_stuffer *stuffer, const uint32_t u)
 
 int s2n_stuffer_read_uint64(struct s2n_stuffer *stuffer, uint64_t * u)
 {
+    notnull_check(u);
     uint8_t data[8];
 
     GUARD(s2n_stuffer_read_bytes(stuffer, data, sizeof(data)));
@@ -145,7 +149,7 @@ int s2n_stuffer_read_uint64(struct s2n_stuffer *stuffer, uint64_t * u)
     *u |= ((uint64_t) data[6]) << 8;
     *u |= data[7];
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_stuffer_write_uint64(struct s2n_stuffer *stuffer, const uint64_t u)
@@ -153,7 +157,7 @@ int s2n_stuffer_write_uint64(struct s2n_stuffer *stuffer, const uint64_t u)
     GUARD(s2n_stuffer_write_network_order(stuffer, u >> (sizeof(uint32_t) * 8), sizeof(uint32_t)));
     GUARD(s2n_stuffer_write_network_order(stuffer, u & UINT32_MAX, sizeof(uint32_t)));
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 static int length_matches_value_check(uint32_t value, uint8_t length)

--- a/stuffer/s2n_stuffer_network_order.c
+++ b/stuffer/s2n_stuffer_network_order.c
@@ -152,7 +152,7 @@ int s2n_stuffer_read_uint64(struct s2n_stuffer *stuffer, uint64_t * u)
 
 int s2n_stuffer_write_uint64(struct s2n_stuffer *stuffer, const uint64_t u)
 {
-    GUARD(s2n_stuffer_write_network_order(stuffer, u >> (sizeof(uint32_t) * sizeof(u)), sizeof(uint32_t)));
+    GUARD(s2n_stuffer_write_network_order(stuffer, u >> SIZEOF_IN_BITS(uint32_t), sizeof(uint32_t)));
     GUARD(s2n_stuffer_write_network_order(stuffer, u & UINT32_MAX, sizeof(uint32_t)));
 
     return S2N_SUCCESS;

--- a/stuffer/s2n_stuffer_network_order.c
+++ b/stuffer/s2n_stuffer_network_order.c
@@ -20,8 +20,6 @@
 #include "utils/s2n_annotations.h"
 #include "utils/s2n_safety.h"
 
-#define SIZEOF_UINT24 3
-
 int s2n_stuffer_write_network_order(struct s2n_stuffer *stuffer, uint32_t input, uint8_t length)
 {
     notnull_check(stuffer);
@@ -54,14 +52,14 @@ int s2n_stuffer_reserve(struct s2n_stuffer *stuffer, struct s2n_stuffer_reservat
 
 int s2n_stuffer_read_uint8(struct s2n_stuffer *stuffer, uint8_t * u)
 {
-    GUARD(s2n_stuffer_read_bytes(stuffer, u, 1));
+    GUARD(s2n_stuffer_read_bytes(stuffer, u, sizeof(uint8_t)));
 
     return S2N_SUCCESS;
 }
 
 int s2n_stuffer_write_uint8(struct s2n_stuffer *stuffer, const uint8_t u)
 {
-    GUARD(s2n_stuffer_write_bytes(stuffer, &u, 1));
+    GUARD(s2n_stuffer_write_bytes(stuffer, &u, sizeof(u)));
 
     return S2N_SUCCESS;
 }
@@ -69,7 +67,7 @@ int s2n_stuffer_write_uint8(struct s2n_stuffer *stuffer, const uint8_t u)
 int s2n_stuffer_read_uint16(struct s2n_stuffer *stuffer, uint16_t * u)
 {
     notnull_check(u);
-    uint8_t data[2];
+    uint8_t data[sizeof(uint16_t)];
 
     GUARD(s2n_stuffer_read_bytes(stuffer, data, sizeof(data)));
 
@@ -92,7 +90,7 @@ int s2n_stuffer_reserve_uint16(struct s2n_stuffer *stuffer, struct s2n_stuffer_r
 int s2n_stuffer_read_uint24(struct s2n_stuffer *stuffer, uint32_t * u)
 {
     notnull_check(u);
-    uint8_t data[3];
+    uint8_t data[SIZEOF_UINT24];
 
     GUARD(s2n_stuffer_read_bytes(stuffer, data, sizeof(data)));
 
@@ -116,7 +114,7 @@ int s2n_stuffer_reserve_uint24(struct s2n_stuffer *stuffer, struct s2n_stuffer_r
 int s2n_stuffer_read_uint32(struct s2n_stuffer *stuffer, uint32_t * u)
 {
     notnull_check(u);
-    uint8_t data[4];
+    uint8_t data[sizeof(uint32_t)];
 
     GUARD(s2n_stuffer_read_bytes(stuffer, data, sizeof(data)));
 
@@ -136,7 +134,7 @@ int s2n_stuffer_write_uint32(struct s2n_stuffer *stuffer, const uint32_t u)
 int s2n_stuffer_read_uint64(struct s2n_stuffer *stuffer, uint64_t * u)
 {
     notnull_check(u);
-    uint8_t data[8];
+    uint8_t data[sizeof(uint64_t)];
 
     GUARD(s2n_stuffer_read_bytes(stuffer, data, sizeof(data)));
 
@@ -154,7 +152,7 @@ int s2n_stuffer_read_uint64(struct s2n_stuffer *stuffer, uint64_t * u)
 
 int s2n_stuffer_write_uint64(struct s2n_stuffer *stuffer, const uint64_t u)
 {
-    GUARD(s2n_stuffer_write_network_order(stuffer, u >> (sizeof(uint32_t) * 8), sizeof(uint32_t)));
+    GUARD(s2n_stuffer_write_network_order(stuffer, u >> (sizeof(uint32_t) * sizeof(u)), sizeof(uint32_t)));
     GUARD(s2n_stuffer_write_network_order(stuffer, u & UINT32_MAX, sizeof(uint32_t)));
 
     return S2N_SUCCESS;

--- a/tests/cbmc/include/cbmc_proof/cbmc_utils.h
+++ b/tests/cbmc/include/cbmc_proof/cbmc_utils.h
@@ -31,25 +31,39 @@ struct store_byte_from_buffer {
 };
 
 /**
- * Asserts whether s2n_stuffer's fields are equivalent, except for read_cursor,
- * which might change after a read operation.
+ * Asserts two s2n_stuffer instances are equivalent, except for read_cursor,
+ * which might change after a read operation. In order to be considered equivalent,
+ * all members (except for read_cursor) from both instances must match, including
+ * all bytes from their underlying blobs (i.e., blob.data field). Prior to using
+ * this function, it is necessary to select a non-deterministic byte from the
+ * rhs s2n_blob instance (use save_byte_from_blob function), so it can properly
+ * assert all bytes from blob.data match.
  */
  void assert_stuffer_immutable_fields_after_read(const struct s2n_stuffer *lhs,
                                                  const struct s2n_stuffer *rhs,
-                                                 const struct store_byte_from_buffer *rhs_byte);
+                                                 const struct store_byte_from_buffer *stored_byte_from_rhs);
+
 /**
- * Asserts whether s2n_blob objects are equivalent.
+ * Asserts two s2n_blob instances are equivalent. In order to be considered equivalent,
+ * all members from both instances must match, including all bytes from their underlying
+ * buffers (i.e., *data field). Prior to using this function, it is necessary to select
+ * a non-deterministic byte from the rhs s2n_blob instance (use save_byte_from_blob function),
+ * so it can properly assert all bytes from *data match.
  */
  void assert_blob_equivalence(const struct s2n_blob *lhs,
                               const struct s2n_blob *rhs,
-                              const struct store_byte_from_buffer *rhs_byte);
+                              const struct store_byte_from_buffer *stored_byte_from_rhs);
 
 /**
- * Asserts whether s2n_stuffer objects are equivalent.
+ * Asserts two s2n_stuffer instances are equivalent. In order to be considered equivalent,
+ * all members from both instances must match, including all bytes from their underlying
+ * blobs (i.e., blob.data field). Prior to using this function, it is necessary to select
+ * a non-deterministic byte from the rhs s2n_blob instance (use save_byte_from_blob function),
+ * so it can properly assert all bytes from blob.data match.
  */
  void assert_stuffer_equivalence(const struct s2n_stuffer *lhs,
                                  const struct s2n_stuffer *rhs,
-                                 const struct store_byte_from_buffer *rhs_byte);
+                                 const struct store_byte_from_buffer *stored_byte_from_rhs);
 
 /**
  * Asserts whether all bytes from two arrays of same length match.

--- a/tests/cbmc/include/cbmc_proof/cbmc_utils.h
+++ b/tests/cbmc/include/cbmc_proof/cbmc_utils.h
@@ -15,11 +15,13 @@
 
 #pragma once
 
-#include <cbmc_proof/nondet.h>
-#include <cbmc_proof/proof_allocators.h>
-#include <utils/s2n_blob.h>
 #include <stddef.h>
 #include <stdint.h>
+
+#include <cbmc_proof/nondet.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <stuffer/s2n_stuffer.h>
+#include <utils/s2n_blob.h>
 
 #define IMPLIES(a, b) (!(a) || (b))
 
@@ -27,6 +29,27 @@ struct store_byte_from_buffer {
     size_t index;
     uint8_t byte;
 };
+
+/**
+ * Asserts whether s2n_stuffer's fields are equivalent, except for read_cursor,
+ * which might change after a read operation.
+ */
+ void assert_stuffer_immutable_fields_after_read(const struct s2n_stuffer *lhs,
+                                                 const struct s2n_stuffer *rhs,
+                                                 const struct store_byte_from_buffer *rhs_byte);
+/**
+ * Asserts whether s2n_blob objects are equivalent.
+ */
+ void assert_blob_equivalence(const struct s2n_blob *lhs,
+                              const struct s2n_blob *rhs,
+                              const struct store_byte_from_buffer *rhs_byte);
+
+/**
+ * Asserts whether s2n_stuffer objects are equivalent.
+ */
+ void assert_stuffer_equivalence(const struct s2n_stuffer *lhs,
+                                 const struct s2n_stuffer *rhs,
+                                 const struct store_byte_from_buffer *rhs_byte);
 
 /**
  * Asserts whether all bytes from two arrays of same length match.

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint16/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint16/Makefile
@@ -1,0 +1,29 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
+
+ENTRY = s2n_stuffer_read_uint16_harness
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint16/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint16/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint16/s2n_stuffer_read_uint16_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint16/s2n_stuffer_read_uint16_harness.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_read_uint16_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+
+    struct s2n_stuffer old_stuffer = *stuffer;
+    uint16_t *dest = can_fail_malloc(sizeof(uint16_t*));
+
+    /* Store a byte from the stuffer to compare after the read */
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    if (s2n_stuffer_read_uint16(stuffer, dest) == S2N_SUCCESS) {
+        assert(stuffer->read_cursor == old_stuffer.read_cursor + sizeof(uint16_t));
+        /* If successful, ensure uint was assembled correctly from stuffer */
+        assert(((uint16_t) stuffer->blob.data[old_stuffer.read_cursor]) << 8
+             | ((uint16_t) stuffer->blob.data[old_stuffer.read_cursor + 1]) == *dest);
+    } else {
+        assert(stuffer->read_cursor == old_stuffer.read_cursor);
+    }
+
+    assert(stuffer->blob.data == old_stuffer.blob.data);
+    assert(stuffer->blob.size == old_stuffer.blob.size);
+    assert(stuffer->write_cursor == old_stuffer.write_cursor);
+    assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+    assert(stuffer->alloced == old_stuffer.alloced);
+    assert(stuffer->growable == old_stuffer.growable);
+    assert(stuffer->tainted == old_stuffer.tainted);
+    assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint16/s2n_stuffer_read_uint16_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint16/s2n_stuffer_read_uint16_harness.c
@@ -43,13 +43,6 @@ void s2n_stuffer_read_uint16_harness() {
         assert(stuffer->read_cursor == old_stuffer.read_cursor);
     }
 
-    assert(stuffer->blob.data == old_stuffer.blob.data);
-    assert(stuffer->blob.size == old_stuffer.blob.size);
-    assert(stuffer->write_cursor == old_stuffer.write_cursor);
-    assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
-    assert(stuffer->alloced == old_stuffer.alloced);
-    assert(stuffer->growable == old_stuffer.growable);
-    assert(stuffer->tainted == old_stuffer.tainted);
-    assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+    assert_stuffer_immutable_fields_after_read(stuffer, &old_stuffer, &old_byte_from_stuffer);
     assert(s2n_stuffer_is_valid(stuffer));
 }

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint24/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint24/Makefile
@@ -1,0 +1,29 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
+
+ENTRY = s2n_stuffer_read_uint24_harness
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint24/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint24/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint24/s2n_stuffer_read_uint24_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint24/s2n_stuffer_read_uint24_harness.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_read_uint24_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+
+    struct s2n_stuffer old_stuffer = *stuffer;
+    uint32_t dest;
+
+    /* Store a byte from the stuffer to compare after the read */
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    if (s2n_stuffer_read_uint24(stuffer, &dest) == S2N_SUCCESS) {
+        assert(stuffer->read_cursor == old_stuffer.read_cursor + sizeof(uint32_t) - 1);
+        /* If successful, ensure uint was assembled correctly from stuffer */
+        assert(((uint32_t) stuffer->blob.data[old_stuffer.read_cursor]) << 16
+             | ((uint32_t) stuffer->blob.data[old_stuffer.read_cursor + 1]) << 8
+             | ((uint32_t) stuffer->blob.data[old_stuffer.read_cursor + 2]) == dest);
+    } else {
+        assert(stuffer->read_cursor == old_stuffer.read_cursor);
+    }
+
+    assert(stuffer->blob.data == old_stuffer.blob.data);
+    assert(stuffer->blob.size == old_stuffer.blob.size);
+    assert(stuffer->write_cursor == old_stuffer.write_cursor);
+    assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+    assert(stuffer->alloced == old_stuffer.alloced);
+    assert(stuffer->growable == old_stuffer.growable);
+    assert(stuffer->tainted == old_stuffer.tainted);
+    assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint24/s2n_stuffer_read_uint24_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint24/s2n_stuffer_read_uint24_harness.c
@@ -23,8 +23,6 @@
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
 
-#define UINT24_LENGTH (sizeof(uint32_t) - 1)
-
 void s2n_stuffer_read_uint24_harness() {
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
@@ -37,7 +35,7 @@ void s2n_stuffer_read_uint24_harness() {
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
     if (s2n_stuffer_read_uint24(stuffer, dest) == S2N_SUCCESS) {
-        assert(stuffer->read_cursor == old_stuffer.read_cursor + UINT24_LENGTH);
+        assert(stuffer->read_cursor == old_stuffer.read_cursor + SIZEOF_UINT24);
         /* If successful, ensure uint was assembled correctly from stuffer */
         assert(((uint32_t) stuffer->blob.data[old_stuffer.read_cursor]) << 16
              | ((uint32_t) stuffer->blob.data[old_stuffer.read_cursor + 1]) << 8

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint24/s2n_stuffer_read_uint24_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint24/s2n_stuffer_read_uint24_harness.c
@@ -44,7 +44,6 @@ void s2n_stuffer_read_uint24_harness() {
     } else {
         assert(stuffer->read_cursor == old_stuffer.read_cursor);
     }
-
     assert_stuffer_immutable_fields_after_read(stuffer, &old_stuffer, &old_byte_from_stuffer);
     assert(s2n_stuffer_is_valid(stuffer));
 }

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint24/s2n_stuffer_read_uint24_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint24/s2n_stuffer_read_uint24_harness.c
@@ -28,29 +28,23 @@ void s2n_stuffer_read_uint24_harness() {
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
 
     struct s2n_stuffer old_stuffer = *stuffer;
-    uint32_t dest;
+    uint32_t *dest = can_fail_malloc(sizeof(uint32_t*));
+
 
     /* Store a byte from the stuffer to compare after the read */
     struct store_byte_from_buffer old_byte_from_stuffer;
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
-    if (s2n_stuffer_read_uint24(stuffer, &dest) == S2N_SUCCESS) {
+    if (s2n_stuffer_read_uint24(stuffer, dest) == S2N_SUCCESS) {
         assert(stuffer->read_cursor == old_stuffer.read_cursor + sizeof(uint32_t) - 1);
         /* If successful, ensure uint was assembled correctly from stuffer */
         assert(((uint32_t) stuffer->blob.data[old_stuffer.read_cursor]) << 16
              | ((uint32_t) stuffer->blob.data[old_stuffer.read_cursor + 1]) << 8
-             | ((uint32_t) stuffer->blob.data[old_stuffer.read_cursor + 2]) == dest);
+             | ((uint32_t) stuffer->blob.data[old_stuffer.read_cursor + 2]) == *dest);
     } else {
         assert(stuffer->read_cursor == old_stuffer.read_cursor);
     }
 
-    assert(stuffer->blob.data == old_stuffer.blob.data);
-    assert(stuffer->blob.size == old_stuffer.blob.size);
-    assert(stuffer->write_cursor == old_stuffer.write_cursor);
-    assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
-    assert(stuffer->alloced == old_stuffer.alloced);
-    assert(stuffer->growable == old_stuffer.growable);
-    assert(stuffer->tainted == old_stuffer.tainted);
-    assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+    assert_stuffer_immutable_fields_after_read(stuffer, &old_stuffer, &old_byte_from_stuffer);
     assert(s2n_stuffer_is_valid(stuffer));
 }

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint32/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint32/Makefile
@@ -1,0 +1,29 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
+
+ENTRY = s2n_stuffer_read_uint32_harness
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint32/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint32/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint32/s2n_stuffer_read_uint32_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint32/s2n_stuffer_read_uint32_harness.c
@@ -28,31 +28,23 @@ void s2n_stuffer_read_uint32_harness() {
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
 
     struct s2n_stuffer old_stuffer = *stuffer;
-    uint32_t dest;
+    uint32_t *dest = can_fail_malloc(sizeof(uint32_t*));
 
     /* Store a byte from the stuffer to compare after the read */
     struct store_byte_from_buffer old_byte_from_stuffer;
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
-    if (s2n_stuffer_read_uint32(stuffer, &dest) == S2N_SUCCESS) {
+    if (s2n_stuffer_read_uint32(stuffer, dest) == S2N_SUCCESS) {
         assert(stuffer->read_cursor == old_stuffer.read_cursor + sizeof(uint32_t));
-
         /* If successful, ensure uint was assembled correctly from stuffer */
         assert(((uint32_t) stuffer->blob.data[old_stuffer.read_cursor]) << 24
              | ((uint32_t) stuffer->blob.data[old_stuffer.read_cursor + 1]) << 16
              | ((uint32_t) stuffer->blob.data[old_stuffer.read_cursor + 2]) << 8
-             | ((uint32_t) stuffer->blob.data[old_stuffer.read_cursor + 3]) == dest);
+             | ((uint32_t) stuffer->blob.data[old_stuffer.read_cursor + 3]) == *dest);
     } else {
-	assert(stuffer->read_cursor == old_stuffer.read_cursor);
+        assert(stuffer->read_cursor == old_stuffer.read_cursor);
     }
 
-    assert(stuffer->blob.data == old_stuffer.blob.data);
-    assert(stuffer->blob.size == old_stuffer.blob.size);
-    assert(stuffer->write_cursor == old_stuffer.write_cursor);
-    assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
-    assert(stuffer->alloced == old_stuffer.alloced);
-    assert(stuffer->growable == old_stuffer.growable);
-    assert(stuffer->tainted == old_stuffer.tainted);
-    assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+    assert_stuffer_immutable_fields_after_read(stuffer, &old_stuffer, &old_byte_from_stuffer);
     assert(s2n_stuffer_is_valid(stuffer));
 }

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint32/s2n_stuffer_read_uint32_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint32/s2n_stuffer_read_uint32_harness.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_read_uint32_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+
+    struct s2n_stuffer old_stuffer = *stuffer;
+    uint32_t dest;
+
+    /* Store a byte from the stuffer to compare after the read */
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    if (s2n_stuffer_read_uint32(stuffer, &dest) == S2N_SUCCESS) {
+        assert(stuffer->read_cursor == old_stuffer.read_cursor + sizeof(uint32_t));
+
+        /* If successful, ensure uint was assembled correctly from stuffer */
+        assert(((uint32_t) stuffer->blob.data[old_stuffer.read_cursor]) << 24
+             | ((uint32_t) stuffer->blob.data[old_stuffer.read_cursor + 1]) << 16
+             | ((uint32_t) stuffer->blob.data[old_stuffer.read_cursor + 2]) << 8
+             | ((uint32_t) stuffer->blob.data[old_stuffer.read_cursor + 3]) == dest);
+    } else {
+	assert(stuffer->read_cursor == old_stuffer.read_cursor);
+    }
+
+    assert(stuffer->blob.data == old_stuffer.blob.data);
+    assert(stuffer->blob.size == old_stuffer.blob.size);
+    assert(stuffer->write_cursor == old_stuffer.write_cursor);
+    assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+    assert(stuffer->alloced == old_stuffer.alloced);
+    assert(stuffer->growable == old_stuffer.growable);
+    assert(stuffer->tainted == old_stuffer.tainted);
+    assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint64/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint64/Makefile
@@ -1,0 +1,29 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 20 seconds.
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
+
+ENTRY = s2n_stuffer_read_uint64_harness
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint64/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint64/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint64/s2n_stuffer_read_uint64_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint64/s2n_stuffer_read_uint64_harness.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_read_uint64_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+
+    struct s2n_stuffer old_stuffer = *stuffer;
+    uint64_t dest;
+
+    /* Store a byte from the stuffer to compare after the read */
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    if (s2n_stuffer_read_uint64(stuffer, &dest) == S2N_SUCCESS) {
+        assert(stuffer->read_cursor == old_stuffer.read_cursor + sizeof(uint64_t));
+        /* If successful, ensure uint was assembled correctly from stuffer */
+        assert(((uint64_t) stuffer->blob.data[old_stuffer.read_cursor]) << 56
+             | ((uint64_t) stuffer->blob.data[old_stuffer.read_cursor + 1]) << 48
+             | ((uint64_t) stuffer->blob.data[old_stuffer.read_cursor + 2]) << 40
+             | ((uint64_t) stuffer->blob.data[old_stuffer.read_cursor + 3]) << 32
+             | ((uint64_t) stuffer->blob.data[old_stuffer.read_cursor + 4]) << 24
+             | ((uint64_t) stuffer->blob.data[old_stuffer.read_cursor + 5]) << 16
+             | ((uint64_t) stuffer->blob.data[old_stuffer.read_cursor + 6]) << 8
+             | ((uint64_t) stuffer->blob.data[old_stuffer.read_cursor + 7]) == dest);
+    } else {
+        assert(stuffer->read_cursor == old_stuffer.read_cursor);
+    }
+
+    assert(stuffer->blob.data == old_stuffer.blob.data);
+    assert(stuffer->blob.size == old_stuffer.blob.size);
+    assert(stuffer->write_cursor == old_stuffer.write_cursor);
+    assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+    assert(stuffer->alloced == old_stuffer.alloced);
+    assert(stuffer->growable == old_stuffer.growable);
+    assert(stuffer->tainted == old_stuffer.tainted);
+    assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint8/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint8/Makefile
@@ -1,0 +1,29 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
+
+ENTRY = s2n_stuffer_read_uint8_harness
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint8/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint8/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint8/s2n_stuffer_read_uint8_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint8/s2n_stuffer_read_uint8_harness.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_read_uint8_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+
+    struct s2n_stuffer old_stuffer = *stuffer;
+    uint8_t dest;
+
+    /* Store a byte from the stuffer to compare after the read. */
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    if (s2n_stuffer_read_uint8(stuffer, &dest) == S2N_SUCCESS) {
+        assert(stuffer->read_cursor == old_stuffer.read_cursor + sizeof(uint8_t));
+        /* If successful, ensure uint was assembled correctly from stuffer */
+        assert(stuffer->blob.data[old_stuffer.read_cursor] == dest);
+    } else {
+        assert(stuffer->read_cursor == old_stuffer.read_cursor);
+    }
+
+    assert(stuffer->blob.data == old_stuffer.blob.data);
+    assert(stuffer->blob.size == old_stuffer.blob.size);
+    assert(stuffer->write_cursor == old_stuffer.write_cursor);
+    assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+    assert(stuffer->alloced == old_stuffer.alloced);
+    assert(stuffer->growable == old_stuffer.growable);
+    assert(stuffer->tainted == old_stuffer.tainted);
+    assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint8/s2n_stuffer_read_uint8_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint8/s2n_stuffer_read_uint8_harness.c
@@ -28,27 +28,20 @@ void s2n_stuffer_read_uint8_harness() {
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
 
     struct s2n_stuffer old_stuffer = *stuffer;
-    uint8_t dest;
+    uint8_t *dest = can_fail_malloc(sizeof(uint8_t*));
 
     /* Store a byte from the stuffer to compare after the read. */
     struct store_byte_from_buffer old_byte_from_stuffer;
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
-    if (s2n_stuffer_read_uint8(stuffer, &dest) == S2N_SUCCESS) {
+    if (s2n_stuffer_read_uint8(stuffer, dest) == S2N_SUCCESS) {
         assert(stuffer->read_cursor == old_stuffer.read_cursor + sizeof(uint8_t));
         /* If successful, ensure uint was assembled correctly from stuffer */
-        assert(stuffer->blob.data[old_stuffer.read_cursor] == dest);
+        assert(stuffer->blob.data[old_stuffer.read_cursor] == *dest);
     } else {
         assert(stuffer->read_cursor == old_stuffer.read_cursor);
     }
 
-    assert(stuffer->blob.data == old_stuffer.blob.data);
-    assert(stuffer->blob.size == old_stuffer.blob.size);
-    assert(stuffer->write_cursor == old_stuffer.write_cursor);
-    assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
-    assert(stuffer->alloced == old_stuffer.alloced);
-    assert(stuffer->growable == old_stuffer.growable);
-    assert(stuffer->tainted == old_stuffer.tainted);
-    assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+    assert_stuffer_immutable_fields_after_read(stuffer, &old_stuffer, &old_byte_from_stuffer);
     assert(s2n_stuffer_is_valid(stuffer));
 }

--- a/tests/cbmc/source/cbmc_utils.c
+++ b/tests/cbmc/source/cbmc_utils.c
@@ -19,7 +19,7 @@
 
 void assert_stuffer_immutable_fields_after_read(const struct s2n_stuffer *lhs,
                                                 const struct s2n_stuffer *rhs,
-                                                const struct store_byte_from_buffer *rhs_byte) {
+                                                const struct store_byte_from_buffer *stored_byte_from_rhs) {
     /* In order to be equivalent, either both are NULL or both are non-NULL */
     if (lhs == rhs) {
         return;
@@ -31,12 +31,12 @@ void assert_stuffer_immutable_fields_after_read(const struct s2n_stuffer *lhs,
     assert(lhs->alloced == rhs->alloced);
     assert(lhs->growable == rhs->growable);
     assert(lhs->tainted == rhs->tainted);
-    assert_blob_equivalence(&lhs->blob, &rhs->blob, rhs_byte);
+    assert_blob_equivalence(&lhs->blob, &rhs->blob, stored_byte_from_rhs);
 }
 
 void assert_blob_equivalence(const struct s2n_blob *lhs,
                              const struct s2n_blob *rhs,
-                             const struct store_byte_from_buffer *rhs_byte) {
+                             const struct store_byte_from_buffer *stored_byte_from_rhs) {
     /* In order to be equivalent, either both are NULL or both are non-NULL */
     if (lhs == rhs) {
         return;
@@ -47,13 +47,13 @@ void assert_blob_equivalence(const struct s2n_blob *lhs,
     assert(lhs->allocated == rhs->allocated);
     assert(lhs->growable == rhs->growable);
     if (lhs->size > 0) {
-        assert_byte_from_blob_matches(lhs, rhs_byte);
+        assert_byte_from_blob_matches(lhs, stored_byte_from_rhs);
     }
 }
 
 void assert_stuffer_equivalence(const struct s2n_stuffer *lhs,
                                 const struct s2n_stuffer *rhs,
-                                const struct store_byte_from_buffer *rhs_byte) {
+                                const struct store_byte_from_buffer *stored_byte_from_rhs) {
     /* In order to be equivalent, either both are NULL or both are non-NULL */
     if (lhs == rhs) {
         return;
@@ -66,7 +66,7 @@ void assert_stuffer_equivalence(const struct s2n_stuffer *lhs,
     assert(lhs->alloced == rhs->alloced);
     assert(lhs->growable == rhs->growable);
     assert(lhs->tainted == rhs->tainted);
-    assert_blob_equivalence(&lhs->blob, &rhs->blob, rhs_byte);
+    assert_blob_equivalence(&lhs->blob, &rhs->blob, stored_byte_from_rhs);
 }
 
 void assert_bytes_match(const uint8_t *const a, const uint8_t *const b, const size_t len) {
@@ -98,7 +98,7 @@ void assert_byte_from_buffer_matches(const uint8_t *const buffer, const struct s
 
 void assert_byte_from_blob_matches(const struct s2n_blob *blob, const struct store_byte_from_buffer *const b) {
     if(blob && blob->size) {
-	assert_byte_from_buffer_matches(blob->data, b);
+        assert_byte_from_buffer_matches(blob->data, b);
     }
 }
 

--- a/tests/cbmc/source/cbmc_utils.c
+++ b/tests/cbmc/source/cbmc_utils.c
@@ -14,7 +14,60 @@
  */
 
 #include <assert.h>
+
 #include <cbmc_proof/cbmc_utils.h>
+
+void assert_stuffer_immutable_fields_after_read(const struct s2n_stuffer *lhs,
+                                                const struct s2n_stuffer *rhs,
+                                                const struct store_byte_from_buffer *rhs_byte) {
+    /* In order to be equivalent, either both are NULL or both are non-NULL */
+    if (lhs == rhs) {
+        return;
+    } else {
+        assert(lhs && rhs);
+    }
+    assert(lhs->write_cursor == rhs->write_cursor);
+    assert(lhs->high_water_mark == rhs->high_water_mark);
+    assert(lhs->alloced == rhs->alloced);
+    assert(lhs->growable == rhs->growable);
+    assert(lhs->tainted == rhs->tainted);
+    assert_blob_equivalence(&lhs->blob, &rhs->blob, rhs_byte);
+}
+
+void assert_blob_equivalence(const struct s2n_blob *lhs,
+                             const struct s2n_blob *rhs,
+                             const struct store_byte_from_buffer *rhs_byte) {
+    /* In order to be equivalent, either both are NULL or both are non-NULL */
+    if (lhs == rhs) {
+        return;
+    } else {
+        assert(lhs && rhs);
+    }
+    assert(lhs->size == rhs->size);
+    assert(lhs->allocated == rhs->allocated);
+    assert(lhs->growable == rhs->growable);
+    if (lhs->size > 0) {
+        assert_byte_from_blob_matches(lhs, rhs_byte);
+    }
+}
+
+void assert_stuffer_equivalence(const struct s2n_stuffer *lhs,
+                                const struct s2n_stuffer *rhs,
+                                const struct store_byte_from_buffer *rhs_byte) {
+    /* In order to be equivalent, either both are NULL or both are non-NULL */
+    if (lhs == rhs) {
+        return;
+    } else {
+        assert(lhs && rhs);
+    }
+    assert(lhs->read_cursor == rhs->read_cursor);
+    assert(lhs->write_cursor == rhs->write_cursor);
+    assert(lhs->high_water_mark == rhs->high_water_mark);
+    assert(lhs->alloced == rhs->alloced);
+    assert(lhs->growable == rhs->growable);
+    assert(lhs->tainted == rhs->tainted);
+    assert_blob_equivalence(&lhs->blob, &rhs->blob, rhs_byte);
+}
 
 void assert_bytes_match(const uint8_t *const a, const uint8_t *const b, const size_t len) {
     assert(!a == !b);


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A.

### Description of changes: 

- Adds a proof harness for the `s2n_stuffer_read_uint*` functions;
- Adds a pre- and post-conditions to the `s2n_stuffer_read_uint*` functions;
- Adds new equivalence functions for CBMC proofs.

### Call-outs:

This PR overrides [PR #1867](https://github.com/awslabs/s2n/pull/1867).

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.