### PR TITLE
Add s2nc no_cert client_auth integration test and fix x509 errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,13 +274,13 @@ if (BUILD_TESTING)
 
     endforeach(test_case)
 
-    add_executable(s2nc "bin/s2nc.c" "bin/echo.c")
+    add_executable(s2nc "bin/s2nc.c" "bin/echo.c" "bin/common.c")
     target_link_libraries(s2nc ${PROJECT_NAME})
     target_include_directories(s2nc PRIVATE $<TARGET_PROPERTY:LibCrypto::Crypto,INTERFACE_INCLUDE_DIRECTORIES>)
     target_include_directories(s2nc PRIVATE api)
     target_compile_options(s2nc PRIVATE -std=gnu99 -D_POSIX_C_SOURCE=200112L)
 
-    add_executable(s2nd "bin/s2nd.c" "bin/echo.c")
+    add_executable(s2nd "bin/s2nd.c" "bin/echo.c" "bin/common.c")
     target_link_libraries(s2nd ${PROJECT_NAME})
     target_include_directories(s2nd PRIVATE $<TARGET_PROPERTY:LibCrypto::Crypto,INTERFACE_INCLUDE_DIRECTORIES>)
     target_include_directories(s2nd PRIVATE api)

--- a/bin/Makefile
+++ b/bin/Makefile
@@ -21,7 +21,7 @@ LDFLAGS += -L../lib/ -L${LIBCRYPTO_ROOT}/lib -ls2n ${LIBS} ${CRYPTO_LIBS}
 CRUFT += s2nc s2nd
 
 s2nc: s2nc.c echo.c
-	${CC} ${CFLAGS} s2nc.c echo.c  -o s2nc ${LDFLAGS}
+	${CC} ${CFLAGS} s2nc.c echo.c common.c -o s2nc ${LDFLAGS}
 
 s2nd: s2nd.c echo.c
-	${CC} ${CFLAGS} s2nd.c echo.c -o s2nd ${LDFLAGS}
+	${CC} ${CFLAGS} s2nd.c echo.c common.c -o s2nd ${LDFLAGS}

--- a/bin/common.c
+++ b/bin/common.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <getopt.h>
+#include <errno.h>
+
+char *load_file_to_cstring(const char *path)
+{
+    FILE *pem_file = fopen(path, "rb");
+    if (!pem_file) {
+       fprintf(stderr, "Failed to open file %s: '%s'\n", path, strerror(errno));
+       return NULL;
+    }
+
+    /* Make sure we can fit the pem into the output buffer */
+    if (fseek(pem_file, 0, SEEK_END) < 0) {
+        fprintf(stderr, "Failed calling fseek: '%s'\n", strerror(errno));
+        fclose(pem_file);
+        return NULL;
+    }
+
+    const long int pem_file_size = ftell(pem_file);
+    if (pem_file_size < 0) {
+        fprintf(stderr, "Failed calling ftell: '%s'\n", strerror(errno));
+        fclose(pem_file);
+        return NULL;
+    }
+
+    rewind(pem_file);
+
+    char *pem_out = malloc(pem_file_size + 1);
+    if (pem_out == NULL) {
+        fprintf(stderr, "Failed allocating memory\n");
+        fclose(pem_file);
+        return NULL;
+    }
+
+    if (fread(pem_out, sizeof(char), pem_file_size, pem_file) < pem_file_size) {
+        fprintf(stderr, "Failed reading file: '%s'\n", strerror(errno));
+        free(pem_out);
+        fclose(pem_file);
+        return NULL;
+    }
+
+    pem_out[pem_file_size] = '\0';
+    fclose(pem_file);
+
+    return pem_out;
+}

--- a/bin/common.h
+++ b/bin/common.h
@@ -1,3 +1,18 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 #pragma once
 
 #define GUARD_EXIT(x, msg)  \
@@ -15,3 +30,6 @@
       return -1;             \
     }                        \
   } while (0)
+
+
+char *load_file_to_cstring(const char *path);

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -67,6 +67,10 @@ void usage()
     fprintf(stderr, "    Directory containing hashed trusted certs. If neither -f or -d are specified. System defaults will be used.\n");
     fprintf(stderr, "  -i,--insecure\n");
     fprintf(stderr, "    Turns off certification validation altogether.\n");
