### PR TITLE
Adds a proof for s2n_stuffer_alloc_ro_from_string

### DIFF
--- a/stuffer/s2n_stuffer_text.c
+++ b/stuffer/s2n_stuffer_text.c
@@ -165,8 +165,9 @@ int s2n_stuffer_read_token(struct s2n_stuffer *stuffer, struct s2n_stuffer *toke
 
 int s2n_stuffer_alloc_ro_from_string(struct s2n_stuffer *stuffer, const char *str)
 {
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
+    notnull_check(str);
     uint32_t length = strlen(str);
-
     GUARD(s2n_stuffer_alloc(stuffer, length + 1));
     return s2n_stuffer_write_bytes(stuffer, (const uint8_t *)str, length);
 }

--- a/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_string/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_string/Makefile
@@ -1,0 +1,41 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enough to get full coverage with 20 seconds of runtime.
+MAX_STRING_LEN = 100
+DEFINES += -DMAX_STRING_LEN=$(MAX_STRING_LEN)
+
+CHECKFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+
+ENTRY = s2n_stuffer_alloc_ro_from_string_harness
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_blob_slice
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_free
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_stuffer_resize
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_add_overflow
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_blob_zero
+
+UNWINDSET += strlen.0:$(call addone,$(MAX_STRING_LEN))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_string/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_string/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_string/s2n_stuffer_alloc_ro_from_string_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_string/s2n_stuffer_alloc_ro_from_string_harness.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_mem.h"
+
+#include <assert.h>
+#include <string.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_stuffer_alloc_ro_from_string_harness() {
+    /* Non-deterministic inputs. */
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    char *str = ensure_c_str_is_allocated(MAX_STRING_LEN);
+
+    /* Save previous state from stuffer. */
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    /* Operation under verification. */
+    if (s2n_stuffer_alloc_ro_from_string(stuffer, str) == S2N_SUCCESS) {
+        /* Post-conditions. */
+        uint32_t length = strlen(str);
+        assert_bytes_match(stuffer->blob.data, (const uint8_t *)str, length);
+        assert(stuffer->alloced);
+        assert(stuffer->blob.size == length + 1);
+        assert(stuffer->write_cursor == length);
+        assert(stuffer->high_water_mark == length);
+    } else {
+        assert(stuffer->blob.data == NULL);
+        assert(stuffer->blob.size == 0);
+        assert(stuffer->read_cursor == 0);
+        assert(stuffer->write_cursor == 0);
+        assert(stuffer->high_water_mark == 0);
+        assert(stuffer->alloced == 0);
+        assert(stuffer->growable == 0);
+        assert(stuffer->tainted == 0);
+    }
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/fuzz/s2n_certificate_extensions_parse_test.c
+++ b/tests/fuzz/s2n_certificate_extensions_parse_test.c
@@ -34,7 +34,7 @@
 
 static uint32_t write_pem_file_to_stuffer_as_chain(struct s2n_stuffer *chain_out_stuffer, const char *pem_data)
 {
-    struct s2n_stuffer chain_in_stuffer, cert_stuffer;
+    struct s2n_stuffer chain_in_stuffer = {0}, cert_stuffer = {0};
     s2n_stuffer_alloc_ro_from_string(&chain_in_stuffer, pem_data);
     s2n_stuffer_growable_alloc(&cert_stuffer, 4096);
     s2n_stuffer_growable_alloc(chain_out_stuffer, 4096);

--- a/tests/unit/s2n_ssl_prf_test.c
+++ b/tests/unit/s2n_ssl_prf_test.c
@@ -40,14 +40,14 @@ int main(int argc, char **argv)
     char server_random_hex_in[] = "537fb7fe649225c9f37904b24916452d51794b3b5735fc7e628b6090db52209f";
     char master_secret_hex_in[] = "02b811717e3aa29e6b0526d7e9ae2b74496d461564401f47498e9cdbdf54c8afa69c25a648b360de2004c74850e8f7db";
 
-    struct s2n_stuffer client_random_in;
-    struct s2n_stuffer server_random_in;
-    struct s2n_stuffer premaster_secret_in;
-    struct s2n_stuffer master_secret_hex_out;
+    struct s2n_stuffer client_random_in = {0};
+    struct s2n_stuffer server_random_in = {0};
+    struct s2n_stuffer premaster_secret_in = {0};
+    struct s2n_stuffer master_secret_hex_out = {0};
     struct s2n_blob master_secret = {.data = master_secret_hex_pad,.size = sizeof(master_secret_hex_pad) };
-    struct s2n_blob pms;
+    struct s2n_blob pms = {0};
 
-    struct s2n_connection *conn;
+    struct s2n_connection *conn = NULL;
 
     BEGIN_TEST();
 
@@ -66,17 +66,17 @@ int main(int argc, char **argv)
 
     /* Parse the hex */
     for (int i = 0; i < 48; i++) {
-        uint8_t c;
+        uint8_t c = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8_hex(&premaster_secret_in, &c));
         conn->secure.rsa_premaster_secret[i] = c;
     }
     for (int i = 0; i < 32; i++) {
-        uint8_t c;
+        uint8_t c = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8_hex(&client_random_in, &c));
         conn->secure.client_random[i] = c;
     }
     for (int i = 0; i < 32; i++) {
-        uint8_t c;
+        uint8_t c = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8_hex(&server_random_in, &c));
         conn->secure.server_random[i] = c;
     }

