### PR TITLE
Implements PQ hybrid shared secret derivation for TLS 1.3

### DIFF
--- a/pq-crypto/README.md
+++ b/pq-crypto/README.md
@@ -19,8 +19,11 @@ post-quantum key exchange scheme and a classical key exchange scheme.
 
 ## Hybrid key exchange
 A hybrid key exchange combines both the high assurance of classical key exchange with the conjectured quantum-resistance
-of newly proposed key exchanges. s2n implements the hybrid specification from [this RFC](https://tools.ietf.org/html/draft-campagna-tls-bike-sike-hybrid-01).
-See [this s2n issue](https://github.com/awslabs/s2n/issues/904) for more up-to-date information.
+of newly proposed key exchanges. For hybrid TLS 1.2, s2n implements the hybrid specification from [this RFC](https://tools.ietf.org/html/draft-campagna-tls-bike-sike-hybrid-01).
+See [this s2n issue](https://github.com/awslabs/s2n/issues/904) for more up-to-date information. For hybrid TLS 1.3, s2n
+implements the hybrid specification from [this draft RFC](https://tools.ietf.org/html/draft-stebila-tls-hybrid-design).
+See also [this doc](https://docs.google.com/spreadsheets/d/12YarzaNv3XQNLnvDsWLlRKwtZFhRrDdWf36YlzwrPeg/edit#gid=0) that
+defines hybrid group values for interoperability.
 
 ## SIKE (Supersingular Isogeny Key Encapsulation)
 The code in the pq-crypto/sike_r1 directory was taken from the [round 1 NIST submission](https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-1/submissions/SIKE.zip).
@@ -47,7 +50,11 @@ the optimized assembly code will significantly improve performance of the post-q
 the architecture is compatible with the assembly code, and falls back to the portable C implementation if it detects incompatibility. However, some users
 may wish to manually force s2n to use the portable C implementation. To do so, simply `export S2N_NO_PQ_ASM=1` as an environment variable before compiling.
 
-## How to add a new PQ KEM family
+## How to disable all PQ Crypto
+Users may have need to compile s2n without any PQ crypto support whatsoever. To so do, `export S2N_NO_PQ=1` as an environment
+variable before compiling.
+
+## How to add a new PQ KEM family for use in hybrid TLS 1.2
 1. Add the code to `pq-crypto/KEM_NAME/`
     1. Update `pq-crypto/Makefile` to build that directory
     1. Update `lib/Makefile` to also include that directory
@@ -64,7 +71,7 @@ may wish to manually force s2n to use the portable C implementation. To do so, s
 1. Create a new `s2n_cipher_preferences` in `tls/s2n_cipher_prefrences.c` that uses the new cipher suite
     1. Once this change is made, the KEM will be available for use in TLS handshakes; ensure that all testing/verification has been completed
     
-## How to add a new variant to an existing PQ KEM family
+## How to add a new variant to an existing PQ KEM family for use in hybrid TLS 1.2
 1. Add the code to `pq-crypto/KEM_NAME/`
     1. Update `pq-crypto/Makefile` to build that directory
     1. Update `lib/Makefile` to also include that directory
@@ -78,7 +85,7 @@ may wish to manually force s2n to use the portable C implementation. To do so, s
 1. Update the appropriate `supported_KEM_NAME_params` array in `tls/s2n_kem.c`
     1. Once this change is made, the KEM extension will be available for use in TLS handshakes; ensure that all testing/verification has been completed 
 
-## How to use PQ cipher suites
+## How to use PQ cipher suites for hybrid TLS 1.2
 1. Checkout s2n `git clone https://github.com/awslabs/s2n.git`
 1. Following the docs/USAGE-GUIDE.md build s2n
 1. Use the sample server and client in the bin directory:

--- a/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
@@ -95,6 +95,17 @@ struct hybrid_test_vector {
 #define X25519_SIKEP434R2_HYBRID_SECRET      (X25519_SHARED_SECRET      SIKEP434R2_SECRET)
 #define SECP256R1_SIKEP434R2_HYBRID_SECRET   (SECP256R1_SHARED_SECRET   SIKEP434R2_SECRET)
 
+/* The expected traffic secrets were calculated from an independent implementation,
+ * using the ECDHE & PQ secrets defined above. */
+#define AES_128_SECP256R1_SIKEP434R2_CLIENT_TRAFFIC_SECRET "2fa1a075eaf636138170e3b2a84f6baa4ac08f846ffe2d005ae5e66b03352c11"
+#define AES_128_SECP256R1_SIKEP434R2_SERVER_TRAFFIC_SECRET "423dfaf8fd66b17aaf8c919a9318f3a6bd69875aacdf022aa58a953a7b6de806"
+#define AES_256_SECP256R1_SIKEP434R2_CLIENT_TRAFFIC_SECRET "f7d349f364f49ff3ae9c4e9e7aa60c41d6c650d09c03d8c076bc714ab76177045e23e7426dceb872d2fe7c0d07abdefd"
+#define AES_256_SECP256R1_SIKEP434R2_SERVER_TRAFFIC_SECRET "184755801232f7b9b5c42cbdc66c793071f4322079e34307fd60261c0f7a27612b3808918218c4000c12f829d6c19ebf"
+#define AES_128_X25519_SIKEP434_CLIENT_TRAFFIC_SECRET "9b9c53221edb5cc1f95ab2ecfc5eb8ec27d6b9fc2159c956333cd90099911dc7"
+#define AES_128_X25519_SIKEP434_SERVER_TRAFFIC_SECRET "29a8786ffc6a48692b95d70ab7e04bcf112afd0a019dff6c15c1d095cfa5ebcc"
+#define AES_256_X25519_SIKEP434_CLIENT_TRAFFIC_SECRET "c7ee90f95fdfd53d97da07e338c7b6aa9e5111864d66d9631048941f45c9fd1a7b119871594140000923a79333040775"
+#define AES_256_X25519_SIKEP434_SERVER_TRAFFIC_SECRET "aff2987e4ed3c2bc55cbd9e3e52db0cc330034dfa709e0a4127c4d74278198720b74a444afa8f0f7dca115797470cef2"
+
 /* A fake transcript string to hash when deriving handshake secrets */
 #define FAKE_TRANSCRIPT "client_hello || server_hello"
 
@@ -113,12 +124,9 @@ int main(int argc, char **argv) {
     S2N_BLOB_FROM_HEX(secp256r1_secret, SECP256R1_SHARED_SECRET);
     S2N_BLOB_FROM_HEX(secp256r1_sikep434r2_hybrid_secret,SECP256R1_SIKEP434R2_HYBRID_SECRET);
 
-    /* The expected client & server traffic secrets were calculated from an
-     * independent implementation, using the parameters defined above. */
-    S2N_BLOB_FROM_HEX(aes_128_secp256r1_sikep434r2_client_secret,
-            "2fa1a075eaf636138170e3b2a84f6baa4ac08f846ffe2d005ae5e66b03352c11");
-    S2N_BLOB_FROM_HEX(aes_128_secp256r1_sikep434r2_server_secret,
-            "423dfaf8fd66b17aaf8c919a9318f3a6bd69875aacdf022aa58a953a7b6de806");
+    S2N_BLOB_FROM_HEX(aes_128_secp256r1_sikep434r2_client_secret, AES_128_SECP256R1_SIKEP434R2_CLIENT_TRAFFIC_SECRET);
+    S2N_BLOB_FROM_HEX(aes_128_secp256r1_sikep434r2_server_secret, AES_128_SECP256R1_SIKEP434R2_SERVER_TRAFFIC_SECRET);
+
     const struct hybrid_test_vector aes_128_sha_256_secp256r1_sikep434r2_vector = {
             .cipher_suite = &s2n_tls13_aes_128_gcm_sha256,
             .transcript = FAKE_TRANSCRIPT,
@@ -131,12 +139,9 @@ int main(int argc, char **argv) {
             .expected_server_traffic_secret = &aes_128_secp256r1_sikep434r2_server_secret,
     };
 
-    /* The expected client & server traffic secrets were calculated from an
-     * independent implementation, using the parameters defined above. */
-    S2N_BLOB_FROM_HEX(aes_256_secp256r1_sikep434r2_client_secret,
-            "f7d349f364f49ff3ae9c4e9e7aa60c41d6c650d09c03d8c076bc714ab76177045e23e7426dceb872d2fe7c0d07abdefd");
-    S2N_BLOB_FROM_HEX(aes_256_secp256r1_sikep434r2_server_secret,
-            "184755801232f7b9b5c42cbdc66c793071f4322079e34307fd60261c0f7a27612b3808918218c4000c12f829d6c19ebf");
+    S2N_BLOB_FROM_HEX(aes_256_secp256r1_sikep434r2_client_secret, AES_256_SECP256R1_SIKEP434R2_CLIENT_TRAFFIC_SECRET);
+    S2N_BLOB_FROM_HEX(aes_256_secp256r1_sikep434r2_server_secret, AES_256_SECP256R1_SIKEP434R2_SERVER_TRAFFIC_SECRET);
+
     const struct hybrid_test_vector aes_256_sha_384_secp256r1_sikep434r2_vector = {
             .cipher_suite = &s2n_tls13_aes_256_gcm_sha384,
             .transcript = FAKE_TRANSCRIPT,
@@ -154,12 +159,9 @@ int main(int argc, char **argv) {
     S2N_BLOB_FROM_HEX(x25519_secret, X25519_SHARED_SECRET);
     S2N_BLOB_FROM_HEX(x25519_sikep434r2_hybrid_secret, X25519_SIKEP434R2_HYBRID_SECRET);
 
-    /* The expected client & server traffic secrets were calculated from an
-     * independent implementation, using the parameters defined above. */
-    S2N_BLOB_FROM_HEX(aes_128_x25519_sikep434r2_client_secret,
-            "9b9c53221edb5cc1f95ab2ecfc5eb8ec27d6b9fc2159c956333cd90099911dc7");
-    S2N_BLOB_FROM_HEX(aes_128_x25519_sikep434r2_server_secret,
-            "29a8786ffc6a48692b95d70ab7e04bcf112afd0a019dff6c15c1d095cfa5ebcc");
+    S2N_BLOB_FROM_HEX(aes_128_x25519_sikep434r2_client_secret, AES_128_X25519_SIKEP434_CLIENT_TRAFFIC_SECRET);
+    S2N_BLOB_FROM_HEX(aes_128_x25519_sikep434r2_server_secret, AES_128_X25519_SIKEP434_SERVER_TRAFFIC_SECRET);
+
     const struct hybrid_test_vector aes_128_sha_256_x25519_sikep434r2_vector = {
             .cipher_suite = &s2n_tls13_aes_128_gcm_sha256,
             .transcript = FAKE_TRANSCRIPT,
@@ -172,12 +174,9 @@ int main(int argc, char **argv) {
             .expected_server_traffic_secret = &aes_128_x25519_sikep434r2_server_secret,
     };
 
-    /* The expected client & server traffic secrets were calculated from an
-     * independent implementation, using the parameters defined above. */
-    S2N_BLOB_FROM_HEX(aes_256_x25519_sikep434r2_client_secret,
-            "c7ee90f95fdfd53d97da07e338c7b6aa9e5111864d66d9631048941f45c9fd1a7b119871594140000923a79333040775");
-    S2N_BLOB_FROM_HEX(aes_256_x25519_sikep434r2_server_secret,
-            "aff2987e4ed3c2bc55cbd9e3e52db0cc330034dfa709e0a4127c4d74278198720b74a444afa8f0f7dca115797470cef2");
+    S2N_BLOB_FROM_HEX(aes_256_x25519_sikep434r2_client_secret, AES_256_X25519_SIKEP434_CLIENT_TRAFFIC_SECRET);
+    S2N_BLOB_FROM_HEX(aes_256_x25519_sikep434r2_server_secret, AES_256_X25519_SIKEP434_SERVER_TRAFFIC_SECRET);
+
     const struct hybrid_test_vector aes_256_sha_284_x25519_sikep434r2_vector = {
             .cipher_suite = &s2n_tls13_aes_256_gcm_sha384,
             .transcript = FAKE_TRANSCRIPT,

--- a/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
@@ -1,0 +1,295 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "utils/s2n_safety.h"
+#include "utils/s2n_mem.h"
+#include "utils/s2n_blob.h"
+
+#include "crypto/s2n_fips.h"
+#include "crypto/s2n_ecc_evp.h"
+
+#include "api/s2n.h"
+
+#include "tls/s2n_connection.h"
+#include "tls/s2n_kem.h"
+
+#include "tests/s2n_test.h"
+#include "tests/testlib/s2n_testlib.h"
+
+#include <openssl/pem.h>
+
+/* Included so we can test functions that are otherwise unavailable */
+#include "tls/s2n_tls13_handshake.c"
+
+#if !defined(S2N_NO_PQ)
+
+/* "Imports" a PEM encoded private ECC key */
+static int read_priv_ecc(EVP_PKEY **pkey, const char *priv_ecc) {
+    size_t key_len = sizeof(char) * strlen(priv_ecc);
+
+    BIO *bio = BIO_new_mem_buf(priv_ecc, key_len);
+    notnull_check(bio);
+    PEM_read_bio_PrivateKey(bio, pkey, 0, NULL);
+    /* Caller should assert notnull_check on *pkey */
+
+    /* BIO_free returns 1 for success */
+    eq_check(1, BIO_free(bio));
+
+    return 0;
+}
+
+static int set_up_conns(struct s2n_connection *client_conn, struct s2n_connection *server_conn,
+        const char *client_priv_ecc, const char *server_priv_ecc, const struct s2n_kem_group *kem_group,
+                struct s2n_blob *pq_shared_secret) {
+    /* These parameters would normally be set during the handshake */
+    client_conn->secure.chosen_client_kem_group_params = &client_conn->secure.client_kem_group_params[0];
+    server_conn->secure.chosen_client_kem_group_params = &server_conn->secure.client_kem_group_params[0];
+
+    server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve = kem_group->curve;
+    server_conn->secure.chosen_client_kem_group_params->ecc_params.negotiated_curve = kem_group->curve;
+    client_conn->secure.server_kem_group_params.ecc_params.negotiated_curve = kem_group->curve;
+    client_conn->secure.chosen_client_kem_group_params->ecc_params.negotiated_curve = kem_group->curve;
+
+    server_conn->secure.server_kem_group_params.kem_group = kem_group;
+    server_conn->secure.chosen_client_kem_group_params->kem_group = kem_group;
+    client_conn->secure.server_kem_group_params.kem_group = kem_group;
+    client_conn->secure.chosen_client_kem_group_params->kem_group = kem_group;
+
+    server_conn->secure.server_kem_group_params.kem_params.kem = kem_group->kem;
+    server_conn->secure.chosen_client_kem_group_params->kem_params.kem = kem_group->kem;
+    client_conn->secure.server_kem_group_params.kem_params.kem = kem_group->kem;
+    client_conn->secure.chosen_client_kem_group_params->kem_params.kem = kem_group->kem;
+
+    /* PQ shared secret is stored in the server_kem_group_params struct, regardless if connection is client or server */
+    GUARD(s2n_dup(pq_shared_secret, &server_conn->secure.server_kem_group_params.kem_params.shared_secret));
+    GUARD(s2n_dup(pq_shared_secret, &client_conn->secure.server_kem_group_params.kem_params.shared_secret));
+
+    /* Populate the client's PQ private key with something - it doesn't have to be a
+     * legitimate private key since it doesn't get used in the shared secret derivation,
+     * but we want to make sure its definitely been freed after shared secret calculation */
+    GUARD(s2n_alloc(&client_conn->secure.chosen_client_kem_group_params->kem_params.private_key, 2));
+    struct s2n_stuffer private_key_stuffer = {0};
+    GUARD(s2n_stuffer_init(&private_key_stuffer,
+                           &client_conn->secure.chosen_client_kem_group_params->kem_params.private_key));
+    uint8_t fake_private_key[] = {3, 3};
+    GUARD(s2n_stuffer_write_bytes(&private_key_stuffer, fake_private_key, 2));
+
+    /* "Import" the provided private ECC keys */
+    eq_check(sizeof(char) * strlen(client_priv_ecc), sizeof(char) * strlen(server_priv_ecc));
+    GUARD(read_priv_ecc(&client_conn->secure.chosen_client_kem_group_params->ecc_params.evp_pkey, client_priv_ecc));
+    notnull_check(client_conn->secure.chosen_client_kem_group_params->ecc_params.evp_pkey);
+    GUARD(read_priv_ecc(&server_conn->secure.server_kem_group_params.ecc_params.evp_pkey, server_priv_ecc));
+    notnull_check(server_conn->secure.server_kem_group_params.ecc_params.evp_pkey);
+
+    /* Each peer sends its public ECC key to the other */
+    struct s2n_stuffer wire;
+    struct s2n_blob server_point_blob, client_point_blob;
+    uint16_t share_size = kem_group->curve->share_size;
+
+    GUARD(s2n_stuffer_growable_alloc(&wire, 1024));
+
+    GUARD(s2n_ecc_evp_write_params_point(&server_conn->secure.server_kem_group_params.ecc_params, &wire));
+    GUARD(s2n_ecc_evp_read_params_point(&wire, share_size, &server_point_blob));
+    GUARD(s2n_ecc_evp_parse_params_point(&server_point_blob, &client_conn->secure.server_kem_group_params.ecc_params));
+
+    GUARD(s2n_ecc_evp_write_params_point(&client_conn->secure.chosen_client_kem_group_params->ecc_params, &wire));
+    GUARD(s2n_ecc_evp_read_params_point(&wire, share_size, &client_point_blob));
+    GUARD(s2n_ecc_evp_parse_params_point(&client_point_blob, &server_conn->secure.chosen_client_kem_group_params->ecc_params));
+
+    GUARD(s2n_stuffer_free(&wire));
+
+    return S2N_SUCCESS;
+}
+
+static int assert_kem_group_params_freed(struct s2n_connection *conn) {
+    eq_check(NULL,conn->secure.server_kem_group_params.ecc_params.evp_pkey);
+    eq_check(NULL,conn->secure.server_kem_group_params.kem_params.shared_secret.data);
+    eq_check(0, conn->secure.server_kem_group_params.kem_params.shared_secret.allocated);
+    eq_check(NULL, conn->secure.server_kem_group_params.kem_params.private_key.data);
+    eq_check(0, conn->secure.server_kem_group_params.kem_params.private_key.allocated);
+    eq_check(NULL, conn->secure.server_kem_group_params.kem_params.public_key.data);
+    eq_check(0, conn->secure.server_kem_group_params.kem_params.public_key.allocated);
+
+    eq_check(NULL, conn->secure.chosen_client_kem_group_params->ecc_params.evp_pkey);
+    eq_check(NULL, conn->secure.chosen_client_kem_group_params->kem_params.shared_secret.data);
+    eq_check(0, conn->secure.chosen_client_kem_group_params->kem_params.shared_secret.allocated);
+    eq_check(NULL, conn->secure.chosen_client_kem_group_params->kem_params.private_key.data);
+    eq_check(0, conn->secure.chosen_client_kem_group_params->kem_params.private_key.allocated);
+    eq_check(NULL, conn->secure.chosen_client_kem_group_params->kem_params.public_key.data);
+    eq_check(0, conn->secure.chosen_client_kem_group_params->kem_params.public_key.allocated);
+
+    return S2N_SUCCESS;
+}
+
+struct hybrid_test_vector {
+    const struct s2n_kem_group *kem_group;
+    const char *client_ecc_key;
+    const char *server_ecc_key;
+    struct s2n_blob *pq_secret;
+    struct s2n_blob *expected_hybrid_secret;
+};
+
+#endif
+
+#define CLIENT_X25519_PRIV_KEY "-----BEGIN PRIVATE KEY-----\n"\
+                               "MC4CAQAwBQYDK2VuBCIEIIgzBrAp631nCDaoA7ilx/8S/cW1lddVQOw9869sROBF\n"\
+                               "-----END PRIVATE KEY-----"
+
+#define SERVER_X25519_PRIV_KEY "-----BEGIN PRIVATE KEY-----\n"\
+                               "MC4CAQAwBQYDK2VuBCIEIIBo+KJ2Zs3vRHQ3sYgHL4zTQPlJPl1y7sW8HT9qRE96\n"\
+                               "-----END PRIVATE KEY-----"
+
+#define CLIENT_SECP256R1_PRIV_KEY "-----BEGIN EC PARAMETERS-----\n"\
+                                  "BggqhkjOPQMBBw==\n"\
+                                  "-----END EC PARAMETERS-----\n"\
+                                  "-----BEGIN EC PRIVATE KEY-----\n"\
+                                  "MHcCAQEEIFCkEmNXACRbWdizfAKP8/Qvx9aplVxLE+Sm2vmCcsY3oAoGCCqGSM49\n"\
+                                  "AwEHoUQDQgAESk526eZ9lf6xrNOiTF8qkYvJDOfc4qqShcbB7qnT67As4pyeQzVm\n"\
+                                  "xfMjmXYBOUnPVBL3FKnIk45sDSCfu++gug==\n"\
+                                  "-----END EC PRIVATE KEY-----"
+
+#define SERVER_SECP256R1_PRIV_KEY "-----BEGIN EC PARAMETERS-----\n"\
+                                  "BggqhkjOPQMBBw==\n"\
+                                  "-----END EC PARAMETERS-----\n"\
+                                  "-----BEGIN EC PRIVATE KEY-----\n"\
+                                  "MHcCAQEEINXLCaZuyYG0HrlSFcHLPFmSnyFm5RqrmyZfgdrxqprXoAoGCCqGSM49\n"\
+                                  "AwEHoUQDQgAEMDuuxEQ1yaA13ceuJP+RC0sbf5ksW6DPlL+yXJiD7cUeWUPrtxbP\n"\
+                                  "ViSR6ex8fYV69oCHgnDnElfE3xaiXiQWBw==\n"\
+                                  "-----END EC PRIVATE KEY-----"
+
+#define X25519_SHARED_SECRET "519be87fa0599077e5673d6f2d910aa150d7fef783c5e1491961fdf63b255910"
+#define SECP256R1_SHARED_SECRET "9348e27655539e08fffe46b35f863dd634e7437cc6bc11c7d329ef5484ec3b60"
+#define SIKEP434R2_SECRET "35f7f8ff388714dedc41f139078cedc9"
+#define X25519_SIKEP434R2_HYBRID_SECRET X25519_SHARED_SECRET SIKEP434R2_SECRET
+#define SECP256R1_SIKEP434R2_HYBRID_SECRET SECP256R1_SHARED_SECRET SIKEP434R2_SECRET
+
+int main(int argc, char **argv) {
+    BEGIN_TEST();
+
+#if !defined(S2N_NO_PQ)
+
+    if (s2n_is_in_fips_mode()) {
+        /* There is no support for PQ KEMs while in FIPS mode */
+        END_TEST();
+    }
+
+    S2N_BLOB_FROM_HEX(sikep434r2_secret, SIKEP434R2_SECRET);
+    S2N_BLOB_FROM_HEX(x25519_secret, X25519_SHARED_SECRET);
+    S2N_BLOB_FROM_HEX(secp256r1_secret, SECP256R1_SHARED_SECRET);
+    S2N_BLOB_FROM_HEX(x25519_sikep434r2_hybrid_secret, X25519_SIKEP434R2_HYBRID_SECRET);
+    S2N_BLOB_FROM_HEX(secp256r1_sikep434r2_hybrid_secret,SECP256R1_SIKEP434R2_HYBRID_SECRET);
+
+    const struct hybrid_test_vector x25519_sikep434r2_vector = {
+            .kem_group = &s2n_x25519_sike_p434_r2,
+            .client_ecc_key = CLIENT_X25519_PRIV_KEY,
+            .server_ecc_key = SERVER_X25519_PRIV_KEY,
+            .pq_secret = &sikep434r2_secret,
+            .expected_hybrid_secret = &x25519_sikep434r2_hybrid_secret,
+    };
+
+    const struct hybrid_test_vector secp256r1_sikep434r2_vector = {
+            .kem_group = &s2n_secp256r1_sike_p434_r2,
+            .client_ecc_key = CLIENT_SECP256R1_PRIV_KEY,
+            .server_ecc_key = SERVER_SECP256R1_PRIV_KEY,
+            .pq_secret = &sikep434r2_secret,
+            .expected_hybrid_secret = &secp256r1_sikep434r2_hybrid_secret,
+    };
+
+    /* Asserting this equality to ensure that this test gets updated if a new kem_group is added */
+    EXPECT_EQUAL(2, S2N_SUPPORTED_KEM_GROUPS_COUNT);
+    const struct hybrid_test_vector *all_test_vectors[S2N_SUPPORTED_KEM_GROUPS_COUNT] = {
+            &x25519_sikep434r2_vector,
+            &secp256r1_sikep434r2_vector
+    };
+
+    struct s2n_connection *client_conn;
+    struct s2n_connection *server_conn;
+
+    {
+        /* Happy case for all supported hybrid key calculations */
+        for (int i = 0; i < s2n_array_len(all_test_vectors); i++) {
+            const struct hybrid_test_vector *test_vector = all_test_vectors[i];
+            const struct s2n_kem_group *kem_group = test_vector->kem_group;
+
+            EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+
+            EXPECT_SUCCESS(set_up_conns(client_conn, server_conn, test_vector->client_ecc_key,
+                    test_vector->server_ecc_key, kem_group, test_vector->pq_secret));
+
+            DEFER_CLEANUP(struct s2n_blob client_calculated_shared_secret = {0}, s2n_free);
+            DEFER_CLEANUP(struct s2n_blob server_calculated_shared_secret = {0}, s2n_free);
+
+            EXPECT_SUCCESS(s2n_tls13_compute_shared_secret(client_conn, &client_calculated_shared_secret));
+            EXPECT_SUCCESS(s2n_tls13_compute_shared_secret(server_conn, &server_calculated_shared_secret));
+
+            S2N_BLOB_EXPECT_EQUAL(client_calculated_shared_secret, server_calculated_shared_secret);
+            EXPECT_EQUAL(test_vector->expected_hybrid_secret->size, client_calculated_shared_secret.size);
+            EXPECT_BYTEARRAY_EQUAL(test_vector->expected_hybrid_secret->data, client_calculated_shared_secret.data,
+                    client_calculated_shared_secret.size);
+
+            EXPECT_SUCCESS(assert_kem_group_params_freed(client_conn));
+            EXPECT_SUCCESS(assert_kem_group_params_freed(server_conn));
+
+            EXPECT_SUCCESS(s2n_connection_free(client_conn));
+            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        }
+    }
+    {
+        /* Various failure cases */
+        const struct hybrid_test_vector *test_vector = all_test_vectors[0];
+        EXPECT_EQUAL(test_vector->kem_group, &s2n_x25519_sike_p434_r2);
+
+        /* Failures because of NULL arguments */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(NULL, NULL), S2N_ERR_NULL);
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, NULL), S2N_ERR_NULL);
+        DEFER_CLEANUP(struct s2n_blob client_calculated_shared_secret = {0}, s2n_free);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(NULL, &client_calculated_shared_secret), S2N_ERR_NULL);
+
+        /* Failure because the chosen_client_kem_group_params is NULL */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, &client_calculated_shared_secret), S2N_ERR_NULL);
+        client_conn->secure.chosen_client_kem_group_params = &client_conn->secure.client_kem_group_params[0];
+
+        /* Failures because the kem_group_params aren't set */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, &client_calculated_shared_secret), S2N_ERR_NULL);
+        client_conn->secure.server_kem_group_params.ecc_params.negotiated_curve = test_vector->kem_group->curve;
+        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, &client_calculated_shared_secret), S2N_ERR_NULL);
+        client_conn->secure.chosen_client_kem_group_params->ecc_params.negotiated_curve = test_vector->kem_group->curve;
+
+        /* Failures because the ECC private keys are NULL */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, &client_calculated_shared_secret), S2N_ERR_NULL);
+        EXPECT_SUCCESS(read_priv_ecc(&client_conn->secure.chosen_client_kem_group_params->ecc_params.evp_pkey, test_vector->client_ecc_key));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, &client_calculated_shared_secret), S2N_ERR_NULL);
+        EXPECT_SUCCESS(read_priv_ecc(&client_conn->secure.server_kem_group_params.ecc_params.evp_pkey, test_vector->server_ecc_key));
+
+        /* Failure because the kem_group is NULL */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, &client_calculated_shared_secret), S2N_ERR_NULL);
+        client_conn->secure.server_kem_group_params.kem_group = test_vector->kem_group;
+
+        /* Failure because pq_shared_secret is NULL */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, &client_calculated_shared_secret), S2N_ERR_NULL);
+        EXPECT_SUCCESS(s2n_dup(test_vector->pq_secret, &client_conn->secure.server_kem_group_params.kem_params.shared_secret));
+
+        /* Finally, success */
+        EXPECT_SUCCESS(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, &client_calculated_shared_secret));
+
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+    }
+
+#endif
+
+    END_TEST();
+}

