### PR TITLE
Adds proof harnesses for s2n_stuffer_reserve* functions

### DIFF
--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -35,6 +35,12 @@ bool s2n_stuffer_is_valid(const struct s2n_stuffer* stuffer)
            stuffer->read_cursor <= stuffer->write_cursor;
 }
 
+extern bool s2n_stuffer_reservation_is_valid(const struct s2n_stuffer_reservation* reservation)
+{
+    return s2n_stuffer_is_valid(reservation->stuffer) &&
+           (reservation->write_cursor == reservation->stuffer->write_cursor);
+}
+
 int s2n_stuffer_init(struct s2n_stuffer *stuffer, struct s2n_blob *in)
 {
     PRECONDITION_POSIX(S2N_OBJECT_PTR_IS_WRITABLE(stuffer));

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -38,7 +38,7 @@ bool s2n_stuffer_is_valid(const struct s2n_stuffer* stuffer)
 bool s2n_stuffer_reservation_is_valid(const struct s2n_stuffer_reservation* reservation)
 {
     return s2n_stuffer_is_valid(reservation->stuffer) &&
-           (reservation->write_cursor == reservation->stuffer->write_cursor);
+           S2N_MEM_IS_WRITABLE(reservation->stuffer->blob.data + reservation->write_cursor, reservation->length);
 }
 
 int s2n_stuffer_init(struct s2n_stuffer *stuffer, struct s2n_blob *in)

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -35,7 +35,7 @@ bool s2n_stuffer_is_valid(const struct s2n_stuffer* stuffer)
            stuffer->read_cursor <= stuffer->write_cursor;
 }
 
