### PR TITLE
Improves documentation for s2n_stuffer and s2n_blob

### DIFF
--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -46,7 +46,7 @@ int s2n_stuffer_init(struct s2n_stuffer *stuffer, struct s2n_blob *in)
     stuffer->alloced = 0;
     stuffer->growable = 0;
     stuffer->tainted = 0;
-    return 0;
+    return S2N_SUCCESS;
 }
 int s2n_stuffer_alloc(struct s2n_stuffer *stuffer, const uint32_t size)
 {
@@ -55,7 +55,7 @@ int s2n_stuffer_alloc(struct s2n_stuffer *stuffer, const uint32_t size)
 
     stuffer->alloced = 1;
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_stuffer_growable_alloc(struct s2n_stuffer *stuffer, const uint32_t size)
@@ -64,7 +64,7 @@ int s2n_stuffer_growable_alloc(struct s2n_stuffer *stuffer, const uint32_t size)
 
     stuffer->growable = 1;
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_stuffer_free(struct s2n_stuffer *stuffer)
@@ -74,7 +74,7 @@ int s2n_stuffer_free(struct s2n_stuffer *stuffer)
     }
     *stuffer = (struct s2n_stuffer) {0};
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_stuffer_resize(struct s2n_stuffer *stuffer, const uint32_t size)
@@ -83,7 +83,7 @@ int s2n_stuffer_resize(struct s2n_stuffer *stuffer, const uint32_t size)
     S2N_ERROR_IF(stuffer->growable == 0, S2N_ERR_RESIZE_STATIC_STUFFER);
 
     if (size == stuffer->blob.size) {
-        return 0;
+        return S2N_SUCCESS;
     }
 
     if (size < stuffer->blob.size) {
@@ -92,7 +92,7 @@ int s2n_stuffer_resize(struct s2n_stuffer *stuffer, const uint32_t size)
 
     GUARD(s2n_realloc(&stuffer->blob, size));
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_stuffer_resize_if_empty(struct s2n_stuffer *stuffer, const uint32_t size)
@@ -112,7 +112,7 @@ int s2n_stuffer_rewrite(struct s2n_stuffer *stuffer)
     stuffer->write_cursor = 0;
     stuffer->read_cursor = 0;
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_stuffer_rewind_read(struct s2n_stuffer *stuffer, const uint32_t size)
@@ -121,14 +121,14 @@ int s2n_stuffer_rewind_read(struct s2n_stuffer *stuffer, const uint32_t size)
         S2N_ERROR(S2N_ERR_STUFFER_OUT_OF_DATA);
     }
     stuffer->read_cursor -= size;
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_stuffer_reread(struct s2n_stuffer *stuffer)
 {
     PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     stuffer->read_cursor = 0;
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_stuffer_wipe_n(struct s2n_stuffer *stuffer, const uint32_t size)
@@ -142,13 +142,13 @@ int s2n_stuffer_wipe_n(struct s2n_stuffer *stuffer, const uint32_t size)
     memset_check(stuffer->blob.data + stuffer->write_cursor, S2N_WIPE_PATTERN, size);
     stuffer->read_cursor = MIN(stuffer->read_cursor, stuffer->write_cursor);
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_stuffer_release_if_empty(struct s2n_stuffer *stuffer)
 {
     if (stuffer->blob.data == NULL) {
-        return 0;
+        return S2N_SUCCESS;
     }
 
     S2N_ERROR_IF(stuffer->read_cursor != stuffer->write_cursor,
@@ -157,7 +157,7 @@ int s2n_stuffer_release_if_empty(struct s2n_stuffer *stuffer)
     GUARD(s2n_stuffer_wipe(stuffer));
     GUARD(s2n_stuffer_resize(stuffer, 0));
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_stuffer_wipe(struct s2n_stuffer *stuffer)
@@ -179,7 +179,7 @@ int s2n_stuffer_skip_read(struct s2n_stuffer *stuffer, uint32_t n)
     S2N_ERROR_IF(s2n_stuffer_data_available(stuffer) < n, S2N_ERR_STUFFER_OUT_OF_DATA);
 
     stuffer->read_cursor += n;
-    return 0;
+    return S2N_SUCCESS;
 }
 
 void *s2n_stuffer_raw_read(struct s2n_stuffer *stuffer, uint32_t data_len)
@@ -208,7 +208,7 @@ int s2n_stuffer_erase_and_read(struct s2n_stuffer *stuffer, struct s2n_blob *out
     memcpy_check(out->data, ptr, out->size);
     memset_check(ptr, 0, out->size);
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_stuffer_read_bytes(struct s2n_stuffer *stuffer, uint8_t * data, uint32_t size)
@@ -220,7 +220,7 @@ int s2n_stuffer_read_bytes(struct s2n_stuffer *stuffer, uint8_t * data, uint32_t
 
     memcpy_check(data, ptr, size);
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_stuffer_erase_and_read_bytes(struct s2n_stuffer *stuffer, uint8_t * data, uint32_t size)
@@ -232,7 +232,7 @@ int s2n_stuffer_erase_and_read_bytes(struct s2n_stuffer *stuffer, uint8_t * data
     memcpy_check(data, ptr, size);
     memset_check(ptr, 0, size);
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_stuffer_skip_write(struct s2n_stuffer *stuffer, const uint32_t n)
@@ -240,7 +240,7 @@ int s2n_stuffer_skip_write(struct s2n_stuffer *stuffer, const uint32_t n)
     GUARD(s2n_stuffer_reserve_space(stuffer, n));
     stuffer->write_cursor += n;
     stuffer->high_water_mark = MAX(stuffer->write_cursor, stuffer->high_water_mark);
-    return 0;
+    return S2N_SUCCESS;
 }
 
 void *s2n_stuffer_raw_write(struct s2n_stuffer *stuffer, const uint32_t data_len)
@@ -265,12 +265,12 @@ int s2n_stuffer_write_bytes(struct s2n_stuffer *stuffer, const uint8_t * data, c
     notnull_check(ptr);
 
     if (ptr == data) {
-        return 0;
+        return S2N_SUCCESS;
     }
 
     memcpy_check(ptr, data, size);
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_stuffer_writev_bytes(struct s2n_stuffer *stuffer, const struct iovec* iov, int iov_count, size_t offs, size_t size)
@@ -296,7 +296,7 @@ int s2n_stuffer_writev_bytes(struct s2n_stuffer *stuffer, const struct iovec* io
         to_skip = 0;
     }
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 static int s2n_stuffer_copy_impl(struct s2n_stuffer *from, struct s2n_stuffer *to, const uint32_t len)
@@ -309,7 +309,7 @@ static int s2n_stuffer_copy_impl(struct s2n_stuffer *from, struct s2n_stuffer *t
 
     memcpy_check(to_ptr, from_ptr, len);
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_stuffer_reserve_space(struct s2n_stuffer *stuffer, uint32_t n)
@@ -339,7 +339,7 @@ int s2n_stuffer_copy(struct s2n_stuffer *from, struct s2n_stuffer *to, const uin
         S2N_ERROR_PRESERVE_ERRNO();
     }
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_stuffer_extract_blob(struct s2n_stuffer *stuffer, struct s2n_blob *out)

--- a/utils/s2n_blob.c
+++ b/utils/s2n_blob.c
@@ -62,7 +62,7 @@ int s2n_blob_slice(const struct s2n_blob *b, struct s2n_blob *slice, uint32_t of
     slice->growable = 0;
     slice->allocated = 0;
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_blob_char_to_lower(struct s2n_blob *b)
@@ -73,7 +73,7 @@ int s2n_blob_char_to_lower(struct s2n_blob *b)
         ptr++;
     }
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 /* An inverse map from an ascii value to a hexidecimal nibble value
@@ -118,5 +118,5 @@ int s2n_hex_string_to_bytes(const char *str, struct s2n_blob *blob)
         blob->data[i / 2] = high_nibble << 4 | low_nibble;
     }
 
-    return 0;
+    return S2N_SUCCESS;
 }


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A.

### Description of changes: 

`s/return 0/return S2N_SUCCESS/g`

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
