### PR TITLE
Minor updates to Cryptol specs

### DIFF
--- a/codebuild/bin/install_saw.sh
+++ b/codebuild/bin/install_saw.sh
@@ -37,7 +37,7 @@ mkdir -p "$DOWNLOAD_DIR"
 cd "$DOWNLOAD_DIR"
 
 #download saw binaries
-curl --retry 3 https://s2n-public-test-dependencies.s3-us-west-2.amazonaws.com/saw-0.4.0.99-2020-03-31-Ubuntu14.04-64.tar.gz --output saw.tar.gz
+curl --retry 3 https://s2n-public-test-dependencies.s3-us-west-2.amazonaws.com/saw-0.6.0.99-2020-10-12-Ubuntu14.04-64.tar.gz --output saw.tar.gz
 
 mkdir -p saw && tar -xzf saw.tar.gz --strip-components=1 -C saw
 mkdir -p "$INSTALL_DIR" && mv saw/* "$INSTALL_DIR"

--- a/codebuild/bin/install_z3_yices.sh
+++ b/codebuild/bin/install_z3_yices.sh
@@ -34,10 +34,11 @@ cd "$DOWNLOAD_DIR"
 curl --retry 3 https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/yices-2.6.1-x86_64-pc-linux-gnu-static-gmp.tar.gz --output yices.tar.gz
 tar -xf yices.tar.gz
 
-curl --retry 3 https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/z3-2017-04-04-Ubuntu14.04-64 --output z3
+curl --retry 3 https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/z3-4.8.8-x64-ubuntu-16.04.zip --output z3.zip
+unzip z3.zip
 
 mkdir -p "$INSTALL_DIR"/bin
-mv z3 "$INSTALL_DIR"/bin
+mv z3-4.8.8-x64-ubuntu-16.04/bin/* "$INSTALL_DIR"/bin
 mv yices-2.6.1/bin/* "$INSTALL_DIR"/bin
 chmod +x  "$INSTALL_DIR"/bin/*
 

--- a/tests/saw/bike_r1/proof/base.saw
+++ b/tests/saw/bike_r1/proof/base.saw
@@ -26,7 +26,7 @@ let verify func overrides spec = verify_unint func overrides [] spec;
 enable_experimental;
 let verify_asm func spec =
     if do_prove then
-        crucible_llvm_verify_x86 m "../../s2n/lib/libs2n.so" func [] false spec
+        crucible_llvm_verify_x86 m "../../s2n/lib/libs2n.so" func [] false spec w4
     else
         crucible_llvm_unsafe_assume_spec m func spec;
 

--- a/tests/saw/bike_r2/proof/base.saw
+++ b/tests/saw/bike_r2/proof/base.saw
@@ -26,7 +26,7 @@ let verify func overrides spec = verify_unint func overrides [] spec;
 enable_experimental;
 let verify_asm func spec =
     if do_prove then
-        crucible_llvm_verify_x86 m "../../s2n/lib/libs2n.so" func [] false spec
+        crucible_llvm_verify_x86 m "../../s2n/lib/libs2n.so" func [] false spec w4
     else
         crucible_llvm_unsafe_assume_spec m func spec;
 

--- a/tests/saw/sike_r2/proof/sike_r2_x64_defs.saw
+++ b/tests/saw/sike_r2/proof/sike_r2_x64_defs.saw
@@ -15,7 +15,7 @@ let asm_globals =
 
 let verify_asm func spec =
     if do_prove then
-        crucible_llvm_verify_x86 m "../../s2n/lib/libs2n.so" func asm_globals false spec
+        crucible_llvm_verify_x86 m "../../s2n/lib/libs2n.so" func asm_globals false spec w4
     else
         crucible_llvm_unsafe_assume_spec m func spec;
 

--- a/tests/saw/spec/DRBG/DRBG_properties.cry
+++ b/tests/saw/spec/DRBG/DRBG_properties.cry
@@ -106,17 +106,17 @@ drbg = drbg_instantiate (nist_aes128_reference_entropy_hex @ 0) (nist_aes128_ref
 
 test_drbg : [8] -> Bit
 test_drbg n =
-  bits_out == nist_aes128_reference_returned_bits_hex @ n &&
-  drbg1.v == nist_aes128_reference_values_hex @ (3 * n) &&
-  drbg2.v == nist_aes128_reference_values_hex @ (3 * n + 1) &&
+  bits_out == nist_aes128_reference_returned_bits_hex @ n /\
+  drbg1.v == nist_aes128_reference_values_hex @ (3 * n) /\
+  drbg2.v == nist_aes128_reference_values_hex @ (3 * n + 1) /\
   drbg3.v == nist_aes128_reference_values_hex @ (3 * n + 2)
   where
     drbg1 = drbg_instantiate (nist_aes128_reference_entropy_hex @ (3*n))
                              (nist_aes128_reference_personalization_strings_hex @ n)
     ((bits1, drbg2) : ([512], s2n_drbg)) =
-      drbg_generate drbg1 (nist_aes128_reference_entropy_hex @ (3 * n + 1)) True
+      drbg_generate`{blocks=4} drbg1 (nist_aes128_reference_entropy_hex @ (3 * n + 1)) True
     ((bits_out, drbg3) : ([512], s2n_drbg)) =
-      drbg_generate drbg2 (nist_aes128_reference_entropy_hex @ (3 * n + 2)) True
+      drbg_generate`{blocks=4} drbg2 (nist_aes128_reference_entropy_hex @ (3 * n + 2)) True
 
 property drbg_tests_pass =
   ~zero == [ test_drbg n | n <- [0 .. 14] ]

--- a/tests/saw/spec/handshake/rfc_handshake_tls13.cry
+++ b/tests/saw/spec/handshake/rfc_handshake_tls13.cry
@@ -121,12 +121,12 @@ doHandshake params = (foldl doState initialHandshake (take`{n} (stateMachine par
                              then updateHandshake hs action.message
                              else hs
         updateHandshake hs value = {
-            messages = update`{ix=(width n)} hs.messages hs.index value,
+            messages = update hs.messages hs.index value,
             index = hs.index + 1
         }
         initialHandshake = {
             messages = repeat { messageType = applicationData, sender = both },
-            index = zero
+            index = 0:[width n]
         }
 
 /*


### PR DESCRIPTION
### Description of changes: 

The changes to tls13 make the spec forward-compatible with pending Cryptol changes. This should help prevent disruption when SAW versions are eventually updated.

The DRBG_properties file also needed some minor changes; it apparently was already several Cryptol versions behind.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
