### PR TITLE
ci: Rename one of the Fuzz tests

### DIFF
--- a/codebuild/fuzz_codebuild.config
+++ b/codebuild/fuzz_codebuild.config
@@ -41,10 +41,10 @@ start_time: 12:00
 build_job_name: s2nFuzzScheduled
 input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_client_cert_recv_test"}]}
 
-[CloudWatchEvent:s2n_client_cert_req_recv_test]
+[CloudWatchEvent:s2n_cert_req_recv_test]
 start_time: 12:00
 build_job_name: s2nFuzzScheduled
-input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_client_cert_req_recv_test"}]}
+input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_cert_req_recv_test"}]}
 
 [CloudWatchEvent:s2n_client_cert_verify_recv_test]
 start_time: 12:00


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

Failing fuzz test 

### Description of changes: 
Addresses the renamed fuzz test file
```
rename from tests/fuzz/s2n_client_cert_req_recv_test.c
rename to tests/fuzz/s2n_cert_req_recv_test.c
```
### Call-outs:

python script must be run post merge to updated the job.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
