### PR TITLE
Check "writer" for current state when processing messages

### DIFF
--- a/tests/unit/s2n_tls12_handshake_test.c
+++ b/tests/unit/s2n_tls12_handshake_test.c
@@ -43,12 +43,12 @@ static int s2n_test_expected_handler(struct s2n_connection* conn)
 }
 
 static int s2n_setup_handler_to_expect(message_type_t expected, uint8_t direction) {
-    for (int i = 0; i < sizeof(tls13_state_machine) / sizeof(struct s2n_handshake_action); i++) {
-        tls13_state_machine[i].handler[0] = s2n_test_handler;
-        tls13_state_machine[i].handler[1] = s2n_test_handler;
+    for (int i = 0; i < s2n_array_len(state_machine); i++) {
+        state_machine[i].handler[0] = s2n_test_handler;
+        state_machine[i].handler[1] = s2n_test_handler;
     }
 
-    tls13_state_machine[expected].handler[direction] = s2n_test_expected_handler;
+    state_machine[expected].handler[direction] = s2n_test_expected_handler;
 
     expected_handler_called = 0;
     unexpected_handler_called = 0;
@@ -56,19 +56,33 @@ static int s2n_setup_handler_to_expect(message_type_t expected, uint8_t directio
     return 0;
 }
 
-int s2n_write_ccs_message(struct s2n_stuffer *output)
+static int s2n_test_write_header(struct s2n_stuffer *output, uint8_t record_type, uint8_t message_type)
 {
-    GUARD(s2n_stuffer_write_uint8(output, TLS_CHANGE_CIPHER_SPEC));
+    GUARD(s2n_stuffer_write_uint8(output, record_type));
 
     /* TLS1.2 protocol version */
     GUARD(s2n_stuffer_write_uint8(output, 3));
     GUARD(s2n_stuffer_write_uint8(output, 3));
 
-    /* Total message size */
-    GUARD(s2n_stuffer_write_uint16(output, 1));
+    if (record_type == TLS_HANDSHAKE) {
+        /* Total message size */
+        GUARD(s2n_stuffer_write_uint16(output, 4));
 
-    /* change spec is always just 0x01 */
-    GUARD(s2n_stuffer_write_uint8(output, 1));
+        GUARD(s2n_stuffer_write_uint8(output, message_type));
+
+        /* Handshake message data size */
+        GUARD(s2n_stuffer_write_uint24(output, 0));
+        return 0;
+    }
+
+    if (record_type == TLS_CHANGE_CIPHER_SPEC) {
+        /* Total message size */
+        GUARD(s2n_stuffer_write_uint16(output, 1));
+
+        /* change spec is always just 0x01 */
+        GUARD(s2n_stuffer_write_uint8(output, 1));
+        return 0;
+    }
 
     return 0;
 }
@@ -160,17 +174,17 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
         EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, NULL, conn));
 
-        EXPECT_SUCCESS(s2n_setup_handler_to_expect(SERVER_CHANGE_CIPHER_SPEC, S2N_CLIENT));
-
         for (int i = 0; i < valid_tls12_handshakes_size; i++) {
             int handshake = valid_tls12_handshakes[i];
 
             conn->handshake.handshake_type = handshake;
-            conn->in_status = ENCRYPTED;
 
             for (int j = 1; j < S2N_MAX_HANDSHAKE_LENGTH; j++) {
+                EXPECT_SUCCESS(s2n_setup_handler_to_expect(SERVER_CHANGE_CIPHER_SPEC, S2N_CLIENT));
                 conn->handshake.message_number = j;
-                EXPECT_SUCCESS(s2n_write_ccs_message(&input));
+                conn->in_status = ENCRYPTED;
+
+                EXPECT_SUCCESS(s2n_test_write_header(&input, TLS_CHANGE_CIPHER_SPEC, 0));
 
                 if (handshakes[i][j] == SERVER_CHANGE_CIPHER_SPEC) {
                     EXPECT_SUCCESS(s2n_handshake_read_io(conn));
@@ -183,7 +197,6 @@ int main(int argc, char **argv)
                 }
 
                 EXPECT_SUCCESS(s2n_stuffer_wipe(&input));
-                break;
             }
         }
 
