### PR TITLE
Adds a proof harness for s2n_is_base64_char function

### DIFF
--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -155,7 +155,7 @@ extern int s2n_stuffer_certificate_from_pem(struct s2n_stuffer *pem, struct s2n_
 /* Read DH parameters om a PEM encoded stuffer to a PKCS3 encoded one */
 extern int s2n_stuffer_dhparams_from_pem(struct s2n_stuffer *pem, struct s2n_stuffer *pkcs3);
 
-extern int s2n_is_base64_char(char c);
+extern bool s2n_is_base64_char(unsigned char c);
 
 /* Copies all valid data from "stuffer" into "out".
  * The old blob "out" pointed to is freed.

--- a/stuffer/s2n_stuffer_base64.c
+++ b/stuffer/s2n_stuffer_base64.c
@@ -32,7 +32,7 @@ static const uint8_t b64[64] = {
  *
  * b64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
  *
- * for i in range(0, 255):
+ * for i in range(0, 256):
  *     if chr(i) in b64:
  *         print str(b64.index(chr(i))) + ", ",
  *      else:
@@ -59,10 +59,10 @@ static const uint8_t b64_inverse[256] = {
     255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
     255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
     255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
-    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255
 };
 
-int s2n_is_base64_char(char c)
+bool s2n_is_base64_char(unsigned char c)
 {
     return (b64_inverse[*((uint8_t*)(&c))] != 255);
 }

--- a/stuffer/s2n_stuffer_base64.c
+++ b/stuffer/s2n_stuffer_base64.c
@@ -41,7 +41,7 @@ static const uint8_t b64[64] = {
  *      if (i + 1) % 16 == 0:
  *          print
  *
- * Note that '=' maps to 64. 
+ * Note that '=' maps to 64.
  */
 static const uint8_t b64_inverse[256] = {
     255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -64,13 +64,13 @@ static const uint8_t b64_inverse[256] = {
 
 int s2n_is_base64_char(char c)
 {
-    return (b64_inverse[(uint8_t) c] != 255);
+    return (b64_inverse[*((uint8_t*)(&c))] != 255);
 }
 
 /**
  * NOTE:
  * In general, shift before masking. This avoids needing to worry about how the
- * signed bit may be handled. 
+ * signed bit may be handled.
  */
 int s2n_stuffer_read_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *out)
 {
@@ -98,7 +98,7 @@ int s2n_stuffer_read_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *out
         }
 
         /* The first two characters can never be '=' and in general
-         * everything has to be a valid character. 
+         * everything has to be a valid character.
          */
         S2N_ERROR_IF(value1 == 64 || value2 == 64 || value2 == 255 || value3 == 255 || value4 == 255, S2N_ERR_INVALID_BASE64);
 
@@ -156,12 +156,12 @@ int s2n_stuffer_write_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *in
         o.data[0] = b64[(i.data[0] >> 2) & 0x3f];
 
         /* Take the bottom 2-bits of the first data byte -  0b00110000 = 0x30
-         * and take the top 4-bits of the second data byte - 0b00001111 = 0x0f 
+         * and take the top 4-bits of the second data byte - 0b00001111 = 0x0f
          */
         o.data[1] = b64[((i.data[0] << 4) & 0x30) | ((i.data[1] >> 4) & 0x0f)];
 
         /* Take the bottom 4-bits of the second data byte - 0b00111100 = 0x3c
-         * and take the top 2-bits of the third data byte - 0b00000011 = 0x03 
+         * and take the top 2-bits of the third data byte - 0b00000011 = 0x03
          */
         o.data[2] = b64[((i.data[1] << 2) & 0x3c) | ((i.data[2] >> 6) & 0x03)];
 
@@ -179,7 +179,7 @@ int s2n_stuffer_write_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *in
         uint8_t c = i.data[0];
 
         /* We at least one data byte left to encode, encode
-         * its first six bits 
+         * its first six bits
          */
         o.data[0] = b64[(c >> 2) & 0x3f];
 

--- a/tests/cbmc/proofs/s2n_is_base64_char/Makefile
+++ b/tests/cbmc/proofs/s2n_is_base64_char/Makefile
@@ -1,0 +1,23 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+CBMCFLAGS +=
+
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_base64.c
+
+ENTRY = s2n_is_base64_char_harness
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_is_base64_char/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_is_base64_char/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_is_base64_char/s2n_is_base64_char_harness.c
+++ b/tests/cbmc/proofs/s2n_is_base64_char/s2n_is_base64_char_harness.c
@@ -20,7 +20,10 @@
 #include <assert.h>
 
 void s2n_is_base64_char_harness() {
-    char c;
-    int result = s2n_is_base64_char(c);
-    assert(result == 0 || result == 1);
+    unsigned char c;
+    bool is_base_64 = ('A' <= c && c <= 'Z') ||
+                      ('a' <= c && c <= 'z') ||
+                      ('0' <= c && c <= '9') ||
+                      c == '+' || c == '/' || c == '=';
+    assert(is_base_64 == s2n_is_base64_char(c));
 }

--- a/tests/cbmc/proofs/s2n_is_base64_char/s2n_is_base64_char_harness.c
+++ b/tests/cbmc/proofs/s2n_is_base64_char/s2n_is_base64_char_harness.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+
+void s2n_is_base64_char_harness() {
+    char c;
+    int result = s2n_is_base64_char(c);
+    assert(result == 0 || result == 1);
+}


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A.

### Description of changes: 

- Adds a proof harness for the `s2n_is_base64_char` function;
- Update `s2n_is_base64_char` function parameters;

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
