### PR TITLE
Adds proof harnesses for the s2n_stuffer module

### DIFF
--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -109,18 +109,21 @@ int s2n_stuffer_resize_if_empty(struct s2n_stuffer *stuffer, const uint32_t size
 
 int s2n_stuffer_rewrite(struct s2n_stuffer *stuffer)
 {
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     stuffer->write_cursor = 0;
     stuffer->read_cursor = 0;
-
+    POSTCONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     return S2N_SUCCESS;
 }
 
 int s2n_stuffer_rewind_read(struct s2n_stuffer *stuffer, const uint32_t size)
 {
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     if(stuffer->read_cursor < size){
         S2N_ERROR(S2N_ERR_STUFFER_OUT_OF_DATA);
     }
     stuffer->read_cursor -= size;
+    POSTCONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     return S2N_SUCCESS;
 }
 
@@ -238,9 +241,11 @@ int s2n_stuffer_erase_and_read_bytes(struct s2n_stuffer *stuffer, uint8_t * data
 
 int s2n_stuffer_skip_write(struct s2n_stuffer *stuffer, const uint32_t n)
 {
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     GUARD(s2n_stuffer_reserve_space(stuffer, n));
     stuffer->write_cursor += n;
     stuffer->high_water_mark = MAX(stuffer->write_cursor, stuffer->high_water_mark);
+    POSTCONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     return S2N_SUCCESS;
 }
 
@@ -255,22 +260,28 @@ void *s2n_stuffer_raw_write(struct s2n_stuffer *stuffer, const uint32_t data_len
 
 int s2n_stuffer_write(struct s2n_stuffer *stuffer, const struct s2n_blob *in)
 {
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
+    PRECONDITION_POSIX(s2n_blob_is_valid(in));
     return s2n_stuffer_write_bytes(stuffer, in->data, in->size);
 }
 
 int s2n_stuffer_write_bytes(struct s2n_stuffer *stuffer, const uint8_t * data, const uint32_t size)
 {
+    PRECONDITION_POSIX(S2N_MEM_IS_READABLE(data, size));
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     GUARD(s2n_stuffer_skip_write(stuffer, size));
 
     void *ptr = stuffer->blob.data + stuffer->write_cursor - size;
     notnull_check(ptr);
 
     if (ptr == data) {
+        POSTCONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
         return S2N_SUCCESS;
     }
 
     memcpy_check(ptr, data, size);
 
+    POSTCONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     return S2N_SUCCESS;
 }
 

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -119,9 +119,7 @@ int s2n_stuffer_rewrite(struct s2n_stuffer *stuffer)
 int s2n_stuffer_rewind_read(struct s2n_stuffer *stuffer, const uint32_t size)
 {
     PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
-    if(stuffer->read_cursor < size){
-        S2N_ERROR(S2N_ERR_STUFFER_OUT_OF_DATA);
-    }
+    ENSURE_POSIX(stuffer->read_cursor >= size, S2N_ERR_STUFFER_OUT_OF_DATA);
     stuffer->read_cursor -= size;
     POSTCONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     return S2N_SUCCESS;

--- a/stuffer/s2n_stuffer_text.c
+++ b/stuffer/s2n_stuffer_text.c
@@ -23,9 +23,10 @@
 int s2n_stuffer_peek_char(struct s2n_stuffer *s2n_stuffer, char *c)
 {
     int r = s2n_stuffer_read_uint8(s2n_stuffer, (uint8_t *) c);
-    if (r == 0) {
+    if (r == S2N_SUCCESS) {
         s2n_stuffer->read_cursor--;
     }
+    POSTCONDITION_POSIX(s2n_stuffer_is_valid(s2n_stuffer));
     return r;
 }
 

--- a/tests/cbmc/proofs/s2n_stuffer_free/s2n_stuffer_free_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_free/s2n_stuffer_free_harness.c
@@ -21,13 +21,6 @@
 #include <cbmc_proof/cbmc_utils.h>
 
 void s2n_calculate_stacktrace() {}
-int munlock(const void *addr, size_t len) {
-    int rval;
-
-    assert(__CPROVER_r_ok(addr, len));
-
-    return rval;
-}
 
 void s2n_stuffer_free_harness() {
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();

--- a/tests/cbmc/proofs/s2n_stuffer_peek_char/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_peek_char/Makefile
@@ -1,0 +1,31 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
+
+ENTRY = s2n_stuffer_peek_char_harness
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_peek_char/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_peek_char/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwind;1;--object-bits;8"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_peek_char_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_peek_char/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_peek_char/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwind;1;--object-bits;8"
-expected: "SUCCESSFUL"
-goto: gotos/s2n_stuffer_peek_char_harness.goto
-jobos: ubuntu16
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_peek_char/s2n_stuffer_peek_char_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_peek_char/s2n_stuffer_peek_char_harness.c
@@ -24,30 +24,23 @@
 #include <cbmc_proof/proof_allocators.h>
 
 void s2n_stuffer_peek_char_harness() {
+    /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
-
-    struct s2n_stuffer old_stuffer = *stuffer;
     uint8_t dest;
 
     /* Store a byte from the stuffer to compare after the read */
+    struct s2n_stuffer old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte_from_stuffer;
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
+    /* Operation under verification. */
     if (s2n_stuffer_peek_char(stuffer, &dest) == S2N_SUCCESS) {
         /* If successful, ensure uint was assembled correctly from stuffer */
         assert(stuffer->blob.data[old_stuffer.read_cursor] == dest);
+        assert_stuffer_immutable_fields_after_read(stuffer, &old_stuffer, &old_byte_from_stuffer);
+    } else {
+        assert_stuffer_equivalence(stuffer, &old_stuffer, &old_byte_from_stuffer);
     }
-
-    assert(stuffer->read_cursor == old_stuffer.read_cursor);
-    assert(stuffer->write_cursor == old_stuffer.write_cursor);
-    assert(stuffer->blob.data == old_stuffer.blob.data);
-    assert(stuffer->blob.size == old_stuffer.blob.size);
-    assert(stuffer->write_cursor == old_stuffer.write_cursor);
-    assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
-    assert(stuffer->alloced == old_stuffer.alloced);
-    assert(stuffer->growable == old_stuffer.growable);
-    assert(stuffer->tainted == old_stuffer.tainted);
-    assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
     assert(s2n_stuffer_is_valid(stuffer));
 }

--- a/tests/cbmc/proofs/s2n_stuffer_peek_char/s2n_stuffer_peek_char_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_peek_char/s2n_stuffer_peek_char_harness.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_peek_char_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+
+    struct s2n_stuffer old_stuffer = *stuffer;
+    uint8_t dest;
+
+    /* Store a byte from the stuffer to compare after the read */
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    if (s2n_stuffer_peek_char(stuffer, &dest) == S2N_SUCCESS) {
+        /* If successful, ensure uint was assembled correctly from stuffer */
+        assert(stuffer->blob.data[old_stuffer.read_cursor] == dest);
+    }
+
+    assert(stuffer->read_cursor == old_stuffer.read_cursor);
+    assert(stuffer->write_cursor == old_stuffer.write_cursor);
+    assert(stuffer->blob.data == old_stuffer.blob.data);
+    assert(stuffer->blob.size == old_stuffer.blob.size);
+    assert(stuffer->write_cursor == old_stuffer.write_cursor);
+    assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+    assert(stuffer->alloced == old_stuffer.alloced);
+    assert(stuffer->growable == old_stuffer.growable);
+    assert(stuffer->tainted == old_stuffer.tainted);
+    assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_raw_write/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_raw_write/Makefile
@@ -1,0 +1,36 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 30 seconds.
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+
+ENTRY = s2n_stuffer_raw_write_harness
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_blob_slice
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_stuffer_wipe_n
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_raw_write/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_raw_write/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwind;1;--object-bits;8"
-expected: "SUCCESSFUL"
-goto: gotos/s2n_stuffer_raw_write_harness.goto
-jobos: ubuntu16
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_raw_write/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_raw_write/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwind;1;--object-bits;8"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_raw_write_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_raw_write/s2n_stuffer_raw_write_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_raw_write/s2n_stuffer_raw_write_harness.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <sys/param.h>
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_raw_write_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    uint32_t data_len;
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct store_byte_from_buffer old_byte_from_stuffer;
+
+    /* Store a byte from the stuffer to compare */
+    if (stuffer->blob.size > 0) {
+        save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+    }
+
+    /* Operation under verification. */
+    void *retval = s2n_stuffer_raw_write(stuffer, data_len);
+
+    if (retval != NULL) {
+        assert(stuffer->write_cursor == old_stuffer.write_cursor + data_len);
+        assert(retval == stuffer->blob.data + old_stuffer.write_cursor);
+        assert(stuffer->high_water_mark == MAX(old_stuffer.write_cursor + data_len, old_stuffer.high_water_mark));
+        assert(stuffer->tainted == 1);
+        if(old_stuffer.blob.size > 0) {
+            assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+        }
+        assert(s2n_stuffer_is_valid(stuffer));
+    } else {
+        assert(stuffer->write_cursor == old_stuffer.write_cursor);
+        assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+    }
+}

--- a/tests/cbmc/proofs/s2n_stuffer_raw_write/s2n_stuffer_raw_write_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_raw_write/s2n_stuffer_raw_write_harness.c
@@ -24,6 +24,7 @@
 #include <cbmc_proof/proof_allocators.h>
 
 void s2n_stuffer_raw_write_harness() {
+    /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
     uint32_t data_len;
@@ -33,13 +34,11 @@ void s2n_stuffer_raw_write_harness() {
         s2n_mem_init();
     }
 
+    /* Save previous state from stuffer. */
     struct s2n_stuffer old_stuffer = *stuffer;
+    /* Store a byte from the stuffer to compare. */
     struct store_byte_from_buffer old_byte_from_stuffer;
-
-    /* Store a byte from the stuffer to compare */
-    if (stuffer->blob.size > 0) {
-        save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
-    }
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
     /* Operation under verification. */
     void *retval = s2n_stuffer_raw_write(stuffer, data_len);

--- a/tests/cbmc/proofs/s2n_stuffer_resize_if_empty/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_resize_if_empty/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
-expected: "SUCCESSFUL"
-goto: gotos/s2n_stuffer_resize_if_empty_harness.goto
-jobos: ubuntu16
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_rewind_read/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_rewind_read/Makefile
@@ -1,0 +1,28 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+
+ENTRY = s2n_stuffer_rewind_read_harness
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_rewind_read/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_rewind_read/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwind;1;--object-bits;8"
-expected: "SUCCESSFUL"
-goto: gotos/s2n_stuffer_rewind_read_harness.goto
-jobos: ubuntu16
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_rewind_read/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_rewind_read/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwind;1;--object-bits;8"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_rewind_read_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_rewind_read/s2n_stuffer_rewind_read_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_rewind_read/s2n_stuffer_rewind_read_harness.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_rewind_read_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    uint32_t size;
+
+    struct s2n_stuffer old_stuffer = *stuffer;
+
+    /* Store a byte from the stuffer to compare after the read */
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    if(s2n_stuffer_rewind_read(stuffer, size) == S2N_SUCCESS) {
+        assert(old_stuffer.read_cursor >= size);
+        assert(stuffer->read_cursor == old_stuffer.read_cursor - size);
+    }
+    else {
+        assert(old_stuffer.read_cursor < size);
+        assert(stuffer->read_cursor == old_stuffer.read_cursor);
+    }
+
+    assert(stuffer->blob.data == old_stuffer.blob.data);
+    assert(stuffer->blob.size == old_stuffer.blob.size);
+    assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+    assert(stuffer->alloced == old_stuffer.alloced);
+    assert(stuffer->growable == old_stuffer.growable);
+    assert(stuffer->tainted == old_stuffer.tainted);
+    assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_rewind_read/s2n_stuffer_rewind_read_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_rewind_read/s2n_stuffer_rewind_read_harness.c
@@ -24,16 +24,18 @@
 #include <cbmc_proof/proof_allocators.h>
 
 void s2n_stuffer_rewind_read_harness() {
+    /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
     uint32_t size;
 
+    /* Save previous state from stuffer. */
     struct s2n_stuffer old_stuffer = *stuffer;
-
-    /* Store a byte from the stuffer to compare after the read */
+    /* Store a byte from the stuffer to compare after the read. */
     struct store_byte_from_buffer old_byte_from_stuffer;
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
+    /* Operation under verification. */
     if(s2n_stuffer_rewind_read(stuffer, size) == S2N_SUCCESS) {
         assert(old_stuffer.read_cursor >= size);
         assert(stuffer->read_cursor == old_stuffer.read_cursor - size);
@@ -42,13 +44,6 @@ void s2n_stuffer_rewind_read_harness() {
         assert(old_stuffer.read_cursor < size);
         assert(stuffer->read_cursor == old_stuffer.read_cursor);
     }
-
-    assert(stuffer->blob.data == old_stuffer.blob.data);
-    assert(stuffer->blob.size == old_stuffer.blob.size);
-    assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
-    assert(stuffer->alloced == old_stuffer.alloced);
-    assert(stuffer->growable == old_stuffer.growable);
-    assert(stuffer->tainted == old_stuffer.tainted);
-    assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+    assert_stuffer_immutable_fields_after_read(stuffer, &old_stuffer, &old_byte_from_stuffer);
     assert(s2n_stuffer_is_valid(stuffer));
 }

--- a/tests/cbmc/proofs/s2n_stuffer_rewrite/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_rewrite/Makefile
@@ -1,0 +1,28 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+
+ENTRY = s2n_stuffer_rewrite_harness
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_rewrite/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_rewrite/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwind;1;--object-bits;8"
-expected: "SUCCESSFUL"
-goto: gotos/s2n_stuffer_rewrite_harness.goto
-jobos: ubuntu16
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_rewrite/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_rewrite/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwind;1;--object-bits;8"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_rewrite_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_rewrite/s2n_stuffer_rewrite_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_rewrite/s2n_stuffer_rewrite_harness.c
@@ -24,25 +24,26 @@
 #include <cbmc_proof/proof_allocators.h>
 
 void s2n_stuffer_rewrite_harness() {
+    /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
 
+    /* Save previous state from stuffer. */
     struct s2n_stuffer old_stuffer = *stuffer;
-
     /* Store a byte from the stuffer to compare after the read */
     struct store_byte_from_buffer old_byte_from_stuffer;
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
+    /* Operation under verification. */
     s2n_stuffer_rewrite(stuffer);
 
+    /* Post-conditions. */
     assert(stuffer->write_cursor == 0);
     assert(stuffer->read_cursor == 0);
-    assert(stuffer->blob.data == old_stuffer.blob.data);
-    assert(stuffer->blob.size == old_stuffer.blob.size);
     assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
     assert(stuffer->alloced == old_stuffer.alloced);
     assert(stuffer->growable == old_stuffer.growable);
     assert(stuffer->tainted == old_stuffer.tainted);
-    assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+    assert_blob_equivalence(&stuffer->blob, &old_stuffer.blob, &old_byte_from_stuffer);
     assert(s2n_stuffer_is_valid(stuffer));
 }

--- a/tests/cbmc/proofs/s2n_stuffer_rewrite/s2n_stuffer_rewrite_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_rewrite/s2n_stuffer_rewrite_harness.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_rewrite_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+
+    struct s2n_stuffer old_stuffer = *stuffer;
+
+    /* Store a byte from the stuffer to compare after the read */
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    s2n_stuffer_rewrite(stuffer);
+
+    assert(stuffer->write_cursor == 0);
+    assert(stuffer->read_cursor == 0);
+    assert(stuffer->blob.data == old_stuffer.blob.data);
+    assert(stuffer->blob.size == old_stuffer.blob.size);
+    assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+    assert(stuffer->alloced == old_stuffer.alloced);
+    assert(stuffer->growable == old_stuffer.growable);
+    assert(stuffer->tainted == old_stuffer.tainted);
+    assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_skip_write/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_write/Makefile
@@ -1,0 +1,36 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 20 seconds.
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+
+ENTRY = s2n_stuffer_skip_write_harness
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_blob_slice
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_stuffer_wipe_n
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_skip_write/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_write/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwind;1;--object-bits;8"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_skip_write_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_skip_write/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_write/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwind;1;--object-bits;8"
-expected: "SUCCESSFUL"
-goto: gotos/s2n_stuffer_skip_write_harness.goto
-jobos: ubuntu16
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_skip_write/s2n_stuffer_skip_write_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_write/s2n_stuffer_skip_write_harness.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <sys/param.h>
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_skip_write_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    uint32_t data_len;
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct store_byte_from_buffer old_byte_from_stuffer;
+
+    /* Store a byte from the stuffer to compare */
+    if (stuffer->blob.size > 0) {
+        save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+    }
+
+    /* Operation under verification. */
+    if (s2n_stuffer_skip_write(stuffer, data_len) == S2N_SUCCESS) {
+        assert(stuffer->write_cursor == old_stuffer.write_cursor + data_len);
+        assert(stuffer->high_water_mark == MAX(old_stuffer.write_cursor + data_len, old_stuffer.high_water_mark));
+        if(old_stuffer.blob.size > 0) {
+            assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+        }
+        assert(s2n_stuffer_is_valid(stuffer));
+    } else {
+        assert(stuffer->write_cursor == old_stuffer.write_cursor);
+        assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+    }
+}

--- a/tests/cbmc/proofs/s2n_stuffer_skip_write/s2n_stuffer_skip_write_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_write/s2n_stuffer_skip_write_harness.c
@@ -24,22 +24,21 @@
 #include <cbmc_proof/proof_allocators.h>
 
 void s2n_stuffer_skip_write_harness() {
+    /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
-    uint32_t data_len;
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    uint32_t data_len;
 
     /* Non-deterministically set initialized (in s2n_mem) to true. */
     if(nondet_bool()) {
         s2n_mem_init();
     }
 
+    /* Save previous state from stuffer. */
     struct s2n_stuffer old_stuffer = *stuffer;
-    struct store_byte_from_buffer old_byte_from_stuffer;
-
     /* Store a byte from the stuffer to compare */
-    if (stuffer->blob.size > 0) {
-        save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
-    }
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
     /* Operation under verification. */
     if (s2n_stuffer_skip_write(stuffer, data_len) == S2N_SUCCESS) {

--- a/tests/cbmc/proofs/s2n_stuffer_write/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write/Makefile
@@ -1,0 +1,36 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 20 seconds.
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+
+ENTRY = s2n_stuffer_write_harness
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_blob_slice
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_stuffer_wipe_n
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write/Makefile
@@ -11,7 +11,7 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Expected runtime is 20 seconds.
+# Expected runtime is 2 minutes.
 
 CBMCFLAGS +=
 

--- a/tests/cbmc/proofs/s2n_stuffer_write/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_write/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwind;1;--object-bits;8"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_write_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_write/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_write/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwind;1;--object-bits;8"
-expected: "SUCCESSFUL"
-goto: gotos/s2n_stuffer_write_harness.goto
-jobos: ubuntu16
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_write/s2n_stuffer_write_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write/s2n_stuffer_write_harness.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+#include <sys/param.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_write_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    struct s2n_blob *blob = cbmc_allocate_s2n_blob();
+    __CPROVER_assume(s2n_blob_is_valid(blob));
+    uint32_t index;
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct s2n_blob old_blob = *blob;
+
+/* There should not be any constraints over size, but that leads to an spurious
+ * unsigned overflow in the following assumption; therefore, we ignore this
+ * check here to keep size as non-deterministic as possible.
+ */
+#pragma CPROVER check push
+#pragma CPROVER check disable "unsigned-overflow"
+    /* Store a byte from the stuffer that wont be overwritten to compare if the write succeeds. */
+    __CPROVER_assume(index < stuffer->blob.size && (index < old_stuffer.write_cursor ||
+                                                    index >= old_stuffer.write_cursor + blob->size));
+#pragma CPROVER check pop
+    uint8_t untouched_byte = stuffer->blob.data[index];
+
+    /* Store a byte from the blob to compare. */
+    struct store_byte_from_buffer old_byte_from_blob;
+    save_byte_from_blob(blob, &old_byte_from_blob);
+
+    /* Operation under verification. */
+    if (s2n_stuffer_write(stuffer, blob) == S2N_SUCCESS) {
+        assert(stuffer->write_cursor == old_stuffer.write_cursor + blob->size);
+        assert(stuffer->blob.data[index] == untouched_byte);
+        assert(stuffer->high_water_mark == MAX(old_stuffer.write_cursor + blob->size, old_stuffer.high_water_mark));
+        assert(s2n_stuffer_is_valid(stuffer));
+    } else {
+        assert(stuffer->write_cursor == old_stuffer.write_cursor);
+        assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+    }
+    assert(stuffer->read_cursor == old_stuffer.read_cursor);
+    assert_byte_from_blob_matches(blob, &old_byte_from_blob);
+}

--- a/tests/cbmc/proofs/s2n_stuffer_write/s2n_stuffer_write_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write/s2n_stuffer_write_harness.c
@@ -38,17 +38,13 @@ void s2n_stuffer_write_harness() {
     /* Save previous state from stuffer. */
     struct s2n_stuffer old_stuffer = *stuffer;
 
-/**
- * There should not be any constraints over blob.size, but that leads to an spurious
- * unsigned overflow in the following assumption; therefore, we ignore this
- * check here to keep blob.size as non-deterministic as possible.
- */
-#pragma CPROVER check push
-#pragma CPROVER check disable "unsigned-overflow"
-    __CPROVER_assume(index < stuffer->blob.size && (index < old_stuffer.write_cursor ||
-                                                    index >= old_stuffer.write_cursor + blob->size));
-#pragma CPROVER check pop
     /* Store a byte from the stuffer that wont be overwritten to compare if the write succeeds. */
+    __CPROVER_assume(index < stuffer->blob.size);
+    if(__CPROVER_overflow_plus(old_stuffer.write_cursor, blob->size)) {
+        __CPROVER_assume(index < old_stuffer.write_cursor);
+    } else {
+        __CPROVER_assume(index < old_stuffer.write_cursor || index >= old_stuffer.write_cursor + blob->size);
+    }
     uint8_t untouched_byte = stuffer->blob.data[index];
 
     /* Store a byte from the blob to compare. */

--- a/tests/cbmc/proofs/s2n_stuffer_write_bytes/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_bytes/Makefile
@@ -1,0 +1,36 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 60 seconds.
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+
+ENTRY = s2n_stuffer_write_bytes_harness
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_blob_slice
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_stuffer_wipe_n
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_bytes/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_write_bytes/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwind;1;--object-bits;8"
+expected: "SUCCESSFUL"
+goto: gotos/s2n_stuffer_write_bytes_harness.goto
+jobos: ubuntu16

--- a/tests/cbmc/proofs/s2n_stuffer_write_bytes/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_write_bytes/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwind;1;--object-bits;8"
-expected: "SUCCESSFUL"
-goto: gotos/s2n_stuffer_write_bytes_harness.goto
-jobos: ubuntu16
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_write_bytes/s2n_stuffer_write_bytes_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_bytes/s2n_stuffer_write_bytes_harness.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+#include <sys/param.h>
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_write_bytes_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    uint32_t size;
+    uint8_t *data = can_fail_malloc(size);
+    uint32_t index;
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    struct s2n_stuffer old_stuffer = *stuffer;
+
+/* There should not be any constraints over size, but that leads to an spurious
+ * unsigned overflow in the following assumption; therefore, we ignore this
+ * check here to keep size as non-deterministic as possible.
+ */
+#pragma CPROVER check push
+#pragma CPROVER check disable "unsigned-overflow"
+    /* Store a byte from the stuffer that wont be overwritten to compare if the write succeeds. */
+    __CPROVER_assume(index < stuffer->blob.size && (index < old_stuffer.write_cursor || index >= old_stuffer.write_cursor + size));
+#pragma CPROVER check pop
+    uint8_t untouched_byte = stuffer->blob.data[index];
+
+    if (s2n_stuffer_write_bytes(stuffer, data, size) == S2N_SUCCESS) {
+        assert(stuffer->write_cursor == old_stuffer.write_cursor + size);
+        assert(stuffer->blob.data[index] == untouched_byte);
+        assert(stuffer->high_water_mark == MAX(old_stuffer.write_cursor + size, old_stuffer.high_water_mark));
+        assert(s2n_stuffer_is_valid(stuffer));
+    } else {
+        assert(stuffer->write_cursor == old_stuffer.write_cursor);
+        assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+    }
+    assert(stuffer->read_cursor == old_stuffer.read_cursor);
+}

--- a/tests/cbmc/proofs/s2n_stuffer_write_bytes/s2n_stuffer_write_bytes_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_bytes/s2n_stuffer_write_bytes_harness.c
@@ -39,15 +39,13 @@ void s2n_stuffer_write_bytes_harness() {
     /* Save previous state from stuffer. */
     struct s2n_stuffer old_stuffer = *stuffer;
 
-/* There should not be any constraints over size, but that leads to an spurious
- * unsigned overflow in the following assumption; therefore, we ignore this
- * check here to keep size as non-deterministic as possible.
- */
-#pragma CPROVER check push
-#pragma CPROVER check disable "unsigned-overflow"
-    __CPROVER_assume(index < stuffer->blob.size && (index < old_stuffer.write_cursor || index >= old_stuffer.write_cursor + size));
-#pragma CPROVER check pop
     /* Store a byte from the stuffer that wont be overwritten to compare if the write succeeds. */
+    __CPROVER_assume(index < stuffer->blob.size);
+    if(__CPROVER_overflow_plus(old_stuffer.write_cursor, size)) {
+        __CPROVER_assume(index < old_stuffer.write_cursor);
+    } else {
+        __CPROVER_assume(index < old_stuffer.write_cursor || index >= old_stuffer.write_cursor + size);
+    }
     uint8_t untouched_byte = stuffer->blob.data[index];
 
     /* Operation under verification. */

--- a/tests/testlib/s2n_hybrid_kem_tests.c
+++ b/tests/testlib/s2n_hybrid_kem_tests.c
@@ -90,8 +90,7 @@ int s2n_test_hybrid_ecdhe_kem_with_kat(const struct s2n_kem *kem, struct s2n_cip
     GUARD(s2n_stuffer_alloc(&certificate_out, S2N_MAX_TEST_PEM_SIZE));
 
     struct s2n_blob temp_blob;
-    temp_blob.data = (uint8_t *) client_chain;
-    temp_blob.size = strlen(client_chain) + 1;
+    GUARD(s2n_blob_init(&temp_blob, (uint8_t *) client_chain, strlen(client_chain) + 1));
     GUARD(s2n_stuffer_write(&certificate_in, &temp_blob));
     GUARD(s2n_stuffer_certificate_from_pem(&certificate_in, &certificate_out));
 

--- a/tests/testlib/s2n_hybrid_kem_tests.c
+++ b/tests/testlib/s2n_hybrid_kem_tests.c
@@ -54,20 +54,20 @@ int s2n_test_hybrid_ecdhe_kem_with_kat(const struct s2n_kem *kem, struct s2n_cip
     S2N_ERROR_IF(s2n_is_in_fips_mode(), S2N_ERR_PQ_KEMS_DISALLOWED_IN_FIPS);
 
     /* Part 1 setup a client and server connection with everything they need for a key exchange */
-    struct s2n_connection *client_conn, *server_conn;
+    struct s2n_connection *client_conn = NULL, *server_conn = NULL;
     GUARD_NONNULL(client_conn = s2n_connection_new(S2N_CLIENT));
     GUARD_NONNULL(server_conn = s2n_connection_new(S2N_SERVER));
 
-    struct s2n_config *server_config, *client_config;
+    struct s2n_config *server_config = NULL, *client_config = NULL;
 
     GUARD_NONNULL(client_config = s2n_config_new());
     GUARD(s2n_config_set_unsafe_for_testing(client_config));
     GUARD(s2n_connection_set_config(client_conn, client_config));
 
     /* Part 1.1 setup server's keypair and the give the client the certificate */
-    char *cert_chain;
-    char *private_key;
-    char *client_chain;
+    char *cert_chain = NULL;
+    char *private_key = NULL;
+    char *client_chain = NULL;
     GUARD_NONNULL(cert_chain = malloc(S2N_MAX_TEST_PEM_SIZE));
     GUARD_NONNULL(private_key = malloc(S2N_MAX_TEST_PEM_SIZE));
     GUARD_NONNULL(client_chain = malloc(S2N_MAX_TEST_PEM_SIZE));
@@ -76,7 +76,7 @@ int s2n_test_hybrid_ecdhe_kem_with_kat(const struct s2n_kem *kem, struct s2n_cip
     GUARD(s2n_read_test_pem(S2N_RSA_2048_PKCS1_KEY, private_key, S2N_MAX_TEST_PEM_SIZE));
     GUARD(s2n_read_test_pem(S2N_RSA_2048_PKCS1_LEAF_CERT, client_chain, S2N_MAX_TEST_PEM_SIZE));
 
-    struct s2n_cert_chain_and_key *chain_and_key;
+    struct s2n_cert_chain_and_key *chain_and_key = NULL;
     GUARD_NONNULL(chain_and_key = s2n_cert_chain_and_key_new());
     GUARD(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain, private_key));
     GUARD(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
@@ -89,14 +89,14 @@ int s2n_test_hybrid_ecdhe_kem_with_kat(const struct s2n_kem *kem, struct s2n_cip
     DEFER_CLEANUP(struct s2n_stuffer certificate_out = {0}, s2n_stuffer_free);
     GUARD(s2n_stuffer_alloc(&certificate_out, S2N_MAX_TEST_PEM_SIZE));
 
-    struct s2n_blob temp_blob;
+    struct s2n_blob temp_blob = {0};
     GUARD(s2n_blob_init(&temp_blob, (uint8_t *) client_chain, strlen(client_chain) + 1));
     GUARD(s2n_stuffer_write(&certificate_in, &temp_blob));
     GUARD(s2n_stuffer_certificate_from_pem(&certificate_in, &certificate_out));
 
     temp_blob.size = s2n_stuffer_data_available(&certificate_out);
     temp_blob.data = s2n_stuffer_raw_read(&certificate_out, temp_blob.size);
-    s2n_pkey_type pkey_type;
+    s2n_pkey_type pkey_type = {0};
     GUARD(s2n_asn1der_to_public_key_and_type(&client_conn->secure.server_public_key, &pkey_type, &temp_blob));
 
     server_conn->handshake_params.our_chain_and_key = chain_and_key;
@@ -124,7 +124,7 @@ int s2n_test_hybrid_ecdhe_kem_with_kat(const struct s2n_kem *kem, struct s2n_cip
 
 #if S2N_LIBCRYPTO_SUPPORTS_CUSTOM_RAND
     /* Part 2.1.1 if we're running in known answer mode check the server's key exchange message matches the expected value */
-    uint8_t *expected_server_key_message;
+    uint8_t *expected_server_key_message = NULL;
     GUARD_NONNULL(expected_server_key_message = malloc(server_key_message_length));
     GUARD(ReadHex(kat_file, expected_server_key_message, server_key_message_length, "expected_server_key_exchange = "));
 
@@ -146,7 +146,7 @@ int s2n_test_hybrid_ecdhe_kem_with_kat(const struct s2n_kem *kem, struct s2n_cip
 
 #if S2N_LIBCRYPTO_SUPPORTS_CUSTOM_RAND
     /* Part 3.1.1 if we're running in known answer mode check the client's key exchange message matches the expected value */
-    uint8_t *expected_client_key_message;
+    uint8_t *expected_client_key_message = NULL;
     GUARD_NONNULL(expected_client_key_message = malloc(client_key_message_length));
     GUARD(ReadHex(kat_file, expected_client_key_message, client_key_message_length, "expected_client_key_exchange = "));
 

--- a/tests/unit/s2n_override_openssl_random_test.c
+++ b/tests/unit/s2n_override_openssl_random_test.c
@@ -89,14 +89,13 @@ int main(int argc, char **argv)
     EXPECT_EQUAL(bytes_used, 0);
 
     /* Parse the DH params */
-    b.data = (uint8_t *) dhparams_pem;
-    b.size = strlen(dhparams_pem) + 1;
+    EXPECT_SUCCESS(s2n_blob_init(&b, (uint8_t *) dhparams_pem, strlen(dhparams_pem) + 1));
     EXPECT_SUCCESS(s2n_stuffer_alloc(&dhparams_in, b.size));
     EXPECT_SUCCESS(s2n_stuffer_alloc(&dhparams_out, b.size));
     EXPECT_SUCCESS(s2n_stuffer_write(&dhparams_in, &b));
     EXPECT_SUCCESS(s2n_stuffer_dhparams_from_pem(&dhparams_in, &dhparams_out));
-    b.size = s2n_stuffer_data_available(&dhparams_out);
-    b.data = s2n_stuffer_raw_read(&dhparams_out, b.size);
+    uint32_t available_size = s2n_stuffer_data_available(&dhparams_out);
+    EXPECT_SUCCESS(s2n_blob_init(&b, s2n_stuffer_raw_read(&dhparams_out, available_size), available_size));
     EXPECT_SUCCESS(s2n_pkcs3_to_dh_params(&dh_params, &b));
 
     EXPECT_SUCCESS(s2n_dh_generate_ephemeral_key(&dh_params));

--- a/tests/unit/s2n_override_openssl_random_test.c
+++ b/tests/unit/s2n_override_openssl_random_test.c
@@ -75,10 +75,10 @@ S2N_RESULT s2n_entropy_generator(struct s2n_blob *blob)
 
 int main(int argc, char **argv)
 {
-    struct s2n_stuffer dhparams_in, dhparams_out;
-    struct s2n_dh_params dh_params;
-    struct s2n_blob b;
-    char *dhparams_pem;
+    struct s2n_stuffer dhparams_in = {0}, dhparams_out = {0};
+    struct s2n_dh_params dh_params = {0};
+    struct s2n_blob b = {0};
+    char *dhparams_pem = NULL;
     uint64_t bytes_used = 0;
 
     BEGIN_TEST();

--- a/tests/unit/s2n_pem_rsa_dhe_test.c
+++ b/tests/unit/s2n_pem_rsa_dhe_test.c
@@ -58,16 +58,15 @@ static uint8_t unmatched_private_key[] =
 
 int main(int argc, char **argv)
 {
-    struct s2n_stuffer certificate_in, certificate_out;
-    struct s2n_stuffer dhparams_in, dhparams_out;
-    struct s2n_stuffer rsa_key_in, rsa_key_out;
-    struct s2n_blob b;
+    struct s2n_stuffer certificate_in, certificate_out = {0};
+    struct s2n_stuffer dhparams_in, dhparams_out = {0};
+    struct s2n_stuffer rsa_key_in, rsa_key_out = {0};
+    struct s2n_blob b = {0};
     char *leaf_cert_pem;
     char *cert_chain_pem;
     char *private_key_pem;
     char *dhparams_pem;
     struct s2n_cert_chain_and_key *chain_and_key;
-    uint32_t available_size;
 
     BEGIN_TEST();
 
@@ -102,10 +101,11 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_stuffer_private_key_from_pem(&rsa_key_in, &rsa_key_out));
     EXPECT_SUCCESS(s2n_stuffer_dhparams_from_pem(&dhparams_in, &dhparams_out));
 
-    struct s2n_pkey priv_key;
-    struct s2n_pkey pub_key;
-    s2n_pkey_type pkey_type;
+    struct s2n_pkey priv_key = {0};
+    struct s2n_pkey pub_key = {0};
+    s2n_pkey_type pkey_type = {0};
 
+    uint32_t available_size = 0;
     available_size = s2n_stuffer_data_available(&certificate_out);
     EXPECT_SUCCESS(s2n_blob_init(&b, s2n_stuffer_raw_read(&certificate_out, available_size), available_size));
     EXPECT_SUCCESS(s2n_asn1der_to_public_key_and_type(&pub_key, &pkey_type, &b));
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
     EXPECT_NOT_NULL(config = s2n_config_new());
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
 
-    struct s2n_dh_params dh_params;
+    struct s2n_dh_params dh_params = {0};
     available_size = s2n_stuffer_data_available(&dhparams_out);
     EXPECT_SUCCESS(s2n_blob_init(&b, s2n_stuffer_raw_read(&dhparams_out, available_size), available_size));
     EXPECT_SUCCESS(s2n_pkcs3_to_dh_params(&dh_params, &b));
@@ -129,8 +129,11 @@ int main(int argc, char **argv)
 
     /* Try signing and verification with RSA */
     uint8_t inputpad[] = "Hello world!";
-    struct s2n_blob signature;
-    struct s2n_hash_state tls10_one, tls10_two, tls12_one, tls12_two;
+    struct s2n_blob signature = {0};
+    struct s2n_hash_state tls10_one = {0};
+    struct s2n_hash_state tls10_two = {0};
+    struct s2n_hash_state tls12_one = {0};
+    struct s2n_hash_state tls12_two = {0};
 
     EXPECT_SUCCESS(s2n_alloc(&signature, s2n_pkey_size(&pub_key)));
 

--- a/tests/unit/s2n_pem_rsa_dhe_test.c
+++ b/tests/unit/s2n_pem_rsa_dhe_test.c
@@ -58,15 +58,15 @@ static uint8_t unmatched_private_key[] =
 
 int main(int argc, char **argv)
 {
-    struct s2n_stuffer certificate_in, certificate_out = {0};
-    struct s2n_stuffer dhparams_in, dhparams_out = {0};
-    struct s2n_stuffer rsa_key_in, rsa_key_out = {0};
+    struct s2n_stuffer certificate_in = {0}, certificate_out = {0};
+    struct s2n_stuffer dhparams_in = {0}, dhparams_out = {0};
+    struct s2n_stuffer rsa_key_in = {0}, rsa_key_out = {0};
     struct s2n_blob b = {0};
-    char *leaf_cert_pem;
-    char *cert_chain_pem;
-    char *private_key_pem;
-    char *dhparams_pem;
-    struct s2n_cert_chain_and_key *chain_and_key;
+    char *leaf_cert_pem = NULL;
+    char *cert_chain_pem = NULL;
+    char *private_key_pem = NULL;
+    char *dhparams_pem = NULL;
+    struct s2n_cert_chain_and_key *chain_and_key = NULL;
 
     BEGIN_TEST();
 
@@ -116,7 +116,7 @@ int main(int argc, char **argv)
 
     EXPECT_SUCCESS(s2n_pkey_match(&pub_key, &priv_key));
 
-    struct s2n_config *config;
+    struct s2n_config *config = NULL;
     EXPECT_NOT_NULL(config = s2n_config_new());
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
 

--- a/tests/unit/s2n_tls13_cert_verify_test.c
+++ b/tests/unit/s2n_tls13_cert_verify_test.c
@@ -86,14 +86,13 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
         EXPECT_SUCCESS(s2n_connection_set_config(verifying_conn, config));
         verifying_conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
 
-        b.data = (uint8_t *) cert_chain_pem;
-        b.size = strlen(cert_chain_pem) + 1;
+        EXPECT_SUCCESS(s2n_blob_init(&b, (uint8_t *) cert_chain_pem, strlen(cert_chain_pem) + 1));
         EXPECT_SUCCESS(s2n_stuffer_write(&certificate_in, &b));
         EXPECT_SUCCESS(s2n_stuffer_certificate_from_pem(&certificate_in, &certificate_out));
 
         /* Extract public key from certificate and set it for verifying connection */
-        b.size = s2n_stuffer_data_available(&certificate_out);
-        b.data = s2n_stuffer_raw_read(&certificate_out, b.size);
+        uint32_t available_size = s2n_stuffer_data_available(&certificate_out);
+        EXPECT_SUCCESS(s2n_blob_init(&b, s2n_stuffer_raw_read(&certificate_out, available_size), available_size));
         if (verifying_conn->mode == S2N_CLIENT) {
             EXPECT_SUCCESS(s2n_asn1der_to_public_key_and_type(&verifying_conn->secure.server_public_key, &pkey_type, &b));
             EXPECT_SUCCESS(s2n_pkey_match(&verifying_conn->secure.server_public_key, sending_conn->handshake_params.our_chain_and_key->private_key));
@@ -165,13 +164,12 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
         verifying_conn->secure.client_cert_sig_scheme = sig_scheme;
         verifying_conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
 
-        b.data = (uint8_t *) cert_chain_pem;
-        b.size = strlen(cert_chain_pem) + 1;
+        EXPECT_SUCCESS(s2n_blob_init(&b, (uint8_t *) cert_chain_pem, strlen(cert_chain_pem) + 1));
         EXPECT_SUCCESS(s2n_stuffer_write(&certificate_in, &b));
         EXPECT_SUCCESS(s2n_stuffer_certificate_from_pem(&certificate_in, &certificate_out));
 
-        b.size = s2n_stuffer_data_available(&certificate_out);
-        b.data = s2n_stuffer_raw_read(&certificate_out, b.size);
+        uint32_t available_size = s2n_stuffer_data_available(&certificate_out);
+        EXPECT_SUCCESS(s2n_blob_init(&b, s2n_stuffer_raw_read(&certificate_out, available_size), available_size));
         if (verifying_conn->mode == S2N_CLIENT) {
             EXPECT_SUCCESS(s2n_asn1der_to_public_key_and_type(&verifying_conn->secure.server_public_key, &pkey_type, &b));
             EXPECT_SUCCESS(s2n_pkey_match(&verifying_conn->secure.server_public_key, verifying_conn->handshake_params.our_chain_and_key->private_key));
@@ -234,13 +232,12 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
         verifying_conn->secure.client_cert_sig_scheme = sig_scheme;
         verifying_conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
 
-        b.data = (uint8_t *) cert_chain_pem;
-        b.size = strlen(cert_chain_pem) + 1;
+        EXPECT_SUCCESS(s2n_blob_init(&b, (uint8_t *) cert_chain_pem, strlen(cert_chain_pem) + 1));
         EXPECT_SUCCESS(s2n_stuffer_write(&certificate_in, &b));
         EXPECT_SUCCESS(s2n_stuffer_certificate_from_pem(&certificate_in, &certificate_out));
 
-        b.size = s2n_stuffer_data_available(&certificate_out);
-        b.data = s2n_stuffer_raw_read(&certificate_out, b.size);
+        uint32_t available_size = s2n_stuffer_data_available(&certificate_out);
+        EXPECT_SUCCESS(s2n_blob_init(&b, s2n_stuffer_raw_read(&certificate_out, available_size), available_size));
         if (verifying_conn->mode == S2N_CLIENT) {
             EXPECT_SUCCESS(s2n_asn1der_to_public_key_and_type(&verifying_conn->secure.server_public_key, &pkey_type, &b));
         } else {
@@ -268,7 +265,7 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
         } else {
             EXPECT_SUCCESS(s2n_pkey_free(&verifying_conn->secure.client_public_key));
         }
-        
+
         free(cert_chain_pem);
         free(private_key_pem);
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(cert_chain));
@@ -305,14 +302,13 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
         verifying_conn->secure.client_cert_sig_scheme = sig_scheme;
         verifying_conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
 
-        b.data = (uint8_t *) cert_chain_pem;
-        b.size = strlen(cert_chain_pem) + 1;
+        EXPECT_SUCCESS(s2n_blob_init(&b, (uint8_t *) cert_chain_pem, strlen(cert_chain_pem) + 1));
         EXPECT_SUCCESS(s2n_stuffer_write(&certificate_in, &b));
 
         EXPECT_SUCCESS(s2n_stuffer_certificate_from_pem(&certificate_in, &certificate_out));
 
-        b.size = s2n_stuffer_data_available(&certificate_out);
-        b.data = s2n_stuffer_raw_read(&certificate_out, b.size);
+        uint32_t available_size = s2n_stuffer_data_available(&certificate_out);
+        EXPECT_SUCCESS(s2n_blob_init(&b, s2n_stuffer_raw_read(&certificate_out, available_size), available_size));
         if (verifying_conn->mode == S2N_CLIENT) {
             EXPECT_SUCCESS(s2n_asn1der_to_public_key_and_type(&verifying_conn->secure.server_public_key, &pkey_type, &b));
         } else {
@@ -329,7 +325,7 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
         /* Reinitialize hash */
         EXPECT_SUCCESS(s2n_hash_init(&verifying_conn->handshake.sha256, S2N_HASH_SHA256));
         EXPECT_SUCCESS(s2n_hash_update(&verifying_conn->handshake.sha256, hello, strlen((char *)hello)));
-        
+
         /* In this case it doesn't matter if we use conn_sig_scheme or client_cert_sig_scheme as they are currently equal */
         verifying_conn->secure.conn_sig_scheme.hash_alg = S2N_HASH_SHA1;
         EXPECT_FAILURE(s2n_tls13_cert_read_and_verify_signature(verifying_conn, &verifying_conn->secure.conn_sig_scheme));

--- a/tests/unit/s2n_tls13_cert_verify_test.c
+++ b/tests/unit/s2n_tls13_cert_verify_test.c
@@ -49,21 +49,21 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
     const char *key_file = test_case->key_file;
     struct s2n_signature_scheme sig_scheme = *test_case->sig_scheme;
 
-    struct s2n_config *config;
+    struct s2n_config *config = NULL;
     EXPECT_NOT_NULL(config = s2n_config_new());
     EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20200207"));
 
     /* Successfully send and receive certificate verify */
     {
         /* Derive private/public keys and set connection variables */
-        struct s2n_stuffer certificate_in, certificate_out;
-        struct s2n_blob b;
-        struct s2n_cert_chain_and_key *cert_chain;
-        char *cert_chain_pem;
-        char *private_key_pem;
-        s2n_pkey_type pkey_type;
+        struct s2n_stuffer certificate_in = {0}, certificate_out = {0};
+        struct s2n_blob b = {0};
+        struct s2n_cert_chain_and_key *cert_chain = NULL;
+        char *cert_chain_pem = NULL;
+        char *private_key_pem = NULL;
+        s2n_pkey_type pkey_type = {0};
 
-        struct s2n_connection *verifying_conn, *sending_conn;
+        struct s2n_connection *verifying_conn = NULL, *sending_conn = NULL;
         EXPECT_NOT_NULL(verifying_conn = s2n_connection_new(verifier_mode));
         EXPECT_NOT_NULL(sending_conn = s2n_connection_new(verifier_mode == S2N_CLIENT ? S2N_SERVER : S2N_CLIENT));
 
@@ -138,13 +138,13 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
     /* Verifying connection errors with incorrect signed content */
     {
         /* Derive private/public keys and set connection variables */
-        struct s2n_stuffer certificate_in, certificate_out;
-        struct s2n_blob b;
-        struct s2n_cert_chain_and_key *cert_chain;
-        char *cert_chain_pem;
-        char *private_key_pem;
-        uint64_t bytes_in_hash;
-        s2n_pkey_type pkey_type;
+        struct s2n_stuffer certificate_in = {0}, certificate_out = {0};
+        struct s2n_blob b = {0};
+        struct s2n_cert_chain_and_key *cert_chain = NULL;
+        char *cert_chain_pem = NULL;
+        char *private_key_pem = NULL;
+        uint64_t bytes_in_hash = 0;
+        s2n_pkey_type pkey_type = {0};
 
         EXPECT_SUCCESS(s2n_stuffer_alloc(&certificate_in, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_stuffer_alloc(&certificate_out, S2N_MAX_TEST_PEM_SIZE));
@@ -155,7 +155,7 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
         EXPECT_SUCCESS(s2n_read_test_pem(key_file, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(cert_chain, cert_chain_pem, private_key_pem));
 
-        struct s2n_connection *verifying_conn;
+        struct s2n_connection *verifying_conn = NULL;
         EXPECT_NOT_NULL(verifying_conn = s2n_connection_new(verifier_mode));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, cert_chain));
         EXPECT_SUCCESS(s2n_connection_set_config(verifying_conn, config));
@@ -207,12 +207,12 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
 
     /* Verifying connection errors with even 1 bit incorrect */
     {
-        struct s2n_stuffer certificate_in, certificate_out;
-        struct s2n_blob b;
-        struct s2n_cert_chain_and_key *cert_chain;
-        char *cert_chain_pem;
-        char *private_key_pem;
-        s2n_pkey_type pkey_type;
+        struct s2n_stuffer certificate_in = {0}, certificate_out = {0};
+        struct s2n_blob b = {0};
+        struct s2n_cert_chain_and_key *cert_chain = NULL;
+        char *cert_chain_pem = NULL;
+        char *private_key_pem = NULL;
+        s2n_pkey_type pkey_type = {0};
 
         EXPECT_SUCCESS(s2n_stuffer_alloc(&certificate_in, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_stuffer_alloc(&certificate_out, S2N_MAX_TEST_PEM_SIZE));
@@ -223,7 +223,7 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
         EXPECT_SUCCESS(s2n_read_test_pem(key_file, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(cert_chain, cert_chain_pem, private_key_pem));
 
-        struct s2n_connection *verifying_conn;
+        struct s2n_connection *verifying_conn = NULL;
         EXPECT_NOT_NULL(verifying_conn = s2n_connection_new(verifier_mode));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, cert_chain));
         EXPECT_SUCCESS(s2n_connection_set_config(verifying_conn, config));
@@ -277,12 +277,12 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
     /* Verifying connection errors with wrong hash/signature algorithms */
     {
         /* Derive private/public keys and set connection variables */
-        struct s2n_stuffer certificate_in, certificate_out;
-        struct s2n_blob b;
-        struct s2n_cert_chain_and_key *cert_chain;
-        char *cert_chain_pem;
-        char *private_key_pem;
-        s2n_pkey_type pkey_type;
+        struct s2n_stuffer certificate_in = {0}, certificate_out = {0};
+        struct s2n_blob b = {0};
+        struct s2n_cert_chain_and_key *cert_chain = NULL;
+        char *cert_chain_pem = NULL;
+        char *private_key_pem = NULL;
+        s2n_pkey_type pkey_type = {0};
 
         EXPECT_SUCCESS(s2n_stuffer_alloc(&certificate_in, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_stuffer_alloc(&certificate_out, S2N_MAX_TEST_PEM_SIZE));
@@ -293,7 +293,7 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
         EXPECT_SUCCESS(s2n_read_test_pem(key_file, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(cert_chain, cert_chain_pem, private_key_pem));
 
-        struct s2n_connection *verifying_conn;
+        struct s2n_connection *verifying_conn = NULL;
         EXPECT_NOT_NULL(verifying_conn = s2n_connection_new(verifier_mode));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, cert_chain));
         EXPECT_SUCCESS(s2n_connection_set_config(verifying_conn, config));

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -89,11 +89,7 @@ static int s2n_mem_malloc_mlock_impl(void **ptr, uint32_t requested, uint32_t *a
     /* Page aligned allocation required for mlock */
     uint32_t allocate;
 
-/* Avoids spurious alarms over signed to unsigned conversion in (uint32_t)page_size. */
-#pragma CPROVER check push
-#pragma CPROVER check disable "conversion"
     GUARD(s2n_align_to(requested, page_size, &allocate));
-#pragma CPROVER check pop
 
     *ptr = NULL;
     S2N_ERROR_IF(posix_memalign(ptr, page_size, allocate) != 0, S2N_ERR_ALLOC);

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -89,7 +89,11 @@ static int s2n_mem_malloc_mlock_impl(void **ptr, uint32_t requested, uint32_t *a
     /* Page aligned allocation required for mlock */
     uint32_t allocate;
 
+/* Avoids spurious alarms over signed to unsigned conversion in (uint32_t)page_size. */
+#pragma CPROVER check push
+#pragma CPROVER check disable "conversion"
     GUARD(s2n_align_to(requested, page_size, &allocate));
+#pragma CPROVER check pop
 
     *ptr = NULL;
     S2N_ERROR_IF(posix_memalign(ptr, page_size, allocate) != 0, S2N_ERR_ALLOC);


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A.

### Description of changes: 

- Adds a proof harness for the `s2n_stuffer_peek_char` function;
- Adds a proof harness for the `s2n_stuffer_raw_write` function;
- Adds a proof harness for the `s2n_stuffer_rewind_read` function;
- Adds a proof harness for the `s2n_stuffer_rewrite` function;
- Adds a proof harness for the `s2n_stuffer_skip_write` function;
- Adds a proof harness for the `s2n_stuffer_write` function;
- Adds a proof harness for the `s2n_stuffer_write_bytes` function;
- Adds a pre- and post-conditions to the `s2n_stuffer` functions mentioned above;

### Call-outs:

This PR overrides [PR #1868](https://github.com/awslabs/s2n/pull/1868) and [PR #1396](https://github.com/awslabs/s2n/pull/1396).

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.