### PR TITLE
Adds a proof for s2n_stuffer_peek_check_for_str

### DIFF
--- a/stuffer/s2n_stuffer_pem.c
+++ b/stuffer/s2n_stuffer_pem.c
@@ -52,7 +52,7 @@ static int s2n_stuffer_pem_read_encapsulation_line(struct s2n_stuffer *pem, cons
 
     /* Check for missing newline between dashes case: "-----END CERTIFICATE----------BEGIN CERTIFICATE-----" */
     if (strncmp(encap_marker, S2N_PEM_END_TOKEN, strlen(S2N_PEM_END_TOKEN)) == 0
-            && s2n_stuffer_peek_check_for_str(pem, S2N_PEM_BEGIN_TOKEN)) {
+            && s2n_stuffer_peek_check_for_str(pem, S2N_PEM_BEGIN_TOKEN) == S2N_SUCCESS) {
         /* Rewind stuffer by 1 byte before BEGIN, so that next read will find the dash before the BEGIN */
         GUARD(s2n_stuffer_rewind_read(pem, 1));
     }

--- a/stuffer/s2n_stuffer_text.c
+++ b/stuffer/s2n_stuffer_text.c
@@ -33,14 +33,16 @@ int s2n_stuffer_peek_char(struct s2n_stuffer *s2n_stuffer, char *c)
 /* Peeks in stuffer to see if expected string is present. */
 int s2n_stuffer_peek_check_for_str(struct s2n_stuffer *s2n_stuffer, const char *expected)
 {
-    int orig_read_pos = s2n_stuffer->read_cursor;
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(s2n_stuffer));
+    uint32_t orig_read_pos = s2n_stuffer->read_cursor;
     int rc = s2n_stuffer_read_expected_str(s2n_stuffer, expected);
     s2n_stuffer->read_cursor = orig_read_pos;
 
-    if (rc == 0) {
+    if (rc == S2N_SUCCESS) {
         return 1;
     }
-    return 0;
+    POSTCONDITION_POSIX(s2n_stuffer_is_valid(s2n_stuffer));
+    return S2N_SUCCESS;
 }
 
 int s2n_stuffer_skip_whitespace(struct s2n_stuffer *s2n_stuffer)

--- a/stuffer/s2n_stuffer_text.c
+++ b/stuffer/s2n_stuffer_text.c
@@ -37,12 +37,8 @@ int s2n_stuffer_peek_check_for_str(struct s2n_stuffer *s2n_stuffer, const char *
     uint32_t orig_read_pos = s2n_stuffer->read_cursor;
     int rc = s2n_stuffer_read_expected_str(s2n_stuffer, expected);
     s2n_stuffer->read_cursor = orig_read_pos;
-
-    if (rc == S2N_SUCCESS) {
-        return 1;
-    }
     POSTCONDITION_POSIX(s2n_stuffer_is_valid(s2n_stuffer));
-    return S2N_SUCCESS;
+    return rc;
 }
 
 int s2n_stuffer_skip_whitespace(struct s2n_stuffer *s2n_stuffer)

--- a/tests/cbmc/proofs/s2n_stuffer_peek_check_for_str/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_peek_check_for_str/Makefile
@@ -1,0 +1,38 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enough to get full coverage with 2 minute of runtime.
+MAX_STRING_LEN = 10
+DEFINES += -DMAX_STRING_LEN=$(MAX_STRING_LEN)
+
+CBMCFLAGS +=
+
+HARNESS_ENTRY = s2n_stuffer_peek_check_for_str_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+
+UNWINDSET += strlen.0:$(call addone,$(MAX_STRING_LEN))
+UNWINDSET += memcmp.0:$(call addone,$(MAX_STRING_LEN))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_peek_check_for_str/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_peek_check_for_str/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_peek_check_for_str/s2n_stuffer_peek_check_for_str_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_peek_check_for_str/s2n_stuffer_peek_check_for_str_harness.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+#include <string.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_peek_check_for_str_harness() {
+    /* Non-deterministic inputs. */
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    char *expected = ensure_c_str_is_allocated(MAX_STRING_LEN);
+
+    /* Store a byte from the stuffer to compare after the read */
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    /* Operation under verification. */
+    if (s2n_stuffer_peek_check_for_str(stuffer, expected) == 1) {
+        uint8_t* actual = stuffer->blob.data + stuffer->read_cursor;
+        assert(!memcmp(actual, expected, strlen(expected)));
+        assert(stuffer->read_cursor == old_stuffer.read_cursor);
+        assert(stuffer->write_cursor == old_stuffer.write_cursor);
+        assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+        assert(stuffer->alloced == old_stuffer.alloced);
+        assert(stuffer->growable == old_stuffer.growable);
+        assert(stuffer->tainted == 1);
+        assert_blob_equivalence(&stuffer->blob, &old_stuffer.blob, &old_byte_from_stuffer);
+    } else {
+        assert(stuffer->write_cursor == old_stuffer.write_cursor);
+        assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+        assert(stuffer->alloced == old_stuffer.alloced);
+        assert(stuffer->growable == old_stuffer.growable);
+        assert_blob_equivalence(&stuffer->blob, &old_stuffer.blob, &old_byte_from_stuffer);
+    }
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_peek_check_for_str/s2n_stuffer_peek_check_for_str_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_peek_check_for_str/s2n_stuffer_peek_check_for_str_harness.c
@@ -36,7 +36,7 @@ void s2n_stuffer_peek_check_for_str_harness() {
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
     /* Operation under verification. */
-    if (s2n_stuffer_peek_check_for_str(stuffer, expected) == 1) {
+    if (s2n_stuffer_peek_check_for_str(stuffer, expected) == S2N_SUCCESS) {
         uint8_t* actual = stuffer->blob.data + stuffer->read_cursor;
         assert(!memcmp(actual, expected, strlen(expected)));
         assert(stuffer->read_cursor == old_stuffer.read_cursor);
@@ -44,9 +44,10 @@ void s2n_stuffer_peek_check_for_str_harness() {
         assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
         assert(stuffer->alloced == old_stuffer.alloced);
         assert(stuffer->growable == old_stuffer.growable);
-        assert(stuffer->tainted == 1);
+        assert(stuffer->tainted);
         assert_blob_equivalence(&stuffer->blob, &old_stuffer.blob, &old_byte_from_stuffer);
     } else {
+        assert(stuffer->read_cursor == old_stuffer.read_cursor);
         assert(stuffer->write_cursor == old_stuffer.write_cursor);
         assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
         assert(stuffer->alloced == old_stuffer.alloced);


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A.

### Description of changes: 

- Adds a proof harness for the `s2n_stuffer_peek_check_for_str` function;
- Adds a pre- and post-conditions to the `s2n_stuffer_peek_check_for_str` function;

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.