### PR TITLE
Adds the missing extra_flags setup in the integrationv2 setup_client function

### DIFF
--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -146,6 +146,9 @@ class S2N(Provider):
         if options.client_certificate_file:
             cmd_line.extend(['--cert', options.client_certificate_file])
 
+        if options.extra_flags is not None:
+            cmd_line.extend(options.extra_flags)
+
         cmd_line.extend([options.host, options.port])
 
         # Clients are always ready to connect


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

### Description of changes: 

Adds the missing extra_flags setup in the  integrationv2 setup_client function. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
