### PR TITLE
Adds proof harnesses for s2n_stuffer_write_uint*

### DIFF
--- a/stuffer/s2n_stuffer_network_order.c
+++ b/stuffer/s2n_stuffer_network_order.c
@@ -22,7 +22,6 @@
 
 int s2n_stuffer_write_network_order(struct s2n_stuffer *stuffer, uint32_t input, uint8_t length)
 {
-    notnull_check(stuffer);
     GUARD(s2n_stuffer_skip_write(stuffer, length));
     uint8_t *data = stuffer->blob.data + stuffer->write_cursor - length;
 
@@ -31,7 +30,7 @@ int s2n_stuffer_write_network_order(struct s2n_stuffer *stuffer, uint32_t input,
         uint8_t shift = (length - i - 1) * 8;
         data[i] = (input >> (shift)) & 0xFF;
     }
-
+    POSTCONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     return S2N_SUCCESS;
 }
 

--- a/tests/cbmc/include/cbmc_proof/endian.h
+++ b/tests/cbmc/include/cbmc_proof/endian.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+# define __LONG_LONG_PAIR(HI, LO) LO, HI
+#elif __BYTE_ORDER == __BIG_ENDIAN
+# define __LONG_LONG_PAIR(HI, LO) HI, LO
+#endif
+
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+# define htobe16(x) __builtin_bswap16 (x)
+# define htole16(x) (x)
+# define be16toh(x) __builtin_bswap16 (x)
+# define le16toh(x) (x)
+
+# define htobe32(x) __builtin_bswap32 (x)
+# define htole32(x) (x)
+# define be32toh(x) __builtin_bswap32 (x)
+# define le32toh(x) (x)
+
+# define htobe64(x) __builtin_bswap64 (x)
+# define htole64(x) (x)
+# define be64toh(x) __builtin_bswap64 (x)
+# define le64toh(x) (x)
+#else
+# define htobe16(x) (x)
+# define htole16(x) __builtin_bswap16 (x)
+# define be16toh(x) (x)
+# define le16toh(x) __builtin_bswap16 (x)
+
+# define htobe32(x) (x)
+# define htole32(x) __builtin_bswap32 (x)
+# define be32toh(x) (x)
+# define le32toh(x) __builtin_bswap32 (x)
+
+# define htobe64(x) (x)
+# define htole64(x) __builtin_bswap64 (x)
+# define be64toh(x) (x)
+# define le64toh(x) __builtin_bswap64 (x)
+#endif

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint16/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint16/Makefile
@@ -1,0 +1,37 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 30 seconds.
+SIZEOF_UINT16 = 2
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+
+ENTRY = s2n_stuffer_write_uint16_harness
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_blob_slice
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_stuffer_wipe_n
+
+UNWINDSET += s2n_stuffer_write_network_order.1:$(shell echo $$((1 + $(SIZEOF_UINT16))))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint16/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint16/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint16/s2n_stuffer_write_uint16_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint16/s2n_stuffer_write_uint16_harness.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_write_uint16_harness() {
+    /* Non-deterministic inputs. */
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    uint16_t src;
+    uint32_t index;
+
+    /* Store a byte from the stuffer to compare if the write fails */
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    /* Store a byte from the stuffer that won't be overwritten to compare if the write succeeds. */
+    __CPROVER_assume(index < stuffer->blob.size && (index < old_stuffer.write_cursor ||
+                                                    index >= old_stuffer.write_cursor + sizeof(uint16_t)));
+    uint8_t untouched_byte = stuffer->blob.data[index];
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    /* Operation under verification. */
+    if (s2n_stuffer_write_uint16(stuffer, src) == S2N_SUCCESS) {
+        assert(stuffer->write_cursor == old_stuffer.write_cursor + sizeof(uint16_t));
+        assert(stuffer->blob.data[index] == untouched_byte);
+        /* Ensure uint was correctly written to the stuffer */
+        assert(((uint16_t) stuffer->blob.data[old_stuffer.write_cursor]) << 8
+             | ((uint16_t) stuffer->blob.data[old_stuffer.write_cursor + 1]) == src);
+        assert(s2n_stuffer_is_valid(stuffer));
+    } else {
+        assert(stuffer->write_cursor == old_stuffer.write_cursor);
+        assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+    }
+    assert(stuffer->alloced == old_stuffer.alloced);
+    assert(stuffer->growable == old_stuffer.growable);
+    assert(stuffer->tainted == old_stuffer.tainted);
+    assert(stuffer->read_cursor == old_stuffer.read_cursor);
+}

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint16/s2n_stuffer_write_uint16_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint16/s2n_stuffer_write_uint16_harness.c
@@ -21,6 +21,7 @@
 #include <assert.h>
 
 #include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/endian.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
 
