### PR TITLE
Adds a proof for s2n_stuffer_skip_expected_char

### DIFF
--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -144,7 +144,7 @@ extern int s2n_stuffer_read_line(struct s2n_stuffer *stuffer, struct s2n_stuffer
 extern int s2n_stuffer_peek_check_for_str(struct s2n_stuffer *s2n_stuffer, const char *expected);
 extern int s2n_stuffer_skip_whitespace(struct s2n_stuffer *stuffer);
 extern int s2n_stuffer_skip_to_char(struct s2n_stuffer *stuffer, char target);
-extern int s2n_stuffer_skip_expected_char(struct s2n_stuffer *stuffer, const char expected, const int min, const int max);
+extern int s2n_stuffer_skip_expected_char(struct s2n_stuffer *stuffer, const char expected, const unsigned int min, const unsigned int max, unsigned int *skipped);
 extern int s2n_stuffer_skip_read_until(struct s2n_stuffer *stuffer, const char* target);
 extern int s2n_stuffer_alloc_ro_from_string(struct s2n_stuffer *stuffer, const char *str);
 

--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -144,7 +144,7 @@ extern int s2n_stuffer_read_line(struct s2n_stuffer *stuffer, struct s2n_stuffer
 extern int s2n_stuffer_peek_check_for_str(struct s2n_stuffer *s2n_stuffer, const char *expected);
 extern int s2n_stuffer_skip_whitespace(struct s2n_stuffer *stuffer);
 extern int s2n_stuffer_skip_to_char(struct s2n_stuffer *stuffer, char target);
-extern int s2n_stuffer_skip_expected_char(struct s2n_stuffer *stuffer, const char expected, const unsigned int min, const unsigned int max, unsigned int *skipped);
+extern int s2n_stuffer_skip_expected_char(struct s2n_stuffer *stuffer, const char expected, const uint32_t min, const uint32_t max, uint32_t *skipped);
 extern int s2n_stuffer_skip_read_until(struct s2n_stuffer *stuffer, const char* target);
 extern int s2n_stuffer_alloc_ro_from_string(struct s2n_stuffer *stuffer, const char *str);
 

--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -144,7 +144,7 @@ extern int s2n_stuffer_read_line(struct s2n_stuffer *stuffer, struct s2n_stuffer
 extern int s2n_stuffer_peek_check_for_str(struct s2n_stuffer *s2n_stuffer, const char *expected);
 extern int s2n_stuffer_skip_whitespace(struct s2n_stuffer *stuffer);
 extern int s2n_stuffer_skip_to_char(struct s2n_stuffer *stuffer, char target);
-extern int s2n_stuffer_skip_expected_char(struct s2n_stuffer *stuffer, const char expected, int min, int max);
+extern int s2n_stuffer_skip_expected_char(struct s2n_stuffer *stuffer, const char expected, const int min, const int max);
 extern int s2n_stuffer_skip_read_until(struct s2n_stuffer *stuffer, const char* target);
 extern int s2n_stuffer_alloc_ro_from_string(struct s2n_stuffer *stuffer, const char *str);
 

--- a/stuffer/s2n_stuffer_pem.c
+++ b/stuffer/s2n_stuffer_pem.c
@@ -38,9 +38,8 @@ static int s2n_stuffer_pem_read_encapsulation_line(struct s2n_stuffer *pem, cons
     /* Skip any number of Chars until a "-" is reached */
     GUARD(s2n_stuffer_skip_to_char(pem, S2N_PEM_DELIMTER_CHAR));
 
-    unsigned int skipped = 0;
     /* Ensure between 1 and 64 '-' chars at start of line */
-    GUARD(s2n_stuffer_skip_expected_char(pem, S2N_PEM_DELIMTER_CHAR, S2N_PEM_DELIMITER_MIN_COUNT, S2N_PEM_DELIMITER_MAX_COUNT, &skipped));
+    GUARD(s2n_stuffer_skip_expected_char(pem, S2N_PEM_DELIMTER_CHAR, S2N_PEM_DELIMITER_MIN_COUNT, S2N_PEM_DELIMITER_MAX_COUNT, NULL));
 
     /* Ensure next string in stuffer is "BEGIN " or "END " */
     GUARD(s2n_stuffer_read_expected_str(pem, encap_marker));
@@ -49,7 +48,7 @@ static int s2n_stuffer_pem_read_encapsulation_line(struct s2n_stuffer *pem, cons
     GUARD(s2n_stuffer_read_expected_str(pem, keyword));
 
     /* Ensure between 1 and 64 '-' chars at end of line */
-    GUARD(s2n_stuffer_skip_expected_char(pem, S2N_PEM_DELIMTER_CHAR, S2N_PEM_DELIMITER_MIN_COUNT, S2N_PEM_DELIMITER_MAX_COUNT, &skipped));
+    GUARD(s2n_stuffer_skip_expected_char(pem, S2N_PEM_DELIMTER_CHAR, S2N_PEM_DELIMITER_MIN_COUNT, S2N_PEM_DELIMITER_MAX_COUNT, NULL));
 
     /* Check for missing newline between dashes case: "-----END CERTIFICATE----------BEGIN CERTIFICATE-----" */
     if (strncmp(encap_marker, S2N_PEM_END_TOKEN, strlen(S2N_PEM_END_TOKEN)) == 0

--- a/stuffer/s2n_stuffer_pem.c
+++ b/stuffer/s2n_stuffer_pem.c
@@ -38,8 +38,9 @@ static int s2n_stuffer_pem_read_encapsulation_line(struct s2n_stuffer *pem, cons
     /* Skip any number of Chars until a "-" is reached */
     GUARD(s2n_stuffer_skip_to_char(pem, S2N_PEM_DELIMTER_CHAR));
 
+    unsigned int skipped = 0;
     /* Ensure between 1 and 64 '-' chars at start of line */
-    GUARD(s2n_stuffer_skip_expected_char(pem, S2N_PEM_DELIMTER_CHAR, S2N_PEM_DELIMITER_MIN_COUNT, S2N_PEM_DELIMITER_MAX_COUNT));
+    GUARD(s2n_stuffer_skip_expected_char(pem, S2N_PEM_DELIMTER_CHAR, S2N_PEM_DELIMITER_MIN_COUNT, S2N_PEM_DELIMITER_MAX_COUNT, &skipped));
 
     /* Ensure next string in stuffer is "BEGIN " or "END " */
     GUARD(s2n_stuffer_read_expected_str(pem, encap_marker));
@@ -48,7 +49,7 @@ static int s2n_stuffer_pem_read_encapsulation_line(struct s2n_stuffer *pem, cons
     GUARD(s2n_stuffer_read_expected_str(pem, keyword));
 
     /* Ensure between 1 and 64 '-' chars at end of line */
-    GUARD(s2n_stuffer_skip_expected_char(pem, S2N_PEM_DELIMTER_CHAR, S2N_PEM_DELIMITER_MIN_COUNT, S2N_PEM_DELIMITER_MAX_COUNT));
+    GUARD(s2n_stuffer_skip_expected_char(pem, S2N_PEM_DELIMTER_CHAR, S2N_PEM_DELIMITER_MIN_COUNT, S2N_PEM_DELIMITER_MAX_COUNT, &skipped));
 
     /* Check for missing newline between dashes case: "-----END CERTIFICATE----------BEGIN CERTIFICATE-----" */
     if (strncmp(encap_marker, S2N_PEM_END_TOKEN, strlen(S2N_PEM_END_TOKEN)) == 0
@@ -125,12 +126,12 @@ static int s2n_stuffer_data_from_pem(struct s2n_stuffer *pem, struct s2n_stuffer
 
 int s2n_stuffer_private_key_from_pem(struct s2n_stuffer *pem, struct s2n_stuffer *asn1) {
     int rc;
-   
+
     rc = s2n_stuffer_data_from_pem(pem, asn1, S2N_PEM_PKCS1_RSA_PRIVATE_KEY);
     if (!rc) {
         return rc;
-    } 
-    
+    }
+
     s2n_stuffer_reread(pem);
     s2n_stuffer_reread(asn1);
 
@@ -144,12 +145,12 @@ int s2n_stuffer_private_key_from_pem(struct s2n_stuffer *pem, struct s2n_stuffer
         s2n_stuffer_reread(pem);
     }
     s2n_stuffer_wipe(asn1);
-    
+
     rc = s2n_stuffer_data_from_pem(pem, asn1, S2N_PEM_PKCS1_EC_PRIVATE_KEY);
     if (!rc) {
         return rc;
     }
-    
+
     /* If it does not match either format, try PKCS#8 */
     s2n_stuffer_reread(pem);
     s2n_stuffer_reread(asn1);

--- a/stuffer/s2n_stuffer_text.c
+++ b/stuffer/s2n_stuffer_text.c
@@ -112,17 +112,18 @@ int s2n_stuffer_skip_expected_char(struct s2n_stuffer *stuffer, const char expec
 {
     PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     PRECONDITION_POSIX(min <= max);
-    notnull_check(skipped);
-    *skipped = 0;
-    while (stuffer->read_cursor < stuffer->write_cursor && *skipped < max) {
+
+    int skip = 0;
+    while (stuffer->read_cursor < stuffer->write_cursor && skip < max) {
         if (stuffer->blob.data[stuffer->read_cursor] == expected){
             stuffer->read_cursor += 1;
-            *skipped += 1;
+            skip += 1;
         } else {
             break;
         }
     }
-    ENSURE_POSIX(*skipped >= min, S2N_ERR_STUFFER_NOT_FOUND);
+    ENSURE_POSIX(skip >= min, S2N_ERR_STUFFER_NOT_FOUND);
+    if(skipped != NULL) *skipped = skip;
     POSTCONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     return S2N_SUCCESS;
 }

--- a/stuffer/s2n_stuffer_text.c
+++ b/stuffer/s2n_stuffer_text.c
@@ -108,12 +108,12 @@ int s2n_stuffer_skip_to_char(struct s2n_stuffer *stuffer, const char target)
 }
 
 /* Skips an expected character in the stuffer between min and max times */
-int s2n_stuffer_skip_expected_char(struct s2n_stuffer *stuffer, const char expected, const unsigned int min, const unsigned int max, unsigned int *skipped)
+int s2n_stuffer_skip_expected_char(struct s2n_stuffer *stuffer, const char expected, const uint32_t min, const uint32_t max, uint32_t *skipped)
 {
     PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     PRECONDITION_POSIX(min <= max);
 
-    int skip = 0;
+    uint32_t skip = 0;
     while (stuffer->read_cursor < stuffer->write_cursor && skip < max) {
         if (stuffer->blob.data[stuffer->read_cursor] == expected){
             stuffer->read_cursor += 1;

--- a/stuffer/s2n_stuffer_text.c
+++ b/stuffer/s2n_stuffer_text.c
@@ -108,21 +108,23 @@ int s2n_stuffer_skip_to_char(struct s2n_stuffer *stuffer, const char target)
 }
 
 /* Skips an expected character in the stuffer between min and max times */
-int s2n_stuffer_skip_expected_char(struct s2n_stuffer *stuffer, const char expected, const int min, const int max)
+int s2n_stuffer_skip_expected_char(struct s2n_stuffer *stuffer, const char expected, const unsigned int min, const unsigned int max, unsigned int *skipped)
 {
     PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
-    int skipped = 0;
-    while (stuffer->read_cursor < stuffer->write_cursor && skipped < max) {
+    PRECONDITION_POSIX(min <= max);
+    notnull_check(skipped);
+    *skipped = 0;
+    while (stuffer->read_cursor < stuffer->write_cursor && *skipped < max) {
         if (stuffer->blob.data[stuffer->read_cursor] == expected){
             stuffer->read_cursor += 1;
-            skipped += 1;
+            *skipped += 1;
         } else {
             break;
         }
     }
-    S2N_ERROR_IF(skipped < min, S2N_ERR_STUFFER_NOT_FOUND);
+    ENSURE_POSIX(*skipped >= min, S2N_ERR_STUFFER_NOT_FOUND);
     POSTCONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
-    return skipped;
+    return S2N_SUCCESS;
 }
 
 /* Read a line of text. Agnostic to LF or CR+LF line endings. */

--- a/stuffer/s2n_stuffer_text.c
+++ b/stuffer/s2n_stuffer_text.c
@@ -108,8 +108,9 @@ int s2n_stuffer_skip_to_char(struct s2n_stuffer *stuffer, const char target)
 }
 
 /* Skips an expected character in the stuffer between min and max times */
-int s2n_stuffer_skip_expected_char(struct s2n_stuffer *stuffer, const char expected, int min, int max)
+int s2n_stuffer_skip_expected_char(struct s2n_stuffer *stuffer, const char expected, const int min, const int max)
 {
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     int skipped = 0;
     while (stuffer->read_cursor < stuffer->write_cursor && skipped < max) {
         if (stuffer->blob.data[stuffer->read_cursor] == expected){
@@ -119,9 +120,8 @@ int s2n_stuffer_skip_expected_char(struct s2n_stuffer *stuffer, const char expec
             break;
         }
     }
-
     S2N_ERROR_IF(skipped < min, S2N_ERR_STUFFER_NOT_FOUND);
-
+    POSTCONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     return skipped;
 }
 

--- a/tests/cbmc/proofs/s2n_stuffer_skip_expected_char/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_expected_char/Makefile
@@ -1,0 +1,31 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enough to get full coverage with 10 seconds of runtime.
+BLOB_SIZE = 10
+DEFINES += -DBLOB_SIZE=$(BLOB_SIZE)
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+
+ENTRY = s2n_stuffer_skip_expected_char_harness
+
+UNWINDSET += s2n_stuffer_skip_expected_char.3:$(call addone,$(BLOB_SIZE))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_skip_expected_char/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_expected_char/Makefile
@@ -17,14 +17,17 @@ DEFINES += -DBLOB_SIZE=$(BLOB_SIZE)
 
 CBMCFLAGS +=
 
-DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
-DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
-DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
-DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
-DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
-DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+HARNESS_ENTRY = s2n_stuffer_skip_expected_char_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
 
-ENTRY = s2n_stuffer_skip_expected_char_harness
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
 
 UNWINDSET += s2n_stuffer_skip_expected_char.3:$(call addone,$(BLOB_SIZE))
 

--- a/tests/cbmc/proofs/s2n_stuffer_skip_expected_char/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_expected_char/Makefile
@@ -29,6 +29,6 @@ PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
 PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
 
-UNWINDSET += s2n_stuffer_skip_expected_char.3:$(call addone,$(BLOB_SIZE))
+UNWINDSET += s2n_stuffer_skip_expected_char.9:$(call addone,$(BLOB_SIZE))
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_skip_expected_char/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_expected_char/Makefile
@@ -29,6 +29,6 @@ PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
 PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
 
-UNWINDSET += s2n_stuffer_skip_expected_char.9:$(call addone,$(BLOB_SIZE))
+UNWINDSET += s2n_stuffer_skip_expected_char.6:$(call addone,$(BLOB_SIZE))
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_skip_expected_char/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_expected_char/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_skip_expected_char/s2n_stuffer_skip_expected_char_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_expected_char/s2n_stuffer_skip_expected_char_harness.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_skip_expected_char_harness() {
+    /* Non-deterministic inputs. */
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    __CPROVER_assume(s2n_blob_is_bounded(&stuffer->blob, BLOB_SIZE));
+    const char expected;
+    int min;
+    int max;
+    uint32_t index;
+
+    /* Save previous state from stuffer. */
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    /* Operation under verification. */
+    int skipped = s2n_stuffer_skip_expected_char(stuffer, expected, min, max);
+    if (skipped >= min) {
+        assert(stuffer->read_cursor == old_stuffer.read_cursor + skipped);
+        if(stuffer->blob.size > 0) {
+            __CPROVER_assume(index >= old_stuffer.read_cursor && index < (old_stuffer.read_cursor + skipped));
+            assert(stuffer->blob.data[index] == expected);
+        }
+    } else {
+        assert(skipped < min);
+    }
+    assert_stuffer_immutable_fields_after_read(stuffer, &old_stuffer, &old_byte_from_stuffer);
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_skip_expected_char/s2n_stuffer_skip_expected_char_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_expected_char/s2n_stuffer_skip_expected_char_harness.c
@@ -45,8 +45,6 @@ void s2n_stuffer_skip_expected_char_harness() {
             __CPROVER_assume(index >= old_stuffer.read_cursor && index < (old_stuffer.read_cursor + skipped));
             assert(stuffer->blob.data[index] == expected);
         }
-    } else {
-        assert(skipped < min);
     }
     assert_stuffer_immutable_fields_after_read(stuffer, &old_stuffer, &old_byte_from_stuffer);
     assert(s2n_stuffer_is_valid(stuffer));

--- a/tests/cbmc/proofs/s2n_stuffer_skip_expected_char/s2n_stuffer_skip_expected_char_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_expected_char/s2n_stuffer_skip_expected_char_harness.c
@@ -28,9 +28,9 @@ void s2n_stuffer_skip_expected_char_harness() {
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
     __CPROVER_assume(s2n_blob_is_bounded(&stuffer->blob, BLOB_SIZE));
     const char expected;
-    unsigned int min;
-    unsigned int max;
-    unsigned int skipped;
+    uint32_t min;
+    uint32_t max;
+    uint32_t skipped;
     uint32_t index;
 
     /* Save previous state from stuffer. */

--- a/tests/cbmc/proofs/s2n_stuffer_skip_expected_char/s2n_stuffer_skip_expected_char_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_expected_char/s2n_stuffer_skip_expected_char_harness.c
@@ -28,8 +28,9 @@ void s2n_stuffer_skip_expected_char_harness() {
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
     __CPROVER_assume(s2n_blob_is_bounded(&stuffer->blob, BLOB_SIZE));
     const char expected;
-    int min;
-    int max;
+    unsigned int min;
+    unsigned int max;
+    unsigned int skipped;
     uint32_t index;
 
     /* Save previous state from stuffer. */
@@ -38,8 +39,8 @@ void s2n_stuffer_skip_expected_char_harness() {
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
     /* Operation under verification. */
-    int skipped = s2n_stuffer_skip_expected_char(stuffer, expected, min, max);
-    if (skipped >= min) {
+    if (s2n_stuffer_skip_expected_char(stuffer, expected, min, max, &skipped) == S2N_SUCCESS) {
+        assert(skipped >= min && skipped <= max);
         /* The read_cursor will move the number of skipped positions. */
         assert(stuffer->read_cursor == old_stuffer.read_cursor + skipped);
         if(stuffer->blob.size > 0) {

--- a/tests/cbmc/proofs/s2n_stuffer_skip_expected_char/s2n_stuffer_skip_expected_char_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_expected_char/s2n_stuffer_skip_expected_char_harness.c
@@ -40,8 +40,10 @@ void s2n_stuffer_skip_expected_char_harness() {
     /* Operation under verification. */
     int skipped = s2n_stuffer_skip_expected_char(stuffer, expected, min, max);
     if (skipped >= min) {
+        /* The read_cursor will move the number of skipped positions. */
         assert(stuffer->read_cursor == old_stuffer.read_cursor + skipped);
         if(stuffer->blob.size > 0) {
+            /* The skipped bytes should match the expected element. */
             __CPROVER_assume(index >= old_stuffer.read_cursor && index < (old_stuffer.read_cursor + skipped));
             assert(stuffer->blob.data[index] == expected);
         }


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A.

### Description of changes: 

- Modifies the signature of `s2n_stuffer_skip_expected_char` to accept `skipped` parameter instead of returning it;
- Modifies implementation to accept a NULL `skipped` parameter;
- Adds a proof harness for the `s2n_stuffer_skip_expected_char` function;
- Adds a pre- and post-conditions to the `s2n_stuffer_skip_expected_char` function;

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.