### PR TITLE
Allow the S2N_NO_PQ environment variable to set the correct build flag.

### DIFF
--- a/s2n.mk
+++ b/s2n.mk
@@ -79,6 +79,11 @@ ifdef S2N_TEST_IN_FIPS_MODE
     DEFAULT_CFLAGS += -DS2N_TEST_IN_FIPS_MODE
 endif
 
+# Don't compile PQ related source code
+ifdef S2N_NO_PQ
+	DEFAULT_CFLAGS += -DS2N_NO_PQ
+endif
+
 # Force the usage of generic C code for PQ crypto, even if the optimized assembly could be used
 ifdef S2N_NO_PQ_ASM
 	DEFAULT_CFLAGS += -DS2N_NO_PQ_ASM

--- a/tests/integration/Makefile
+++ b/tests/integration/Makefile
@@ -28,8 +28,12 @@ ifeq ($(S2N_CORKED_IO),true)
 	HANDSHAKE_TEST_PARAMS:=--use_corked_io $(HANDSHAKE_TEST_PARAMS)
 endif
 
-.PHONY : all
+.PHONY : al
+ifdef S2N_NO_PQ
+all: tls13 client_endpoints dynamic_record old_s_client s_client s_server gnutls_cli gnutls_serv sslyze
+else
 all: tls13 client_endpoints dynamic_record old_s_client s_client s_server gnutls_cli gnutls_serv sslyze pq_handshake
