### PR TITLE
Adds a proof harness for s2n_stuffer_resize

### DIFF
--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -106,7 +106,7 @@ int s2n_stuffer_resize(struct s2n_stuffer *stuffer, const uint32_t size)
         memset_check(stuffer->blob.data + size, 0, (stuffer->blob.size - size));
         if (stuffer->read_cursor > size) stuffer->read_cursor = size;
         if (stuffer->write_cursor > size) stuffer->write_cursor = size;
-        if (stuffer->high_water_mark > size) stuffer->high_water_mark = stuffer->write_cursor;
+        if (stuffer->high_water_mark > size) stuffer->high_water_mark = size;
         stuffer->blob.size = size;
         return S2N_SUCCESS;
     }

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -103,7 +103,7 @@ int s2n_stuffer_resize(struct s2n_stuffer *stuffer, const uint32_t size)
     }
 
     if (size < stuffer->blob.size) {
-        memset_check(stuffer->blob.data + size, 0, (stuffer->blob.size - size));
+        memset_check(stuffer->blob.data + size, S2N_WIPE_PATTERN, (stuffer->blob.size - size));
         if (stuffer->read_cursor > size) stuffer->read_cursor = size;
         if (stuffer->write_cursor > size) stuffer->write_cursor = size;
         if (stuffer->high_water_mark > size) stuffer->high_water_mark = size;

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -90,8 +90,8 @@ int s2n_stuffer_free(struct s2n_stuffer *stuffer)
 
 int s2n_stuffer_resize(struct s2n_stuffer *stuffer, const uint32_t size)
 {
-    S2N_ERROR_IF(stuffer->tainted == 1, S2N_ERR_RESIZE_TAINTED_STUFFER);
-    S2N_ERROR_IF(stuffer->growable == 0, S2N_ERR_RESIZE_STATIC_STUFFER);
+    ENSURE_POSIX(!stuffer->tainted, S2N_ERR_RESIZE_TAINTED_STUFFER);
+    ENSURE_POSIX(stuffer->growable, S2N_ERR_RESIZE_STATIC_STUFFER);
 
     if (size == stuffer->blob.size) {
         return S2N_SUCCESS;
@@ -99,6 +99,7 @@ int s2n_stuffer_resize(struct s2n_stuffer *stuffer, const uint32_t size)
 
     if (size < stuffer->blob.size) {
         GUARD(s2n_stuffer_wipe_n(stuffer, stuffer->blob.size - size));
+        if (stuffer->high_water_mark > size) stuffer->high_water_mark = stuffer->write_cursor;
     }
 
     GUARD(s2n_realloc(&stuffer->blob, size));

--- a/tests/cbmc/proofs/s2n_stuffer_resize/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_resize/Makefile
@@ -1,0 +1,39 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 40 seconds.
+CBMCFLAGS +=
+
+HARNESS_ENTRY = s2n_stuffer_resize_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/error/s2n_errno.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_resize/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_resize/Makefile
@@ -34,6 +34,9 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+
 UNWINDSET +=
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_resize/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_resize/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_resize/s2n_stuffer_resize_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_resize/s2n_stuffer_resize_harness.c
@@ -1,0 +1,77 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "error/s2n_errno.h"
+#include "stuffer/s2n_stuffer.h"
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_stuffer_resize_harness() {
+    /* Non-deterministic inputs. */
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    uint32_t size;
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    /* Save previous state. */
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    /* Operation under verification. */
+    if (s2n_stuffer_resize(stuffer, size) == S2N_SUCCESS) {
+        assert(!stuffer->tainted);
+        assert(stuffer->growable);
+        assert(stuffer->blob.size == size);
+        assert(s2n_stuffer_is_valid(stuffer));
+
+        if (size == old_stuffer.blob.size) {
+            assert_stuffer_equivalence(stuffer, &old_stuffer, &old_byte_from_stuffer);
+        } else if (size == 0) {
+            assert(stuffer->blob.data == NULL);
+            assert(stuffer->blob.size == 0);
+            assert(stuffer->blob.allocated == 0);
+            assert(stuffer->blob.growable == 0);
+        } else if (size > old_stuffer.blob.size) {
+            if(size < old_stuffer.blob.allocated) {
+                assert(stuffer->blob.data == old_stuffer.blob.data);
+                assert(stuffer->blob.allocated == old_stuffer.blob.allocated);
+                assert(stuffer->blob.growable == old_stuffer.blob.growable);
+            } else {
+                /* Confirms bytes were maintained. */
+                if (old_stuffer.blob.size > 0) assert_byte_from_buffer_matches(stuffer->blob.data, &old_byte_from_stuffer);
+                assert(stuffer->blob.growable == 1);
+            }
+        } else { /* size < old_stuffer.blob.size */
+            size_t index;
+            /* Confirms wiped portion. */
+            __CPROVER_assume(index >= size && index < old_stuffer.blob.size);
+            assert(stuffer->blob.data[index] == 0);
+            assert(stuffer->blob.allocated == old_stuffer.blob.allocated);
+            assert(stuffer->blob.growable == old_stuffer.blob.growable);
+        }
+    } else {
+        assert(stuffer->alloced == old_stuffer.alloced);
+        assert(stuffer->growable == old_stuffer.growable);
+        assert(stuffer->tainted == old_stuffer.tainted);
+    }
+}

--- a/tests/cbmc/proofs/s2n_stuffer_resize/s2n_stuffer_resize_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_resize/s2n_stuffer_resize_harness.c
@@ -65,7 +65,7 @@ void s2n_stuffer_resize_harness() {
             size_t index;
             /* Confirms wiped portion. */
             __CPROVER_assume(index >= size && index < old_stuffer.blob.size);
-            assert(stuffer->blob.data[index] == 0);
+            assert(stuffer->blob.data[index] == S2N_WIPE_PATTERN);
             assert(stuffer->blob.allocated == old_stuffer.blob.allocated);
             assert(stuffer->blob.growable == old_stuffer.blob.growable);
         }


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A.

### Description of changes: 

- Adds a proof harness for the `s2n_stuffer_resize` function;
- Adds a pre- and post-conditions to the `s2n_stuffer_resize` function;

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.