### PR TITLE
Use only one fd per client/server in tests

### DIFF
--- a/tests/testlib/s2n_testlib.h
+++ b/tests/testlib/s2n_testlib.h
@@ -39,15 +39,14 @@ void s2n_print_connection(struct s2n_connection *conn, const char *marker);
 int s2n_connection_set_io_stuffers(struct s2n_stuffer *input, struct s2n_stuffer *output, struct s2n_connection *conn);
 
 struct s2n_test_io_pair {
-    int client_read;
-    int client_write;
-    int server_read;
-    int server_write;
+    int client;
+    int server;
 };
 int s2n_io_pair_init(struct s2n_test_io_pair *io_pair);
 int s2n_io_pair_init_non_blocking(struct s2n_test_io_pair *io_pair);
 int s2n_io_pair_close(struct s2n_test_io_pair *io_pair);
 int s2n_io_pair_close_one_end(struct s2n_test_io_pair *io_pair, int mode_to_close);
+int s2n_io_pair_shutdown_one_end(struct s2n_test_io_pair *io_pair, int mode_to_close, int how);
 
 int s2n_connection_set_io_pair(struct s2n_connection *conn, struct s2n_test_io_pair *io_pair);
 int s2n_connections_set_io_pair(struct s2n_connection *client, struct s2n_connection *server,

--- a/tests/unit/s2n_client_extensions_test.c
+++ b/tests/unit/s2n_client_extensions_test.c
@@ -120,10 +120,10 @@ static int negotiate_kem(const uint8_t client_extensions[], const size_t client_
     server_conn->secure.kem_params.kem = NULL;
 
     /* Send the client hello */
-    eq_check(write(io_pair->client_write, record_header, record_header_len),record_header_len);
-    eq_check(write(io_pair->client_write, message_header, message_header_len),message_header_len);
-    eq_check(write(io_pair->client_write, client_hello_message, client_hello_len),client_hello_len);
-    eq_check(write(io_pair->client_write, client_extensions, client_extensions_len),client_extensions_len);
+    eq_check(write(io_pair->client, record_header, record_header_len),record_header_len);
+    eq_check(write(io_pair->client, message_header, message_header_len),message_header_len);
+    eq_check(write(io_pair->client, client_hello_message, client_hello_len),client_hello_len);
+    eq_check(write(io_pair->client, client_extensions, client_extensions_len),client_extensions_len);
 
     GUARD(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
     if (s2n_negotiate(server_conn, &server_blocked) == 0) {
@@ -353,10 +353,10 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
         /* Send the client hello */
-        EXPECT_EQUAL(write(io_pair.client_write, record_header, sizeof(record_header)), sizeof(record_header));
-        EXPECT_EQUAL(write(io_pair.client_write, message_header, sizeof(message_header)), sizeof(message_header));
-        EXPECT_EQUAL(write(io_pair.client_write, client_hello_message, sizeof(client_hello_message)), sizeof(client_hello_message));
-        EXPECT_EQUAL(write(io_pair.client_write, client_extensions, sizeof(client_extensions)), sizeof(client_extensions));
+        EXPECT_EQUAL(write(io_pair.client, record_header, sizeof(record_header)), sizeof(record_header));
+        EXPECT_EQUAL(write(io_pair.client, message_header, sizeof(message_header)), sizeof(message_header));
+        EXPECT_EQUAL(write(io_pair.client, client_hello_message, sizeof(client_hello_message)), sizeof(client_hello_message));
+        EXPECT_EQUAL(write(io_pair.client, client_extensions, sizeof(client_extensions)), sizeof(client_extensions));
 
         /* Verify that the CLIENT HELLO is accepted */
         s2n_negotiate(server_conn, &server_blocked);
@@ -477,10 +477,10 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
         /* Send the client hello */
-        EXPECT_EQUAL(write(io_pair.client_write, record_header, sizeof(record_header)), sizeof(record_header));
-        EXPECT_EQUAL(write(io_pair.client_write, message_header, sizeof(message_header)), sizeof(message_header));
-        EXPECT_EQUAL(write(io_pair.client_write, client_hello_message, sizeof(client_hello_message)), sizeof(client_hello_message));
-        EXPECT_EQUAL(write(io_pair.client_write, client_extensions, sizeof(client_extensions)), sizeof(client_extensions));
+        EXPECT_EQUAL(write(io_pair.client, record_header, sizeof(record_header)), sizeof(record_header));
+        EXPECT_EQUAL(write(io_pair.client, message_header, sizeof(message_header)), sizeof(message_header));
+        EXPECT_EQUAL(write(io_pair.client, client_hello_message, sizeof(client_hello_message)), sizeof(client_hello_message));
+        EXPECT_EQUAL(write(io_pair.client, client_extensions, sizeof(client_extensions)), sizeof(client_extensions));
 
         /* Verify that we fail for duplicated extension type Bad Message */
         EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
@@ -559,10 +559,10 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
         /* Send the client hello */
-        EXPECT_EQUAL(write(io_pair.client_write, record_header, sizeof(record_header)), sizeof(record_header));
-        EXPECT_EQUAL(write(io_pair.client_write, message_header, sizeof(message_header)), sizeof(message_header));
-        EXPECT_EQUAL(write(io_pair.client_write, client_hello_message, sizeof(client_hello_message)), sizeof(client_hello_message));
-        EXPECT_EQUAL(write(io_pair.client_write, client_extensions, sizeof(client_extensions)), sizeof(client_extensions));
+        EXPECT_EQUAL(write(io_pair.client, record_header, sizeof(record_header)), sizeof(record_header));
+        EXPECT_EQUAL(write(io_pair.client, message_header, sizeof(message_header)), sizeof(message_header));
+        EXPECT_EQUAL(write(io_pair.client, client_hello_message, sizeof(client_hello_message)), sizeof(client_hello_message));
+        EXPECT_EQUAL(write(io_pair.client, client_extensions, sizeof(client_extensions)), sizeof(client_extensions));
 
         /* Verify that the CLIENT HELLO is accepted */
         s2n_negotiate(server_conn, &server_blocked);
@@ -653,10 +653,10 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
         /* Send the client hello */
-        EXPECT_EQUAL(write(io_pair.client_write, record_header, sizeof(record_header)), sizeof(record_header));
-        EXPECT_EQUAL(write(io_pair.client_write, message_header, sizeof(message_header)), sizeof(message_header));
-        EXPECT_EQUAL(write(io_pair.client_write, client_hello_message, sizeof(client_hello_message)), sizeof(client_hello_message));
-        EXPECT_EQUAL(write(io_pair.client_write, client_extensions, sizeof(client_extensions)), sizeof(client_extensions));
+        EXPECT_EQUAL(write(io_pair.client, record_header, sizeof(record_header)), sizeof(record_header));
+        EXPECT_EQUAL(write(io_pair.client, message_header, sizeof(message_header)), sizeof(message_header));
+        EXPECT_EQUAL(write(io_pair.client, client_hello_message, sizeof(client_hello_message)), sizeof(client_hello_message));
+        EXPECT_EQUAL(write(io_pair.client, client_extensions, sizeof(client_extensions)), sizeof(client_extensions));
 
         /* Verify that we fail for non-empty renegotiated_connection */
         EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
@@ -668,7 +668,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_free(server_config));
         
         /* Clear pipe since negotiation failed mid-handshake */
-        EXPECT_SUCCESS(read(io_pair.client_read, buf, sizeof(buf)));
+        EXPECT_SUCCESS(read(io_pair.client, buf, sizeof(buf)));
     }
 
     /* Client doesn't use the OCSP extension. */

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -338,8 +338,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
         /* Send the client hello message */
-        EXPECT_EQUAL(write(io_pair.client_write, sslv2_client_hello_header, sslv2_client_hello_header_len), sslv2_client_hello_header_len);
-        EXPECT_EQUAL(write(io_pair.client_write, sslv2_client_hello, sslv2_client_hello_len), sslv2_client_hello_len);
+        EXPECT_EQUAL(write(io_pair.client, sslv2_client_hello_header, sslv2_client_hello_header_len), sslv2_client_hello_header_len);
+        EXPECT_EQUAL(write(io_pair.client, sslv2_client_hello, sslv2_client_hello_len), sslv2_client_hello_len);
 
         /* Verify that the sent client hello message is accepted */
         s2n_negotiate(server_conn, &server_blocked);
@@ -518,9 +518,9 @@ int main(int argc, char **argv)
         ext_data = NULL;
 
         /* Send the client hello message */
-        EXPECT_EQUAL(write(io_pair.client_write, record_header, sizeof(record_header)), sizeof(record_header));
-        EXPECT_EQUAL(write(io_pair.client_write, message_header, sizeof(message_header)), sizeof(message_header));
-        EXPECT_EQUAL(write(io_pair.client_write, sent_client_hello, sent_client_hello_len), sent_client_hello_len);
+        EXPECT_EQUAL(write(io_pair.client, record_header, sizeof(record_header)), sizeof(record_header));
+        EXPECT_EQUAL(write(io_pair.client, message_header, sizeof(message_header)), sizeof(message_header));
+        EXPECT_EQUAL(write(io_pair.client, sent_client_hello, sent_client_hello_len), sent_client_hello_len);
 
         /* Verify that the sent client hello message is accepted */
         s2n_negotiate(server_conn, &server_blocked);
@@ -697,9 +697,9 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
        /* Re-send the client hello message */
-        EXPECT_EQUAL(write(io_pair.client_write, record_header, sizeof(record_header)), sizeof(record_header));
-        EXPECT_EQUAL(write(io_pair.client_write, message_header, sizeof(message_header)), sizeof(message_header));
-        EXPECT_EQUAL(write(io_pair.client_write, sent_client_hello, sent_client_hello_len), sent_client_hello_len);
+        EXPECT_EQUAL(write(io_pair.client, record_header, sizeof(record_header)), sizeof(record_header));
+        EXPECT_EQUAL(write(io_pair.client, message_header, sizeof(message_header)), sizeof(message_header));
+        EXPECT_EQUAL(write(io_pair.client, sent_client_hello, sent_client_hello_len), sent_client_hello_len);
 
         /* Verify that the sent client hello message is accepted */
         s2n_negotiate(server_conn, &server_blocked);
@@ -820,9 +820,9 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
         /* Send the client hello message */
-        EXPECT_EQUAL(write(io_pair.client_write, record_header, sizeof(record_header)), sizeof(record_header));
-        EXPECT_EQUAL(write(io_pair.client_write, message_header, sizeof(message_header)), sizeof(message_header));
-        EXPECT_EQUAL(write(io_pair.client_write, sent_client_hello, sent_client_hello_len), sent_client_hello_len);
+        EXPECT_EQUAL(write(io_pair.client, record_header, sizeof(record_header)), sizeof(record_header));
+        EXPECT_EQUAL(write(io_pair.client, message_header, sizeof(message_header)), sizeof(message_header));
+        EXPECT_EQUAL(write(io_pair.client, sent_client_hello, sent_client_hello_len), sent_client_hello_len);
 
         /* Verify that the sent client hello message is accepted */
         s2n_negotiate(server_conn, &server_blocked);

--- a/tests/unit/s2n_client_record_version_test.c
+++ b/tests/unit/s2n_client_record_version_test.c
@@ -104,7 +104,7 @@ int main(int argc, char **argv)
 
         /* we need only first 10 bytes to get to ClientHello protocol version */
         while (buf_occupied < 10) {
-            ssize_t n = read(io_pair.server_read, buf + buf_occupied, sizeof(buf) - buf_occupied);
+            ssize_t n = read(io_pair.server, buf + buf_occupied, sizeof(buf) - buf_occupied);
 
             /* We should be able to read 10 bytes without blocking */
             EXPECT_TRUE(n > 0);
@@ -123,7 +123,7 @@ int main(int argc, char **argv)
 
         /* Read the rest of the pipe */
         while (1) {
-            ssize_t n = read(io_pair.server_read, buf, sizeof(buf));
+            ssize_t n = read(io_pair.server, buf, sizeof(buf));
 
             if (n > 0) {
                 continue;
@@ -136,9 +136,9 @@ int main(int argc, char **argv)
         }
 
         /* Write the server hello */
-        EXPECT_EQUAL(write(io_pair.server_write, record_header, sizeof(record_header)), sizeof(record_header));
-        EXPECT_EQUAL(write(io_pair.server_write, message_header, sizeof(message_header)), sizeof(message_header));
-        EXPECT_EQUAL(write(io_pair.server_write, server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
+        EXPECT_EQUAL(write(io_pair.server, record_header, sizeof(record_header)), sizeof(record_header));
+        EXPECT_EQUAL(write(io_pair.server, message_header, sizeof(message_header)), sizeof(message_header));
+        EXPECT_EQUAL(write(io_pair.server, server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
 
         /* Verify that we proceed with handshake */
         EXPECT_EQUAL(s2n_negotiate(client_conn, &client_blocked), -1);
@@ -159,7 +159,7 @@ int main(int argc, char **argv)
         buf_occupied = 0;
         /* We need only first 5 bytes to get to record protocol version */
         while (buf_occupied < 5) {
-            ssize_t n = read(io_pair.server_read, buf + buf_occupied, sizeof(buf) - buf_occupied);
+            ssize_t n = read(io_pair.server, buf + buf_occupied, sizeof(buf) - buf_occupied);
 
             /* We should be able to read 5 bytes without blocking */
             EXPECT_TRUE(n > 0);
@@ -236,7 +236,7 @@ int main(int argc, char **argv)
 
         /* we need only first 10 bytes to get to ClientHello protocol version */
         while (buf_occupied < 10) {
-            ssize_t n = read(io_pair.server_read, buf + buf_occupied, sizeof(buf) - buf_occupied);
+            ssize_t n = read(io_pair.server, buf + buf_occupied, sizeof(buf) - buf_occupied);
 
             /* We should be able to read 10 bytes without blocking */
             EXPECT_TRUE(n > 0);
@@ -255,7 +255,7 @@ int main(int argc, char **argv)
 
         /* Read the rest of the pipe */
         while (1) {
-            ssize_t n = read(io_pair.server_read, buf, sizeof(buf));
+            ssize_t n = read(io_pair.server, buf, sizeof(buf));
 
             if (n > 0) {
                 continue;
@@ -268,9 +268,9 @@ int main(int argc, char **argv)
         }
 
         /* Write the server hello */
-        EXPECT_EQUAL(write(io_pair.server_write, record_header, sizeof(record_header)), sizeof(record_header));
-        EXPECT_EQUAL(write(io_pair.server_write, message_header, sizeof(message_header)), sizeof(message_header));
-        EXPECT_EQUAL(write(io_pair.server_write, server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
+        EXPECT_EQUAL(write(io_pair.server, record_header, sizeof(record_header)), sizeof(record_header));
+        EXPECT_EQUAL(write(io_pair.server, message_header, sizeof(message_header)), sizeof(message_header));
+        EXPECT_EQUAL(write(io_pair.server, server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
 
         /* Verify that we proceed with handshake */
         EXPECT_EQUAL(s2n_negotiate(client_conn, &client_blocked), -1);
@@ -291,7 +291,7 @@ int main(int argc, char **argv)
         buf_occupied = 0;
         /* We need only first 5 bytes to get to record protocol version */
         while (buf_occupied < 5) {
-            ssize_t n = read(io_pair.server_read, buf + buf_occupied, sizeof(buf) - buf_occupied);
+            ssize_t n = read(io_pair.server, buf + buf_occupied, sizeof(buf) - buf_occupied);
 
             /* We should be able to read 5 bytes without blocking */
             EXPECT_TRUE(n > 0);

--- a/tests/unit/s2n_client_secure_renegotiation_test.c
+++ b/tests/unit/s2n_client_secure_renegotiation_test.c
@@ -109,10 +109,10 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(client_blocked, S2N_BLOCKED_ON_READ);
 
         /* Write the server hello */
-        EXPECT_EQUAL(write(io_pair.server_write, record_header, sizeof(record_header)), sizeof(record_header));
-        EXPECT_EQUAL(write(io_pair.server_write, message_header, sizeof(message_header)), sizeof(message_header));
-        EXPECT_EQUAL(write(io_pair.server_write, server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
-        EXPECT_EQUAL(write(io_pair.server_write, server_extensions, sizeof(server_extensions)), sizeof(server_extensions));
+        EXPECT_EQUAL(write(io_pair.server, record_header, sizeof(record_header)), sizeof(record_header));
+        EXPECT_EQUAL(write(io_pair.server, message_header, sizeof(message_header)), sizeof(message_header));
+        EXPECT_EQUAL(write(io_pair.server, server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
+        EXPECT_EQUAL(write(io_pair.server, server_extensions, sizeof(server_extensions)), sizeof(server_extensions));
 
         /* Verify that we proceed with handshake */
         EXPECT_EQUAL(s2n_negotiate(client_conn, &client_blocked), -1);
@@ -182,9 +182,9 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(client_blocked, S2N_BLOCKED_ON_READ);
 
         /* Write the server hello */
-        EXPECT_EQUAL(write(io_pair.server_write, record_header, sizeof(record_header)), sizeof(record_header));
-        EXPECT_EQUAL(write(io_pair.server_write, message_header, sizeof(message_header)), sizeof(message_header));
-        EXPECT_EQUAL(write(io_pair.server_write, server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
+        EXPECT_EQUAL(write(io_pair.server, record_header, sizeof(record_header)), sizeof(record_header));
+        EXPECT_EQUAL(write(io_pair.server, message_header, sizeof(message_header)), sizeof(message_header));
+        EXPECT_EQUAL(write(io_pair.server, server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
 
         /* Verify that we proceed with handshake */
         EXPECT_EQUAL(s2n_negotiate(client_conn, &client_blocked), -1);
@@ -265,10 +265,10 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(client_blocked, S2N_BLOCKED_ON_READ);
 
         /* Write the server hello */
-        EXPECT_EQUAL(write(io_pair.server_write, record_header, sizeof(record_header)), sizeof(record_header));
-        EXPECT_EQUAL(write(io_pair.server_write, message_header, sizeof(message_header)), sizeof(message_header));
-        EXPECT_EQUAL(write(io_pair.server_write, server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
-        EXPECT_EQUAL(write(io_pair.server_write, server_extensions, sizeof(server_extensions)), sizeof(server_extensions));
+        EXPECT_EQUAL(write(io_pair.server, record_header, sizeof(record_header)), sizeof(record_header));
+        EXPECT_EQUAL(write(io_pair.server, message_header, sizeof(message_header)), sizeof(message_header));
+        EXPECT_EQUAL(write(io_pair.server, server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
+        EXPECT_EQUAL(write(io_pair.server, server_extensions, sizeof(server_extensions)), sizeof(server_extensions));
 
         /* Verify that we fail for non-empty renegotiated_connection */
         EXPECT_SUCCESS(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));

--- a/tests/unit/s2n_drain_alert_test.c
+++ b/tests/unit/s2n_drain_alert_test.c
@@ -105,16 +105,15 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
     /* Send the client hello */
-    EXPECT_EQUAL(write(io_pair.client_write, record_header, sizeof(record_header)), sizeof(record_header));
-    EXPECT_EQUAL(write(io_pair.client_write, message_header, sizeof(message_header)), sizeof(message_header));
-    EXPECT_EQUAL(write(io_pair.client_write, client_hello_message, sizeof(client_hello_message)), sizeof(client_hello_message));
+    EXPECT_EQUAL(write(io_pair.client, record_header, sizeof(record_header)), sizeof(record_header));
+    EXPECT_EQUAL(write(io_pair.client, message_header, sizeof(message_header)), sizeof(message_header));
+    EXPECT_EQUAL(write(io_pair.client, client_hello_message, sizeof(client_hello_message)), sizeof(client_hello_message));
 
     /* Send an alert from client to server */
-    EXPECT_EQUAL(write(io_pair.client_write, alert_record, sizeof(alert_record)), sizeof(alert_record));
+    EXPECT_EQUAL(write(io_pair.client, alert_record, sizeof(alert_record)), sizeof(alert_record));
 
     /* Close the client read/write end */
-    EXPECT_SUCCESS(close(io_pair.client_read));
-    EXPECT_SUCCESS(close(io_pair.client_write));
+    EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_CLIENT));
 
     /* Expect the server to fail due to an incoming alert. We should not fail due to an I/O error(EPIPE). */
     s2n_negotiate(server_conn, &server_blocked);
@@ -127,8 +126,7 @@ int main(int argc, char **argv)
     free(cert_chain);
     free(private_key);
 
-    EXPECT_SUCCESS(close(io_pair.server_read));
-    EXPECT_SUCCESS(close(io_pair.server_write));
+    EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
 
     END_TEST();
 }

--- a/tests/unit/s2n_release_non_empty_buffers_test.c
+++ b/tests/unit/s2n_release_non_empty_buffers_test.c
@@ -122,8 +122,8 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
     /* Make pipes non-blocking */
-    EXPECT_SUCCESS(s2n_fd_set_non_blocking(io_pair.server_read));
-    EXPECT_SUCCESS(s2n_fd_set_non_blocking(io_pair.server_write));
+    EXPECT_SUCCESS(s2n_fd_set_non_blocking(io_pair.server));
+    EXPECT_SUCCESS(s2n_fd_set_non_blocking(io_pair.server));
 
     /* Set up our I/O callbacks. Use stuffers for the "I/O context" */
     EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&in, 0));
@@ -137,14 +137,14 @@ int main(int argc, char **argv)
 
         /* check to see if we need to copy more over from the pipes to the buffers
          * to continue the handshake */
-        s2n_stuffer_recv_from_fd(&in, io_pair.server_read, MAX_BUF_SIZE);
-        s2n_stuffer_send_to_fd(&out, io_pair.server_write, s2n_stuffer_data_available(&out));
+        s2n_stuffer_recv_from_fd(&in, io_pair.server, MAX_BUF_SIZE);
+        s2n_stuffer_send_to_fd(&out, io_pair.server, s2n_stuffer_data_available(&out));
     } while (blocked);
 
     /* Receive only 100 bytes of the record and try to call s2n_recv */
     n = 0;
     while (n < 100) {
-        ret = s2n_stuffer_recv_from_fd(&in, io_pair.server_read, 100 - n);
+        ret = s2n_stuffer_recv_from_fd(&in, io_pair.server, 100 - n);
 
         if (ret < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
             continue;
@@ -163,7 +163,7 @@ int main(int argc, char **argv)
 
     /* Read the rest of the buffer and expect s2n_recv to succeed */
     do {
-        ret = s2n_stuffer_recv_from_fd(&in, io_pair.server_read, MAX_BUF_SIZE);
+        ret = s2n_stuffer_recv_from_fd(&in, io_pair.server, MAX_BUF_SIZE);
 
         if (ret < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
             continue;
@@ -189,8 +189,8 @@ int main(int argc, char **argv)
             server_shutdown = 1;
         }
 
-        s2n_stuffer_recv_from_fd(&in, io_pair.server_read, MAX_BUF_SIZE);
-        s2n_stuffer_send_to_fd(&out, io_pair.server_write, s2n_stuffer_data_available(&out));
+        s2n_stuffer_recv_from_fd(&in, io_pair.server, MAX_BUF_SIZE);
+        s2n_stuffer_send_to_fd(&out, io_pair.server, s2n_stuffer_data_available(&out));
     } while (!server_shutdown);
 
     EXPECT_SUCCESS(s2n_connection_free(conn));

--- a/tests/unit/s2n_self_talk_alerts_test.c
+++ b/tests/unit/s2n_self_talk_alerts_test.c
@@ -158,7 +158,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_io_pair_init(&io_pair));
 
         /* Set up the callback to send an alert after receiving ClientHello */
-        struct alert_ctx warning_alert = {.write_fd = io_pair.server_write, .invoked = 0, .level = TLS_ALERT_LEVEL_WARNING, .code = TLS_ALERT_UNRECOGNIZED_NAME};
+        struct alert_ctx warning_alert = {.write_fd = io_pair.server, .invoked = 0, .level = TLS_ALERT_LEVEL_WARNING, .code = TLS_ALERT_UNRECOGNIZED_NAME};
         EXPECT_SUCCESS(s2n_config_set_client_hello_cb(config, client_hello_send_alert, &warning_alert));
 
         /* Create a child process */
@@ -223,7 +223,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_io_pair_init(&io_pair));
 
         /* Set up the callback to send an alert after receiving ClientHello */
-        struct alert_ctx fatal_alert = {.write_fd = io_pair.server_write, .invoked = 0, .level = TLS_ALERT_LEVEL_FATAL, .code = TLS_ALERT_UNRECOGNIZED_NAME};
+        struct alert_ctx fatal_alert = {.write_fd = io_pair.server, .invoked = 0, .level = TLS_ALERT_LEVEL_FATAL, .code = TLS_ALERT_UNRECOGNIZED_NAME};
         EXPECT_SUCCESS(s2n_config_set_client_hello_cb(config, client_hello_send_alert, &fatal_alert));
 
         /* Create a child process */
@@ -269,7 +269,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_io_pair_init(&io_pair));
 
         /* Set up the callback to send an alert after receiving ClientHello */
-        struct alert_ctx warning_alert = {.write_fd = io_pair.server_write, .invoked = 0, .level = TLS_ALERT_LEVEL_WARNING, .code = TLS_ALERT_UNRECOGNIZED_NAME};
+        struct alert_ctx warning_alert = {.write_fd = io_pair.server, .invoked = 0, .level = TLS_ALERT_LEVEL_WARNING, .code = TLS_ALERT_UNRECOGNIZED_NAME};
         EXPECT_SUCCESS(s2n_config_set_client_hello_cb(config, client_hello_send_alert, &warning_alert));
 
         /* Create a child process */

--- a/tests/unit/s2n_self_talk_broken_pipe_test.c
+++ b/tests/unit/s2n_self_talk_broken_pipe_test.c
@@ -17,6 +17,7 @@
 
 #include "testlib/s2n_testlib.h"
 
+#include <sys/socket.h>
 #include <sys/wait.h>
 #include <unistd.h>
 #include <time.h>
@@ -62,7 +63,7 @@ void mock_client(struct s2n_test_io_pair *io_pair)
     }
 
     /* Close client read fd to mock half closed pipe at server side */
-    close(io_pair->client_read);
+    s2n_io_pair_shutdown_one_end(io_pair, S2N_CLIENT, SHUT_RD);
     /* Give server a chance to send data on broken pipe */
     sleep(2);
 
@@ -81,7 +82,7 @@ void mock_client(struct s2n_test_io_pair *io_pair)
     /* Give the server a chance to avoid a sigpipe */
     sleep(1);
 
-    close(io_pair->client_write);
+    s2n_io_pair_shutdown_one_end(io_pair, S2N_CLIENT, SHUT_WR);
 
     _exit(0);
 }

--- a/tests/unit/s2n_self_talk_custom_io_test.c
+++ b/tests/unit/s2n_self_talk_custom_io_test.c
@@ -134,8 +134,8 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&in, &out, conn));
     
     /* Make our pipes non-blocking */
-    EXPECT_SUCCESS(s2n_fd_set_non_blocking(io_pair.server_read));
-    EXPECT_SUCCESS(s2n_fd_set_non_blocking(io_pair.server_write));
+    EXPECT_SUCCESS(s2n_fd_set_non_blocking(io_pair.server));
+    EXPECT_SUCCESS(s2n_fd_set_non_blocking(io_pair.server));
 
     /* Negotiate the handshake. */
     do {
@@ -147,8 +147,8 @@ int main(int argc, char **argv)
         /* check to see if we need to copy more over from the pipes to the buffers
          * to continue the handshake
          */
-        s2n_stuffer_recv_from_fd(&in, io_pair.server_read, MAX_BUF_SIZE);
-        s2n_stuffer_send_to_fd(&out, io_pair.server_write, s2n_stuffer_data_available(&out));
+        s2n_stuffer_recv_from_fd(&in, io_pair.server, MAX_BUF_SIZE);
+        s2n_stuffer_send_to_fd(&out, io_pair.server, s2n_stuffer_data_available(&out));
     } while (blocked);
    
     /* Shutdown after negotiating */
@@ -162,8 +162,8 @@ int main(int argc, char **argv)
             server_shutdown = 1;
         }
 
-        s2n_stuffer_recv_from_fd(&in, io_pair.server_read, MAX_BUF_SIZE);
-        s2n_stuffer_send_to_fd(&out, io_pair.server_write, s2n_stuffer_data_available(&out));
+        s2n_stuffer_recv_from_fd(&in, io_pair.server, MAX_BUF_SIZE);
+        s2n_stuffer_send_to_fd(&out, io_pair.server, s2n_stuffer_data_available(&out));
     } while (!server_shutdown);
     
     EXPECT_SUCCESS(s2n_connection_free(conn));

--- a/tests/unit/s2n_self_talk_nonblocking_test.c
+++ b/tests/unit/s2n_self_talk_nonblocking_test.c
@@ -268,8 +268,7 @@ int test_send(int use_tls13, int use_iov, int prefer_throughput)
     EXPECT_SUCCESS(kill(pid, SIGSTOP));
 
     /* Make our pipes non-blocking */
-    s2n_fd_set_non_blocking(io_pair.server_read);
-    s2n_fd_set_non_blocking(io_pair.server_write);
+    s2n_fd_set_non_blocking(io_pair.server);
 
     /* Try to all 10MB of data, should be enough to fill PIPEBUF, so
        we'll get blocked at some point */
@@ -300,8 +299,7 @@ int test_send(int use_tls13, int use_iov, int prefer_throughput)
     EXPECT_SUCCESS(kill(pid, SIGCONT));
 
     /* Make our sockets blocking again */
-    s2n_fd_set_blocking(io_pair.server_read);
-    s2n_fd_set_blocking(io_pair.server_write);
+    s2n_fd_set_blocking(io_pair.server);
 
     /* Actually send the remaining data */
     while (remaining) {


### PR DESCRIPTION
### Description of changes: 

Unlike pipe, socketpair produces a bi-directional way of communication, so we don't need to split up fds between read and write.

### Testing:

Update to existing unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
