### PR TITLE
Adds a proof for s2n_stuffer_skip_whitespace

### DIFF
--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -142,7 +142,7 @@ extern int s2n_stuffer_peek_char(struct s2n_stuffer *stuffer, char *c);
 extern int s2n_stuffer_read_token(struct s2n_stuffer *stuffer, struct s2n_stuffer *token, char delim);
 extern int s2n_stuffer_read_line(struct s2n_stuffer *stuffer, struct s2n_stuffer *token);
 extern int s2n_stuffer_peek_check_for_str(struct s2n_stuffer *s2n_stuffer, const char *expected);
-extern int s2n_stuffer_skip_whitespace(struct s2n_stuffer *stuffer);
+extern int s2n_stuffer_skip_whitespace(struct s2n_stuffer *stuffer, uint32_t *skipped);
 extern int s2n_stuffer_skip_to_char(struct s2n_stuffer *stuffer, char target);
 extern int s2n_stuffer_skip_expected_char(struct s2n_stuffer *stuffer, const char expected, const uint32_t min, const uint32_t max, uint32_t *skipped);
 extern int s2n_stuffer_skip_read_until(struct s2n_stuffer *stuffer, const char* target);

--- a/stuffer/s2n_stuffer_pem.c
+++ b/stuffer/s2n_stuffer_pem.c
@@ -58,7 +58,7 @@ static int s2n_stuffer_pem_read_encapsulation_line(struct s2n_stuffer *pem, cons
     }
 
     /* Skip newlines and other whitepsace that may be after the dashes */
-    GUARD(s2n_stuffer_skip_whitespace(pem));
+    GUARD(s2n_stuffer_skip_whitespace(pem, NULL));
     return 0;
 }
 

--- a/stuffer/s2n_stuffer_text.c
+++ b/stuffer/s2n_stuffer_text.c
@@ -55,11 +55,10 @@ int s2n_stuffer_skip_whitespace(struct s2n_stuffer *s2n_stuffer, uint32_t *skipp
             skip += 1;
             break;
         default:
-            if(skipped != NULL) *skipped = skip;
-            POSTCONDITION_POSIX(s2n_stuffer_is_valid(s2n_stuffer));
-            return S2N_SUCCESS;
+            goto finished;
         }
     }
+    finished:
     if(skipped != NULL) *skipped = skip;
     POSTCONDITION_POSIX(s2n_stuffer_is_valid(s2n_stuffer));
     return S2N_SUCCESS;

--- a/stuffer/s2n_stuffer_text.c
+++ b/stuffer/s2n_stuffer_text.c
@@ -43,6 +43,7 @@ int s2n_stuffer_peek_check_for_str(struct s2n_stuffer *s2n_stuffer, const char *
 
 int s2n_stuffer_skip_whitespace(struct s2n_stuffer *s2n_stuffer)
 {
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(s2n_stuffer));
     int skipped = 0;
     while (s2n_stuffer->read_cursor < s2n_stuffer->write_cursor) {
         switch (s2n_stuffer->blob.data[s2n_stuffer->read_cursor]) {
@@ -54,10 +55,11 @@ int s2n_stuffer_skip_whitespace(struct s2n_stuffer *s2n_stuffer)
             skipped += 1;
             break;
         default:
+            POSTCONDITION_POSIX(s2n_stuffer_is_valid(s2n_stuffer));
             return skipped;
         }
     }
-
+    POSTCONDITION_POSIX(s2n_stuffer_is_valid(s2n_stuffer));
     return skipped;
 }
 