+    fprintf(stderr, "  --cert [file path]\n");
+    fprintf(stderr, "    Path to a PEM encoded certificate. Optional. Will only be used for client auth\n");
+    fprintf(stderr, "  --key [file path]\n");
+    fprintf(stderr, "    Path to a PEM encoded private key that matches cert. Will only be used for client auth\n");
     fprintf(stderr, "  -r,--reconnect\n");
     fprintf(stderr, "    Drop and re-make the connection using Session ticket. If session ticket is disabled, then re-make the connection using Session-ID \n");
     fprintf(stderr, "  -T,--no-session-ticket \n");
@@ -221,6 +225,10 @@ int main(int argc, char *const *argv)
     const char *server_name = NULL;
     const char *ca_file = NULL;
     const char *ca_dir = NULL;
+    const char *client_cert = NULL;
+    const char *client_key = NULL;
+    bool client_cert_input = false;
+    bool client_key_input = false;
     uint16_t mfl_value = 0;
     uint8_t insecure = 0;
     int reconnect = 0;
@@ -247,6 +255,8 @@ int main(int argc, char *const *argv)
         {"mfl", required_argument, 0, 'm'},
         {"ca-file", required_argument, 0, 'f'},
         {"ca-dir", required_argument, 0, 'd'},
+        {"cert", required_argument, 0, 'l'},
+        {"key", required_argument, 0, 'k'},
         {"insecure", no_argument, 0, 'i'},
         {"reconnect", no_argument, 0, 'r'},
         {"no-session-ticket", no_argument, 0, 'T'},
