### PR TITLE
Added check for empty cipher suites in client hello

### DIFF
--- a/tests/unit/s2n_client_hello_recv_test.c
+++ b/tests/unit/s2n_client_hello_recv_test.c
@@ -323,28 +323,28 @@ int main(int argc, char **argv)
 
     /* s2n receiving a client hello will error when parsing an empty cipher suite */
     {
-            EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-            EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
 
-            EXPECT_SUCCESS(s2n_connection_set_config(client_conn, tls13_config));
-            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "default_tls13"));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, tls13_config));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "default_tls13"));
 
-            hello_stuffer = &client_conn->handshake.io;
+        hello_stuffer = &client_conn->handshake.io;
 
-            EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
+        EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
 
-            uint8_t empty_cipher_suite[S2N_TLS_CIPHER_SUITE_LEN] = {0};
+        uint8_t empty_cipher_suite[S2N_TLS_CIPHER_SUITE_LEN] = {0};
 
-            /* Move write_cursor to cipher_suite position */
-            EXPECT_SUCCESS(s2n_stuffer_rewrite(hello_stuffer));
-            EXPECT_SUCCESS(s2n_stuffer_skip_write(hello_stuffer, S2N_TLS_PROTOCOL_VERSION_LEN + S2N_TLS_RANDOM_DATA_LEN + 1));
-            EXPECT_SUCCESS(s2n_stuffer_write_bytes(hello_stuffer, empty_cipher_suite, S2N_TLS_CIPHER_SUITE_LEN));
+        /* Move write_cursor to cipher_suite position */
+        EXPECT_SUCCESS(s2n_stuffer_rewrite(hello_stuffer));
+        EXPECT_SUCCESS(s2n_stuffer_skip_write(hello_stuffer, S2N_TLS_PROTOCOL_VERSION_LEN + S2N_TLS_RANDOM_DATA_LEN + 1));
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(hello_stuffer, empty_cipher_suite, S2N_TLS_CIPHER_SUITE_LEN));
 
-            EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &hello_stuffer->blob));
-            EXPECT_FAILURE_WITH_ERRNO(s2n_client_hello_recv(server_conn), S2N_ERR_BAD_MESSAGE);
+        EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &hello_stuffer->blob));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_client_hello_recv(server_conn), S2N_ERR_BAD_MESSAGE);
 
-            s2n_connection_free(server_conn);
-            s2n_connection_free(client_conn);
+        s2n_connection_free(server_conn);
+        s2n_connection_free(client_conn);
     }
 
     /* s2n receiving a sslv2 client hello will error when parsing an empty cipher suite */
@@ -373,7 +373,6 @@ int main(int argc, char **argv)
         EXPECT_FAILURE_WITH_ERRNO(s2n_client_hello_recv(server_conn), S2N_ERR_BAD_MESSAGE);
 
         s2n_connection_free(server_conn);
-
     }
 
     s2n_config_free(tls12_config);

--- a/tests/unit/s2n_client_hello_recv_test.c
+++ b/tests/unit/s2n_client_hello_recv_test.c
@@ -321,6 +321,61 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_disable_tls13());
     }
 
