### PR TITLE
Adds a proof harness for s2n_stuffer_skip_to_char

### DIFF
--- a/stuffer/s2n_stuffer_text.c
+++ b/stuffer/s2n_stuffer_text.c
@@ -103,8 +103,8 @@ int s2n_stuffer_skip_to_char(struct s2n_stuffer *stuffer, const char target)
         }
         stuffer->read_cursor += 1;
     }
-
-    return 0;
+    POSTCONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
+    return S2N_SUCCESS;
 }
 
 /* Skips an expected character in the stuffer between min and max times */

--- a/tests/cbmc/proofs/s2n_stuffer_skip_to_char/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_to_char/Makefile
@@ -1,0 +1,33 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enough to get full coverage with 40 seconds of runtime.
+BLOB_SIZE = 10
+DEFINES += -DBLOB_SIZE=$(BLOB_SIZE)
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
+
+ENTRY = s2n_stuffer_skip_to_char_harness
+
+UNWINDSET += s2n_stuffer_skip_to_char.5:$(call addone,$(BLOB_SIZE))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_skip_to_char/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_to_char/Makefile
@@ -15,19 +15,20 @@
 BLOB_SIZE = 10
 DEFINES += -DBLOB_SIZE=$(BLOB_SIZE)
 
-CBMCFLAGS +=
+HARNESS_ENTRY = s2n_stuffer_skip_to_char_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
 
-DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
-DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
-DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
-DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
-DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
-DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
-DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
-DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
 
-ENTRY = s2n_stuffer_skip_to_char_harness
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
 
-UNWINDSET += s2n_stuffer_skip_to_char.5:$(call addone,$(BLOB_SIZE))
+UNWINDSET += s2n_stuffer_skip_to_char.3:$(call addone,$(BLOB_SIZE))
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_skip_to_char/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_to_char/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_skip_to_char/s2n_stuffer_skip_to_char_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_to_char/s2n_stuffer_skip_to_char_harness.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_skip_to_char_harness() {
+    /* Non-deterministic inputs. */
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    __CPROVER_assume(s2n_blob_is_bounded(&stuffer->blob, BLOB_SIZE));
+    const char target;
+
+    /* Save previous state from stuffer. */
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    /* Operation under verification. */
+    if (s2n_stuffer_skip_to_char(stuffer, target) == S2N_SUCCESS) {
+        if(s2n_stuffer_data_available(&old_stuffer) == 0) {
+            assert(stuffer->read_cursor == old_stuffer.read_cursor);
+        } else if (s2n_stuffer_data_available(stuffer) == 0) {
+            size_t index;
+            __CPROVER_assume(index >= old_stuffer.read_cursor && index < old_stuffer.write_cursor);
+            assert(stuffer->blob.data[index] != *((uint8_t *)(&target)));
+        } else {
+            assert(stuffer->blob.data[stuffer->read_cursor] == *((uint8_t *)(&target)));
+        }
+    }
+    assert_stuffer_immutable_fields_after_read(stuffer, &old_stuffer, &old_byte_from_stuffer);
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_skip_to_char/s2n_stuffer_skip_to_char_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_to_char/s2n_stuffer_skip_to_char_harness.c
@@ -37,12 +37,9 @@ void s2n_stuffer_skip_to_char_harness() {
     if (s2n_stuffer_skip_to_char(stuffer, target) == S2N_SUCCESS) {
         if(s2n_stuffer_data_available(&old_stuffer) == 0) {
             assert(stuffer->read_cursor == old_stuffer.read_cursor);
-        } else if (s2n_stuffer_data_available(stuffer) == 0) {
             size_t index;
             __CPROVER_assume(index >= old_stuffer.read_cursor && index < old_stuffer.write_cursor);
             assert(stuffer->blob.data[index] != *((uint8_t *)(&target)));
-        } else {
-            assert(stuffer->blob.data[stuffer->read_cursor] == *((uint8_t *)(&target)));
         }
     }
     assert_stuffer_immutable_fields_after_read(stuffer, &old_stuffer, &old_byte_from_stuffer);

--- a/tests/cbmc/proofs/s2n_stuffer_skip_to_char/s2n_stuffer_skip_to_char_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_to_char/s2n_stuffer_skip_to_char_harness.c
@@ -14,6 +14,7 @@
  */
 
 #include "api/s2n.h"
+#include "error/s2n_errno.h"
 #include "stuffer/s2n_stuffer.h"
 
 #include <assert.h>
@@ -35,11 +36,9 @@ void s2n_stuffer_skip_to_char_harness() {
 
     /* Operation under verification. */
     if (s2n_stuffer_skip_to_char(stuffer, target) == S2N_SUCCESS) {
-        if(s2n_stuffer_data_available(&old_stuffer) == 0) {
-            assert(stuffer->read_cursor == old_stuffer.read_cursor);
-            size_t index;
-            __CPROVER_assume(index >= old_stuffer.read_cursor && index < old_stuffer.write_cursor);
-            assert(stuffer->blob.data[index] != *((uint8_t *)(&target)));
+        assert(S2N_IMPLIES(s2n_stuffer_data_available(&old_stuffer) == 0, stuffer->read_cursor == old_stuffer.read_cursor));
+        if(s2n_stuffer_data_available(stuffer) > 0) {
+            assert(stuffer->blob.data[stuffer->read_cursor] == target);
         }
     }
     assert_stuffer_immutable_fields_after_read(stuffer, &old_stuffer, &old_byte_from_stuffer);

--- a/tests/cbmc/proofs/s2n_stuffer_skip_to_char/s2n_stuffer_skip_to_char_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_to_char/s2n_stuffer_skip_to_char_harness.c
@@ -39,6 +39,9 @@ void s2n_stuffer_skip_to_char_harness() {
         assert(S2N_IMPLIES(s2n_stuffer_data_available(&old_stuffer) == 0, stuffer->read_cursor == old_stuffer.read_cursor));
         if(s2n_stuffer_data_available(stuffer) > 0) {
             assert(stuffer->blob.data[stuffer->read_cursor] == target);
+            size_t index;
+            __CPROVER_assume(index >= old_stuffer.read_cursor && index < stuffer->read_cursor);
+            assert(stuffer->blob.data[index] != target);
         }
     }
     assert_stuffer_immutable_fields_after_read(stuffer, &old_stuffer, &old_byte_from_stuffer);


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A.

### Description of changes: 

- Adds a proof harness for the `s2n_stuffer_skip_to_char` function;
- Adds a pre- and post-conditions to the `s2n_stuffer_skip_to_char` function;

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.