### PR TITLE
SNI match test

### DIFF
--- a/tests/integrationv2/common.py
+++ b/tests/integrationv2/common.py
@@ -270,6 +270,8 @@ class ProviderOptions(object):
             client_trust_store=None,
             reconnects_before_exit=None,
             reconnect=None,
+            verify_hostname=None,
+            server_name=None,
             protocol=None):
 
         # Client or server
@@ -316,6 +318,13 @@ class ProviderOptions(object):
 
         # Tell the client to reconnect
         self.reconnect = reconnect
+
+        # Tell the client to verify that the hostname returned by the server
+        # matches this argument
+        self.verify_hostname = verify_hostname
+
+        # Tell the client to send this server name to the server
+        self.server_name = server_name
 
         # Extra flags to pass to the provider
         self.extra_flags = extra_flags

--- a/tests/integrationv2/configuration.py
+++ b/tests/integrationv2/configuration.py
@@ -1,4 +1,7 @@
+import collections
+
 from common import Certificates, Ciphers, Curves, Protocols, AvailablePorts
+from constants import TEST_SNI_CERT_DIRECTORY
 from providers import S2N, OpenSSL, BoringSSL
 
 
@@ -95,3 +98,248 @@ PROVIDERS = [S2N, OpenSSL]
 
 # List of ports available to tests.
 available_ports = AvailablePorts()
