### PR TITLE
Rename kem_preferences->count to kem_preferences->kem_count

### DIFF
--- a/tests/unit/s2n_client_pq_kem_extension_test.c
+++ b/tests/unit/s2n_client_pq_kem_extension_test.c
@@ -59,11 +59,11 @@ int main(int argc, char **argv)
         uint16_t size;
         EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &size));
         EXPECT_EQUAL(size, s2n_stuffer_data_available(&stuffer));
-        EXPECT_EQUAL(size, kem_preferences->count * sizeof(kem_extension_size));
+        EXPECT_EQUAL(size, kem_preferences->kem_count * sizeof(kem_extension_size));
 
         /* Should write ids */
         uint16_t actual_id;
-        for (int i = 0; i < kem_preferences->count; i++) {
+        for (int i = 0; i < kem_preferences->kem_count; i++) {
             GUARD(s2n_stuffer_read_uint16(&stuffer, &actual_id));
             EXPECT_EQUAL(actual_id, kem_preferences->kems[i]->kem_extension_id);
         }
@@ -104,7 +104,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_client_pq_kem_extension.send(conn, &stuffer));
 
         EXPECT_SUCCESS(s2n_client_pq_kem_extension.recv(conn, &stuffer));
-        EXPECT_EQUAL(conn->secure.client_pq_kem_extension.size, kem_preferences->count * sizeof(kem_extension_size));
+        EXPECT_EQUAL(conn->secure.client_pq_kem_extension.size, kem_preferences->kem_count * sizeof(kem_extension_size));
         EXPECT_NOT_NULL(conn->secure.client_pq_kem_extension.data);
         EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
 

--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -29,7 +29,7 @@ int main(int argc, char **argv)
         EXPECT_TRUE(s2n_ecc_is_extension_required(security_policy));
         EXPECT_FALSE(s2n_pq_kem_is_extension_required(security_policy));
         EXPECT_NULL(security_policy->kem_preferences->kems);
-        EXPECT_EQUAL(0, security_policy->kem_preferences->count);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_count);
         EXPECT_FALSE(s2n_security_policy_supports_tls13(security_policy));
 
         security_policy = NULL;
@@ -45,7 +45,7 @@ int main(int argc, char **argv)
         EXPECT_TRUE(s2n_ecc_is_extension_required(security_policy));
 #if !defined(S2N_NO_PQ)
         EXPECT_TRUE(s2n_pq_kem_is_extension_required(security_policy));
-        EXPECT_EQUAL(4, security_policy->kem_preferences->count);
+        EXPECT_EQUAL(4, security_policy->kem_preferences->kem_count);
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_r2r1);
 #else
@@ -58,7 +58,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_find_security_policy_from_version("KMS-TLS-1-0-2018-10", &security_policy));
         EXPECT_TRUE(s2n_ecc_is_extension_required(security_policy));
         EXPECT_FALSE(s2n_pq_kem_is_extension_required(security_policy));
-        EXPECT_EQUAL(0, security_policy->kem_preferences->count);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_count);
         EXPECT_NULL(security_policy->kem_preferences->kems);
 
 #if !defined(S2N_NO_PQ)
@@ -66,7 +66,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_find_security_policy_from_version("KMS-PQ-TLS-1-0-2019-06", &security_policy));
         EXPECT_TRUE(s2n_ecc_is_extension_required(security_policy));
         EXPECT_TRUE(s2n_pq_kem_is_extension_required(security_policy));
-        EXPECT_EQUAL(2, security_policy->kem_preferences->count);
+        EXPECT_EQUAL(2, security_policy->kem_preferences->kem_count);
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_r1);
 
@@ -74,7 +74,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_find_security_policy_from_version("PQ-SIKE-TEST-TLS-1-0-2019-11", &security_policy));
         EXPECT_TRUE(s2n_ecc_is_extension_required(security_policy));
         EXPECT_TRUE(s2n_pq_kem_is_extension_required(security_policy));
-        EXPECT_EQUAL(1, security_policy->kem_preferences->count);
+        EXPECT_EQUAL(1, security_policy->kem_preferences->kem_count);
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_sike_r1);
 
@@ -82,7 +82,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_find_security_policy_from_version("PQ-SIKE-TEST-TLS-1-0-2020-02", &security_policy));
         EXPECT_TRUE(s2n_ecc_is_extension_required(security_policy));
         EXPECT_TRUE(s2n_pq_kem_is_extension_required(security_policy));
-        EXPECT_EQUAL(2, security_policy->kem_preferences->count);
+        EXPECT_EQUAL(2, security_policy->kem_preferences->kem_count);
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_sike_r2r1);
 
