### PR TITLE
Adds a proof harness for s2n_stuffer_write_vector_size

### DIFF
--- a/crypto/s2n_certificate.c
+++ b/crypto/s2n_certificate.c
@@ -403,7 +403,7 @@ int s2n_send_cert_chain(struct s2n_connection *conn, struct s2n_stuffer *out, st
     struct s2n_cert *cur_cert = chain->head;
     notnull_check(cur_cert);
 
-    struct s2n_stuffer_reservation cert_chain_size;
+    struct s2n_stuffer_reservation cert_chain_size = {0};
     GUARD(s2n_stuffer_reserve_uint24(out, &cert_chain_size));
 
     /* Send certs and extensions (in TLS 1.3) */
@@ -429,7 +429,7 @@ int s2n_send_cert_chain(struct s2n_connection *conn, struct s2n_stuffer *out, st
         cur_cert = cur_cert->next;
     }
 
-    GUARD(s2n_stuffer_write_vector_size(cert_chain_size));
+    GUARD(s2n_stuffer_write_vector_size(&cert_chain_size));
 
     return 0;
 }

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -37,7 +37,8 @@ bool s2n_stuffer_is_valid(const struct s2n_stuffer* stuffer)
 
 bool s2n_stuffer_reservation_is_valid(const struct s2n_stuffer_reservation* reservation)
 {
-    return s2n_stuffer_is_valid(reservation->stuffer) &&
+    return S2N_OBJECT_PTR_IS_READABLE(reservation) &&
+           s2n_stuffer_is_valid(reservation->stuffer) &&
            S2N_MEM_IS_WRITABLE(reservation->stuffer->blob.data + reservation->write_cursor, reservation->length);
 }
 