--- a/tests/unit/s2n_stuffer_base64_test.c
+++ b/tests/unit/s2n_stuffer_base64_test.c
@@ -24,7 +24,7 @@ int main(int argc, char **argv)
 {
     char hello_world[] = "Hello world!";
     uint8_t hello_world_base64[] = "SGVsbG8gd29ybGQhAA==";
-    struct s2n_stuffer stuffer, known_data, scratch, entropy, mirror;
+    struct s2n_stuffer stuffer = {0}, known_data = {0}, scratch = {0}, entropy = {0}, mirror = {0};
     uint8_t pad[50];
     struct s2n_blob r = {.data = pad, .size = sizeof(pad)};
 

--- a/tests/unit/s2n_tls_prf_test.c
+++ b/tests/unit/s2n_tls_prf_test.c
@@ -40,14 +40,14 @@ int main(int argc, char **argv)
     char server_random_hex_in[] = "537eefc29f337c5eedacd00a1889b031261701872d666a74fa999dc13bcd8821";
     char master_secret_hex_in[] = "c8c610686237cd024a2d8e0391f61a8a4464c2c9576ea2b5ccf3af68139ec07c6a1720097063de968f2341f77b837120";
 
-    struct s2n_stuffer client_random_in;
-    struct s2n_stuffer server_random_in;
-    struct s2n_stuffer premaster_secret_in;
-    struct s2n_stuffer master_secret_hex_out;
+    struct s2n_stuffer client_random_in = {0};
+    struct s2n_stuffer server_random_in = {0};
+    struct s2n_stuffer premaster_secret_in = {0};
+    struct s2n_stuffer master_secret_hex_out = {0};
     struct s2n_blob master_secret = {.data = master_secret_hex_pad,.size = sizeof(master_secret_hex_pad) };
-    struct s2n_blob pms;
+    struct s2n_blob pms = {0};
 
-    struct s2n_connection *conn;
+    struct s2n_connection *conn = NULL;
 
     BEGIN_TEST();
 
@@ -64,17 +64,17 @@ int main(int argc, char **argv)
 
     /* Parse the hex */
     for (int i = 0; i < 48; i++) {
-        uint8_t c;
+        uint8_t c = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8_hex(&premaster_secret_in, &c));
         conn->secure.rsa_premaster_secret[i] = c;
     }
     for (int i = 0; i < 32; i++) {
-        uint8_t c;
+        uint8_t c = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8_hex(&client_random_in, &c));
         conn->secure.client_random[i] = c;
     }
     for (int i = 0; i < 32; i++) {
-        uint8_t c;
+        uint8_t c = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8_hex(&server_random_in, &c));
         conn->secure.server_random[i] = c;
     }

--- a/tests/unit/s2n_x509_validator_test.c
+++ b/tests/unit/s2n_x509_validator_test.c
@@ -51,7 +51,7 @@ static int read_file(struct s2n_stuffer *file_output, const char *path, uint32_t
 #endif /* S2N_OCSP_STAPLING_SUPPORTED */
 
 static uint32_t write_pem_file_to_stuffer_as_chain(struct s2n_stuffer *chain_out_stuffer, const char *pem_data) {
-    struct s2n_stuffer chain_in_stuffer, cert_stuffer;
+    struct s2n_stuffer chain_in_stuffer = {0}, cert_stuffer = {0};
     s2n_stuffer_alloc_ro_from_string(&chain_in_stuffer, pem_data);
     s2n_stuffer_growable_alloc(&cert_stuffer, 4096);
     s2n_stuffer_growable_alloc(chain_out_stuffer, 4096);


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A.

### Description of changes: 

- Adds a proof harness for the `s2n_stuffer_alloc_ro_from_string` function;
- Adds a pre- and post-conditions to the `s2n_stuffer_alloc_ro_from_string` function;

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.