+
+
+
+# Server certificates used to test matching domain names client with server_name
+# ( cert_path, private_key_path, domains[] )
+SNI_CERTS = {
+    "alligator" : ( TEST_SNI_CERT_DIRECTORY + "alligator_cert.pem", TEST_SNI_CERT_DIRECTORY + "alligator_key.pem",
+            ["www.alligator.com"]),
+    "second_alligator_rsa" : ( TEST_SNI_CERT_DIRECTORY + "second_alligator_rsa_cert.pem", TEST_SNI_CERT_DIRECTORY + "second_alligator_rsa_key.pem",
+            ["www.alligator.com"]),
+    "alligator_ecdsa" : ( TEST_SNI_CERT_DIRECTORY + "alligator_ecdsa_cert.pem", TEST_SNI_CERT_DIRECTORY +
+            "alligator_ecdsa_key.pem", ["www.alligator.com"]),
+    "beaver"    : ( TEST_SNI_CERT_DIRECTORY + "beaver_cert.pem", TEST_SNI_CERT_DIRECTORY + "beaver_key.pem",
+            ["www.beaver.com"]),
+    "many_animals" : (TEST_SNI_CERT_DIRECTORY + "many_animal_sans_rsa_cert.pem", TEST_SNI_CERT_DIRECTORY + "many_animal_sans_rsa_key.pem",
+            ["www.catfish.com",
+            "www.dolphin.com",
+            "www.elephant.com",
+            "www.falcon.com",
+            "www.gorilla.com",
+            "www.horse.com",
+            "www.impala.com",
+            # "Simple hostname"
+            "Jackal",
+            "k.e.e.l.b.i.l.l.e.d.t.o.u.c.a.n",
+            # SAN on this cert is actually "ladybug.ladybug"
+            # Verify case insensitivity works as expected.
+            "LADYBUG.LADYBUG",
+            "com.penguin.macaroni"
+            ]),
+    "narwhal_cn" : ( TEST_SNI_CERT_DIRECTORY + "narwhal_cn_cert.pem", TEST_SNI_CERT_DIRECTORY + "narwhal_cn_key.pem",
+            ["www.narwhal.com"]),
+    "octopus_cn_platypus_san" : ( TEST_SNI_CERT_DIRECTORY + "octopus_cn_platypus_san_cert.pem", TEST_SNI_CERT_DIRECTORY
+            + "octopus_cn_platypus_san_key.pem", ["www.platypus.com"]),
+    "quail_cn_rattlesnake_cn" : ( TEST_SNI_CERT_DIRECTORY + "quail_cn_rattlesnake_cn_cert.pem", TEST_SNI_CERT_DIRECTORY
+            + "quail_cn_rattlesnake_cn_key.pem", ["www.quail.com", "www.rattlesnake.com"]),
+    "many_animals_mixed_case" : (TEST_SNI_CERT_DIRECTORY + "many_animal_sans_mixed_case_rsa_cert.pem", 
+            TEST_SNI_CERT_DIRECTORY + "many_animal_sans_mixed_case_rsa_key.pem",
+            ["alligator.com",
+            "beaver.com",
+            "catFish.com",
+            "WWW.dolphin.COM",
+            "www.ELEPHANT.com",
+            "www.Falcon.Com",
+            "WWW.gorilla.COM",
+            "www.horse.com",
+            "WWW.IMPALA.COM",
+            "WwW.jAcKaL.cOm"]),
+    "embedded_wildcard" : ( TEST_SNI_CERT_DIRECTORY + "embedded_wildcard_rsa_cert.pem",
+            TEST_SNI_CERT_DIRECTORY + "embedded_wildcard_rsa_key.pem", ["www.labelstart*labelend.com"]),
+    "non_empty_label_wildcard" : ( TEST_SNI_CERT_DIRECTORY + "non_empty_label_wildcard_rsa_cert.pem",
+            TEST_SNI_CERT_DIRECTORY + "non_empty_label_wildcard_rsa_key.pem", ["WILD*.middle.end"]),
+    "trailing_wildcard" : ( TEST_SNI_CERT_DIRECTORY + "trailing_wildcard_rsa_cert.pem",
+            TEST_SNI_CERT_DIRECTORY + "trailing_wildcard_rsa_key.pem", ["the.prefix.*"]),
+    "wildcard_insect" : ( TEST_SNI_CERT_DIRECTORY + "wildcard_insect_rsa_cert.pem",
+            TEST_SNI_CERT_DIRECTORY + "wildcard_insect_rsa_key.pem",
+            ["ant.insect.hexapod",
+            "BEE.insect.hexapod",
+            "wasp.INSECT.hexapod",
+            "butterfly.insect.hexapod",
+            ]),
+    "termite" : ( TEST_SNI_CERT_DIRECTORY + "termite_rsa_cert.pem", TEST_SNI_CERT_DIRECTORY + "termite_rsa_key.pem",
+            [ "termite.insect.hexapod" ]),
+    "underwing" : ( TEST_SNI_CERT_DIRECTORY + "underwing_ecdsa_cert.pem", TEST_SNI_CERT_DIRECTORY + "underwing_ecdsa_key.pem",
+            [ "underwing.insect.hexapod" ])
+}
+
+
+# Test cases for certificate selection.
+# Test inputs: server certificates to load into s2nd, client SNI and capabilities, outputs are selected server cert
+# and negotiated cipher.
+MultiCertTest = collections.namedtuple('MultiCertTest', 'description server_certs client_sni client_ciphers expected_cert expect_matching_hostname')
+MULTI_CERT_TEST_CASES= [
+    MultiCertTest(
+        description="Test basic SNI match for default cert.",
+        server_certs=[SNI_CERTS["alligator"], SNI_CERTS["beaver"], SNI_CERTS["alligator_ecdsa"]],
+        client_sni="www.alligator.com",
+        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
+        expected_cert=SNI_CERTS["alligator"],
+        expect_matching_hostname=True),
+    MultiCertTest(
+        description="Test basic SNI matches for non-default cert.",
+        server_certs=[SNI_CERTS["alligator"], SNI_CERTS["beaver"], SNI_CERTS["alligator_ecdsa"]],
+        client_sni="www.beaver.com",
+        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
+        expected_cert=SNI_CERTS["beaver"],
+        expect_matching_hostname=True),
+    MultiCertTest(
+        description="Test default cert is selected when there are no SNI matches.",
+        server_certs=[SNI_CERTS["alligator"], SNI_CERTS["beaver"], SNI_CERTS["alligator_ecdsa"]],
+        client_sni="not.a.match",
+        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
+        expected_cert=SNI_CERTS["alligator"],
+        expect_matching_hostname=False),
+    MultiCertTest(
+        description="Test default cert is selected when no SNI is sent.",
+        server_certs=[SNI_CERTS["alligator"], SNI_CERTS["beaver"], SNI_CERTS["alligator_ecdsa"]],
+        client_sni=None,
+        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
+        expected_cert=SNI_CERTS["alligator"],
+        expect_matching_hostname=False),
+    MultiCertTest(
+        description="Test ECDSA cert is selected with matching domain and client only supports ECDSA.",
+        server_certs=[SNI_CERTS["alligator"], SNI_CERTS["beaver"], SNI_CERTS["alligator_ecdsa"]],
+        client_sni="www.alligator.com",
+        client_ciphers=[Ciphers.ECDHE_ECDSA_AES128_SHA],
+        expected_cert=SNI_CERTS["alligator_ecdsa"],
+        expect_matching_hostname=True),
+    MultiCertTest(
+        description="Test ECDSA cert selected when: domain matches for both ECDSA+RSA, client supports ECDSA+RSA "\
+                    " ciphers, ECDSA is higher priority on server side.",
+        server_certs=[SNI_CERTS["alligator"], SNI_CERTS["beaver"], SNI_CERTS["alligator_ecdsa"]],
+        client_sni="www.alligator.com",
+        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA, Ciphers.ECDHE_ECDSA_AES128_SHA],
+        expected_cert=SNI_CERTS["alligator_ecdsa"],
+        expect_matching_hostname=True),
+    MultiCertTest(
+        description="Test domain match is highest priority. Domain matching ECDSA certificate should be selected"\
+                    " even if domain mismatched RSA certificate is available and RSA cipher is higher priority.",
+        server_certs=[SNI_CERTS["beaver"], SNI_CERTS["alligator_ecdsa"]],
+        client_sni="www.alligator.com",
+        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA, Ciphers.ECDHE_ECDSA_AES128_SHA256],
+        expected_cert=SNI_CERTS["alligator_ecdsa"],
+        expect_matching_hostname=True),
+    MultiCertTest(
+        description="Test certificate with single SAN entry matching is selected before mismatched multi SAN cert",
+        server_certs=[SNI_CERTS["many_animals"] , SNI_CERTS["alligator"]],
+        client_sni="www.alligator.com",
+        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
+        expected_cert=SNI_CERTS["alligator"],
+        expect_matching_hostname=True),
+        # many_animals was the first cert added
+    MultiCertTest(
+        description="Test default cert with multiple sans and no SNI sent.",
+        server_certs=[SNI_CERTS["many_animals"] , SNI_CERTS["alligator"]],
+        client_sni=None,
+        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
+        expected_cert=SNI_CERTS["many_animals"],
+        expect_matching_hostname=False),
+    MultiCertTest(
+        description="Test certificate match with CN",
+        server_certs=[ SNI_CERTS["alligator"], SNI_CERTS["narwhal_cn"] ],
+        client_sni="www.narwhal.com",
+        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
+        expected_cert=SNI_CERTS["narwhal_cn"],
+        expect_matching_hostname=True),
+    MultiCertTest(
+        description="Test SAN+CN cert can match using SAN.",
+        server_certs=[ SNI_CERTS["alligator"], SNI_CERTS["octopus_cn_platypus_san"] ],
+        client_sni="www.platypus.com",
+        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
+        expected_cert=SNI_CERTS["octopus_cn_platypus_san"],
+        expect_matching_hostname=True),
+    MultiCertTest(
+        description="Test that CN is not considered for matching if the certificate contains SANs.",
+        server_certs=[ SNI_CERTS["alligator"], SNI_CERTS["octopus_cn_platypus_san"] ],
+        client_sni="www.octopus.com",
+        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
+        expected_cert=SNI_CERTS["alligator"],
+        expect_matching_hostname=False),
+    MultiCertTest(
+        description="Test certificate with multiple CNs can match.",
+        server_certs=[ SNI_CERTS["alligator"], SNI_CERTS["quail_cn_rattlesnake_cn"] ],
+        client_sni="www.rattlesnake.com",
+        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
+        expected_cert=SNI_CERTS["quail_cn_rattlesnake_cn"],
+        expect_matching_hostname=False),
+    MultiCertTest(
+        description="Test cert with embedded wildcard is not treated as a wildcard.",
+        server_certs=[ SNI_CERTS["alligator"], SNI_CERTS["embedded_wildcard"] ],
+        client_sni="www.labelstartWILDCARDlabelend.com",
+        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
+        expected_cert=SNI_CERTS["alligator"],
+        expect_matching_hostname=False),
+    MultiCertTest(
+        description="Test non empty left label wildcard cert is not treated as a wildcard."\
+                    " s2n only supports wildcards with a single * as the left label",
+        server_certs=[ SNI_CERTS["alligator"], SNI_CERTS["non_empty_label_wildcard"] ],
+        client_sni="WILDCARD.middle.end",
+        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
+        expected_cert=SNI_CERTS["alligator"],
+        expect_matching_hostname=False),
+    MultiCertTest(
+        description="Test cert with trailing * is not treated as wildcard.",
+        server_certs=[ SNI_CERTS["alligator"], SNI_CERTS["trailing_wildcard"] ],
+        client_sni="the.prefix.WILDCARD",
+        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
+        expected_cert=SNI_CERTS["alligator"],
+        expect_matching_hostname=False),
+    MultiCertTest(
+        description="Certificate with exact sni match(termite.insect.hexapod) is preferred over wildcard"\
+                    " *.insect.hexapod",
+        server_certs=[ SNI_CERTS["wildcard_insect"], SNI_CERTS["alligator"], SNI_CERTS["termite"] ],
+        client_sni="termite.insect.hexapod",
+        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
+        expected_cert=SNI_CERTS["termite"],
+        expect_matching_hostname=True),
+    MultiCertTest(
+        description="ECDSA Certificate with exact sni match(underwing.insect.hexapod) is preferred over RSA wildcard"\
+                    " *.insect.hexapod when RSA ciphers are higher priority than ECDSA in sever preferences.",
+        server_certs=[ SNI_CERTS["wildcard_insect"], SNI_CERTS["alligator"], SNI_CERTS["underwing"] ],
+        client_sni="underwing.insect.hexapod",
+        # AES128-GCM-SHA256 is prioritized about ECDHE-ECDSA-AES128-SHA in
+        # the "test_all" server cipher preferences
+        client_ciphers=[Ciphers.AES128_GCM_SHA256, Ciphers.ECDHE_ECDSA_AES128_SHA],
+        expected_cert=SNI_CERTS["underwing"],
+        expect_matching_hostname=True),
+    MultiCertTest(
+        description="Firstly loaded matching certificate should be selected among certificates with the same domain names",
+        server_certs=[ SNI_CERTS["alligator"], SNI_CERTS["second_alligator_rsa"] ],
+        client_sni="www.alligator.com",
+        client_ciphers=[Ciphers.AES128_GCM_SHA256],
+        expected_cert=SNI_CERTS["alligator"],
+        expect_matching_hostname=True),
+    MultiCertTest(
+        description="Firstly loaded matching certificate should be selected among matching+non-matching certificates",
+        server_certs=[ SNI_CERTS["beaver"], SNI_CERTS["alligator"], SNI_CERTS["second_alligator_rsa"] ],
+        client_sni="www.alligator.com",
+        client_ciphers=[Ciphers.AES128_GCM_SHA256],
+        expected_cert=SNI_CERTS["alligator"],
+        expect_matching_hostname=True)]
+# Positive test for wildcard matches
+MULTI_CERT_TEST_CASES.extend([MultiCertTest(
+        description="Test wildcard *.insect.hexapod matches subdomain " + specific_insect_domain,
+        server_certs=[ SNI_CERTS["alligator"], SNI_CERTS["wildcard_insect"] ],
+        client_sni=specific_insect_domain,
+        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
+        expected_cert=SNI_CERTS["wildcard_insect"],
+        expect_matching_hostname=True) for specific_insect_domain in SNI_CERTS["wildcard_insect"][2]])
+# Positive test for basic SAN matches
+MULTI_CERT_TEST_CASES.extend([MultiCertTest(
+        description="Match SAN " + many_animal_domain + " in many_animals cert",
+        server_certs= [ SNI_CERTS["alligator"], SNI_CERTS["many_animals"] ],
+        client_sni=many_animal_domain,
+        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
+        expected_cert=SNI_CERTS["many_animals"],
+        expect_matching_hostname=True) for many_animal_domain in SNI_CERTS["many_animals"][2]])
+# Positive test for mixed cased SAN matches
+MULTI_CERT_TEST_CASES.extend([MultiCertTest(
+        description="Match SAN " + many_animal_domain + " in many_animals_mixed_case cert",
+        server_certs= [SNI_CERTS["alligator"] , SNI_CERTS["many_animals_mixed_case"]],
+        client_sni=many_animal_domain,
+        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
+        expected_cert=SNI_CERTS["many_animals_mixed_case"],
+        expect_matching_hostname=True) for many_animal_domain in SNI_CERTS["many_animals_mixed_case"][2]])

