### PR TITLE
Generate correct cbmc-batch.yaml locally

### DIFF
--- a/tests/cbmc/proofs/Makefile.cbmc_batch
+++ b/tests/cbmc/proofs/Makefile.cbmc_batch
@@ -50,7 +50,7 @@ define yaml_encode_options
        "$(shell echo $(1) | sed 's/ ,/ /g' | sed 's/ /;/g')"
 endef
 
-$(ENTRY).yaml: 
+$(ENTRY).yaml:
 	echo 'batchpkg: $(BATCHPKG)' > $@
 	echo 'build: true' >> $@
 	echo 'cbmcflags: $(call yaml_encode_options,$(CHECKFLAGS) $(CBMCFLAGS))' >> $@
@@ -64,11 +64,17 @@ $(ENTRY).yaml:
 
 batch-yaml: $(ENTRY).yaml Makefile
 
-cbmc-batch.yaml: 
+cbmc-batch.yaml:
 	echo 'cbmcflags: $(strip $(call yaml_encode_options,$(CHECKFLAGS) $(CBMCFLAGS)))' > $@
 	echo 'expected: "SUCCESSFUL"' >> $@
 	echo 'goto: gotos/$(ENTRY).goto' >> $@
 	echo 'jobos: ubuntu16' >> $@
+
+empty-cbmc-batch.yaml:
+	echo ':' > 'cbmc-batch.yaml'
+	echo '  This file marks this directory as containing a CBMC proof. This file' >> 'cbmc-batch.yaml'
+	echo '  is automatically clobbered in CI and replaced with parameters for' >> 'cbmc-batch.yaml'
+	echo '  running the proof.' >> 'cbmc-batch.yaml'
 
 ci-yaml: cbmc-batch.yaml Makefile
 

--- a/tests/cbmc/proofs/s2n_blob_init/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_blob_init/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--bounds-check;--conversion-check;--div-by-zero-check;--enum-range-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
-expected: "SUCCESSFUL"
-goto: gotos/s2n_blob_init_harness.goto
-jobos: ubuntu16
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_blob_is_growable/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_blob_is_growable/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--bounds-check;--conversion-check;--div-by-zero-check;--enum-range-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
-expected: "SUCCESSFUL"
-goto: gotos/s2n_blob_is_growable_harness.goto
-jobos: ubuntu16
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A.

### Description of changes: 

- Updates `Makefile.cbmc-batch` file to properly generate `cbmc-batch.yaml` files locally;
- Clean up existing `cbmc-batch.yaml` files. These files are generated during CI and do not need to contain any implementation, just a standard message.

### Call-outs:

N/A.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
