### PR TITLE
Adds --pointer-primitive-check flag on CBMC proofs

### DIFF
--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -31,8 +31,8 @@ bool s2n_stuffer_is_valid(const struct s2n_stuffer* stuffer)
      */
     return S2N_OBJECT_PTR_IS_READABLE(stuffer) &&
            s2n_blob_is_valid(&stuffer->blob) &&
+           stuffer->high_water_mark < stuffer->blob.size &&
            /* <= is valid because we can have a fully written/read stuffer */
-           stuffer->high_water_mark <= stuffer->blob.size &&
            stuffer->write_cursor <= stuffer->high_water_mark &&
            stuffer->read_cursor <= stuffer->write_cursor;
 }

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -31,8 +31,9 @@ bool s2n_stuffer_is_valid(const struct s2n_stuffer* stuffer)
      */
     return S2N_OBJECT_PTR_IS_READABLE(stuffer) &&
            s2n_blob_is_valid(&stuffer->blob) &&
+           /* <= is NOT valid here because the last read/write-able index is blob.size - 1 */
            stuffer->high_water_mark < stuffer->blob.size &&
-           /* <= is valid because we can have a fully written/read stuffer */
+           /* <= is valid below because we can have a fully written/read stuffer */
            stuffer->write_cursor <= stuffer->high_water_mark &&
            stuffer->read_cursor <= stuffer->write_cursor;
 }

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -57,7 +57,7 @@ bool s2n_stuffer_reservation_is_valid(const struct s2n_stuffer_reservation* rese
     }
     return S2N_IMPLIES(
         reserve_obj.length > 0,
-        (reserve_obj.write_cursor < stuffer_obj.blob.size &&
+        (reserve_obj.write_cursor < stuffer_obj.write_cursor &&
          S2N_MEM_IS_WRITABLE(stuffer_obj.blob.data + reserve_obj.write_cursor, reserve_obj.length))
     );
 }

