### PR TITLE
Migrate PQ handshake test to integv2.

### DIFF
--- a/tests/integrationv2/common.py
+++ b/tests/integrationv2/common.py
@@ -200,8 +200,11 @@ class Ciphers(object):
     ECDHE_RSA_CHACHA20_POLY1305 = Cipher("ECDHE_RSA_CHACHA20_POLY1305", Protocols.TLS12, True, False)
     CHACHA20_POLY1305_SHA256 = Cipher("CHACHA20_POLY1305_SHA256", Protocols.TLS13, True, False)
 
-    KMS_PQ_TLS_1_0_2019_06 = Cipher("KMS_PQ_TLS_1_0_2019_06", Protocols.TLS10, False, False)
-    PQ_SIKE_TEST_TLS_1_0_2019_11 = Cipher("PQ_SIKE_TEST_TLS_1_0_2019_11", Protocols.TLS10, False, False)
+    KMS_TLS_1_0_2018_10 = Cipher("KMS-TLS-1-0-2018-10", Protocols.TLS10, False, False)
+    KMS_PQ_TLS_1_0_2019_06 = Cipher("KMS-PQ-TLS-1-0-2019-06", Protocols.TLS10, False, False)
+    KMS_PQ_TLS_1_0_2020_02 = Cipher("KMS-PQ-TLS-1-0-2020-02", Protocols.TLS10, False, False)
+    PQ_SIKE_TEST_TLS_1_0_2019_11 = Cipher("PQ-SIKE-TEST-TLS-1-0-2019-11", Protocols.TLS10, False, False)
+    PQ_SIKE_TEST_TLS_1_0_2020_02 = Cipher("PQ-SIKE-TEST-TLS-1-0-2020-02", Protocols.TLS10, False, False)
 
 
 class Curve(object):

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -225,7 +225,10 @@ class OpenSSL(Provider):
     def _cipher_to_cmdline(self, protocol, cipher):
         cmdline = list()
 
-        cmdline.append('-cipher')
+        if cipher.min_version is Protocols.TLS13:
+            cmdline.append('-ciphersuites')
+        else:
+            cmdline.append('-cipher')
 
         ciphers = []
         if type(cipher) is list:
@@ -267,7 +270,7 @@ class OpenSSL(Provider):
             cmd_line.append('-tls1')
 
         if self.options.cipher is not None:
-            cmd_line.extend(self.cipher_to_cmdline(self.options.protocol, self.options.cipher))
+            cmd_line.extend(self._cipher_to_cmdline(self.options.protocol, self.options.cipher))
 
         if self.options.curve is not None:
             cmd_line.extend(['-curves', str(self.options.curve)])
@@ -328,7 +331,7 @@ class OpenSSL(Provider):
             cmd_line.append('-tls1')
 
         if self.options.cipher is not None:
-            cmd_line.extend(self.cipher_to_cmdline(self.options.protocol, self.options.cipher))
+            cmd_line.extend(self._cipher_to_cmdline(self.options.protocol, self.options.cipher))
             if self.options.cipher.parameters is not None:
                 cmd_line.extend(['-dhparam', self.options.cipher.parameters])
 

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -173,7 +173,9 @@ class S2N(Provider):
         if self.options.protocol == Protocols.TLS13:
             cmd_line.append('--tls13')
 
-        cmd_line.extend(['-c', 'test_all'])
+        if self.options.cipher is not None:
+            cmd_line.extend(['-c', 'test_all'])
+
         if self.options.use_client_auth is True:
             cmd_line.append('-m')
             cmd_line.extend(['-t', self.options.client_certificate_file])

