### PR TITLE
Adds a proof for s2n_stuffer_read_expected_str

### DIFF
--- a/stuffer/s2n_stuffer_text.c
+++ b/stuffer/s2n_stuffer_text.c
@@ -63,10 +63,16 @@ int s2n_stuffer_skip_whitespace(struct s2n_stuffer *s2n_stuffer)
 
 int s2n_stuffer_read_expected_str(struct s2n_stuffer *stuffer, const char *expected)
 {
-    void *actual = s2n_stuffer_raw_read(stuffer, strlen(expected));
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
+    notnull_check(expected);
+    size_t expected_length = strlen(expected);
+    ENSURE_POSIX(s2n_stuffer_data_available(stuffer) >= expected_length, S2N_ERR_STUFFER_OUT_OF_DATA);
+    uint8_t *actual =  stuffer->blob.data + stuffer->read_cursor;
     notnull_check(actual);
-    S2N_ERROR_IF(memcmp(actual, expected, strlen(expected)), S2N_ERR_STUFFER_NOT_FOUND);
-    return 0;
+    ENSURE_POSIX(!memcmp(actual, expected, expected_length), S2N_ERR_STUFFER_NOT_FOUND);
+    stuffer->read_cursor += expected_length;
+    POSTCONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
+    return S2N_SUCCESS;
 }
 
 /* Read from stuffer until the target string is found, or until there is no more data. */

--- a/tests/cbmc/proofs/s2n_stuffer_peek_check_for_str/s2n_stuffer_peek_check_for_str_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_peek_check_for_str/s2n_stuffer_peek_check_for_str_harness.c
@@ -39,20 +39,7 @@ void s2n_stuffer_peek_check_for_str_harness() {
     if (s2n_stuffer_peek_check_for_str(stuffer, expected) == S2N_SUCCESS) {
         uint8_t* actual = stuffer->blob.data + stuffer->read_cursor;
         assert(!memcmp(actual, expected, strlen(expected)));
-        assert(stuffer->read_cursor == old_stuffer.read_cursor);
-        assert(stuffer->write_cursor == old_stuffer.write_cursor);
-        assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
-        assert(stuffer->alloced == old_stuffer.alloced);
-        assert(stuffer->growable == old_stuffer.growable);
-        assert(stuffer->tainted);
-        assert_blob_equivalence(&stuffer->blob, &old_stuffer.blob, &old_byte_from_stuffer);
-    } else {
-        assert(stuffer->read_cursor == old_stuffer.read_cursor);
-        assert(stuffer->write_cursor == old_stuffer.write_cursor);
-        assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
-        assert(stuffer->alloced == old_stuffer.alloced);
-        assert(stuffer->growable == old_stuffer.growable);
-        assert_blob_equivalence(&stuffer->blob, &old_stuffer.blob, &old_byte_from_stuffer);
     }
+    assert_stuffer_equivalence(stuffer, &old_stuffer, &old_byte_from_stuffer);
     assert(s2n_stuffer_is_valid(stuffer));
 }

--- a/tests/cbmc/proofs/s2n_stuffer_read_expected_str/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_expected_str/Makefile
@@ -1,0 +1,36 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enough to get full coverage with 1 minute of runtime.
+MAX_STRING_LEN = 10
+DEFINES += -DMAX_STRING_LEN=$(MAX_STRING_LEN)
+
+HARNESS_ENTRY = s2n_stuffer_read_expected_str_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+
+UNWINDSET += strlen.0:$(call addone,$(MAX_STRING_LEN))
+UNWINDSET += memcmp.0:$(call addone,$(MAX_STRING_LEN))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_read_expected_str/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_read_expected_str/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_read_expected_str/s2n_stuffer_read_expected_str_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_expected_str/s2n_stuffer_read_expected_str_harness.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+#include <string.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_read_expected_str_harness() {
+    /* Non-deterministic inputs. */
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    char *expected = ensure_c_str_is_allocated(MAX_STRING_LEN);
+
+    /* Store a byte from the stuffer to compare after the read */
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    /* Operation under verification. */
+    if (s2n_stuffer_read_expected_str(stuffer, expected) == S2N_SUCCESS) {
+        uint8_t* actual = stuffer->blob.data + stuffer->read_cursor - strlen(expected);
+        assert(!memcmp(actual, expected, strlen(expected)));
+        assert(stuffer->read_cursor == old_stuffer.read_cursor + strlen(expected));
+    } else {
+        assert(stuffer->read_cursor == old_stuffer.read_cursor);
+    }
+    assert(stuffer->write_cursor == old_stuffer.write_cursor);
+    assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+    assert(stuffer->alloced == old_stuffer.alloced);
+    assert(stuffer->growable == old_stuffer.growable);
+    assert_blob_equivalence(&stuffer->blob, &old_stuffer.blob, &old_byte_from_stuffer);
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_read_expected_str/s2n_stuffer_read_expected_str_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_expected_str/s2n_stuffer_read_expected_str_harness.c
@@ -43,10 +43,6 @@ void s2n_stuffer_read_expected_str_harness() {
     } else {
         assert(stuffer->read_cursor == old_stuffer.read_cursor);
     }
-    assert(stuffer->write_cursor == old_stuffer.write_cursor);
-    assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
-    assert(stuffer->alloced == old_stuffer.alloced);
-    assert(stuffer->growable == old_stuffer.growable);
-    assert_blob_equivalence(&stuffer->blob, &old_stuffer.blob, &old_byte_from_stuffer);
+    assert_stuffer_immutable_fields_after_read(stuffer, &old_stuffer, &old_byte_from_stuffer);
     assert(s2n_stuffer_is_valid(stuffer));
 }


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A.

### Description of changes: 

- Adds a proof harness for the `s2n_stuffer_read_expected_str` function;
- Adds a pre- and post-conditions to the `s2n_stuffer_read_expected_str` function;

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.