### PR TITLE
Fix security policy test for S2N_NO_PQ

### DIFF
--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -50,7 +50,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_r2r1);
 #else
         EXPECT_FALSE(s2n_pq_kem_is_extension_required(security_policy));
-        EXPECT_EQUAL(0, security_policy->kem_preferences->count);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_count);
         EXPECT_NULL(security_policy->kem_preferences->kems);
 #endif
 


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A

### Description of changes: 

Fixes `s2n_security_policies_test` for the case when `S2N_NO_PQ` is defined.

### Call-outs:

Apparently I missed this in my previous commit (https://github.com/awslabs/s2n/commit/8123d4788ad5c468af61725e34a235ab03c2bab8)

### Testing:

Existing tests passed locally when building with the `S2N_NO_PQ` flag.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