--- a/stuffer/s2n_stuffer_text.c
+++ b/stuffer/s2n_stuffer_text.c
@@ -44,7 +44,7 @@ int s2n_stuffer_peek_check_for_str(struct s2n_stuffer *s2n_stuffer, const char *
 int s2n_stuffer_skip_whitespace(struct s2n_stuffer *s2n_stuffer, uint32_t *skipped)
 {
     PRECONDITION_POSIX(s2n_stuffer_is_valid(s2n_stuffer));
-    uint32_t skip = 0;
+    uint32_t initial_read_cursor = s2n_stuffer->read_cursor;
     while (s2n_stuffer->read_cursor < s2n_stuffer->write_cursor) {
         switch (s2n_stuffer->blob.data[s2n_stuffer->read_cursor]) {
         case ' ':              /* We don't use isspace, because it changes under locales */
@@ -52,14 +52,13 @@ int s2n_stuffer_skip_whitespace(struct s2n_stuffer *s2n_stuffer, uint32_t *skipp
         case '\n':
         case '\r':
             s2n_stuffer->read_cursor += 1;
-            skip += 1;
             break;
         default:
             goto finished;
         }
     }
     finished:
-    if(skipped != NULL) *skipped = skip;
+    if(skipped != NULL) *skipped = s2n_stuffer->read_cursor - initial_read_cursor;
     POSTCONDITION_POSIX(s2n_stuffer_is_valid(s2n_stuffer));
     return S2N_SUCCESS;
 }

--- a/stuffer/s2n_stuffer_text.c
+++ b/stuffer/s2n_stuffer_text.c
@@ -41,10 +41,10 @@ int s2n_stuffer_peek_check_for_str(struct s2n_stuffer *s2n_stuffer, const char *
     return rc;
 }
 
-int s2n_stuffer_skip_whitespace(struct s2n_stuffer *s2n_stuffer)
+int s2n_stuffer_skip_whitespace(struct s2n_stuffer *s2n_stuffer, uint32_t *skipped)
 {
     PRECONDITION_POSIX(s2n_stuffer_is_valid(s2n_stuffer));
-    int skipped = 0;
+    uint32_t skip = 0;
     while (s2n_stuffer->read_cursor < s2n_stuffer->write_cursor) {
         switch (s2n_stuffer->blob.data[s2n_stuffer->read_cursor]) {
         case ' ':              /* We don't use isspace, because it changes under locales */
@@ -52,15 +52,17 @@ int s2n_stuffer_skip_whitespace(struct s2n_stuffer *s2n_stuffer)
         case '\n':
         case '\r':
             s2n_stuffer->read_cursor += 1;
-            skipped += 1;
+            skip += 1;
             break;
         default:
+            if(skipped != NULL) *skipped = skip;
             POSTCONDITION_POSIX(s2n_stuffer_is_valid(s2n_stuffer));
-            return skipped;
+            return S2N_SUCCESS;
         }
     }
+    if(skipped != NULL) *skipped = skip;
     POSTCONDITION_POSIX(s2n_stuffer_is_valid(s2n_stuffer));
-    return skipped;
+    return S2N_SUCCESS;
 }
 
 int s2n_stuffer_read_expected_str(struct s2n_stuffer *stuffer, const char *expected)

--- a/tests/cbmc/proofs/s2n_stuffer_skip_whitespace/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_whitespace/Makefile
@@ -1,0 +1,31 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enough to get full coverage with 4 minutes of runtime.
+BLOB_SIZE = 2
+DEFINES += -DBLOB_SIZE=$(BLOB_SIZE)
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+
+ENTRY = s2n_stuffer_skip_whitespace_harness
+
+UNWINDSET += s2n_stuffer_skip_whitespace.6:$(call addone,$(BLOB_SIZE))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_skip_whitespace/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_whitespace/Makefile
@@ -12,20 +12,23 @@
 # limitations under the License.
 
 # Enough to get full coverage with 4 minutes of runtime.
-BLOB_SIZE = 2
-DEFINES += -DBLOB_SIZE=$(BLOB_SIZE)
+MAX_BLOB_SIZE = 2
+DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
 
-CBMCFLAGS +=
+CHECKFLAGS +=
 
-DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
-DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
-DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
-DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
-DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
-DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+HARNESS_ENTRY = s2n_stuffer_skip_whitespace_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
 
-ENTRY = s2n_stuffer_skip_whitespace_harness
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
 
-UNWINDSET += s2n_stuffer_skip_whitespace.6:$(call addone,$(BLOB_SIZE))
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+
+UNWINDSET += s2n_stuffer_skip_whitespace.6:$(call addone,$(MAX_BLOB_SIZE))
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_skip_whitespace/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_whitespace/Makefile
@@ -29,6 +29,12 @@ PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
 PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
 
+UNWINDSET += s2n_stuffer_skip_whitespace.0:$(call addone,$(MAX_BLOB_SIZE))
+UNWINDSET += s2n_stuffer_skip_whitespace.1:$(call addone,$(MAX_BLOB_SIZE))
+UNWINDSET += s2n_stuffer_skip_whitespace.2:$(call addone,$(MAX_BLOB_SIZE))
+UNWINDSET += s2n_stuffer_skip_whitespace.3:$(call addone,$(MAX_BLOB_SIZE))
+UNWINDSET += s2n_stuffer_skip_whitespace.4:$(call addone,$(MAX_BLOB_SIZE))
+UNWINDSET += s2n_stuffer_skip_whitespace.5:$(call addone,$(MAX_BLOB_SIZE))
 UNWINDSET += s2n_stuffer_skip_whitespace.6:$(call addone,$(MAX_BLOB_SIZE))
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_skip_whitespace/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_whitespace/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_skip_whitespace/s2n_stuffer_skip_whitespace_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_whitespace/s2n_stuffer_skip_whitespace_harness.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_skip_whitespace_harness() {
+    /* Non-deterministic inputs. */
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    __CPROVER_assume(s2n_blob_is_bounded(&stuffer->blob, BLOB_SIZE));
+
+    /* Save previous state from stuffer. */
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    /* Operation under verification. */
+    int skipped = s2n_stuffer_skip_whitespace(stuffer);
+    if (skipped > 0) {
+        assert_stuffer_immutable_fields_after_read(stuffer, &old_stuffer, &old_byte_from_stuffer);
+        assert(stuffer->read_cursor == old_stuffer.read_cursor + skipped);
+    } else {
+        assert_stuffer_equivalence(stuffer, &old_stuffer, &old_byte_from_stuffer);
+    }
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_skip_whitespace/s2n_stuffer_skip_whitespace_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_whitespace/s2n_stuffer_skip_whitespace_harness.c
@@ -35,14 +35,20 @@ void s2n_stuffer_skip_whitespace_harness() {
 
     /* Operation under verification. */
     if(s2n_stuffer_skip_whitespace(stuffer, &skipped) == S2N_SUCCESS) {
+        size_t index;
         if (skipped > 0) {
             assert(stuffer->read_cursor == old_stuffer.read_cursor + skipped);
-            size_t index;
             __CPROVER_assume(index >= old_stuffer.read_cursor && index < stuffer->read_cursor);
             assert(stuffer->blob.data[index] == ' '  ||
                    stuffer->blob.data[index] == '\t' ||
                    stuffer->blob.data[index] == '\n' ||
                    stuffer->blob.data[index] == '\r');
+        } else {
+            assert((stuffer->read_cursor >= stuffer->write_cursor) ||
+                   (stuffer->blob.data[old_stuffer.read_cursor] != ' '  &&
+                    stuffer->blob.data[old_stuffer.read_cursor] != '\t' &&
+                    stuffer->blob.data[old_stuffer.read_cursor] != '\n' &&
+                    stuffer->blob.data[old_stuffer.read_cursor] != '\r'));
         }
     }
     assert_stuffer_immutable_fields_after_read(stuffer, &old_stuffer, &old_byte_from_stuffer);

--- a/tests/unit/s2n_stuffer_text_test.c
+++ b/tests/unit/s2n_stuffer_text_test.c
@@ -23,6 +23,7 @@
 int main(int argc, char **argv)
 {
     char c;
+    uint32_t skipped = 0;
     struct s2n_stuffer stuffer, token;
     struct s2n_blob pad_blob, token_blob;
     char text[] = "    This is some text\r\n\tmore text";
@@ -43,7 +44,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_write_text(&stuffer, text, sizeof(text)));
 
         /* Skip 4 bytes of whitespace */
-        EXPECT_EQUAL(s2n_stuffer_skip_whitespace(&stuffer), 4);
+        EXPECT_SUCCESS(s2n_stuffer_skip_whitespace(&stuffer, &skipped));
+        EXPECT_EQUAL(skipped, 4);
         EXPECT_SUCCESS(s2n_stuffer_peek_char(&stuffer, &c));
         EXPECT_EQUAL(c, 'T');
 
@@ -52,14 +54,15 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(memcmp(out, "This is some text", 17), 0);
 
         /* Skip 3 bytes of whitespace */
-        EXPECT_EQUAL(s2n_stuffer_skip_whitespace(&stuffer), 3);
+        EXPECT_SUCCESS(s2n_stuffer_skip_whitespace(&stuffer, &skipped));
+        EXPECT_EQUAL(skipped, 3);
 
         /* Read the next 10 chars (including the terminating zero) */
         EXPECT_SUCCESS(s2n_stuffer_read_text(&stuffer, out, 10));
         EXPECT_EQUAL(memcmp(out, "more text", 10), 0);
 
         /* Test end of stream behaviour */
-        EXPECT_SUCCESS(s2n_stuffer_skip_whitespace(&stuffer));
+        EXPECT_SUCCESS(s2n_stuffer_skip_whitespace(&stuffer, NULL));
         EXPECT_FAILURE(s2n_stuffer_peek_char(&stuffer, &c));
         EXPECT_FAILURE(s2n_stuffer_read_char(&stuffer, &c));
     }


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A.

### Description of changes: 

- Adds a proof harness for the `s2n_stuffer_skip_whitespace` function;
- Adds a pre- and post-conditions to the `s2n_stuffer_skip_whitespace` function;

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.