### PR TITLE
Removes s2n_stuffer_release_if_empty function

### DIFF
--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -151,8 +151,7 @@ int s2n_stuffer_wipe_n(struct s2n_stuffer *stuffer, const uint32_t size)
 }
 
 bool s2n_stuffer_is_consumed(struct s2n_stuffer *stuffer) {
-      PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
-      return (stuffer->read_cursor == stuffer->write_cursor);
+      return stuffer && (stuffer->read_cursor == stuffer->write_cursor);
 }
 
 int s2n_stuffer_wipe(struct s2n_stuffer *stuffer)

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -150,19 +150,9 @@ int s2n_stuffer_wipe_n(struct s2n_stuffer *stuffer, const uint32_t size)
     return S2N_SUCCESS;
 }
 
-int s2n_stuffer_release_if_empty(struct s2n_stuffer *stuffer)
-{
-    if (stuffer->blob.data == NULL) {
-        return S2N_SUCCESS;
-    }
-
-    S2N_ERROR_IF(stuffer->read_cursor != stuffer->write_cursor,
-            S2N_ERR_STUFFER_HAS_UNPROCESSED_DATA);
-
-    GUARD(s2n_stuffer_wipe(stuffer));
-    GUARD(s2n_stuffer_resize(stuffer, 0));
-
-    return S2N_SUCCESS;
+bool s2n_stuffer_is_consumed(struct s2n_stuffer *stuffer) {
+      PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
+      return (stuffer->read_cursor == stuffer->write_cursor);
 }
 
 int s2n_stuffer_wipe(struct s2n_stuffer *stuffer)

--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -73,7 +73,6 @@ extern int s2n_stuffer_reread(struct s2n_stuffer *stuffer);
 extern int s2n_stuffer_rewrite(struct s2n_stuffer *stuffer);
 extern int s2n_stuffer_wipe(struct s2n_stuffer *stuffer);
 extern int s2n_stuffer_wipe_n(struct s2n_stuffer *stuffer, const uint32_t n);
-extern int s2n_stuffer_release_if_consumed(struct s2n_stuffer *stuffer);
 extern bool s2n_stuffer_is_consumed(struct s2n_stuffer *stuffer);
 
 /* Basic read and write */

--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -73,7 +73,8 @@ extern int s2n_stuffer_reread(struct s2n_stuffer *stuffer);
 extern int s2n_stuffer_rewrite(struct s2n_stuffer *stuffer);
 extern int s2n_stuffer_wipe(struct s2n_stuffer *stuffer);
 extern int s2n_stuffer_wipe_n(struct s2n_stuffer *stuffer, const uint32_t n);
-extern int s2n_stuffer_release_if_empty(struct s2n_stuffer *stuffer);
+extern int s2n_stuffer_release_if_consumed(struct s2n_stuffer *stuffer);
+extern bool s2n_stuffer_is_consumed(struct s2n_stuffer *stuffer);
 
 /* Basic read and write */
 extern int s2n_stuffer_read(struct s2n_stuffer *stuffer, struct s2n_blob *out);

--- a/tests/cbmc/proofs/s2n_stuffer_is_consumed/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_is_consumed/Makefile
@@ -1,0 +1,35 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+
+CBMCFLAGS +=
+
+HARNESS_ENTRY = s2n_stuffer_is_consumed_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+
+PROJECT_SOURCES += $(SRCDIR)/error/s2n_errno.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += s2n_calculate_stacktrace
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_is_consumed/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_is_consumed/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_is_consumed/s2n_stuffer_is_consumed_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_is_consumed/s2n_stuffer_is_consumed_harness.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_stuffer_is_consumed_harness() {
+    /* Non-deterministic inputs. */
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+
+    /* Save previous state. */
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    /* Operation under verification. */
+    if (s2n_stuffer_is_consumed(stuffer)) {
+        assert(stuffer->read_cursor == old_stuffer.write_cursor);
+    } else {
+        assert(stuffer->read_cursor != old_stuffer.write_cursor);
+    }
+
+    /* Post-conditions. */
+    assert(s2n_stuffer_is_valid(stuffer));
+    assert_stuffer_equivalence(stuffer, &old_stuffer, &old_byte_from_stuffer);
+}

--- a/tests/cbmc/proofs/s2n_stuffer_resize_if_empty/s2n_stuffer_resize_if_empty_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_resize_if_empty/s2n_stuffer_resize_if_empty_harness.c
@@ -15,6 +15,7 @@
 
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_mem.h"
 
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/proof_allocators.h>

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -538,12 +538,11 @@ int s2n_connection_release_buffers(struct s2n_connection *conn)
     PRECONDITION_POSIX(s2n_stuffer_is_valid(&conn->out));
     PRECONDITION_POSIX(s2n_stuffer_is_valid(&conn->in));
 
-    if(s2n_stuffer_is_consumed(&conn->out)) {
-        GUARD(s2n_stuffer_resize(&conn->out, 0));
-    }
-    if(s2n_stuffer_is_consumed(&conn->in)) {
-        GUARD(s2n_stuffer_resize(&conn->in, 0));
-    }
+    ENSURE_POSIX(s2n_stuffer_is_consumed(&conn->out), S2N_ERR_STUFFER_HAS_UNPROCESSED_DATA);
+    GUARD(s2n_stuffer_resize(&conn->out, 0));
+
+    ENSURE_POSIX(s2n_stuffer_is_consumed(&conn->in), S2N_ERR_STUFFER_HAS_UNPROCESSED_DATA);
+    GUARD(s2n_stuffer_resize(&conn->in, 0));
 
     POSTCONDITION_POSIX(s2n_stuffer_is_valid(&conn->out));
     POSTCONDITION_POSIX(s2n_stuffer_is_valid(&conn->in));

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -538,10 +538,10 @@ int s2n_connection_release_buffers(struct s2n_connection *conn)
     PRECONDITION_POSIX(s2n_stuffer_is_valid(&conn->out));
     PRECONDITION_POSIX(s2n_stuffer_is_valid(&conn->in));
 
-    if(conn->out.blob.data != NULL && s2n_stuffer_is_consumed(&conn->out)) {
+    if(s2n_stuffer_is_consumed(&conn->out)) {
         GUARD(s2n_stuffer_resize(&conn->out, 0));
     }
-    if(conn->in.blob.data != NULL && s2n_stuffer_is_consumed(&conn->in)) {
+    if(s2n_stuffer_is_consumed(&conn->in)) {
         GUARD(s2n_stuffer_resize(&conn->in, 0));
     }
 


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

#2091 

### Description of changes: 

- Removes `s2n_stuffer_release_if_empty` (based on this [comment](https://github.com/awslabs/s2n/pull/2036#issuecomment-652623558));
- Adds a new `s2n_stuffer_is_consumed` function;
- Adds a proof harness for the `s2n_stuffer_is_consumed` function;
- Adds a pre- and post-conditions to `s2n_connection_release_buffers` function;

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.