@@ -201,17 +214,17 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
         EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, NULL, conn));
 
-        EXPECT_SUCCESS(s2n_setup_handler_to_expect(CLIENT_CHANGE_CIPHER_SPEC, S2N_SERVER));
-
         for (int i = 0; i < valid_tls12_handshakes_size; i++) {
             int handshake = valid_tls12_handshakes[i];
 
             conn->handshake.handshake_type = handshake;
-            conn->in_status = ENCRYPTED;
 
             for (int j = 1; j < S2N_MAX_HANDSHAKE_LENGTH; j++) {
+                EXPECT_SUCCESS(s2n_setup_handler_to_expect(CLIENT_CHANGE_CIPHER_SPEC, S2N_SERVER));
                 conn->handshake.message_number = j;
-                EXPECT_SUCCESS(s2n_write_ccs_message(&input));
+                conn->in_status = ENCRYPTED;
+
+                EXPECT_SUCCESS(s2n_test_write_header(&input, TLS_CHANGE_CIPHER_SPEC, 0));
 
                 if (handshakes[i][j] == CLIENT_CHANGE_CIPHER_SPEC) {
                     EXPECT_SUCCESS(s2n_handshake_read_io(conn));
@@ -224,7 +237,6 @@ int main(int argc, char **argv)
                 }
 
                 EXPECT_SUCCESS(s2n_stuffer_wipe(&input));
-                break;
             }
         }
 

--- a/tests/unit/s2n_tls13_state_machine_handshake_test.c
+++ b/tests/unit/s2n_tls13_state_machine_handshake_test.c
@@ -74,7 +74,9 @@ static int s2n_test_write_header(struct s2n_stuffer *output, uint8_t record_type
     if (record_type == TLS_HANDSHAKE) {
         /* Total message size */
         GUARD(s2n_stuffer_write_uint16(output, 4));
+
         GUARD(s2n_stuffer_write_uint8(output, message_type));
+
         /* Handshake message data size */
         GUARD(s2n_stuffer_write_uint24(output, 0));
         return 0;
@@ -83,6 +85,7 @@ static int s2n_test_write_header(struct s2n_stuffer *output, uint8_t record_type
     if (record_type == TLS_CHANGE_CIPHER_SPEC) {
         /* Total message size */
         GUARD(s2n_stuffer_write_uint16(output, 1));
+
         /* change spec is always just 0x01 */
         GUARD(s2n_stuffer_write_uint8(output, 1));
         return 0;
@@ -308,6 +311,81 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_stuffer_free(&input));
         EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test: TLS1.3 s2n_handshake_read_io should accept only the expected message */
+    {
+        /* TLS1.3 should accept the expected message */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+            conn->actual_protocol_version = S2N_TLS13;
+
+            struct s2n_stuffer input;
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
+            EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, NULL, conn));
+
+            conn->handshake.handshake_type = 0;
+            conn->handshake.message_number = 0;
+            EXPECT_SUCCESS(s2n_setup_handler_to_expect(CLIENT_HELLO, S2N_SERVER));
+
+            EXPECT_SUCCESS(s2n_test_write_header(&input, TLS_HANDSHAKE, TLS_CLIENT_HELLO));
+            EXPECT_SUCCESS(s2n_handshake_read_io(conn));
+
+            EXPECT_EQUAL(conn->handshake.message_number, 1);
+            EXPECT_FALSE(unexpected_handler_called);
+            EXPECT_TRUE(expected_handler_called);
+
+            EXPECT_SUCCESS(s2n_stuffer_free(&input));
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* TLS1.3 should error for an unexpected message */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+            conn->actual_protocol_version = S2N_TLS13;
+
+            struct s2n_stuffer input;
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
+            EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, NULL, conn));
+
+            conn->handshake.handshake_type = 0;
+            conn->handshake.message_number = 0;
+            EXPECT_SUCCESS(s2n_setup_handler_to_expect(CLIENT_HELLO, S2N_SERVER));
+
+            EXPECT_SUCCESS(s2n_test_write_header(&input, TLS_HANDSHAKE, TLS_CERTIFICATE));
+            EXPECT_FAILURE_WITH_ERRNO(s2n_handshake_read_io(conn), S2N_ERR_BAD_MESSAGE);
+
+            EXPECT_EQUAL(conn->handshake.message_number, 0);
+            EXPECT_FALSE(unexpected_handler_called);
+            EXPECT_FALSE(expected_handler_called);
+
+            EXPECT_SUCCESS(s2n_stuffer_free(&input));
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* TLS1.3 should error for an expected message from the wrong writer */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            conn->actual_protocol_version = S2N_TLS13;
+
+            struct s2n_stuffer input;
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
+            EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, NULL, conn));
+
+            conn->handshake.handshake_type = 0;
+            conn->handshake.message_number = 0;
+            EXPECT_SUCCESS(s2n_setup_handler_to_expect(CLIENT_HELLO, S2N_SERVER));
+
+            EXPECT_SUCCESS(s2n_test_write_header(&input, TLS_HANDSHAKE, TLS_CLIENT_HELLO));
+            EXPECT_FAILURE_WITH_ERRNO(s2n_handshake_read_io(conn), S2N_ERR_BAD_MESSAGE);
+
+            EXPECT_EQUAL(conn->handshake.message_number, 0);
+            EXPECT_FALSE(unexpected_handler_called);
+            EXPECT_FALSE(expected_handler_called);
+
+            EXPECT_SUCCESS(s2n_stuffer_free(&input));
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
     }
 
     /* Test: TLS1.3 s2n_conn_set_handshake_type sets FULL_HANDSHAKE, HELLO_RETRY_REQUEST, and CLIENT_AUTH */