--- a/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
@@ -191,8 +191,9 @@ int main(int argc, char **argv) {
     };
 #endif
 
+    EXPECT_EQUAL(2, S2N_MAX_NUM_SUPPORTED_KEM_GROUPS);
+
 #if EVP_APIS_SUPPORTED
-    EXPECT_EQUAL(2, S2N_SUPPORTED_KEM_GROUPS_COUNT);
     const struct hybrid_test_vector *all_test_vectors[] = {
             &aes_128_sha_256_secp256r1_sikep434r2,
             &aes_256_sha_384_secp256r1_sikep434r2,
@@ -200,7 +201,6 @@ int main(int argc, char **argv) {
             &aes_256_sha_284_x25519_sikep434r2_vector,
     };
 #else
-    EXPECT_EQUAL(1, S2N_SUPPORTED_KEM_GROUPS_COUNT);
     const struct hybrid_test_vector *all_test_vectors[] = {
             &aes_128_sha_256_secp256r1_sikep434r2,
             &aes_256_sha_384_secp256r1_sikep434r2,

--- a/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
@@ -36,16 +36,10 @@
 #if !defined(S2N_NO_PQ)
 
 /* "Imports" a PEM encoded private ECC key */
-static int read_priv_ecc(EVP_PKEY **pkey, const char *priv_ecc) {
+static int read_priv_ecc(EVP_PKEY **pkey, char *priv_ecc) {
     size_t key_len = sizeof(char) * strlen(priv_ecc);
 
-#if defined(LIBRESSL_VERSION_NUMBER)
-    /* LibreSSL's API is different from OpenSSL's */
     BIO *bio = BIO_new_mem_buf((void *)priv_ecc, key_len);
-#else
-    BIO *bio = BIO_new_mem_buf(priv_ecc, key_len);
-#endif
-
     notnull_check(bio);
     PEM_read_bio_PrivateKey(bio, pkey, 0, NULL);
     /* Caller should assert notnull_check on *pkey */
@@ -57,7 +51,7 @@ static int read_priv_ecc(EVP_PKEY **pkey, const char *priv_ecc) {
 }
 
 static int set_up_conns(struct s2n_connection *client_conn, struct s2n_connection *server_conn,
-        const char *client_priv_ecc, const char *server_priv_ecc, const struct s2n_kem_group *kem_group,
+        char *client_priv_ecc, char *server_priv_ecc, const struct s2n_kem_group *kem_group,
                 struct s2n_blob *pq_shared_secret) {
     /* These parameters would normally be set during the handshake */
     client_conn->secure.chosen_client_kem_group_params = &client_conn->secure.client_kem_group_params[0];
@@ -141,8 +135,8 @@ static int assert_kem_group_params_freed(struct s2n_connection *conn) {
 
 struct hybrid_test_vector {
     const struct s2n_kem_group *kem_group;
-    const char *client_ecc_key;
-    const char *server_ecc_key;
+    char *client_ecc_key;
+    char *server_ecc_key;
     struct s2n_blob *pq_secret;
     struct s2n_blob *expected_hybrid_secret;
 };

--- a/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
@@ -208,9 +208,16 @@ int main(int argc, char **argv) {
     };
 
     /* Asserting this equality to ensure that this test gets updated if a new kem_group is added */
+#if EVP_APIS_SUPPORTED
     EXPECT_EQUAL(2, S2N_SUPPORTED_KEM_GROUPS_COUNT);
-    const struct hybrid_test_vector *all_test_vectors[S2N_SUPPORTED_KEM_GROUPS_COUNT] = {
+#else
+    EXPECT_EQUAL(1, S2N_SUPPORTED_KEM_GROUPS_COUNT);
+#endif
+
+    const struct hybrid_test_vector *all_test_vectors[] = {
+#if EVP_APIS_SUPPORTED
             &x25519_sikep434r2_vector,
+#endif
             &secp256r1_sikep434r2_vector
     };
 
@@ -249,8 +256,7 @@ int main(int argc, char **argv) {
     }
     {
         /* Various failure cases */
-        const struct hybrid_test_vector *test_vector = all_test_vectors[0];
-        EXPECT_EQUAL(test_vector->kem_group, &s2n_x25519_sike_p434_r2);
+        const struct hybrid_test_vector *test_vector = &secp256r1_sikep434r2_vector;
 
         /* Failures because of NULL arguments */
         EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(NULL, NULL), S2N_ERR_NULL);

--- a/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
@@ -36,10 +36,23 @@
 #if !defined(S2N_NO_PQ)
 
 /* "Imports" a PEM encoded private ECC key */
-static int read_priv_ecc(EVP_PKEY **pkey, char *priv_ecc) {
+static int read_priv_ecc(EVP_PKEY **pkey, const char *priv_ecc) {
     size_t key_len = sizeof(char) * strlen(priv_ecc);
 
-    BIO *bio = BIO_new_mem_buf((void *)priv_ecc, key_len);
+#if defined(LIBRESSL_VERSION_NUMBER)
+    /* Some moderate hackery to get around LibreSSL's non-const API signature */
+
+    DEFER_CLEANUP(struct s2n_blob priv_ecc_blob = { 0 }, s2n_free);
+    GUARD(s2n_alloc(&priv_ecc_blob, key_len));
+    for (size_t i = 0; i < key_len; i++) {
+        priv_ecc_blob.data[i] = priv_ecc[i];
+    }
+
+    BIO *bio = BIO_new_mem_buf((void *)priv_ecc_blob.data, key_len);
+#else
+    BIO *bio = BIO_new_mem_buf((const void *)priv_ecc, key_len);
+#endif
+
     notnull_check(bio);
     PEM_read_bio_PrivateKey(bio, pkey, 0, NULL);
     /* Caller should assert notnull_check on *pkey */
@@ -51,7 +64,7 @@ static int read_priv_ecc(EVP_PKEY **pkey, char *priv_ecc) {
 }
 
 static int set_up_conns(struct s2n_connection *client_conn, struct s2n_connection *server_conn,
-        char *client_priv_ecc, char *server_priv_ecc, const struct s2n_kem_group *kem_group,
+        const char *client_priv_ecc, const char *server_priv_ecc, const struct s2n_kem_group *kem_group,
                 struct s2n_blob *pq_shared_secret) {
     /* These parameters would normally be set during the handshake */
     client_conn->secure.chosen_client_kem_group_params = &client_conn->secure.client_kem_group_params[0];
@@ -135,8 +148,8 @@ static int assert_kem_group_params_freed(struct s2n_connection *conn) {
 
 struct hybrid_test_vector {
     const struct s2n_kem_group *kem_group;
-    char *client_ecc_key;
-    char *server_ecc_key;
+    const char *client_ecc_key;
+    const char *server_ecc_key;
     struct s2n_blob *pq_secret;
     struct s2n_blob *expected_hybrid_secret;
 };

--- a/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
@@ -186,19 +186,9 @@ int main(int argc, char **argv) {
     }
 
     S2N_BLOB_FROM_HEX(sikep434r2_secret, SIKEP434R2_SECRET);
-    S2N_BLOB_FROM_HEX(x25519_secret, X25519_SHARED_SECRET);
+
     S2N_BLOB_FROM_HEX(secp256r1_secret, SECP256R1_SHARED_SECRET);
-    S2N_BLOB_FROM_HEX(x25519_sikep434r2_hybrid_secret, X25519_SIKEP434R2_HYBRID_SECRET);
     S2N_BLOB_FROM_HEX(secp256r1_sikep434r2_hybrid_secret,SECP256R1_SIKEP434R2_HYBRID_SECRET);
-
-    const struct hybrid_test_vector x25519_sikep434r2_vector = {
-            .kem_group = &s2n_x25519_sike_p434_r2,
-            .client_ecc_key = CLIENT_X25519_PRIV_KEY,
-            .server_ecc_key = SERVER_X25519_PRIV_KEY,
-            .pq_secret = &sikep434r2_secret,
-            .expected_hybrid_secret = &x25519_sikep434r2_hybrid_secret,
-    };
-
     const struct hybrid_test_vector secp256r1_sikep434r2_vector = {
             .kem_group = &s2n_secp256r1_sike_p434_r2,
             .client_ecc_key = CLIENT_SECP256R1_PRIV_KEY,
@@ -207,19 +197,27 @@ int main(int argc, char **argv) {
             .expected_hybrid_secret = &secp256r1_sikep434r2_hybrid_secret,
     };
 
-    /* Asserting this equality to ensure that this test gets updated if a new kem_group is added */
-#if EVP_APIS_SUPPORTED
-    EXPECT_EQUAL(2, S2N_SUPPORTED_KEM_GROUPS_COUNT);
-#else
-    EXPECT_EQUAL(1, S2N_SUPPORTED_KEM_GROUPS_COUNT);
-#endif
+    EXPECT_TRUE(S2N_SUPPORTED_KEM_GROUPS_COUNT > 0);
+    const struct hybrid_test_vector *all_test_vectors[S2N_SUPPORTED_KEM_GROUPS_COUNT];
+    all_test_vectors[0] = &secp256r1_sikep434r2_vector;
 
-    const struct hybrid_test_vector *all_test_vectors[] = {
 #if EVP_APIS_SUPPORTED
-            &x25519_sikep434r2_vector,
-#endif
-            &secp256r1_sikep434r2_vector
+    /* All x25519 based kem_groups require EVP_APIS_SUPPORTED */
+    S2N_BLOB_FROM_HEX(x25519_secret, X25519_SHARED_SECRET);
+    S2N_BLOB_FROM_HEX(x25519_sikep434r2_hybrid_secret, X25519_SIKEP434R2_HYBRID_SECRET);
+    const struct hybrid_test_vector x25519_sikep434r2_vector = {
+            .kem_group = &s2n_x25519_sike_p434_r2,
+            .client_ecc_key = CLIENT_X25519_PRIV_KEY,
+            .server_ecc_key = SERVER_X25519_PRIV_KEY,
+            .pq_secret = &sikep434r2_secret,
+            .expected_hybrid_secret = &x25519_sikep434r2_hybrid_secret,
     };
+
+    EXPECT_EQUAL(2, S2N_SUPPORTED_KEM_GROUPS_COUNT);
+    all_test_vectors[1] = &x25519_sikep434r2_vector;
+#else
+        EXPECT_EQUAL(1, S2N_SUPPORTED_KEM_GROUPS_COUNT);
+#endif
 
     struct s2n_connection *client_conn;
     struct s2n_connection *server_conn;

--- a/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
@@ -191,9 +191,8 @@ int main(int argc, char **argv) {
     };
 #endif
 
-    EXPECT_EQUAL(2, S2N_MAX_NUM_SUPPORTED_KEM_GROUPS);
-
 #if EVP_APIS_SUPPORTED
+    EXPECT_EQUAL(2, S2N_SUPPORTED_KEM_GROUPS_COUNT);
     const struct hybrid_test_vector *all_test_vectors[] = {
             &aes_128_sha_256_secp256r1_sikep434r2_vector,
             &aes_256_sha_384_secp256r1_sikep434r2_vector,
@@ -201,6 +200,7 @@ int main(int argc, char **argv) {
             &aes_256_sha_284_x25519_sikep434r2_vector,
     };
 #else
+    EXPECT_EQUAL(1, S2N_SUPPORTED_KEM_GROUPS_COUNT);
     const struct hybrid_test_vector *all_test_vectors[] = {
             &aes_128_sha_256_secp256r1_sikep434r2,
             &aes_256_sha_384_secp256r1_sikep434r2,

--- a/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
@@ -202,8 +202,8 @@ int main(int argc, char **argv) {
 #else
     EXPECT_EQUAL(1, S2N_SUPPORTED_KEM_GROUPS_COUNT);
     const struct hybrid_test_vector *all_test_vectors[] = {
-            &aes_128_sha_256_secp256r1_sikep434r2,
-            &aes_256_sha_384_secp256r1_sikep434r2,
+            &aes_128_sha_256_secp256r1_sikep434r2_vector,
+            &aes_256_sha_384_secp256r1_sikep434r2_vector,
     };
 #endif
 

--- a/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
@@ -19,11 +19,13 @@
 
 #include "crypto/s2n_fips.h"
 #include "crypto/s2n_ecc_evp.h"
+#include "crypto/s2n_hash.h"
 
 #include "api/s2n.h"
 
 #include "tls/s2n_connection.h"
 #include "tls/s2n_kem.h"
+#include "tls/s2n_cipher_suites.h"
 
 #include "tests/s2n_test.h"
 #include "tests/testlib/s2n_testlib.h"
@@ -35,12 +37,300 @@
 
 #if !defined(S2N_NO_PQ)
 
-/* "Imports" a PEM encoded private ECC key */
+static int read_priv_ecc(EVP_PKEY **pkey, const char *priv_ecc);
+static int set_up_conns(struct s2n_connection *client_conn, struct s2n_connection *server_conn,
+                        const char *client_priv_ecc, const char *server_priv_ecc, const struct s2n_kem_group *kem_group,
+                        struct s2n_blob *pq_shared_secret);
+static int assert_kem_group_params_freed(struct s2n_connection *conn);
+
+struct hybrid_test_vector {
+    const struct s2n_kem_group *kem_group;
+    const struct s2n_cipher_suite *cipher_suite;
+    const char *transcript;
+    const char *client_ecc_key;
+    const char *server_ecc_key;
+    struct s2n_blob *pq_secret;
+    struct s2n_blob *expected_hybrid_secret;
+    struct s2n_blob *expected_client_traffic_secret;
+    struct s2n_blob *expected_server_traffic_secret;
+};
+
+#endif
+
+/* PEM-encoded ECC private keys */
+#define CLIENT_X25519_PRIV_KEY "-----BEGIN PRIVATE KEY-----\n"\
+                               "MC4CAQAwBQYDK2VuBCIEIIgzBrAp631nCDaoA7ilx/8S/cW1lddVQOw9869sROBF\n"\
+                               "-----END PRIVATE KEY-----"
+
+#define SERVER_X25519_PRIV_KEY "-----BEGIN PRIVATE KEY-----\n"\
+                               "MC4CAQAwBQYDK2VuBCIEIIBo+KJ2Zs3vRHQ3sYgHL4zTQPlJPl1y7sW8HT9qRE96\n"\
+                               "-----END PRIVATE KEY-----"
+
+#define CLIENT_SECP256R1_PRIV_KEY "-----BEGIN EC PARAMETERS-----\n"\
+                                  "BggqhkjOPQMBBw==\n"\
+                                  "-----END EC PARAMETERS-----\n"\
+                                  "-----BEGIN EC PRIVATE KEY-----\n"\
+                                  "MHcCAQEEIFCkEmNXACRbWdizfAKP8/Qvx9aplVxLE+Sm2vmCcsY3oAoGCCqGSM49\n"\
+                                  "AwEHoUQDQgAESk526eZ9lf6xrNOiTF8qkYvJDOfc4qqShcbB7qnT67As4pyeQzVm\n"\
+                                  "xfMjmXYBOUnPVBL3FKnIk45sDSCfu++gug==\n"\
+                                  "-----END EC PRIVATE KEY-----"
+
+#define SERVER_SECP256R1_PRIV_KEY "-----BEGIN EC PARAMETERS-----\n"\
+                                  "BggqhkjOPQMBBw==\n"\
+                                  "-----END EC PARAMETERS-----\n"\
+                                  "-----BEGIN EC PRIVATE KEY-----\n"\
+                                  "MHcCAQEEINXLCaZuyYG0HrlSFcHLPFmSnyFm5RqrmyZfgdrxqprXoAoGCCqGSM49\n"\
+                                  "AwEHoUQDQgAEMDuuxEQ1yaA13ceuJP+RC0sbf5ksW6DPlL+yXJiD7cUeWUPrtxbP\n"\
+                                  "ViSR6ex8fYV69oCHgnDnElfE3xaiXiQWBw==\n"\
+                                  "-----END EC PRIVATE KEY-----"
+
+/* ECDHE shared secrets computed from the private keys above */
+#define X25519_SHARED_SECRET "519be87fa0599077e5673d6f2d910aa150d7fef783c5e1491961fdf63b255910"
+#define SECP256R1_SHARED_SECRET "9348e27655539e08fffe46b35f863dd634e7437cc6bc11c7d329ef5484ec3b60"
+
+/* PQ shared secrets taken from the first entry in the NIST KAT files */
+#define SIKEP434R2_SECRET "35f7f8ff388714dedc41f139078cedc9"
+
+/* Hybrid shared secrets are the concatenation: ECDHE || PQ */
+#define X25519_SIKEP434R2_HYBRID_SECRET X25519_SHARED_SECRET SIKEP434R2_SECRET
+#define SECP256R1_SIKEP434R2_HYBRID_SECRET SECP256R1_SHARED_SECRET SIKEP434R2_SECRET
+
+/* A fake transcript string to hash when deriving handshake secrets */
+#define FAKE_TRANSCRIPT "client_hello || server_hello"
+
+int main(int argc, char **argv) {
+    BEGIN_TEST();
+
+#if !defined(S2N_NO_PQ)
+
+    if (s2n_is_in_fips_mode()) {
+        /* There is no support for PQ KEMs while in FIPS mode */
+        END_TEST();
+    }
+
+    S2N_BLOB_FROM_HEX(sikep434r2_secret, SIKEP434R2_SECRET);
+
+    S2N_BLOB_FROM_HEX(secp256r1_secret, SECP256R1_SHARED_SECRET);
+    S2N_BLOB_FROM_HEX(secp256r1_sikep434r2_hybrid_secret,SECP256R1_SIKEP434R2_HYBRID_SECRET);
+
+    /* The expected client & server traffic secrets were calculated from an
+     * independent implementation, using the parameters defined above. */
+    S2N_BLOB_FROM_HEX(aes_128_secp256r1_sikep434r2_client_secret,
+            "2fa1a075eaf636138170e3b2a84f6baa4ac08f846ffe2d005ae5e66b03352c11");
+    S2N_BLOB_FROM_HEX(aes_128_secp256r1_sikep434r2_server_secret,
+            "423dfaf8fd66b17aaf8c919a9318f3a6bd69875aacdf022aa58a953a7b6de806");
+    const struct hybrid_test_vector aes_128_sha_256_secp256r1_sikep434r2 = {
+            .cipher_suite = &s2n_tls13_aes_128_gcm_sha256,
+            .transcript = FAKE_TRANSCRIPT,
+            .kem_group = &s2n_secp256r1_sike_p434_r2,
+            .client_ecc_key = CLIENT_SECP256R1_PRIV_KEY,
+            .server_ecc_key = SERVER_SECP256R1_PRIV_KEY,
+            .pq_secret = &sikep434r2_secret,
+            .expected_hybrid_secret = &secp256r1_sikep434r2_hybrid_secret,
+            .expected_client_traffic_secret = &aes_128_secp256r1_sikep434r2_client_secret,
+            .expected_server_traffic_secret = &aes_128_secp256r1_sikep434r2_server_secret,
+    };
+
+    /* The expected client & server traffic secrets were calculated from an
+     * independent implementation, using the parameters defined above. */
+    S2N_BLOB_FROM_HEX(aes_256_secp256r1_sikep434r2_client_secret,
+            "f7d349f364f49ff3ae9c4e9e7aa60c41d6c650d09c03d8c076bc714ab76177045e23e7426dceb872d2fe7c0d07abdefd");
+    S2N_BLOB_FROM_HEX(aes_256_secp256r1_sikep434r2_server_secret,
+            "184755801232f7b9b5c42cbdc66c793071f4322079e34307fd60261c0f7a27612b3808918218c4000c12f829d6c19ebf");
+    const struct hybrid_test_vector aes_256_sha_384_secp256r1_sikep434r2 = {
+            .cipher_suite = &s2n_tls13_aes_256_gcm_sha384,
+            .transcript = FAKE_TRANSCRIPT,
+            .kem_group = &s2n_secp256r1_sike_p434_r2,
+            .client_ecc_key = CLIENT_SECP256R1_PRIV_KEY,
+            .server_ecc_key = SERVER_SECP256R1_PRIV_KEY,
+            .pq_secret = &sikep434r2_secret,
+            .expected_hybrid_secret = &secp256r1_sikep434r2_hybrid_secret,
+            .expected_client_traffic_secret = &aes_256_secp256r1_sikep434r2_client_secret,
+            .expected_server_traffic_secret = &aes_256_secp256r1_sikep434r2_server_secret,
+    };
+
+#if EVP_APIS_SUPPORTED
+    /* All x25519 based kem_groups require EVP_APIS_SUPPORTED */
+    S2N_BLOB_FROM_HEX(x25519_secret, X25519_SHARED_SECRET);
+    S2N_BLOB_FROM_HEX(x25519_sikep434r2_hybrid_secret, X25519_SIKEP434R2_HYBRID_SECRET);
+
+    /* The expected client & server traffic secrets were calculated from an
+     * independent implementation, using the parameters defined above. */
+    S2N_BLOB_FROM_HEX(aes_128_x25519_sikep434r2_client_secret,
+            "9b9c53221edb5cc1f95ab2ecfc5eb8ec27d6b9fc2159c956333cd90099911dc7");
+    S2N_BLOB_FROM_HEX(aes_128_x25519_sikep434r2_server_secret,
+            "29a8786ffc6a48692b95d70ab7e04bcf112afd0a019dff6c15c1d095cfa5ebcc");
+    const struct hybrid_test_vector aes_128_sha_256_x25519_sikep434r2_vector = {
+            .cipher_suite = &s2n_tls13_aes_128_gcm_sha256,
+            .transcript = FAKE_TRANSCRIPT,
+            .kem_group = &s2n_x25519_sike_p434_r2,
+            .client_ecc_key = CLIENT_X25519_PRIV_KEY,
+            .server_ecc_key = SERVER_X25519_PRIV_KEY,
+            .pq_secret = &sikep434r2_secret,
+            .expected_hybrid_secret = &x25519_sikep434r2_hybrid_secret,
+            .expected_client_traffic_secret = &aes_128_x25519_sikep434r2_client_secret,
+            .expected_server_traffic_secret = &aes_128_x25519_sikep434r2_server_secret,
+    };
+
+    /* The expected client & server traffic secrets were calculated from an
+     * independent implementation, using the parameters defined above. */
+    S2N_BLOB_FROM_HEX(aes_256_x25519_sikep434r2_client_secret,
+            "c7ee90f95fdfd53d97da07e338c7b6aa9e5111864d66d9631048941f45c9fd1a7b119871594140000923a79333040775");
+    S2N_BLOB_FROM_HEX(aes_256_x25519_sikep434r2_server_secret,
+            "aff2987e4ed3c2bc55cbd9e3e52db0cc330034dfa709e0a4127c4d74278198720b74a444afa8f0f7dca115797470cef2");
+    const struct hybrid_test_vector aes_256_sha_284_x25519_sikep434r2_vector = {
+            .cipher_suite = &s2n_tls13_aes_256_gcm_sha384,
+            .transcript = FAKE_TRANSCRIPT,
+            .kem_group = &s2n_x25519_sike_p434_r2,
+            .client_ecc_key = CLIENT_X25519_PRIV_KEY,
+            .server_ecc_key = SERVER_X25519_PRIV_KEY,
+            .pq_secret = &sikep434r2_secret,
+            .expected_hybrid_secret = &x25519_sikep434r2_hybrid_secret,
+            .expected_client_traffic_secret = &aes_256_x25519_sikep434r2_client_secret,
+            .expected_server_traffic_secret = &aes_256_x25519_sikep434r2_server_secret,
+    };
+#endif
+
+#if EVP_APIS_SUPPORTED
+    EXPECT_EQUAL(2, S2N_SUPPORTED_KEM_GROUPS_COUNT);
+    const struct hybrid_test_vector *all_test_vectors[] = {
+            &aes_128_sha_256_secp256r1_sikep434r2,
+            &aes_256_sha_384_secp256r1_sikep434r2,
+            &aes_128_sha_256_x25519_sikep434r2_vector,
+            &aes_256_sha_284_x25519_sikep434r2_vector,
+    };
+#else
+    EXPECT_EQUAL(1, S2N_SUPPORTED_KEM_GROUPS_COUNT);
+    const struct hybrid_test_vector *all_test_vectors[] = {
+            &aes_128_sha_256_secp256r1_sikep434r2,
+            &aes_256_sha_384_secp256r1_sikep434r2,
+    };
+#endif
+
+
+    struct s2n_connection *client_conn;
+    struct s2n_connection *server_conn;
+
+    {
+        /* Happy cases for computing the hybrid shared secret and client & server traffic secrets */
+        for (int i = 0; i < s2n_array_len(all_test_vectors); i++) {
+            const struct hybrid_test_vector *test_vector = all_test_vectors[i];
+            const struct s2n_kem_group *kem_group = test_vector->kem_group;
+
+            /* Set up connections */
+            EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+
+            EXPECT_SUCCESS(set_up_conns(client_conn, server_conn, test_vector->client_ecc_key,
+                    test_vector->server_ecc_key, kem_group, test_vector->pq_secret));
+
+            /* Calculate the hybrid shared secret */
+            DEFER_CLEANUP(struct s2n_blob client_calculated_shared_secret = {0}, s2n_free);
+            DEFER_CLEANUP(struct s2n_blob server_calculated_shared_secret = {0}, s2n_free);
+            EXPECT_SUCCESS(s2n_tls13_compute_shared_secret(client_conn, &client_calculated_shared_secret));
+            EXPECT_SUCCESS(s2n_tls13_compute_shared_secret(server_conn, &server_calculated_shared_secret));
+
+            /* Assert correctness of hybrid shared secret */
+            S2N_BLOB_EXPECT_EQUAL(client_calculated_shared_secret, server_calculated_shared_secret);
+            EXPECT_EQUAL(test_vector->expected_hybrid_secret->size, client_calculated_shared_secret.size);
+            EXPECT_BYTEARRAY_EQUAL(test_vector->expected_hybrid_secret->data, client_calculated_shared_secret.data,
+                    client_calculated_shared_secret.size);
+
+            EXPECT_SUCCESS(assert_kem_group_params_freed(client_conn));
+            EXPECT_SUCCESS(assert_kem_group_params_freed(server_conn));
+
+            /* Compute the transcript hash, then use the hybrid shared secret to derive
+             * the client & server traffic secrets */
+            DEFER_CLEANUP(struct s2n_tls13_keys secrets = {0}, s2n_tls13_keys_free);
+            EXPECT_SUCCESS(s2n_tls13_keys_init(&secrets, test_vector->cipher_suite->prf_alg));
+            EXPECT_SUCCESS(s2n_tls13_derive_early_secrets(&secrets));
+
+            DEFER_CLEANUP(struct s2n_hash_state hash_state, s2n_hash_free);
+            EXPECT_SUCCESS(s2n_hash_new(&hash_state));
+            EXPECT_SUCCESS(s2n_hash_init(&hash_state, secrets.hash_algorithm));
+            EXPECT_SUCCESS(s2n_hash_update(&hash_state, test_vector->transcript, strlen(test_vector->transcript)));
+
+            s2n_tls13_key_blob(client_traffic_secret, secrets.size);
+            s2n_tls13_key_blob(server_traffic_secret, secrets.size);
+
+            EXPECT_SUCCESS(s2n_tls13_derive_handshake_secrets(&secrets, &client_calculated_shared_secret,
+                    &hash_state, &client_traffic_secret, &server_traffic_secret));
+
+            /* Assert correctness of traffic secrets */
+            EXPECT_EQUAL(test_vector->expected_client_traffic_secret->size, client_traffic_secret.size);
+            EXPECT_BYTEARRAY_EQUAL(test_vector->expected_client_traffic_secret->data, client_traffic_secret.data,
+                    client_traffic_secret.size);
+
+            EXPECT_EQUAL(test_vector->expected_server_traffic_secret->size, server_traffic_secret.size);
+            EXPECT_BYTEARRAY_EQUAL(test_vector->expected_server_traffic_secret->data, server_traffic_secret.data,
+                    server_traffic_secret.size);
+
+            EXPECT_SUCCESS(s2n_connection_free(client_conn));
+            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        }
+    }
+    {
+        /* Various failure cases for s2n_tls13_compute_shared_secret() */
+        const struct hybrid_test_vector *test_vector = &aes_128_sha_256_secp256r1_sikep434r2;
+
+        /* Failures because of NULL arguments */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(NULL, NULL), S2N_ERR_NULL);
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, NULL), S2N_ERR_NULL);
+        DEFER_CLEANUP(struct s2n_blob client_calculated_shared_secret = {0}, s2n_free);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(NULL, &client_calculated_shared_secret), S2N_ERR_NULL);
+
+        /* Failures because classic (non-hybrid) parameters were configured */
+        client_conn->secure.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
+        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, &client_calculated_shared_secret), S2N_ERR_SAFETY);
+        client_conn->secure.server_ecc_evp_params.negotiated_curve = NULL;
+        EXPECT_SUCCESS(read_priv_ecc(&client_conn->secure.server_ecc_evp_params.evp_pkey, test_vector->client_ecc_key));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, &client_calculated_shared_secret), S2N_ERR_SAFETY);
+        EXPECT_SUCCESS(s2n_ecc_evp_params_free(&client_conn->secure.server_ecc_evp_params));
+
+        /* Failure because the chosen_client_kem_group_params is NULL */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, &client_calculated_shared_secret), S2N_ERR_NULL);
+        client_conn->secure.chosen_client_kem_group_params = &client_conn->secure.client_kem_group_params[0];
+
+        /* Failures because the kem_group_params aren't set */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, &client_calculated_shared_secret), S2N_ERR_NULL);
+        client_conn->secure.server_kem_group_params.ecc_params.negotiated_curve = test_vector->kem_group->curve;
+        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, &client_calculated_shared_secret), S2N_ERR_NULL);
+        client_conn->secure.chosen_client_kem_group_params->ecc_params.negotiated_curve = test_vector->kem_group->curve;
+
+        /* Failures because the ECC private keys are NULL */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, &client_calculated_shared_secret), S2N_ERR_NULL);
+        EXPECT_SUCCESS(read_priv_ecc(&client_conn->secure.chosen_client_kem_group_params->ecc_params.evp_pkey, test_vector->client_ecc_key));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, &client_calculated_shared_secret), S2N_ERR_NULL);
+        EXPECT_SUCCESS(read_priv_ecc(&client_conn->secure.server_kem_group_params.ecc_params.evp_pkey, test_vector->server_ecc_key));
+
+        /* Failure because the kem_group is NULL */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, &client_calculated_shared_secret), S2N_ERR_NULL);
+        client_conn->secure.server_kem_group_params.kem_group = test_vector->kem_group;
+
+        /* Failure because pq_shared_secret is NULL */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, &client_calculated_shared_secret), S2N_ERR_NULL);
+        EXPECT_SUCCESS(s2n_dup(test_vector->pq_secret, &client_conn->secure.server_kem_group_params.kem_params.shared_secret));
+
+        /* Finally, success */
+        EXPECT_SUCCESS(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, &client_calculated_shared_secret));
+
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+    }
+
+#endif
+
+    END_TEST();
+}
+
+#if !defined(S2N_NO_PQ)
+
 static int read_priv_ecc(EVP_PKEY **pkey, const char *priv_ecc) {
     size_t key_len = sizeof(char) * strlen(priv_ecc);
 
 #if defined(LIBRESSL_VERSION_NUMBER)
-    /* Some moderate hackery to get around LibreSSL's non-const API signature */
+    /* LibreSSL's BIO_new_mem_buf() function signature requires a non-const
+     * input buffer. */
 
     DEFER_CLEANUP(struct s2n_blob priv_ecc_blob = { 0 }, s2n_free);
     GUARD(s2n_alloc(&priv_ecc_blob, key_len));
@@ -64,8 +354,8 @@ static int read_priv_ecc(EVP_PKEY **pkey, const char *priv_ecc) {
 }
 
 static int set_up_conns(struct s2n_connection *client_conn, struct s2n_connection *server_conn,
-        const char *client_priv_ecc, const char *server_priv_ecc, const struct s2n_kem_group *kem_group,
-                struct s2n_blob *pq_shared_secret) {
+                        const char *client_priv_ecc, const char *server_priv_ecc, const struct s2n_kem_group *kem_group,
+                        struct s2n_blob *pq_shared_secret) {
     /* These parameters would normally be set during the handshake */
     client_conn->secure.chosen_client_kem_group_params = &client_conn->secure.client_kem_group_params[0];
     server_conn->secure.chosen_client_kem_group_params = &server_conn->secure.client_kem_group_params[0];
@@ -146,175 +436,4 @@ static int assert_kem_group_params_freed(struct s2n_connection *conn) {
     return S2N_SUCCESS;
 }
 
-struct hybrid_test_vector {
-    const struct s2n_kem_group *kem_group;
-    const char *client_ecc_key;
-    const char *server_ecc_key;
-    struct s2n_blob *pq_secret;
-    struct s2n_blob *expected_hybrid_secret;
-};
-
 #endif
-
-#define CLIENT_X25519_PRIV_KEY "-----BEGIN PRIVATE KEY-----\n"\
-                               "MC4CAQAwBQYDK2VuBCIEIIgzBrAp631nCDaoA7ilx/8S/cW1lddVQOw9869sROBF\n"\
-                               "-----END PRIVATE KEY-----"
-
-#define SERVER_X25519_PRIV_KEY "-----BEGIN PRIVATE KEY-----\n"\
-                               "MC4CAQAwBQYDK2VuBCIEIIBo+KJ2Zs3vRHQ3sYgHL4zTQPlJPl1y7sW8HT9qRE96\n"\
-                               "-----END PRIVATE KEY-----"
-
-#define CLIENT_SECP256R1_PRIV_KEY "-----BEGIN EC PARAMETERS-----\n"\
-                                  "BggqhkjOPQMBBw==\n"\
-                                  "-----END EC PARAMETERS-----\n"\
-                                  "-----BEGIN EC PRIVATE KEY-----\n"\
-                                  "MHcCAQEEIFCkEmNXACRbWdizfAKP8/Qvx9aplVxLE+Sm2vmCcsY3oAoGCCqGSM49\n"\
-                                  "AwEHoUQDQgAESk526eZ9lf6xrNOiTF8qkYvJDOfc4qqShcbB7qnT67As4pyeQzVm\n"\
-                                  "xfMjmXYBOUnPVBL3FKnIk45sDSCfu++gug==\n"\
-                                  "-----END EC PRIVATE KEY-----"
-
-#define SERVER_SECP256R1_PRIV_KEY "-----BEGIN EC PARAMETERS-----\n"\
-                                  "BggqhkjOPQMBBw==\n"\
-                                  "-----END EC PARAMETERS-----\n"\
-                                  "-----BEGIN EC PRIVATE KEY-----\n"\
-                                  "MHcCAQEEINXLCaZuyYG0HrlSFcHLPFmSnyFm5RqrmyZfgdrxqprXoAoGCCqGSM49\n"\
-                                  "AwEHoUQDQgAEMDuuxEQ1yaA13ceuJP+RC0sbf5ksW6DPlL+yXJiD7cUeWUPrtxbP\n"\
-                                  "ViSR6ex8fYV69oCHgnDnElfE3xaiXiQWBw==\n"\
-                                  "-----END EC PRIVATE KEY-----"
-
-#define X25519_SHARED_SECRET "519be87fa0599077e5673d6f2d910aa150d7fef783c5e1491961fdf63b255910"
-#define SECP256R1_SHARED_SECRET "9348e27655539e08fffe46b35f863dd634e7437cc6bc11c7d329ef5484ec3b60"
-#define SIKEP434R2_SECRET "35f7f8ff388714dedc41f139078cedc9"
-#define X25519_SIKEP434R2_HYBRID_SECRET X25519_SHARED_SECRET SIKEP434R2_SECRET
-#define SECP256R1_SIKEP434R2_HYBRID_SECRET SECP256R1_SHARED_SECRET SIKEP434R2_SECRET
-
-int main(int argc, char **argv) {
-    BEGIN_TEST();
-
-#if !defined(S2N_NO_PQ)
-
-    if (s2n_is_in_fips_mode()) {
-        /* There is no support for PQ KEMs while in FIPS mode */
-        END_TEST();
-    }
-
-    S2N_BLOB_FROM_HEX(sikep434r2_secret, SIKEP434R2_SECRET);
-
-    S2N_BLOB_FROM_HEX(secp256r1_secret, SECP256R1_SHARED_SECRET);
-    S2N_BLOB_FROM_HEX(secp256r1_sikep434r2_hybrid_secret,SECP256R1_SIKEP434R2_HYBRID_SECRET);
-    const struct hybrid_test_vector secp256r1_sikep434r2_vector = {
-            .kem_group = &s2n_secp256r1_sike_p434_r2,
-            .client_ecc_key = CLIENT_SECP256R1_PRIV_KEY,
-            .server_ecc_key = SERVER_SECP256R1_PRIV_KEY,
-            .pq_secret = &sikep434r2_secret,
-            .expected_hybrid_secret = &secp256r1_sikep434r2_hybrid_secret,
-    };
-
-    EXPECT_TRUE(S2N_SUPPORTED_KEM_GROUPS_COUNT > 0);
-    const struct hybrid_test_vector *all_test_vectors[S2N_SUPPORTED_KEM_GROUPS_COUNT];
-    all_test_vectors[0] = &secp256r1_sikep434r2_vector;
-
-#if EVP_APIS_SUPPORTED
-    /* All x25519 based kem_groups require EVP_APIS_SUPPORTED */
-    S2N_BLOB_FROM_HEX(x25519_secret, X25519_SHARED_SECRET);
-    S2N_BLOB_FROM_HEX(x25519_sikep434r2_hybrid_secret, X25519_SIKEP434R2_HYBRID_SECRET);
-    const struct hybrid_test_vector x25519_sikep434r2_vector = {
-            .kem_group = &s2n_x25519_sike_p434_r2,
-            .client_ecc_key = CLIENT_X25519_PRIV_KEY,
-            .server_ecc_key = SERVER_X25519_PRIV_KEY,
-            .pq_secret = &sikep434r2_secret,
-            .expected_hybrid_secret = &x25519_sikep434r2_hybrid_secret,
-    };
-
-    EXPECT_EQUAL(2, S2N_SUPPORTED_KEM_GROUPS_COUNT);
-    all_test_vectors[1] = &x25519_sikep434r2_vector;
-#else
-        EXPECT_EQUAL(1, S2N_SUPPORTED_KEM_GROUPS_COUNT);
-#endif
-
-    struct s2n_connection *client_conn;
-    struct s2n_connection *server_conn;
-
-    {
-        /* Happy case for all supported hybrid key calculations */
-        for (int i = 0; i < s2n_array_len(all_test_vectors); i++) {
-            const struct hybrid_test_vector *test_vector = all_test_vectors[i];
-            const struct s2n_kem_group *kem_group = test_vector->kem_group;
-
-            EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-            EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-
-            EXPECT_SUCCESS(set_up_conns(client_conn, server_conn, test_vector->client_ecc_key,
-                    test_vector->server_ecc_key, kem_group, test_vector->pq_secret));
-
-            DEFER_CLEANUP(struct s2n_blob client_calculated_shared_secret = {0}, s2n_free);
-            DEFER_CLEANUP(struct s2n_blob server_calculated_shared_secret = {0}, s2n_free);
-
-            EXPECT_SUCCESS(s2n_tls13_compute_shared_secret(client_conn, &client_calculated_shared_secret));
-            EXPECT_SUCCESS(s2n_tls13_compute_shared_secret(server_conn, &server_calculated_shared_secret));
-
-            S2N_BLOB_EXPECT_EQUAL(client_calculated_shared_secret, server_calculated_shared_secret);
-            EXPECT_EQUAL(test_vector->expected_hybrid_secret->size, client_calculated_shared_secret.size);
-            EXPECT_BYTEARRAY_EQUAL(test_vector->expected_hybrid_secret->data, client_calculated_shared_secret.data,
-                    client_calculated_shared_secret.size);
-
-            EXPECT_SUCCESS(assert_kem_group_params_freed(client_conn));
-            EXPECT_SUCCESS(assert_kem_group_params_freed(server_conn));
-
-            EXPECT_SUCCESS(s2n_connection_free(client_conn));
-            EXPECT_SUCCESS(s2n_connection_free(server_conn));
-        }
-    }
-    {
-        /* Various failure cases */
-        const struct hybrid_test_vector *test_vector = &secp256r1_sikep434r2_vector;
-
-        /* Failures because of NULL arguments */
-        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(NULL, NULL), S2N_ERR_NULL);
-        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, NULL), S2N_ERR_NULL);
-        DEFER_CLEANUP(struct s2n_blob client_calculated_shared_secret = {0}, s2n_free);
-        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(NULL, &client_calculated_shared_secret), S2N_ERR_NULL);
-
-        /* Failures because classic (non-hybrid) parameters were configured */
-        client_conn->secure.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
-        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, &client_calculated_shared_secret), S2N_ERR_SAFETY);
-        client_conn->secure.server_ecc_evp_params.negotiated_curve = NULL;
-        EXPECT_SUCCESS(read_priv_ecc(&client_conn->secure.server_ecc_evp_params.evp_pkey, test_vector->client_ecc_key));
-        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, &client_calculated_shared_secret), S2N_ERR_SAFETY);
-        EXPECT_SUCCESS(s2n_ecc_evp_params_free(&client_conn->secure.server_ecc_evp_params));
-
-        /* Failure because the chosen_client_kem_group_params is NULL */
-        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, &client_calculated_shared_secret), S2N_ERR_NULL);
-        client_conn->secure.chosen_client_kem_group_params = &client_conn->secure.client_kem_group_params[0];
-
-        /* Failures because the kem_group_params aren't set */
-        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, &client_calculated_shared_secret), S2N_ERR_NULL);
-        client_conn->secure.server_kem_group_params.ecc_params.negotiated_curve = test_vector->kem_group->curve;
-        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, &client_calculated_shared_secret), S2N_ERR_NULL);
-        client_conn->secure.chosen_client_kem_group_params->ecc_params.negotiated_curve = test_vector->kem_group->curve;
-
-        /* Failures because the ECC private keys are NULL */
-        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, &client_calculated_shared_secret), S2N_ERR_NULL);
-        EXPECT_SUCCESS(read_priv_ecc(&client_conn->secure.chosen_client_kem_group_params->ecc_params.evp_pkey, test_vector->client_ecc_key));
-        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, &client_calculated_shared_secret), S2N_ERR_NULL);
-        EXPECT_SUCCESS(read_priv_ecc(&client_conn->secure.server_kem_group_params.ecc_params.evp_pkey, test_vector->server_ecc_key));
-
-        /* Failure because the kem_group is NULL */
-        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, &client_calculated_shared_secret), S2N_ERR_NULL);
-        client_conn->secure.server_kem_group_params.kem_group = test_vector->kem_group;
-
-        /* Failure because pq_shared_secret is NULL */
-        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, &client_calculated_shared_secret), S2N_ERR_NULL);
-        EXPECT_SUCCESS(s2n_dup(test_vector->pq_secret, &client_conn->secure.server_kem_group_params.kem_params.shared_secret));
-
-        /* Finally, success */
-        EXPECT_SUCCESS(s2n_tls13_compute_pq_hybrid_shared_secret(client_conn, &client_calculated_shared_secret));
-
-        EXPECT_SUCCESS(s2n_connection_free(client_conn));
-    }
-
-#endif
-
-    END_TEST();
-}

