### PR TITLE
Add integration test to verify version negotiation against S2N and OpenSSL providers

### DIFF
--- a/tests/integrationv2/test_happy_path.py
+++ b/tests/integrationv2/test_happy_path.py
@@ -15,7 +15,6 @@ from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
 def test_s2n_server_happy_path(managed_process, cipher, provider, curve, protocol, certificate):
-    host = "localhost"
     port = next(available_ports)
 
     # s2nd can receive large amounts of data because all the data is
@@ -70,7 +69,6 @@ def test_s2n_server_happy_path(managed_process, cipher, provider, curve, protoco
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
 def test_s2n_client_happy_path(managed_process, cipher, provider, curve, protocol, certificate):
-    host = "localhost"
     port = next(available_ports)
 
     # We can only send 4096 bytes here because of the way some servers chunk

--- a/tests/integrationv2/test_version_negotiation.py
+++ b/tests/integrationv2/test_version_negotiation.py
@@ -1,0 +1,116 @@
+import copy
+import pytest
+
+from configuration import available_ports, ALL_TEST_CIPHERS, ALL_TEST_CURVES, ALL_TEST_CERTS
+from common import ProviderOptions, Protocols, data_bytes
+from fixtures import managed_process
+from providers import Provider, S2N, OpenSSL
+from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version, get_expected_openssl_version
+
+
+@pytest.mark.uncollect_if(func=invalid_test_parameters)
+@pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
+@pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
+@pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
+@pytest.mark.parametrize("protocol", [Protocols.TLS12, Protocols.TLS11, Protocols.TLS10], ids=get_parameter_name)
+@pytest.mark.parametrize("provider", [S2N, OpenSSL], ids=get_parameter_name)
+def test_s2nc_tls13_negotiates_tls12(managed_process, cipher, curve, protocol, provider, certificate):
+    host = "localhost"
+    port = next(available_ports)
+
+    random_bytes = data_bytes(24)
+    client_options = ProviderOptions(
+        mode=Provider.ClientMode,
+        host="localhost",
+        port=port,
+        cipher=cipher,
+        curve=curve,
+        data_to_send=random_bytes,
+        insecure=True,
+        protocol=Protocols.TLS13)
+
+    server_options = copy.copy(client_options)
+    server_options.data_to_send = None
+    server_options.mode = Provider.ServerMode
+    server_options.key = certificate.key
+    server_options.cert = certificate.cert
+    server_options.protocol = protocol
+
+    server = managed_process(provider, server_options, timeout=5)
+    client = managed_process(S2N, client_options, timeout=5)
+
+    client_version = get_expected_s2n_version(Protocols.TLS13, provider)
+    actual_version = get_expected_s2n_version(protocol, provider)
+
+    for results in client.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+        assert bytes("Client protocol version: {}".format(client_version).encode('utf-8')) in results.stdout
+        assert bytes("Actual protocol version: {}".format(actual_version).encode('utf-8')) in results.stdout
+
+    for results in server.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+        if provider is S2N:
+            # The server is only TLS12, so it reads the version from the CLIENT_HELLO, which is never above TLS12
+            # This check only cares about S2N. Trying to maintain expected output of other providers doesn't
+            # add benefit to whether the S2N client was able to negotiate a lower TLS version.
+            assert bytes("Client protocol version: {}".format(actual_version).encode('utf-8')) in results.stdout
+            assert bytes("Actual protocol version: {}".format(actual_version).encode('utf-8')) in results.stdout
+
+        assert random_bytes in results.stdout
+
+
+@pytest.mark.uncollect_if(func=invalid_test_parameters)
+@pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
+@pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
+@pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
+@pytest.mark.parametrize("protocol", [Protocols.TLS12, Protocols.TLS11, Protocols.TLS10], ids=get_parameter_name)
+@pytest.mark.parametrize("provider", [S2N, OpenSSL], ids=get_parameter_name)
+def test_s2nd_tls13_negotiates_tls12(managed_process, cipher, curve, protocol, provider, certificate):
+    host = "localhost"
+    port = next(available_ports)
+
+    random_bytes = data_bytes(24)
+    client_options = ProviderOptions(
+        mode=Provider.ClientMode,
+        host="localhost",
+        port=port,
+        cipher=cipher,
+        curve=curve,
+        data_to_send=random_bytes,
+        insecure=True,
+        protocol=protocol)
+
+    server_options = copy.copy(client_options)
+    server_options.data_to_send = None
+    server_options.mode = Provider.ServerMode
+    server_options.key = certificate.key
+    server_options.cert = certificate.cert
+    server_options.protocol = Protocols.TLS13
+
+    server = managed_process(S2N, server_options, timeout=5)
+    client = managed_process(provider, client_options, timeout=5)
+
+    server_version = get_expected_s2n_version(Protocols.TLS13, provider)
+    actual_version = get_expected_s2n_version(protocol, provider)
+
+    for results in client.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+        if provider is S2N:
+            # The client will get the server version from the SERVER HELLO, which will be the negotiated version
+            assert bytes("Server protocol version: {}".format(actual_version).encode('utf-8')) in results.stdout
+            assert bytes("Actual protocol version: {}".format(actual_version).encode('utf-8')) in results.stdout
+        elif provider is OpenSSL:
+            # This check cares about other providers because we want to know that they did negotiate the version
+            # that our S2N server intended to negotiate.
+            openssl_version = get_expected_openssl_version(protocol)
+            assert bytes("Protocol  : {}".format(openssl_version).encode('utf-8')) in results.stdout
+
+    for results in server.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+        assert bytes("Server protocol version: {}".format(server_version).encode('utf-8')) in results.stdout
+        assert bytes("Actual protocol version: {}".format(actual_version).encode('utf-8')) in results.stdout
+        assert random_bytes in results.stdout

--- a/tests/integrationv2/test_version_negotiation.py
+++ b/tests/integrationv2/test_version_negotiation.py
@@ -15,7 +15,6 @@ from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_
 @pytest.mark.parametrize("protocol", [Protocols.TLS12, Protocols.TLS11, Protocols.TLS10], ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [S2N, OpenSSL], ids=get_parameter_name)
 def test_s2nc_tls13_negotiates_tls12(managed_process, cipher, curve, protocol, provider, certificate):
-    host = "localhost"
     port = next(available_ports)
 
     random_bytes = data_bytes(24)
@@ -68,7 +67,6 @@ def test_s2nc_tls13_negotiates_tls12(managed_process, cipher, curve, protocol, p
 @pytest.mark.parametrize("protocol", [Protocols.TLS12, Protocols.TLS11, Protocols.TLS10], ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [S2N, OpenSSL], ids=get_parameter_name)
 def test_s2nd_tls13_negotiates_tls12(managed_process, cipher, curve, protocol, provider, certificate):
-    host = "localhost"
     port = next(available_ports)
 
     random_bytes = data_bytes(24)

--- a/tests/integrationv2/utils.py
+++ b/tests/integrationv2/utils.py
@@ -1,5 +1,5 @@
 from common import Protocols
-from providers import S2N
+from providers import S2N, OpenSSL
 
 
 def get_expected_s2n_version(protocol, provider):
@@ -7,13 +7,26 @@ def get_expected_s2n_version(protocol, provider):
     s2nd and s2nc print a number for the negotiated TLS version.
 
     provider is s2n's peer. If s2n tries to speak to s2n < tls13,
-    tls12 is alway chosen. This is true even when the requested
+    tls12 is always chosen. This is true even when the requested
     protocol is less than tls12.
     """
     if provider == S2N and protocol != Protocols.TLS13:
         version = '33'
     else:
         version = protocol.value
+
+    return version
+
+
+def get_expected_openssl_version(protocol):
+    if protocol == Protocols.TLS13:
+        version = 'TLSv1.3'
+    elif protocol == Protocols.TLS12:
+        version = 'TLSv1.2'
+    elif protocol == Protocols.TLS11:
+        version = 'TLSv1.1'
+    elif protocol == Protocols.TLS10:
+        version = 'TLSv1'
 
     return version
 
@@ -41,7 +54,7 @@ def invalid_test_parameters(*args, **kwargs):
 
         # NOTE: We don't detect the version of OpenSSL at the moment,
         # so we will deselect these tests.
-        if cipher.openssl1_1_1 is False:
+        if provider is not None and provider is OpenSSL and cipher.openssl1_1_1 is False:
             return True
 
     # If we are using a cipher that depends on a specific certificate algorithm


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

 resolves #1443, resolves #1726, resolves #1558

### Description of changes: 

Adds integration tests to verify version negotiation against S2N and OpenSSL providers and OpenSSL providers:

 * client can request TLS13 and fallback to lower TLS versions.
 * server can request TLS13 and fallback to lower TLS versions.

### Testing:

Ran integ tests

```
PASSED test_version_negotiation.py::test_s2nd_tls13_negotiates_tls12[<class 'providers.OpenSSL'>-TLS1.0-RSA_4096_SHA512-P-256-ECDHE_RSA_AES128_SHA]
PASSED test_version_negotiation.py::test_s2nd_tls13_negotiates_tls12[<class 'providers.OpenSSL'>-TLS1.0-RSA_4096_SHA512-P-256-ECDHE_RSA_AES256_SHA]
PASSED test_version_negotiation.py::test_s2nd_tls13_negotiates_tls12[<class 'providers.OpenSSL'>-TLS1.0-RSA_4096_SHA512-P-384-DHE_RSA_AES128_SHA]
PASSED test_version_negotiation.py::test_s2nd_tls13_negotiates_tls12[<class 'providers.OpenSSL'>-TLS1.0-RSA_4096_SHA512-P-384-DHE_RSA_AES256_SHA]
PASSED test_version_negotiation.py::test_s2nd_tls13_negotiates_tls12[<class 'providers.OpenSSL'>-TLS1.0-RSA_4096_SHA512-P-384-AES128_SHA]
PASSED test_version_negotiation.py::test_s2nd_tls13_negotiates_tls12[<class 'providers.OpenSSL'>-TLS1.0-RSA_4096_SHA512-P-384-AES256_SHA]
PASSED test_version_negotiation.py::test_s2nd_tls13_negotiates_tls12[<class 'providers.OpenSSL'>-TLS1.0-RSA_4096_SHA512-P-384-ECDHE_RSA_AES128_SHA]
PASSED test_version_negotiation.py::test_s2nd_tls13_negotiates_tls12[<class 'providers.OpenSSL'>-TLS1.0-RSA_4096_SHA512-P-384-ECDHE_RSA_AES256_SHA]
==================================================================================================================================== 3024 passed, 11592 deselected in 353.27s (0:05:53) ====================================================================================================================================
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
