### PR TITLE
Fix s2n_fd_set_blocking to be a no-op on already blocking pipe

### DIFF
--- a/tests/testlib/s2n_connection_test_utils.c
+++ b/tests/testlib/s2n_connection_test_utils.c
@@ -26,7 +26,7 @@
 
 
 int s2n_fd_set_blocking(int fd) {
-    return fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) ^ O_NONBLOCK);
+    return fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) & ~O_NONBLOCK);
 }
 
 int s2n_fd_set_non_blocking(int fd) {


### PR DESCRIPTION
### Description of changes: 

Previously `s2n_fd_set_blocking` `xor`-ed the `O_NONBLOCK`, which resulted in flipping back to non-blocking mode if fd was already in blocking mode.

This pr changes the logic to negate `O_NONBLOCK` and `and` it with existing flags.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