--- a/tests/integrationv2/configuration.py
+++ b/tests/integrationv2/configuration.py
@@ -104,65 +104,106 @@ available_ports = AvailablePorts()
 # Server certificates used to test matching domain names client with server_name
 # ( cert_path, private_key_path, domains[] )
 SNI_CERTS = {
-    "alligator" : ( TEST_SNI_CERT_DIRECTORY + "alligator_cert.pem", TEST_SNI_CERT_DIRECTORY + "alligator_key.pem",
-            ["www.alligator.com"]),
-    "second_alligator_rsa" : ( TEST_SNI_CERT_DIRECTORY + "second_alligator_rsa_cert.pem", TEST_SNI_CERT_DIRECTORY + "second_alligator_rsa_key.pem",
-            ["www.alligator.com"]),
-    "alligator_ecdsa" : ( TEST_SNI_CERT_DIRECTORY + "alligator_ecdsa_cert.pem", TEST_SNI_CERT_DIRECTORY +
-            "alligator_ecdsa_key.pem", ["www.alligator.com"]),
-    "beaver"    : ( TEST_SNI_CERT_DIRECTORY + "beaver_cert.pem", TEST_SNI_CERT_DIRECTORY + "beaver_key.pem",
-            ["www.beaver.com"]),
-    "many_animals" : (TEST_SNI_CERT_DIRECTORY + "many_animal_sans_rsa_cert.pem", TEST_SNI_CERT_DIRECTORY + "many_animal_sans_rsa_key.pem",
-            ["www.catfish.com",
-            "www.dolphin.com",
-            "www.elephant.com",
-            "www.falcon.com",
-            "www.gorilla.com",
-            "www.horse.com",
-            "www.impala.com",
-            # "Simple hostname"
-            "Jackal",
-            "k.e.e.l.b.i.l.l.e.d.t.o.u.c.a.n",
-            # SAN on this cert is actually "ladybug.ladybug"
-            # Verify case insensitivity works as expected.
-            "LADYBUG.LADYBUG",
-            "com.penguin.macaroni"
-            ]),
-    "narwhal_cn" : ( TEST_SNI_CERT_DIRECTORY + "narwhal_cn_cert.pem", TEST_SNI_CERT_DIRECTORY + "narwhal_cn_key.pem",
-            ["www.narwhal.com"]),
-    "octopus_cn_platypus_san" : ( TEST_SNI_CERT_DIRECTORY + "octopus_cn_platypus_san_cert.pem", TEST_SNI_CERT_DIRECTORY
-            + "octopus_cn_platypus_san_key.pem", ["www.platypus.com"]),
-    "quail_cn_rattlesnake_cn" : ( TEST_SNI_CERT_DIRECTORY + "quail_cn_rattlesnake_cn_cert.pem", TEST_SNI_CERT_DIRECTORY
-            + "quail_cn_rattlesnake_cn_key.pem", ["www.quail.com", "www.rattlesnake.com"]),
-    "many_animals_mixed_case" : (TEST_SNI_CERT_DIRECTORY + "many_animal_sans_mixed_case_rsa_cert.pem", 
-            TEST_SNI_CERT_DIRECTORY + "many_animal_sans_mixed_case_rsa_key.pem",
-            ["alligator.com",
-            "beaver.com",
-            "catFish.com",
-            "WWW.dolphin.COM",
-            "www.ELEPHANT.com",
-            "www.Falcon.Com",
-            "WWW.gorilla.COM",
-            "www.horse.com",
-            "WWW.IMPALA.COM",
-            "WwW.jAcKaL.cOm"]),
-    "embedded_wildcard" : ( TEST_SNI_CERT_DIRECTORY + "embedded_wildcard_rsa_cert.pem",
-            TEST_SNI_CERT_DIRECTORY + "embedded_wildcard_rsa_key.pem", ["www.labelstart*labelend.com"]),
-    "non_empty_label_wildcard" : ( TEST_SNI_CERT_DIRECTORY + "non_empty_label_wildcard_rsa_cert.pem",
-            TEST_SNI_CERT_DIRECTORY + "non_empty_label_wildcard_rsa_key.pem", ["WILD*.middle.end"]),
-    "trailing_wildcard" : ( TEST_SNI_CERT_DIRECTORY + "trailing_wildcard_rsa_cert.pem",
-            TEST_SNI_CERT_DIRECTORY + "trailing_wildcard_rsa_key.pem", ["the.prefix.*"]),
-    "wildcard_insect" : ( TEST_SNI_CERT_DIRECTORY + "wildcard_insect_rsa_cert.pem",
-            TEST_SNI_CERT_DIRECTORY + "wildcard_insect_rsa_key.pem",
-            ["ant.insect.hexapod",
-            "BEE.insect.hexapod",
-            "wasp.INSECT.hexapod",
-            "butterfly.insect.hexapod",
-            ]),
-    "termite" : ( TEST_SNI_CERT_DIRECTORY + "termite_rsa_cert.pem", TEST_SNI_CERT_DIRECTORY + "termite_rsa_key.pem",
-            [ "termite.insect.hexapod" ]),
-    "underwing" : ( TEST_SNI_CERT_DIRECTORY + "underwing_ecdsa_cert.pem", TEST_SNI_CERT_DIRECTORY + "underwing_ecdsa_key.pem",
-            [ "underwing.insect.hexapod" ])
+    "alligator" : (
+        TEST_SNI_CERT_DIRECTORY + "alligator_cert.pem",
+        TEST_SNI_CERT_DIRECTORY + "alligator_key.pem",
+        ["www.alligator.com"]
+    ),
+    "second_alligator_rsa" : (
+        TEST_SNI_CERT_DIRECTORY + "second_alligator_rsa_cert.pem",
+        TEST_SNI_CERT_DIRECTORY + "second_alligator_rsa_key.pem",
+        ["www.alligator.com"]
+    ),
+    "alligator_ecdsa" : (
+        TEST_SNI_CERT_DIRECTORY + "alligator_ecdsa_cert.pem",
+        TEST_SNI_CERT_DIRECTORY + "alligator_ecdsa_key.pem",
+        ["www.alligator.com"]
+    ),
+    "beaver" : (
+        TEST_SNI_CERT_DIRECTORY + "beaver_cert.pem",
+        TEST_SNI_CERT_DIRECTORY + "beaver_key.pem",
+        ["www.beaver.com"]
+    ),
+    "many_animals" : (
+        TEST_SNI_CERT_DIRECTORY + "many_animal_sans_rsa_cert.pem",
+        TEST_SNI_CERT_DIRECTORY + "many_animal_sans_rsa_key.pem",
+        ["www.catfish.com",
+        "www.dolphin.com",
+        "www.elephant.com",
+        "www.falcon.com",
+        "www.gorilla.com",
+        "www.horse.com",
+        "www.impala.com",
+        # "Simple hostname"
+        "Jackal",
+        "k.e.e.l.b.i.l.l.e.d.t.o.u.c.a.n",
+        # SAN on this cert is actually "ladybug.ladybug"
+        # Verify case insensitivity works as expected.
+        "LADYBUG.LADYBUG",
+        "com.penguin.macaroni"]
+    ),
+    "narwhal_cn" : (
+        TEST_SNI_CERT_DIRECTORY + "narwhal_cn_cert.pem",
+        TEST_SNI_CERT_DIRECTORY + "narwhal_cn_key.pem",
+        ["www.narwhal.com"]
+    ),
+    "octopus_cn_platypus_san" : (
+        TEST_SNI_CERT_DIRECTORY + "octopus_cn_platypus_san_cert.pem",
+        TEST_SNI_CERT_DIRECTORY + "octopus_cn_platypus_san_key.pem",
+        ["www.platypus.com"]
+    ),
+    "quail_cn_rattlesnake_cn" : (
+        TEST_SNI_CERT_DIRECTORY + "quail_cn_rattlesnake_cn_cert.pem",
+        TEST_SNI_CERT_DIRECTORY + "quail_cn_rattlesnake_cn_key.pem",
+        ["www.quail.com", "www.rattlesnake.com"]
+    ),
+    "many_animals_mixed_case" : (
+        TEST_SNI_CERT_DIRECTORY + "many_animal_sans_mixed_case_rsa_cert.pem",
+        TEST_SNI_CERT_DIRECTORY + "many_animal_sans_mixed_case_rsa_key.pem",
+        ["alligator.com",
+        "beaver.com",
+        "catFish.com",
+        "WWW.dolphin.COM",
+        "www.ELEPHANT.com",
+        "www.Falcon.Com",
+        "WWW.gorilla.COM",
+        "www.horse.com",
+        "WWW.IMPALA.COM",
+        "WwW.jAcKaL.cOm"]
+    ),
+    "embedded_wildcard" : (
+        TEST_SNI_CERT_DIRECTORY + "embedded_wildcard_rsa_cert.pem",
+        TEST_SNI_CERT_DIRECTORY + "embedded_wildcard_rsa_key.pem",
+        ["www.labelstart*labelend.com"]
+    ),
+    "non_empty_label_wildcard" : (
+        TEST_SNI_CERT_DIRECTORY + "non_empty_label_wildcard_rsa_cert.pem",
+        TEST_SNI_CERT_DIRECTORY + "non_empty_label_wildcard_rsa_key.pem",
+        ["WILD*.middle.end"]
+    ),
+    "trailing_wildcard" : (
+        TEST_SNI_CERT_DIRECTORY + "trailing_wildcard_rsa_cert.pem",
+        TEST_SNI_CERT_DIRECTORY + "trailing_wildcard_rsa_key.pem",
+        ["the.prefix.*"]
+    ),
+    "wildcard_insect" : (
+        TEST_SNI_CERT_DIRECTORY + "wildcard_insect_rsa_cert.pem",
+        TEST_SNI_CERT_DIRECTORY + "wildcard_insect_rsa_key.pem",
+        ["ant.insect.hexapod",
+        "BEE.insect.hexapod",
+        "wasp.INSECT.hexapod",
+        "butterfly.insect.hexapod"]
+    ),
+    "termite" : (
+        TEST_SNI_CERT_DIRECTORY + "termite_rsa_cert.pem",
+        TEST_SNI_CERT_DIRECTORY + "termite_rsa_key.pem",
+        [ "termite.insect.hexapod" ]
+    ),
+    "underwing" : (
+        TEST_SNI_CERT_DIRECTORY + "underwing_ecdsa_cert.pem",
+        TEST_SNI_CERT_DIRECTORY + "underwing_ecdsa_key.pem",
+        [ "underwing.insect.hexapod" ]
+    )
 }
 
 