+    /* s2n receiving a client hello will error when parsing an empty cipher suite */
+    {
+            EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+
+            EXPECT_SUCCESS(s2n_connection_set_config(client_conn, tls13_config));
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "default_tls13"));
+
+            hello_stuffer = &client_conn->handshake.io;
+
+            EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
+
+            uint8_t empty_cipher_suite[S2N_TLS_CIPHER_SUITE_LEN] = {0};
+
+            /* Move write_cursor to cipher_suite position */
+            EXPECT_SUCCESS(s2n_stuffer_rewrite(hello_stuffer));
+            EXPECT_SUCCESS(s2n_stuffer_skip_write(hello_stuffer, S2N_TLS_PROTOCOL_VERSION_LEN + S2N_TLS_RANDOM_DATA_LEN + 1));
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(hello_stuffer, empty_cipher_suite, S2N_TLS_CIPHER_SUITE_LEN));
+
+            EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &hello_stuffer->blob));
+            EXPECT_FAILURE_WITH_ERRNO(s2n_client_hello_recv(server_conn), S2N_ERR_BAD_MESSAGE);
+
+            s2n_connection_free(server_conn);
+            s2n_connection_free(client_conn);
+    }
+
+    /* s2n receiving a sslv2 client hello will error when parsing an empty cipher suite */
+    {
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, tls12_config));
+
+        /* Record version and protocol version are in the header for SSLv2 */
+        server_conn->client_hello_version = S2N_SSLv2;
+        server_conn->client_protocol_version = S2N_TLS12;
+
+        /* Writing a sslv2 client hello with a length 0 cipher suite list */
+        uint8_t sslv2_client_hello[] = {
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x20,
+            SSLv2_CLIENT_HELLO_CIPHER_SUITES,
+            SSLv2_CLIENT_HELLO_CHALLENGE,
+        };
+
+        struct s2n_blob client_hello = {
+            .data = sslv2_client_hello,
+            .size = sizeof(sslv2_client_hello),
+            .allocated = 0,
+            .growable = 0
+        };
+        EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &client_hello));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_client_hello_recv(server_conn), S2N_ERR_BAD_MESSAGE);
+
+        s2n_connection_free(server_conn);
+
+    }
+
     s2n_config_free(tls12_config);
     s2n_config_free(tls13_config);
     s2n_cert_chain_and_key_free(chain_and_key);

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -41,8 +41,6 @@
 
 #define LENGTH_TO_CIPHER_LIST (S2N_TLS_PROTOCOL_VERSION_LEN + S2N_TLS_RANDOM_DATA_LEN + 1)
 