--- a/tests/integrationv2/test_pq_handshake.py
+++ b/tests/integrationv2/test_pq_handshake.py
@@ -1,0 +1,129 @@
+import copy
+import pytest
+
+from configuration import available_ports, PROVIDERS, PROTOCOLS
+from common import Ciphers, ProviderOptions, Protocols, data_bytes
+from fixtures import managed_process
+from providers import Provider, S2N
+from utils import get_expected_s2n_version
+
+
+pq_handshake_test_vectors = [
+    # The first set of vectors specify client and server cipher preference versions that are compatible for a successful PQ handshake
+    {
+        "client_ciphers": Ciphers.KMS_PQ_TLS_1_0_2019_06,
+        "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2019_06,
+        "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384",
+        "expected_kem": "BIKE1r1-Level1",
+    },
+    {
+        "client_ciphers": Ciphers.KMS_PQ_TLS_1_0_2019_06,
+        "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_02,
+        "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384",
+        "expected_kem": "BIKE1r1-Level1",
+    },
+    {
+        "client_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_02,
+        "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_02,
+        "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384",
+        "expected_kem": "BIKE1r2-Level1",
+    },
+    {
+        "client_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_02,
+        "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2019_06,
+        "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384",
+        "expected_kem": "BIKE1r1-Level1",
+    },
+    {
+        "client_ciphers": Ciphers.PQ_SIKE_TEST_TLS_1_0_2019_11,
+        "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2019_06,
+        "expected_cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384",
+        "expected_kem": "SIKEp503r1-KEM",
+    },
+    {
+        "client_ciphers": Ciphers.PQ_SIKE_TEST_TLS_1_0_2019_11,
+        "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_02,
+        "expected_cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384",
+        "expected_kem": "SIKEp503r1-KEM",
+    },
+    {
+        "client_ciphers": Ciphers.PQ_SIKE_TEST_TLS_1_0_2020_02,
+        "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2019_06,
+        "expected_cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384",
+        "expected_kem": "SIKEp503r1-KEM",
+    },
+    {
+        "client_ciphers": Ciphers.PQ_SIKE_TEST_TLS_1_0_2020_02,
+        "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_02,
+        "expected_cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384",
+        "expected_kem": "SIKEp434r2-KEM",
+    },
+    # The last set of vectors specify a "mismatch" between PQ cipher preferences - a classic handshake should be completed
+    {
+        "client_ciphers": Ciphers.KMS_PQ_TLS_1_0_2019_06,
+        "server_ciphers": Ciphers.KMS_TLS_1_0_2018_10,
+        "expected_cipher": "ECDHE-RSA-AES256-GCM-SHA384",
+        "expected_kem": "NONE",
+    },
+    {
+        "client_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_02,
+        "server_ciphers": Ciphers.KMS_TLS_1_0_2018_10,
+        "expected_cipher": "ECDHE-RSA-AES256-GCM-SHA384",
+        "expected_kem": "NONE",
+    },
+    {
+        "client_ciphers": Ciphers.KMS_TLS_1_0_2018_10,
+        "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2019_06,
+        "expected_cipher": "ECDHE-RSA-AES256-GCM-SHA384",
+        "expected_kem": "NONE",
+    },
+    {
+        "client_ciphers": Ciphers.KMS_TLS_1_0_2018_10,
+        "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_02,
+        "expected_cipher": "ECDHE-RSA-AES256-GCM-SHA384",
+        "expected_kem": "NONE",
+    },
+]
+
+
+@pytest.mark.parametrize("vector", pq_handshake_test_vectors)
+def test_pq_handshake(managed_process, vector):
+    host = "localhost"
+    port = next(available_ports)
+
+    # We are manually passing the cipher flag to s2nc and s2nd.
+    # This is because PQ ciphers are specific to S2N at this point
+    # in time.
+    client_options = ProviderOptions(
+        mode=Provider.ClientMode,
+        host=host,
+        port=port,
+        insecure=True,
+        cipher=None,
+        extra_flags=['--ciphers', vector['client_ciphers'].name],
+        protocol=Protocols.TLS12)
+
+    server_options = ProviderOptions(
+        mode = Provider.ServerMode,
+        host=host,
+        port=port,
+        cipher=None,
+        extra_flags=['--ciphers', vector['server_ciphers'].name],
+        protocol=Protocols.TLS12)
+
+    server = managed_process(S2N, server_options, timeout=5)
+    client = managed_process(S2N, client_options, timeout=5)
+
+    for results in client.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+
+    expected_version = get_expected_s2n_version(Protocols.TLS12, S2N)
+
+    for results in server.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+        assert bytes("Actual protocol version: {}".format(expected_version).encode('utf-8')) in results.stdout
+        assert bytes("KEM: {}".format(vector['expected_kem']).encode('utf-8')) in results.stdout
+        assert bytes("Cipher negotiated: {}".format(vector['expected_cipher']).encode('utf-8')) in results.stdout
+


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

### Resolved issues:

 resolves #1973

### Description of changes: 

Migrate PQ handshake test to integv2.
 * s2nc support for extra flags
 * allow None to be passed as a cipher to s2n


### Call-outs:

This test is assuming that S2N is the only provider which can handle PQ handshakes. This is why PQ cipher vectors are stored in this specific test.

### Testing:

Integration testing


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
