### PR TITLE
Add CBMC proof for s2n_free

### DIFF
--- a/tests/cbmc/proofs/s2n_free/Makefile
+++ b/tests/cbmc/proofs/s2n_free/Makefile
@@ -11,22 +11,23 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-###########
-#Use the default set of CBMC flags
+ABSTRACTIONS += $(HELPERDIR)/stubs/munlock.c
+ABSTRACTIONS += $(HELPERDIR)/stubs/s2n_calculate_stacktrace.c
+ABSTRACTIONS += $(HELPERDIR)/stubs/sysconf.c
+
 CHECKFLAGS +=
 
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
 DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
-DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
-DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+
 DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
 
 ENTRY = s2n_free_harness
 
-#No loops to unwind
-UNWINDSET +=
-###########
-
 REMOVE_FUNCTION_BODY += --remove-function-body s2n_mem_cleanup_impl
+
+UNWINDSET +=
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_free/Makefile
+++ b/tests/cbmc/proofs/s2n_free/Makefile
@@ -1,0 +1,32 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CHECKFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+
+ENTRY = s2n_free_harness
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_mem_cleanup_impl
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_free/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_free/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_free/s2n_free_harness.c
+++ b/tests/cbmc/proofs/s2n_free/s2n_free_harness.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "utils/s2n_blob.h"
+#include "error/s2n_errno.h"
+
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/cbmc_utils.h>
+
+int munlock(const void *addr, size_t len)
+{
+    assert(S2N_MEM_IS_WRITABLE(addr,len));
+    return nondet_int();
+}
+
+int s2n_calculate_stacktrace() { return nondet_int(); }
+
+long sysconf(int name) { return nondet_long(); }
+
+void s2n_free_harness() {
+    struct s2n_blob *blob = cbmc_allocate_s2n_blob();
+
+    __CPROVER_assume(s2n_blob_is_valid( blob ));
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    if (s2n_free(blob) == 0) {
+        assert_all_zeroes(blob, sizeof(*blob));
+    }
+}

--- a/tests/cbmc/proofs/s2n_free/s2n_free_harness.c
+++ b/tests/cbmc/proofs/s2n_free/s2n_free_harness.c
@@ -43,7 +43,11 @@ void s2n_free_harness() {
 #pragma CPROVER check disable "pointer"
     /* Regardless of the result of s2n_free, verify that the
        data pointed to in the blob was zeroed */
-    assert_all_bytes_are(old_blob.data, 0, old_blob.size);
+    if (old_blob.size > 0 && old_blob.data != NULL) {
+        size_t i;
+        __CPROVER_assume(i < old_blob.size);
+        assert(old_blob.data[i] == 0);
+    }
 #pragma CPROVER check pop
 
 }