--- a/stuffer/s2n_stuffer_text.c
+++ b/stuffer/s2n_stuffer_text.c
@@ -68,8 +68,11 @@ int s2n_stuffer_read_expected_str(struct s2n_stuffer *stuffer, const char *expec
     PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     notnull_check(expected);
     size_t expected_length = strlen(expected);
+    if (expected_length == 0) {
+        return S2N_SUCCESS;
+    }
     ENSURE_POSIX(s2n_stuffer_data_available(stuffer) >= expected_length, S2N_ERR_STUFFER_OUT_OF_DATA);
-    uint8_t *actual =  stuffer->blob.data + stuffer->read_cursor;
+    uint8_t *actual = stuffer->blob.data + stuffer->read_cursor;
     notnull_check(actual);
     ENSURE_POSIX(!memcmp(actual, expected, expected_length), S2N_ERR_STUFFER_NOT_FOUND);
     stuffer->read_cursor += expected_length;
@@ -83,6 +86,9 @@ int s2n_stuffer_skip_read_until(struct s2n_stuffer *stuffer, const char *target)
     PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     notnull_check(target);
     const int len = strlen(target);
+    if (len == 0) {
+        return S2N_SUCCESS;
+    }
     while (s2n_stuffer_data_available(stuffer) >= len) {
         GUARD(s2n_stuffer_skip_to_char(stuffer, target[0]));
         GUARD(s2n_stuffer_skip_read(stuffer, len));

--- a/tests/cbmc/proofs/Makefile-project-defines
+++ b/tests/cbmc/proofs/Makefile-project-defines
@@ -32,7 +32,9 @@ INCLUDES += -I$(SRCDIR)/api
 AWS_DEEP_CHECKS ?= 0
 DEFINES += -DAWS_DEEP_CHECKS=$(AWS_DEEP_CHECKS)
 
-CBMC_FLAG_POINTER_PRIMITIVE_CHECK =
+# Extra CBMC flags not enabled by Makefile.common
+# CHECKFLAGS += --enum-range-check
+CHECKFLAGS += --pointer-primitive-check
 
 ################################################################
 # Remove function bodies that are not used in the proofs.

--- a/tests/cbmc/proofs/s2n_pkcs3_to_dh_params/Makefile
+++ b/tests/cbmc/proofs/s2n_pkcs3_to_dh_params/Makefile
@@ -41,6 +41,6 @@ UNWINDSET +=
 # function and the second interacts with OpenSSL functions. Since OpenSSL
 # is not emulated by CBMC, these do not fall within the scope of the proof.
 REMOVE_FUNCTION_BODY += DECLARE_ASN1_ITEM
-REMOVE_FUNCTION_BODY += s2n_check_p_g_dh_params
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_dhe_c_s2n_check_p_g_dh_params
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_peek_check_for_str/s2n_stuffer_peek_check_for_str_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_peek_check_for_str/s2n_stuffer_peek_check_for_str_harness.c
@@ -35,9 +35,10 @@ void s2n_stuffer_peek_check_for_str_harness()
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
     /* Operation under verification. */
-    if (s2n_stuffer_peek_check_for_str(stuffer, expected) == S2N_SUCCESS) {
+    size_t expected_length = (expected != NULL) ? strlen(expected) : 0;
+    if (expected_length > 0 && s2n_stuffer_peek_check_for_str(stuffer, expected) == S2N_SUCCESS) {
         uint8_t *actual = stuffer->blob.data + stuffer->read_cursor;
-        assert(!memcmp(actual, expected, strlen(expected)));
+        assert(!memcmp(actual, expected, expected_length));
     }
     assert_stuffer_equivalence(stuffer, &old_stuffer, &old_byte_from_stuffer);
     assert(s2n_stuffer_is_valid(stuffer));

--- a/tests/cbmc/proofs/s2n_stuffer_read_expected_str/s2n_stuffer_read_expected_str_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_expected_str/s2n_stuffer_read_expected_str_harness.c
@@ -35,10 +35,11 @@ void s2n_stuffer_read_expected_str_harness()
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
     /* Operation under verification. */
-    if (s2n_stuffer_read_expected_str(stuffer, expected) == S2N_SUCCESS) {
-        uint8_t *actual = stuffer->blob.data + stuffer->read_cursor - strlen(expected);
-        assert(!memcmp(actual, expected, strlen(expected)));
-        assert(stuffer->read_cursor == old_stuffer.read_cursor + strlen(expected));
+    size_t expected_length = (expected != NULL) ? strlen(expected) : 0;
+    if (expected_length > 0 && s2n_stuffer_read_expected_str(stuffer, expected) == S2N_SUCCESS) {
+        uint8_t *actual = stuffer->blob.data + stuffer->read_cursor - expected_length;
+        assert(!memcmp(actual, expected, expected_length));
+        assert(stuffer->read_cursor == old_stuffer.read_cursor + expected_length);
     } else {
         assert(stuffer->read_cursor == old_stuffer.read_cursor);
     }

--- a/tests/cbmc/proofs/s2n_stuffer_skip_read_until/s2n_stuffer_skip_read_until_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_read_until/s2n_stuffer_skip_read_until_harness.c
@@ -36,8 +36,8 @@ void s2n_stuffer_skip_read_until_harness()
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
     /* Operation under verification. */
-    if (s2n_stuffer_skip_read_until(stuffer, target) == S2N_SUCCESS) {
-        const int len = strlen(target);
+    size_t len = (target != NULL) ? strlen(target) : 0;
+    if (len > 0 && s2n_stuffer_skip_read_until(stuffer, target) == S2N_SUCCESS) {
         if (s2n_stuffer_data_available(stuffer) >= len) {
             uint8_t *actual = stuffer->blob.data + stuffer->read_cursor - len;
             assert((strncmp(( char * )actual, target, len) == 0) || (s2n_stuffer_data_available(stuffer) < len));

--- a/tests/cbmc/proofs/s2n_stuffer_writev_bytes/s2n_stuffer_writev_bytes_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_writev_bytes/s2n_stuffer_writev_bytes_harness.c
@@ -31,10 +31,10 @@ void s2n_stuffer_writev_bytes_harness()
 
     size_t iov_count;
     __CPROVER_assume(iov_count < MAX_IOVEC_SIZE);
-    struct iovec *iov = can_fail_malloc(iov_count * sizeof(*iov));
+    struct iovec *iov = bounded_malloc(iov_count * sizeof(*iov));
     __CPROVER_assume(iov != NULL);
     for (int i = 0; i < iov_count; i++) {
-        iov[ i ].iov_base = can_fail_malloc(iov[ i ].iov_len);
+        iov[ i ].iov_base = bounded_malloc(iov[ i ].iov_len);
     }
 
     uint32_t offs;

--- a/tests/cbmc/proofs/s2n_stuffer_writev_bytes/s2n_stuffer_writev_bytes_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_writev_bytes/s2n_stuffer_writev_bytes_harness.c
@@ -31,7 +31,7 @@ void s2n_stuffer_writev_bytes_harness()
 
     size_t iov_count;
     __CPROVER_assume(iov_count < MAX_IOVEC_SIZE);
-    struct iovec *iov = can_fail_malloc(iov_count * sizeof(struct iovec));
+    struct iovec *iov = can_fail_malloc(iov_count * sizeof(*iov));
     __CPROVER_assume(iov != NULL);
     for (int i = 0; i < iov_count; i++) {
         iov[ i ].iov_base = can_fail_malloc(iov[ i ].iov_len);

--- a/tests/cbmc/proofs/s2n_stuffer_writev_bytes/s2n_stuffer_writev_bytes_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_writev_bytes/s2n_stuffer_writev_bytes_harness.c
@@ -28,10 +28,15 @@ void s2n_stuffer_writev_bytes_harness()
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+
     size_t iov_count;
     __CPROVER_assume(iov_count < MAX_IOVEC_SIZE);
-    struct iovec iov[ iov_count ];
-    for (int i = 0; i < iov_count; i++) { iov[ i ].iov_base = can_fail_malloc(iov[ i ].iov_len); }
+    struct iovec *iov = can_fail_malloc(iov_count * sizeof(struct iovec));
+    __CPROVER_assume(iov != NULL);
+    for (int i = 0; i < iov_count; i++) {
+        iov[ i ].iov_base = can_fail_malloc(iov[ i ].iov_len);
+    }
+
     uint32_t offs;
     uint32_t size;
 

--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -13,8 +13,6 @@
  * permissions and limitations under the License.
  */
 
-#include <error/s2n_errno.h>
-
 #include <cbmc_proof/make_common_datastructures.h>
 
 bool s2n_blob_is_bounded(const struct s2n_blob *blob, const size_t max_size) { return (blob->size <= max_size); }

--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -77,17 +77,7 @@ const char *nondet_c_str_is_allocated(size_t max_size)
 struct s2n_stuffer_reservation *cbmc_allocate_s2n_stuffer_reservation()
 {
     struct s2n_stuffer_reservation *reservation = can_fail_malloc(sizeof(*reservation));
-    if (reservation != NULL) {
-        __CPROVER_assume(reservation->write_cursor <= UINT32_MAX - reservation->length);
-        uint32_t write_cursor_max = reservation->write_cursor + reservation->length;
-
-        reservation->stuffer = cbmc_allocate_s2n_stuffer();
-        if (reservation->stuffer != NULL) {
-            struct s2n_blob *blob = &reservation->stuffer->blob;
-            uint32_t blob_size = blob->growable ? blob->allocated : blob->size;
-            __CPROVER_assume(write_cursor_max < blob_size);
-        }
-    }
+    if (reservation != NULL) { reservation->stuffer = cbmc_allocate_s2n_stuffer(); }
     return reservation;
 }
 

--- a/tests/cbmc/sources/proof_allocators.c
+++ b/tests/cbmc/sources/proof_allocators.c
@@ -28,7 +28,7 @@ void *bounded_calloc(size_t num, size_t size)
 void *bounded_malloc(size_t size)
 {
     __CPROVER_assume(size <= MAX_MALLOC);
-    return malloc(size);
+    return (size == 0) ? NULL : malloc(size);
 }
 
 void *can_fail_calloc(size_t num, size_t size) { return nondet_bool() ? NULL : bounded_calloc(num, size); }


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A.

### Description of changes: 

- Adds a new flag`--pointer-primitive-check` to CBMC proofs. This ensures that all pointers passed to CBMC primitive functions are valid.
- Fix a warning due to a function being defined after use, instead of before.

### Call-outs:

This PR depends on https://github.com/awslabs/s2n/pull/2225
This PR overrides https://github.com/awslabs/s2n/pull/1958

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
