### PR TITLE
Adds a proof harness for s2n_stuffer_reserve_space

### DIFF
--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -332,7 +332,7 @@ int s2n_stuffer_reserve_space(struct s2n_stuffer *stuffer, uint32_t n)
     if (s2n_stuffer_space_remaining(stuffer) < n) {
         S2N_ERROR_IF(!stuffer->growable, S2N_ERR_STUFFER_IS_FULL);
         /* Always grow a stuffer by at least 1k */
-        const uint32_t growth = MAX(n - s2n_stuffer_space_remaining(stuffer), 1024);
+        const uint32_t growth = MAX(n - s2n_stuffer_space_remaining(stuffer), S2N_MIN_STUFFER_GROWTH_IN_BYTES);
         uint32_t new_size = 0;
         GUARD(s2n_add_overflow(stuffer->blob.size, growth, &new_size));
         GUARD(s2n_stuffer_resize(stuffer, new_size));

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -328,6 +328,7 @@ static int s2n_stuffer_copy_impl(struct s2n_stuffer *from, struct s2n_stuffer *t
 
 int s2n_stuffer_reserve_space(struct s2n_stuffer *stuffer, uint32_t n)
 {
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     if (s2n_stuffer_space_remaining(stuffer) < n) {
         S2N_ERROR_IF(!stuffer->growable, S2N_ERR_STUFFER_IS_FULL);
         /* Always grow a stuffer by at least 1k */
@@ -336,6 +337,7 @@ int s2n_stuffer_reserve_space(struct s2n_stuffer *stuffer, uint32_t n)
         GUARD(s2n_add_overflow(stuffer->blob.size, growth, &new_size));
         GUARD(s2n_stuffer_resize(stuffer, new_size));
     }
+    POSTCONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     return S2N_SUCCESS;
 }
 

--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -22,6 +22,8 @@
 
 #include "utils/s2n_blob.h"
 
+#define S2N_MIN_STUFFER_GROWTH_IN_BYTES 1024
+
 /* Using a non-zero value
  * (a) makes wiped data easy to see in the debugger
  * (b) makes use of wiped data obvious since this is unlikely to be a valid bit pattern

--- a/tests/cbmc/proofs/s2n_stuffer_reserve_space/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve_space/Makefile
@@ -1,0 +1,39 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 20 seconds.
+
+ABSTRACTIONS += $(HELPERDIR)/stubs/s2n_calculate_stacktrace.c
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/error/s2n_errno.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+
+ENTRY = s2n_stuffer_reserve_space_harness
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_blob_slice
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_calculate_stacktrace
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_stuffer_wipe_n
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_reserve_space/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve_space/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_reserve_space/s2n_stuffer_reserve_space_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve_space/s2n_stuffer_reserve_space_harness.c
@@ -52,6 +52,11 @@ void s2n_stuffer_reserve_space_harness() {
             assert_stuffer_equivalence(stuffer, &old_stuffer, &old_byte_from_stuffer);
         }
     } else {
+        /*
+         * s2n_realloc could fail, so we can onyl guarantee equivalence of
+         * data pointer, but not the elements in it.
+         */
+        assert(stuffer->blob.data == old_stuffer.blob.data);
         assert(stuffer->blob.size == old_stuffer.blob.size);
         assert(stuffer->write_cursor == old_stuffer.write_cursor);
         assert(stuffer->high_water_mark == old_stuffer.high_water_mark);

--- a/tests/cbmc/proofs/s2n_stuffer_reserve_space/s2n_stuffer_reserve_space_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve_space/s2n_stuffer_reserve_space_harness.c
@@ -45,7 +45,7 @@ void s2n_stuffer_reserve_space_harness() {
         assert(s2n_stuffer_is_valid(stuffer));
         if(s2n_stuffer_space_remaining(&old_stuffer) < size) {
             /* Always grow a stuffer by at least 1k */
-            assert(stuffer->blob.size == (MAX(size - s2n_stuffer_space_remaining(&old_stuffer), 1024) +
+            assert(stuffer->blob.size == (MAX(size - s2n_stuffer_space_remaining(&old_stuffer), S2N_MIN_STUFFER_GROWTH_IN_BYTES) +
                                           old_stuffer.blob.size));
             assert(stuffer->blob.allocated >= size);
         } else {

--- a/tests/cbmc/proofs/s2n_stuffer_reserve_space/s2n_stuffer_reserve_space_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve_space/s2n_stuffer_reserve_space_harness.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_mem.h"
+
+#include <sys/param.h>
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_stuffer_reserve_space_harness() {
+    /* Non-deterministic inputs. */
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    uint32_t size;
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    /* Save previous state. */
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_blob(&stuffer->blob, &old_byte);
+
+    /* Operation under verification. */
+    if (s2n_stuffer_reserve_space(stuffer, size) == S2N_SUCCESS) {
+        assert(s2n_stuffer_is_valid(stuffer));
+        if(s2n_stuffer_space_remaining(stuffer) < size) {
+            assert(stuffer->blob.size == MAX(size - s2n_stuffer_space_remaining(stuffer), 1024));
+            assert(stuffer->blob.allocated >= size);
+        }
+    } else {
+        assert(stuffer->blob.size == old_stuffer.blob.size);
+        assert(stuffer->write_cursor == old_stuffer.write_cursor);
+        assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+        assert(stuffer->alloced == old_stuffer.alloced);
+        assert(stuffer->growable == old_stuffer.growable);
+        assert(stuffer->tainted == old_stuffer.tainted);
+    }
+}


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A.

### Description of changes: 

- Adds a proof harness for the `s2n_stuffer_reserve_space` function;
- Adds a pre- and post-conditions to the `s2n_stuffer_reserve_space` function;

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.