### PR TITLE
Added check to ensure hello retry cipher suite and server hello cipher suite are the same

### DIFF
--- a/tests/unit/s2n_client_auth_handshake_test.c
+++ b/tests/unit/s2n_client_auth_handshake_test.c
@@ -54,7 +54,6 @@ int s2n_test_client_auth_negotiation(struct s2n_config *server_config, struct s2
     client_conn->actual_protocol_version = S2N_TLS13;
     client_conn->secure.conn_sig_scheme = s2n_ecdsa_secp256r1_sha256;
     client_conn->secure.client_cert_sig_scheme = s2n_ecdsa_secp256r1_sha256;
-    client_conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
     if (!no_cert) {
         client_conn->handshake_params.our_chain_and_key = ecdsa_cert;
     }

--- a/tests/unit/s2n_client_auth_handshake_test.c
+++ b/tests/unit/s2n_client_auth_handshake_test.c
@@ -54,6 +54,7 @@ int s2n_test_client_auth_negotiation(struct s2n_config *server_config, struct s2
     client_conn->actual_protocol_version = S2N_TLS13;
     client_conn->secure.conn_sig_scheme = s2n_ecdsa_secp256r1_sha256;
     client_conn->secure.client_cert_sig_scheme = s2n_ecdsa_secp256r1_sha256;
+    client_conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
     if (!no_cert) {
         client_conn->handshake_params.our_chain_and_key = ecdsa_cert;
     }

--- a/tests/unit/s2n_client_hello_retry_test.c
+++ b/tests/unit/s2n_client_hello_retry_test.c
@@ -481,7 +481,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
-    /* Test server_hello_receive raises a S2N_ERR_CIPHER_TYPE error when the cipher suite supplied
+    /* Test server_hello_receive raises a S2N_ERR_CIPHER_NOT_SUPPORTED error when the cipher suite supplied
      * by the Server Hello does not match the cipher suite supplied by the Hello Retry Request */
     {
         struct s2n_connection *server_conn;
@@ -498,7 +498,6 @@ int main(int argc, char **argv)
         client_conn->handshake.handshake_type |= FULL_HANDSHAKE;
         client_conn->handshake.message_number = SERVER_HELLO_MSG_NO;
 
-
         /* Server Hello with cipher suite that does not match Hello Retry Request cipher suite */
         server_conn->secure.cipher_suite = &s2n_tls13_chacha20_poly1305_sha256;
         EXPECT_SUCCESS(s2n_server_hello_send(server_conn));
@@ -507,7 +506,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_copy(&server_conn->handshake.io, &client_conn->handshake.io,
                                         s2n_stuffer_data_available(&server_conn->handshake.io)));
 
-        EXPECT_FAILURE_WITH_ERRNO(s2n_server_hello_recv(client_conn), S2N_ERR_CIPHER_TYPE);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_server_hello_recv(client_conn), S2N_ERR_CIPHER_NOT_SUPPORTED);
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));

--- a/tests/unit/s2n_client_hello_retry_test.c
+++ b/tests/unit/s2n_client_hello_retry_test.c
@@ -480,6 +480,85 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
+    /* Test server_hello_receive raises a S2N_ERR_BAD_MESSAGE error when the cipher suite supplied
+     * by the Server Hello does not match the cipher suite supplied by the Hello Retry Request */
+    {
+        struct s2n_config *server_config;
+        struct s2n_config *client_config;
+
+        struct s2n_connection *server_conn;
+        struct s2n_connection *client_conn;
+
+        struct s2n_cert_chain_and_key *tls13_chain_and_key;
+        char tls13_cert_chain[S2N_MAX_TEST_PEM_SIZE] = {0};
+        char tls13_private_key[S2N_MAX_TEST_PEM_SIZE] = {0};
+
+        EXPECT_NOT_NULL(server_config = s2n_config_new());
+        EXPECT_NOT_NULL(client_config = s2n_config_new());
+
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+
+        EXPECT_NOT_NULL(tls13_chain_and_key = s2n_cert_chain_and_key_new());
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_ECDSA_P384_PKCS1_CERT_CHAIN, tls13_cert_chain, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_ECDSA_P384_PKCS1_KEY, tls13_private_key, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(tls13_chain_and_key, tls13_cert_chain, tls13_private_key));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(client_config, tls13_chain_and_key));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, tls13_chain_and_key));
+
+
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
+
+        /* The client will offer the default tls13 ciphersuites */
+        s2n_connection_set_cipher_preferences(client_conn, "default_tls13");
+
+        /* Force the client to send an empty list of keyshares */
+        EXPECT_SUCCESS(s2n_connection_set_keyshare_by_name_for_testing(client_conn, "none"));
+
+        /* ClientHello 1 */
+        EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
+        EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io,
+                                        s2n_stuffer_data_available(&client_conn->handshake.io)));
+        EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
+        EXPECT_TRUE(s2n_is_hello_retry_handshake(server_conn));
+        EXPECT_SUCCESS(s2n_set_connection_hello_retry_flags(server_conn));
+
+        /* Server HelloRetryRequest */
+        EXPECT_SUCCESS(s2n_server_hello_retry_send(server_conn));
+        EXPECT_SUCCESS(s2n_set_connection_hello_retry_flags(server_conn));
+
+        EXPECT_SUCCESS(s2n_stuffer_wipe(&client_conn->handshake.io));
+        EXPECT_SUCCESS(s2n_stuffer_copy(&server_conn->handshake.io, &client_conn->handshake.io,
+                                        s2n_stuffer_data_available(&server_conn->handshake.io)));
+        client_conn->handshake.message_number = HELLO_RETRY_MSG_NO;
+        EXPECT_SUCCESS(s2n_server_hello_recv(client_conn));
+
+        EXPECT_EQUAL(client_conn->secure.cipher_suite, &s2n_tls13_aes_256_gcm_sha384);
+
+        /* ClientHello 2 */
+        EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
+        EXPECT_SUCCESS(s2n_stuffer_wipe(&server_conn->handshake.io));
+        EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io,
+                                        s2n_stuffer_data_available(&client_conn->handshake.io)));
+        EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
+
+        /* Server Hello with cipher suite that does not match Hello Retry Request cipher suite */
+        server_conn->secure.cipher_suite = &s2n_tls13_chacha20_poly1305_sha256;
+        EXPECT_SUCCESS(s2n_server_hello_send(server_conn));
+
+        EXPECT_SUCCESS(s2n_stuffer_wipe(&client_conn->handshake.io));
+        EXPECT_SUCCESS(s2n_stuffer_copy(&server_conn->handshake.io, &client_conn->handshake.io,
+                                        s2n_stuffer_data_available(&server_conn->handshake.io)));
+
+        EXPECT_FAILURE_WITH_ERRNO(s2n_server_hello_recv(client_conn), S2N_ERR_BAD_MESSAGE);
+
+        EXPECT_SUCCESS(s2n_config_free(client_config));
+        EXPECT_SUCCESS(s2n_config_free(server_config));
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(tls13_chain_and_key));
+    }
+
     EXPECT_SUCCESS(s2n_disable_tls13());
 
     END_TEST();