--- a/tests/unit/s2n_tls13_state_machine_handshake_test.c
+++ b/tests/unit/s2n_tls13_state_machine_handshake_test.c
@@ -63,7 +63,7 @@ static int s2n_setup_handler_to_expect(message_type_t expected, uint8_t directio
     return 0;
 }
 
-int s2n_test_write_header(struct s2n_stuffer *output, uint8_t record_type, uint8_t message_type)
+static int s2n_test_write_header(struct s2n_stuffer *output, uint8_t record_type, uint8_t message_type)
 {
     GUARD(s2n_stuffer_write_uint8(output, record_type));
 
@@ -74,9 +74,7 @@ int s2n_test_write_header(struct s2n_stuffer *output, uint8_t record_type, uint8
     if (record_type == TLS_HANDSHAKE) {
         /* Total message size */
         GUARD(s2n_stuffer_write_uint16(output, 4));
-
         GUARD(s2n_stuffer_write_uint8(output, message_type));
-
         /* Handshake message data size */
         GUARD(s2n_stuffer_write_uint24(output, 0));
         return 0;
@@ -85,7 +83,6 @@ int s2n_test_write_header(struct s2n_stuffer *output, uint8_t record_type, uint8
     if (record_type == TLS_CHANGE_CIPHER_SPEC) {
         /* Total message size */
         GUARD(s2n_stuffer_write_uint16(output, 1));
-
         /* change spec is always just 0x01 */
         GUARD(s2n_stuffer_write_uint8(output, 1));
         return 0;
@@ -240,7 +237,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
         EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, NULL, conn));
 
-        GUARD(s2n_setup_handler_to_expect(SERVER_CHANGE_CIPHER_SPEC, S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_setup_handler_to_expect(SERVER_CHANGE_CIPHER_SPEC, S2N_CLIENT));
 
         for (int i = 0; i < valid_tls13_handshakes_size; i++) {
             int handshake = valid_tls13_handshakes[i];
@@ -255,12 +252,16 @@ int main(int argc, char **argv)
 
                 EXPECT_SUCCESS(s2n_handshake_read_io(conn));
 
-                EXPECT_EQUAL(conn->handshake.message_number, j);
+                if (tls13_handshakes[i][j] == SERVER_CHANGE_CIPHER_SPEC) {
+                    EXPECT_EQUAL(conn->handshake.message_number, j + 1);
+                } else {
+                    EXPECT_EQUAL(conn->handshake.message_number, j);
+                }
+
                 EXPECT_FALSE(unexpected_handler_called);
                 EXPECT_TRUE(expected_handler_called);
 
                 EXPECT_SUCCESS(s2n_stuffer_wipe(&input));
-                break;
             }
         }
 
@@ -277,7 +278,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
         EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, NULL, conn));
 
-        GUARD(s2n_setup_handler_to_expect(CLIENT_CHANGE_CIPHER_SPEC, S2N_SERVER));
+        EXPECT_SUCCESS(s2n_setup_handler_to_expect(CLIENT_CHANGE_CIPHER_SPEC, S2N_SERVER));
 
         for (int i = 0; i < valid_tls13_handshakes_size; i++) {
             int handshake = valid_tls13_handshakes[i];
@@ -292,12 +293,16 @@ int main(int argc, char **argv)
 
                 EXPECT_SUCCESS(s2n_handshake_read_io(conn));
 
-                EXPECT_EQUAL(conn->handshake.message_number, j);
+                if (tls13_handshakes[i][j] == CLIENT_CHANGE_CIPHER_SPEC) {
+                    EXPECT_EQUAL(conn->handshake.message_number, j + 1);
+                } else {
+                    EXPECT_EQUAL(conn->handshake.message_number, j);
+                }
+
                 EXPECT_FALSE(unexpected_handler_called);
                 EXPECT_TRUE(expected_handler_called);
 
                 EXPECT_SUCCESS(s2n_stuffer_wipe(&input));
-                break;
             }
         }
 
