### PR TITLE
[DO NOT MERGE] Updates the default list of keyshares sent by the client

### DIFF
--- a/tests/integration/common/s2n_test_common.py
+++ b/tests/integration/common/s2n_test_common.py
@@ -146,6 +146,14 @@ def get_s2n_cmd(scenario):
         s2n_cmd.append("--insecure")
         s2n_cmd.append("--echo")
 
+    if scenario.s2n_mode.is_client():
+        if scenario.curve.name == "X25519":
+            s2n_cmd.extend(["--keyshares", "x25519"])
+        elif scenario.curve.name == "P-256":
+            s2n_cmd.extend(["--keyshares", "secp256r1"])
+        elif scenario.curve.name == "P-384":
+            s2n_cmd.extend(["--keyshares", "secp384r1"])
+
     if scenario.version is Version.TLS13:
         s2n_cmd.append("--tls13")
 

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -149,6 +149,13 @@ class S2N(Provider):
         if self.options.extra_flags is not None:
             cmd_line.extend(self.options.extra_flags)
 
+        if self.options.curve == Curves.X25519:
+            cmd_line.extend(["--keyshares", "x25519"])
+        elif self.options.curve == Curves.P256:
+            cmd_line.extend(["--keyshares", "secp256r1"])
+        elif self.options.curve == Curves.P384:
+            cmd_line.extend(["--keyshares", "secp384r1"])
+
         cmd_line.extend([self.options.host, self.options.port])
 
         # Clients are always ready to connect

--- a/tests/unit/s2n_server_key_share_extension_test.c
+++ b/tests/unit/s2n_server_key_share_extension_test.c
@@ -302,6 +302,8 @@ int main(int argc, char **argv)
             server_conn->actual_protocol_version = S2N_TLS13;
 
             EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(server_conn, &ecc_pref));
+            EXPECT_SUCCESS(s2n_connection_set_keyshare_by_name_for_testing(server_conn, ecc_pref->ecc_curves[i]->name));
+            EXPECT_SUCCESS(s2n_connection_set_keyshare_by_name_for_testing(client_conn, ecc_pref->ecc_curves[i]->name));
             EXPECT_NOT_NULL(ecc_pref);
 
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&client_hello_key_share, 1024));


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

 resolves https://github.com/awslabs/s2n/issues/2011

### Description of changes: 

Updates the s2n client side default behaviour from sending keyshares for all supported groups to sending keyshares for only the highest priority supported group obtained from the ecc_preferences list.

### Testing:

- unit tests
- integration test
- integrationv2 tests 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