--- a/tests/unit/s2n_server_hello_retry_test.c
+++ b/tests/unit/s2n_server_hello_retry_test.c
@@ -412,7 +412,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(tls13_chain_and_key));
     }
 
-    /* Test s2n_set_hello_retry_required corectly sets the handshake type to HELLO_RETRY_REQUEST,
+    /* Test s2n_set_hello_retry_required correctly sets the handshake type to HELLO_RETRY_REQUEST,
      * when conn->actual_protocol_version is set to TLS1.3 version */
     {
         struct s2n_connection *conn;

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -1084,11 +1084,11 @@ int s2n_set_cipher_as_client(struct s2n_connection *conn, uint8_t wire[S2N_TLS_C
 
     /* See if the cipher is one we support */
     cipher_suite = s2n_cipher_suite_from_wire(wire);
-    S2N_ERROR_IF(cipher_suite == NULL, S2N_ERR_CIPHER_NOT_SUPPORTED);
+    ENSURE_POSIX(cipher_suite != NULL, S2N_ERR_CIPHER_NOT_SUPPORTED);
 
     /* Verify cipher suite sent in server hello is the same as sent in hello retry */
-    if (conn->secure.cipher_suite != &s2n_null_cipher_suite) {
-        ENSURE_POSIX(conn->secure.cipher_suite->iana_value == cipher_suite->iana_value, S2N_ERR_BAD_MESSAGE);
+    if (s2n_conn_get_current_message_type(conn) == SERVER_HELLO && s2n_is_hello_retry_handshake(conn)) {
+        ENSURE_POSIX(conn->secure.cipher_suite->iana_value == cipher_suite->iana_value, S2N_ERR_CIPHER_TYPE);
         return S2N_SUCCESS;
     }
     conn->secure.cipher_suite = cipher_suite;

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -1087,8 +1087,8 @@ int s2n_set_cipher_as_client(struct s2n_connection *conn, uint8_t wire[S2N_TLS_C
     ENSURE_POSIX(cipher_suite != NULL, S2N_ERR_CIPHER_NOT_SUPPORTED);
 
     /* Verify cipher suite sent in server hello is the same as sent in hello retry */
-    if (s2n_conn_get_current_message_type(conn) == SERVER_HELLO && s2n_is_hello_retry_handshake(conn)) {
-        ENSURE_POSIX(conn->secure.cipher_suite->iana_value == cipher_suite->iana_value, S2N_ERR_CIPHER_TYPE);
+    if (s2n_is_hello_retry_handshake(conn) && !s2n_is_hello_retry_message(conn)) {
+        ENSURE_POSIX(conn->secure.cipher_suite->iana_value == cipher_suite->iana_value, S2N_ERR_CIPHER_NOT_SUPPORTED);
         return S2N_SUCCESS;
     }
     conn->secure.cipher_suite = cipher_suite;


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

 resolves #1729 
### Description of changes: 
Adds check to ensure that the cipher suite sent in the hello retry request is the same as sent in the forthcoming server hello. Also small spelling fix.
### Call-outs:

N/A
### Testing:

Added a unit test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