-int s2n_parse_client_hello(struct s2n_connection *conn);
-
 int main(int argc, char **argv)
 {
     struct s2n_cert_chain_and_key *chain_and_key, *ecdsa_chain_and_key;
@@ -837,101 +835,6 @@ int main(int argc, char **argv)
         s2n_connection_free(server_conn);
         s2n_config_free(server_config);
         free(sent_client_hello);
-    }
-    
-     /* s2n_parse_client_hello */
-    {
-        /* s2n will error when parsing an empty cipher suite */
-        {
-            struct s2n_connection *client_conn;
-            struct s2n_connection *server_conn;
-            struct s2n_stuffer *hello_stuffer;
-            struct s2n_config *tls13_config;
-            struct s2n_cert_chain_and_key *tls13_chain_and_key;
-            char *tls13_cert_chain;
-            char *tls13_private_key;
-
-            EXPECT_NOT_NULL(tls13_cert_chain = malloc(S2N_MAX_TEST_PEM_SIZE));
-            EXPECT_NOT_NULL(tls13_private_key = malloc(S2N_MAX_TEST_PEM_SIZE));
-            EXPECT_NOT_NULL(tls13_config = s2n_config_new());
-            EXPECT_NOT_NULL(tls13_chain_and_key = s2n_cert_chain_and_key_new());
-            s2n_config_set_cipher_preferences(tls13_config, "test_all");
-
-            EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-            EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-            
-            EXPECT_SUCCESS(s2n_connection_set_config(client_conn, tls13_config));
-            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "default_tls13"));
-
-            hello_stuffer = &client_conn->handshake.io;
-
-            EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
-
-            uint8_t empty_cipher_suite[S2N_TLS_CIPHER_SUITE_LEN] = {0};
-
-            /* Move write_cursor to cipher_suite position */
-            EXPECT_SUCCESS(s2n_stuffer_rewrite(hello_stuffer));
-            EXPECT_SUCCESS(s2n_stuffer_skip_write(hello_stuffer, S2N_TLS_PROTOCOL_VERSION_LEN + S2N_TLS_RANDOM_DATA_LEN + 1));
-            EXPECT_SUCCESS(s2n_stuffer_write_bytes(hello_stuffer, empty_cipher_suite, S2N_TLS_CIPHER_SUITE_LEN));
-
-            EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &hello_stuffer->blob));
-            EXPECT_FAILURE_WITH_ERRNO(s2n_parse_client_hello(server_conn), S2N_ERR_BAD_MESSAGE);
-
-            s2n_connection_free(server_conn);
-            s2n_connection_free(client_conn);
-            s2n_cert_chain_and_key_free(tls13_chain_and_key);
-            free(tls13_cert_chain);
-            free(tls13_private_key);
-        }
-        
-        /* s2n will error when parsing an empty cipher suite and client is sslv2 */
-        {
-            struct s2n_connection *server_conn;
-            EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-
-            struct s2n_config *tls12_config;
-            char *cert_chain;
-            char *private_key;
-
-            EXPECT_NOT_NULL(cert_chain = malloc(S2N_MAX_TEST_PEM_SIZE));
-            EXPECT_NOT_NULL(private_key = malloc(S2N_MAX_TEST_PEM_SIZE));
-            EXPECT_NOT_NULL(tls12_config = s2n_config_new());
-            EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
-            s2n_config_set_cipher_preferences(tls12_config, "test_all_tls12");
-
-
-            EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
-            EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key, S2N_MAX_TEST_PEM_SIZE));
-            EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain, private_key));
-            EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(tls12_config, chain_and_key));
-
-            EXPECT_SUCCESS(s2n_connection_set_config(server_conn, tls12_config));
-
-            /* Record version and protocol version are in the header for SSLv2 */
-            server_conn->client_hello_version = S2N_SSLv2;
-            server_conn->client_protocol_version = S2N_TLS12;
-
-            /* Writing a sslv2 client hello with a length 0 cipher suite list */
-            uint8_t sslv2_client_hello[] = {
-                0x00, 0x00, 0x00, 0x00, 0x00, 0x20,
-                SSLv2_CLIENT_HELLO_CIPHER_SUITES,
-                SSLv2_CLIENT_HELLO_CHALLENGE,
-            };
-
-            struct s2n_blob client_hello = {
-                .data = sslv2_client_hello,
-                .size = sizeof(sslv2_client_hello),
-                .allocated = 0,
-                .growable = 0
-            };
-            EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &client_hello));
-            EXPECT_FAILURE_WITH_ERRNO(s2n_client_hello_recv(server_conn), S2N_ERR_BAD_MESSAGE);
-
-            s2n_connection_free(server_conn);
-            s2n_config_free(tls12_config);
-            free(cert_chain);
-            free(private_key);
-        }
     }
 
     EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -387,7 +387,8 @@ int s2n_sslv2_client_hello_recv(struct s2n_connection *conn)
     /* We start 5 bytes into the record */
     uint16_t cipher_suites_length;
     GUARD(s2n_stuffer_read_uint16(in, &cipher_suites_length));
-    S2N_ERROR_IF(cipher_suites_length % S2N_SSLv2_CIPHER_SUITE_LEN || cipher_suites_length == 0, S2N_ERR_BAD_MESSAGE);
+    ENSURE_POSIX(cipher_suites_length > 0, S2N_ERR_BAD_MESSAGE);
+    ENSURE_POSIX(cipher_suites_length % S2N_SSLv2_CIPHER_SUITE_LEN == 0, S2N_ERR_BAD_MESSAGE);
 
     uint16_t session_id_length;
     GUARD(s2n_stuffer_read_uint16(in, &session_id_length));

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -177,8 +177,9 @@ static int s2n_parse_client_hello(struct s2n_connection *conn)
 
     uint16_t cipher_suites_length = 0;
     GUARD(s2n_stuffer_read_uint16(in, &cipher_suites_length));
