### PR TITLE
Adds a proof harness for s2n_stuffer_extract_blob

### DIFF
--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -360,7 +360,6 @@ int s2n_stuffer_extract_blob(struct s2n_stuffer *stuffer, struct s2n_blob *out)
 {
     PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     notnull_check(out);
-    //GUARD(s2n_free(out));
     GUARD(s2n_realloc(out , s2n_stuffer_data_available(stuffer)));
 
     if (s2n_stuffer_data_available(stuffer) > 0) {

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -360,8 +360,8 @@ int s2n_stuffer_extract_blob(struct s2n_stuffer *stuffer, struct s2n_blob *out)
 {
     PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     notnull_check(out);
-    GUARD(s2n_free(out));
-    GUARD(s2n_alloc(out, s2n_stuffer_data_available(stuffer)));
+    //GUARD(s2n_free(out));
+    GUARD(s2n_realloc(out , s2n_stuffer_data_available(stuffer)));
 
     if (s2n_stuffer_data_available(stuffer) > 0) {
         memcpy_check(out->data,

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -368,5 +368,7 @@ int s2n_stuffer_extract_blob(struct s2n_stuffer *stuffer, struct s2n_blob *out)
                      stuffer->blob.data + stuffer->read_cursor,
                      s2n_stuffer_data_available(stuffer));
     }
+
+    POSTCONDITION_POSIX(s2n_blob_is_valid(out));
     return S2N_SUCCESS;
 }

--- a/tests/cbmc/proofs/s2n_stuffer_extract_blob/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_extract_blob/Makefile
@@ -1,0 +1,36 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 20 seconds.
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/error/s2n_errno.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+
+ENTRY = s2n_stuffer_extract_blob_harness
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_blob_slice
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_ensure_memcpy_trace
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_extract_blob/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_extract_blob/Makefile
@@ -29,7 +29,6 @@ ENTRY = s2n_stuffer_extract_blob_harness
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += --remove-function-body s2n_blob_slice
-REMOVE_FUNCTION_BODY += --remove-function-body s2n_ensure_memcpy_trace
 
 UNWINDSET +=
 

--- a/tests/cbmc/proofs/s2n_stuffer_extract_blob/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_extract_blob/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_extract_blob/s2n_stuffer_extract_blob_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_extract_blob/s2n_stuffer_extract_blob_harness.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "error/s2n_errno.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_mem.h"
+
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_stuffer_extract_blob_harness() {
+    /* Non-deterministic inputs. */
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    struct s2n_blob *blob = cbmc_allocate_s2n_blob();
+    __CPROVER_assume(s2n_blob_is_valid(blob));
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    /* Save previous state. */
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    /* Operation under verification. */
+    if (s2n_stuffer_extract_blob(stuffer, blob) == S2N_SUCCESS) {
+        assert(s2n_blob_is_valid(blob));
+    }
+
+    /* Post-conditions. */
+    assert(s2n_stuffer_is_valid(stuffer));
+    assert_stuffer_equivalence(stuffer, &old_stuffer, &old_byte_from_stuffer);
+}

--- a/tests/cbmc/proofs/s2n_stuffer_extract_blob/s2n_stuffer_extract_blob_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_extract_blob/s2n_stuffer_extract_blob_harness.c
@@ -39,20 +39,15 @@ void s2n_stuffer_extract_blob_harness() {
     struct s2n_stuffer old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte_from_stuffer;
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
-    //struct store_byte_from_buffer old_byte_from_available_region;
-    //save_byte_from_array(stuffer->blob.data + stuffer->read_cursor, s2n_stuffer_data_available(stuffer), &old_byte_from_available_region);
-    uint32_t index;
-    /* Store a byte from the stuffer that won't be overwritten to compare if the write succeeds. */
-    __CPROVER_assume(index >= old_stuffer.read_cursor && index < old_stuffer.write_cursor);
-    uint8_t untouched_byte = stuffer->blob.data[index];
 
     /* Operation under verification. */
     if (s2n_stuffer_extract_blob(stuffer, blob) == S2N_SUCCESS) {
         assert(s2n_blob_is_valid(blob));
+        assert(blob->size == s2n_stuffer_data_available(stuffer));
         if (blob->size > 0) {
-            size_t i;
-            __CPROVER_assume(i < blob->size);
-            assert(blob->data[i] = untouched_byte);
+            uint32_t index;
+            __CPROVER_assume(index < blob->size);
+            assert(blob->data[index] == stuffer->blob.data[stuffer->read_cursor + index]);
         }
     }
 

--- a/tests/cbmc/proofs/s2n_stuffer_extract_blob/s2n_stuffer_extract_blob_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_extract_blob/s2n_stuffer_extract_blob_harness.c
@@ -39,10 +39,21 @@ void s2n_stuffer_extract_blob_harness() {
     struct s2n_stuffer old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte_from_stuffer;
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+    //struct store_byte_from_buffer old_byte_from_available_region;
+    //save_byte_from_array(stuffer->blob.data + stuffer->read_cursor, s2n_stuffer_data_available(stuffer), &old_byte_from_available_region);
+    uint32_t index;
+    /* Store a byte from the stuffer that won't be overwritten to compare if the write succeeds. */
+    __CPROVER_assume(index >= old_stuffer.read_cursor && index < old_stuffer.write_cursor);
+    uint8_t untouched_byte = stuffer->blob.data[index];
 
     /* Operation under verification. */
     if (s2n_stuffer_extract_blob(stuffer, blob) == S2N_SUCCESS) {
         assert(s2n_blob_is_valid(blob));
+        if (blob->size > 0) {
+            size_t i;
+            __CPROVER_assume(i < blob->size);
+            assert(blob->data[i] = untouched_byte);
+        }
     }
 
     /* Post-conditions. */


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A.

### Description of changes: 

- Adds a proof harness for the `s2n_stuffer_extract_blob` function;
- Adds a pre- and post-conditions to the `s2n_stuffer_extract_blob` function;

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.