### PR TITLE
Updates s2n_blob and s2n_stuffer validity functions

### DIFF
--- a/crypto/s2n_certificate.c
+++ b/crypto/s2n_certificate.c
@@ -512,6 +512,6 @@ s2n_pkey_type s2n_cert_chain_and_key_get_pkey_type(struct s2n_cert_chain_and_key
 
 s2n_cert_private_key *s2n_cert_chain_and_key_get_private_key(struct s2n_cert_chain_and_key *chain_and_key)
 {
-    ENSURE_PTR_NONNULL(chain_and_key);
+    ENSURE_REF_PTR(chain_and_key);
     return chain_and_key->private_key;
 }

--- a/crypto/s2n_ecc_evp.c
+++ b/crypto/s2n_ecc_evp.c
@@ -55,17 +55,17 @@ const struct s2n_ecc_named_curve s2n_ecc_curve_secp384r1 =
 
 #if EVP_APIS_SUPPORTED
 const struct s2n_ecc_named_curve s2n_ecc_curve_x25519 = {
-    .iana_id = TLS_EC_CURVE_ECDH_X25519, 
-    .libcrypto_nid = NID_X25519, 
-    .name = "x25519", 
+    .iana_id = TLS_EC_CURVE_ECDH_X25519,
+    .libcrypto_nid = NID_X25519,
+    .name = "x25519",
     .share_size = 32
 };
-#else 
+#else
 const struct s2n_ecc_named_curve s2n_ecc_curve_x25519 = {0};
 #endif
 
-/* All curves that s2n supports. New curves MUST be added here. 
- * This list is a super set of all the curves present in s2n_ecc_preferences list. 
+/* All curves that s2n supports. New curves MUST be added here.
+ * This list is a super set of all the curves present in s2n_ecc_preferences list.
  */
 const struct s2n_ecc_named_curve *const s2n_all_supported_curves_list[] = {
     &s2n_ecc_curve_secp256r1,
@@ -158,7 +158,7 @@ static int s2n_ecc_evp_compute_shared_secret(EVP_PKEY *own_key, EVP_PKEY *peer_p
     }
 
     size_t shared_secret_size;
-    
+
     DEFER_CLEANUP(EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new(own_key, NULL), EVP_PKEY_CTX_free_pointer);
     S2N_ERROR_IF(ctx == NULL, S2N_ERR_ECDHE_SHARED_SECRET);
 
@@ -177,7 +177,7 @@ static int s2n_ecc_evp_compute_shared_secret(EVP_PKEY *own_key, EVP_PKEY *peer_p
 
 int s2n_ecc_evp_generate_ephemeral_key(struct s2n_ecc_evp_params *ecc_evp_params) {
     notnull_check(ecc_evp_params->negotiated_curve);
-    S2N_ERROR_IF(ecc_evp_params->evp_pkey != NULL, S2N_ERR_ECDHE_GEN_KEY); 
+    S2N_ERROR_IF(ecc_evp_params->evp_pkey != NULL, S2N_ERR_ECDHE_GEN_KEY);
     S2N_ERROR_IF(s2n_ecc_evp_generate_own_key(ecc_evp_params->negotiated_curve, &ecc_evp_params->evp_pkey) != 0,
                  S2N_ERR_ECDHE_GEN_KEY);
     S2N_ERROR_IF(ecc_evp_params->evp_pkey == NULL, S2N_ERR_ECDHE_GEN_KEY);
@@ -198,15 +198,15 @@ int s2n_ecc_evp_compute_shared_secret_from_params(struct s2n_ecc_evp_params *pri
     return 0;
 }
 
-int s2n_ecc_evp_compute_shared_secret_as_server(struct s2n_ecc_evp_params *ecc_evp_params, 
+int s2n_ecc_evp_compute_shared_secret_as_server(struct s2n_ecc_evp_params *ecc_evp_params,
                                             struct s2n_stuffer *Yc_in, struct s2n_blob *shared_key) {
     notnull_check(ecc_evp_params->negotiated_curve);
-    notnull_check(ecc_evp_params->evp_pkey); 
+    notnull_check(ecc_evp_params->evp_pkey);
     notnull_check(Yc_in);
 
     uint8_t client_public_len;
     struct s2n_blob client_public_blob = {0};
-    
+
     DEFER_CLEANUP(EVP_PKEY *peer_key = EVP_PKEY_new(), EVP_PKEY_free_pointer);
     S2N_ERROR_IF(peer_key == NULL, S2N_ERR_BAD_MESSAGE);
     GUARD(s2n_stuffer_read_uint8(Yc_in, &client_public_len));
@@ -244,17 +244,17 @@ int s2n_ecc_evp_compute_shared_secret_as_server(struct s2n_ecc_evp_params *ecc_e
 
 }
 
-int s2n_ecc_evp_compute_shared_secret_as_client(struct s2n_ecc_evp_params *ecc_evp_params, 
+int s2n_ecc_evp_compute_shared_secret_as_client(struct s2n_ecc_evp_params *ecc_evp_params,
                                             struct s2n_stuffer *Yc_out, struct s2n_blob *shared_key) {
 
-    DEFER_CLEANUP(struct s2n_ecc_evp_params client_params = {0}, s2n_ecc_evp_params_free); 
+    DEFER_CLEANUP(struct s2n_ecc_evp_params client_params = {0}, s2n_ecc_evp_params_free);
 
     notnull_check(ecc_evp_params->negotiated_curve);
     client_params.negotiated_curve = ecc_evp_params->negotiated_curve;
     GUARD(s2n_ecc_evp_generate_own_key(client_params.negotiated_curve, &client_params.evp_pkey));
     S2N_ERROR_IF(client_params.evp_pkey == NULL, S2N_ERR_ECDHE_GEN_KEY);
 
-    if (s2n_ecc_evp_compute_shared_secret(client_params.evp_pkey, ecc_evp_params->evp_pkey, 
+    if (s2n_ecc_evp_compute_shared_secret(client_params.evp_pkey, ecc_evp_params->evp_pkey,
                                           ecc_evp_params->negotiated_curve->iana_id, shared_key) != S2N_SUCCESS) {
         S2N_ERROR(S2N_ERR_ECDHE_SHARED_SECRET);
     }
@@ -265,7 +265,7 @@ int s2n_ecc_evp_compute_shared_secret_as_client(struct s2n_ecc_evp_params *ecc_e
         S2N_ERROR(S2N_ERR_ECDHE_SERIALIZING);
     }
     return 0;
-    
+
 }
 
 #if (!EVP_APIS_SUPPORTED)
@@ -352,7 +352,7 @@ int s2n_ecc_evp_write_params_point(struct s2n_ecc_evp_params *ecc_evp_params, st
     if (size != ecc_evp_params->negotiated_curve->share_size) {
         OPENSSL_free(encoded_point);
         S2N_ERROR(S2N_ERR_ECDHE_SERIALIZING);
-    } 
+    }
     else {
         point_blob.data = s2n_stuffer_raw_write(out, ecc_evp_params->negotiated_curve->share_size);
         notnull_check(point_blob.data);

--- a/error/s2n_errno.h
+++ b/error/s2n_errno.h
@@ -283,17 +283,18 @@ extern __thread const char *s2n_debug_str;
  * Violations of the function contracts are undefined behaviour.
  */
 #ifdef CBMC
+#    define S2N_OBJECT_PTR_IS_READABLE(ptr) S2N_MEM_IS_READABLE((ptr), sizeof(*(ptr)))
+#    define S2N_OBJECT_PTR_IS_WRITABLE(ptr) S2N_MEM_IS_WRITABLE((ptr), sizeof(*(ptr)))
 #    define S2N_MEM_IS_READABLE(base, len) (((len) == 0) || __CPROVER_r_ok((base), (len)))
 #    define S2N_MEM_IS_WRITABLE(base, len) (((len) == 0) || __CPROVER_w_ok((base), (len)))
 #else
 /* the C runtime does not give a way to check these properties,
  * but we can at least check that the pointer is valid */
-#    define S2N_MEM_IS_READABLE(base, len) (((len) == 0) || (base))
-#    define S2N_MEM_IS_WRITABLE(base, len) (((len) == 0) || (base))
+#    define S2N_OBJECT_PTR_IS_READABLE(ptr) ((ptr) != NULL)
+#    define S2N_OBJECT_PTR_IS_WRITABLE(ptr) ((ptr) != NULL)
+#    define S2N_MEM_IS_READABLE(base, len) (((len) == 0) || (base) != NULL)
+#    define S2N_MEM_IS_WRITABLE(base, len) (((len) == 0) || (base) != NULL)
 #endif /* CBMC */
-
-#define S2N_OBJECT_PTR_IS_READABLE(ptr) S2N_MEM_IS_READABLE((ptr), sizeof(*(ptr)))
-#define S2N_OBJECT_PTR_IS_WRITABLE(ptr) S2N_MEM_IS_WRITABLE((ptr), sizeof(*(ptr)))
 
 #define S2N_IMPLIES(a, b) (!(a) || (b))
 

--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -52,7 +52,7 @@ struct s2n_stuffer {
 #define s2n_stuffer_space_remaining( s )  ((s)->blob.size - (s)->write_cursor)
 #define s2n_stuffer_is_wiped( s )         ((s)->high_water_mark == 0)
 /* Check basic validity constraints on the stuffer: e.g. that cursors point within the blob */
-extern bool s2n_stuffer_is_valid(const struct s2n_stuffer* stuffer);
+extern int s2n_stuffer_validate(const struct s2n_stuffer* stuffer);
 
 /* Initialize and destroying stuffers */
 extern int s2n_stuffer_init(struct s2n_stuffer *stuffer, struct s2n_blob *in);

--- a/stuffer/s2n_stuffer_network_order.c
+++ b/stuffer/s2n_stuffer_network_order.c
@@ -172,7 +172,7 @@ static int length_matches_value_check(uint32_t value, uint8_t length)
 static int s2n_stuffer_write_reservation_impl(struct s2n_stuffer_reservation reservation, uint32_t u)
 {
     reservation.stuffer->write_cursor = reservation.write_cursor;
-    S2N_ERROR_IF(!s2n_stuffer_is_valid(reservation.stuffer), S2N_ERR_PRECONDITION_VIOLATION);
+    GUARD(s2n_stuffer_validate(reservation.stuffer));
 
     GUARD(length_matches_value_check(u, reservation.length));
     GUARD(s2n_stuffer_write_network_order(reservation.stuffer, u, reservation.length));

--- a/tests/cbmc/proofs/s2n_blob_init/s2n_blob_init_harness.c
+++ b/tests/cbmc/proofs/s2n_blob_init/s2n_blob_init_harness.c
@@ -24,16 +24,16 @@
 void s2n_blob_init_harness()
 {
     /* Non-deterministic inputs. */
-    struct s2n_blob * blob = can_fail_malloc( sizeof( *blob ) );
+    struct s2n_blob *blob = can_fail_malloc(sizeof(*blob));
     uint32_t size;
-    uint8_t * data = can_fail_malloc( size );
+    uint8_t *data = can_fail_malloc(size);
 
     /* Pre-conditions. */
     __CPROVER_assume(S2N_IMPLIES(size != 0, data != NULL));
 
     /* Operation under verification. */
-    if( s2n_blob_init( blob, data, size ) == S2N_SUCCESS )
+    if(s2n_blob_init(blob, data, size) == S2N_SUCCESS)
     {
-        assert( s2n_blob_is_valid( blob ) );
+        assert(s2n_blob_validate(blob) == S2N_SUCCESS);
     }
 }

--- a/tests/cbmc/proofs/s2n_blob_is_growable/s2n_blob_is_growable_harness.c
+++ b/tests/cbmc/proofs/s2n_blob_is_growable/s2n_blob_is_growable_harness.c
@@ -24,7 +24,7 @@
 void s2n_blob_is_growable_harness() {
     /* Non-deterministic inputs. */
     struct s2n_blob *blob = cbmc_allocate_s2n_blob();
-    __CPROVER_assume(S2N_IMPLIES(blob!= NULL, s2n_blob_is_valid(blob)));
+    __CPROVER_assume(S2N_IMPLIES(blob!= NULL, s2n_blob_validate(blob) == S2N_SUCCESS));
 
     /* Operation under verification. */
     if(s2n_blob_is_growable(blob)) {
@@ -35,5 +35,5 @@ void s2n_blob_is_growable_harness() {
     }
 
     /* Post-condition. */
-    if(blob != NULL) assert(s2n_blob_is_valid(blob));
+    if(blob != NULL) assert(s2n_blob_validate(blob) == S2N_SUCCESS);
 }

--- a/tests/cbmc/proofs/s2n_blob_zero/s2n_blob_zero_harness.c
+++ b/tests/cbmc/proofs/s2n_blob_zero/s2n_blob_zero_harness.c
@@ -25,12 +25,12 @@ void s2n_blob_zero_harness()
 {
     /* Non-deterministic inputs. */
     struct s2n_blob *blob = cbmc_allocate_s2n_blob();
-    __CPROVER_assume(s2n_blob_is_valid(blob));
+    __CPROVER_assume(s2n_blob_validate(blob) == S2N_SUCCESS);
 
     /* Operation under verification. */
     if(s2n_blob_zero(blob) == S2N_SUCCESS && blob->size != 0)
     {
         assert_all_zeroes(blob->data, blob->size);
     }
-    assert(s2n_blob_is_valid(blob));
+    assert(s2n_blob_validate(blob) == S2N_SUCCESS);
 }

--- a/tests/cbmc/proofs/s2n_stuffer_alloc/s2n_stuffer_alloc_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc/s2n_stuffer_alloc_harness.c
@@ -23,7 +23,7 @@ void s2n_stuffer_alloc_harness() {
   struct s2n_stuffer *stuffer = can_fail_malloc(sizeof(*stuffer));
   struct s2n_blob* in = cbmc_allocate_s2n_blob();
   if (s2n_stuffer_init(stuffer, in) == S2N_SUCCESS){
-    assert(s2n_stuffer_is_valid(stuffer));
-    assert(s2n_blob_is_valid(in));
+    assert(s2n_stuffer_validate(stuffer) == S2N_SUCCESS);
+    assert(s2n_blob_validate(in) == S2N_SUCCESS);
   };
 }

--- a/tests/cbmc/proofs/s2n_stuffer_copy/s2n_stuffer_copy_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_copy/s2n_stuffer_copy_harness.c
@@ -24,12 +24,12 @@
 
 void s2n_stuffer_copy_harness() {
     struct s2n_stuffer *from = cbmc_allocate_s2n_stuffer();
-    __CPROVER_assume(s2n_stuffer_is_valid(from));
+    __CPROVER_assume(s2n_stuffer_validate(from) == S2N_SUCCESS);
     struct s2n_stuffer old_stuffer = *from;
     struct store_byte_from_buffer old_byte;
     save_byte_from_blob(&from->blob, &old_byte);
     struct s2n_stuffer *to = cbmc_allocate_s2n_stuffer();
-    __CPROVER_assume(s2n_stuffer_is_valid(to));
+    __CPROVER_assume(s2n_stuffer_validate(to) == S2N_SUCCESS);
     uint32_t length;
 
     s2n_stuffer_copy(from, to, length);
@@ -43,6 +43,6 @@ void s2n_stuffer_copy_harness() {
     assert(from->growable == old_stuffer.growable);
     assert(from->tainted == old_stuffer.tainted);
     assert_byte_from_blob_matches(&from->blob, &old_byte);
-    assert(s2n_stuffer_is_valid(from));
+    assert(s2n_stuffer_validate(from) == S2N_SUCCESS);
 
 }

--- a/tests/cbmc/proofs/s2n_stuffer_erase_and_read/s2n_stuffer_erase_and_read_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_erase_and_read/s2n_stuffer_erase_and_read_harness.c
@@ -27,8 +27,8 @@ void s2n_calculate_stacktrace() {}
 void s2n_stuffer_erase_and_read_harness() {
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     struct s2n_blob *blob = cbmc_allocate_s2n_blob();
-    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
-    __CPROVER_assume(s2n_blob_is_valid(blob));
+    __CPROVER_assume(s2n_stuffer_validate(stuffer) == S2N_SUCCESS);
+    __CPROVER_assume(s2n_blob_validate(blob) == S2N_SUCCESS);
 
     struct s2n_stuffer old_stuffer = *stuffer;
     struct s2n_blob old_blob = *blob;
@@ -46,7 +46,7 @@ void s2n_stuffer_erase_and_read_harness() {
     if (s2n_stuffer_erase_and_read(stuffer, blob) == S2N_SUCCESS) {
         assert(stuffer->read_cursor == old_stuffer.read_cursor + old_blob.size);
         assert_all_zeroes(&(old_stuffer.blob.data[old_stuffer.read_cursor]), old_blob.size);
-        assert_byte_from_blob_matches(blob, &copied_byte); 
+        assert_byte_from_blob_matches(blob, &copied_byte);
     } else {
         assert(stuffer->read_cursor == old_stuffer.read_cursor);
         assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
@@ -65,6 +65,6 @@ void s2n_stuffer_erase_and_read_harness() {
     assert(blob->growable == old_blob.growable);
     assert(blob->size == old_blob.size);
 
-    assert(s2n_stuffer_is_valid(stuffer));
-    assert(s2n_blob_is_valid(stuffer));
+    assert(s2n_stuffer_validate(stuffer) == S2N_SUCCESS);
+    assert(s2n_blob_validate(stuffer) == S2N_SUCCESS);
 }

--- a/tests/cbmc/proofs/s2n_stuffer_erase_and_read_bytes/s2n_stuffer_erase_and_read_bytes_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_erase_and_read_bytes/s2n_stuffer_erase_and_read_bytes_harness.c
@@ -23,8 +23,8 @@
 void s2n_stuffer_erase_and_read_bytes_harness() {
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     struct s2n_blob *blob = cbmc_allocate_s2n_blob();
-    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
-    __CPROVER_assume(s2n_blob_is_valid(blob));
+    __CPROVER_assume(s2n_stuffer_validate(stuffer) == S2N_SUCCESS);
+    __CPROVER_assume(s2n_blob_validate(blob) == S2N_SUCCESS);
     struct s2n_stuffer old_stuffer = *stuffer;
     struct s2n_blob old_blob = *blob;
     struct store_byte_from_buffer old_byte;
@@ -57,6 +57,6 @@ void s2n_stuffer_erase_and_read_bytes_harness() {
     assert(blob->growable == old_blob.growable);
     assert(blob->size == old_blob.size);
 
-    assert(s2n_stuffer_is_valid(stuffer));
-    assert(s2n_blob_is_valid(blob));
+    assert(s2n_stuffer_validate(stuffer) == S2N_SUCCESS);
+    assert(s2n_blob_validate(blob) == S2N_SUCCESS);
 }

--- a/tests/cbmc/proofs/s2n_stuffer_free/s2n_stuffer_free_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_free/s2n_stuffer_free_harness.c
@@ -31,7 +31,7 @@ int munlock(const void *addr, size_t len) {
 
 void s2n_stuffer_free_harness() {
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
-    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    __CPROVER_assume(s2n_stuffer_validate(stuffer) == S2N_SUCCESS);
 
     if (s2n_stuffer_free(stuffer) == 0) {
         assert_all_zeroes(stuffer, sizeof(*stuffer));

--- a/tests/cbmc/proofs/s2n_stuffer_init/s2n_stuffer_init_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_init/s2n_stuffer_init_harness.c
@@ -23,7 +23,7 @@ void s2n_stuffer_init_harness() {
   struct s2n_stuffer *stuffer = can_fail_malloc(sizeof(*stuffer));
   struct s2n_blob* in = cbmc_allocate_s2n_blob();
   if (s2n_stuffer_init(stuffer, in) == S2N_SUCCESS){
-    assert(s2n_stuffer_is_valid(stuffer));
-    assert(s2n_blob_is_valid(in));
+    assert(s2n_stuffer_validate(stuffer) == S2N_SUCCESS);
+    assert(s2n_blob_validate(in) == S2N_SUCCESS);
   };
 }

--- a/tests/cbmc/proofs/s2n_stuffer_raw_read/s2n_stuffer_raw_read_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_raw_read/s2n_stuffer_raw_read_harness.c
@@ -23,7 +23,7 @@
 
 void s2n_stuffer_raw_read_harness() {
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
-    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    __CPROVER_assume(s2n_stuffer_validate(stuffer) == S2N_SUCCESS);
     struct s2n_stuffer old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte;
     save_byte_from_blob(&stuffer->blob, &old_byte);
@@ -46,5 +46,5 @@ void s2n_stuffer_raw_read_harness() {
     assert(stuffer->alloced == old_stuffer.alloced);
     assert(stuffer->growable == old_stuffer.growable);
     assert_byte_from_blob_matches(&stuffer->blob, &old_byte);
-    assert(s2n_stuffer_is_valid(stuffer));
+    assert(s2n_stuffer_validate(stuffer) == S2N_SUCCESS);
 }

--- a/tests/cbmc/proofs/s2n_stuffer_read/s2n_stuffer_read_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read/s2n_stuffer_read_harness.c
@@ -23,13 +23,13 @@
 void s2n_stuffer_read_harness() {
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     struct s2n_blob *blob = cbmc_allocate_s2n_blob();
-    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
-    __CPROVER_assume(s2n_blob_is_valid(blob));
+    __CPROVER_assume(s2n_stuffer_validate(stuffer) == S2N_SUCCESS);
+    __CPROVER_assume(s2n_blob_validate(blob) == S2N_SUCCESS);
     struct s2n_stuffer old_stuffer = *stuffer;
     struct s2n_blob old_blob = *blob;
     struct store_byte_from_buffer old_byte;
     save_byte_from_blob(&stuffer->blob, &old_byte);
-   
+
     /* int s2n_stuffer_read(struct s2n_stuffer *stuffer, struct s2n_blob *out) */
     if (s2n_stuffer_read(stuffer, blob) == S2N_SUCCESS) {
         assert(stuffer->read_cursor == old_stuffer.read_cursor + old_blob.size);
@@ -51,6 +51,6 @@ void s2n_stuffer_read_harness() {
     assert(blob->size == old_blob.size);
 
     assert_byte_from_blob_matches(&stuffer->blob, &old_byte);
-    assert(s2n_stuffer_is_valid(stuffer));
-    assert(s2n_blob_is_valid(stuffer));
+    assert(s2n_stuffer_validate(stuffer) == S2N_SUCCESS);
+    assert(s2n_blob_validate(stuffer) == S2N_SUCCESS);
 }

--- a/tests/cbmc/proofs/s2n_stuffer_read_bytes/s2n_stuffer_read_bytes_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_bytes/s2n_stuffer_read_bytes_harness.c
@@ -28,8 +28,8 @@ void s2n_calculate_stacktrace() {}
 void s2n_stuffer_read_bytes_harness() {
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     struct s2n_blob *blob = cbmc_allocate_s2n_blob();
-    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
-    __CPROVER_assume(s2n_blob_is_valid(blob));
+    __CPROVER_assume(s2n_stuffer_validate(stuffer) == S2N_SUCCESS);
+    __CPROVER_assume(s2n_blob_validate(blob) == S2N_SUCCESS);
 
     struct s2n_stuffer old_stuffer = *stuffer;
     struct s2n_blob old_blob = *blob;
@@ -51,6 +51,6 @@ void s2n_stuffer_read_bytes_harness() {
 	    assert(stuffer->read_cursor == old_stuffer.read_cursor);
     }
 
-    assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer); 
-    assert(s2n_stuffer_is_valid(stuffer));
+    assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+    assert(s2n_stuffer_validate(stuffer) == S2N_SUCCESS);
 }

--- a/tests/cbmc/proofs/s2n_stuffer_reread/s2n_stuffer_reread_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_reread/s2n_stuffer_reread_harness.c
@@ -22,7 +22,7 @@
 
 void s2n_stuffer_reread_harness() {
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
-    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    __CPROVER_assume(s2n_stuffer_validate(stuffer) == S2N_SUCCESS);
     struct s2n_stuffer old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte;
     save_byte_from_blob(&stuffer->blob, &old_byte);
@@ -39,5 +39,5 @@ void s2n_stuffer_reread_harness() {
     assert(stuffer->growable == old_stuffer.growable);
     assert(stuffer->tainted == old_stuffer.tainted);
     assert_byte_from_blob_matches(&stuffer->blob, &old_byte);
-    assert(s2n_stuffer_is_valid(stuffer));
+    assert(s2n_stuffer_validate(stuffer) == S2N_SUCCESS);
 }

--- a/tests/cbmc/proofs/s2n_stuffer_resize_if_empty/s2n_stuffer_resize_if_empty_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_resize_if_empty/s2n_stuffer_resize_if_empty_harness.c
@@ -27,7 +27,7 @@
 void s2n_stuffer_resize_if_empty_harness() {
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
-    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    __CPROVER_assume(s2n_stuffer_validate(stuffer) == S2N_SUCCESS);
     uint32_t size;
 
     /* Non-deterministically set initialized (in s2n_mem) to true. */
@@ -57,5 +57,5 @@ void s2n_stuffer_resize_if_empty_harness() {
     }
 
     /* Post-conditions. */
-    assert(s2n_stuffer_is_valid(stuffer));
+    assert(s2n_stuffer_validate(stuffer) == S2N_SUCCESS);
 }

--- a/tests/cbmc/proofs/s2n_stuffer_skip_read/s2n_stuffer_skip_read_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_read/s2n_stuffer_skip_read_harness.c
@@ -22,12 +22,12 @@
 
 void s2n_stuffer_skip_read_harness() {
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
-    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    __CPROVER_assume(s2n_stuffer_validate(stuffer) == S2N_SUCCESS);
     struct s2n_stuffer old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte;
     save_byte_from_blob(&stuffer->blob, &old_byte);
     uint32_t n;
-   
+
     if (s2n_stuffer_skip_read(stuffer, n) == S2N_SUCCESS) {
 	assert(stuffer->read_cursor == old_stuffer.read_cursor + n);
     } else {
@@ -43,5 +43,5 @@ void s2n_stuffer_skip_read_harness() {
     assert(stuffer->growable == old_stuffer.growable);
     assert(stuffer->tainted == old_stuffer.tainted);
     assert_byte_from_blob_matches(&stuffer->blob, &old_byte);
-    assert(s2n_stuffer_is_valid(stuffer));
+    assert(s2n_stuffer_validate(stuffer) == S2N_SUCCESS);
 }

--- a/tests/cbmc/proofs/s2n_stuffer_wipe/s2n_stuffer_wipe_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_wipe/s2n_stuffer_wipe_harness.c
@@ -15,21 +15,23 @@
 
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
+
 #include <assert.h>
 #include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
 void s2n_stuffer_wipe_harness() {
-  struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
 
-  __CPROVER_assume( s2n_stuffer_is_valid(stuffer) );
-  __CPROVER_assume( stuffer->high_water_mark );
+    __CPROVER_assume(s2n_stuffer_validate(stuffer) == S2N_SUCCESS);
+    __CPROVER_assume(stuffer->high_water_mark);
 
-  if ( s2n_stuffer_wipe(stuffer) == S2N_SUCCESS ){
-    assert( s2n_stuffer_is_valid(stuffer) );
-    assert( stuffer->high_water_mark == 0 );
-    assert( stuffer->tainted == 0 );
-    assert( stuffer->write_cursor == 0 );
-    assert( stuffer->read_cursor == 0);
-  };
+    if (s2n_stuffer_wipe(stuffer) == S2N_SUCCESS)
+    {
+        assert(s2n_stuffer_validate(stuffer) == S2N_SUCCESS);
+        assert(stuffer->high_water_mark == 0);
+        assert(stuffer->tainted == 0);
+        assert(stuffer->write_cursor == 0);
+        assert(stuffer->read_cursor == 0);
+    }
 }

--- a/tests/cbmc/proofs/s2n_stuffer_wipe_n/s2n_stuffer_wipe_n_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_wipe_n/s2n_stuffer_wipe_n_harness.c
@@ -20,12 +20,13 @@
 #include <cbmc_proof/make_common_datastructures.h>
 
 void s2n_stuffer_wipe_n_harness() {
-  struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
-  uint32_t n;
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    uint32_t n;
 
-  __CPROVER_assume( s2n_stuffer_is_valid(stuffer) );
+    __CPROVER_assume(s2n_stuffer_validate(stuffer) == S2N_SUCCESS);
 
-  if (s2n_stuffer_wipe_n(stuffer, n) == S2N_SUCCESS){
-    assert(s2n_stuffer_is_valid(stuffer));
-  };
+    if (s2n_stuffer_wipe_n(stuffer, n) == S2N_SUCCESS)
+    {
+        assert(s2n_stuffer_validate(stuffer) == S2N_SUCCESS);
+    }
 }

--- a/tests/unit/s2n_blob_test.c
+++ b/tests/unit/s2n_blob_test.c
@@ -25,20 +25,20 @@ int main(int argc, char **argv)
     BEGIN_TEST();
 
     /* Null blob is not valid */
-    EXPECT_FALSE(s2n_blob_is_valid(NULL));
+    EXPECT_FAILURE(s2n_blob_validate(NULL));
 
     /* Invalid blob is not valid */
     struct s2n_blob b1 = {.data = 0, .size = 101 };
-    EXPECT_FALSE(s2n_blob_is_valid(&b1));
+    EXPECT_FAILURE(s2n_blob_validate(&b1));
 
     /* Size of 0 is OK if data is null */
     struct s2n_blob b2 = {.data = 0, .size = 0 };
-    EXPECT_TRUE(s2n_blob_is_valid(&b2));
+    EXPECT_SUCCESS(s2n_blob_validate(&b2));
 
     /* Valid blob is valid */
     uint8_t array[12];
     struct s2n_blob b3 = {.data = array, .size = sizeof(array)};
-    EXPECT_TRUE(s2n_blob_is_valid(&b3));
+    EXPECT_SUCCESS(s2n_blob_validate(&b3));
 
     /* Null blob is not growable */
     EXPECT_FALSE(s2n_blob_is_growable(NULL));

--- a/tests/unit/s2n_stuffer_test.c
+++ b/tests/unit/s2n_stuffer_test.c
@@ -161,27 +161,27 @@ int main(int argc, char **argv)
     struct s2n_blob b5 = {.data = 0,.size = 0 };
     EXPECT_FAILURE(s2n_stuffer_init(NULL, &b5));
 
-    /* Check s2n_stuffer_is_valid() function */
-    EXPECT_FALSE(s2n_stuffer_is_valid(NULL));
+    /* Check s2n_stuffer_validate() function */
+    EXPECT_FAILURE(s2n_stuffer_validate(NULL));
     uint8_t valid_blob_array[12];
     struct s2n_blob blob_valid = {.data = valid_blob_array,.size = sizeof(valid_blob_array)};
     struct s2n_blob blob_invalid = {.data = 0,.size = sizeof(valid_blob_array)};
 
     struct s2n_stuffer stuffer_valid;
     EXPECT_SUCCESS(s2n_stuffer_init(&stuffer_valid, &blob_valid));
-    EXPECT_TRUE(s2n_stuffer_is_valid(&stuffer));
+    EXPECT_SUCCESS(s2n_stuffer_validate(&stuffer));
 
     struct s2n_stuffer stuffer_invalid1 = {.blob = blob_invalid};
-    EXPECT_FALSE(s2n_stuffer_is_valid(&stuffer_invalid1));
+    EXPECT_FAILURE(s2n_stuffer_validate(&stuffer_invalid1));
 
     struct s2n_stuffer stuffer_invalid2 = {.blob = blob_valid, .write_cursor = 13};
-    EXPECT_FALSE(s2n_stuffer_is_valid(&stuffer_invalid2));
+    EXPECT_FAILURE(s2n_stuffer_validate(&stuffer_invalid2));
 
     struct s2n_stuffer stuffer_invalid3 = {.blob = blob_valid, .read_cursor = 13};
-    EXPECT_FALSE(s2n_stuffer_is_valid(&stuffer_invalid3));
+    EXPECT_FAILURE(s2n_stuffer_validate(&stuffer_invalid3));
 
     struct s2n_stuffer stuffer_invalid4 = {.blob = blob_valid, .read_cursor = 12, .write_cursor = 1};
-    EXPECT_FALSE(s2n_stuffer_is_valid(&stuffer_invalid4));
+    EXPECT_FAILURE(s2n_stuffer_validate(&stuffer_invalid4));
 
     struct s2n_stuffer reserve_test_stuffer = {0};
     EXPECT_SUCCESS(s2n_stuffer_alloc(&reserve_test_stuffer, 1024));

--- a/tls/s2n_async_pkey.c
+++ b/tls/s2n_async_pkey.c
@@ -94,7 +94,7 @@ DEFINE_POINTER_CLEANUP_FUNC(struct s2n_async_pkey_op *, s2n_async_pkey_op_free);
 
 static S2N_RESULT s2n_async_get_actions(s2n_async_pkey_op_type type, const struct s2n_async_pkey_op_actions **actions)
 {
-    ENSURE_NONNULL(actions);
+    ENSURE_REF(actions);
 
     switch (type) {
         case S2N_ASYNC_DECRYPT:
@@ -111,7 +111,7 @@ static S2N_RESULT s2n_async_get_actions(s2n_async_pkey_op_type type, const struc
 
 static S2N_RESULT s2n_async_pkey_op_allocate(struct s2n_async_pkey_op **op)
 {
-    ENSURE_NONNULL(op);
+    ENSURE_REF(op);
     ENSURE(*op == NULL, S2N_ERR_SAFETY);
 
     /* allocate memory */
@@ -130,10 +130,10 @@ static S2N_RESULT s2n_async_pkey_op_allocate(struct s2n_async_pkey_op **op)
 S2N_RESULT s2n_async_pkey_decrypt(struct s2n_connection *conn, struct s2n_blob *encrypted,
                                   struct s2n_blob *init_decrypted, s2n_async_pkey_decrypt_complete on_complete)
 {
-    ENSURE_NONNULL(conn);
-    ENSURE_NONNULL(encrypted);
-    ENSURE_NONNULL(init_decrypted);
-    ENSURE_NONNULL(on_complete);
+    ENSURE_REF(conn);
+    ENSURE_REF(encrypted);
+    ENSURE_REF(init_decrypted);
+    ENSURE_REF(on_complete);
 
     if (conn->config->async_pkey_cb) {
         GUARD_RESULT(s2n_async_pkey_decrypt_async(conn, encrypted, init_decrypted, on_complete));
@@ -147,10 +147,10 @@ S2N_RESULT s2n_async_pkey_decrypt(struct s2n_connection *conn, struct s2n_blob *
 S2N_RESULT s2n_async_pkey_decrypt_async(struct s2n_connection *conn, struct s2n_blob *encrypted,
                                         struct s2n_blob *init_decrypted, s2n_async_pkey_decrypt_complete on_complete)
 {
-    ENSURE_NONNULL(conn);
-    ENSURE_NONNULL(encrypted);
-    ENSURE_NONNULL(init_decrypted);
-    ENSURE_NONNULL(on_complete);
+    ENSURE_REF(conn);
+    ENSURE_REF(encrypted);
+    ENSURE_REF(init_decrypted);
+    ENSURE_REF(on_complete);
     ENSURE(conn->handshake.async_state == S2N_ASYNC_NOT_INVOKED, S2N_ERR_ASYNC_MORE_THAN_ONE);
 
     DEFER_CLEANUP(struct s2n_async_pkey_op *op = NULL, s2n_async_pkey_op_free_pointer);
@@ -185,10 +185,10 @@ S2N_RESULT s2n_async_pkey_decrypt_async(struct s2n_connection *conn, struct s2n_
 S2N_RESULT s2n_async_pkey_decrypt_sync(struct s2n_connection *conn, struct s2n_blob *encrypted,
                                        struct s2n_blob *init_decrypted, s2n_async_pkey_decrypt_complete on_complete)
 {
-    ENSURE_NONNULL(conn);
-    ENSURE_NONNULL(encrypted);
-    ENSURE_NONNULL(init_decrypted);
-    ENSURE_NONNULL(on_complete);
+    ENSURE_REF(conn);
+    ENSURE_REF(encrypted);
+    ENSURE_REF(init_decrypted);
+    ENSURE_REF(on_complete);
 
     const struct s2n_pkey *pkey = conn->handshake_params.our_chain_and_key->private_key;
 
@@ -201,9 +201,9 @@ S2N_RESULT s2n_async_pkey_decrypt_sync(struct s2n_connection *conn, struct s2n_b
 S2N_RESULT s2n_async_pkey_sign(struct s2n_connection *conn, s2n_signature_algorithm sig_alg,
                                struct s2n_hash_state *digest, s2n_async_pkey_sign_complete on_complete)
 {
-    ENSURE_NONNULL(conn);
-    ENSURE_NONNULL(digest);
-    ENSURE_NONNULL(on_complete);
+    ENSURE_REF(conn);
+    ENSURE_REF(digest);
+    ENSURE_REF(on_complete);
 
     if (conn->config->async_pkey_cb) {
         GUARD_RESULT(s2n_async_pkey_sign_async(conn, sig_alg, digest, on_complete));
@@ -217,9 +217,9 @@ S2N_RESULT s2n_async_pkey_sign(struct s2n_connection *conn, s2n_signature_algori
 S2N_RESULT s2n_async_pkey_sign_async(struct s2n_connection *conn, s2n_signature_algorithm sig_alg,
                                      struct s2n_hash_state *digest, s2n_async_pkey_sign_complete on_complete)
 {
-    ENSURE_NONNULL(conn);
-    ENSURE_NONNULL(digest);
-    ENSURE_NONNULL(on_complete);
+    ENSURE_REF(conn);
+    ENSURE_REF(digest);
+    ENSURE_REF(on_complete);
     ENSURE(conn->handshake.async_state == S2N_ASYNC_NOT_INVOKED, S2N_ERR_ASYNC_MORE_THAN_ONE);
 
     DEFER_CLEANUP(struct s2n_async_pkey_op *op = NULL, s2n_async_pkey_op_free_pointer);
@@ -255,9 +255,9 @@ S2N_RESULT s2n_async_pkey_sign_async(struct s2n_connection *conn, s2n_signature_
 S2N_RESULT s2n_async_pkey_sign_sync(struct s2n_connection *conn, s2n_signature_algorithm sig_alg,
                                     struct s2n_hash_state *digest, s2n_async_pkey_sign_complete on_complete)
 {
-    ENSURE_NONNULL(conn);
-    ENSURE_NONNULL(digest);
-    ENSURE_NONNULL(on_complete);
+    ENSURE_REF(conn);
+    ENSURE_REF(digest);
+    ENSURE_REF(on_complete);
 
     const struct s2n_pkey *pkey = conn->handshake_params.our_chain_and_key->private_key;
     DEFER_CLEANUP(struct s2n_blob signed_content = { 0 }, s2n_free);
@@ -274,8 +274,8 @@ S2N_RESULT s2n_async_pkey_sign_sync(struct s2n_connection *conn, s2n_signature_a
 
 int s2n_async_pkey_op_perform(struct s2n_async_pkey_op *op, s2n_cert_private_key *key)
 {
-    ENSURE_POSIX_NONNULL(op);
-    ENSURE_POSIX_NONNULL(key);
+    ENSURE_POSIX_REF(op);
+    ENSURE_POSIX_REF(key);
     ENSURE_POSIX(!op->complete, S2N_ERR_ASYNC_ALREADY_PERFORMED);
 
     const struct s2n_async_pkey_op_actions *actions = NULL;
@@ -290,8 +290,8 @@ int s2n_async_pkey_op_perform(struct s2n_async_pkey_op *op, s2n_cert_private_key
 
 int s2n_async_pkey_op_apply(struct s2n_async_pkey_op *op, struct s2n_connection *conn)
 {
-    ENSURE_POSIX_NONNULL(op);
-    ENSURE_POSIX_NONNULL(conn);
+    ENSURE_POSIX_REF(op);
+    ENSURE_POSIX_REF(conn);
     ENSURE_POSIX(op->complete, S2N_ERR_ASYNC_NOT_PERFORMED);
     ENSURE_POSIX(!op->applied, S2N_ERR_ASYNC_ALREADY_APPLIED);
     /* We could have just used op->conn and removed a conn argument, but we want caller
@@ -318,7 +318,7 @@ int s2n_async_pkey_op_apply(struct s2n_async_pkey_op *op, struct s2n_connection 
 
 int s2n_async_pkey_op_free(struct s2n_async_pkey_op *op)
 {
-    ENSURE_POSIX_NONNULL(op);
+    ENSURE_POSIX_REF(op);
     const struct s2n_async_pkey_op_actions *actions = NULL;
     GUARD_AS_POSIX(s2n_async_get_actions(op->type, &actions));
 
@@ -332,8 +332,8 @@ int s2n_async_pkey_op_free(struct s2n_async_pkey_op *op)
 
 S2N_RESULT s2n_async_pkey_decrypt_perform(struct s2n_async_pkey_op *op, s2n_cert_private_key *pkey)
 {
-    ENSURE_NONNULL(op);
-    ENSURE_NONNULL(pkey);
+    ENSURE_REF(op);
+    ENSURE_REF(pkey);
 
     struct s2n_async_pkey_decrypt_data *decrypt = &op->op.decrypt;
 
@@ -344,8 +344,8 @@ S2N_RESULT s2n_async_pkey_decrypt_perform(struct s2n_async_pkey_op *op, s2n_cert
 
 S2N_RESULT s2n_async_pkey_decrypt_apply(struct s2n_async_pkey_op *op, struct s2n_connection *conn)
 {
-    ENSURE_NONNULL(op);
-    ENSURE_NONNULL(conn);
+    ENSURE_REF(op);
+    ENSURE_REF(conn);
 
     struct s2n_async_pkey_decrypt_data *decrypt = &op->op.decrypt;
 
@@ -356,7 +356,7 @@ S2N_RESULT s2n_async_pkey_decrypt_apply(struct s2n_async_pkey_op *op, struct s2n
 
 S2N_RESULT s2n_async_pkey_decrypt_free(struct s2n_async_pkey_op *op)
 {
-    ENSURE_NONNULL(op);
+    ENSURE_REF(op);
 
     struct s2n_async_pkey_decrypt_data *decrypt = &op->op.decrypt;
 
@@ -370,8 +370,8 @@ S2N_RESULT s2n_async_pkey_decrypt_free(struct s2n_async_pkey_op *op)
 
 S2N_RESULT s2n_async_pkey_sign_perform(struct s2n_async_pkey_op *op, s2n_cert_private_key *pkey)
 {
-    ENSURE_NONNULL(op);
-    ENSURE_NONNULL(pkey);
+    ENSURE_REF(op);
+    ENSURE_REF(pkey);
 
     struct s2n_async_pkey_sign_data *sign = &op->op.sign;
 
@@ -385,8 +385,8 @@ S2N_RESULT s2n_async_pkey_sign_perform(struct s2n_async_pkey_op *op, s2n_cert_pr
 
 S2N_RESULT s2n_async_pkey_sign_apply(struct s2n_async_pkey_op *op, struct s2n_connection *conn)
 {
-    ENSURE_NONNULL(op);
-    ENSURE_NONNULL(conn);
+    ENSURE_REF(op);
+    ENSURE_REF(conn);
 
     struct s2n_async_pkey_sign_data *sign = &op->op.sign;
 
@@ -397,7 +397,7 @@ S2N_RESULT s2n_async_pkey_sign_apply(struct s2n_async_pkey_op *op, struct s2n_co
 
 S2N_RESULT s2n_async_pkey_sign_free(struct s2n_async_pkey_op *op)
 {
-    ENSURE_NONNULL(op);
+    ENSURE_REF(op);
 
     struct s2n_async_pkey_sign_data *sign = &op->op.sign;
 
@@ -406,4 +406,3 @@ S2N_RESULT s2n_async_pkey_sign_free(struct s2n_async_pkey_op *op)
 
     return S2N_RESULT_OK;
 }
-

--- a/utils/s2n_array.c
+++ b/utils/s2n_array.c
@@ -21,7 +21,7 @@
 
 static S2N_RESULT s2n_array_enlarge(struct s2n_array *array, uint32_t capacity)
 {
-    ENSURE_NONNULL(array);
+    ENSURE_REF(array);
 
     /* Acquire the memory */
     uint32_t mem_needed;
@@ -54,15 +54,15 @@ struct s2n_array *s2n_array_new(size_t element_size)
 
 S2N_RESULT s2n_array_pushback(struct s2n_array *array, void **element)
 {
-    ENSURE_NONNULL(array);
-    ENSURE_NONNULL(element);
+    ENSURE_REF(array);
+    ENSURE_REF(element);
     return s2n_array_insert(array, array->len, element);
 }
 
 S2N_RESULT s2n_array_get(struct s2n_array *array, uint32_t index, void **element)
 {
-    ENSURE_NONNULL(array);
-    ENSURE_NONNULL(element);
+    ENSURE_REF(array);
+    ENSURE_REF(element);
     ENSURE(index < array->len, S2N_ERR_ARRAY_INDEX_OOB);
     *element = array->mem.data + array->element_size * index;
     return S2N_RESULT_OK;
@@ -78,8 +78,8 @@ S2N_RESULT s2n_array_insert_and_copy(struct s2n_array *array, uint32_t index, vo
 
 S2N_RESULT s2n_array_insert(struct s2n_array *array, uint32_t index, void **element)
 {
-    ENSURE_NONNULL(array);
-    ENSURE_NONNULL(element);
+    ENSURE_REF(array);
+    ENSURE_REF(element);
     /* index == len is ok since we're about to add one element */
     ENSURE(index <= array->len, S2N_ERR_ARRAY_INDEX_OOB);
 
@@ -108,7 +108,7 @@ S2N_RESULT s2n_array_insert(struct s2n_array *array, uint32_t index, void **elem
 
 S2N_RESULT s2n_array_remove(struct s2n_array *array, uint32_t index)
 {
-    ENSURE_NONNULL(array);
+    ENSURE_REF(array);
     ENSURE(index < array->len, S2N_ERR_ARRAY_INDEX_OOB);
 
     /* If the removed element is the last one, no need to move anything.
@@ -130,7 +130,7 @@ S2N_RESULT s2n_array_remove(struct s2n_array *array, uint32_t index)
 
 S2N_RESULT s2n_array_num_elements(struct s2n_array *array, uint32_t *len)
 {
-    ENSURE_NONNULL(array);
+    ENSURE_REF(array);
 
     *len = array->len;
 
@@ -139,7 +139,7 @@ S2N_RESULT s2n_array_num_elements(struct s2n_array *array, uint32_t *len)
 
 S2N_RESULT s2n_array_capacity(struct s2n_array *array, uint32_t *capacity)
 {
-    ENSURE_NONNULL(array);
+    ENSURE_REF(array);
 
     *capacity = array->mem.size / array->element_size;
 
@@ -148,10 +148,10 @@ S2N_RESULT s2n_array_capacity(struct s2n_array *array, uint32_t *capacity)
 
 S2N_RESULT s2n_array_free_p(struct s2n_array **parray)
 {
-    ENSURE_NONNULL(parray);
+    ENSURE_REF(parray);
     struct s2n_array *array = *parray;
 
-    ENSURE_NONNULL(array);
+    ENSURE_REF(array);
     /* Free the elements */
     GUARD_AS_RESULT(s2n_free(&array->mem));
 

--- a/utils/s2n_blob.c
+++ b/utils/s2n_blob.c
@@ -24,22 +24,22 @@
 
 #include <s2n.h>
 
-bool s2n_blob_is_valid(const struct s2n_blob* b)
+int s2n_blob_validate(const struct s2n_blob* b)
 {
-    return S2N_OBJECT_PTR_IS_READABLE(b) &&
-           S2N_IMPLIES(b->data == NULL, b->size == 0) &&
-           S2N_IMPLIES(b->growable == 0, b->allocated == 0) &&
-           S2N_IMPLIES(b->growable != 0, b->size <= b->allocated) &&
-           S2N_MEM_IS_READABLE(b->data, b->allocated) &&
-           S2N_MEM_IS_READABLE(b->data, b->size);
+    ENSURE_POSIX_REF(b);
+    ENSURE_POSIX(S2N_IMPLIES(b->growable == 0, b->allocated == 0), S2N_FAILURE);
+    ENSURE_POSIX(S2N_IMPLIES(b->growable != 0, S2N_MEM_IS_READABLE(b->data, b->allocated)), S2N_FAILURE);
+    ENSURE_POSIX(S2N_IMPLIES(b->growable != 0, b->size <= b->allocated), S2N_FAILURE);
+    ENSURE_POSIX(S2N_MEM_IS_READABLE(b->data, b->size), S2N_FAILURE);
+    return S2N_SUCCESS;
 }
 
 int s2n_blob_init(struct s2n_blob *b, uint8_t * data, uint32_t size)
 {
-    notnull_check(b);
-    PRECONDITION_POSIX(S2N_MEM_IS_READABLE(data,size));
+    ENSURE_POSIX_REF(b);
+    GUARD(S2N_MEM_IS_READABLE(data,size));
     *b = (struct s2n_blob) {.data = data, .size = size, .allocated = 0, .growable = 0};
-    POSTCONDITION_POSIX(s2n_blob_is_valid(b));
+    GUARD(s2n_blob_validate(b));
     return S2N_SUCCESS;
 }
 

--- a/utils/s2n_blob.c
+++ b/utils/s2n_blob.c
@@ -45,9 +45,9 @@ int s2n_blob_init(struct s2n_blob *b, uint8_t * data, uint32_t size)
 
 int s2n_blob_zero(struct s2n_blob *b)
 {
-    PRECONDITION_POSIX(s2n_blob_is_valid(b));
+    GUARD(s2n_blob_validate(b));
     memset_check(b->data, 0, MAX(b->allocated, b->size));
-    POSTCONDITION_POSIX(s2n_blob_is_valid(b));
+    GUARD(s2n_blob_validate(b));
     return S2N_SUCCESS;
 }
 

--- a/utils/s2n_blob.h
+++ b/utils/s2n_blob.h
@@ -39,7 +39,7 @@ struct s2n_blob {
 
 
 extern bool s2n_blob_is_growable(const struct s2n_blob* b);
-extern bool s2n_blob_is_valid(const struct s2n_blob* b);
+extern int s2n_blob_validate(const struct s2n_blob* b);
 extern int s2n_blob_init(struct s2n_blob *b, uint8_t * data, uint32_t size);
 extern int s2n_blob_zero(struct s2n_blob *b);
 extern int s2n_blob_char_to_lower(struct s2n_blob *b);

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -89,19 +89,9 @@
 #define ENSURE_NE( a , b )                           ENSURE((a) != (b), S2N_ERR_SAFETY)
 
 /**
- * Ensures `x` is not `NULL`, otherwise the function will `BAIL` with a `S2N_ERR_NULL` error
- */
-#define ENSURE_NONNULL( x )                          ENSURE((x) != NULL, S2N_ERR_NULL)
-
-/**
  * Ensures the `condition` is `true`, otherwise the function will `BAIL_POSIX` with an `error`
  */
 #define ENSURE_POSIX( condition , error )           __S2N_ENSURE((condition), BAIL_POSIX(error))
-
-/**
- * Ensures `x` is not `NULL`, otherwise the function will `BAIL_POSIX` with an `error`
- */
-#define ENSURE_POSIX_NONNULL( x )                   ENSURE_POSIX((x) != NULL, S2N_ERR_NULL)
 
 /**
  * Ensures the `condition` is `true`, otherwise the function will `BAIL_PTR` with an `error`
@@ -111,7 +101,7 @@
 /**
  * Ensures `x` is not `NULL`, otherwise the function will `BAIL_PTR` with an `error`
  */
-#define ENSURE_PTR_NONNULL( x )                     ENSURE_PTR((x) != NULL, S2N_ERR_NULL)
+#define ENSURE_REF_PTR( x )                         ENSURE_PTR(S2N_OBJECT_PTR_IS_READABLE(x), S2N_ERR_NULL)
 
 /**
  * Ensures `x` is a readable reference, otherwise the function will `BAIL` with `S2N_ERR_NULL`
@@ -297,7 +287,7 @@
 /**
  * Performs a safe memset
  */
-#define CHECKED_MEMSET( d , c , n )                 __S2N_ENSURE_SAFE_MEMSET((d), (c), (n), ENSURE_NONNULL)
+#define CHECKED_MEMSET( d , c , n )                 __S2N_ENSURE_SAFE_MEMSET((d), (c), (n), ENSURE_REF)
 
 /* Returns `true` if s2n is in unit test mode, `false` otherwise */
 bool s2n_in_unit_test();
@@ -363,10 +353,10 @@ extern int s2n_add_overflow(uint32_t a, uint32_t b, uint32_t* out);
 
 /* `NULL` check a pointer */
 
-/* Note: this macro is replaced by ENSURE_POSIX_NONNULL */
-#define notnull_check( ptr )                        ENSURE_POSIX_NONNULL(ptr)
-/* Note: this macro is replaced by ENSURE_PTR_NONNULL */
-#define notnull_check_ptr( ptr )                    ENSURE_PTR_NONNULL(ptr)
+/* Note: this macro is replaced by ENSURE_POSIX_REF */
+#define notnull_check( ptr )                        ENSURE_POSIX_REF(ptr)
+/* Note: this macro is replaced by ENSURE_REF_PTR */
+#define notnull_check_ptr( ptr )                    ENSURE_REF_PTR(ptr)
 
 /* Range check a number */
 #define gte_check( n , min )                        ENSURE_POSIX((n) >= (min), S2N_ERR_SAFETY)
@@ -390,6 +380,6 @@ extern int s2n_add_overflow(uint32_t a, uint32_t b, uint32_t* out);
 
 #define memcpy_check( d , s , n )                   __S2N_ENSURE_SAFE_MEMCPY((d), (s), (n), GUARD_POSIX_NONNULL)
 /* This will fail to build if d is an array. Cast the array to a pointer first! */
-#define memset_check( d , c , n )                   __S2N_ENSURE_SAFE_MEMSET((d), (c), (n), ENSURE_POSIX_NONNULL)
+#define memset_check( d , c , n )                   __S2N_ENSURE_SAFE_MEMSET((d), (c), (n), ENSURE_POSIX_REF)
 
 /* END COMPATIBILITY LAYER */

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -94,26 +94,6 @@
 #define ENSURE_NONNULL( x )                          ENSURE((x) != NULL, S2N_ERR_NULL)
 
 /**
- * Ensures `min <= n <= max`
- */
-#define ENSURE_INCLUSIVE_RANGE( min , n , max )      \
-  do {                                               \
-    __typeof( n ) __tmp_n = ( n );                   \
-    ENSURE_GTE(__tmp_n, min);                        \
-    ENSURE_LTE(__tmp_n, max);                        \
-  } while(0)
-
-/**
- * Ensures `min < n < max`
- */
-#define ENSURE_EXCLUSIVE_RANGE( min , n , max )      \
-  do {                                               \
-    __typeof( n ) __tmp_n = ( n );                   \
-    ENSURE_GT(__tmp_n, min);                         \
-    ENSURE_LT(__tmp_n, max);                         \
-  } while(0)
-
-/**
  * Ensures the `condition` is `true`, otherwise the function will `BAIL_POSIX` with an `error`
  */
 #define ENSURE_POSIX( condition , error )           __S2N_ENSURE((condition), BAIL_POSIX(error))
@@ -132,6 +112,46 @@
  * Ensures `x` is not `NULL`, otherwise the function will `BAIL_PTR` with an `error`
  */
 #define ENSURE_PTR_NONNULL( x )                     ENSURE_PTR((x) != NULL, S2N_ERR_NULL)
+
+/**
+ * Ensures `x` is a readable reference, otherwise the function will `BAIL` with `S2N_ERR_NULL`
+ */
+#define ENSURE_REF( x )                             ENSURE(S2N_OBJECT_PTR_IS_READABLE(x), S2N_ERR_NULL)
+
+/**
+ * Ensures `x` is a readable reference, otherwise the function will `BAIL_POSIX` with `S2N_ERR_NULL`
+ */
+#define ENSURE_POSIX_REF( x )                       ENSURE_POSIX(S2N_OBJECT_PTR_IS_READABLE(x), S2N_ERR_NULL)
+
+/**
+ * Ensures `x` is a mutable reference, otherwise the function will `BAIL` with `S2N_ERR_NULL`
+ */
+#define ENSURE_MUT( x )                             ENSURE(S2N_OBJECT_PTR_IS_WRITABLE(x), S2N_ERR_NULL)
+
+/**
+ * Ensures `x` is a mutable reference, otherwise the function will `BAIL_POSIX` with `S2N_ERR_NULL`
+ */
+#define ENSURE_POSIX_MUT( x )                       ENSURE_POSIX(S2N_OBJECT_PTR_IS_WRITABLE(x), S2N_ERR_NULL)
+
+/**
+ * Ensures `min <= n <= max`
+ */
+#define ENSURE_INCLUSIVE_RANGE( min , n , max )      \
+  do {                                               \
+    __typeof( n ) __tmp_n = ( n );                   \
+    ENSURE_GTE(__tmp_n, min);                        \
+    ENSURE_LTE(__tmp_n, max);                        \
+  } while(0)
+
+/**
+ * Ensures `min < n < max`
+ */
+#define ENSURE_EXCLUSIVE_RANGE( min , n , max )      \
+  do {                                               \
+    __typeof( n ) __tmp_n = ( n );                   \
+    ENSURE_GT(__tmp_n, min);                         \
+    ENSURE_LT(__tmp_n, max);                         \
+  } while(0)
 
 /**
  * Ensures the `condition` is `true`, otherwise the function will `BAIL` with a `S2N_ERR_PRECONDITION_VIOLATION` error

--- a/utils/s2n_set.c
+++ b/utils/s2n_set.c
@@ -25,9 +25,9 @@
  * Returns an error if the element already exists */
 static S2N_RESULT s2n_set_binary_search(struct s2n_set *set, void *element, uint32_t* out)
 {
-    ENSURE_NONNULL(set);
-    ENSURE_NONNULL(element);
-    ENSURE_NONNULL(out);
+    ENSURE_REF(set);
+    ENSURE_REF(element);
+    ENSURE_REF(out);
     struct s2n_array *array = set->data;
     int (*comparator)(const void*, const void*) = set->comparator;
 
@@ -67,7 +67,7 @@ static S2N_RESULT s2n_set_binary_search(struct s2n_set *set, void *element, uint
 
 struct s2n_set *s2n_set_new(size_t element_size, int (*comparator)(const void*, const void*))
 {
-    ENSURE_PTR_NONNULL(comparator);
+    ENSURE_REF_PTR(comparator);
     struct s2n_blob mem = {0};
     GUARD_POSIX_PTR(s2n_alloc(&mem, sizeof(struct s2n_set)));
     struct s2n_set *set = (void *) mem.data;
@@ -90,8 +90,8 @@ S2N_RESULT s2n_set_add(struct s2n_set *set, void *element)
 
 S2N_RESULT s2n_set_get(struct s2n_set *set, uint32_t index, void **element)
 {
-    ENSURE_NONNULL(set);
-    ENSURE_NONNULL(element);
+    ENSURE_REF(set);
+    ENSURE_REF(element);
 
     GUARD_RESULT(s2n_array_get(set->data, index, element));
 
@@ -107,10 +107,10 @@ S2N_RESULT s2n_set_remove(struct s2n_set *set, uint32_t index)
 
 S2N_RESULT s2n_set_free_p(struct s2n_set **pset)
 {
-    ENSURE_NONNULL(pset);
+    ENSURE_REF(pset);
     struct s2n_set *set = *pset;
 
-    ENSURE_NONNULL(set);
+    ENSURE_REF(set);
     GUARD_RESULT(s2n_array_free(set->data));
     GUARD_AS_RESULT(s2n_free_object((uint8_t **)pset, sizeof(struct s2n_set)));
 
@@ -120,15 +120,15 @@ S2N_RESULT s2n_set_free_p(struct s2n_set **pset)
 
 S2N_RESULT s2n_set_free(struct s2n_set *set)
 {
-    ENSURE_NONNULL(set);
+    ENSURE_REF(set);
     return s2n_set_free_p(&set);
 }
 
 
 S2N_RESULT s2n_set_len(struct s2n_set *set, uint32_t *len)
 {
-    ENSURE_NONNULL(set);
-    ENSURE_NONNULL(len);
+    ENSURE_REF(set);
+    ENSURE_REF(len);
 
     GUARD_RESULT(s2n_array_num_elements(set->data, len));
 


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:
N/A.

### Description of changes: 

Introduces a new set of validity functions for `s2n_blob` and `s2n_stuffer` based on this [suggestion](https://github.com/awslabs/s2n/pull/1927#discussion_r434757710).
### Call-outs:

This PR depends on https://github.com/awslabs/s2n/pull/1991.
### Testing:

The tests and proofs impacted by this PR are updated accordingly here as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