-extern bool s2n_stuffer_reservation_is_valid(const struct s2n_stuffer_reservation* reservation)
+bool s2n_stuffer_reservation_is_valid(const struct s2n_stuffer_reservation* reservation)
 {
     return s2n_stuffer_is_valid(reservation->stuffer) &&
            (reservation->write_cursor == reservation->stuffer->write_cursor);

--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -120,6 +120,8 @@ struct s2n_stuffer_reservation {
     uint32_t write_cursor;
     uint8_t length;
 };
+/* Check basic validity constraints on the s2n_stuffer_reservation: e.g. stuffer validity. */
+extern bool s2n_stuffer_reservation_is_valid(const struct s2n_stuffer_reservation* reservation);
 extern int s2n_stuffer_reserve_uint16(struct s2n_stuffer *stuffer, struct s2n_stuffer_reservation *reservation);
 extern int s2n_stuffer_reserve_uint24(struct s2n_stuffer *stuffer, struct s2n_stuffer_reservation *reservation);
 extern int s2n_stuffer_write_vector_size(struct s2n_stuffer_reservation reservation);

--- a/stuffer/s2n_stuffer_network_order.c
+++ b/stuffer/s2n_stuffer_network_order.c
@@ -36,14 +36,12 @@ int s2n_stuffer_write_network_order(struct s2n_stuffer *stuffer, const uint64_t 
     return S2N_SUCCESS;
 }
 
-int s2n_stuffer_reserve(struct s2n_stuffer *stuffer, struct s2n_stuffer_reservation *reservation, uint8_t length)
+int s2n_stuffer_reserve(struct s2n_stuffer *stuffer, struct s2n_stuffer_reservation *reservation, const uint8_t length)
 {
     PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     notnull_check(reservation);
 
-    reservation->stuffer = stuffer;
-    reservation->write_cursor = stuffer->write_cursor;
-    reservation->length = length;
+    *reservation = (struct s2n_stuffer_reservation) {.stuffer = stuffer, .write_cursor = stuffer->write_cursor, .length = length};
 
     GUARD(s2n_stuffer_skip_write(stuffer, reservation->length));
     memset_check(stuffer->blob.data + reservation->write_cursor, S2N_WIPE_PATTERN, reservation->length);

--- a/stuffer/s2n_stuffer_network_order.c
+++ b/stuffer/s2n_stuffer_network_order.c
@@ -46,7 +46,6 @@ int s2n_stuffer_reserve(struct s2n_stuffer *stuffer, struct s2n_stuffer_reservat
     GUARD(s2n_stuffer_skip_write(stuffer, reservation->length));
     memset_check(stuffer->blob.data + reservation->write_cursor, S2N_WIPE_PATTERN, reservation->length);
     POSTCONDITION_POSIX(s2n_stuffer_reservation_is_valid(reservation));
-    POSTCONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     return S2N_SUCCESS;
 }
 

--- a/stuffer/s2n_stuffer_network_order.c
+++ b/stuffer/s2n_stuffer_network_order.c
@@ -38,7 +38,7 @@ int s2n_stuffer_write_network_order(struct s2n_stuffer *stuffer, const uint64_t 
 
 int s2n_stuffer_reserve(struct s2n_stuffer *stuffer, struct s2n_stuffer_reservation *reservation, uint8_t length)
 {
-    notnull_check(stuffer);
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     notnull_check(reservation);
 
     reservation->stuffer = stuffer;
@@ -47,7 +47,8 @@ int s2n_stuffer_reserve(struct s2n_stuffer *stuffer, struct s2n_stuffer_reservat
 
     GUARD(s2n_stuffer_skip_write(stuffer, reservation->length));
     memset_check(stuffer->blob.data + reservation->write_cursor, S2N_WIPE_PATTERN, reservation->length);
-
+    POSTCONDITION_POSIX(s2n_stuffer_reservation_is_valid(reservation));
+    POSTCONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     return S2N_SUCCESS;
 }
 

--- a/tests/cbmc/include/cbmc_proof/make_common_datastructures.h
+++ b/tests/cbmc/include/cbmc_proof/make_common_datastructures.h
@@ -56,3 +56,8 @@ const char *ensure_c_str_is_allocated(size_t max_size);
  * with as much nondet as possible, len < max_size.
  */
 const char *nondet_c_str_is_allocated(size_t max_size);
+
+/*
+ * Properly allocates s2n_stuffer_reservation for CBMC proofs.
+ */
+struct s2n_stuffer_reservation* cbmc_allocate_s2n_stuffer_reservation();

--- a/tests/cbmc/proofs/s2n_stuffer_reserve/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve/Makefile
@@ -1,0 +1,36 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 20 seconds.
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+
+ENTRY = s2n_stuffer_reserve_harness
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_blob_slice
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_stuffer_wipe_n
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_reserve/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_reserve/s2n_stuffer_reserve_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve/s2n_stuffer_reserve_harness.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <sys/param.h>
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_mem.h"
+
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_reserve_harness() {
+    /* Non-deterministic inputs. */
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    struct s2n_stuffer_reservation *reservation = nondet_bool() ? NULL : cbmc_allocate_s2n_stuffer_reservation();
+    uint8_t length;
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    /* Save previous state from stuffer. */
+    struct s2n_stuffer old_stuffer = *stuffer;
+    /* Store a byte from the stuffer to compare */
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    /* Operation under verification. */
+    if (s2n_stuffer_reserve(stuffer, reservation, length) == S2N_SUCCESS) {
+        assert(stuffer->write_cursor == old_stuffer.write_cursor + length);
+        assert(stuffer->high_water_mark == MAX(old_stuffer.write_cursor + length, old_stuffer.high_water_mark));
+        if(old_stuffer.blob.size > 0) {
+            assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
+            size_t index;
+            __CPROVER_assume(index >= reservation->write_cursor &&
+                             index < (reservation->write_cursor + reservation->length));
+            assert(stuffer->blob.data[index] == S2N_WIPE_PATTERN);
+            assert(reservation->stuffer->blob.data[index] == S2N_WIPE_PATTERN);
+        }
+        assert(stuffer == reservation->stuffer);
+        assert(stuffer->write_cursor == reservation->write_cursor);
+        assert(s2n_stuffer_is_valid(stuffer));
+        assert(s2n_stuffer_reservation_is_valid(reservation));
+    } else {
+        assert(stuffer->read_cursor == old_stuffer.read_cursor);
+        assert(stuffer->alloced == old_stuffer.alloced);
+        assert(stuffer->growable == old_stuffer.growable);
+        assert(stuffer->tainted == old_stuffer.tainted);
+    }
+}

--- a/tests/cbmc/proofs/s2n_stuffer_reserve_uint16/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve_uint16/Makefile
@@ -11,18 +11,17 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Expected runtime is 30 seconds.
+# Expected runtime is 20 seconds.
 
 CBMCFLAGS +=
 
-HARNESS_ENTRY = s2n_stuffer_reserve_harness
+HARNESS_ENTRY = s2n_stuffer_reserve_uint16_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
 
 PROOF_SOURCES += $(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
-PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c

--- a/tests/cbmc/proofs/s2n_stuffer_reserve_uint16/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve_uint16/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_reserve_uint16/s2n_stuffer_reserve_uint16_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve_uint16/s2n_stuffer_reserve_uint16_harness.c
@@ -22,18 +22,16 @@
 #include <assert.h>
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
-#include <cbmc_proof/nondet.h>
 #include <cbmc_proof/proof_allocators.h>
 
-void s2n_stuffer_reserve_harness() {
+void s2n_stuffer_reserve_uint16_harness() {
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
     struct s2n_stuffer_reservation *reservation = cbmc_allocate_s2n_stuffer_reservation();
-    const uint8_t length;
 
     /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if (nondet_bool()) {
+    if(nondet_bool()) {
         s2n_mem_init();
     }
 
@@ -44,11 +42,11 @@ void s2n_stuffer_reserve_harness() {
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
     /* Operation under verification. */
-    if (s2n_stuffer_reserve(stuffer, reservation, length) == S2N_SUCCESS) {
-        assert(stuffer->write_cursor == old_stuffer.write_cursor + length);
-        assert(stuffer->high_water_mark == MAX(old_stuffer.write_cursor + length, old_stuffer.high_water_mark));
-        assert(reservation->length == length);
-        if (old_stuffer.blob.size > 0 && reservation->length > 0) {
+    if (s2n_stuffer_reserve_uint16(stuffer, reservation) == S2N_SUCCESS) {
+        assert(stuffer->write_cursor == old_stuffer.write_cursor + sizeof(uint16_t));
+        assert(stuffer->high_water_mark == MAX(old_stuffer.write_cursor + sizeof(uint16_t), old_stuffer.high_water_mark));
+        assert(reservation->length == sizeof(uint16_t));
+        if(old_stuffer.blob.size > 0) {
             size_t index;
             __CPROVER_assume(index >= reservation->write_cursor &&
                              index < (reservation->write_cursor + reservation->length));

--- a/tests/cbmc/proofs/s2n_stuffer_reserve_uint24/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve_uint24/Makefile
@@ -11,11 +11,11 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Expected runtime is 30 seconds.
+# Expected runtime is 20 seconds.
 
 CBMCFLAGS +=
 
-HARNESS_ENTRY = s2n_stuffer_reserve_harness
+HARNESS_ENTRY = s2n_stuffer_reserve_uint24_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
 
 PROOF_SOURCES += $(HARNESS_FILE)

--- a/tests/cbmc/proofs/s2n_stuffer_reserve_uint24/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve_uint24/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_reserve_uint24/s2n_stuffer_reserve_uint24_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve_uint24/s2n_stuffer_reserve_uint24_harness.c
@@ -22,18 +22,16 @@
 #include <assert.h>
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
-#include <cbmc_proof/nondet.h>
 #include <cbmc_proof/proof_allocators.h>
 
-void s2n_stuffer_reserve_harness() {
+void s2n_stuffer_reserve_uint24_harness() {
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
-    struct s2n_stuffer_reservation *reservation = nondet_bool() ? NULL : cbmc_allocate_s2n_stuffer_reservation();
-    uint8_t length = nondet_uint8_t();
+    struct s2n_stuffer_reservation *reservation = cbmc_allocate_s2n_stuffer_reservation();
 
     /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if (nondet_bool()) {
+    if(nondet_bool()) {
         s2n_mem_init();
     }
 
@@ -44,11 +42,11 @@ void s2n_stuffer_reserve_harness() {
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
     /* Operation under verification. */
-    if (s2n_stuffer_reserve(stuffer, reservation, length) == S2N_SUCCESS) {
-        assert(stuffer->write_cursor == old_stuffer.write_cursor + length);
-        assert(stuffer->high_water_mark == MAX(old_stuffer.write_cursor + length, old_stuffer.high_water_mark));
-        assert(reservation->length == length);
-        if (old_stuffer.blob.size > 0 && reservation->length > 0) {
+    if (s2n_stuffer_reserve_uint24(stuffer, reservation) == S2N_SUCCESS) {
+        assert(stuffer->write_cursor == old_stuffer.write_cursor + SIZEOF_UINT24);
+        assert(stuffer->high_water_mark == MAX(old_stuffer.write_cursor + SIZEOF_UINT24, old_stuffer.high_water_mark));
+        assert(reservation->length == SIZEOF_UINT24);
+        if(old_stuffer.blob.size > 0) {
             size_t index;
             __CPROVER_assume(index >= reservation->write_cursor &&
                              index < (reservation->write_cursor + reservation->length));

--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -69,3 +69,11 @@ const char *nondet_c_str_is_allocated(size_t max_size) {
     __CPROVER_assume(IMPLIES(str != NULL, str[cap - 1] == 0));
     return str;
 }
+
+struct s2n_stuffer_reservation* cbmc_allocate_s2n_stuffer_reservation() {
+    struct s2n_stuffer_reservation* reservation = can_fail_malloc(sizeof(*reservation));
+    if (reservation != NULL) {
+        reservation->stuffer = cbmc_allocate_s2n_stuffer();
+    }
+    return reservation;
+}


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A.

### Description of changes: 

- Adds a set of predicates for the `s2n_stuffer_reservation` structure;
- Adds a proof harness for the `s2n_stuffer_reserve` function;
- Adds a pre- and post-conditions to the `s2n_stuffer_reserve` function;
- Adds a proof harness for the `s2n_stuffer_reserve_uint24` function;

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.