--- a/tests/cbmc/proofs/s2n_free/s2n_free_harness.c
+++ b/tests/cbmc/proofs/s2n_free/s2n_free_harness.c
@@ -33,7 +33,7 @@ void s2n_free_harness() {
 
     struct s2n_blob old_blob = *blob;
 
-    if (s2n_free(blob) == 0) {
+    if (s2n_free(blob) == S2N_SUCCESS) {
         /* If the call worked, assert all bytes in the blob struct
            are zero */
         assert_all_zeroes(blob, sizeof(*blob));

--- a/tests/cbmc/proofs/s2n_free_object/Makefile
+++ b/tests/cbmc/proofs/s2n_free_object/Makefile
@@ -11,14 +11,17 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+ABSTRACTIONS += $(HELPERDIR)/stubs/munlock.c
+ABSTRACTIONS += $(HELPERDIR)/stubs/s2n_calculate_stacktrace.c
+ABSTRACTIONS += $(HELPERDIR)/stubs/sysconf.c
+
 CHECKFLAGS +=
 
-
-DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
-DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
 DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
-DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
 DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
 
 ENTRY = s2n_free_object_harness
 

--- a/tests/cbmc/proofs/s2n_free_object/Makefile
+++ b/tests/cbmc/proofs/s2n_free_object/Makefile
@@ -1,0 +1,29 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+CHECKFLAGS +=
+
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+
+ENTRY = s2n_free_object_harness
+
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_free_object/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_free_object/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_free_object/s2n_free_object_harness.c
+++ b/tests/cbmc/proofs/s2n_free_object/s2n_free_object_harness.c
@@ -30,18 +30,17 @@ void s2n_free_object_harness() {
         s2n_mem_init();
     }
 
-    if (s2n_free_object(&data, size) == 0) {
+    if (s2n_free_object(&data, size) == S2N_SUCCESS) {
         assert(data == NULL);
+    }
 
 #pragma CPROVER check push
 #pragma CPROVER check disable "pointer"
-        /* Verify that the memory was zeroed */
-        if (size > 0 && old_data != NULL) {
-            size_t i;
-            __CPROVER_assume(i < size);
-            assert(old_data[i] == 0);
-        }
-#pragma CPROVER check pop
-
+    /* Verify that the memory was zeroed */
+    if (size > 0 && old_data != NULL) {
+        size_t i;
+        __CPROVER_assume(i < size);
+        assert(old_data[i] == 0);
     }
+#pragma CPROVER check pop
 }

--- a/tests/cbmc/proofs/s2n_free_object/s2n_free_object_harness.c
+++ b/tests/cbmc/proofs/s2n_free_object/s2n_free_object_harness.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "utils/s2n_blob.h"
+#include "error/s2n_errno.h"
+
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/cbmc_utils.h>
+
+int munlock(const void *addr, size_t len)
+{
+    assert(S2N_MEM_IS_WRITABLE(addr,len));
+    return nondet_int();
+}
+
+long sysconf(int name) { return nondet_long(); }
+
+int s2n_calculate_stacktrace() { return nondet_int(); }
+
+void s2n_free_object_harness() {
+    uint32_t size;
+    uint8_t * data = can_fail_malloc( size );
+    uint8_t * data_copy = data;
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    if (s2n_free_object(&data, size) == 0) {
+        assert(data == NULL);
+
+#pragma CPROVER check push
+#pragma CPROVER check disable "pointer"
+        /* Verify that the memory was zeroed */
+        if (size > 0 && data_copy != NULL) {
+            size_t i;
+            __CPROVER_assume(i < size);
+            assert(data_copy[i] == 0);
+        }
+#pragma CPROVER check pop
+
+    }
+}

--- a/tests/cbmc/proofs/s2n_free_object/s2n_free_object_harness.c
+++ b/tests/cbmc/proofs/s2n_free_object/s2n_free_object_harness.c
@@ -14,28 +14,16 @@
  */
 
 #include "api/s2n.h"
-#include "utils/s2n_blob.h"
-#include "error/s2n_errno.h"
 
 #include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
-#include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/cbmc_utils.h>
-
-int munlock(const void *addr, size_t len)
-{
-    assert(S2N_MEM_IS_WRITABLE(addr,len));
-    return nondet_int();
-}
-
-long sysconf(int name) { return nondet_long(); }
-
-int s2n_calculate_stacktrace() { return nondet_int(); }
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
 
 void s2n_free_object_harness() {
     uint32_t size;
     uint8_t * data = can_fail_malloc( size );
-    uint8_t * data_copy = data;
+    uint8_t * old_data = data;
 
     /* Non-deterministically set initialized (in s2n_mem) to true. */
     if(nondet_bool()) {
@@ -48,10 +36,10 @@ void s2n_free_object_harness() {
 #pragma CPROVER check push
 #pragma CPROVER check disable "pointer"
         /* Verify that the memory was zeroed */
-        if (size > 0 && data_copy != NULL) {
+        if (size > 0 && old_data != NULL) {
             size_t i;
             __CPROVER_assume(i < size);
-            assert(data_copy[i] == 0);
+            assert(old_data[i] == 0);
         }
 #pragma CPROVER check pop
 

--- a/tests/cbmc/stubs/munlock.c
+++ b/tests/cbmc/stubs/munlock.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "error/s2n_errno.h"
+
+#include <cbmc_proof/nondet.h>
+
+int munlock(const void *addr, size_t len)
+{
+    assert(S2N_MEM_IS_WRITABLE(addr,len));
+    return nondet_int();
+}
+

--- a/tests/cbmc/stubs/sysconf.c
+++ b/tests/cbmc/stubs/sysconf.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cbmc_proof/nondet.h>
+
+long sysconf(int name)
+{
+    return nondet_long();
+}

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -209,7 +209,6 @@ int s2n_realloc(struct s2n_blob *b, uint32_t size)
 
 int s2n_free_object(uint8_t **p_data, uint32_t size)
 {
-    S2N_ERROR_IF(initialized == false, S2N_ERR_NOT_INITIALIZED);
     notnull_check(p_data);
 
     if (*p_data == NULL) {

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -260,6 +260,8 @@ int s2n_mem_cleanup(void)
 
 int s2n_free(struct s2n_blob *b)
 {
+    PRECONDITION_POSIX(s2n_blob_is_valid(b));
+
     S2N_ERROR_IF(initialized == false, S2N_ERR_NOT_INITIALIZED);
     S2N_ERROR_IF(!s2n_blob_is_growable(b), S2N_ERR_FREE_STATIC_BLOB);
 

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -262,11 +262,12 @@ int s2n_free(struct s2n_blob *b)
 {
     PRECONDITION_POSIX(s2n_blob_is_valid(b));
 
+    /* To avoid memory leaks, don't exit the function until the memory
+       has been freed */
+    int zero_rc = s2n_blob_zero(b);
+
     S2N_ERROR_IF(initialized == false, S2N_ERR_NOT_INITIALIZED);
     S2N_ERROR_IF(!s2n_blob_is_growable(b), S2N_ERR_FREE_STATIC_BLOB);
-
-    /* To avoid memory leaks, still free the data even if we can't unlock / wipe it */
-    int zero_rc = s2n_blob_zero(b);
 
     GUARD(s2n_mem_free_cb(b->data, b->allocated));
 


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

 N/A

### Description of changes: 

Add proof for s2n_free
Add a precondition to s2n_free to match the proof

### Testing:

Unit testing after precondition change.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