@@ -90,7 +90,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_find_security_policy_from_version("KMS-PQ-TLS-1-0-2020-02", &security_policy));
         EXPECT_TRUE(s2n_ecc_is_extension_required(security_policy));
         EXPECT_TRUE(s2n_pq_kem_is_extension_required(security_policy));
-        EXPECT_EQUAL(4, security_policy->kem_preferences->count);
+        EXPECT_EQUAL(4, security_policy->kem_preferences->kem_count);
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_r2r1);
 #else
@@ -105,7 +105,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_find_security_policy_from_version("20141001", &security_policy));
         EXPECT_FALSE(s2n_ecc_is_extension_required(security_policy));
         EXPECT_FALSE(s2n_pq_kem_is_extension_required(security_policy));
-        EXPECT_EQUAL(0, security_policy->kem_preferences->count);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_count);
         EXPECT_NULL(security_policy->kem_preferences->kems);
     }
 
@@ -204,7 +204,7 @@ int main(int argc, char **argv)
         };
 
         const struct s2n_kem_preferences fake_kem_preference = {
-            .count = 1,
+            .kem_count = 1,
             .kems = NULL,
         };
 

--- a/tls/extensions/s2n_client_pq_kem.c
+++ b/tls/extensions/s2n_client_pq_kem.c
@@ -50,8 +50,8 @@ static int s2n_client_pq_kem_send(struct s2n_connection *conn, struct s2n_stuffe
     GUARD(s2n_connection_get_kem_preferences(conn, &kem_preferences));
     notnull_check(kem_preferences);
 
-    GUARD(s2n_stuffer_write_uint16(out, kem_preferences->count * sizeof(kem_extension_size)));
-    for (int i = 0; i < kem_preferences->count; i++) {
+    GUARD(s2n_stuffer_write_uint16(out, kem_preferences->kem_count * sizeof(kem_extension_size)));
+    for (int i = 0; i < kem_preferences->kem_count; i++) {
         GUARD(s2n_stuffer_write_uint16(out, kem_preferences->kems[i]->kem_extension_id));
     }
 

--- a/tls/s2n_kem_preferences.c
+++ b/tls/s2n_kem_preferences.c
@@ -45,31 +45,31 @@ const struct s2n_kem *pq_kems_sike_r2r1[2] = {
 
 /* Includes only round 1 PQ KEM params */
 const struct s2n_kem_preferences kem_preferences_kms_pq_tls_1_0_2019_06 = {
-    .count = s2n_array_len(pq_kems_r1),
+    .kem_count = s2n_array_len(pq_kems_r1),
     .kems = pq_kems_r1,
 };
 
 /* Includes round 1 and round 2 PQ KEM params. */
 const struct s2n_kem_preferences kem_preferences_kms_pq_tls_1_0_2020_02 = {
-    .count = s2n_array_len(pq_kems_r2r1),
+    .kem_count = s2n_array_len(pq_kems_r2r1),
     .kems = pq_kems_r2r1,
 };
 
 /* Includes only SIKE round 1 (for integration tests) */
 const struct s2n_kem_preferences kem_preferences_pq_sike_test_tls_1_0_2019_11 = {
-    .count = s2n_array_len(pq_kems_sike_r1),
+    .kem_count = s2n_array_len(pq_kems_sike_r1),
     .kems = pq_kems_sike_r1,
 };
 
 /* Includes only SIKE round 1 and round 2 (for integration tests). */
 const struct s2n_kem_preferences kem_preferences_pq_sike_test_tls_1_0_2020_02 = {
-    .count = s2n_array_len(pq_kems_sike_r2r1),
+    .kem_count = s2n_array_len(pq_kems_sike_r2r1),
     .kems = pq_kems_sike_r2r1,
 };
 
 #endif
 
 const struct s2n_kem_preferences kem_preferences_null = {
-    .count = 0,
+    .kem_count = 0,
     .kems = NULL,
 };

--- a/tls/s2n_kem_preferences.h
+++ b/tls/s2n_kem_preferences.h
@@ -19,7 +19,7 @@
 #include "tls/s2n_kex.h"
 
 struct s2n_kem_preferences {
-    uint8_t count;
+    uint8_t kem_count;
     const struct s2n_kem **kems;
 };
 

--- a/tls/s2n_kex.c
+++ b/tls/s2n_kex.c
@@ -51,7 +51,7 @@ static int s2n_check_kem(const struct s2n_cipher_suite *cipher_suite, struct s2n
     GUARD(s2n_connection_get_kem_preferences(conn, &kem_preferences));
     notnull_check(kem_preferences);
 
-    if (kem_preferences->count == 0) {
+    if (kem_preferences->kem_count == 0) {
         return 0;
     }
 
@@ -69,14 +69,14 @@ static int s2n_check_kem(const struct s2n_cipher_suite *cipher_suite, struct s2n
     if (client_kem_pref_list == NULL || client_kem_pref_list->data == NULL) {
         /* If the client did not send a PQ KEM extension, then the server can pick its preferred parameter */
         if (s2n_choose_kem_without_peer_pref_list(cipher_suite->iana_value, kem_preferences->kems,
-                kem_preferences->count, &chosen_kem)
+                                                  kem_preferences->kem_count, &chosen_kem)
             != 0) {
             return 0;
         }
     } else {
         /* If the client did send a PQ KEM extension, then the server must find a mutually supported parameter. */
         if (s2n_choose_kem_with_peer_pref_list(cipher_suite->iana_value, client_kem_pref_list, kem_preferences->kems,
-                kem_preferences->count, &chosen_kem)
+                                               kem_preferences->kem_count, &chosen_kem)
             != 0) {
             return 0;
         }
@@ -100,11 +100,11 @@ static int s2n_configure_kem(const struct s2n_cipher_suite *cipher_suite, struct
     if (proposed_kems == NULL || proposed_kems->data == NULL) {
         /* If the client did not send a PQ KEM extension, then the server can pick its preferred parameter */
         GUARD(s2n_choose_kem_without_peer_pref_list(cipher_suite->iana_value, kem_preferences->kems,
-            kem_preferences->count, &chosen_kem));
+                                                    kem_preferences->kem_count, &chosen_kem));
     } else {
         /* If the client did send a PQ KEM extension, then the server must find a mutually supported parameter. */
         GUARD(s2n_choose_kem_with_peer_pref_list(cipher_suite->iana_value, proposed_kems, kem_preferences->kems,
-            kem_preferences->count, &chosen_kem));
+                                                 kem_preferences->kem_count, &chosen_kem));
     }
 
     conn->secure.kem_params.kem = chosen_kem;

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -592,10 +592,10 @@ int s2n_security_policies_init()
         }
 
         if (security_policy_selection[i].pq_kem_extension_required == 1) {
-            S2N_ERROR_IF(kem_preference->count == 0, S2N_ERR_INVALID_SECURITY_POLICY);
+            S2N_ERROR_IF(kem_preference->kem_count == 0, S2N_ERR_INVALID_SECURITY_POLICY);
             S2N_ERROR_IF(kem_preference->kems == NULL, S2N_ERR_INVALID_SECURITY_POLICY);
         } else {
-            S2N_ERROR_IF(kem_preference->count != 0, S2N_ERR_INVALID_SECURITY_POLICY);
+            S2N_ERROR_IF(kem_preference->kem_count != 0, S2N_ERR_INVALID_SECURITY_POLICY);
             S2N_ERROR_IF(kem_preference->kems!= NULL, S2N_ERR_INVALID_SECURITY_POLICY);
         }
     }