@@ -51,8 +52,7 @@ void s2n_stuffer_write_uint16_harness() {
         assert(stuffer->write_cursor == old_stuffer.write_cursor + sizeof(uint16_t));
         assert(stuffer->blob.data[index] == untouched_byte);
         /* Ensure uint was correctly written to the stuffer */
-        assert(((uint16_t) stuffer->blob.data[old_stuffer.write_cursor]) << 8
-             | ((uint16_t) stuffer->blob.data[old_stuffer.write_cursor + 1]) == src);
+        assert(be16toh(*((uint16_t*)(stuffer->blob.data+old_stuffer.write_cursor))) == src);
         assert(s2n_stuffer_is_valid(stuffer));
     } else {
         assert(stuffer->write_cursor == old_stuffer.write_cursor);

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint24/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint24/Makefile
@@ -1,0 +1,37 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 50 seconds.
+SIZEOF_UINT24 = 3
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+
+ENTRY = s2n_stuffer_write_uint24_harness
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_blob_slice
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_stuffer_wipe_n
+
+UNWINDSET += s2n_stuffer_write_network_order.1:$(shell echo $$((1 + $(SIZEOF_UINT24))))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint24/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint24/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint24/s2n_stuffer_write_uint24_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint24/s2n_stuffer_write_uint24_harness.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_write_uint24_harness() {
+    /* Non-deterministic inputs. */
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    uint32_t src;
+    uint32_t index;
+
+    /* Store a byte from the stuffer to compare if the write fails */
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    /* Store a byte from the stuffer that won't be overwritten to compare if the write succeeds. */
+    __CPROVER_assume(index < stuffer->blob.size && (index < old_stuffer.write_cursor ||
+                                                    index >= old_stuffer.write_cursor + (size_t)SIZEOF_UINT24));
+    uint8_t untouched_byte = stuffer->blob.data[index];
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    /* Operation under verification. */
+    if (s2n_stuffer_write_uint24(stuffer, src) == S2N_SUCCESS) {
+        assert(stuffer->write_cursor == old_stuffer.write_cursor + SIZEOF_UINT24);
+        assert(stuffer->blob.data[index] == untouched_byte);
+        /* Ensure uint was correctly written to the stuffer */
+        assert(((uint32_t) stuffer->blob.data[old_stuffer.write_cursor]) << 16
+             | ((uint32_t) stuffer->blob.data[old_stuffer.write_cursor + 1]) << 8
+             | ((uint32_t) stuffer->blob.data[old_stuffer.write_cursor + 2]) == (src & 0xFFFFFF));
+        assert(s2n_stuffer_is_valid(stuffer));
+    } else {
+        assert(stuffer->write_cursor == old_stuffer.write_cursor);
+        assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+    }
+    assert(stuffer->alloced == old_stuffer.alloced);
+    assert(stuffer->growable == old_stuffer.growable);
+    assert(stuffer->tainted == old_stuffer.tainted);
+    assert(stuffer->read_cursor == old_stuffer.read_cursor);
+}

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint32/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint32/Makefile
@@ -1,0 +1,37 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 50 seconds.
+SIZEOF_UINT32 = 4
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+
+ENTRY = s2n_stuffer_write_uint32_harness
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_blob_slice
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_stuffer_wipe_n
+
+UNWINDSET += s2n_stuffer_write_network_order.1:$(shell echo $$((1 + $(SIZEOF_UINT32))))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint32/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint32/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint32/s2n_stuffer_write_uint32_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint32/s2n_stuffer_write_uint32_harness.c
@@ -21,6 +21,7 @@
 #include <assert.h>
 
 #include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/endian.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
 
@@ -51,10 +52,7 @@ void s2n_stuffer_write_uint32_harness() {
         assert(stuffer->write_cursor == old_stuffer.write_cursor + sizeof(uint32_t));
         assert(stuffer->blob.data[index] == untouched_byte);
         /* Ensure uint was correctly written to the stuffer */
-        assert(((uint32_t) stuffer->blob.data[old_stuffer.write_cursor]) << 24
-             | ((uint32_t) stuffer->blob.data[old_stuffer.write_cursor + 1]) << 16
-             | ((uint32_t) stuffer->blob.data[old_stuffer.write_cursor + 2]) << 8
-             | ((uint32_t) stuffer->blob.data[old_stuffer.write_cursor + 3]) == src);
+        assert(be32toh(*((uint32_t*)(stuffer->blob.data+old_stuffer.write_cursor))) == src);
         assert(s2n_stuffer_is_valid(stuffer));
     } else {
         assert(stuffer->write_cursor == old_stuffer.write_cursor);

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint32/s2n_stuffer_write_uint32_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint32/s2n_stuffer_write_uint32_harness.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_write_uint32_harness() {
+    /* Non-deterministic inputs. */
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    uint32_t src;
+    uint32_t index;
+
+    /* Store a byte from the stuffer to compare if the write fails */
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    /* Store a byte from the stuffer that won't be overwritten to compare if the write succeeds. */
+    __CPROVER_assume(index < stuffer->blob.size && (index < old_stuffer.write_cursor ||
+                                                    index >= old_stuffer.write_cursor + sizeof(uint32_t)));
+    uint8_t untouched_byte = stuffer->blob.data[index];
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    /* Operation under verification. */
+    if (s2n_stuffer_write_uint32(stuffer, src) == S2N_SUCCESS) {
+        assert(stuffer->write_cursor == old_stuffer.write_cursor + sizeof(uint32_t));
+        assert(stuffer->blob.data[index] == untouched_byte);
+        /* Ensure uint was correctly written to the stuffer */
+        assert(((uint32_t) stuffer->blob.data[old_stuffer.write_cursor]) << 24
+             | ((uint32_t) stuffer->blob.data[old_stuffer.write_cursor + 1]) << 16
+             | ((uint32_t) stuffer->blob.data[old_stuffer.write_cursor + 2]) << 8
+             | ((uint32_t) stuffer->blob.data[old_stuffer.write_cursor + 3]) == src);
+        assert(s2n_stuffer_is_valid(stuffer));
+    } else {
+        assert(stuffer->write_cursor == old_stuffer.write_cursor);
+        assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+    }
+    assert(stuffer->alloced == old_stuffer.alloced);
+    assert(stuffer->growable == old_stuffer.growable);
+    assert(stuffer->tainted == old_stuffer.tainted);
+    assert(stuffer->read_cursor == old_stuffer.read_cursor);
+}

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint64/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint64/Makefile
@@ -1,0 +1,37 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 50 seconds.
+SIZEOF_UINT64 = 8
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+
+ENTRY = s2n_stuffer_write_uint64_harness
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_blob_slice
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_stuffer_wipe_n
+
+UNWINDSET += s2n_stuffer_write_network_order.1:$(shell echo $$((1 + $(SIZEOF_UINT64))))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint64/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint64/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint64/s2n_stuffer_write_uint64_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint64/s2n_stuffer_write_uint64_harness.c
@@ -21,6 +21,7 @@
 #include <assert.h>
 
 #include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/endian.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
 
@@ -51,14 +52,7 @@ void s2n_stuffer_write_uint64_harness() {
         assert(stuffer->write_cursor == old_stuffer.write_cursor + sizeof(uint64_t));
         assert(stuffer->blob.data[index] == untouched_byte);
         /* Ensure uint was correctly written to the stuffer */
-        assert(((uint64_t) stuffer->blob.data[old_stuffer.write_cursor]) << 56
-             | ((uint64_t) stuffer->blob.data[old_stuffer.write_cursor + 1]) << 48
-             | ((uint64_t) stuffer->blob.data[old_stuffer.write_cursor + 2]) << 40
-             | ((uint64_t) stuffer->blob.data[old_stuffer.write_cursor + 3]) << 32
-             | ((uint64_t) stuffer->blob.data[old_stuffer.write_cursor + 4]) << 24
-             | ((uint64_t) stuffer->blob.data[old_stuffer.write_cursor + 5]) << 16
-             | ((uint64_t) stuffer->blob.data[old_stuffer.write_cursor + 6]) << 8
-             | ((uint64_t) stuffer->blob.data[old_stuffer.write_cursor + 7]) == src);
+        assert(be64toh(*((uint64_t*)(stuffer->blob.data+old_stuffer.write_cursor))) == src);
         assert(s2n_stuffer_is_valid(stuffer));
     }
     assert(stuffer->alloced == old_stuffer.alloced);

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint64/s2n_stuffer_write_uint64_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint64/s2n_stuffer_write_uint64_harness.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_write_uint64_harness() {
+    /* Non-deterministic inputs. */
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    uint64_t src;
+    uint32_t index;
+
+    /* Store a byte from the stuffer to compare if the write fails */
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    /* Store a byte from the stuffer that won't be overwritten to compare if the write succeeds. */
+    __CPROVER_assume(index < stuffer->blob.size && (index < old_stuffer.write_cursor ||
+                                                    index >= old_stuffer.write_cursor + sizeof(uint64_t)));
+    uint8_t untouched_byte = stuffer->blob.data[index];
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    /* Operation under verification. */
+    if (s2n_stuffer_write_uint64(stuffer, src) == S2N_SUCCESS) {
+        assert(stuffer->write_cursor == old_stuffer.write_cursor + sizeof(uint64_t));
+        assert(stuffer->blob.data[index] == untouched_byte);
+        /* Ensure uint was correctly written to the stuffer */
+        assert(((uint64_t) stuffer->blob.data[old_stuffer.write_cursor]) << 56
+             | ((uint64_t) stuffer->blob.data[old_stuffer.write_cursor + 1]) << 48
+             | ((uint64_t) stuffer->blob.data[old_stuffer.write_cursor + 2]) << 40
+             | ((uint64_t) stuffer->blob.data[old_stuffer.write_cursor + 3]) << 32
+             | ((uint64_t) stuffer->blob.data[old_stuffer.write_cursor + 4]) << 24
+             | ((uint64_t) stuffer->blob.data[old_stuffer.write_cursor + 5]) << 16
+             | ((uint64_t) stuffer->blob.data[old_stuffer.write_cursor + 6]) << 8
+             | ((uint64_t) stuffer->blob.data[old_stuffer.write_cursor + 7]) == src);
+        assert(s2n_stuffer_is_valid(stuffer));
+    }
+    assert(stuffer->alloced == old_stuffer.alloced);
+    assert(stuffer->growable == old_stuffer.growable);
+    assert(stuffer->tainted == old_stuffer.tainted);
+    assert(stuffer->read_cursor == old_stuffer.read_cursor);
+}

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint8/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint8/Makefile
@@ -1,0 +1,37 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 30 seconds.
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+
+ENTRY = s2n_stuffer_write_uint8_harness
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_blob_slice
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_stuffer_wipe_n
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint8/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint8/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint8/s2n_stuffer_write_uint8_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint8/s2n_stuffer_write_uint8_harness.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_write_uint8_harness() {
+    /* Non-deterministic inputs. */
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    uint8_t src;
+    uint32_t index;
+
+    /* Store a byte from the stuffer to compare if the write fails */
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    /* Store a byte from the stuffer that won't be overwritten to compare if the write succeeds. */
+    __CPROVER_assume(index < stuffer->blob.size && (index < old_stuffer.write_cursor ||
+                                                    index >= old_stuffer.write_cursor + sizeof(uint8_t)));
+    uint8_t untouched_byte = stuffer->blob.data[index];
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    /* Operation under verification. */
+    if (s2n_stuffer_write_uint8(stuffer, src) == S2N_SUCCESS) {
+        assert(stuffer->write_cursor == old_stuffer.write_cursor + sizeof(uint8_t));
+        assert(stuffer->blob.data[index] == untouched_byte);
+        /* Ensure uint was correctly written to the stuffer */
+        assert(stuffer->blob.data[old_stuffer.write_cursor] == src);
+        assert(s2n_stuffer_is_valid(stuffer));
+    } else {
+        assert(stuffer->write_cursor == old_stuffer.write_cursor);
+        assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+    }
+    assert(stuffer->alloced == old_stuffer.alloced);
+    assert(stuffer->growable == old_stuffer.growable);
+    assert(stuffer->tainted == old_stuffer.tainted);
+    assert(stuffer->read_cursor == old_stuffer.read_cursor);
+}


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A.

### Description of changes: 

- Adds a proof harness for the `s2n_stuffer_write_uint*` functions;
- Adds a pre- and post-conditions to the `s2n_stuffer_write_uint*` functions;

### Call-outs:

This PR depends on [PR #1978](https://github.com/awslabs/s2n/pull/1978).
This PR overrides [PR #1867](https://github.com/awslabs/s2n/pull/1867).

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.