### PR TITLE
Adds a proof harness for s2n_stuffer_growable_alloc

### DIFF
--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -50,11 +50,13 @@ int s2n_stuffer_init(struct s2n_stuffer *stuffer, struct s2n_blob *in)
 }
 int s2n_stuffer_alloc(struct s2n_stuffer *stuffer, const uint32_t size)
 {
+    notnull_check(stuffer);
     GUARD(s2n_alloc(&stuffer->blob, size));
     GUARD(s2n_stuffer_init(stuffer, &stuffer->blob));
 
     stuffer->alloced = 1;
 
+    POSTCONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     return S2N_SUCCESS;
 }
 
@@ -64,6 +66,7 @@ int s2n_stuffer_growable_alloc(struct s2n_stuffer *stuffer, const uint32_t size)
 
     stuffer->growable = 1;
 
+    POSTCONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     return S2N_SUCCESS;
 }
 

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -51,6 +51,7 @@ int s2n_stuffer_init(struct s2n_stuffer *stuffer, struct s2n_blob *in)
 int s2n_stuffer_alloc(struct s2n_stuffer *stuffer, const uint32_t size)
 {
     notnull_check(stuffer);
+    *stuffer = (struct s2n_stuffer) {0};
     GUARD(s2n_alloc(&stuffer->blob, size));
     GUARD(s2n_stuffer_init(stuffer, &stuffer->blob));
 

--- a/tests/cbmc/proofs/s2n_stuffer_alloc/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc/Makefile
@@ -11,8 +11,8 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-###########
-#Use the default set of CBMC flags
+# Expected runtime is 20 seconds.
+
 CHECKFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
@@ -20,11 +20,15 @@ DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
 DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
 DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
 DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
 
 ENTRY = s2n_stuffer_alloc_harness
 
-#No loops to unwind
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_blob_slice
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_ensure_memcpy_trace
+
 UNWINDSET +=
-###########
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_alloc/s2n_stuffer_alloc_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc/s2n_stuffer_alloc_harness.c
@@ -42,11 +42,13 @@ void s2n_stuffer_alloc_harness() {
         assert(stuffer->blob.size == size);
         assert(s2n_stuffer_is_valid(stuffer));
     } else {
-        assert(stuffer->read_cursor == old_stuffer.read_cursor);
-        assert(stuffer->write_cursor == old_stuffer.write_cursor);
-        assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
-        assert(stuffer->alloced == old_stuffer.alloced);
-        assert(stuffer->growable == old_stuffer.growable);
-        assert(stuffer->tainted == old_stuffer.tainted);
+        assert(stuffer->blob.data == NULL);
+        assert(stuffer->blob.size == 0);
+        assert(stuffer->read_cursor == 0);
+        assert(stuffer->write_cursor == 0);
+        assert(stuffer->high_water_mark == 0);
+        assert(stuffer->alloced == 0);
+        assert(stuffer->growable == 0);
+        assert(stuffer->tainted == 0);
     }
 }

--- a/tests/cbmc/proofs/s2n_stuffer_growable_alloc/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_growable_alloc/Makefile
@@ -1,0 +1,34 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 20 seconds.
+
+CHECKFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+
+ENTRY = s2n_stuffer_growable_alloc_harness
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_blob_slice
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_ensure_memcpy_trace
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_growable_alloc/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_growable_alloc/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_growable_alloc/s2n_stuffer_growable_alloc_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_growable_alloc/s2n_stuffer_growable_alloc_harness.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "error/s2n_errno.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_mem.h"
+
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_stuffer_growable_alloc_harness() {
+    /* Non-deterministic inputs. */
+    struct s2n_stuffer *stuffer = nondet_bool() ? cbmc_allocate_s2n_stuffer(): NULL;
+    __CPROVER_assume(S2N_IMPLIES(stuffer != NULL, s2n_stuffer_is_valid(stuffer)));
+    uint32_t size;
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    /* Operation under verification. */
+    if (s2n_stuffer_growable_alloc(stuffer, size) == S2N_SUCCESS) {
+        /* Post-conditions. */
+        assert(stuffer->growable == 1);
+        assert(stuffer->alloced == 1);
+        assert(stuffer->blob.size == size);
+        assert(s2n_stuffer_is_valid(stuffer));
+    }
+}

--- a/tests/cbmc/proofs/s2n_stuffer_growable_alloc/s2n_stuffer_growable_alloc_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_growable_alloc/s2n_stuffer_growable_alloc_harness.c
@@ -44,11 +44,13 @@ void s2n_stuffer_growable_alloc_harness() {
         assert(stuffer->blob.size == size);
         assert(s2n_stuffer_is_valid(stuffer));
     } else {
-        assert(stuffer->read_cursor == old_stuffer.read_cursor);
-        assert(stuffer->write_cursor == old_stuffer.write_cursor);
-        assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
-        assert(stuffer->alloced == old_stuffer.alloced);
-        assert(stuffer->growable == old_stuffer.growable);
-        assert(stuffer->tainted == old_stuffer.tainted);
+        assert(stuffer->blob.data == NULL);
+        assert(stuffer->blob.size == 0);
+        assert(stuffer->read_cursor == 0);
+        assert(stuffer->write_cursor == 0);
+        assert(stuffer->high_water_mark == 0);
+        assert(stuffer->alloced == 0);
+        assert(stuffer->growable == 0);
+        assert(stuffer->tainted == 0);
     }
 }


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A.

### Description of changes: 

- Adds a proof harness for the `s2n_stuffer_growable_alloc` function;
- Adds a pre- and post-conditions to the `s2n_stuffer_growable_alloc` function;
- Updates `s2n_stuffer_alloc` proof harness.

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.