### PR TITLE
Improve self-talk test utils

### DIFF
--- a/tests/testlib/s2n_test_server_client.c
+++ b/tests/testlib/s2n_test_server_client.c
@@ -15,40 +15,42 @@
 
 #include "testlib/s2n_testlib.h"
 
-int s2n_negotiate_test_server_and_client(struct s2n_connection *server_conn, struct s2n_connection *client_conn)
+static int s2n_try_negotiate(struct s2n_connection *conn, bool *is_done, bool peer_is_done)
 {
-    int server_rc = -1;
-    int client_rc = -1;
-    s2n_blocked_status server_blocked;
-    s2n_blocked_status client_blocked;
-    int server_done = 0;
-    int client_done = 0;
+    s2n_blocked_status blocked;
+    int rc = s2n_negotiate(conn, &blocked);
 
-    do {
-        if (!server_done) {
-            s2n_errno = S2N_ERR_T_OK;
-            server_rc = s2n_negotiate(server_conn, &server_blocked);
+    /* If we succeeded, we're done. */
+    if(rc == S2N_SUCCESS) {
+        *is_done = true;
+        return S2N_SUCCESS;
+    }
 
-            if (s2n_error_get_type(s2n_errno) != S2N_ERR_T_BLOCKED || client_done) {
-                /* Success, fatal error, or the peer is done and we're still blocked. */
-                server_done = 1;
-            }
-        }
-        if (!client_done) {
-            s2n_errno = S2N_ERR_T_OK;
-            client_rc = s2n_negotiate(client_conn, &client_blocked);
+    /* If we failed for any error other than 'blocked', propagate the error. */
+    if(s2n_error_get_type(s2n_errno) != S2N_ERR_T_BLOCKED) {
+        S2N_ERROR_PRESERVE_ERRNO();
+    }
 
-            if (s2n_error_get_type(s2n_errno) != S2N_ERR_T_BLOCKED || server_done) {
-                /* Success, fatal error, or the peer is done and we're still blocked. */
-                client_done = 1;
-            }
-        }
-    } while (!client_done || !server_done);
+    /* If we're blocked but our peer is done writing, propagate the error. */
+    if(peer_is_done) {
+        S2N_ERROR_PRESERVE_ERRNO();
+    }
 
-    int rc = (server_rc == 0 && client_rc == 0) ? 0 : -1;
-    return rc;
+    *is_done = false;
+    return S2N_SUCCESS;
 }
 
+int s2n_negotiate_test_server_and_client(struct s2n_connection *server_conn, struct s2n_connection *client_conn)
+{
+    bool server_done = 0, client_done = 0;
+
+    do {
+        GUARD(s2n_try_negotiate(client_conn, &client_done, server_done));
+        GUARD(s2n_try_negotiate(server_conn, &server_done, client_done));
+    } while (!client_done || !server_done);
+
+    return S2N_SUCCESS;
+}
 
 int s2n_shutdown_test_server_and_client(struct s2n_connection *server_conn, struct s2n_connection *client_conn)
 {

--- a/tests/unit/s2n_mutual_auth_test.c
+++ b/tests/unit/s2n_mutual_auth_test.c
@@ -38,8 +38,6 @@ static uint8_t verify_host_fn(const char *host_name, size_t host_name_len, void 
     return verify_data->allow;
 }
 
-static const int MAX_TRIES = 100;
-
 int main(int argc, char **argv)
 {
     struct s2n_config *config;

--- a/tests/unit/s2n_mutual_auth_test.c
+++ b/tests/unit/s2n_mutual_auth_test.c
@@ -83,8 +83,6 @@ int main(int argc, char **argv)
         struct s2n_security_policy server_security_policy;
         struct s2n_connection *client_conn;
         struct s2n_connection *server_conn;
-        s2n_blocked_status client_blocked;
-        s2n_blocked_status server_blocked;
         struct s2n_stuffer client_to_server;
         struct s2n_stuffer server_to_client;
 
@@ -119,19 +117,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&server_to_client, &client_to_server, client_conn));
         EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&client_to_server, &server_to_client, server_conn));
 
-        int tries = 0;
-        do {
-            int ret;
-            ret = s2n_negotiate(client_conn, &client_blocked);
-            EXPECT_TRUE(ret == 0 || (client_blocked && errno == EAGAIN));
-            ret = s2n_negotiate(server_conn, &server_blocked);
-            EXPECT_TRUE(ret == 0 || (server_blocked && errno == EAGAIN));
-            tries += 1;
-
-            if (tries >= MAX_TRIES) {
-               FAIL();
-            }
-        } while (client_blocked || server_blocked);
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
         /* Verify that both connections negotiated Mutual Auth */
         EXPECT_TRUE(s2n_connection_client_cert_used(server_conn));
@@ -143,7 +129,6 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_free(&server_to_client));
         EXPECT_SUCCESS(s2n_stuffer_free(&client_to_server));
     }
