### PR TITLE
Add TEST_DEBUG_PRINT macro for debug info in tests

### DIFF
--- a/s2n.mk
+++ b/s2n.mk
@@ -121,6 +121,11 @@ ifdef S2N_DEBUG
 	CFLAGS += ${DEBUG_CFLAGS}
 endif
 
+# Prints more information when running tests
+ifdef S2N_TEST_DEBUG
+	DEFAULT_CFLAGS += -DS2N_TEST_DEBUG
+endif
+
 LLVM_GCOV_MARKER_FILE=${COVERAGE_DIR}/use-llvm-gcov.tmp
 
 ifeq ($(S2N_UNSAFE_FUZZING_MODE),1)

--- a/tests/s2n_test.h
+++ b/tests/s2n_test.h
@@ -185,3 +185,12 @@ int test_count;
             }                                                                  \
         }                                                                      \
     } while (0)
+
+#if defined(S2N_TEST_DEBUG)
+#define TEST_DEBUG_PRINT(...)                \
+    do {                                     \
+        (void) fprintf(stderr, __VA_ARGS__); \
+    } while (0)
+#else
+#define TEST_DEBUG_PRINT(...)
+#endif

--- a/tests/unit/s2n_mem_usage_test.c
+++ b/tests/unit/s2n_mem_usage_test.c
@@ -173,12 +173,12 @@ int main(int argc, char **argv)
     free(servers);
 
     TEST_DEBUG_PRINT("\n");
-    TEST_DEBUG_PRINT("VmData initial:              %10zu\n", vm_data_initial);
-    TEST_DEBUG_PRINT("VmData after allocations:    %10zu\n", vm_data_after_allocation);
-    TEST_DEBUG_PRINT("VmData after handshakes:     %10zu\n", vm_data_after_handshakes);
-    TEST_DEBUG_PRINT("VmData after free handshake: %10zu\n", vm_data_after_free_handshake);
-    TEST_DEBUG_PRINT("VmData after release:        %10zu\n", vm_data_after_release_buffers);
-    TEST_DEBUG_PRINT("Max VmData diff allowed:     %10zu\n", maxAllowedMemDiff);
+    TEST_DEBUG_PRINT("VmData initial:              %10zd\n", vm_data_initial);
+    TEST_DEBUG_PRINT("VmData after allocations:    %10zd\n", vm_data_after_allocation);
+    TEST_DEBUG_PRINT("VmData after handshakes:     %10zd\n", vm_data_after_handshakes);
+    TEST_DEBUG_PRINT("VmData after free handshake: %10zd\n", vm_data_after_free_handshake);
+    TEST_DEBUG_PRINT("VmData after release:        %10zd\n", vm_data_after_release_buffers);
+    TEST_DEBUG_PRINT("Max VmData diff allowed:     %10zd\n", maxAllowedMemDiff);
     TEST_DEBUG_PRINT("Number of connections used:  %10zu\n", connectionsToUse);
 
     EXPECT_TRUE(vm_data_after_allocation - vm_data_initial < maxAllowedMemDiff);

--- a/tests/unit/s2n_mem_usage_test.c
+++ b/tests/unit/s2n_mem_usage_test.c
@@ -172,16 +172,14 @@ int main(int argc, char **argv)
     free(clients);
     free(servers);
 
-#if 0
-    fprintf(stdout, "\n");
-    fprintf(stdout, "VmData initial:              %10zu\n", vm_data_initial);
-    fprintf(stdout, "VmData after allocations:    %10zu\n", vm_data_after_allocation);
-    fprintf(stdout, "VmData after handshakes:     %10zu\n", vm_data_after_handshakes);
-    fprintf(stdout, "VmData after free handshake: %10zu\n", vm_data_after_free_handshake);
-    fprintf(stdout, "VmData after release:        %10zu\n", vm_data_after_release_buffers);
-    fprintf(stdout, "Max VmData diff allowed:     %10zu\n", maxAllowedMemDiff);
-    fprintf(stdout, "Number of connections used:  %10zu\n", connectionsToUse);
-#endif
+    TEST_DEBUG_PRINT("\n");
+    TEST_DEBUG_PRINT("VmData initial:              %10zu\n", vm_data_initial);
+    TEST_DEBUG_PRINT("VmData after allocations:    %10zu\n", vm_data_after_allocation);
+    TEST_DEBUG_PRINT("VmData after handshakes:     %10zu\n", vm_data_after_handshakes);
+    TEST_DEBUG_PRINT("VmData after free handshake: %10zu\n", vm_data_after_free_handshake);
+    TEST_DEBUG_PRINT("VmData after release:        %10zu\n", vm_data_after_release_buffers);
+    TEST_DEBUG_PRINT("Max VmData diff allowed:     %10zu\n", maxAllowedMemDiff);
+    TEST_DEBUG_PRINT("Number of connections used:  %10zu\n", connectionsToUse);
 
     EXPECT_TRUE(vm_data_after_allocation - vm_data_initial < maxAllowedMemDiff);
     EXPECT_TRUE(vm_data_after_handshakes - vm_data_initial < maxAllowedMemDiff);


### PR DESCRIPTION
### Resolved issues:

One of the feedback from #1969 

### Description of changes: 

Some tests may benefit from additional information when they fail, however most of the time tests pass and this information just clutters the output. As a compromise this change adds a TEST_DEBUG_PRINT macro which prints debug information if S2N_TEST_DEBUG is defined.

### Call-outs:

One possible improvement can be always printing the debug information into some buffer and printing the buffer to console anytime the test fails, but decided to keep this simple for now as we can improve this later if needed.

### Testing:

Updated one of the existing tests which previously used `#if 0`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
