### PR TITLE
Test mutual authentication across all versions of TLS.

### DIFF
--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -136,6 +136,8 @@ class S2N(Provider):
                 cmd_line.extend(['-c', 'KMS-PQ-TLS-1-0-2019-06'])
             elif options.cipher is Ciphers.PQ_SIKE_TEST_TLS_1_0_2019_11:
                 cmd_line.extend(['-c', 'PQ-SIKE-TEST-TLS-1-0-2019-11'])
+            else:
+                cmd_line.extend(['-c', 'test_all'])
         else:
             cmd_line.extend(['-c', 'test_all'])
 


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

 resolves #1873

### Description of changes: 

Test mutual authentication across all versions of TLS.
 * Add multiple protocols to each test and update expected values.
 * Update tests to use new certificate paths.
 * Remove manual checks for cert compatibility.

### Call-outs:

Added a missing `else` condition in the s2n provider. This was needed to get this test working, but may conflict with some other inflight PRs.

### Testing:

Integration testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