--- a/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
@@ -92,8 +92,8 @@ struct hybrid_test_vector {
 #define SIKEP434R2_SECRET "35f7f8ff388714dedc41f139078cedc9"
 
 /* Hybrid shared secrets are the concatenation: ECDHE || PQ */
-#define X25519_SIKEP434R2_HYBRID_SECRET X25519_SHARED_SECRET SIKEP434R2_SECRET
-#define SECP256R1_SIKEP434R2_HYBRID_SECRET SECP256R1_SHARED_SECRET SIKEP434R2_SECRET
+#define X25519_SIKEP434R2_HYBRID_SECRET      (X25519_SHARED_SECRET      SIKEP434R2_SECRET)
+#define SECP256R1_SIKEP434R2_HYBRID_SECRET   (SECP256R1_SHARED_SECRET   SIKEP434R2_SECRET)
 
 /* A fake transcript string to hash when deriving handshake secrets */
 #define FAKE_TRANSCRIPT "client_hello || server_hello"
@@ -119,7 +119,7 @@ int main(int argc, char **argv) {
             "2fa1a075eaf636138170e3b2a84f6baa4ac08f846ffe2d005ae5e66b03352c11");
     S2N_BLOB_FROM_HEX(aes_128_secp256r1_sikep434r2_server_secret,
             "423dfaf8fd66b17aaf8c919a9318f3a6bd69875aacdf022aa58a953a7b6de806");
-    const struct hybrid_test_vector aes_128_sha_256_secp256r1_sikep434r2 = {
+    const struct hybrid_test_vector aes_128_sha_256_secp256r1_sikep434r2_vector = {
             .cipher_suite = &s2n_tls13_aes_128_gcm_sha256,
             .transcript = FAKE_TRANSCRIPT,
             .kem_group = &s2n_secp256r1_sike_p434_r2,
@@ -137,7 +137,7 @@ int main(int argc, char **argv) {
             "f7d349f364f49ff3ae9c4e9e7aa60c41d6c650d09c03d8c076bc714ab76177045e23e7426dceb872d2fe7c0d07abdefd");
     S2N_BLOB_FROM_HEX(aes_256_secp256r1_sikep434r2_server_secret,
             "184755801232f7b9b5c42cbdc66c793071f4322079e34307fd60261c0f7a27612b3808918218c4000c12f829d6c19ebf");
-    const struct hybrid_test_vector aes_256_sha_384_secp256r1_sikep434r2 = {
+    const struct hybrid_test_vector aes_256_sha_384_secp256r1_sikep434r2_vector = {
             .cipher_suite = &s2n_tls13_aes_256_gcm_sha384,
             .transcript = FAKE_TRANSCRIPT,
             .kem_group = &s2n_secp256r1_sike_p434_r2,
@@ -195,8 +195,8 @@ int main(int argc, char **argv) {
 
 #if EVP_APIS_SUPPORTED
     const struct hybrid_test_vector *all_test_vectors[] = {
-            &aes_128_sha_256_secp256r1_sikep434r2,
-            &aes_256_sha_384_secp256r1_sikep434r2,
+            &aes_128_sha_256_secp256r1_sikep434r2_vector,
+            &aes_256_sha_384_secp256r1_sikep434r2_vector,
             &aes_128_sha_256_x25519_sikep434r2_vector,
             &aes_256_sha_284_x25519_sikep434r2_vector,
     };
@@ -271,7 +271,7 @@ int main(int argc, char **argv) {
     }
     {
         /* Various failure cases for s2n_tls13_compute_shared_secret() */
-        const struct hybrid_test_vector *test_vector = &aes_128_sha_256_secp256r1_sikep434r2;
+        const struct hybrid_test_vector *test_vector = &aes_128_sha_256_secp256r1_sikep434r2_vector;
 
         /* Failures because of NULL arguments */
         EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(NULL, NULL), S2N_ERR_NULL);

--- a/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
@@ -39,7 +39,13 @@
 static int read_priv_ecc(EVP_PKEY **pkey, const char *priv_ecc) {
     size_t key_len = sizeof(char) * strlen(priv_ecc);
 
+#if defined(LIBRESSL_VERSION_NUMBER)
+    /* LibreSSL's API is different from OpenSSL's */
+    BIO *bio = BIO_new_mem_buf((void *)priv_ecc, key_len);
+#else
     BIO *bio = BIO_new_mem_buf(priv_ecc, key_len);
+#endif
+
     notnull_check(bio);
     PEM_read_bio_PrivateKey(bio, pkey, 0, NULL);
     /* Caller should assert notnull_check on *pkey */

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -300,6 +300,10 @@ static int s2n_connection_wipe_keys(struct s2n_connection *conn)
     for (int i=0; i < S2N_ECC_EVP_SUPPORTED_CURVES_COUNT; i++) {
         GUARD(s2n_ecc_evp_params_free(&conn->secure.client_ecc_evp_params[i]));
     }
+    GUARD(s2n_kem_group_free(&conn->secure.server_kem_group_params));
+    for (int i = 0; i < S2N_SUPPORTED_KEM_GROUPS_COUNT; i++) {
+        GUARD(s2n_kem_group_free(&conn->secure.client_kem_group_params[i]));
+    }
     GUARD(s2n_kem_free(&conn->secure.kem_params));
     GUARD(s2n_free(&conn->secure.client_cert_chain));
     GUARD(s2n_free(&conn->ct_response));

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -301,7 +301,7 @@ static int s2n_connection_wipe_keys(struct s2n_connection *conn)
         GUARD(s2n_ecc_evp_params_free(&conn->secure.client_ecc_evp_params[i]));
     }
     GUARD(s2n_kem_group_free(&conn->secure.server_kem_group_params));
-    for (int i = 0; i < S2N_MAX_NUM_SUPPORTED_KEM_GROUPS; i++) {
+    for (int i = 0; i < S2N_SUPPORTED_KEM_GROUPS_COUNT; i++) {
         GUARD(s2n_kem_group_free(&conn->secure.client_kem_group_params[i]));
     }
     GUARD(s2n_kem_free(&conn->secure.kem_params));

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -301,7 +301,7 @@ static int s2n_connection_wipe_keys(struct s2n_connection *conn)
         GUARD(s2n_ecc_evp_params_free(&conn->secure.client_ecc_evp_params[i]));
     }
     GUARD(s2n_kem_group_free(&conn->secure.server_kem_group_params));
-    for (int i = 0; i < S2N_SUPPORTED_KEM_GROUPS_COUNT; i++) {
+    for (int i = 0; i < S2N_MAX_NUM_SUPPORTED_KEM_GROUPS; i++) {
         GUARD(s2n_kem_group_free(&conn->secure.client_kem_group_params[i]));
     }
     GUARD(s2n_kem_free(&conn->secure.kem_params));

--- a/tls/s2n_crypto.h
+++ b/tls/s2n_crypto.h
@@ -39,7 +39,7 @@ struct s2n_crypto_parameters {
     struct s2n_ecc_evp_params client_ecc_evp_params[S2N_ECC_EVP_SUPPORTED_CURVES_COUNT];
     struct s2n_kem_group_params server_kem_group_params;
     struct s2n_kem_group_params *chosen_client_kem_group_params;
-    struct s2n_kem_group_params client_kem_group_params[S2N_SUPPORTED_KEM_GROUPS_COUNT];
+    struct s2n_kem_group_params client_kem_group_params[S2N_MAX_NUM_SUPPORTED_KEM_GROUPS];
     struct s2n_kem_params kem_params;
     struct s2n_blob client_key_exchange_message;
     struct s2n_blob client_pq_kem_extension;

--- a/tls/s2n_crypto.h
+++ b/tls/s2n_crypto.h
@@ -39,7 +39,7 @@ struct s2n_crypto_parameters {
     struct s2n_ecc_evp_params client_ecc_evp_params[S2N_ECC_EVP_SUPPORTED_CURVES_COUNT];
     struct s2n_kem_group_params server_kem_group_params;
     struct s2n_kem_group_params *chosen_client_kem_group_params;
-    struct s2n_kem_group_params client_kem_group_params[S2N_MAX_NUM_SUPPORTED_KEM_GROUPS];
+    struct s2n_kem_group_params client_kem_group_params[S2N_SUPPORTED_KEM_GROUPS_COUNT];
     struct s2n_kem_params kem_params;
     struct s2n_blob client_key_exchange_message;
     struct s2n_blob client_pq_kem_extension;

--- a/tls/s2n_crypto.h
+++ b/tls/s2n_crypto.h
@@ -37,6 +37,9 @@ struct s2n_crypto_parameters {
     struct s2n_ecc_evp_params server_ecc_evp_params;
     const struct s2n_ecc_named_curve * mutually_supported_groups[S2N_ECC_EVP_SUPPORTED_CURVES_COUNT];
     struct s2n_ecc_evp_params client_ecc_evp_params[S2N_ECC_EVP_SUPPORTED_CURVES_COUNT];
+    struct s2n_kem_group_params server_kem_group_params;
+    struct s2n_kem_group_params *chosen_client_kem_group_params;
+    struct s2n_kem_group_params client_kem_group_params[S2N_SUPPORTED_KEM_GROUPS_COUNT];
     struct s2n_kem_params kem_params;
     struct s2n_blob client_key_exchange_message;
     struct s2n_blob client_pq_kem_extension;

--- a/tls/s2n_kem.c
+++ b/tls/s2n_kem.c
@@ -126,9 +126,11 @@ const struct s2n_iana_to_kem kem_mapping[3] = {
 };
 
 /* Specific assignments of KEM group IDs and names have not yet been
- * published in an RFC (or draft). For IDs, there is consensus to use
- * values in the proposed reserved range defined in
- * https://tools.ietf.org/html/draft-stebila-tls-hybrid-design */
+ * published in an RFC (or draft). There is consensus in the
+ * community to use values in the proposed reserved range defined in
+ * https://tools.ietf.org/html/draft-stebila-tls-hybrid-design.
+ * Values for interoperability are defined in
+ * https://docs.google.com/spreadsheets/d/12YarzaNv3XQNLnvDsWLlRKwtZFhRrDdWf36YlzwrPeg/edit#gid=0. */
 const struct s2n_kem_group s2n_x25519_sike_p434_r2 = {
         .name = "x25519_sike-p434-r2",
         .iana_id = TLS_PQ_KEM_GROUP_ID_X25519_SIKE_P434_R2,

--- a/tls/s2n_kem.c
+++ b/tls/s2n_kem.c
@@ -131,19 +131,23 @@ const struct s2n_iana_to_kem kem_mapping[3] = {
  * https://tools.ietf.org/html/draft-stebila-tls-hybrid-design.
  * Values for interoperability are defined in
  * https://docs.google.com/spreadsheets/d/12YarzaNv3XQNLnvDsWLlRKwtZFhRrDdWf36YlzwrPeg/edit#gid=0. */
-const struct s2n_kem_group s2n_x25519_sike_p434_r2 = {
-        .name = "x25519_sike-p434-r2",
-        .iana_id = TLS_PQ_KEM_GROUP_ID_X25519_SIKE_P434_R2,
-        .curve = &s2n_ecc_curve_x25519,
-        .kem = &s2n_sike_p434_r2,
-};
-
 const struct s2n_kem_group s2n_secp256r1_sike_p434_r2 = {
         .name = "secp256r1_sike-p434-r2",
         .iana_id = TLS_PQ_KEM_GROUP_ID_SECP256R1_SIKE_P434_R2,
         .curve = &s2n_ecc_curve_secp256r1,
         .kem = &s2n_sike_p434_r2,
 };
+
+#if EVP_APIS_SUPPORTED
+const struct s2n_kem_group s2n_x25519_sike_p434_r2 = {
+        .name = "x25519_sike-p434-r2",
+        .iana_id = TLS_PQ_KEM_GROUP_ID_X25519_SIKE_P434_R2,
+        .curve = &s2n_ecc_curve_x25519,
+        .kem = &s2n_sike_p434_r2,
+};
+#else
+const struct s2n_kem_group s2n_x25519_sike_p434_r2 = { 0 };
+#endif
 
 #else
 

--- a/tls/s2n_kem.h
+++ b/tls/s2n_kem.h
@@ -71,7 +71,7 @@ struct s2n_kem_group_params {
  * even if S2N_NO_PQ is defined. The macro is used to declare
  * the size of arrays in s2n_crypto.h and ISO C forbids zero-size
  * arrays. */
-#define S2N_SUPPORTED_KEM_GROUPS_COUNT 2
+#define S2N_SUPPORTED_KEM_GROUPS_COUNT 1
 
 #if !defined(S2N_NO_PQ)
 
@@ -81,7 +81,14 @@ extern const struct s2n_kem s2n_sike_p503_r1;
 extern const struct s2n_kem s2n_sike_p434_r2;
 extern const struct s2n_kem s2n_kyber_512_r2;
 
+#if EVP_APIS_SUPPORTED
+
+/* All x25519 based kem_groups require EVP_APIS_SUPPORTED */
+#undef S2N_SUPPORTED_KEM_GROUPS_COUNT
+#define S2N_SUPPORTED_KEM_GROUPS_COUNT 2
 extern const struct s2n_kem_group s2n_x25519_sike_p434_r2;
+#endif
+
 extern const struct s2n_kem_group s2n_secp256r1_sike_p434_r2;
 
 #endif

--- a/tls/s2n_kem.h
+++ b/tls/s2n_kem.h
@@ -67,6 +67,8 @@ struct s2n_kem_group_params {
     struct s2n_ecc_evp_params ecc_params;
 };
 
+#define S2N_MAX_NUM_SUPPORTED_KEM_GROUPS 2
+
 #if !defined(S2N_NO_PQ)
     extern const struct s2n_kem s2n_bike1_l1_r1;
     extern const struct s2n_kem s2n_bike1_l1_r2;
@@ -74,29 +76,12 @@ struct s2n_kem_group_params {
     extern const struct s2n_kem s2n_sike_p434_r2;
     extern const struct s2n_kem s2n_kyber_512_r2;
 
-    #define S2N_NUM_SECP256R1_KEM_GROUPS 1
     extern const struct s2n_kem_group s2n_secp256r1_sike_p434_r2;
 
     #if EVP_APIS_SUPPORTED
-        /* If EVP_APIS_SUPPORTED, then we support x25519 based kem_groups */
-        #define S2N_NUM_X25519_KEM_GROUPS 1
         extern const struct s2n_kem_group s2n_x25519_sike_p434_r2;
-    #else
-        /* If *not* EVP_APIS_SUPPORTED, then we *do not* supported x25519 */
-        #define S2N_NUM_X25519_KEM_GROUPS 0
     #endif
-
-    #define S2N_SUPPORTED_KEM_GROUPS_COUNT (S2N_NUM_SECP256R1_KEM_GROUPS + S2N_NUM_X25519_KEM_GROUPS)
-
-#else
-    /* If S2N_NO_PQ is defined, we must still define
-     * S2N_SUPPORTED_KEM_GROUPS_COUNT to be non-zero.
-     * This value is used to declare the size of
-     * certain arrays in s2n_crypto.h and ISO C forbids
-     * zero-size arrays. */
-
-    #define S2N_SUPPORTED_KEM_GROUPS_COUNT 1
-#endif /* !defined(S2N_NO_PQ) */
+#endif
 
 extern int s2n_kem_generate_keypair(struct s2n_kem_params *kem_params);
 extern int s2n_kem_encapsulate(struct s2n_kem_params *kem_params, struct s2n_blob *ciphertext);

--- a/tls/s2n_kem.h
+++ b/tls/s2n_kem.h
@@ -67,7 +67,12 @@ struct s2n_kem_group_params {
     struct s2n_ecc_evp_params ecc_params;
 };
 
-#define S2N_MAX_NUM_SUPPORTED_KEM_GROUPS 2
+/* x25519 based kem_groups require EVP_APIS_SUPPORTED */
+#if EVP_APIS_SUPPORTED
+#define S2N_SUPPORTED_KEM_GROUPS_COUNT 2
+#else
+#define S2N_SUPPORTED_KEM_GROUPS_COUNT 1
+#endif
 
 #if !defined(S2N_NO_PQ)
     extern const struct s2n_kem s2n_bike1_l1_r1;
@@ -77,10 +82,7 @@ struct s2n_kem_group_params {
     extern const struct s2n_kem s2n_kyber_512_r2;
 
     extern const struct s2n_kem_group s2n_secp256r1_sike_p434_r2;
-
-    #if EVP_APIS_SUPPORTED
-        extern const struct s2n_kem_group s2n_x25519_sike_p434_r2;
-    #endif
+    extern const struct s2n_kem_group s2n_x25519_sike_p434_r2;
 #endif
 
 extern int s2n_kem_generate_keypair(struct s2n_kem_params *kem_params);

--- a/tls/s2n_kem.h
+++ b/tls/s2n_kem.h
@@ -16,9 +16,11 @@
 #pragma once
 
 #include <stdint.h>
+
 #include "tls/s2n_crypto_constants.h"
 #include "utils/s2n_blob.h"
 #include "stuffer/s2n_stuffer.h"
+#include "crypto/s2n_ecc_evp.h"
 
 typedef uint16_t kem_extension_size;
 typedef uint16_t kem_public_key_size;
@@ -52,6 +54,25 @@ struct s2n_iana_to_kem {
     uint8_t kem_count;
 };
 
+struct s2n_kem_group {
+    const char *name;
+    uint16_t iana_id;
+    const struct s2n_ecc_named_curve *curve;
+    const struct s2n_kem *kem;
+};
+
+struct s2n_kem_group_params {
+    const struct s2n_kem_group *kem_group;
+    struct s2n_kem_params kem_params;
+    struct s2n_ecc_evp_params ecc_params;
+};
+
+/* S2N_SUPPORTED_KEM_GROUPS_COUNT must be defined as non-zero,
+ * even if S2N_NO_PQ is defined. The macro is used to declare
+ * the size of arrays in s2n_crypto.h and ISO C forbids zero-size
+ * arrays. */
+#define S2N_SUPPORTED_KEM_GROUPS_COUNT 2
+
 #if !defined(S2N_NO_PQ)
 
 extern const struct s2n_kem s2n_bike1_l1_r1;
@@ -59,6 +80,9 @@ extern const struct s2n_kem s2n_bike1_l1_r2;
 extern const struct s2n_kem s2n_sike_p503_r1;
 extern const struct s2n_kem s2n_sike_p434_r2;
 extern const struct s2n_kem s2n_kyber_512_r2;
+
+extern const struct s2n_kem_group s2n_x25519_sike_p434_r2;
+extern const struct s2n_kem_group s2n_secp256r1_sike_p434_r2;
 
 #endif
 
@@ -74,6 +98,7 @@ extern int s2n_choose_kem_without_peer_pref_list(const uint8_t iana_value[S2N_TL
                                         const uint8_t num_server_supported_kems, const struct s2n_kem **chosen_kem);
 
 extern int s2n_kem_free(struct s2n_kem_params *kem_params);
+extern int s2n_kem_group_free(struct s2n_kem_group_params *kem_group_params);
 
 extern int s2n_cipher_suite_to_kem(const uint8_t iana_value[S2N_TLS_CIPHER_SUITE_LEN], const struct s2n_iana_to_kem **supported_params);
 extern int s2n_get_kem_from_extension_id(kem_extension_size kem_id, const struct s2n_kem **kem);

--- a/tls/s2n_kem.h
+++ b/tls/s2n_kem.h
@@ -86,7 +86,7 @@ struct s2n_kem_group_params {
         #define S2N_NUM_X25519_KEM_GROUPS 0
     #endif
 
-    #define S2N_SUPPORTED_KEM_GROUPS_COUNT S2N_NUM_SECP256R1_KEM_GROUPS + S2N_NUM_X25519_KEM_GROUPS
+    #define S2N_SUPPORTED_KEM_GROUPS_COUNT (S2N_NUM_SECP256R1_KEM_GROUPS + S2N_NUM_X25519_KEM_GROUPS)
 
 #else
     /* If S2N_NO_PQ is defined, we must still define

--- a/tls/s2n_kem.h
+++ b/tls/s2n_kem.h
@@ -67,31 +67,36 @@ struct s2n_kem_group_params {
     struct s2n_ecc_evp_params ecc_params;
 };
 
-/* S2N_SUPPORTED_KEM_GROUPS_COUNT must be defined as non-zero,
- * even if S2N_NO_PQ is defined. The macro is used to declare
- * the size of arrays in s2n_crypto.h and ISO C forbids zero-size
- * arrays. */
-#define S2N_SUPPORTED_KEM_GROUPS_COUNT 1
-
 #if !defined(S2N_NO_PQ)
+    extern const struct s2n_kem s2n_bike1_l1_r1;
+    extern const struct s2n_kem s2n_bike1_l1_r2;
+    extern const struct s2n_kem s2n_sike_p503_r1;
+    extern const struct s2n_kem s2n_sike_p434_r2;
+    extern const struct s2n_kem s2n_kyber_512_r2;
 
-extern const struct s2n_kem s2n_bike1_l1_r1;
-extern const struct s2n_kem s2n_bike1_l1_r2;
-extern const struct s2n_kem s2n_sike_p503_r1;
-extern const struct s2n_kem s2n_sike_p434_r2;
-extern const struct s2n_kem s2n_kyber_512_r2;
+    #define S2N_NUM_SECP256R1_KEM_GROUPS 1
+    extern const struct s2n_kem_group s2n_secp256r1_sike_p434_r2;
 
-#if EVP_APIS_SUPPORTED
+    #if EVP_APIS_SUPPORTED
+        /* If EVP_APIS_SUPPORTED, then we support x25519 based kem_groups */
+        #define S2N_NUM_X25519_KEM_GROUPS 1
+        extern const struct s2n_kem_group s2n_x25519_sike_p434_r2;
+    #else
+        /* If *not* EVP_APIS_SUPPORTED, then we *do not* supported x25519 */
+        #define S2N_NUM_X25519_KEM_GROUPS 0
+    #endif
 
-/* All x25519 based kem_groups require EVP_APIS_SUPPORTED */
-#undef S2N_SUPPORTED_KEM_GROUPS_COUNT
-#define S2N_SUPPORTED_KEM_GROUPS_COUNT 2
-extern const struct s2n_kem_group s2n_x25519_sike_p434_r2;
-#endif
+    #define S2N_SUPPORTED_KEM_GROUPS_COUNT S2N_NUM_SECP256R1_KEM_GROUPS + S2N_NUM_X25519_KEM_GROUPS
 
-extern const struct s2n_kem_group s2n_secp256r1_sike_p434_r2;
+#else
+    /* If S2N_NO_PQ is defined, we must still define
+     * S2N_SUPPORTED_KEM_GROUPS_COUNT to be non-zero.
+     * This value is used to declare the size of
+     * certain arrays in s2n_crypto.h and ISO C forbids
+     * zero-size arrays. */
 
-#endif
+    #define S2N_SUPPORTED_KEM_GROUPS_COUNT 1
+#endif /* !defined(S2N_NO_PQ) */
 
 extern int s2n_kem_generate_keypair(struct s2n_kem_params *kem_params);
 extern int s2n_kem_encapsulate(struct s2n_kem_params *kem_params, struct s2n_blob *ciphertext);

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -84,6 +84,8 @@ int s2n_tls13_compute_ecc_shared_secret(struct s2n_connection *conn, struct s2n_
     return 0;
 }
 
+/* Computes the ECDHE+PQKEM hybrid shared secret as defined in
+ * https://tools.ietf.org/html/draft-stebila-tls-hybrid-design */
 int s2n_tls13_compute_pq_hybrid_shared_secret(struct s2n_connection *conn, struct s2n_blob *shared_secret) {
     notnull_check(conn);
     notnull_check(shared_secret);

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -135,11 +135,15 @@ int s2n_tls13_compute_pq_hybrid_shared_secret(struct s2n_connection *conn, struc
     return S2N_SUCCESS;
 }
 
+static int s2n_tls13_pq_hybrid_supported(struct s2n_connection *conn) {
+    return conn->secure.server_kem_group_params.kem_group != NULL;
+}
+
 int s2n_tls13_compute_shared_secret(struct s2n_connection *conn, struct s2n_blob *shared_secret)
 {
     notnull_check(conn);
 
-    if (conn->secure.server_kem_group_params.kem_group != NULL) {
+    if (s2n_tls13_pq_hybrid_supported(conn)) {
         GUARD(s2n_tls13_compute_pq_hybrid_shared_secret(conn, shared_secret));
     } else {
         GUARD(s2n_tls13_compute_ecc_shared_secret(conn, shared_secret));

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -88,6 +88,10 @@ int s2n_tls13_compute_pq_hybrid_shared_secret(struct s2n_connection *conn, struc
     notnull_check(conn);
     notnull_check(shared_secret);
 
+    /* conn->secure.server_ecc_evp_params should be set only during a classic/non-hybrid handshake */
+    eq_check(NULL, conn->secure.server_ecc_evp_params.negotiated_curve);
+    eq_check(NULL, conn->secure.server_ecc_evp_params.evp_pkey);
+
     struct s2n_kem_group_params *server_kem_group_params = &conn->secure.server_kem_group_params;
     notnull_check(server_kem_group_params);
     struct s2n_ecc_evp_params *server_ecc_params = &server_kem_group_params->ecc_params;

--- a/tls/s2n_tls_parameters.h
+++ b/tls/s2n_tls_parameters.h
@@ -70,7 +70,8 @@
 #define TLS_PQ_KEM_EXTENSION_ID_KYBER_512_R2 23
 
 /* TLS 1.3 hybrid post-quantum definitions are from the proposed reserved range defined
- * in https://tools.ietf.org/html/draft-stebila-tls-hybrid-design */
+ * in https://tools.ietf.org/html/draft-stebila-tls-hybrid-design. Values for interoperability
+ * are defined in https://docs.google.com/spreadsheets/d/12YarzaNv3XQNLnvDsWLlRKwtZFhRrDdWf36YlzwrPeg/edit#gid=0. */
 #define TLS_PQ_KEM_GROUP_ID_X25519_SIKE_P434_R2 0x2F27
 #define TLS_PQ_KEM_GROUP_ID_SECP256R1_SIKE_P434_R2 0x2F1F
 

--- a/tls/s2n_tls_parameters.h
+++ b/tls/s2n_tls_parameters.h
@@ -58,7 +58,7 @@
 #define TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256  0xCC, 0xA9
 #define TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256      0xCC, 0xAA
 
-/* TLS Hybrid post-quantum definitions from https://tools.ietf.org/html/draft-campagna-tls-bike-sike-hybrid */
+/* TLS 1.2 hybrid post-quantum definitions from https://tools.ietf.org/html/draft-campagna-tls-bike-sike-hybrid */
 #define TLS_ECDHE_BIKE_RSA_WITH_AES_256_GCM_SHA384 0xFF, 0x04
 #define TLS_ECDHE_SIKE_RSA_WITH_AES_256_GCM_SHA384 0xFF, 0x08
 #define TLS_ECDHE_KYBER_RSA_WITH_AES_256_GCM_SHA384 0xFF, 0x0C
@@ -68,6 +68,11 @@
 #define TLS_PQ_KEM_EXTENSION_ID_SIKE_P503_R1 10
 #define TLS_PQ_KEM_EXTENSION_ID_SIKE_P434_R2 19
 #define TLS_PQ_KEM_EXTENSION_ID_KYBER_512_R2 23
+
+/* TLS 1.3 hybrid post-quantum definitions are from the proposed reserved range defined
+ * in https://tools.ietf.org/html/draft-stebila-tls-hybrid-design */
+#define TLS_PQ_KEM_GROUP_ID_X25519_SIKE_P434_R2 0x2F27
+#define TLS_PQ_KEM_GROUP_ID_SECP256R1_SIKE_P434_R2 0x2F1F
 
 /* From https://tools.ietf.org/html/rfc7507 */
 #define TLS_FALLBACK_SCSV                   0x56, 0x00


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

### Resolved issues:

N/A

### Description of changes: 

* Implements PQ hybrid shared secrets derivation for TLS 1.3: `s2n_tls13_compute_pq_hybrid_shared_secret()`
* For now, defines two `kem_group`s: `s2n_x25519_sike_p434_r2` and `s2n_secp256r1_sike_p434_r2`
* Adds structure to `struct s2n_crypto` to be used during hybrid 1.3 handshakes
* Adds `s2n_kem_group_free()` that is analogous to `s2n_kem_free()`

### Call-outs:

None of the hybrid 1.3 client or server functionality has been implemented, so there are no integration tests yet. This change should be completely backward compatible with classic 1.3.

### Testing:

* Unit/known answer test for `s2n_tls13_compute_pq_hybrid_shared_secret()`
* Unit test for `s2n_kem_group_free()`
  * Small refactor in the way `s2n_kem_test` tests `s2n_kem_free()` to accommodate code re-use
* Ran tests locally while building with `S2N_NO_PQ=1`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