+endif
 
 tls13:
 	( \

--- a/tests/integration/Makefile
+++ b/tests/integration/Makefile
@@ -28,7 +28,7 @@ ifeq ($(S2N_CORKED_IO),true)
 	HANDSHAKE_TEST_PARAMS:=--use_corked_io $(HANDSHAKE_TEST_PARAMS)
 endif
 
-.PHONY : al
+.PHONY : all
 ifdef S2N_NO_PQ
 all: tls13 client_endpoints dynamic_record old_s_client s_client s_server gnutls_cli gnutls_serv sslyze
 else

--- a/tests/integration/s2n_client_endpoint_handshake_test.py
+++ b/tests/integration/s2n_client_endpoint_handshake_test.py
@@ -36,9 +36,25 @@ well_known_endpoints = [
     {"endpoint": "twitter.com"},
     {"endpoint": "wikipedia.org"},
     {"endpoint": "yahoo.com"},
-    {"endpoint": "kms.us-east-1.amazonaws.com", "cipher_preference_version": "KMS-PQ-TLS-1-0-2019-06", "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384"},
-    {"endpoint": "kms.us-east-1.amazonaws.com", "cipher_preference_version": "PQ-SIKE-TEST-TLS-1-0-2019-11", "expected_cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384"}
 ]
+
+if os.getenv("S2N_NO_PQ") is None:
+    # If PQ was compiled into S2N, test the PQ preferences against KMS
+    pq_endpoints = [
+        {
+            "endpoint": "kms.us-east-1.amazonaws.com",
+            "cipher_preference_version": "KMS-PQ-TLS-1-0-2019-06",
+            "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384"
+        },
+        {
+            "endpoint": "kms.us-east-1.amazonaws.com",
+            "cipher_preference_version": "PQ-SIKE-TEST-TLS-1-0-2019-11",
+            "expected_cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384"
+        }
+    ]
+
+    well_known_endpoints.extend(pq_endpoints)
+
 
 # Make an exception to allow failure (if CI is having issues)
 allowed_endpoints_failures = [

--- a/tests/testlib/s2n_nist_kats.h
+++ b/tests/testlib/s2n_nist_kats.h
@@ -32,7 +32,7 @@
 
 static inline int FindMarker(FILE *infile, const char *marker)
 {
-    char line[MAX_MARKER_LEN];
+    int8_t line[MAX_MARKER_LEN];
     uint32_t i, len;
 
     len = (int)strlen(marker);
@@ -48,7 +48,7 @@ static inline int FindMarker(FILE *infile, const char *marker)
     line[len] = '\0';
 
     while ( 1 ) {
-        if ( !strncmp(line, marker, len) ) {
+        if ( !strncmp((char*)line, marker, len) ) {
             return 0;
         }
 

--- a/tests/unit/s2n_client_extensions_test.c
+++ b/tests/unit/s2n_client_extensions_test.c
@@ -63,6 +63,7 @@ static uint8_t sct_list[] = {
 
 extern message_type_t s2n_conn_get_current_message_type(struct s2n_connection *conn);
 
+#if !defined(S2N_NO_PQ)
 /* Helper function to allow us to easily repeat the PQ extension test for many scenarios.
  * If the KEM negotiation is expected to fail (because of e.g. a client/server extension
  * mismatch), pass in expected_kem_id = -1. The tests should always EXPECT_SUCCESS when
@@ -149,6 +150,7 @@ static int negotiate_kem(const uint8_t client_extensions[], const size_t client_
     
     return 0;
 }
+#endif
 
 int main(int argc, char **argv)
 {

--- a/tests/unit/s2n_kem_test.c
+++ b/tests/unit/s2n_kem_test.c
@@ -33,6 +33,8 @@ const uint8_t TEST_SHARED_SECRET[] = { 4, 4, 4, 4 };
 #define TEST_CIPHERTEXT_LENGTH 5
 const uint8_t TEST_CIPHERTEXT[] = { 5, 5, 5, 5, 5 };
 
+#if !defined(S2N_NO_PQ)
+
 static const uint8_t bike_iana[S2N_TLS_CIPHER_SUITE_LEN] = { TLS_ECDHE_BIKE_RSA_WITH_AES_256_GCM_SHA384 };
 static const uint8_t sike_iana[S2N_TLS_CIPHER_SUITE_LEN] = { TLS_ECDHE_SIKE_RSA_WITH_AES_256_GCM_SHA384 };
 static const uint8_t classic_ecdhe_iana[S2N_TLS_CIPHER_SUITE_LEN] = { TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA };
@@ -86,6 +88,8 @@ static int check_client_server_agreed_kem(const uint8_t iana_value[S2N_TLS_CIPHE
 
     return 0;
 }
+
+#endif
 
 int main(int argc, char **argv)
 {

--- a/tests/unit/s2n_kex_with_kem_test.c
+++ b/tests/unit/s2n_kex_with_kem_test.c
@@ -27,6 +27,7 @@
 
 #include "utils/s2n_safety.h"
 
+#if !defined(S2N_NO_PQ)
 static struct s2n_kex s2n_test_kem_kex = {
         .server_key_recv_read_data = &s2n_kem_server_key_recv_read_data,
         .server_key_recv_parse_data = &s2n_kem_server_key_recv_parse_data,
@@ -153,6 +154,7 @@ static int assert_kex_fips_checks(struct s2n_cipher_suite *cipher_suite, const c
 
     return ret_val;
 }
+#endif
 
 int main(int argc, char **argv)
 {

--- a/tls/s2n_kem.c
+++ b/tls/s2n_kem.c
@@ -104,9 +104,15 @@ const struct s2n_iana_to_kem kem_mapping[2] = {
 
 #else
 
-/* Compiler warns that zero-length arrays are undefined according to the C standard. So make kem_mapping NULL if
- * Post Quantum ciphers are disabled, and have s2n_cipher_suite_to_kem() detect NULL and treat it as zero-length. */
-const struct s2n_iana_to_kem *kem_mapping = NULL;
+/* Compiler warns that zero-length arrays are undefined according to the C standard. Instead, a
+   single NULL KEM mapping with a 0 count will be detected and treated as 0 length. */
+const struct s2n_iana_to_kem kem_mapping[1] = {
+        {
+            .iana_value = { TLS_NULL_WITH_NULL_NULL },
+            .kems = NULL,
+            .kem_count = 0,
+        }
+};
 
 #endif
 
@@ -243,7 +249,7 @@ int s2n_kem_free(struct s2n_kem_params *kem_params)
 int s2n_cipher_suite_to_kem(const uint8_t iana_value[S2N_TLS_CIPHER_SUITE_LEN], const struct s2n_iana_to_kem **compatible_params)
 {
     /* cppcheck-suppress knownConditionTrueFalse */
-    S2N_ERROR_IF(kem_mapping == NULL, S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+    S2N_ERROR_IF(kem_mapping[0].kem_count == 0, S2N_ERR_KEM_UNSUPPORTED_PARAMS);
 
     for (int i = 0; i < s2n_array_len(kem_mapping); i++) {
         const struct s2n_iana_to_kem *candidate = &kem_mapping[i];
@@ -257,7 +263,7 @@ int s2n_cipher_suite_to_kem(const uint8_t iana_value[S2N_TLS_CIPHER_SUITE_LEN], 
 
 int s2n_get_kem_from_extension_id(kem_extension_size kem_id, const struct s2n_kem **kem) {
     /* cppcheck-suppress knownConditionTrueFalse */
-    S2N_ERROR_IF(kem_mapping == NULL, S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+    S2N_ERROR_IF(kem_mapping[0].kem_count == 0, S2N_ERR_KEM_UNSUPPORTED_PARAMS);
 
     for (int i = 0; i < s2n_array_len(kem_mapping); i++) {
         const struct s2n_iana_to_kem *iana_to_kem = &kem_mapping[i];

--- a/tls/s2n_kem.c
+++ b/tls/s2n_kem.c
@@ -249,7 +249,7 @@ int s2n_kem_free(struct s2n_kem_params *kem_params)
 int s2n_cipher_suite_to_kem(const uint8_t iana_value[S2N_TLS_CIPHER_SUITE_LEN], const struct s2n_iana_to_kem **compatible_params)
 {
     /* cppcheck-suppress knownConditionTrueFalse */
-    S2N_ERROR_IF(kem_mapping[0].kem_count == 0, S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+    ENSURE_POSIX(kem_mapping[0].kem_count > 0, S2N_ERR_KEM_UNSUPPORTED_PARAMS);
 
     for (int i = 0; i < s2n_array_len(kem_mapping); i++) {
         const struct s2n_iana_to_kem *candidate = &kem_mapping[i];
@@ -263,7 +263,7 @@ int s2n_cipher_suite_to_kem(const uint8_t iana_value[S2N_TLS_CIPHER_SUITE_LEN], 
 
 int s2n_get_kem_from_extension_id(kem_extension_size kem_id, const struct s2n_kem **kem) {
     /* cppcheck-suppress knownConditionTrueFalse */
-    S2N_ERROR_IF(kem_mapping[0].kem_count == 0, S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+    ENSURE_POSIX(kem_mapping[0].kem_count > 0, S2N_ERR_KEM_UNSUPPORTED_PARAMS);
 
     for (int i = 0; i < s2n_array_len(kem_mapping); i++) {
         const struct s2n_iana_to_kem *iana_to_kem = &kem_mapping[i];


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

 resolves #1904, resolves #1882 

### Description of changes: 

Update the Make system to detect the S2N_NO_PQ env variable and set the build
flag appropriately.

Update integration tests to take this flag into account.

Fix a couple bugs which broke the build when the S2N_NO_PQ flag was passed.

### Call-outs:

There is an open issue to use a runtime call to determine if PQ is available (similar to FIPS). This was not added here due to existing functions and structures that are conditionally compiled. A runtime check would require us to always build PQ code, which may be an unexpected change for customers.

We switched from `char` to `int8_t` in `tests/testlib/s2n_nist_kats.h`. EOF is negative, so an unsigned type isn't the correct way to check for the condition. This was not noticed in our normal builds, but failed in ARM builds causing a timeout.

### Testing:


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