@@ -258,7 +268,7 @@ int main(int argc, char *const *argv)
 
     while (1) {
         int option_index = 0;
-        int c = getopt_long(argc, argv, "a:c:ehn:sf:d:D:t:irTC", long_options, &option_index);
+        int c = getopt_long(argc, argv, "a:c:ehn:sf:d:l:k:D:t:irTC", long_options, &option_index);
         if (c == -1) {
             break;
         }
@@ -292,6 +302,14 @@ int main(int argc, char *const *argv)
             break;
         case 'd':
             ca_dir = optarg;
+            break;
+        case 'l':
+            client_cert = load_file_to_cstring(optarg);
+            client_cert_input = true;
+            break;
+        case 'k':
+            client_key = load_file_to_cstring(optarg);
+            client_key_input = true;
             break;
         case 'i':
             insecure = 1;
@@ -384,6 +402,16 @@ int main(int argc, char *const *argv)
 
         struct s2n_config *config = s2n_config_new();
         setup_s2n_config(config, cipher_prefs, type, &unsafe_verify_data, host, alpn_protocols, mfl_value);
+
+        if (client_cert_input != client_key_input) {
+            print_s2n_error("Client cert/key pair must be given.");
+        }
+
+        if (client_cert_input) {
+            struct s2n_cert_chain_and_key *chain_and_key = s2n_cert_chain_and_key_new();
+            GUARD_EXIT(s2n_cert_chain_and_key_load_pem(chain_and_key, client_cert, client_key), "Error getting certificate/key");
+            GUARD_EXIT(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key), "Error setting certificate/key");
+        }
 
         if (ca_file || ca_dir) {
             if (s2n_config_set_verification_ca_location(config, ca_file, ca_dir) < 0) {

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -235,51 +235,6 @@ extern void print_s2n_error(const char *app_error);
 extern int echo(struct s2n_connection *conn, int sockfd);
 extern int negotiate(struct s2n_connection *conn);
 
-/* Caller is expected to free the memory returned. */
-static char *load_file_to_cstring(const char *path)
-{
-    FILE *pem_file = fopen(path, "rb");
-    if (!pem_file) {
-       fprintf(stderr, "Failed to open file %s: '%s'\n", path, strerror(errno));
-       return NULL;
-    }
-
-    /* Make sure we can fit the pem into the output buffer */
-    if (fseek(pem_file, 0, SEEK_END) < 0) {
-        fprintf(stderr, "Failed calling fseek: '%s'\n", strerror(errno));
-        fclose(pem_file);
-        return NULL;
-    }
-
-    const long int pem_file_size = ftell(pem_file);
-    if (pem_file_size < 0) {
-        fprintf(stderr, "Failed calling ftell: '%s'\n", strerror(errno));
-        fclose(pem_file);
-        return NULL;
-    }
-
-    rewind(pem_file);
-
-    char *pem_out = malloc(pem_file_size + 1);
-    if (pem_out == NULL) {
-        fprintf(stderr, "Failed allocating memory\n");
-        fclose(pem_file);
-        return NULL;
-    }
-
-    if (fread(pem_out, sizeof(char), pem_file_size, pem_file) < pem_file_size) {
-        fprintf(stderr, "Failed reading file: '%s'\n", strerror(errno));
-        free(pem_out);
-        fclose(pem_file);
-        return NULL;
-    }
-
-    pem_out[pem_file_size] = '\0';
-    fclose(pem_file);
-
-    return pem_out;
-}
-
 void usage()
 {
     fprintf(stderr, "usage: s2nd [options] host port\n");

--- a/tests/integrationv2/common.py
+++ b/tests/integrationv2/common.py
@@ -264,6 +264,7 @@ class ProviderOptions(object):
             client_key_file=None,
             client_certificate_file=None,
             extra_flags=None,
+            client_trust_store=None,
             protocol=None):
 
         # Client or server
@@ -302,6 +303,7 @@ class ProviderOptions(object):
         # Parameters to configure client authentication
         self.use_client_auth = use_client_auth
         self.client_certificate_file = client_certificate_file
+        self.client_trust_store = client_trust_store
         self.client_key_file = client_key_file
 
         self.extra_flags = extra_flags

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -119,14 +119,17 @@ class S2N(Provider):
 
         if options.insecure is True:
             cmd_line.append('--insecure')
-        else:
-            if options.cert is not None:
-                cmd_line.extend(['-f', options.cert])
-
+        elif options.client_trust_store is not None:
+            cmd_line.extend(['-f', options.client_trust_store])
         if options.protocol == Protocols.TLS13:
             cmd_line.append('--tls13')
 
         cmd_line.extend(['-c', 'test_all'])
+
+        if options.client_key_file:
+            cmd_line.extend(['--key', options.client_key_file])
+        if options.client_certificate_file:
+            cmd_line.extend(['--cert', options.client_certificate_file])
 
         cmd_line.extend([options.host, options.port])
 
@@ -241,6 +244,8 @@ class OpenSSL(Provider):
         # Additional debugging that will be captured incase of failure
         cmd_line.extend(['-debug', '-tlsextdebug'])
 
+        cmd_line.append('-state')
+
         if options.cert is not None:
             cmd_line.extend(['-cert', options.cert])
         if options.key is not None:
@@ -264,6 +269,8 @@ class OpenSSL(Provider):
 
         if options.curve is not None:
             cmd_line.extend(['-curves', str(options.curve)])
+        if options.use_client_auth is True:
+            cmd_line.extend(['-verify', '1'])
 
         return cmd_line
 

--- a/tests/integrationv2/test_client_authentication.py
+++ b/tests/integrationv2/test_client_authentication.py
@@ -20,9 +20,9 @@ def test_client_auth_with_s2n_server(managed_process, cipher, provider, curve, p
     host = "localhost"
     port = next(available_ports)
 
-    # NOTE: Client Auth is failing for ECDSA client certs
+    # NOTE: Currently do not support different signature schemes for client and server
     if 'ecdsa' in certificate.cert:
-        pytest.skip("Skipping known failure, ECDSA client auth certificate")
+        pytest.skip("Skipping known failure, do not support different sig schemes for client and server")
 
     random_bytes = data_bytes(64)
     client_options = ProviderOptions(
@@ -117,3 +117,105 @@ def test_client_auth_with_s2n_server_using_nonmatching_certs(managed_process, ci
         assert results.exception is None
         assert results.exit_code == 255
         assert b'Error: Mutual Auth was required, but not negotiated' in results.stderr
+
+
+@pytest.mark.uncollect_if(func=invalid_test_parameters)
+@pytest.mark.parametrize("cipher", [cipher for cipher in ALL_TEST_CIPHERS if 'ECDSA' not in cipher.name], ids=get_parameter_name)
+@pytest.mark.parametrize("curve", ALL_TEST_CURVES)
+@pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
+@pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
+def test_client_auth_with_s2n_client_no_cert(managed_process, cipher, curve, protocol, certificate):
+    host = "localhost"
+    port = next(available_ports)
+
+    # NOTE: Currently do not support different signature schemes for client and server
+    if 'ecdsa' in certificate.cert:
+        pytest.skip("Skipping known failure, do not support different sig schemes for client and server")
+
+    random_bytes = data_bytes(64)
+    client_options = ProviderOptions(
+        mode=Provider.ClientMode,
+        host="localhost",
+        port=port,
+        cipher=cipher,
+        curve=curve,
+        data_to_send=random_bytes,
+        use_client_auth=True,
+        client_trust_store= "../pems/rsa_2048_sha256_wildcard_cert.pem",
+        insecure=False,
+        protocol=protocol)
+
+    server_options = copy.copy(client_options)
+    server_options.data_to_send = None
+    server_options.mode = Provider.ServerMode
+    server_options.key = "../pems/rsa_2048_sha256_wildcard_key.pem"
+    server_options.cert = "../pems/rsa_2048_sha256_wildcard_cert.pem"
+
+    # Passing the type of client and server as a parameter will
+    # allow us to use a fixture to enumerate all possibilities.
+    server = managed_process(OpenSSL, server_options, timeout=5)
+    client = managed_process(S2N, client_options, timeout=5)
+
+    # The client should connect and return without error
+    for results in client.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+        
+    # Openssl should indicate the procotol version in a successful connection.
+    for results in server.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+        assert random_bytes in results.stdout
+        assert bytes("SSL_accept:SSLv3/TLS read client certificate\nSSL_accept:SSLv3/TLS read finished".encode('utf-8')) in results.stderr
+
+
+@pytest.mark.uncollect_if(func=invalid_test_parameters)
+@pytest.mark.parametrize("cipher", [cipher for cipher in ALL_TEST_CIPHERS if 'ECDSA' not in cipher.name], ids=get_parameter_name)
+@pytest.mark.parametrize("curve", ALL_TEST_CURVES)
+@pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
+@pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
+def test_client_auth_with_s2n_client_with_cert(managed_process, cipher, curve, protocol, certificate):
+    host = "localhost"
+    port = next(available_ports)
+
+    # NOTE: Currently do not support different signature schemes for client and server
+    if 'ecdsa' in certificate.cert:
+        pytest.skip("Skipping known failure, do not support different sig schemes for client and server")
+
+    random_bytes = data_bytes(64)
+    client_options = ProviderOptions(
+        mode=Provider.ClientMode,
+        host="localhost",
+        port=port,
+        cipher=cipher,
+        curve=curve,
+        data_to_send=random_bytes,
+        use_client_auth=True,
+        client_key_file=certificate.key,
+        client_certificate_file=certificate.cert,
+        client_trust_store= "../pems/rsa_2048_sha256_wildcard_cert.pem",
+        insecure=False,
+        protocol=protocol)
+
+    server_options = copy.copy(client_options)
+    server_options.data_to_send = None
+    server_options.mode = Provider.ServerMode
+    server_options.key = "../pems/rsa_2048_sha256_wildcard_key.pem"
+    server_options.cert = "../pems/rsa_2048_sha256_wildcard_cert.pem"
+
+    # Passing the type of client and server as a parameter will
+    # allow us to use a fixture to enumerate all possibilities.
+    server = managed_process(OpenSSL, server_options, timeout=5)
+    client = managed_process(S2N, client_options, timeout=5)
+
+    # The client should connect and return without error
+    for results in client.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+        
+    # Openssl should indicate the procotol version in a successful connection.
+    for results in server.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+        assert random_bytes in results.stdout
+        assert bytes("SSL_accept:SSLv3/TLS read client certificate\nSSL_accept:SSLv3/TLS read certificate verify\nSSL_accept:SSLv3/TLS read finished".encode('utf-8')) in results.stderr

--- a/tests/unit/s2n_x509_validator_test.c
+++ b/tests/unit/s2n_x509_validator_test.c
@@ -407,8 +407,8 @@ int main(int argc, char **argv) {
         struct s2n_pkey public_key_out;
         EXPECT_SUCCESS(s2n_pkey_zero_init(&public_key_out));
         s2n_pkey_type pkey_type;
-        EXPECT_EQUAL(S2N_CERT_ERR_MAX_CHAIN_DEPTH_EXCEEDED,
-                     s2n_x509_validator_validate_cert_chain(&validator, connection, chain_data, chain_len, &pkey_type, &public_key_out));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_x509_validator_validate_cert_chain(&validator, connection, chain_data, chain_len, &pkey_type, &public_key_out),
+                        S2N_ERR_CERT_UNTRUSTED);
         s2n_stuffer_free(&chain_stuffer);
         EXPECT_EQUAL(0, verify_data.callback_invoked);
         EXPECT_EQUAL(S2N_PKEY_TYPE_RSA, pkey_type);

--- a/tls/s2n_server_cert.c
+++ b/tls/s2n_server_cert.c
@@ -45,8 +45,8 @@ int s2n_server_cert_recv(struct s2n_connection *conn)
     cert_chain.data = s2n_stuffer_raw_read(&conn->handshake.io, size_of_all_certificates);
     notnull_check(cert_chain.data);
 
-    S2N_ERROR_IF(s2n_x509_validator_validate_cert_chain(&conn->x509_validator, conn, cert_chain.data,
-                         cert_chain.size, &actual_cert_pkey_type, &public_key) != S2N_CERT_OK, S2N_ERR_CERT_UNTRUSTED);
+    GUARD(s2n_x509_validator_validate_cert_chain(&conn->x509_validator, conn, cert_chain.data,
+                         cert_chain.size, &actual_cert_pkey_type, &public_key));
 
     GUARD(s2n_is_cert_type_valid_for_auth(conn, actual_cert_pkey_type));
     GUARD(s2n_pkey_setup_for_type(&public_key, actual_cert_pkey_type));

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -278,20 +278,15 @@ s2n_cert_validation_code s2n_x509_validator_validate_cert_chain(struct s2n_x509_
                                                                 uint8_t *cert_chain_in, uint32_t cert_chain_len,
                                                                 s2n_pkey_type *pkey_type, struct s2n_pkey *public_key_out) {
 
-    if (!validator->skip_cert_validation && !s2n_x509_trust_store_has_certs(validator->trust_store)) {
-        return S2N_CERT_ERR_UNTRUSTED;
-    }
+    S2N_ERROR_IF(!validator->skip_cert_validation && !s2n_x509_trust_store_has_certs(validator->trust_store), S2N_ERR_CERT_UNTRUSTED);
 
     DEFER_CLEANUP(X509_STORE_CTX *ctx = NULL, X509_STORE_CTX_free_pointer);
 
     struct s2n_blob cert_chain_blob = {.data = cert_chain_in, .size = cert_chain_len};
     DEFER_CLEANUP(struct s2n_stuffer cert_chain_in_stuffer = {0}, s2n_stuffer_free);
-    if (s2n_stuffer_init(&cert_chain_in_stuffer, &cert_chain_blob) < 0) {
-        return S2N_CERT_ERR_INVALID;
-    }
-    if (s2n_stuffer_write(&cert_chain_in_stuffer, &cert_chain_blob) < 0) {
-        return S2N_CERT_ERR_INVALID;
-    }
+
+    S2N_ERROR_IF(s2n_stuffer_init(&cert_chain_in_stuffer, &cert_chain_blob) < 0, S2N_ERR_CERT_UNTRUSTED);
+    S2N_ERROR_IF(s2n_stuffer_write(&cert_chain_in_stuffer, &cert_chain_blob) < 0, S2N_ERR_CERT_UNTRUSTED);
 
     uint32_t certificate_count = 0;
 
@@ -303,42 +298,31 @@ s2n_cert_validation_code s2n_x509_validator_validate_cert_chain(struct s2n_x509_
     while (s2n_stuffer_data_available(&cert_chain_in_stuffer) && certificate_count < validator->max_chain_depth) {
         uint32_t certificate_size = 0;
 
-        if (s2n_stuffer_read_uint24(&cert_chain_in_stuffer, &certificate_size) < 0) {
-            return S2N_CERT_ERR_INVALID;
-        }
-
-        if (certificate_size == 0 || certificate_size > s2n_stuffer_data_available(&cert_chain_in_stuffer)) {
-            return S2N_CERT_ERR_INVALID;
-        }
+        S2N_ERROR_IF(s2n_stuffer_read_uint24(&cert_chain_in_stuffer, &certificate_size) < 0, S2N_ERR_CERT_UNTRUSTED);
+        S2N_ERROR_IF(certificate_size == 0 || certificate_size > s2n_stuffer_data_available(&cert_chain_in_stuffer), S2N_ERR_CERT_UNTRUSTED);
 
         struct s2n_blob asn1cert = {0};
         asn1cert.size = certificate_size;
         asn1cert.data = s2n_stuffer_raw_read(&cert_chain_in_stuffer, certificate_size);
-        if (asn1cert.data == NULL) {
-            return S2N_CERT_ERR_INVALID;
-        }
+        notnull_check(asn1cert.data);
 
         const uint8_t *data = asn1cert.data;
 
         if (!validator->skip_cert_validation) {
             /* the cert is der encoded, just convert it. */
             server_cert = d2i_X509(NULL, &data, asn1cert.size);
-            if (!server_cert) {
-                return S2N_CERT_ERR_INVALID;
-            }
+            S2N_ERROR_IF(!server_cert, S2N_ERR_CERT_UNTRUSTED);
 
             /* add the cert to the chain. */
             if (!sk_X509_push(validator->cert_chain, server_cert)) {
                 X509_free(server_cert);
-                return S2N_CERT_ERR_INVALID;
+                S2N_ERROR(S2N_ERR_CERT_UNTRUSTED);
             }
          }
 
         /* Pull the public key from the first certificate */
         if (certificate_count == 0) {
-            if (s2n_asn1der_to_public_key_and_type(&public_key, pkey_type, &asn1cert) < 0) {
-                return S2N_CERT_ERR_INVALID;
-            }
+            S2N_ERROR_IF(s2n_asn1der_to_public_key_and_type(&public_key, pkey_type, &asn1cert) < 0, S2N_ERR_CERT_UNTRUSTED);
         }
 
         /* certificate extensions is a field in TLS 1.3 - https://tools.ietf.org/html/rfc8446#section-4.4.2 */
@@ -356,34 +340,19 @@ s2n_cert_validation_code s2n_x509_validator_validate_cert_chain(struct s2n_x509_
     }
 
     /* if this occurred we exceeded validator->max_chain_depth */
-    if (!validator->skip_cert_validation && s2n_stuffer_data_available(&cert_chain_in_stuffer)) {
-        return S2N_CERT_ERR_MAX_CHAIN_DEPTH_EXCEEDED;
-    }
-
-    if (certificate_count < 1) {
-        return S2N_CERT_ERR_INVALID;
-    }
-
+    S2N_ERROR_IF(!validator->skip_cert_validation && s2n_stuffer_data_available(&cert_chain_in_stuffer), S2N_ERR_CERT_UNTRUSTED);
+    S2N_ERROR_IF(certificate_count < 1, S2N_ERR_CERT_UNTRUSTED);
 
     if (!validator->skip_cert_validation) {
         X509 *leaf = sk_X509_value(validator->cert_chain, 0);
-        if (!leaf) {
-            return S2N_CERT_ERR_INVALID;
-        }
-
-        if (conn->verify_host_fn && !s2n_verify_host_information(validator, conn, leaf)) {
-            return S2N_CERT_ERR_UNTRUSTED;
-        }
+        S2N_ERROR_IF(!leaf, S2N_ERR_CERT_UNTRUSTED);
+        S2N_ERROR_IF(conn->verify_host_fn && !s2n_verify_host_information(validator, conn, leaf), S2N_ERR_CERT_UNTRUSTED);
 
         /* now that we have a chain, get the store and check against it. */
         ctx = X509_STORE_CTX_new();
 
-        int op_code = X509_STORE_CTX_init(ctx, validator->trust_store->trust_store, leaf,
-                                          validator->cert_chain);
-
-        if (op_code <= 0) {
-            return S2N_CERT_ERR_INVALID;
-        }
+        int op_code = X509_STORE_CTX_init(ctx, validator->trust_store->trust_store, leaf, validator->cert_chain);
+        S2N_ERROR_IF(op_code <= 0, S2N_ERR_CERT_UNTRUSTED);
 
         X509_VERIFY_PARAM *param = X509_STORE_CTX_get0_param(ctx);
         X509_VERIFY_PARAM_set_depth(param, validator->max_chain_depth);
@@ -398,9 +367,7 @@ s2n_cert_validation_code s2n_x509_validator_validate_cert_chain(struct s2n_x509_
 
         op_code = X509_verify_cert(ctx);
 
-        if (op_code <= 0) {
-            return S2N_CERT_ERR_UNTRUSTED;
-        }
+        S2N_ERROR_IF(op_code <= 0, S2N_ERR_CERT_UNTRUSTED);
     }
 
 


### PR DESCRIPTION


* Add s2nc no_cert client_auth integration test and fix x509 errors

* Add key and cert to s2nc

* Update client auth with cert test

_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

 resolves #ISSUE-NUMBER1, resolves #ISSUE-NUMBER2, etc.

### Description of changes: 

Describe s2n’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.
### Call-outs:

Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