--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -124,7 +124,7 @@ struct s2n_stuffer_reservation {
 extern bool s2n_stuffer_reservation_is_valid(const struct s2n_stuffer_reservation* reservation);
 extern int s2n_stuffer_reserve_uint16(struct s2n_stuffer *stuffer, struct s2n_stuffer_reservation *reservation);
 extern int s2n_stuffer_reserve_uint24(struct s2n_stuffer *stuffer, struct s2n_stuffer_reservation *reservation);
-extern int s2n_stuffer_write_vector_size(struct s2n_stuffer_reservation reservation);
+extern int s2n_stuffer_write_vector_size(struct s2n_stuffer_reservation *reservation);
 
 /* Copy one stuffer to another */
 extern int s2n_stuffer_copy(struct s2n_stuffer *from, struct s2n_stuffer *to, uint32_t len);

--- a/stuffer/s2n_stuffer_network_order.c
+++ b/stuffer/s2n_stuffer_network_order.c
@@ -170,7 +170,7 @@ static int length_matches_value_check(uint32_t value, uint8_t length)
 static int s2n_stuffer_write_reservation_impl(struct s2n_stuffer_reservation reservation, uint32_t u)
 {
     reservation.stuffer->write_cursor = reservation.write_cursor;
-    S2N_ERROR_IF(!s2n_stuffer_is_valid(reservation.stuffer), S2N_ERR_PRECONDITION_VIOLATION);
+    ENSURE_POSIX(s2n_stuffer_is_valid(reservation.stuffer), S2N_ERR_PRECONDITION_VIOLATION);
 
     GUARD(length_matches_value_check(u, reservation.length));
     GUARD(s2n_stuffer_write_network_order(reservation.stuffer, u, reservation.length));
@@ -181,7 +181,6 @@ static int s2n_stuffer_write_reservation_impl(struct s2n_stuffer_reservation res
 int s2n_stuffer_write_reservation(struct s2n_stuffer_reservation reservation, uint32_t u)
 {
     PRECONDITION_POSIX(s2n_stuffer_reservation_is_valid(&reservation));
-
     uint32_t old_write_cursor = reservation.stuffer->write_cursor;
     int result = s2n_stuffer_write_reservation_impl(reservation, u);
     reservation.stuffer->write_cursor = old_write_cursor;
@@ -190,6 +189,9 @@ int s2n_stuffer_write_reservation(struct s2n_stuffer_reservation reservation, ui
 
 int s2n_stuffer_write_vector_size(struct s2n_stuffer_reservation reservation)
 {
-    uint32_t size = reservation.stuffer->write_cursor - reservation.write_cursor - reservation.length;
+    PRECONDITION_POSIX(s2n_stuffer_reservation_is_valid(&reservation));
+    uint32_t size = 0;
+    GUARD(s2n_sub_overflow(reservation.stuffer->write_cursor, reservation.write_cursor, &size));
+    GUARD(s2n_sub_overflow(size, reservation.length, &size));
     return s2n_stuffer_write_reservation(reservation, size);
 }

--- a/stuffer/s2n_stuffer_network_order.c
+++ b/stuffer/s2n_stuffer_network_order.c
@@ -174,13 +174,13 @@ static int s2n_stuffer_write_reservation_impl(struct s2n_stuffer_reservation res
 
     GUARD(length_matches_value_check(u, reservation.length));
     GUARD(s2n_stuffer_write_network_order(reservation.stuffer, u, reservation.length));
-
+    POSTCONDITION_POSIX(s2n_stuffer_is_valid(reservation.stuffer));
     return S2N_SUCCESS;
 }
 
 int s2n_stuffer_write_reservation(struct s2n_stuffer_reservation reservation, uint32_t u)
 {
-    notnull_check(reservation.stuffer);
+    PRECONDITION_POSIX(s2n_stuffer_reservation_is_valid(&reservation));
 
     uint32_t old_write_cursor = reservation.stuffer->write_cursor;
     int result = s2n_stuffer_write_reservation_impl(reservation, u);

--- a/stuffer/s2n_stuffer_network_order.c
+++ b/stuffer/s2n_stuffer_network_order.c
@@ -167,10 +167,10 @@ static int length_matches_value_check(uint32_t value, uint8_t length)
     return S2N_SUCCESS;
 }
 
-static int s2n_stuffer_write_reservation_impl(struct s2n_stuffer_reservation* reservation, uint32_t u)
+static int s2n_stuffer_write_reservation_impl(struct s2n_stuffer_reservation* reservation, const uint32_t u)
 {
     reservation->stuffer->write_cursor = reservation->write_cursor;
-    ENSURE_POSIX(s2n_stuffer_is_valid(reservation->stuffer), S2N_ERR_PRECONDITION_VIOLATION);
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(reservation->stuffer));
 
     GUARD(length_matches_value_check(u, reservation->length));
     GUARD(s2n_stuffer_write_network_order(reservation->stuffer, u, reservation->length));
@@ -178,7 +178,7 @@ static int s2n_stuffer_write_reservation_impl(struct s2n_stuffer_reservation* re
     return S2N_SUCCESS;
 }
 
-int s2n_stuffer_write_reservation(struct s2n_stuffer_reservation* reservation, uint32_t u)
+int s2n_stuffer_write_reservation(struct s2n_stuffer_reservation* reservation, const uint32_t u)
 {
     PRECONDITION_POSIX(s2n_stuffer_reservation_is_valid(reservation));
     uint32_t old_write_cursor = reservation->stuffer->write_cursor;

--- a/stuffer/s2n_stuffer_network_order.c
+++ b/stuffer/s2n_stuffer_network_order.c
@@ -167,31 +167,31 @@ static int length_matches_value_check(uint32_t value, uint8_t length)
     return S2N_SUCCESS;
 }
 
-static int s2n_stuffer_write_reservation_impl(struct s2n_stuffer_reservation reservation, uint32_t u)
+static int s2n_stuffer_write_reservation_impl(struct s2n_stuffer_reservation* reservation, uint32_t u)
 {
-    reservation.stuffer->write_cursor = reservation.write_cursor;
-    ENSURE_POSIX(s2n_stuffer_is_valid(reservation.stuffer), S2N_ERR_PRECONDITION_VIOLATION);
+    reservation->stuffer->write_cursor = reservation->write_cursor;
+    ENSURE_POSIX(s2n_stuffer_is_valid(reservation->stuffer), S2N_ERR_PRECONDITION_VIOLATION);
 
-    GUARD(length_matches_value_check(u, reservation.length));
-    GUARD(s2n_stuffer_write_network_order(reservation.stuffer, u, reservation.length));
-    POSTCONDITION_POSIX(s2n_stuffer_is_valid(reservation.stuffer));
+    GUARD(length_matches_value_check(u, reservation->length));
+    GUARD(s2n_stuffer_write_network_order(reservation->stuffer, u, reservation->length));
+    POSTCONDITION_POSIX(s2n_stuffer_is_valid(reservation->stuffer));
     return S2N_SUCCESS;
 }
 
-int s2n_stuffer_write_reservation(struct s2n_stuffer_reservation reservation, uint32_t u)
+int s2n_stuffer_write_reservation(struct s2n_stuffer_reservation* reservation, uint32_t u)
 {
-    PRECONDITION_POSIX(s2n_stuffer_reservation_is_valid(&reservation));
-    uint32_t old_write_cursor = reservation.stuffer->write_cursor;
+    PRECONDITION_POSIX(s2n_stuffer_reservation_is_valid(reservation));
+    uint32_t old_write_cursor = reservation->stuffer->write_cursor;
     int result = s2n_stuffer_write_reservation_impl(reservation, u);
-    reservation.stuffer->write_cursor = old_write_cursor;
+    reservation->stuffer->write_cursor = old_write_cursor;
     return result;
 }
 
-int s2n_stuffer_write_vector_size(struct s2n_stuffer_reservation reservation)
+int s2n_stuffer_write_vector_size(struct s2n_stuffer_reservation* reservation)
 {
-    PRECONDITION_POSIX(s2n_stuffer_reservation_is_valid(&reservation));
+    PRECONDITION_POSIX(s2n_stuffer_reservation_is_valid(reservation));
     uint32_t size = 0;
-    GUARD(s2n_sub_overflow(reservation.stuffer->write_cursor, reservation.write_cursor, &size));
-    GUARD(s2n_sub_overflow(size, reservation.length, &size));
+    GUARD(s2n_sub_overflow(reservation->stuffer->write_cursor, reservation->write_cursor, &size));
+    GUARD(s2n_sub_overflow(size, reservation->length, &size));
     return s2n_stuffer_write_reservation(reservation, size);
 }

--- a/tests/cbmc/proofs/s2n_stuffer_write_reservation/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_reservation/Makefile
@@ -1,0 +1,38 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 40 seconds.
+MAX_LENGTH = 3
+DEFINES += -DMAX_LENGTH=$(MAX_LENGTH)
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+
+ENTRY = s2n_stuffer_write_reservation_harness
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_blob_slice
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_stuffer_wipe_n
+
+ UNWINDSET += s2n_stuffer_write_network_order.1:$(shell echo $$((1 + $(MAX_LENGTH))))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_reservation/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_reservation/Makefile
@@ -11,7 +11,7 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Expected runtime is 40 seconds.
+# Expected runtime is 23 minutes.
 MAX_LENGTH = 3
 DEFINES += -DMAX_LENGTH=$(MAX_LENGTH)
 
@@ -40,6 +40,14 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
 
- UNWINDSET += s2n_stuffer_write_network_order.4:$(shell echo $$((1 + $(MAX_LENGTH))))
+UNWINDSET += s2n_stuffer_write_network_order.0:$(shell echo $$((1 + $(MAX_LENGTH))))
+UNWINDSET += s2n_stuffer_write_network_order.1:$(shell echo $$((1 + $(MAX_LENGTH))))
+UNWINDSET += s2n_stuffer_write_network_order.2:$(shell echo $$((1 + $(MAX_LENGTH))))
+UNWINDSET += s2n_stuffer_write_network_order.3:$(shell echo $$((1 + $(MAX_LENGTH))))
+UNWINDSET += s2n_stuffer_write_network_order.4:$(shell echo $$((1 + $(MAX_LENGTH))))
+UNWINDSET += s2n_stuffer_write_network_order.5:$(shell echo $$((1 + $(MAX_LENGTH))))
+UNWINDSET += s2n_stuffer_write_network_order.6:$(shell echo $$((1 + $(MAX_LENGTH))))
+UNWINDSET += s2n_stuffer_write_network_order.7:$(shell echo $$((1 + $(MAX_LENGTH))))
+UNWINDSET += s2n_stuffer_write_reservation_harness.0:$(shell echo $$((1 + $(MAX_LENGTH))))
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_reservation/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_write_reservation/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_write_reservation/s2n_stuffer_write_reservation_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_reservation/s2n_stuffer_write_reservation_harness.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <sys/param.h>
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_mem.h"
+
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/nondet.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_write_reservation_harness() {
+    /* Non-deterministic inputs. */
+    struct s2n_stuffer_reservation *reservation = cbmc_allocate_s2n_stuffer_reservation();
+    __CPROVER_assume(s2n_stuffer_reservation_is_valid(reservation));
+    __CPROVER_assume(reservation->length < MAX_LENGTH);
+    uint32_t u = nondet_uint32_t();
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    /* Save previous state from stuffer. */
+    struct s2n_stuffer old_stuffer = *(reservation->stuffer);
+
+    /* Operation under verification. */
+    if (s2n_stuffer_write_reservation(*reservation, u) == S2N_SUCCESS) {
+        assert(reservation->stuffer->write_cursor == old_stuffer.write_cursor);
+    } else {
+        assert(reservation->stuffer->read_cursor == old_stuffer.read_cursor);
+        assert(reservation->stuffer->alloced == old_stuffer.alloced);
+        assert(reservation->stuffer->growable == old_stuffer.growable);
+        assert(reservation->stuffer->tainted == old_stuffer.tainted);
+    }
+}

--- a/tests/cbmc/proofs/s2n_stuffer_write_reservation/s2n_stuffer_write_reservation_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_reservation/s2n_stuffer_write_reservation_harness.c
@@ -30,23 +30,26 @@ void s2n_stuffer_write_reservation_harness() {
     struct s2n_stuffer_reservation *reservation = cbmc_allocate_s2n_stuffer_reservation();
     __CPROVER_assume(s2n_stuffer_reservation_is_valid(reservation));
     __CPROVER_assume(reservation->length < MAX_LENGTH);
-    uint32_t u = nondet_uint32_t();
+    uint32_t u;
 
     /* Non-deterministically set initialized (in s2n_mem) to true. */
     if(nondet_bool()) {
         s2n_mem_init();
     }
 
-    /* Save previous state from stuffer. */
-    struct s2n_stuffer old_stuffer = *(reservation->stuffer);
+    /* Save previous state from stuffer_reservation. */
+    struct s2n_stuffer_reservation old_stuffer_reservation = *reservation;
 
     /* Operation under verification. */
-    if (s2n_stuffer_write_reservation(*reservation, u) == S2N_SUCCESS) {
-        assert(reservation->stuffer->write_cursor == old_stuffer.write_cursor);
+    if (s2n_stuffer_write_reservation(reservation, u) == S2N_SUCCESS) {
+        assert(s2n_stuffer_reservation_is_valid(reservation));
+        assert(reservation->stuffer->write_cursor == old_stuffer_reservation.stuffer->write_cursor);
     } else {
-        assert(reservation->stuffer->read_cursor == old_stuffer.read_cursor);
-        assert(reservation->stuffer->alloced == old_stuffer.alloced);
-        assert(reservation->stuffer->growable == old_stuffer.growable);
-        assert(reservation->stuffer->tainted == old_stuffer.tainted);
+        assert(reservation->stuffer->write_cursor == old_stuffer_reservation.stuffer->write_cursor);
+        assert(reservation->stuffer->high_water_mark == old_stuffer_reservation.stuffer->high_water_mark);
     }
+    assert(reservation->stuffer->alloced == old_stuffer_reservation.stuffer->alloced);
+    assert(reservation->stuffer->growable == old_stuffer_reservation.stuffer->growable);
+    assert(reservation->stuffer->tainted == old_stuffer_reservation.stuffer->tainted);
+    assert(reservation->stuffer->read_cursor == old_stuffer_reservation.stuffer->read_cursor);
 }

--- a/tests/cbmc/proofs/s2n_stuffer_write_vector_size/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_vector_size/Makefile
@@ -17,15 +17,13 @@ DEFINES += -DMAX_LENGTH=$(MAX_LENGTH)
 
 CBMCFLAGS +=
 
-HARNESS_ENTRY = s2n_stuffer_write_reservation_harness
+HARNESS_ENTRY = s2n_stuffer_write_vector_size_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
 
 PROOF_SOURCES += $(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
-PROOF_SOURCES += $(PROOF_STUB)/mlock.c
-PROOF_SOURCES += $(PROOF_STUB)/munlock.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 
@@ -37,7 +35,9 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += s2n_add_overflow
 REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_stuffer_resize
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
 
  UNWINDSET += s2n_stuffer_write_network_order.4:$(shell echo $$((1 + $(MAX_LENGTH))))

--- a/tests/cbmc/proofs/s2n_stuffer_write_vector_size/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_vector_size/Makefile
@@ -11,7 +11,7 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Expected runtime is 40 seconds.
+# Expected runtime is 18 minutes.
 MAX_LENGTH = 3
 DEFINES += -DMAX_LENGTH=$(MAX_LENGTH)
 

--- a/tests/cbmc/proofs/s2n_stuffer_write_vector_size/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_write_vector_size/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_write_vector_size/s2n_stuffer_write_vector_size_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_vector_size/s2n_stuffer_write_vector_size_harness.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <sys/param.h>
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_mem.h"
+
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/nondet.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_write_vector_size_harness() {
+    /* Non-deterministic inputs. */
+    struct s2n_stuffer_reservation *reservation = cbmc_allocate_s2n_stuffer_reservation();
+    __CPROVER_assume(s2n_stuffer_reservation_is_valid(reservation));
+    __CPROVER_assume(reservation->length < MAX_LENGTH);
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    /* Save previous state from stuffer. */
+    struct s2n_stuffer old_stuffer = *(reservation->stuffer);
+
+    /* Operation under verification. */
+    if (s2n_stuffer_write_vector_size(*reservation) == S2N_SUCCESS) {
+        assert(reservation->stuffer->write_cursor == old_stuffer.write_cursor);
+    } else {
+        assert(reservation->stuffer->read_cursor == old_stuffer.read_cursor);
+        assert(reservation->stuffer->alloced == old_stuffer.alloced);
+        assert(reservation->stuffer->growable == old_stuffer.growable);
+        assert(reservation->stuffer->tainted == old_stuffer.tainted);
+    }
+}

--- a/tests/cbmc/proofs/s2n_stuffer_write_vector_size/s2n_stuffer_write_vector_size_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_vector_size/s2n_stuffer_write_vector_size_harness.c
@@ -36,16 +36,19 @@ void s2n_stuffer_write_vector_size_harness() {
         s2n_mem_init();
     }
 
-    /* Save previous state from stuffer. */
-    struct s2n_stuffer old_stuffer = *(reservation->stuffer);
+    /* Save previous state from stuffer_reservation. */
+    struct s2n_stuffer_reservation old_stuffer_reservation = *reservation;
 
     /* Operation under verification. */
-    if (s2n_stuffer_write_vector_size(*reservation) == S2N_SUCCESS) {
-        assert(reservation->stuffer->write_cursor == old_stuffer.write_cursor);
+    if (s2n_stuffer_write_vector_size(reservation) == S2N_SUCCESS) {
+        assert(s2n_stuffer_reservation_is_valid(reservation));
+        assert(reservation->stuffer->write_cursor == old_stuffer_reservation.stuffer->write_cursor);
     } else {
-        assert(reservation->stuffer->read_cursor == old_stuffer.read_cursor);
-        assert(reservation->stuffer->alloced == old_stuffer.alloced);
-        assert(reservation->stuffer->growable == old_stuffer.growable);
-        assert(reservation->stuffer->tainted == old_stuffer.tainted);
+        assert(reservation->stuffer->write_cursor == old_stuffer_reservation.stuffer->write_cursor);
+        assert(reservation->stuffer->high_water_mark == old_stuffer_reservation.stuffer->high_water_mark);
     }
+    assert(reservation->stuffer->alloced == old_stuffer_reservation.stuffer->alloced);
+    assert(reservation->stuffer->growable == old_stuffer_reservation.stuffer->growable);
+    assert(reservation->stuffer->tainted == old_stuffer_reservation.stuffer->tainted);
+    assert(reservation->stuffer->read_cursor == old_stuffer_reservation.stuffer->read_cursor);
 }

--- a/tests/unit/s2n_certificate_extensions_test.c
+++ b/tests/unit/s2n_certificate_extensions_test.c
@@ -245,11 +245,11 @@ int main(int argc, char **argv)
             DEFER_CLEANUP(struct s2n_stuffer stuffer, s2n_stuffer_free);
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
-            struct s2n_stuffer_reservation size;
+            struct s2n_stuffer_reservation size = {0};
             EXPECT_SUCCESS(s2n_stuffer_reserve_uint24(&stuffer, &size));
             EXPECT_SUCCESS(s2n_write_test_cert(&stuffer, chain_and_key));
             EXPECT_SUCCESS(s2n_extension_list_send(S2N_EXTENSION_LIST_CERTIFICATE, setup_conn, &stuffer));
-            EXPECT_SUCCESS(s2n_stuffer_write_vector_size(size));
+            EXPECT_SUCCESS(s2n_stuffer_write_vector_size(&size));
 
             /* TLS1.2 does NOT process extensions */
             {
@@ -288,7 +288,7 @@ int main(int argc, char **argv)
 
         /* Test: extensions only processed on first certificate */
         {
-            struct s2n_stuffer_reservation size;
+            struct s2n_stuffer_reservation size = {0};
 
             /* Extensions on second cert ignored */
             {
@@ -303,7 +303,7 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_extension_list_send(S2N_EXTENSION_LIST_EMPTY, conn, &stuffer));
                 EXPECT_SUCCESS(s2n_write_test_cert(&stuffer, chain_and_key));
                 EXPECT_SUCCESS(s2n_extension_list_send(S2N_EXTENSION_LIST_CERTIFICATE, conn, &stuffer));
-                EXPECT_SUCCESS(s2n_stuffer_write_vector_size(size));
+                EXPECT_SUCCESS(s2n_stuffer_write_vector_size(&size));
 
                 EXPECT_SUCCESS(s2n_x509_validator_validate_cert_chain_test(conn, &stuffer));
 
@@ -326,7 +326,7 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_extension_list_send(S2N_EXTENSION_LIST_CERTIFICATE, conn, &stuffer));
                 EXPECT_SUCCESS(s2n_write_test_cert(&stuffer, chain_and_key));
                 EXPECT_SUCCESS(s2n_extension_list_send(S2N_EXTENSION_LIST_EMPTY, conn, &stuffer));
-                EXPECT_SUCCESS(s2n_stuffer_write_vector_size(size));
+                EXPECT_SUCCESS(s2n_stuffer_write_vector_size(&size));
 
                 EXPECT_SUCCESS(s2n_x509_validator_validate_cert_chain_test(conn, &stuffer));
 

--- a/tests/unit/s2n_extension_list_parse_test.c
+++ b/tests/unit/s2n_extension_list_parse_test.c
@@ -187,13 +187,13 @@ int main()
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         /* Reserve size */
-        struct s2n_stuffer_reservation extension_list_size;
+        struct s2n_stuffer_reservation extension_list_size = {0};
         EXPECT_SUCCESS(s2n_stuffer_reserve_uint16(&stuffer, &extension_list_size));
         /* Write extensions */
         EXPECT_SUCCESS(s2n_extension_send(&test_extension, conn, &stuffer));
         /* Check / write size */
         EXPECT_TRUE(s2n_stuffer_data_available(&stuffer) > extension_list_size.length);
-        EXPECT_SUCCESS(s2n_stuffer_write_vector_size(extension_list_size));
+        EXPECT_SUCCESS(s2n_stuffer_write_vector_size(&extension_list_size));
 
         EXPECT_SUCCESS(s2n_extension_list_parse(&stuffer, &parsed_extension_list));
 
@@ -215,14 +215,14 @@ int main()
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         /* Reserve size */
-        struct s2n_stuffer_reservation extension_list_size;
+        struct s2n_stuffer_reservation extension_list_size = {0};
         EXPECT_SUCCESS(s2n_stuffer_reserve_uint16(&stuffer, &extension_list_size));
         /* Write extensions */
         EXPECT_SUCCESS(s2n_stuffer_write_uint16(&stuffer, 0));
         EXPECT_SUCCESS(s2n_stuffer_write_uint16(&stuffer, 100));
         /* Check / write size */
         EXPECT_TRUE(s2n_stuffer_data_available(&stuffer) > extension_list_size.length);
-        EXPECT_SUCCESS(s2n_stuffer_write_vector_size(extension_list_size));
+        EXPECT_SUCCESS(s2n_stuffer_write_vector_size(&extension_list_size));
 
         EXPECT_FAILURE_WITH_ERRNO(s2n_extension_list_parse(&stuffer, &parsed_extension_list),
                 S2N_ERR_BAD_MESSAGE);
@@ -241,13 +241,13 @@ int main()
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         /* Reserve size */
-        struct s2n_stuffer_reservation extension_list_size;
+        struct s2n_stuffer_reservation extension_list_size = {0};
         EXPECT_SUCCESS(s2n_stuffer_reserve_uint16(&stuffer, &extension_list_size));
         /* Write extensions */
         EXPECT_SUCCESS(s2n_extension_send(&empty_test_extension, conn, &stuffer));
         /* Check / write size */
         EXPECT_TRUE(s2n_stuffer_data_available(&stuffer) > extension_list_size.length);
-        EXPECT_SUCCESS(s2n_stuffer_write_vector_size(extension_list_size));
+        EXPECT_SUCCESS(s2n_stuffer_write_vector_size(&extension_list_size));
 
         EXPECT_SUCCESS(s2n_extension_list_parse(&stuffer, &parsed_extension_list));
 
@@ -269,14 +269,14 @@ int main()
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         /* Reserve size */
-        struct s2n_stuffer_reservation extension_list_size;
+        struct s2n_stuffer_reservation extension_list_size = {0};
         EXPECT_SUCCESS(s2n_stuffer_reserve_uint16(&stuffer, &extension_list_size));
         /* Write extension - use grease value as type */
         EXPECT_SUCCESS(s2n_stuffer_write_uint16(&stuffer, S2N_UNKNOWN_EXTENSION_IANA));
         EXPECT_SUCCESS(s2n_stuffer_write_uint16(&stuffer, 0));
         /* Check / write size */
         EXPECT_TRUE(s2n_stuffer_data_available(&stuffer) > extension_list_size.length);
-        EXPECT_SUCCESS(s2n_stuffer_write_vector_size(extension_list_size));
+        EXPECT_SUCCESS(s2n_stuffer_write_vector_size(&extension_list_size));
 
         EXPECT_SUCCESS(s2n_extension_list_parse(&stuffer, &parsed_extension_list));
 
@@ -294,14 +294,14 @@ int main()
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         /* Reserve size */
-        struct s2n_stuffer_reservation extension_list_size;
+        struct s2n_stuffer_reservation extension_list_size = {0};
         EXPECT_SUCCESS(s2n_stuffer_reserve_uint16(&stuffer, &extension_list_size));
         /* Write extensions */
         EXPECT_SUCCESS(s2n_extension_send(&test_extension, conn, &stuffer));
         EXPECT_SUCCESS(s2n_extension_send(&test_extension, conn, &stuffer));
         /* Check / write size */
         EXPECT_TRUE(s2n_stuffer_data_available(&stuffer) > extension_list_size.length);
-        EXPECT_SUCCESS(s2n_stuffer_write_vector_size(extension_list_size));
+        EXPECT_SUCCESS(s2n_stuffer_write_vector_size(&extension_list_size));
 
         EXPECT_FAILURE_WITH_ERRNO(s2n_extension_list_parse(&stuffer, &parsed_extension_list),
                 S2N_ERR_DUPLICATE_EXTENSION);
@@ -317,14 +317,14 @@ int main()
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         /* Reserve size */
-        struct s2n_stuffer_reservation extension_list_size;
+        struct s2n_stuffer_reservation extension_list_size = {0};
         EXPECT_SUCCESS(s2n_stuffer_reserve_uint16(&stuffer, &extension_list_size));
         /* Write extensions */
         EXPECT_SUCCESS(s2n_extension_send(&empty_test_extension, conn, &stuffer));
         EXPECT_SUCCESS(s2n_extension_send(&empty_test_extension, conn, &stuffer));
         /* Check / write size */
         EXPECT_TRUE(s2n_stuffer_data_available(&stuffer) > extension_list_size.length);
-        EXPECT_SUCCESS(s2n_stuffer_write_vector_size(extension_list_size));
+        EXPECT_SUCCESS(s2n_stuffer_write_vector_size(&extension_list_size));
 
         EXPECT_FAILURE_WITH_ERRNO(s2n_extension_list_parse(&stuffer, &parsed_extension_list),
                 S2N_ERR_DUPLICATE_EXTENSION);
@@ -346,7 +346,7 @@ int main()
         test_extension_3.send = s2n_extension_send_other_test_data;
 
         /* Reserve size */
-        struct s2n_stuffer_reservation extension_list_size;
+        struct s2n_stuffer_reservation extension_list_size = {0};
         EXPECT_SUCCESS(s2n_stuffer_reserve_uint16(&stuffer, &extension_list_size));
         /* Write extensions */
         EXPECT_SUCCESS(s2n_extension_send(&test_extension, conn, &stuffer));
@@ -356,7 +356,7 @@ int main()
         EXPECT_SUCCESS(s2n_extension_send(&test_extension_3, conn, &stuffer));
         /* Check / write size */
         EXPECT_TRUE(s2n_stuffer_data_available(&stuffer) > extension_list_size.length);
-        EXPECT_SUCCESS(s2n_stuffer_write_vector_size(extension_list_size));
+        EXPECT_SUCCESS(s2n_stuffer_write_vector_size(&extension_list_size));
 
         EXPECT_SUCCESS(s2n_extension_list_parse(&stuffer, &parsed_extension_list));
 

--- a/tests/unit/s2n_server_extensions_test.c
+++ b/tests/unit/s2n_server_extensions_test.c
@@ -513,11 +513,11 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
             /* Write extensions - just status_request */
-            struct s2n_stuffer_reservation extension_list_size;
+            struct s2n_stuffer_reservation extension_list_size = {0};
             EXPECT_SUCCESS(s2n_stuffer_reserve_uint16(&stuffer, &extension_list_size));
             EXPECT_SUCCESS(s2n_extension_send(&s2n_server_status_request_extension,
                     server_conn, &stuffer));
-            EXPECT_SUCCESS(s2n_stuffer_write_vector_size(extension_list_size));
+            EXPECT_SUCCESS(s2n_stuffer_write_vector_size(&extension_list_size));
 
             EXPECT_EQUAL(client_conn->status_type, S2N_STATUS_REQUEST_NONE);
             EXPECT_EQUAL(client_conn->server_protocol_version, S2N_UNKNOWN_PROTOCOL_VERSION);
@@ -542,13 +542,13 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
             /* Write extensions - supported_versions + status_request */
-            struct s2n_stuffer_reservation extension_list_size;
+            struct s2n_stuffer_reservation extension_list_size = {0};
             EXPECT_SUCCESS(s2n_stuffer_reserve_uint16(&stuffer, &extension_list_size));
             EXPECT_SUCCESS(s2n_extension_send(&s2n_server_supported_versions_extension,
                     server_conn, &stuffer));
             EXPECT_SUCCESS(s2n_extension_send(&s2n_server_status_request_extension,
                     server_conn, &stuffer));
-            EXPECT_SUCCESS(s2n_stuffer_write_vector_size(extension_list_size));
+            EXPECT_SUCCESS(s2n_stuffer_write_vector_size(&extension_list_size));
 
             EXPECT_EQUAL(client_conn->status_type, S2N_STATUS_REQUEST_NONE);
             EXPECT_EQUAL(client_conn->server_protocol_version, S2N_UNKNOWN_PROTOCOL_VERSION);

--- a/tests/unit/s2n_stuffer_network_order_test.c
+++ b/tests/unit/s2n_stuffer_network_order_test.c
@@ -22,7 +22,7 @@
 #define SIZEOF_UINT24 3
 
 int s2n_stuffer_write_network_order(struct s2n_stuffer *stuffer, uint32_t input, uint8_t length);
-int s2n_stuffer_write_reservation(struct s2n_stuffer_reservation reservation, uint32_t u);
+int s2n_stuffer_write_reservation(struct s2n_stuffer_reservation* reservation, const uint32_t u);
 
 int main(int argc, char **argv)
 {
@@ -214,24 +214,24 @@ int main(int argc, char **argv)
 
         /* Null checks */
         reservation.stuffer = NULL;
-        EXPECT_FAILURE(s2n_stuffer_write_reservation(reservation, 0));
+        EXPECT_FAILURE(s2n_stuffer_write_reservation(&reservation, 0));
         EXPECT_EQUAL(stuffer.write_cursor, expected_write_cursor);
         reservation.stuffer = &stuffer;
 
         /* Should throw an error if reservation has wrong size */
         reservation.length = sizeof(uint64_t);
-        EXPECT_FAILURE_WITH_ERRNO(s2n_stuffer_write_reservation(reservation, 0), S2N_ERR_PRECONDITION_VIOLATION);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_stuffer_write_reservation(&reservation, 0), S2N_ERR_PRECONDITION_VIOLATION);
         EXPECT_EQUAL(stuffer.write_cursor, expected_write_cursor);
         reservation.length = sizeof(uint16_t);
 
         /* Should throw an error if value length does not match reservation length */
-        EXPECT_FAILURE_WITH_ERRNO(s2n_stuffer_write_reservation(reservation, UINT32_MAX), S2N_ERR_PRECONDITION_VIOLATION);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_stuffer_write_reservation(&reservation, UINT32_MAX), S2N_ERR_PRECONDITION_VIOLATION);
         EXPECT_EQUAL(stuffer.write_cursor, expected_write_cursor);
 
         /* Should throw an error if rewriting would require an invalid stuffer state.
          * ( A write cursor being greater than the high water mark is an invalid stuffer state.) */
         reservation.write_cursor = stuffer.high_water_mark + 1;
-        EXPECT_FAILURE_WITH_ERRNO(s2n_stuffer_write_reservation(reservation, 0), S2N_ERR_PRECONDITION_VIOLATION);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_stuffer_write_reservation(&reservation, 0), S2N_ERR_PRECONDITION_VIOLATION);
         EXPECT_EQUAL(stuffer.write_cursor, expected_write_cursor);
 
         /* Happy case: successfully rewrites a uint16_t */
@@ -251,9 +251,9 @@ int main(int argc, char **argv)
             /* Rewrite reserved uint16s */
             uint16_t expected_value = 0xabcd;
             expected_write_cursor = stuffer.write_cursor;
-            EXPECT_SUCCESS(s2n_stuffer_write_reservation(reservation, expected_value));
+            EXPECT_SUCCESS(s2n_stuffer_write_reservation(&reservation, expected_value));
             EXPECT_EQUAL(stuffer.write_cursor, expected_write_cursor);
-            EXPECT_SUCCESS(s2n_stuffer_write_reservation(other_reservation, expected_value));
+            EXPECT_SUCCESS(s2n_stuffer_write_reservation(&other_reservation, expected_value));
             EXPECT_EQUAL(stuffer.write_cursor, expected_write_cursor);
 
             /* Make sure expected values read back */

--- a/tests/unit/s2n_stuffer_network_order_test.c
+++ b/tests/unit/s2n_stuffer_network_order_test.c
@@ -220,12 +220,12 @@ int main(int argc, char **argv)
 
         /* Should throw an error if reservation has wrong size */
         reservation.length = sizeof(uint64_t);
-        EXPECT_FAILURE_WITH_ERRNO(s2n_stuffer_write_reservation(reservation, 0), S2N_ERR_SIZE_MISMATCH);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_stuffer_write_reservation(reservation, 0), S2N_ERR_PRECONDITION_VIOLATION);
         EXPECT_EQUAL(stuffer.write_cursor, expected_write_cursor);
         reservation.length = sizeof(uint16_t);
 
         /* Should throw an error if value length does not match reservation length */
-        EXPECT_FAILURE_WITH_ERRNO(s2n_stuffer_write_reservation(reservation, UINT32_MAX), S2N_ERR_SIZE_MISMATCH);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_stuffer_write_reservation(reservation, UINT32_MAX), S2N_ERR_PRECONDITION_VIOLATION);
         EXPECT_EQUAL(stuffer.write_cursor, expected_write_cursor);
 
         /* Should throw an error if rewriting would require an invalid stuffer state.

--- a/tests/unit/s2n_stuffer_network_order_test.c
+++ b/tests/unit/s2n_stuffer_network_order_test.c
@@ -282,7 +282,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_reserve_uint16(&stuffer, &reservation));
 
             EXPECT_SUCCESS(s2n_stuffer_skip_write(&stuffer, test_sizes[i]));
-            EXPECT_SUCCESS(s2n_stuffer_write_vector_size(reservation));
+            EXPECT_SUCCESS(s2n_stuffer_write_vector_size(&reservation));
 
             EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &actual_value));
             EXPECT_EQUAL(actual_value, test_sizes[i]);

--- a/tls/extensions/s2n_client_key_share.c
+++ b/tls/extensions/s2n_client_key_share.c
@@ -146,12 +146,12 @@ static int s2n_ecdhe_supported_curves_send(struct s2n_connection *conn, struct s
 
 static int s2n_client_key_share_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    struct s2n_stuffer_reservation shares_size;
+    struct s2n_stuffer_reservation shares_size = {0};
     GUARD(s2n_stuffer_reserve_uint16(out, &shares_size));
 
     GUARD(s2n_ecdhe_supported_curves_send(conn, out));
 
-    GUARD(s2n_stuffer_write_vector_size(shares_size));
+    GUARD(s2n_stuffer_write_vector_size(&shares_size));
 
     return S2N_SUCCESS;
 }
@@ -255,7 +255,7 @@ uint32_t s2n_extensions_client_key_share_size(struct s2n_connection *conn)
 
     for (uint32_t i = 0; i < ecc_pref->count ; i++) {
         s2n_client_key_share_extension_size += S2N_SIZE_OF_KEY_SHARE_SIZE + S2N_SIZE_OF_NAMED_GROUP;
-        s2n_client_key_share_extension_size += ecc_pref->ecc_curves[i]->share_size; 
+        s2n_client_key_share_extension_size += ecc_pref->ecc_curves[i]->share_size;
     }
 
     return s2n_client_key_share_extension_size;

--- a/tls/extensions/s2n_client_server_name.c
+++ b/tls/extensions/s2n_client_server_name.c
@@ -44,7 +44,7 @@ static bool s2n_client_server_name_should_send(struct s2n_connection *conn)
 
 static int s2n_client_server_name_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    struct s2n_stuffer_reservation server_name_list_size;
+    struct s2n_stuffer_reservation server_name_list_size = {0};
     GUARD(s2n_stuffer_reserve_uint16(out, &server_name_list_size));
 
     /* NameType, as described by RFC6066.
@@ -54,7 +54,7 @@ static int s2n_client_server_name_send(struct s2n_connection *conn, struct s2n_s
     GUARD(s2n_stuffer_write_uint16(out, strlen(conn->server_name)));
     GUARD(s2n_stuffer_write_bytes(out, (const uint8_t *) conn->server_name, strlen(conn->server_name)));
 
-    GUARD(s2n_stuffer_write_vector_size(server_name_list_size));
+    GUARD(s2n_stuffer_write_vector_size(&server_name_list_size));
     return S2N_SUCCESS;
 }
 

--- a/tls/extensions/s2n_extension_list.c
+++ b/tls/extensions/s2n_extension_list.c
@@ -31,14 +31,14 @@ int s2n_extension_list_send(s2n_extension_list_id list_type, struct s2n_connecti
     s2n_extension_type_list *extension_type_list;
     GUARD(s2n_extension_type_list_get(list_type, &extension_type_list));
 
-    struct s2n_stuffer_reservation total_extensions_size;
+    struct s2n_stuffer_reservation total_extensions_size = {0};
     GUARD(s2n_stuffer_reserve_uint16(out, &total_extensions_size));
 
     for (int i = 0; i < extension_type_list->count; i++) {
         GUARD(s2n_extension_send(extension_type_list->extension_types[i], conn, out));
     }
 
-    GUARD(s2n_stuffer_write_vector_size(total_extensions_size));
+    GUARD(s2n_stuffer_write_vector_size(&total_extensions_size));
     return S2N_SUCCESS;
 }
 

--- a/tls/extensions/s2n_extension_type.c
+++ b/tls/extensions/s2n_extension_type.c
@@ -104,14 +104,14 @@ int s2n_extension_send(const s2n_extension_type *extension_type, struct s2n_conn
     GUARD(s2n_stuffer_write_uint16(out, extension_type->iana_value));
 
     /* Reserve space for extension size */
-    struct s2n_stuffer_reservation extension_size_bytes;
+    struct s2n_stuffer_reservation extension_size_bytes = {0};
     GUARD(s2n_stuffer_reserve_uint16(out, &extension_size_bytes));
 
     /* Write extension data */
     GUARD(extension_type->send(conn, out));
 
     /* Record extension size */
-    GUARD(s2n_stuffer_write_vector_size(extension_size_bytes));
+    GUARD(s2n_stuffer_write_vector_size(&extension_size_bytes));
 
     /* Set request bit flag */
     if (!extension_type->is_response) {

--- a/utils/s2n_safety.c
+++ b/utils/s2n_safety.c
@@ -166,15 +166,6 @@ int s2n_in_unit_test_set(bool newval)
     return S2N_SUCCESS;
 }
 
-int s2n_mul_overflow(uint32_t a, uint32_t b, uint32_t* out)
-{
-    notnull_check(out);
-    const uint64_t result = ((uint64_t) a) * ((uint64_t) b);
-    S2N_ERROR_IF(result > UINT32_MAX, S2N_ERR_INTEGER_OVERFLOW);
-    *out = (uint32_t) result;
-    return S2N_SUCCESS;
-}
-
 int s2n_align_to(uint32_t initial, uint32_t alignment, uint32_t* out)
 {
     PRECONDITION_POSIX(alignment != 0);
@@ -190,8 +181,18 @@ int s2n_align_to(uint32_t initial, uint32_t alignment, uint32_t* out)
     return S2N_SUCCESS;
 }
 
+int s2n_mul_overflow(uint32_t a, uint32_t b, uint32_t* out)
+{
+    notnull_check(out);
+    const uint64_t result = ((uint64_t) a) * ((uint64_t) b);
+    S2N_ERROR_IF(result > UINT32_MAX, S2N_ERR_INTEGER_OVERFLOW);
+    *out = (uint32_t) result;
+    return S2N_SUCCESS;
+}
+
 int s2n_add_overflow(uint32_t a, uint32_t b, uint32_t* out)
 {
+    notnull_check(out);
     uint64_t result = ((uint64_t) a) + ((uint64_t) b);
     S2N_ERROR_IF(result > UINT32_MAX, S2N_ERR_INTEGER_OVERFLOW);
     *out = (uint32_t) result;
@@ -200,6 +201,7 @@ int s2n_add_overflow(uint32_t a, uint32_t b, uint32_t* out)
 
 int s2n_sub_overflow(uint32_t a, uint32_t b, uint32_t* out)
 {
+    notnull_check(out);
     S2N_ERROR_IF(a < b, S2N_ERR_INTEGER_OVERFLOW);
     *out = a - b;
     return S2N_SUCCESS;

--- a/utils/s2n_safety.c
+++ b/utils/s2n_safety.c
@@ -197,3 +197,10 @@ int s2n_add_overflow(uint32_t a, uint32_t b, uint32_t* out)
     *out = (uint32_t) result;
     return S2N_SUCCESS;
 }
+
+int s2n_sub_overflow(uint32_t a, uint32_t b, uint32_t* out)
+{
+    S2N_ERROR_IF(a < b, S2N_ERR_INTEGER_OVERFLOW);
+    *out = a - b;
+    return S2N_SUCCESS;
+}

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -344,7 +344,7 @@ extern int s2n_mul_overflow(uint32_t a, uint32_t b, uint32_t* out);
  */
 extern int s2n_align_to(uint32_t initial, uint32_t alignment, uint32_t* out);
 extern int s2n_add_overflow(uint32_t a, uint32_t b, uint32_t* out);
-
+extern int s2n_sub_overflow(uint32_t a, uint32_t b, uint32_t* out);
 /* START COMPATIBILITY LAYER */
 
 /**


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A.

### Description of changes: 

- Adds a new `s2n_sub_overflow` function;
- Adds a proof harness for the `s2n_stuffer_write_reservation` function;
- Adds a pre- and post-conditions to the `s2n_stuffer_write_reservation` function;
- Adds a proof harness for the `s2n_stuffer_write_vector_size` function;
- Adds a pre- and post-conditions to the `s2n_stuffer_write_vector_size` function;
- Updates `s2n_stuffer_network_order` unit test;

### Call-outs:

This PR depends on https://github.com/awslabs/s2n/pull/2058

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.