### PR TITLE
Fix overflow error

### DIFF
--- a/tls/s2n_cipher_suites.h
+++ b/tls/s2n_cipher_suites.h
@@ -52,7 +52,7 @@
  * approximately 2^-57 for Authenticated Encryption (AE) security.
  * S2N_TLS13_MAXIMUM_RECORD_NUMBER is 2^24.5 rounded down to the nearest whole number.
  */
-#define S2N_TLS13_MAXIMUM_RECORD_NUMBER            23726566L
+#define S2N_TLS13_MAXIMUM_RECORD_NUMBER            ((uint64_t) 23726566)
 #define S2N_TLS13_AES_GCM_MAXIMUM_BYTES_TO_ENCRYPT (S2N_TLS13_MAXIMUM_FRAGMENT_LENGTH * S2N_TLS13_MAXIMUM_RECORD_NUMBER)
 
 typedef enum {


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

### Description of changes: 

The build broke for some environments due to the definition of a "long". We should instead always use a uint64_t.

### Testing:
Working: https://godbolt.org/z/xF4ziy
Not Working: https://godbolt.org/z/_94qzu

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
