### PR TITLE
Adds proof harnesses for s2n_stuffer_file functions

### DIFF
--- a/stuffer/s2n_stuffer_file.c
+++ b/stuffer/s2n_stuffer_file.c
@@ -67,20 +67,25 @@ int s2n_stuffer_send_to_fd(struct s2n_stuffer *stuffer, int wfd, uint32_t len)
 
 int s2n_stuffer_alloc_ro_from_fd(struct s2n_stuffer *stuffer, int rfd)
 {
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     struct stat st = {0};
 
     S2N_ERROR_IF(fstat(rfd, &st) < 0, S2N_ERR_FSTAT);
 
-    stuffer->blob.data = mmap(0, st.st_size, PROT_READ, MAP_PRIVATE, rfd, 0);
+    ENSURE_POSIX(st.st_size > 0 && st.st_size <= SIZE_MAX, S2N_FAILURE);
+    stuffer->blob.data = mmap(NULL, st.st_size, PROT_READ, MAP_PRIVATE, rfd, 0);
     S2N_ERROR_IF(stuffer->blob.data == MAP_FAILED, S2N_ERR_MMAP);
 
-    stuffer->blob.size = st.st_size;
+    ENSURE_POSIX(st.st_size >= 0 && st.st_size <= UINT32_MAX, S2N_FAILURE);
+    stuffer->blob.size = (uint32_t)st.st_size;
 
     return s2n_stuffer_init(stuffer, &stuffer->blob);
 }
 
 int s2n_stuffer_alloc_ro_from_file(struct s2n_stuffer *stuffer, const char *file)
 {
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
+    notnull_check(file);
     int fd;
 
     do {

--- a/stuffer/s2n_stuffer_file.c
+++ b/stuffer/s2n_stuffer_file.c
@@ -70,13 +70,15 @@ int s2n_stuffer_alloc_ro_from_fd(struct s2n_stuffer *stuffer, int rfd)
     PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     struct stat st = {0};
 
-    S2N_ERROR_IF(fstat(rfd, &st) < 0, S2N_ERR_FSTAT);
+    ENSURE_POSIX(fstat(rfd, &st) < 0, S2N_ERR_FSTAT);
 
-    ENSURE_POSIX(st.st_size > 0 && st.st_size <= SIZE_MAX, S2N_FAILURE);
+    ENSURE_POSIX(st.st_size > 0, S2N_FAILURE);
+    ENSURE_POSIX(st.st_size <= SIZE_MAX, S2N_FAILURE);
     stuffer->blob.data = mmap(NULL, st.st_size, PROT_READ, MAP_PRIVATE, rfd, 0);
-    S2N_ERROR_IF(stuffer->blob.data == MAP_FAILED, S2N_ERR_MMAP);
+    ENSURE_POSIX(stuffer->blob.data == MAP_FAILED, S2N_ERR_MMAP);
 
-    ENSURE_POSIX(st.st_size >= 0 && st.st_size <= UINT32_MAX, S2N_FAILURE);
+    ENSURE_POSIX(st.st_size >= 0, S2N_FAILURE);
+    ENSURE_POSIX(st.st_size <= UINT32_MAX, S2N_FAILURE);
     stuffer->blob.size = (uint32_t)st.st_size;
 
     return s2n_stuffer_init(stuffer, &stuffer->blob);

--- a/stuffer/s2n_stuffer_file.c
+++ b/stuffer/s2n_stuffer_file.c
@@ -67,26 +67,27 @@ int s2n_stuffer_send_to_fd(struct s2n_stuffer *stuffer, int wfd, uint32_t len)
 
 int s2n_stuffer_alloc_ro_from_fd(struct s2n_stuffer *stuffer, int rfd)
 {
-    PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
+    PRECONDITION_POSIX(S2N_OBJECT_PTR_IS_WRITABLE(stuffer));
     struct stat st = {0};
 
     ENSURE_POSIX(fstat(rfd, &st) < 0, S2N_ERR_FSTAT);
 
     ENSURE_POSIX(st.st_size > 0, S2N_FAILURE);
     ENSURE_POSIX(st.st_size <= SIZE_MAX, S2N_FAILURE);
-    stuffer->blob.data = mmap(NULL, st.st_size, PROT_READ, MAP_PRIVATE, rfd, 0);
-    ENSURE_POSIX(stuffer->blob.data == MAP_FAILED, S2N_ERR_MMAP);
+    uint8_t *map = mmap(NULL, st.st_size, PROT_READ, MAP_PRIVATE, rfd, 0);
+    ENSURE_POSIX(map == MAP_FAILED, S2N_ERR_MMAP);
 
     ENSURE_POSIX(st.st_size >= 0, S2N_FAILURE);
     ENSURE_POSIX(st.st_size <= UINT32_MAX, S2N_FAILURE);
-    stuffer->blob.size = (uint32_t)st.st_size;
 
-    return s2n_stuffer_init(stuffer, &stuffer->blob);
+    struct s2n_blob b = {0};
+    ENSURE_POSIX(s2n_blob_init(&b, map, (uint32_t)st.st_size), S2N_FAILURE);
+    return s2n_stuffer_init(stuffer, &b);
 }
 
 int s2n_stuffer_alloc_ro_from_file(struct s2n_stuffer *stuffer, const char *file)
 {
-    PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
+    PRECONDITION_POSIX(S2N_OBJECT_PTR_IS_WRITABLE(stuffer));
     notnull_check(file);
     int fd;
 

--- a/tests/cbmc/include/cbmc_proof/make_common_datastructures.h
+++ b/tests/cbmc/include/cbmc_proof/make_common_datastructures.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/proof_allocators.h>
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
@@ -49,3 +50,9 @@ struct s2n_stuffer* cbmc_allocate_s2n_stuffer();
  * with as much nondet as possible, len < max_size.
  */
 const char *ensure_c_str_is_allocated(size_t max_size);
+
+/*
+ * Nondeterministically return a valid-allocated const string or NULL,
+ * with as much nondet as possible, len < max_size.
+ */
+const char *nondet_c_str_is_allocated(size_t max_size);

--- a/tests/cbmc/include/cbmc_proof/nondet.h
+++ b/tests/cbmc/include/cbmc_proof/nondet.h
@@ -18,6 +18,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <sys/stat.h>
 
 /**
  * These functions provide a way to get unconstrained values of the correct types for use in CBMC proofs
@@ -33,3 +34,4 @@ uint32_t nondet_uint32_t();
 uint64_t nondet_uint64_t();
 uint8_t nondet_uint8_t();
 void *nondet_voidp();
+off_t nondet_off_t();

--- a/tests/cbmc/include/cbmc_proof/nondet.h
+++ b/tests/cbmc/include/cbmc_proof/nondet.h
@@ -28,6 +28,7 @@
  */
 bool nondet_bool();
 int nondet_int();
+unsigned int nondet_unsigned_int();
 size_t nondet_size_t();
 uint16_t nondet_uint16_t();
 uint32_t nondet_uint32_t();

--- a/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_fd/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_fd/Makefile
@@ -1,0 +1,32 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+
+ABSTRACTIONS += $(HELPERDIR)/stubs/fstat.c
+ABSTRACTIONS += $(HELPERDIR)/stubs/mmap.c
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_file.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+
+ENTRY = s2n_stuffer_alloc_ro_from_fd_harness
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_fd/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_fd/Makefile
@@ -13,19 +13,22 @@
 
 # Expected runtime is 10 seconds.
 
-ABSTRACTIONS += $(HELPERDIR)/stubs/fstat.c
-ABSTRACTIONS += $(HELPERDIR)/stubs/mmap.c
-
 CBMCFLAGS +=
 
-DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
-DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
-DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
-DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
-DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_file.c
-DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+HARNESS_ENTRY = s2n_stuffer_alloc_ro_from_fd_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
 
-ENTRY = s2n_stuffer_alloc_ro_from_fd_harness
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/fstat.c
+PROOF_SOURCES += $(PROOF_STUB)/mmap.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_file.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
 
 UNWINDSET +=
 

--- a/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_fd/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_fd/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_fd/s2n_stuffer_alloc_ro_from_fd_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_fd/s2n_stuffer_alloc_ro_from_fd_harness.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "error/s2n_errno.h"
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_alloc_ro_from_fd_harness() {
+    /* Non-deterministic inputs. */
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    int rfd;
+
+    /* Store a byte from the stuffer to compare if the write fails */
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    /* Operation under verification. */
+    if (s2n_stuffer_alloc_ro_from_fd(stuffer, rfd) == S2N_SUCCESS) {
+        assert(s2n_stuffer_is_valid(stuffer));
+    } else {
+        assert(stuffer->read_cursor == old_stuffer.read_cursor);
+        assert(stuffer->write_cursor == old_stuffer.write_cursor);
+        assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+        assert(stuffer->alloced == old_stuffer.alloced);
+        assert(stuffer->growable == old_stuffer.growable);
+        assert(stuffer->tainted == old_stuffer.tainted);
+    }
+}

--- a/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_fd/s2n_stuffer_alloc_ro_from_fd_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_fd/s2n_stuffer_alloc_ro_from_fd_harness.c
@@ -40,6 +40,8 @@ void s2n_stuffer_alloc_ro_from_fd_harness() {
     if (s2n_stuffer_alloc_ro_from_fd(stuffer, rfd) == S2N_SUCCESS) {
         assert(s2n_stuffer_is_valid(stuffer));
     } else {
-        if (s2n_stuffer_is_valid(stuffer)) assert_stuffer_equivalence(stuffer, &old_stuffer, &old_byte_from_stuffer);
+        if (s2n_stuffer_is_valid(stuffer)) {
+            assert_stuffer_equivalence(stuffer, &old_stuffer, &old_byte_from_stuffer);
+        }
     }
 }

--- a/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_fd/s2n_stuffer_alloc_ro_from_fd_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_fd/s2n_stuffer_alloc_ro_from_fd_harness.c
@@ -38,6 +38,7 @@ void s2n_stuffer_alloc_ro_from_fd_harness() {
     if (s2n_stuffer_alloc_ro_from_fd(stuffer, rfd) == S2N_SUCCESS) {
         assert(s2n_stuffer_is_valid(stuffer));
     } else {
+        /* The function may failed while preparing blob, so we can't assert its equivalence. */
         assert(stuffer->read_cursor == old_stuffer.read_cursor);
         assert(stuffer->write_cursor == old_stuffer.write_cursor);
         assert(stuffer->high_water_mark == old_stuffer.high_water_mark);

--- a/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_fd/s2n_stuffer_alloc_ro_from_fd_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_fd/s2n_stuffer_alloc_ro_from_fd_harness.c
@@ -26,24 +26,20 @@
 void s2n_stuffer_alloc_ro_from_fd_harness() {
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
-    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
     int rfd;
 
     /* Store a byte from the stuffer to compare if the write fails */
-    struct s2n_stuffer old_stuffer = *stuffer;
+    struct s2n_stuffer old_stuffer;
     struct store_byte_from_buffer old_byte_from_stuffer;
-    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+    if(s2n_stuffer_is_valid(stuffer)) {
+        old_stuffer = *stuffer;
+        save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+    }
 
     /* Operation under verification. */
     if (s2n_stuffer_alloc_ro_from_fd(stuffer, rfd) == S2N_SUCCESS) {
         assert(s2n_stuffer_is_valid(stuffer));
     } else {
-        /* The function may failed while preparing blob, so we can't assert its equivalence. */
-        assert(stuffer->read_cursor == old_stuffer.read_cursor);
-        assert(stuffer->write_cursor == old_stuffer.write_cursor);
-        assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
-        assert(stuffer->alloced == old_stuffer.alloced);
-        assert(stuffer->growable == old_stuffer.growable);
-        assert(stuffer->tainted == old_stuffer.tainted);
+        if (s2n_stuffer_is_valid(stuffer)) assert_stuffer_equivalence(stuffer, &old_stuffer, &old_byte_from_stuffer);
     }
 }

--- a/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_file/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_file/Makefile
@@ -1,0 +1,35 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+ABSTRACTIONS += $(HELPERDIR)/stubs/fstat.c
+ABSTRACTIONS += $(HELPERDIR)/stubs/mmap.c
+ABSTRACTIONS += $(HELPERDIR)/stubs/open.c
+
+# Enough to get full coverage with 10 seconds of runtime.
+MAX_STRING_LEN = 10
+DEFINES += -DMAX_STRING_LEN=$(MAX_STRING_LEN)
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_file.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+
+ENTRY = s2n_stuffer_alloc_ro_from_file_harness
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_file/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_file/Makefile
@@ -11,24 +11,27 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-ABSTRACTIONS += $(HELPERDIR)/stubs/fstat.c
-ABSTRACTIONS += $(HELPERDIR)/stubs/mmap.c
-ABSTRACTIONS += $(HELPERDIR)/stubs/open.c
-
 # Enough to get full coverage with 10 seconds of runtime.
 MAX_STRING_LEN = 10
 DEFINES += -DMAX_STRING_LEN=$(MAX_STRING_LEN)
 
 CBMCFLAGS +=
 
-DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
-DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
-DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
-DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
-DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_file.c
-DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+HARNESS_ENTRY = s2n_stuffer_alloc_ro_from_file_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
 
-ENTRY = s2n_stuffer_alloc_ro_from_file_harness
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/fstat.c
+PROOF_SOURCES += $(PROOF_STUB)/mmap.c
+PROOF_SOURCES += $(PROOF_STUB)/open.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_file.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
 
 UNWINDSET +=
 

--- a/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_file/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_file/Makefile
@@ -24,6 +24,7 @@ PROOF_SOURCES += $(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/close.c
 PROOF_SOURCES += $(PROOF_STUB)/fstat.c
 PROOF_SOURCES += $(PROOF_STUB)/mmap.c
 PROOF_SOURCES += $(PROOF_STUB)/open.c
@@ -33,6 +34,6 @@ PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
 PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_file.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
 
-UNWINDSET +=
+UNWINDSET += s2n_stuffer_alloc_ro_from_file.9:3
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_file/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_file/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_file/s2n_stuffer_alloc_ro_from_file_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_file/s2n_stuffer_alloc_ro_from_file_harness.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "error/s2n_errno.h"
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_alloc_ro_from_file_harness() {
+    /* Non-deterministic inputs. */
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    char *file = nondet_bool() ? ensure_c_str_is_allocated(MAX_STRING_LEN) : NULL;
+
+    /* Store a byte from the stuffer to compare if the write fails */
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    /* Operation under verification. */
+    if (s2n_stuffer_alloc_ro_from_file(stuffer, file) == S2N_SUCCESS) {
+        assert(s2n_stuffer_is_valid(stuffer));
+    } else {
+        assert(stuffer->read_cursor == old_stuffer.read_cursor);
+        assert(stuffer->write_cursor == old_stuffer.write_cursor);
+        assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+        assert(stuffer->alloced == old_stuffer.alloced);
+        assert(stuffer->growable == old_stuffer.growable);
+        assert(stuffer->tainted == old_stuffer.tainted);
+    }
+}

--- a/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_file/s2n_stuffer_alloc_ro_from_file_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_file/s2n_stuffer_alloc_ro_from_file_harness.c
@@ -18,6 +18,7 @@
 #include "stuffer/s2n_stuffer.h"
 
 #include <assert.h>
+#include <errno.h>
 
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
@@ -40,6 +41,11 @@ void s2n_stuffer_alloc_ro_from_file_harness() {
     if (s2n_stuffer_alloc_ro_from_file(stuffer, file) == S2N_SUCCESS) {
         assert(s2n_stuffer_is_valid(stuffer));
     } else {
-        if (s2n_stuffer_is_valid(stuffer)) assert_stuffer_equivalence(stuffer, &old_stuffer, &old_byte_from_stuffer);
+        if (s2n_stuffer_is_valid(stuffer) &&
+            errno != EBADF && /* The stuffer might not be equivalent if close() fails. */
+            errno != EINTR &&
+            errno != EIO) {
+            assert_stuffer_equivalence(stuffer, &old_stuffer, &old_byte_from_stuffer);
+        }
     }
 }

--- a/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_file/s2n_stuffer_alloc_ro_from_file_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_file/s2n_stuffer_alloc_ro_from_file_harness.c
@@ -27,7 +27,7 @@ void s2n_stuffer_alloc_ro_from_file_harness() {
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
-    char *file = nondet_bool() ? ensure_c_str_is_allocated(MAX_STRING_LEN) : NULL;
+    char *file = nondet_c_str_is_allocated(MAX_STRING_LEN);
 
     /* Store a byte from the stuffer to compare if the write fails */
     struct s2n_stuffer old_stuffer = *stuffer;
@@ -38,6 +38,7 @@ void s2n_stuffer_alloc_ro_from_file_harness() {
     if (s2n_stuffer_alloc_ro_from_file(stuffer, file) == S2N_SUCCESS) {
         assert(s2n_stuffer_is_valid(stuffer));
     } else {
+        /* The function may failed while preparing blob, so we can't assert its equivalence. */
         assert(stuffer->read_cursor == old_stuffer.read_cursor);
         assert(stuffer->write_cursor == old_stuffer.write_cursor);
         assert(stuffer->high_water_mark == old_stuffer.high_water_mark);

--- a/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_file/s2n_stuffer_alloc_ro_from_file_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_file/s2n_stuffer_alloc_ro_from_file_harness.c
@@ -26,24 +26,20 @@
 void s2n_stuffer_alloc_ro_from_file_harness() {
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
-    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
     char *file = nondet_c_str_is_allocated(MAX_STRING_LEN);
 
     /* Store a byte from the stuffer to compare if the write fails */
-    struct s2n_stuffer old_stuffer = *stuffer;
+    struct s2n_stuffer old_stuffer;
     struct store_byte_from_buffer old_byte_from_stuffer;
-    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+    if(s2n_stuffer_is_valid(stuffer)) {
+        old_stuffer = *stuffer;
+        save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+    }
 
     /* Operation under verification. */
     if (s2n_stuffer_alloc_ro_from_file(stuffer, file) == S2N_SUCCESS) {
         assert(s2n_stuffer_is_valid(stuffer));
     } else {
-        /* The function may failed while preparing blob, so we can't assert its equivalence. */
-        assert(stuffer->read_cursor == old_stuffer.read_cursor);
-        assert(stuffer->write_cursor == old_stuffer.write_cursor);
-        assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
-        assert(stuffer->alloced == old_stuffer.alloced);
-        assert(stuffer->growable == old_stuffer.growable);
-        assert(stuffer->tainted == old_stuffer.tainted);
+        if (s2n_stuffer_is_valid(stuffer)) assert_stuffer_equivalence(stuffer, &old_stuffer, &old_byte_from_stuffer);
     }
 }

--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -58,3 +58,14 @@ const char *ensure_c_str_is_allocated(size_t max_size) {
     __CPROVER_assume(str[cap - 1] == 0);
     return str;
 }
+
+const char *nondet_c_str_is_allocated(size_t max_size) {
+    size_t cap;
+    __CPROVER_assume(cap > 0 && cap <= max_size);
+    const char *str = can_fail_malloc(cap);
+    /* Ensure that its a valid c string. Since all bytes are nondeterminstic, the actual
+     * string length is 0..str_cap
+     */
+    __CPROVER_assume(IMPLIES(str != NULL, str[cap - 1] == 0));
+    return str;
+}

--- a/tests/cbmc/stubs/close.c
+++ b/tests/cbmc/stubs/close.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <assert.h>
+#include <cbmc_proof/nondet.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <errno.h>
+#include <unistd.h>
+
+static bool loop_flag = false;
+
+int close(int fd) {
+    assert(fd >= -1 && fd <= 65536 /* File descriptor limit. */);
+    if(nondet_bool()) {
+        return 0;
+    }
+    __CPROVER_assume(errno == EBADF || errno == EINTR || errno == EIO);
+    return -1;
+}

--- a/tests/cbmc/stubs/fstat.c
+++ b/tests/cbmc/stubs/fstat.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <assert.h>
+#include <cbmc_proof/nondet.h>
+#include <sys/stat.h>
+
+off_t nondet_off_t();
+
+int fstat(int fd, struct stat *buf) {
+    assert(buf != NULL);
+    buf->st_size = nondet_off_t();
+    return nondet_bool() ? 0 : -1;
+}

--- a/tests/cbmc/stubs/fstat.c
+++ b/tests/cbmc/stubs/fstat.c
@@ -17,10 +17,8 @@
 #include <cbmc_proof/nondet.h>
 #include <sys/stat.h>
 
-off_t nondet_off_t();
-
 int fstat(int fd, struct stat *buf) {
-    assert(buf != NULL);
+    assert(__CPROVER_w_ok(buf, sizeof(*buf)));
     buf->st_size = nondet_off_t();
     return nondet_bool() ? 0 : -1;
 }

--- a/tests/cbmc/stubs/mmap.c
+++ b/tests/cbmc/stubs/mmap.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <assert.h>
+#include <cbmc_proof/nondet.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <sys/mman.h>
+
+void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
+    assert(length > 0);
+    if(nondet_bool()) {
+        uint8_t *buf = can_fail_malloc(length);
+        return buf;
+    }
+    return MAP_FAILED;
+}

--- a/tests/cbmc/stubs/mmap.c
+++ b/tests/cbmc/stubs/mmap.c
@@ -19,6 +19,7 @@
 #include <sys/mman.h>
 
 void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
+    assert(addr == NULL);
     assert(length > 0);
     if(nondet_bool()) {
         uint8_t *buf = can_fail_malloc(length);

--- a/tests/cbmc/stubs/open.c
+++ b/tests/cbmc/stubs/open.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <assert.h>
+#include <cbmc_proof/nondet.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <sys/fcntl.h>
+
+int open(const char *path, int, ...) {
+    assert(path != NULL);
+    return 0;
+}

--- a/tests/cbmc/stubs/open.c
+++ b/tests/cbmc/stubs/open.c
@@ -16,12 +16,22 @@
 #include <assert.h>
 #include <cbmc_proof/nondet.h>
 #include <cbmc_proof/proof_allocators.h>
+#include <errno.h>
 #include <sys/fcntl.h>
 
-#include <stdarg.h>
+static bool loop_flag = false;
 
 int open(const char *path, int flag, ...) {
     assert(path != NULL);
     assert(flag == O_RDONLY || flag == O_WRONLY || flag == O_RDWR);
-    return 0;
+    int rval = 0;
+    errno = nondet_int();
+    if(loop_flag) {
+        __CPROVER_assume(errno != EINTR);
+        return rval;
+    }
+    loop_flag = true;
+    rval = nondet_int();
+    __CPROVER_assume(rval >= -1 && rval <= 65536 /* File descriptor limit. */);
+    return rval;
 }

--- a/tests/cbmc/stubs/open.c
+++ b/tests/cbmc/stubs/open.c
@@ -18,7 +18,10 @@
 #include <cbmc_proof/proof_allocators.h>
 #include <sys/fcntl.h>
 
-int open(const char *path, int, ...) {
+#include <stdarg.h>
+
+int open(const char *path, int flag, ...) {
     assert(path != NULL);
+    assert(flag == O_RDONLY || flag == O_WRONLY || flag == O_RDWR);
     return 0;
 }


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A.

### Description of changes: 

- Adds a proof harness for the `s2n_stuffer_alloc_ro_from_fd` function;
- Adds a pre- and post-conditions to the `s2n_stuffer_alloc_ro_from_fd` function;
- Adds a proof harness for the `s2n_stuffer_alloc_ro_from_file` function;
- Adds a pre- and post-conditions to the `s2n_stuffer_alloc_ro_from_file` function;

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.