### PR TITLE
Add well known endpoint test to integv2

### DIFF
--- a/tests/integrationv2/common.py
+++ b/tests/integrationv2/common.py
@@ -200,6 +200,9 @@ class Ciphers(object):
     ECDHE_RSA_CHACHA20_POLY1305 = Cipher("ECDHE_RSA_CHACHA20_POLY1305", Protocols.TLS12, True, False)
     CHACHA20_POLY1305_SHA256 = Cipher("CHACHA20_POLY1305_SHA256", Protocols.TLS13, True, False)
 
+    KMS_PQ_TLS_1_0_2019_06 = Cipher("KMS_PQ_TLS_1_0_2019_06", Protocols.TLS10, False, False)
+    PQ_SIKE_TEST_TLS_1_0_2019_11 = Cipher("PQ_SIKE_TEST_TLS_1_0_2019_11", Protocols.TLS10, False, False)
+
 
 class Curve(object):
     def __init__(self, name, min_protocol=Protocols.SSLv3):

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -131,7 +131,13 @@ class S2N(Provider):
         if options.protocol == Protocols.TLS13:
             cmd_line.append('--tls13')
 
-        cmd_line.extend(['-c', 'test_all'])
+        if options.cipher is not None:
+            if options.cipher is Ciphers.KMS_PQ_TLS_1_0_2019_06:
+                cmd_line.extend(['-c', 'KMS-PQ-TLS-1-0-2019-06'])
+            elif options.cipher is Ciphers.PQ_SIKE_TEST_TLS_1_0_2019_11:
+                cmd_line.extend(['-c', 'PQ-SIKE-TEST-TLS-1-0-2019-11'])
+        else:
+            cmd_line.extend(['-c', 'test_all'])
 
         if options.client_key_file:
             cmd_line.extend(['--key', options.client_key_file])

--- a/tests/integrationv2/test_well_known_endpoints.py
+++ b/tests/integrationv2/test_well_known_endpoints.py
@@ -1,0 +1,65 @@
+import copy
+import os
+import pytest
+
+from configuration import available_ports, PROTOCOLS
+from common import ProviderOptions, Protocols, Ciphers
+from fixtures import managed_process
+from providers import Provider, S2N
+from utils import invalid_test_parameters, get_parameter_name
+
+
+ENDPOINTS = [
+    {"endpoint": "amazon.com"},
+    {"endpoint": "facebook.com"},
+    {"endpoint": "google.com"},
+    {"endpoint": "netflix.com"},
+    {"endpoint": "s3.amazonaws.com"},
+    {"endpoint": "twitter.com"},
+    {"endpoint": "wikipedia.org"},
+    {"endpoint": "yahoo.com"},
+]
+
+
+if os.getenv("S2N_NO_PQ") is None:
+    # If PQ was compiled into S2N, test the PQ preferences against KMS
+    pq_endpoints = [
+        {
+            "endpoint": "kms.us-east-1.amazonaws.com",
+            "cipher_preference_version": Ciphers.KMS_PQ_TLS_1_0_2019_06,
+            "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384"
+        },
+        {
+            "endpoint": "kms.us-east-1.amazonaws.com",
+            "cipher_preference_version": Ciphers.PQ_SIKE_TEST_TLS_1_0_2019_11,
+            "expected_cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384"
+        }
+    ]
+
+    ENDPOINTS.extend(pq_endpoints)
+
+
+@pytest.mark.uncollect_if(func=invalid_test_parameters)
+@pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
+@pytest.mark.parametrize("endpoint", ENDPOINTS, ids=lambda x: "{}-{}".format(x['endpoint'], x.get('cipher_preference_version', 'Default')))
+def test_well_known_endpoints(managed_process, protocol, endpoint):
+    port = "443"
+
+    client_options = ProviderOptions(
+        mode=Provider.ClientMode,
+        host=endpoint['endpoint'],
+        port=port,
+        insecure=False,
+        protocol=protocol)
+
+    if 'cipher_preference_version' in endpoint:
+        client_options.cipher = endpoint['cipher_preference_version']
+
+    client = managed_process(S2N, client_options, timeout=5)
+
+    for results in client.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+
+        if 'expected_cipher' in endpoint:
+            assert bytes(endpoint['expected_cipher'].encode('utf-8')) in results.stdout


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

 resolves #1972

### Description of changes: 

Adds an integration test for well known endpoints.

* Verify correct cipher when connecting to PQ endpoint.

### Call-outs:

We don't send an actual GET request to the peer. This is because we close the connection after stdin has been flushed. This is required for most tests, but the key update test and this test require waiting for data to come back from the peer. This behavior will be addressed in #1841.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
