### PR TITLE
Integv2 fragmentation test

### DIFF
--- a/tests/integrationv2/configuration.py
+++ b/tests/integrationv2/configuration.py
@@ -260,7 +260,7 @@ MULTI_CERT_TEST_CASES= [
                     " even if domain mismatched RSA certificate is available and RSA cipher is higher priority.",
         server_certs=[SNI_CERTS["beaver"], SNI_CERTS["alligator_ecdsa"]],
         client_sni="www.alligator.com",
-        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA, Ciphers.ECDHE_ECDSA_AES128_SHA256],
+        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA256, Ciphers.ECDHE_ECDSA_AES128_SHA256],
         expected_cert=SNI_CERTS["alligator_ecdsa"],
         expect_matching_hostname=True),
     MultiCertTest(

--- a/tests/integrationv2/test_fragmentation.py
+++ b/tests/integrationv2/test_fragmentation.py
@@ -1,0 +1,111 @@
+import copy
+import pytest
+
+from configuration import available_ports, PROTOCOLS
+from common import ProviderOptions, Ciphers, Certificates, data_bytes
+from fixtures import managed_process
+from providers import Provider, S2N, OpenSSL
+from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version
+
+
+def multi_cipher_name(c):
+    return ':'.join([x.name for x in c])
+
+
+multi_cipher = [Ciphers.AES256_SHA, Ciphers.ECDHE_ECDSA_AES256_SHA]
+@pytest.mark.uncollect_if(func=invalid_test_parameters)
+@pytest.mark.parametrize("multi_cipher", [multi_cipher], ids=multi_cipher_name)
+@pytest.mark.parametrize("provider", [OpenSSL])
+@pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
+@pytest.mark.parametrize("certificate", [Certificates.RSA_4096_SHA384, Certificates.ECDSA_384], ids=get_parameter_name)
+def test_s2n_server_low_latency(managed_process, multi_cipher, provider, protocol, certificate):
+    port = next(available_ports)
+
+    random_bytes = data_bytes(65519)
+    client_options = ProviderOptions(
+        mode=Provider.ClientMode,
+        host="localhost",
+        port=port,
+        cipher=multi_cipher,
+        data_to_send=random_bytes,
+        insecure=True,
+        protocol=protocol)
+
+    server_options = copy.copy(client_options)
+    server_options.data_to_send = None
+    server_options.mode = Provider.ServerMode
+    server_options.extra_flags=['--prefer-low-latency']
+    server_options.key = certificate.key
+    server_options.cert = certificate.cert
+
+    # Passing the type of client and server as a parameter will
+    # allow us to use a fixture to enumerate all possibilities.
+    server = managed_process(S2N, server_options, timeout=5)
+    client = managed_process(provider, client_options, timeout=5)
+
+    # The client will be one of all supported providers. We
+    # just want to make sure there was no exception and that
+    # the client exited cleanly.
+    for results in client.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+
+    expected_version = get_expected_s2n_version(protocol, provider)
+
+    # The server is always S2N in this test, so we can examine
+    # the stdout reliably.
+    for results in server.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+        assert bytes("Actual protocol version: {}".format(expected_version).encode('utf-8')) in results.stdout
+        assert random_bytes in results.stdout
+
+
+@pytest.mark.uncollect_if(func=invalid_test_parameters)
+@pytest.mark.parametrize("multi_cipher", [multi_cipher], ids=multi_cipher_name)
+@pytest.mark.parametrize("provider", [OpenSSL])
+@pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
+@pytest.mark.parametrize("certificate", [Certificates.RSA_4096_SHA384, Certificates.ECDSA_384], ids=get_parameter_name)
+@pytest.mark.parametrize("frag_len", [512, 2048, 8192, 12345, 16384], ids=get_parameter_name)
+def test_s2n_server_framented_data(managed_process, multi_cipher, provider, protocol, frag_len, certificate):
+    port = next(available_ports)
+
+    random_bytes = data_bytes(65519)
+    client_options = ProviderOptions(
+        mode=Provider.ClientMode,
+        host="localhost",
+        port=port,
+        cipher=multi_cipher,
+        data_to_send=random_bytes,
+        insecure=True,
+        extra_flags=['-max_send_frag', str(frag_len)],
+        protocol=protocol)
+
+    server_options = copy.copy(client_options)
+    server_options.extra_flags = None
+    server_options.data_to_send = None
+    server_options.mode = Provider.ServerMode
+    server_options.key = certificate.key
+    server_options.cert = certificate.cert
+
+    # Passing the type of client and server as a parameter will
+    # allow us to use a fixture to enumerate all possibilities.
+    server = managed_process(S2N, server_options, timeout=5)
+    client = managed_process(provider, client_options, timeout=5)
+
+    # The client will be one of all supported providers. We
+    # just want to make sure there was no exception and that
+    # the client exited cleanly.
+    for results in client.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+
+    expected_version = get_expected_s2n_version(protocol, provider)
+
+    # The server is always S2N in this test, so we can examine
+    # the stdout reliably.
+    for results in server.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+        assert bytes("Actual protocol version: {}".format(expected_version).encode('utf-8')) in results.stdout
+        assert random_bytes in results.stdout

--- a/tests/integrationv2/test_fragmentation.py
+++ b/tests/integrationv2/test_fragmentation.py
@@ -38,22 +38,15 @@ def test_s2n_server_low_latency(managed_process, multi_cipher, provider, protoco
     server_options.key = certificate.key
     server_options.cert = certificate.cert
 
-    # Passing the type of client and server as a parameter will
-    # allow us to use a fixture to enumerate all possibilities.
     server = managed_process(S2N, server_options, timeout=5)
     client = managed_process(provider, client_options, timeout=5)
 
-    # The client will be one of all supported providers. We
-    # just want to make sure there was no exception and that
-    # the client exited cleanly.
     for results in client.get_results():
         assert results.exception is None
         assert results.exit_code == 0
 
     expected_version = get_expected_s2n_version(protocol, provider)
 
-    # The server is always S2N in this test, so we can examine
-    # the stdout reliably.
     for results in server.get_results():
         assert results.exception is None
         assert results.exit_code == 0
@@ -88,22 +81,15 @@ def test_s2n_server_framented_data(managed_process, multi_cipher, provider, prot
     server_options.key = certificate.key
     server_options.cert = certificate.cert
 
-    # Passing the type of client and server as a parameter will
-    # allow us to use a fixture to enumerate all possibilities.
     server = managed_process(S2N, server_options, timeout=5)
     client = managed_process(provider, client_options, timeout=5)
 
-    # The client will be one of all supported providers. We
-    # just want to make sure there was no exception and that
-    # the client exited cleanly.
     for results in client.get_results():
         assert results.exception is None
         assert results.exit_code == 0
 
     expected_version = get_expected_s2n_version(protocol, provider)
 
-    # The server is always S2N in this test, so we can examine
-    # the stdout reliably.
     for results in server.get_results():
         assert results.exception is None
         assert results.exit_code == 0

--- a/tests/integrationv2/test_pq_handshake.py
+++ b/tests/integrationv2/test_pq_handshake.py
@@ -59,7 +59,7 @@ pq_handshake_test_vectors = [
         "expected_cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384",
         "expected_kem": "SIKEp434r2-KEM",
     },
-    # The last set of vectors verify that a standard handshake can be completed when only one side support PQ
+    # The last set of vectors verify that a standard handshake can be completed when only one side supports PQ
     # by specifing a "mismatch" between PQ cipher preferences
     {
         "client_ciphers": Ciphers.KMS_PQ_TLS_1_0_2019_06,

--- a/tests/integrationv2/utils.py
+++ b/tests/integrationv2/utils.py
@@ -52,7 +52,7 @@ def invalid_test_parameters(*args, **kwargs):
         if protocol is not None:
             if cipher.min_version > protocol:
                 return True
-            if protocol is Protocols.TLS13 and cipher.min_version < Protocols.TLS13:
+            if protocol is Protocols.TLS13 and cipher.min_version < protocol:
                 return True
 
         # NOTE: We don't detect the version of OpenSSL at the moment,


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

### Resolved issues:

 resolves #1975

### Description of changes: 

The existing integration test framework uses gnuTLS to do max fragmentation testing. This change moves this behavior to the integv2 framework, and uses OpenSSL instead of gnuTLS.

The prefer-low-latency test is also migrated in this change, because it was labeled as a fragmentation test.

### Call-outs:

The decision to use OpenSSL was done to prevent writing the gnuTLS provider for this one specific test. When the gnuTLS provider is written, the frag test can continue in that provider as well.

There is a refactor commit in this PR which should disappear when the refactor PR is merged.

### Testing:

integ test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