-    S2N_ERROR_IF(cipher_suites_length % S2N_TLS_CIPHER_SUITE_LEN || cipher_suites_length == 0, S2N_ERR_BAD_MESSAGE);
-
+    ENSURE_POSIX(cipher_suites_length > 0, S2N_ERR_BAD_MESSAGE);
+    ENSURE_POSIX(cipher_suites_length % S2N_TLS_CIPHER_SUITE_LEN == 0, S2N_ERR_BAD_MESSAGE);
+   
     client_hello->cipher_suites.size = cipher_suites_length;
     client_hello->cipher_suites.data = s2n_stuffer_raw_read(in, cipher_suites_length);
     notnull_check(client_hello->cipher_suites.data);

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -44,6 +44,8 @@
 #include "utils/s2n_random.h"
 #include "utils/s2n_safety.h"
 
+int s2n_parse_client_hello(struct s2n_connection *conn);
+
 struct s2n_client_hello *s2n_connection_get_client_hello(struct s2n_connection *conn) {
     if (conn->client_hello.parsed != 1) {
         return NULL;
@@ -144,7 +146,7 @@ int s2n_collect_client_hello(struct s2n_connection *conn, struct s2n_stuffer *so
     return 0;
 }
 
-static int s2n_parse_client_hello(struct s2n_connection *conn)
+int s2n_parse_client_hello(struct s2n_connection *conn)
 {
     notnull_check(conn);
     GUARD(s2n_collect_client_hello(conn, &conn->handshake.io));
@@ -177,7 +179,7 @@ static int s2n_parse_client_hello(struct s2n_connection *conn)
 
     uint16_t cipher_suites_length = 0;
     GUARD(s2n_stuffer_read_uint16(in, &cipher_suites_length));
-    S2N_ERROR_IF(cipher_suites_length % S2N_TLS_CIPHER_SUITE_LEN, S2N_ERR_BAD_MESSAGE);
+    S2N_ERROR_IF(cipher_suites_length % S2N_TLS_CIPHER_SUITE_LEN || cipher_suites_length == 0, S2N_ERR_BAD_MESSAGE);
 
     client_hello->cipher_suites.size = cipher_suites_length;
     client_hello->cipher_suites.data = s2n_stuffer_raw_read(in, cipher_suites_length);
@@ -386,7 +388,7 @@ int s2n_sslv2_client_hello_recv(struct s2n_connection *conn)
     /* We start 5 bytes into the record */
     uint16_t cipher_suites_length;
     GUARD(s2n_stuffer_read_uint16(in, &cipher_suites_length));
-    S2N_ERROR_IF(cipher_suites_length % S2N_SSLv2_CIPHER_SUITE_LEN, S2N_ERR_BAD_MESSAGE);
+    S2N_ERROR_IF(cipher_suites_length % S2N_SSLv2_CIPHER_SUITE_LEN || cipher_suites_length == 0, S2N_ERR_BAD_MESSAGE);
 
     uint16_t session_id_length;
     GUARD(s2n_stuffer_read_uint16(in, &session_id_length));

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -44,8 +44,6 @@
 #include "utils/s2n_random.h"
 #include "utils/s2n_safety.h"
 
-int s2n_parse_client_hello(struct s2n_connection *conn);
-
 struct s2n_client_hello *s2n_connection_get_client_hello(struct s2n_connection *conn) {
     if (conn->client_hello.parsed != 1) {
         return NULL;
@@ -146,7 +144,7 @@ int s2n_collect_client_hello(struct s2n_connection *conn, struct s2n_stuffer *so
     return 0;
 }
 
-int s2n_parse_client_hello(struct s2n_connection *conn)
+static int s2n_parse_client_hello(struct s2n_connection *conn)
 {
     notnull_check(conn);
     GUARD(s2n_collect_client_hello(conn, &conn->handshake.io));


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A
### Description of changes: 

Added check for empty cipher suite list while parsing the client hello. I also added this check for parsing a sslv2 client hello. 
### Call-outs:

N/A
### Testing:

Added two unit tests to make sure s2n_parse_client_hello() is failing correctly when given an empty cipher suite.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