--- a/tests/integrationv2/constants.py
+++ b/tests/integrationv2/constants.py
@@ -1,1 +1,2 @@
 TEST_CERT_DIRECTORY="../pems/"
+TEST_SNI_CERT_DIRECTORY="../pems/sni/"

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -188,28 +188,52 @@ class S2N(Provider):
 
 class OpenSSL(Provider):
 
+    supported_ciphers = {
+        Ciphers.AES128_GCM_SHA256: 'TLS_AES_128_GCM_SHA256',
+        Ciphers.AES256_GCM_SHA384: 'TLS_AES_256_GCM_SHA384',
+        Ciphers.CHACHA20_POLY1305_SHA256: 'TLS_CHACHA20_POLY1305_SHA256',
+    }
+
     def __init__(self, options: ProviderOptions):
         self.ready_to_send_input_marker = None
         Provider.__init__(self, options)
 
-    def cipher_to_cmdline(self, protocol, cipher):
+    def _join_ciphers(self, ciphers):
+        """
+        Given a list of ciphers, join the names with a ':' like OpenSSL expects
+        """
+        assert type(ciphers) is list
+
+        cipher_list = []
+        for c in ciphers:
+            if c.min_version is Protocols.TLS13:
+                cipher_list.append(OpenSSL.supported_ciphers[c])
+            else:
+                # This replace is only done for ciphers that are not TLS13 specific.
+                # Run `openssl ciphers` to view the inconsistency in naming.
+                cipher_list.append(c.name.replace("_", "-"))
+
+        ciphers = ':'.join(cipher_list)
+
+        return ciphers
+
+    def _cipher_to_cmdline(self, protocol, cipher):
         cmdline = list()
 
