### PR TITLE
Adds a proof harness for s2n_stuffer_read_line

### DIFF
--- a/stuffer/s2n_stuffer_text.c
+++ b/stuffer/s2n_stuffer_text.c
@@ -135,6 +135,8 @@ int s2n_stuffer_skip_expected_char(struct s2n_stuffer *stuffer, const char expec
 /* Read a line of text. Agnostic to LF or CR+LF line endings. */
 int s2n_stuffer_read_line(struct s2n_stuffer *stuffer, struct s2n_stuffer *token)
 {
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(token));
     /* Consume an LF terminated line */
     GUARD(s2n_stuffer_read_token(stuffer, token, '\n'));
 
@@ -142,8 +144,9 @@ int s2n_stuffer_read_line(struct s2n_stuffer *stuffer, struct s2n_stuffer *token
     if ((s2n_stuffer_data_available(token) > 0) && (token->blob.data[(token->write_cursor - 1)] == '\r')) {
         token->write_cursor--;
     }
-
-    return 0;
+    POSTCONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
+    POSTCONDITION_POSIX(s2n_stuffer_is_valid(token));
+    return S2N_SUCCESS;
 }
 
 int s2n_stuffer_read_token(struct s2n_stuffer *stuffer, struct s2n_stuffer *token, char delim)

--- a/tests/cbmc/proofs/s2n_stuffer_read_line/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_line/Makefile
@@ -1,0 +1,44 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enough to get full coverage with 2 minutes of runtime.
+MAX_BLOB_SIZE = 3
+DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
+
+CHECKFLAGS +=
+
+HARNESS_ENTRY = s2n_stuffer_read_line_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
+
+UNWINDSET += s2n_stuffer_read_token.0:$(call addone,$(MAX_BLOB_SIZE))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_read_line/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_read_line/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_read_line/s2n_stuffer_read_line_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_line/s2n_stuffer_read_line_harness.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_mem.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_stuffer_read_line_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    __CPROVER_assume(s2n_blob_is_bounded(&stuffer->blob, MAX_BLOB_SIZE));
+    struct s2n_stuffer *line = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(line));
+
+    /* Store previous state from the stuffer. */
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    /* Store previous state from the line. */
+    struct s2n_stuffer old_line = *line;
+    struct store_byte_from_buffer old_byte_from_line;
+    save_byte_from_blob(&line->blob, &old_byte_from_line);
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    if (s2n_stuffer_read_line(stuffer, line) == S2N_SUCCESS) {
+        assert(s2n_stuffer_is_valid(line));
+        if (line->write_cursor > old_line.write_cursor) {
+            assert(line->blob.data[line->write_cursor - 1] != '\n');
+            uint32_t line_size = line->write_cursor - old_line.write_cursor;
+            if(line_size != 0) assert_bytes_match(line->blob.data + old_line.write_cursor, stuffer->blob.data + old_stuffer.read_cursor, line_size);
+        }
+    } else {
+        assert_stuffer_equivalence(stuffer, &old_stuffer, &old_byte_from_stuffer);
+        /*
+         * s2n_realloc could fail, so we can only guarantee equivalence of
+         * data pointer, but not the elements in it.
+         */
+        assert(line->blob.data == old_line.blob.data);
+        assert(line->blob.size == old_line.blob.size);
+        assert(line->read_cursor == old_line.read_cursor);
+        assert(line->write_cursor == old_line.write_cursor);
+        assert(line->high_water_mark == old_line.high_water_mark);
+        assert(line->alloced == old_line.alloced);
+        assert(line->growable == old_line.growable);
+        assert(line->tainted == old_line.tainted);
+    }
+
+    assert_stuffer_immutable_fields_after_read(stuffer, &old_stuffer, &old_byte_from_stuffer);
+    assert(s2n_stuffer_is_valid(stuffer));
+}


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A.

### Description of changes: 

- Adds a proof harness for the `s2n_stuffer_read_line` function;
- Adds a pre- and post-conditions to the `s2n_stuffer_read_line` function;

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.