-
 
     /*
      * Test Mutual Auth using **s2n_config_set_client_auth_type**
@@ -157,8 +142,6 @@ int main(int argc, char **argv)
         struct s2n_security_policy server_security_policy;
         struct s2n_connection *client_conn;
         struct s2n_connection *server_conn;
-        s2n_blocked_status client_blocked;
-        s2n_blocked_status server_blocked;
         struct s2n_stuffer client_to_server;
         struct s2n_stuffer server_to_client;
 
@@ -189,19 +172,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&server_to_client, &client_to_server, client_conn));
         EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&client_to_server, &server_to_client, server_conn));
 
-        int tries = 0;
-        do {
-            int ret;
-            ret = s2n_negotiate(client_conn, &client_blocked);
-            EXPECT_TRUE(ret == 0 || (client_blocked && errno == EAGAIN));
-            ret = s2n_negotiate(server_conn, &server_blocked);
-            EXPECT_TRUE(ret == 0 || (server_blocked && errno == EAGAIN));
-            tries += 1;
-
-            if (tries >= MAX_TRIES) {
-               FAIL();
-            }
-        } while (client_blocked || server_blocked);
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
         /* Verify that both connections negotiated Mutual Auth */
         EXPECT_TRUE(s2n_connection_client_cert_used(server_conn));
@@ -226,8 +197,6 @@ int main(int argc, char **argv)
         struct s2n_security_policy server_security_policy;
         struct s2n_connection *client_conn;
         struct s2n_connection *server_conn;
-        s2n_blocked_status client_blocked;
-        s2n_blocked_status server_blocked;
         struct s2n_stuffer client_to_server;
         struct s2n_stuffer server_to_client;
 
@@ -263,19 +232,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&server_to_client, &client_to_server, client_conn));
         EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&client_to_server, &server_to_client, server_conn));
 
-        int tries = 0;
-        do {
-            int ret;
-            ret = s2n_negotiate(client_conn, &client_blocked);
-            EXPECT_TRUE(ret == 0 || (client_blocked && errno == EAGAIN));
-            ret = s2n_negotiate(server_conn, &server_blocked);
-            EXPECT_TRUE(ret == 0 || (server_blocked && errno == EAGAIN));
-            tries += 1;
-
-            if (tries >= MAX_TRIES) {
-               FAIL();
-            }
-        } while (client_blocked || server_blocked);
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
         /* Verify that both connections negotiated Mutual Auth */
         EXPECT_TRUE(s2n_connection_client_cert_used(server_conn));
@@ -300,8 +257,6 @@ int main(int argc, char **argv)
         struct s2n_security_policy server_security_policy;
         struct s2n_connection *client_conn;
         struct s2n_connection *server_conn;
-        s2n_blocked_status client_blocked;
-        s2n_blocked_status server_blocked;
         struct s2n_stuffer client_to_server;
         struct s2n_stuffer server_to_client;
 
@@ -337,20 +292,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&server_to_client, &client_to_server, client_conn));
         EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&client_to_server, &server_to_client, server_conn));
 
-        int tries = 0;
-        int failures = 0;
-        do {
-            int client_ret, server_ret;
-            client_ret = s2n_negotiate(client_conn, &client_blocked);
-            server_ret = s2n_negotiate(server_conn, &server_blocked);
-            tries += 1;
+        EXPECT_FAILURE(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
-            if (client_ret != 0 || server_ret != 0) {
-               failures ++;
-            }
-        } while ((client_blocked || server_blocked) && tries < MAX_TRIES);
-
-        EXPECT_EQUAL(failures, MAX_TRIES);
         /* Verify that NEITHER connections negotiated Mutual Auth */
         EXPECT_FALSE(s2n_connection_client_cert_used(server_conn));
         EXPECT_FALSE(s2n_connection_client_cert_used(client_conn));

--- a/tests/unit/s2n_testlib_test.c
+++ b/tests/unit/s2n_testlib_test.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "testlib/s2n_testlib.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Test that s2n_negotiate_test_server_and_client produces useful errors.
+     * In the past, we failed to surface errors and instead reported io errors when
+     * the failed connection's peer couldn't read the next expected message.
+     *
+     * We should always report the actual error to allow better debugging of tests.
+     */
+    {
+        struct s2n_connection *server_conn;
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+
+        /* Create nonblocking pipes */
+        struct s2n_test_piped_io piped_io;
+        GUARD(s2n_piped_io_init_non_blocking(&piped_io));
+        GUARD(s2n_connection_set_piped_io(server_conn, &piped_io));
+
+        /* This should NEVER fail with an error related to blocked IO. */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate_test_server_and_client(server_conn, NULL), S2N_ERR_NULL);
+
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+    }
+
+    END_TEST();
+}

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1047,8 +1047,11 @@ static int s2n_handle_retry_state(struct s2n_connection *conn)
     return 0;
 }
 
-int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status * blocked)
+int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status *blocked)
 {
+    notnull_check(conn);
+    notnull_check(blocked);
+
     errno = 0;
     s2n_errno = S2N_ERR_OK;
 


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

### Description of changes: 

Our current self-talk test utility method doesn't handle errors properly. Instead of failing when the error occurs, it fails when our peer tries to read the message we failed to write due to the error. This means that all the self-talk tests that use this method only ever fail with "blocked" errors. This makes debugging the tests painful.

While I was fixing this, I also updated any test that had implemented its own version to just use the common test utility, so we only have to get this right once.

I also added notnull_checks to s2n_negotiate so my test would pass instead of seg fault :(

### Testing:

I wrote a test for our test method to ensure it produces the right error. The behavior I'm testing doesn't get triggered by other unit tests because it only matters to failing tests; this only comes up when a developer is trying to get a failing test to pass.

Before the fix, the new test would produce:
```
 Error Message: 'underlying I/O operation would block'
 Debug String: 'Error encountered in s2n_recv.c line 70'
 System Error: Resource temporarily unavailable (11)
```
That's not helpful :( After the fix, the test produces:
```
 Error Message: 'NULL pointer encountered'
 Debug String: 'Error encountered in s2n_handshake_io.c line 1052'
 System Error: Socket operation on non-socket (88)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