@@ -305,7 +310,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
-    /* Test: TLS1.3 s2n_conn_set_handshake_type sets FULL_HANDSHAKE, HELLO_RETRY_REQUEST, and CLIENT_AUTH*/
+    /* Test: TLS1.3 s2n_conn_set_handshake_type sets FULL_HANDSHAKE, HELLO_RETRY_REQUEST, and CLIENT_AUTH */
     {
         struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
 

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -892,7 +892,8 @@ static int s2n_handshake_read_io(struct s2n_connection *conn)
     if (record_type == TLS_CHANGE_CIPHER_SPEC) {
         /* TLS1.2 should not receive unexpected change cipher spec messages, but TLS1.3 might. */
         if (!IS_TLS13_HANDSHAKE(conn)) {
-            S2N_ERROR_IF(EXPECTED_RECORD_TYPE(conn) != TLS_CHANGE_CIPHER_SPEC, S2N_ERR_BAD_MESSAGE);
+            ENSURE_POSIX(EXPECTED_RECORD_TYPE(conn) == TLS_CHANGE_CIPHER_SPEC, S2N_ERR_BAD_MESSAGE);
+            ENSURE_POSIX(!CONNECTION_IS_WRITER(conn), S2N_ERR_BAD_MESSAGE);
         }
 
         S2N_ERROR_IF(s2n_stuffer_data_available(&conn->in) != 1, S2N_ERR_BAD_MESSAGE);
@@ -907,7 +908,7 @@ static int s2n_handshake_read_io(struct s2n_connection *conn)
         conn->in_status = ENCRYPTED;
 
         /* Advance the state machine if this was an expected message */
-        if (EXPECTED_RECORD_TYPE(conn) == TLS_CHANGE_CIPHER_SPEC) {
+        if (EXPECTED_RECORD_TYPE(conn) == TLS_CHANGE_CIPHER_SPEC && !CONNECTION_IS_WRITER(conn)) {
             GUARD(s2n_advance_message(conn));
         }
 

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -965,7 +965,8 @@ static int s2n_handshake_read_io(struct s2n_connection *conn)
             conn->handshake.handshake_type &= ~OCSP_STATUS;
         }
 
-        S2N_ERROR_IF(actual_handshake_message_type != EXPECTED_MESSAGE_TYPE(conn), S2N_ERR_BAD_MESSAGE);
+        ENSURE_POSIX(actual_handshake_message_type == EXPECTED_MESSAGE_TYPE(conn), S2N_ERR_BAD_MESSAGE);
+        ENSURE_POSIX(!CONNECTION_IS_WRITER(conn), S2N_ERR_BAD_MESSAGE);
 
         /* Call the relevant handler */
         r = ACTIVE_STATE(conn).handler[conn->mode] (conn);

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -440,6 +440,9 @@ static const char* handshake_type_names[] = {
 #define EXPECTED_RECORD_TYPE( conn )  ACTIVE_STATE( conn ).record_type
 #define EXPECTED_MESSAGE_TYPE( conn ) ACTIVE_STATE( conn ).message_type
 
+#define CONNECTION_WRITER( conn ) (conn->mode == S2N_CLIENT ? 'C' : 'S')
+#define CONNECTION_IS_WRITER( conn ) (ACTIVE_STATE(conn).writer == CONNECTION_WRITER(conn))
+
 /* Used in our test cases */
 message_type_t s2n_conn_get_current_message_type(struct s2n_connection *conn)
 {
@@ -450,10 +453,7 @@ static int s2n_advance_message(struct s2n_connection *conn)
 {
     /* Get the mode: 'C'lient or 'S'erver */
     char previous_writer = ACTIVE_STATE(conn).writer;
-    char this_mode = 'S';
-    if (conn->mode == S2N_CLIENT) {
-        this_mode = 'C';
-    }
+    char this_mode = CONNECTION_WRITER(conn);
 
     /* Actually advance the message number */
     conn->handshake.message_number++;
@@ -1021,9 +1021,7 @@ static int s2n_handle_retry_state(struct s2n_connection *conn)
         S2N_ERROR_PRESERVE_ERRNO();
     }
 
-    const char connection_mode = conn->mode == S2N_CLIENT ? 'C' : 'S';
-
-    if (ACTIVE_STATE(conn).writer != connection_mode) {
+    if (!CONNECTION_IS_WRITER(conn)) {
         /* We're done parsing the record, reset everything */
         GUARD(s2n_stuffer_wipe(&conn->header_in));
         GUARD(s2n_stuffer_wipe(&conn->in));
@@ -1040,7 +1038,7 @@ static int s2n_handle_retry_state(struct s2n_connection *conn)
         S2N_ERROR_PRESERVE_ERRNO();
     }
 
-    if (ACTIVE_STATE(conn).writer == connection_mode) {
+    if (CONNECTION_IS_WRITER(conn)) {
         /* If we're the writer and handler just finished, update the record header if
          * needed and let the s2n_handshake_write_io write the data to the socket */
         if (EXPECTED_RECORD_TYPE(conn) == TLS_HANDSHAKE) {
@@ -1060,8 +1058,6 @@ int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status *blocked)
     notnull_check(conn);
     notnull_check(blocked);
 
-    const char connection_mode = conn->mode == S2N_CLIENT ? 'C' : 'S';
-
     while (ACTIVE_STATE(conn).writer != 'B') {
         errno = 0;
         s2n_errno = S2N_ERR_OK;
@@ -1075,7 +1071,7 @@ int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status *blocked)
             GUARD(s2n_handle_retry_state(conn));
         }
 
-        if (ACTIVE_STATE(conn).writer == connection_mode) {
+        if (CONNECTION_IS_WRITER(conn)) {
             *blocked = S2N_BLOCKED_ON_WRITE;
             const int write_result = s2n_handshake_write_io(conn);
 


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

### Description of changes: 

S2N identifies whether to read or write for the current state in the s2n_negotiate loop, then calls either s2n_handshake_read_io or s2n_handshake_write_io. However, while s2n_handshake_write_io always writes exactly one message (the current state's message), s2n_handshake_read_io may process multiple states/messages if a tls record contains multiple messages.

s2n_handshake_read_io checks that it is processing the right message for the current state, but it does NOT check that the current state is a read state. s2n_negotiate handles this check for the first message in a record, but not any subsequent messages. I therefore add checks to ensure we are only acting on a message in s2n_handshake_read_io if the current state is a read state.

### Call-outs:

**How do the unit tests work?** I reused the strategy used by some older tests to verify that the state machine processes CCS messages properly. The tests set all state handlers to no-op function pointers. We can therefore only worry about the state machine, without needing to worry about writing valid messages or setting up the connection state.

**Why didn't the old CCS state machine tests catch this?** [A typo](https://github.com/awslabs/s2n/blob/master/tests/unit/s2n_tls13_state_machine_handshake_test.c#L300) that bailed out of the tests early and never actually ran the checks.

### Testing:

New unit tests for the handshake messages, corrected tests for the CCS messages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