-        # Prior to TLS13 the -cipher flag is used
-        if cipher.min_version == Protocols.TLS13:
-            supported_ciphers = {
-                Ciphers.AES128_GCM_SHA256: 'TLS_AES_128_GCM_SHA256',
-                Ciphers.AES256_GCM_SHA384: 'TLS_AES_256_GCM_SHA384',
-                Ciphers.CHACHA20_POLY1305_SHA256: 'TLS_CHACHA20_POLY1305_SHA256',
-            }
+        cmdline.append('-cipher')
 
-            cmdline.append('-ciphersuites')
-            cmdline.append(supported_ciphers[cipher])
+        ciphers = []
+        if type(cipher) is list:
+            ciphers.append(self._join_ciphers(cipher))
         else:
-            cmdline.append('-cipher')
-            cmdline.append(cipher.name.replace("_", "-"))
+            if cipher.min_version == Protocols.TLS13:
+                ciphers.append(OpenSSL.supported_ciphers[cipher])
+            else:
+                # This replace is only done for ciphers that are not TLS13 specific.
+                # Run `openssl ciphers` to view the inconsistency in naming.
+                ciphers.append(cipher.name.replace("_", "-"))
 
-        return cmdline
+        return cmdline + ciphers
 
     def setup_client(self, options: ProviderOptions):
         # s_client prints this message before it is ready to send/receive data