--- a/tls/s2n_server_key_exchange.c
+++ b/tls/s2n_server_key_exchange.c
@@ -187,8 +187,8 @@ int s2n_kem_server_key_recv_parse_data(struct s2n_connection *conn, struct s2n_k
 
     const struct s2n_cipher_suite *cipher_suite = conn->secure.cipher_suite;
     const struct s2n_kem *match = NULL;
-    S2N_ERROR_IF(s2n_choose_kem_with_peer_pref_list(cipher_suite->iana_value, &kem_data->kem_name, kem_preferences->kems, 
-                 kem_preferences->count, &match) != 0, S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+    S2N_ERROR_IF(s2n_choose_kem_with_peer_pref_list(cipher_suite->iana_value, &kem_data->kem_name, kem_preferences->kems,
+                                                    kem_preferences->kem_count, &match) != 0, S2N_ERR_KEM_UNSUPPORTED_PARAMS);
     conn->secure.kem_params.kem = match;
 
     S2N_ERROR_IF(kem_data->raw_public_key.size != conn->secure.kem_params.kem->public_key_length, S2N_ERR_BAD_MESSAGE);


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A

### Description of changes: 

Renames `kem_preferences->count` to `kem_preferences->kem_count`.

### Call-outs:

In the near future, we will be adding additional structure to `kem_preferences` for PQ TLS 1.3 - `kem_group` and `kem_group_count`. This refactor will help disambiguate and avoid confusion as to what `count` is referring to.

Making this change in it's own PR for ease of review.

### Testing:

Existing tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
