### PR TITLE
Changed encrypted bytes threshold to a record limit

### DIFF
--- a/crypto/s2n_sequence.c
+++ b/crypto/s2n_sequence.c
@@ -15,6 +15,8 @@
 
 #include "crypto/s2n_sequence.h"
 
+#include "tls/s2n_crypto.h"
+
 #include "error/s2n_errno.h"
 
 #include "utils/s2n_blob.h"
@@ -37,4 +39,18 @@ int s2n_increment_sequence_number(struct s2n_blob *sequence_number)
     }
 
     return 0;
+}
+
+int s2n_convert_sequence_number(struct s2n_blob *sequence_number, uint64_t *output)
+{
+    notnull_check(sequence_number);
+    
+    int position = S2N_TLS_SEQUENCE_NUM_LEN - 1;
+    /* Each uint8_t can hold 2^8 values */
+    int power = 8;
+    for (int i = 0; i < sequence_number->size; i++) {
+        *output += (uint64_t) sequence_number->data[i] << (position * power);
+        position--;
+    }
+    return S2N_SUCCESS;
 }

--- a/crypto/s2n_sequence.c
+++ b/crypto/s2n_sequence.c
@@ -21,6 +21,8 @@
 
 #include "utils/s2n_blob.h"
 
+#define SEQUENCE_NUMBER_POWER 8
+
 int s2n_increment_sequence_number(struct s2n_blob *sequence_number)
 {
     for (int i = sequence_number->size - 1; i >= 0; i--) {
@@ -43,15 +45,14 @@ int s2n_increment_sequence_number(struct s2n_blob *sequence_number)
 
 int s2n_sequence_number_to_uint64(struct s2n_blob *sequence_number, uint64_t *output)
 {
-    
     notnull_check(sequence_number);
-    notnull_check(output);
+
     uint8_t shift = 0;
     *output = 0;
 
     for (int i = sequence_number->size - 1; i >= 0; i--) {
         *output += (uint64_t) sequence_number->data[i] << shift;
-        shift += 8;
+        shift += SEQUENCE_NUMBER_POWER;
     }
     return S2N_SUCCESS;
 }

--- a/crypto/s2n_sequence.c
+++ b/crypto/s2n_sequence.c
@@ -51,7 +51,7 @@ int s2n_sequence_number_to_uint64(struct s2n_blob *sequence_number, uint64_t *ou
     *output = 0;
 
     for (int i = sequence_number->size - 1; i >= 0; i--) {
-        *output += (uint64_t) sequence_number->data[i] << shift;
+        *output += ((uint64_t) sequence_number->data[i]) << shift;
         shift += SEQUENCE_NUMBER_POWER;
     }
     return S2N_SUCCESS;

--- a/crypto/s2n_sequence.c
+++ b/crypto/s2n_sequence.c
@@ -41,16 +41,17 @@ int s2n_increment_sequence_number(struct s2n_blob *sequence_number)
     return 0;
 }
 
-int s2n_convert_sequence_number(struct s2n_blob *sequence_number, uint64_t *output)
+int s2n_sequence_number_to_uint64(struct s2n_blob *sequence_number, uint64_t *output)
 {
-    notnull_check(sequence_number);
     
-    int position = S2N_TLS_SEQUENCE_NUM_LEN - 1;
-    /* Each uint8_t can hold 2^8 values */
-    int power = 8;
-    for (int i = 0; i < sequence_number->size; i++) {
-        *output += (uint64_t) sequence_number->data[i] << (position * power);
-        position--;
+    notnull_check(sequence_number);
+    notnull_check(output);
+    uint8_t shift = 0;
+    *output = 0;
+
+    for (int i = sequence_number->size - 1; i >= 0; i--) {
+        *output += (uint64_t) sequence_number->data[i] << shift;
+        shift += 8;
     }
     return S2N_SUCCESS;
 }

--- a/crypto/s2n_sequence.h
+++ b/crypto/s2n_sequence.h
@@ -20,4 +20,4 @@
 #include "utils/s2n_blob.h"
 
 extern int s2n_increment_sequence_number(struct s2n_blob *sequence_number);
-int s2n_convert_sequence_number(struct s2n_blob *sequence_number, uint64_t *output);
+int s2n_sequence_number_to_uint64(struct s2n_blob *sequence_number, uint64_t *output);

--- a/crypto/s2n_sequence.h
+++ b/crypto/s2n_sequence.h
@@ -20,3 +20,4 @@
 #include "utils/s2n_blob.h"
 
 extern int s2n_increment_sequence_number(struct s2n_blob *sequence_number);
+int s2n_convert_sequence_number(struct s2n_blob *sequence_number, uint64_t *output);

--- a/tests/unit/s2n_key_update_test.c
+++ b/tests/unit/s2n_key_update_test.c
@@ -27,6 +27,7 @@
 #include "utils/s2n_blob.h"
 
 int s2n_key_update_write(struct s2n_blob *out); 
+int s2n_check_key_limits(struct s2n_connection *conn, struct s2n_blob *sequence_number); 
 
 int main(int argc, char **argv)
 {
@@ -135,16 +136,14 @@ int main(int argc, char **argv)
             client_conn->actual_protocol_version = S2N_TLS13;
             client_conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
             memcpy_check(client_conn->secure.client_app_secret, application_secret.data, application_secret.size);
-
-            uint8_t data_size = 1;
-            client_conn->secure.client_sequence_number[0] = 1; 
+            uint8_t expected_sequence_number[S2N_TLS_SEQUENCE_NUM_LEN] = {0};
+   
             client_conn->key_update_pending = true;
 
-            EXPECT_SUCCESS(s2n_key_update_send(client_conn, data_size));
+            EXPECT_SUCCESS(s2n_key_update_send(client_conn));
 
             EXPECT_EQUAL(client_conn->key_update_pending, false);
-            EXPECT_EQUAL(client_conn->secure.client_sequence_number[0], 0);
-            EXPECT_EQUAL(client_conn->encrypted_bytes_out, 0);
+            EXPECT_BYTEARRAY_EQUAL(client_conn->secure.client_sequence_number, expected_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN);
 
             EXPECT_SUCCESS(s2n_connection_free(client_conn));
         }
@@ -156,20 +155,23 @@ int main(int argc, char **argv)
             client_conn->actual_protocol_version = S2N_TLS13;
             client_conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
             memcpy_check(client_conn->secure.client_app_secret, application_secret.data, application_secret.size);
+            uint8_t expected_sequence_number[S2N_TLS_SEQUENCE_NUM_LEN] = {0};
 
-            uint8_t data_size = 1;
-            client_conn->secure.client_sequence_number[0] = 1; 
             client_conn->key_update_pending = false;
-            client_conn->encrypted_bytes_out = S2N_TLS13_AES_GCM_MAXIMUM_BYTES_TO_ENCRYPT;
 
-            EXPECT_SUCCESS(s2n_key_update_send(client_conn, data_size));
+            /* set record number to encryption limit */ 
+            client_conn->secure.client_sequence_number[4] = 1;
+            client_conn->secure.client_sequence_number[5] = 106;
+            client_conn->secure.client_sequence_number[6] = 9;
+            client_conn->secure.client_sequence_number[7] = 229;
+
+            EXPECT_SUCCESS(s2n_key_update_send(client_conn));
 
             EXPECT_EQUAL(client_conn->key_update_pending, false);
-            EXPECT_EQUAL(client_conn->secure.client_sequence_number[0], 0);
-            EXPECT_EQUAL(client_conn->encrypted_bytes_out, 0);
+            EXPECT_BYTEARRAY_EQUAL(client_conn->secure.client_sequence_number, expected_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN);
             
             EXPECT_SUCCESS(s2n_connection_free(client_conn));
-        }
+        } 
         /* Key update is not triggered */
         {
             struct s2n_connection *client_conn;
@@ -177,52 +179,65 @@ int main(int argc, char **argv)
             client_conn->actual_protocol_version = S2N_TLS13;
             client_conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
             memcpy_check(client_conn->secure.client_app_secret, application_secret.data, application_secret.size);
+            uint8_t expected_sequence_number[S2N_TLS_SEQUENCE_NUM_LEN] = {0};
 
-            uint8_t data_size = 1;
-            client_conn->secure.client_sequence_number[0] = 1; 
+            client_conn->secure.client_sequence_number[7] = 1; 
+            expected_sequence_number[7] = 1;
             client_conn->key_update_pending = false;
-            client_conn->encrypted_bytes_out = 1;
 
-            EXPECT_SUCCESS(s2n_key_update_send(client_conn, data_size));
+            EXPECT_SUCCESS(s2n_key_update_send(client_conn));
 
             EXPECT_EQUAL(client_conn->key_update_pending, false);
-            EXPECT_EQUAL(client_conn->secure.client_sequence_number[0], 1);
-            EXPECT_EQUAL(client_conn->encrypted_bytes_out, 1);
+            EXPECT_BYTEARRAY_EQUAL(client_conn->secure.client_sequence_number, expected_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN);
             
             EXPECT_SUCCESS(s2n_connection_free(client_conn));
-        }
+        } 
     }
     /* s2n_check_key_limits */
     {
         /* Key update NOT triggered when encrypted bytes exactly matches encryption limit */
         {
             struct s2n_connection *conn;
-            uint8_t data_size = 1;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             conn->actual_protocol_version = S2N_TLS13;
             conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
-            EXPECT_EQUAL(conn->key_update_pending, 0);
-            conn->encrypted_bytes_out = S2N_TLS13_AES_GCM_MAXIMUM_BYTES_TO_ENCRYPT - data_size;
+            struct s2n_blob sequence_number = {0};
+            EXPECT_SUCCESS(s2n_blob_init(&sequence_number, conn->secure.server_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
+            EXPECT_EQUAL(conn->key_update_pending, false);
 
-            EXPECT_SUCCESS(s2n_check_key_limits(conn, data_size));
-            EXPECT_EQUAL(conn->key_update_pending, 0);
+            /* set record number to encryption limit - 1 */
+            conn->secure.server_sequence_number[4] = 1;
+            conn->secure.server_sequence_number[5] = 106;
+            conn->secure.server_sequence_number[6] = 9;
+            conn->secure.server_sequence_number[7] = 228;
+
+            EXPECT_SUCCESS(s2n_check_key_limits(conn, &sequence_number));
+            
+            EXPECT_EQUAL(conn->key_update_pending, false);
 
             EXPECT_SUCCESS(s2n_connection_free(conn)); 
         }
 
-        /* Key update is triggered when encrypted bytes exceeds encryption limit */
+        /* Key update is triggered when record limit exceeds encryption limit */
         {
             struct s2n_connection *conn;
-            uint8_t data_size = 1;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             conn->actual_protocol_version = S2N_TLS13;
             conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
+            struct s2n_blob sequence_number = {0};
+            EXPECT_SUCCESS(s2n_blob_init(&sequence_number, conn->secure.server_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
 
-            EXPECT_EQUAL(conn->key_update_pending, 0);
-            conn->encrypted_bytes_out = S2N_TLS13_AES_GCM_MAXIMUM_BYTES_TO_ENCRYPT + 1;
+            EXPECT_EQUAL(conn->key_update_pending, false);
 
-            EXPECT_SUCCESS(s2n_check_key_limits(conn, data_size));
-            EXPECT_EQUAL(conn->key_update_pending, 1);
+            /* set record number to encryption limit */
+            conn->secure.server_sequence_number[4] = 1;
+            conn->secure.server_sequence_number[5] = 106;
+            conn->secure.server_sequence_number[6] = 9;
+            conn->secure.server_sequence_number[7] = 229;
+
+            EXPECT_SUCCESS(s2n_check_key_limits(conn, &sequence_number));
+
+            EXPECT_EQUAL(conn->key_update_pending, true);
 
             EXPECT_SUCCESS(s2n_connection_free(conn)); 
         }
@@ -230,16 +245,18 @@ int main(int argc, char **argv)
         /* Key update NOT triggered when encrypted bytes are below encryption limit */
         {
             struct s2n_connection *conn;
-            uint8_t data_size = 1;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             conn->actual_protocol_version = S2N_TLS13;
             conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
-            
-            EXPECT_EQUAL(conn->key_update_pending, 0);
-            conn->encrypted_bytes_out = S2N_TLS13_AES_GCM_MAXIMUM_BYTES_TO_ENCRYPT - 5;
+            struct s2n_blob sequence_number = {0};
+            EXPECT_SUCCESS(s2n_blob_init(&sequence_number, conn->secure.server_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
 
-            EXPECT_SUCCESS(s2n_check_key_limits(conn, data_size));
-            EXPECT_EQUAL(conn->key_update_pending, 0);
+            EXPECT_EQUAL(conn->key_update_pending, false);
+            /* set record number to below encryption limit */
+            conn->secure.server_sequence_number[7] = 229;
+
+            EXPECT_SUCCESS(s2n_check_key_limits(conn, &sequence_number));
+            EXPECT_EQUAL(conn->key_update_pending, false);
 
             EXPECT_SUCCESS(s2n_connection_free(conn)); 
         }
@@ -248,37 +265,46 @@ int main(int argc, char **argv)
         /* Skip test if libcrypto doesn't support the cipher */
         if (s2n_chacha20_poly1305.is_available()) {
             struct s2n_connection *conn;
-            uint8_t data_size = 1;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             conn->actual_protocol_version = S2N_TLS13;
             /* Setting cipher suite to suite that does not have an encryption limit */
             conn->secure.cipher_suite = &s2n_tls13_chacha20_poly1305_sha256;
-            
-            EXPECT_EQUAL(conn->key_update_pending, 0);
-            conn->encrypted_bytes_out = UINT64_MAX;
+            struct s2n_blob sequence_number = {0};
+            EXPECT_SUCCESS(s2n_blob_init(&sequence_number, conn->secure.server_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
 
-            EXPECT_SUCCESS(s2n_check_key_limits(conn, data_size));
             EXPECT_EQUAL(conn->key_update_pending, 0);
+            for (int i = 0; i < S2N_TLS_SEQUENCE_NUM_LEN; i++) {
+                conn->secure.server_sequence_number[i] = UINT8_MAX;
+            }
+
+            EXPECT_SUCCESS(s2n_check_key_limits(conn, &sequence_number));
+
+            EXPECT_EQUAL(conn->key_update_pending, false);
 
             EXPECT_SUCCESS(s2n_connection_free(conn)); 
         }
 
         /* Key update NOT triggered when cipher suite does not have encryption limit and
-         * when encrypted_bytes_out exactly equals UINT64_MAX
+         * when record limit exactly equals UINT64_MAX
          */
         if (s2n_chacha20_poly1305.is_available()) {
             struct s2n_connection *conn;
-            uint8_t data_size = 1;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             conn->actual_protocol_version = S2N_TLS13;
             /* Setting cipher suite to suite that does not have an encryption limit */
             conn->secure.cipher_suite = &s2n_tls13_chacha20_poly1305_sha256;
+            struct s2n_blob sequence_number = {0};
+            EXPECT_SUCCESS(s2n_blob_init(&sequence_number, conn->secure.server_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
             
             EXPECT_EQUAL(conn->key_update_pending, 0);
-            conn->encrypted_bytes_out = UINT64_MAX - data_size;
+            for (int i = 0; i < S2N_TLS_SEQUENCE_NUM_LEN; i++) {
+                conn->secure.server_sequence_number[i] = UINT8_MAX;
+            }
+            conn->secure.server_sequence_number[7] -= 1;
+            
+            EXPECT_SUCCESS(s2n_check_key_limits(conn, &sequence_number));
 
-            EXPECT_SUCCESS(s2n_check_key_limits(conn, data_size));
-            EXPECT_EQUAL(conn->key_update_pending, 0);
+            EXPECT_EQUAL(conn->key_update_pending, false);
 
             EXPECT_SUCCESS(s2n_connection_free(conn)); 
         }

--- a/tests/unit/s2n_key_update_test.c
+++ b/tests/unit/s2n_key_update_test.c
@@ -162,7 +162,7 @@ int main(int argc, char **argv)
 
             client_conn->key_update_pending = false;
 
-            for (uint8_t i = 0; i < S2N_TLS_SEQUENCE_NUM_LEN; i++) {
+            for (size_t i = 0; i < S2N_TLS_SEQUENCE_NUM_LEN; i++) {
                 client_conn->secure.client_sequence_number[i] = max_record_limit[i];
             }
             
@@ -207,12 +207,12 @@ int main(int argc, char **argv)
             
             EXPECT_EQUAL(conn->key_update_pending, false);
 
-            for (uint8_t i = 0; i < S2N_TLS_SEQUENCE_NUM_LEN; i++) {
+            for (size_t i = 0; i < S2N_TLS_SEQUENCE_NUM_LEN; i++) {
                 conn->secure.server_sequence_number[i] = max_record_limit[i];
             }
             /* Change sequence number to be exactly record limit - 1 */
             conn->secure.server_sequence_number[S2N_TLS_SEQUENCE_NUM_LEN - 1] -= 1; 
-            
+
             EXPECT_SUCCESS(s2n_check_record_limit(conn, &sequence_number));
             
             EXPECT_EQUAL(conn->key_update_pending, false);
@@ -231,7 +231,7 @@ int main(int argc, char **argv)
             
             EXPECT_EQUAL(conn->key_update_pending, false);
 
-            for (uint8_t i = 0; i < S2N_TLS_SEQUENCE_NUM_LEN; i++) {
+            for (size_t i = 0; i < S2N_TLS_SEQUENCE_NUM_LEN; i++) {
                 conn->secure.server_sequence_number[i] = max_record_limit[i];
             }
 
@@ -274,7 +274,7 @@ int main(int argc, char **argv)
 
             EXPECT_EQUAL(conn->key_update_pending, 0);
 
-            for (int i = 0; i < S2N_TLS_SEQUENCE_NUM_LEN; i++) {
+            for (size_t i = 0; i < S2N_TLS_SEQUENCE_NUM_LEN; i++) {
                 conn->secure.server_sequence_number[i] = UINT8_MAX;
             }
 
@@ -299,7 +299,7 @@ int main(int argc, char **argv)
             
             EXPECT_EQUAL(conn->key_update_pending, 0);
 
-            for (int i = 0; i < S2N_TLS_SEQUENCE_NUM_LEN; i++) {
+            for (size_t i = 0; i < S2N_TLS_SEQUENCE_NUM_LEN; i++) {
                 conn->secure.server_sequence_number[i] = UINT8_MAX;
             }
             conn->secure.server_sequence_number[S2N_TLS_SEQUENCE_NUM_LEN - 1] -= 1;

--- a/tests/unit/s2n_key_update_test.c
+++ b/tests/unit/s2n_key_update_test.c
@@ -35,6 +35,9 @@ int main(int argc, char **argv)
     "4bc28934ddd802b00f479e14a72d7725dab45d32b3b145f29"
     "e4c5b56677560eb5236b168c71c5c75aa52f3e20ee89bfb"); 
 
+    /* The maximum record number converted to base 256 */
+    uint8_t max_record_limit[S2N_TLS_SEQUENCE_NUM_LEN] = {0, 0, 0, 0, 1, 106, 9, 229};
+
     BEGIN_TEST();
     /* s2n_key_update_write */
     {
@@ -157,8 +160,6 @@ int main(int argc, char **argv)
             memcpy_check(client_conn->secure.client_app_secret, application_secret.data, application_secret.size);
             uint8_t zeroed_sequence_number[S2N_TLS_SEQUENCE_NUM_LEN] = {0};
 
-            /* The maximum record number converted to base 256 */
-            uint8_t max_record_limit[S2N_TLS_SEQUENCE_NUM_LEN] = {0, 0, 0, 0, 1, 106, 9, 229};
             client_conn->key_update_pending = false;
 
             for (uint8_t i = 0; i < S2N_TLS_SEQUENCE_NUM_LEN; i++) {
@@ -203,15 +204,15 @@ int main(int argc, char **argv)
             conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
             struct s2n_blob sequence_number = {0};
             EXPECT_SUCCESS(s2n_blob_init(&sequence_number, conn->secure.server_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
-
-            /* The maximum record number - 1 converted to base 256 */
-            uint8_t max_record_limit[S2N_TLS_SEQUENCE_NUM_LEN] = {0, 0, 0, 0, 1, 106, 9, 228};
+            
             EXPECT_EQUAL(conn->key_update_pending, false);
 
             for (uint8_t i = 0; i < S2N_TLS_SEQUENCE_NUM_LEN; i++) {
                 conn->secure.server_sequence_number[i] = max_record_limit[i];
             }
-
+            /* Change sequence number to be exactly record limit - 1 */
+            conn->secure.server_sequence_number[S2N_TLS_SEQUENCE_NUM_LEN - 1] -= 1; 
+            
             EXPECT_SUCCESS(s2n_check_record_limit(conn, &sequence_number));
             
             EXPECT_EQUAL(conn->key_update_pending, false);
@@ -228,8 +229,6 @@ int main(int argc, char **argv)
             struct s2n_blob sequence_number = {0};
             EXPECT_SUCCESS(s2n_blob_init(&sequence_number, conn->secure.server_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
             
-            /* The maximum record number converted to base 256 */
-            uint8_t max_record_limit[S2N_TLS_SEQUENCE_NUM_LEN] = {0, 0, 0, 0, 1, 106, 9, 229};
             EXPECT_EQUAL(conn->key_update_pending, false);
 
             for (uint8_t i = 0; i < S2N_TLS_SEQUENCE_NUM_LEN; i++) {

--- a/tests/unit/s2n_post_handshake_test.c
+++ b/tests/unit/s2n_post_handshake_test.c
@@ -111,9 +111,8 @@ int main(int argc, char **argv)
             conn->actual_protocol_version = S2N_TLS13;
             conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;    
             s2n_blocked_status blocked;
-            uint8_t size = 1; 
 
-            EXPECT_SUCCESS(s2n_post_handshake_send(conn, &blocked, size));
+            EXPECT_SUCCESS(s2n_post_handshake_send(conn, &blocked));
             EXPECT_TRUE(s2n_stuffer_data_available(&conn->out) == 0);
 
             EXPECT_SUCCESS(s2n_connection_free(conn)); 

--- a/tests/unit/s2n_send_key_update_test.c
+++ b/tests/unit/s2n_send_key_update_test.c
@@ -35,6 +35,7 @@ static int s2n_test_init_encryption(struct s2n_connection *conn)
     struct s2n_cipher_suite *cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
     conn->server->cipher_suite = cipher_suite;
     conn->client->cipher_suite = cipher_suite;
+    conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
  
     /* Just some data that's the right length */
     S2N_BLOB_FROM_HEX(key, "0123456789abcdef0123456789abcdef");
@@ -80,8 +81,9 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         server_conn->actual_protocol_version = S2N_TLS13;
         client_conn->actual_protocol_version = S2N_TLS13;
-        server_conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
-        client_conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
+        
+        uint8_t zero_sequence_number[S2N_TLS_SEQUENCE_NUM_LEN] = {0};
+
         EXPECT_SUCCESS(s2n_test_init_encryption(server_conn));
         EXPECT_SUCCESS(s2n_test_init_encryption(client_conn));
 
@@ -94,7 +96,10 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&output, &input, client_conn));
         
         /* Mimic key update send conditions */
-        server_conn->encrypted_bytes_out = S2N_TLS13_AES_GCM_MAXIMUM_BYTES_TO_ENCRYPT;
+        server_conn->secure.server_sequence_number[4] = 1;
+        server_conn->secure.server_sequence_number[5] = 106;
+        server_conn->secure.server_sequence_number[6] = 9;
+        server_conn->secure.server_sequence_number[7] = 229;
 
         /* Next message to send will trigger key update message*/
         s2n_blocked_status blocked;
@@ -103,17 +108,14 @@ int main(int argc, char **argv)
         
         /* Verify key update happened */
         EXPECT_BYTEARRAY_NOT_EQUAL(server_conn->secure.server_app_secret, client_conn->secure.server_app_secret, S2N_TLS13_SECRET_MAX_LEN);
-
-        /* Verify encrypted_bytes_out is being counted correctly */
-        uint8_t expected_encrypted_bytes_out = sizeof(message) +
-            server_conn->secure.cipher_suite->record_alg->cipher->io.aead.tag_size + TLS13_CONTENT_TYPE_LENGTH;
-        EXPECT_EQUAL(server_conn->encrypted_bytes_out, expected_encrypted_bytes_out);
+        EXPECT_BYTEARRAY_EQUAL(server_conn->secure.server_sequence_number, zero_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN);
         
         /* Receive keyupdate message */
         uint8_t data[100];
         EXPECT_SUCCESS(s2n_recv(client_conn, data, sizeof(message), &blocked));
         EXPECT_BYTEARRAY_EQUAL(data, message, sizeof(message));
         EXPECT_BYTEARRAY_EQUAL(client_conn->secure.server_app_secret, server_conn->secure.server_app_secret, S2N_TLS13_SECRET_MAX_LEN);
+        EXPECT_BYTEARRAY_EQUAL(client_conn->secure.server_sequence_number, zero_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN);
         
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));

--- a/tests/unit/s2n_send_key_update_test.c
+++ b/tests/unit/s2n_send_key_update_test.c
@@ -99,7 +99,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&output, &input, client_conn));
         
         /* Mimic key update send conditions */
-        for (int i = 0; i < S2N_TLS_SEQUENCE_NUM_LEN; i++) {
+        for (size_t i = 0; i < S2N_TLS_SEQUENCE_NUM_LEN; i++) {
             server_conn->secure.server_sequence_number[i] = max_record_limit[i];
         }
 

--- a/tests/unit/s2n_send_key_update_test.c
+++ b/tests/unit/s2n_send_key_update_test.c
@@ -73,6 +73,9 @@ int main(int argc, char **argv)
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_enable_tls13());
 
+    /* The maximum record number converted to base 256 */
+    uint8_t max_record_limit[S2N_TLS_SEQUENCE_NUM_LEN] = {0, 0, 0, 0, 1, 106, 9, 229};
+
     /* s2n_send sends key update if necessary */
     {
         struct s2n_connection *server_conn;
@@ -96,10 +99,9 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&output, &input, client_conn));
         
         /* Mimic key update send conditions */
-        server_conn->secure.server_sequence_number[4] = 1;
-        server_conn->secure.server_sequence_number[5] = 106;
-        server_conn->secure.server_sequence_number[6] = 9;
-        server_conn->secure.server_sequence_number[7] = 229;
+        for (int i = 0; i < S2N_TLS_SEQUENCE_NUM_LEN; i++) {
+            server_conn->secure.server_sequence_number[i] = max_record_limit[i];
+        }
 
         /* Next message to send will trigger key update message*/
         s2n_blocked_status blocked;

--- a/tests/unit/s2n_sequence_number_test.c
+++ b/tests/unit/s2n_sequence_number_test.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "crypto/s2n_sequence.h"
+
+#include "error/s2n_errno.h"
+
+#include "tls/s2n_crypto.h"
+
+#include "s2n_test.h"
+
+#include "testlib/s2n_testlib.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+    /* s2n_convert_sequence_number */
+    {
+        /* Converts zero */
+        {
+            uint64_t output = 0;
+            uint8_t data[S2N_TLS_SEQUENCE_NUM_LEN];
+            struct s2n_blob sequence_number = {0};
+            
+            EXPECT_SUCCESS(s2n_blob_init(&sequence_number, data, S2N_TLS_SEQUENCE_NUM_LEN));
+
+            EXPECT_SUCCESS(s2n_convert_sequence_number(&sequence_number, &output));
+
+            EXPECT_EQUAL(output, 0); 
+        }
+
+        /* Converts one */
+        {
+            uint64_t output = 0;
+            uint8_t data[S2N_TLS_SEQUENCE_NUM_LEN];
+            struct s2n_blob sequence_number = {0};
+
+            EXPECT_SUCCESS(s2n_blob_init(&sequence_number, data, S2N_TLS_SEQUENCE_NUM_LEN));
+            EXPECT_SUCCESS(s2n_blob_zero(&sequence_number));
+            sequence_number.data[7] = 1;
+
+            EXPECT_SUCCESS(s2n_convert_sequence_number(&sequence_number, &output));
+            
+            EXPECT_EQUAL(output, 1); 
+        }
+
+        /* Converts max possible sequence number */
+        {
+            uint64_t output = 0;
+            uint8_t data[S2N_TLS_SEQUENCE_NUM_LEN];
+            struct s2n_blob sequence_number = {0};
+            
+            EXPECT_SUCCESS(s2n_blob_init(&sequence_number, data, S2N_TLS_SEQUENCE_NUM_LEN));
+            EXPECT_SUCCESS(s2n_blob_zero(&sequence_number));
+
+            for (int i = 0; i < S2N_TLS_SEQUENCE_NUM_LEN; i++) {
+                sequence_number.data[i] = UINT8_MAX;
+            }
+            
+            EXPECT_SUCCESS(s2n_convert_sequence_number(&sequence_number, &output));
+
+            EXPECT_EQUAL(output, 18446744073709551615U);     
+        }
+
+        /* Converts max record number value */
+        {
+            uint64_t output = 0;
+            uint8_t data[S2N_TLS_SEQUENCE_NUM_LEN];
+            struct s2n_blob sequence_number = {0};
+            
+            EXPECT_SUCCESS(s2n_blob_init(&sequence_number, data, S2N_TLS_SEQUENCE_NUM_LEN));
+            EXPECT_SUCCESS(s2n_blob_zero(&sequence_number));
+
+            sequence_number.data[4] = 1;
+            sequence_number.data[5] = 106;
+            sequence_number.data[6] = 9;
+            sequence_number.data[7] = 229;
+            
+            EXPECT_SUCCESS(s2n_convert_sequence_number(&sequence_number, &output));
+
+            EXPECT_EQUAL(output, S2N_TLS13_AES_GCM_MAXIMUM_RECORD_NUMBER);   
+        }
+    }
+    END_TEST();
+}

--- a/tests/unit/s2n_sequence_number_test.c
+++ b/tests/unit/s2n_sequence_number_test.c
@@ -26,18 +26,17 @@
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
-    /* s2n_convert_sequence_number */
+    /* s2n_sequence_number_to_uint64 */
     {
         /* Converts zero */
         {
-            uint64_t output = 0;
-            uint8_t data[S2N_TLS_SEQUENCE_NUM_LEN];
+            uint64_t output = 1;
+            uint8_t data[S2N_TLS_SEQUENCE_NUM_LEN]= {0};
             struct s2n_blob sequence_number = {0};
             
             EXPECT_SUCCESS(s2n_blob_init(&sequence_number, data, S2N_TLS_SEQUENCE_NUM_LEN));
-            EXPECT_SUCCESS(s2n_blob_zero(&sequence_number));
 
-            EXPECT_SUCCESS(s2n_convert_sequence_number(&sequence_number, &output));
+            EXPECT_SUCCESS(s2n_sequence_number_to_uint64(&sequence_number, &output));
 
             EXPECT_EQUAL(output, 0); 
         }
@@ -45,14 +44,13 @@ int main(int argc, char **argv)
         /* Converts one */
         {
             uint64_t output = 0;
-            uint8_t data[S2N_TLS_SEQUENCE_NUM_LEN];
+            uint8_t data[S2N_TLS_SEQUENCE_NUM_LEN]  = {0};
+            data[S2N_TLS_SEQUENCE_NUM_LEN - 1] = 1;
             struct s2n_blob sequence_number = {0};
-
+            
             EXPECT_SUCCESS(s2n_blob_init(&sequence_number, data, S2N_TLS_SEQUENCE_NUM_LEN));
-            EXPECT_SUCCESS(s2n_blob_zero(&sequence_number));
-            sequence_number.data[7] = 1;
 
-            EXPECT_SUCCESS(s2n_convert_sequence_number(&sequence_number, &output));
+            EXPECT_SUCCESS(s2n_sequence_number_to_uint64(&sequence_number, &output));
             
             EXPECT_EQUAL(output, 1); 
         }
@@ -60,7 +58,7 @@ int main(int argc, char **argv)
         /* Converts max possible sequence number */
         {
             uint64_t output = 0;
-            uint8_t data[S2N_TLS_SEQUENCE_NUM_LEN];
+            uint8_t data[S2N_TLS_SEQUENCE_NUM_LEN] = {0};
             struct s2n_blob sequence_number = {0};
             
             EXPECT_SUCCESS(s2n_blob_init(&sequence_number, data, S2N_TLS_SEQUENCE_NUM_LEN));
@@ -70,7 +68,7 @@ int main(int argc, char **argv)
                 sequence_number.data[i] = UINT8_MAX;
             }
             
-            EXPECT_SUCCESS(s2n_convert_sequence_number(&sequence_number, &output));
+            EXPECT_SUCCESS(s2n_sequence_number_to_uint64(&sequence_number, &output));
 
             EXPECT_EQUAL(output, 18446744073709551615U);     
         }
@@ -78,18 +76,14 @@ int main(int argc, char **argv)
         /* Converts max record number value */
         {
             uint64_t output = 0;
-            uint8_t data[S2N_TLS_SEQUENCE_NUM_LEN];
+            
+            /* The maximum record number converted to base 256 */
+            uint8_t data[S2N_TLS_SEQUENCE_NUM_LEN] = {0, 0, 0, 0, 1, 106, 9, 229};
             struct s2n_blob sequence_number = {0};
             
             EXPECT_SUCCESS(s2n_blob_init(&sequence_number, data, S2N_TLS_SEQUENCE_NUM_LEN));
-            EXPECT_SUCCESS(s2n_blob_zero(&sequence_number));
-
-            sequence_number.data[4] = 1;
-            sequence_number.data[5] = 106;
-            sequence_number.data[6] = 9;
-            sequence_number.data[7] = 229;
             
-            EXPECT_SUCCESS(s2n_convert_sequence_number(&sequence_number, &output));
+            EXPECT_SUCCESS(s2n_sequence_number_to_uint64(&sequence_number, &output));
 
             EXPECT_EQUAL(output, S2N_TLS13_AES_GCM_MAXIMUM_RECORD_NUMBER);   
         }

--- a/tests/unit/s2n_sequence_number_test.c
+++ b/tests/unit/s2n_sequence_number_test.c
@@ -64,7 +64,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_blob_init(&sequence_number, data, S2N_TLS_SEQUENCE_NUM_LEN));
             EXPECT_SUCCESS(s2n_blob_zero(&sequence_number));
 
-            for (int i = 0; i < S2N_TLS_SEQUENCE_NUM_LEN; i++) {
+            for (size_t i = 0; i < S2N_TLS_SEQUENCE_NUM_LEN; i++) {
                 sequence_number.data[i] = UINT8_MAX;
             }
             

--- a/tests/unit/s2n_sequence_number_test.c
+++ b/tests/unit/s2n_sequence_number_test.c
@@ -35,6 +35,7 @@ int main(int argc, char **argv)
             struct s2n_blob sequence_number = {0};
             
             EXPECT_SUCCESS(s2n_blob_init(&sequence_number, data, S2N_TLS_SEQUENCE_NUM_LEN));
+            EXPECT_SUCCESS(s2n_blob_zero(&sequence_number));
 
             EXPECT_SUCCESS(s2n_convert_sequence_number(&sequence_number, &output));
 

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -185,14 +185,14 @@ const struct s2n_record_algorithm s2n_tls13_record_alg_aes128_gcm = {
     .cipher = &s2n_tls13_aes128_gcm,
     .hmac_alg = S2N_HMAC_NONE, /* previously used in 1.2 prf, we do not need this */
     .flags = S2N_TLS13_RECORD_AEAD_NONCE,
-    .encryption_limit = S2N_TLS13_AES_GCM_MAXIMUM_BYTES_TO_ENCRYPT,
+    .encryption_limit = S2N_TLS13_AES_GCM_MAXIMUM_RECORD_NUMBER,
 };
 
 const struct s2n_record_algorithm s2n_tls13_record_alg_aes256_gcm = {
     .cipher = &s2n_tls13_aes256_gcm,
     .hmac_alg = S2N_HMAC_NONE,
     .flags = S2N_TLS13_RECORD_AEAD_NONCE,
-    .encryption_limit = S2N_TLS13_AES_GCM_MAXIMUM_BYTES_TO_ENCRYPT,
+    .encryption_limit = S2N_TLS13_AES_GCM_MAXIMUM_RECORD_NUMBER,
 };
 
 const struct s2n_record_algorithm s2n_tls13_record_alg_chacha20_poly1305 = {

--- a/tls/s2n_cipher_suites.h
+++ b/tls/s2n_cipher_suites.h
@@ -50,10 +50,10 @@
  * For AES-GCM, up to 2^24.5 full-size records (about 24 million) may be
  * encrypted on a given connection while keeping a safety margin of
  * approximately 2^-57 for Authenticated Encryption (AE) security.
- * S2N_TLS13_MAXIMUM_RECORD_NUMBER is 2^24.5 rounded down to the nearest whole number.
+ * S2N_TLS13_MAXIMUM_RECORD_NUMBER is 2^24.5 rounded down to the nearest whole number
+ * minus 1 for the key update message.
  */
-#define S2N_TLS13_MAXIMUM_RECORD_NUMBER            ((uint64_t) 23726566)
-#define S2N_TLS13_AES_GCM_MAXIMUM_BYTES_TO_ENCRYPT (S2N_TLS13_MAXIMUM_FRAGMENT_LENGTH * S2N_TLS13_MAXIMUM_RECORD_NUMBER)
+#define S2N_TLS13_AES_GCM_MAXIMUM_RECORD_NUMBER ((uint64_t) 23726565)
 
 typedef enum {
     S2N_AUTHENTICATION_RSA = 0,

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -240,7 +240,6 @@ struct s2n_connection {
     /* Keep some accounting on each connection */
     uint64_t wire_bytes_in;
     uint64_t wire_bytes_out;
-    uint64_t encrypted_bytes_out;
 
     /* Is the connection open or closed ? We use C's only
      * atomic type as both the reader and the writer threads

--- a/tls/s2n_key_update.c
+++ b/tls/s2n_key_update.c
@@ -108,7 +108,7 @@ int s2n_check_record_limit(struct s2n_connection *conn, struct s2n_blob *sequenc
     if (output + 1 > conn->secure.cipher_suite->record_alg->encryption_limit) {
         conn->key_update_pending = true;
     }
-    
+
     return S2N_SUCCESS;
 }
 

--- a/tls/s2n_key_update.c
+++ b/tls/s2n_key_update.c
@@ -20,9 +20,13 @@
 #include "tls/s2n_tls13_handshake.h"
 #include "tls/s2n_record.h"
 
+#include "crypto/s2n_sequence.h"
+
 #include "utils/s2n_safety.h"
 
 int s2n_key_update_write(struct s2n_blob *out);
+int s2n_check_key_limits(struct s2n_connection *conn, struct s2n_blob *sequence_number); 
+
 
 int s2n_key_update_recv(struct s2n_connection *conn, struct s2n_stuffer *request)
 {
@@ -44,11 +48,18 @@ int s2n_key_update_recv(struct s2n_connection *conn, struct s2n_stuffer *request
     return S2N_SUCCESS;
 }
 
-int s2n_key_update_send(struct s2n_connection *conn, size_t size) 
+int s2n_key_update_send(struct s2n_connection *conn) 
 {
     notnull_check(conn);
 
-    GUARD(s2n_check_key_limits(conn, size));
+    struct s2n_blob sequence_number = {0};
+    if (conn->mode == S2N_CLIENT) {
+        GUARD(s2n_blob_init(&sequence_number, conn->secure.client_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
+    } else {
+        GUARD(s2n_blob_init(&sequence_number, conn->secure.server_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
+    }
+
+    GUARD(s2n_check_key_limits(conn, &sequence_number));
 
     if (conn->key_update_pending) {
         uint8_t key_update_data[S2N_KEY_UPDATE_MESSAGE_SIZE];
@@ -64,7 +75,6 @@ int s2n_key_update_send(struct s2n_connection *conn, size_t size)
         /* Update encryption key */
         GUARD(s2n_update_application_traffic_keys(conn, conn->mode, SENDING));
         conn->key_update_pending = false;
-        conn->encrypted_bytes_out = 0;
     }
 
     return S2N_SUCCESS;
@@ -85,13 +95,17 @@ int s2n_key_update_write(struct s2n_blob *out)
     return S2N_SUCCESS;
 }
 
-int s2n_check_key_limits(struct s2n_connection *conn, size_t size) 
+int s2n_check_key_limits(struct s2n_connection *conn, struct s2n_blob *sequence_number)
 {
     notnull_check(conn);
+    notnull_check(sequence_number);
     notnull_check(conn->secure.cipher_suite);
     notnull_check(conn->secure.cipher_suite->record_alg);
 
-    if (conn->encrypted_bytes_out + size > conn->secure.cipher_suite->record_alg->encryption_limit) {
+    uint64_t output = 0;
+    GUARD(s2n_convert_sequence_number(sequence_number, &output));
+
+    if (output + 1 > conn->secure.cipher_suite->record_alg->encryption_limit) {
         conn->key_update_pending = true;
     }
 

--- a/tls/s2n_key_update.h
+++ b/tls/s2n_key_update.h
@@ -31,5 +31,4 @@ typedef enum {
 } keyupdate_request;
 
 int s2n_key_update_recv(struct s2n_connection *conn, struct s2n_stuffer *request);
-int s2n_key_update_send(struct s2n_connection *conn, size_t size);
-int s2n_check_key_limits(struct s2n_connection *conn, size_t size); 
+int s2n_key_update_send(struct s2n_connection *conn);

--- a/tls/s2n_post_handshake.c
+++ b/tls/s2n_post_handshake.c
@@ -57,11 +57,11 @@ int s2n_post_handshake_recv(struct s2n_connection *conn)
     return S2N_SUCCESS;
 }
 
-int s2n_post_handshake_send(struct s2n_connection *conn, s2n_blocked_status *blocked, size_t size)
+int s2n_post_handshake_send(struct s2n_connection *conn, s2n_blocked_status *blocked)
 {
     notnull_check(conn);
 
-    GUARD(s2n_key_update_send(conn, size));
+    GUARD(s2n_key_update_send(conn));
     GUARD(s2n_flush(conn, blocked));
     GUARD(s2n_stuffer_rewrite(&conn->out));
 

--- a/tls/s2n_post_handshake.h
+++ b/tls/s2n_post_handshake.h
@@ -18,4 +18,4 @@
 #include "tls/s2n_connection.h"
 
 int s2n_post_handshake_recv(struct s2n_connection *conn);
-int s2n_post_handshake_send(struct s2n_connection *conn, s2n_blocked_status *blocked, size_t size);
+int s2n_post_handshake_send(struct s2n_connection *conn, s2n_blocked_status *blocked);

--- a/tls/s2n_record_write.c
+++ b/tls/s2n_record_write.c
@@ -406,7 +406,7 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
         conn->client = current_client_crypto;
         conn->server = current_server_crypto;
     }
-    conn->encrypted_bytes_out += encrypted_length;
+
     conn->wire_bytes_out += actual_fragment_length + S2N_TLS_RECORD_HEADER_LENGTH;
 
     return data_bytes_to_take;

--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -171,7 +171,7 @@ ssize_t s2n_sendv_with_offset(struct s2n_connection *conn, const struct iovec *b
     
         GUARD(s2n_stuffer_rewrite(&conn->out));
 
-        GUARD(s2n_post_handshake_send(conn, blocked, to_write));
+        GUARD(s2n_post_handshake_send(conn, blocked));
     
         /* Write and encrypt the record */
         GUARD(s2n_record_writev(conn, TLS_APPLICATION_DATA, bufs, count, 


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

 resolves #1966 

### Description of changes: 

Currently s2n initiates a key update when we have encrypted a specific number of bytes with a given key. This should be switched to a specific number of records.
### Call-outs:

s2n stores sequence numbers in an 8 element array, where each element is a uint8_t (it can hold 2^8 values). This means that in order to compare the sequence number to a decimal limit, we will have to convert the number from base 256 to base 10. This is done in the function s2n_covert_sequence_number().
### Testing:

Altered all the unit test code that dealt with the encrypted bytes. Added a unit test file called sequence_number_test to check that the conversion from base 256 to base 10 is correct.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