@@ -238,7 +262,7 @@ class OpenSSL(Provider):
             cmd_line.append('-tls1')
 
         if options.cipher is not None:
-            cmd_line.extend(self.cipher_to_cmdline(options.protocol, options.cipher))
+            cmd_line.extend(self._cipher_to_cmdline(options.protocol, options.cipher))
 
         if options.curve is not None:
             cmd_line.extend(['-curves', str(options.curve)])
@@ -249,6 +273,12 @@ class OpenSSL(Provider):
 
         if options.reconnect is True:
             cmd_line.append('-reconnect')
+
+        if options.server_name is not None:
+            cmd_line.extend(['-servername', options.server_name])
+            if options.verify_hostname is not None:
+                cmd_line.extend(['-verify_hostname', options.server_name])
+
 
         if options.extra_flags is not None:
             cmd_line.extend(options.extra_flags)
@@ -294,7 +324,7 @@ class OpenSSL(Provider):
             cmd_line.append('-tls1')
 
         if options.cipher is not None:
-            cmd_line.extend(self.cipher_to_cmdline(options.protocol, options.cipher))
+            cmd_line.extend(self._cipher_to_cmdline(options.protocol, options.cipher))
             if options.cipher.parameters is not None:
                 cmd_line.extend(['-dhparam', options.cipher.parameters])
 

--- a/tests/integrationv2/test_sni_match.py
+++ b/tests/integrationv2/test_sni_match.py
@@ -1,0 +1,76 @@
+import copy
+import pytest
+
+from configuration import available_ports, MULTI_CERT_TEST_CASES, PROVIDERS, PROTOCOLS
+from common import ProviderOptions, Protocols, data_bytes
+from fixtures import managed_process
+from providers import Provider, S2N, OpenSSL
+from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version
+
+
+def filter_cipher_list(*args, **kwargs):
+    """
+    The framework normally filters out ciphers that are not supported by the chosen
+    protocol. That doesn't happen in this test because of the unique way ciphers are
+    grouped for the multi certificate tests.
+
+    This function handles that unique grouping.
+    """
+    protocol = kwargs.get('protocol')
+    cert_test_case = kwargs.get('cert_test_case')
+
+    lowest_protocol_cipher = min(cert_test_case.client_ciphers, key=lambda x: x.min_version)
+    if protocol < lowest_protocol_cipher.min_version:
+        return True
+
+    return False
+
+
+@pytest.mark.uncollect_if(func=invalid_test_parameters)
+@pytest.mark.uncollect_if(func=filter_cipher_list)
+@pytest.mark.parametrize("provider", [OpenSSL])
+@pytest.mark.parametrize("protocol", [Protocols.TLS13, Protocols.TLS12], ids=get_parameter_name)
+@pytest.mark.parametrize("cert_test_case", MULTI_CERT_TEST_CASES)
+def test_sni_match(managed_process, provider, protocol, cert_test_case):
+    host = "localhost"
+    port = next(available_ports)
+
+    client_options = ProviderOptions(
+        mode=Provider.ClientMode,
+        host=host,
+        port=port,
+        insecure=False,
+        verify_hostname=True,
+        server_name=cert_test_case.client_sni,
+        cipher = cert_test_case.client_ciphers,
+        protocol=protocol)
+
+    server_options = ProviderOptions(
+        mode = Provider.ServerMode,
+        host=host,
+        port=port,
+        extra_flags=[],
+        protocol=protocol)
+
+    # Setup the certificate chain for S2ND based on the multicert test case
+    cert_key_list = [(cert[0],cert[1]) for cert in cert_test_case.server_certs]
+    for cert_key_path in cert_key_list:
+        server_options.extra_flags.extend(['--cert', cert_key_path[0]])
+        server_options.extra_flags.extend(['--key', cert_key_path[1]])
+
+    server = managed_process(S2N, server_options, timeout=5)
+    client = managed_process(provider, client_options, timeout=5)
+
+    for results in client.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+
+    expected_version = get_expected_s2n_version(protocol, provider)
+
+    for results in server.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+        assert bytes("Actual protocol version: {}".format(expected_version).encode('utf-8')) in results.stdout
+        if cert_test_case.client_sni is not None:
+            assert bytes("Server name: {}".format(cert_test_case.client_sni).encode('utf-8')) in results.stdout
+


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

 resolves #1974

### Description of changes: 
Migrate the SNI match test to the new integv2 framework.

 * Support multiple ciphers in the OpenSSL provider

### Call-outs:

* Two of the commits in this PR are actually from another integ test that hasn't been merged.

* A custom filter was needed for this test because the ciphers are stored in a MultiCert object, which is unique to this test. This filter allows us to remove tests for TLS13 ciphers when the TLS12 protocol is chosen.

* The OpenSSL provider has some additional logic added to support multiple ciphers. The code isn't fantastic, but it supports OpenSSL's inconsistent cipher naming.

### Testing:

Integration testing.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
