### PR TITLE
Adds a proof harness for s2n_stuffer_*_base64

### DIFF
--- a/stuffer/s2n_stuffer_base64.c
+++ b/stuffer/s2n_stuffer_base64.c
@@ -77,12 +77,13 @@ int s2n_stuffer_read_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *out
     PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     PRECONDITION_POSIX(s2n_stuffer_is_valid(out));
     uint8_t pad[4] = {0};
+    size_t pad_len = s2n_array_len(pad);
     int bytes_this_round = 3;
     struct s2n_blob o = {0};
-    GUARD(s2n_blob_init(&o, pad, sizeof(pad)));
+    GUARD(s2n_blob_init(&o, pad, pad_len));
 
     do {
-        if (s2n_stuffer_data_available(stuffer) < 4) {
+        if (s2n_stuffer_data_available(stuffer) < pad_len) {
             break;
         }
 
@@ -155,9 +156,9 @@ int s2n_stuffer_write_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *in
     uint8_t outpad[4] = {0};
     uint8_t inpad[3] = {0};
     struct s2n_blob o = {0};
-    GUARD(s2n_blob_init(&o, outpad, sizeof(outpad)));
+    GUARD(s2n_blob_init(&o, outpad, s2n_array_len(outpad)));
     struct s2n_blob i = {0};
-    GUARD(s2n_blob_init(&i, inpad, sizeof(inpad)));
+    GUARD(s2n_blob_init(&i, inpad, s2n_array_len(inpad)));
 
     while (s2n_stuffer_data_available(in) > 2) {
         GUARD(s2n_stuffer_read(in, &i));

--- a/stuffer/s2n_stuffer_base64.c
+++ b/stuffer/s2n_stuffer_base64.c
@@ -97,7 +97,7 @@ int s2n_stuffer_read_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *out
         /* We assume the entire thing is base64 data, thus, terminate cleanly if we encounter a non-base64 character */
         if (value1 == 255) {
             /* Undo the read */
-            stuffer->read_cursor -= 4;
+            stuffer->read_cursor -= pad_len;
             S2N_ERROR(S2N_ERR_INVALID_BASE64);
         }
 

--- a/stuffer/s2n_stuffer_base64.c
+++ b/stuffer/s2n_stuffer_base64.c
@@ -76,9 +76,9 @@ int s2n_stuffer_read_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *out
 {
     PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     PRECONDITION_POSIX(s2n_stuffer_is_valid(out));
-    uint8_t pad[4];
+    uint8_t pad[4] = {0};
     int bytes_this_round = 3;
-    struct s2n_blob o;
+    struct s2n_blob o = {0};
     GUARD(s2n_blob_init(&o, pad, sizeof(pad)));
 
     do {
@@ -152,10 +152,12 @@ int s2n_stuffer_write_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *in
 {
     PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     PRECONDITION_POSIX(s2n_stuffer_is_valid(in));
-    uint8_t outpad[4];
-    uint8_t inpad[3];
-    struct s2n_blob o = {.data = outpad,.size = sizeof(outpad) };
-    struct s2n_blob i = {.data = inpad,.size = sizeof(inpad) };
+    uint8_t outpad[4] = {0};
+    uint8_t inpad[3] = {0};
+    struct s2n_blob o = {0};
+    GUARD(s2n_blob_init(&o, outpad, sizeof(outpad)));
+    struct s2n_blob i = {0};
+    GUARD(s2n_blob_init(&i, inpad, sizeof(inpad)));
 
     while (s2n_stuffer_data_available(in) > 2) {
         GUARD(s2n_stuffer_read(in, &i));

--- a/stuffer/s2n_stuffer_base64.c
+++ b/stuffer/s2n_stuffer_base64.c
@@ -76,14 +76,11 @@ int s2n_stuffer_read_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *out
 {
     PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     PRECONDITION_POSIX(s2n_stuffer_is_valid(out));
-    uint8_t pad[4] = {0};
-    size_t pad_len = s2n_array_len(pad);
     int bytes_this_round = 3;
-    struct s2n_blob o = {0};
-    GUARD(s2n_blob_init(&o, pad, pad_len));
+    s2n_stack_blob(o, 4, 4);
 
     do {
-        if (s2n_stuffer_data_available(stuffer) < pad_len) {
+        if (s2n_stuffer_data_available(stuffer) < o.size) {
             break;
         }
 
@@ -97,7 +94,7 @@ int s2n_stuffer_read_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *out
         /* We assume the entire thing is base64 data, thus, terminate cleanly if we encounter a non-base64 character */
         if (value1 == 255) {
             /* Undo the read */
-            stuffer->read_cursor -= pad_len;
+            stuffer->read_cursor -= o.size;
             S2N_ERROR(S2N_ERR_INVALID_BASE64);
         }
 
@@ -153,12 +150,8 @@ int s2n_stuffer_write_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *in
 {
     PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     PRECONDITION_POSIX(s2n_stuffer_is_valid(in));
-    uint8_t outpad[4] = {0};
-    uint8_t inpad[3] = {0};
-    struct s2n_blob o = {0};
-    GUARD(s2n_blob_init(&o, outpad, s2n_array_len(outpad)));
-    struct s2n_blob i = {0};
-    GUARD(s2n_blob_init(&i, inpad, s2n_array_len(inpad)));
+    s2n_stack_blob(o, 4, 4);
+    s2n_stack_blob(i, 3, 3);
 
     while (s2n_stuffer_data_available(in) > 2) {
         GUARD(s2n_stuffer_read(in, &i));

--- a/stuffer/s2n_stuffer_base64.c
+++ b/stuffer/s2n_stuffer_base64.c
@@ -97,7 +97,7 @@ int s2n_stuffer_read_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *out
         /* Terminate cleanly if we encounter a non-base64 character */
         if (value1 == 255) {
             /* Undo the read */
-            stuffer->read_cursor -= 4;
+            stuffer->read_cursor -= pad_len;
             return S2N_SUCCESS;
         }
 

--- a/stuffer/s2n_stuffer_base64.c
+++ b/stuffer/s2n_stuffer_base64.c
@@ -94,11 +94,11 @@ int s2n_stuffer_read_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *out
         uint8_t value3 = b64_inverse[o.data[2]];
         uint8_t value4 = b64_inverse[o.data[3]];
 
-        /* Terminate cleanly if we encounter a non-base64 character */
+        /* We assume the entire thing is base64 data, thus, terminate cleanly if we encounter a non-base64 character */
         if (value1 == 255) {
             /* Undo the read */
-            stuffer->read_cursor -= pad_len;
-            return S2N_SUCCESS;
+            stuffer->read_cursor -= 4;
+            S2N_ERROR(S2N_ERR_INVALID_BASE64);
         }
 
         /* The first two characters can never be '=' and in general

--- a/stuffer/s2n_stuffer_base64.c
+++ b/stuffer/s2n_stuffer_base64.c
@@ -78,13 +78,12 @@ int s2n_stuffer_read_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *out
     PRECONDITION_POSIX(s2n_stuffer_is_valid(out));
     uint8_t pad[4];
     int bytes_this_round = 3;
-    struct s2n_blob o;// = {.data = pad,.size = sizeof(pad) };
+    struct s2n_blob o;
     GUARD(s2n_blob_init(&o, pad, sizeof(pad)));
 
     do {
         if (s2n_stuffer_data_available(stuffer) < 4) {
             break;
-            //return S2N_SUCCESS;
         }
 
         GUARD(s2n_stuffer_read(stuffer, &o));

--- a/stuffer/s2n_stuffer_base64.c
+++ b/stuffer/s2n_stuffer_base64.c
@@ -74,13 +74,17 @@ bool s2n_is_base64_char(unsigned char c)
  */
 int s2n_stuffer_read_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *out)
 {
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(out));
     uint8_t pad[4];
     int bytes_this_round = 3;
-    struct s2n_blob o = {.data = pad,.size = sizeof(pad) };
+    struct s2n_blob o;// = {.data = pad,.size = sizeof(pad) };
+    GUARD(s2n_blob_init(&o, pad, sizeof(pad)));
 
     do {
         if (s2n_stuffer_data_available(stuffer) < 4) {
             break;
+            //return S2N_SUCCESS;
         }
 
         GUARD(s2n_stuffer_read(stuffer, &o));
@@ -94,7 +98,7 @@ int s2n_stuffer_read_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *out
         if (value1 == 255) {
             /* Undo the read */
             stuffer->read_cursor -= 4;
-            return 0;
+            return S2N_SUCCESS;
         }
 
         /* The first two characters can never be '=' and in general
@@ -140,14 +144,15 @@ int s2n_stuffer_read_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *out
             *ptr = ((value3 << 6) & 0xc0) | (value4 & 0x3f);
             ptr++;
         }
-
     } while (bytes_this_round == 3);
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_stuffer_write_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *in)
 {
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(in));
     uint8_t outpad[4];
     uint8_t inpad[3];
     struct s2n_blob o = {.data = outpad,.size = sizeof(outpad) };
@@ -206,5 +211,5 @@ int s2n_stuffer_write_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *in
         GUARD(s2n_stuffer_write(stuffer, &o));
     }
 
-    return 0;
+    return S2N_SUCCESS;
 }

--- a/tests/cbmc/proofs/s2n_stuffer_read_base64/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_base64/Makefile
@@ -1,0 +1,43 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+# Enough to get full coverage with 10 seconds of runtime.
+MAX_BLOB_SIZE = 4
+DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
+
+ROUND = 1
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_base64.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+
+ENTRY = s2n_stuffer_read_base64_harness
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_blob_slice
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_stuffer_wipe_n
+
+UNWINDSET += s2n_stuffer_read_base64.20:$(call addone,$(ROUND))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_read_base64/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_base64/Makefile
@@ -41,6 +41,6 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
 
-UNWINDSET += s2n_stuffer_read_base64.18:$(MAX_BLOB_SIZE)
+UNWINDSET += s2n_stuffer_read_base64.23:$(MAX_BLOB_SIZE)
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_read_base64/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_base64/Makefile
@@ -11,33 +11,36 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Expected runtime is 10 seconds.
-# Enough to get full coverage with 10 seconds of runtime.
+# Enough to get full coverage with 3 minutes of runtime.
 MAX_BLOB_SIZE = 4
 DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
 
-ROUND = 1
-
 CBMCFLAGS +=
 
-DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
-DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
-DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
-DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
-DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_base64.c
-DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
-DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
-DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
-DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
-DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+HARNESS_ENTRY = s2n_stuffer_read_base64_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
 
-ENTRY = s2n_stuffer_read_base64_harness
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_base64.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
-REMOVE_FUNCTION_BODY += --remove-function-body s2n_blob_slice
-REMOVE_FUNCTION_BODY += --remove-function-body s2n_mem_cleanup_impl
-REMOVE_FUNCTION_BODY += --remove-function-body s2n_stuffer_wipe_n
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
 
-UNWINDSET += s2n_stuffer_read_base64.20:$(call addone,$(ROUND))
+UNWINDSET += s2n_stuffer_read_base64.18:$(MAX_BLOB_SIZE)
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_read_base64/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_read_base64/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_read_base64/s2n_stuffer_read_base64_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_base64/s2n_stuffer_read_base64_harness.c
@@ -46,6 +46,11 @@ void s2n_stuffer_read_base64_harness() {
 
     if (s2n_stuffer_read_base64(stuffer, out) == S2N_SUCCESS) {
         assert(s2n_stuffer_is_valid(out));
+	      if(s2n_stuffer_data_available(&old_stuffer) >= 4) {
+	          size_t index;
+	          __CPROVER_assume(index >= old_stuffer.read_cursor && index < old_stuffer.write_cursor);
+	          assert(s2n_is_base64_char(stuffer->blob.data[index]));
+	      }
     }
 
     assert_stuffer_immutable_fields_after_read(stuffer, &old_stuffer, &old_byte_from_stuffer);

--- a/tests/cbmc/proofs/s2n_stuffer_read_base64/s2n_stuffer_read_base64_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_base64/s2n_stuffer_read_base64_harness.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_mem.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_read_base64_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    __CPROVER_assume(s2n_blob_is_bounded(&stuffer->blob, MAX_BLOB_SIZE));
+
+    struct s2n_stuffer *out = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(out));
+
+    /* Save previous state from stuffer. */
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    /* Save previous state from out. */
+    struct s2n_stuffer old_out = *out;
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    if (s2n_stuffer_read_base64(stuffer, out) == S2N_SUCCESS) {
+        assert(s2n_stuffer_is_valid(out));
+    }
+
+    assert_stuffer_immutable_fields_after_read(stuffer, &old_stuffer, &old_byte_from_stuffer);
+    assert(s2n_stuffer_is_valid(stuffer));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_write_base64/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_base64/Makefile
@@ -11,35 +11,36 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Expected runtime is 10 seconds.
-# Enough to get full coverage with 10 seconds of runtime.
-MAX_BLOB_SIZE = 2
+# Enough to get full coverage with 7 minutes of runtime.
+MAX_BLOB_SIZE = 4
 DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
-
-ABSTRACTIONS += $(HELPERDIR)/stubs/mlock.c
-ABSTRACTIONS += $(HELPERDIR)/stubs/munlock.c
-ABSTRACTIONS += $(HELPERDIR)/stubs/s2n_calculate_stacktrace.c
-ABSTRACTIONS += $(HELPERDIR)/stubs/sysconf.c
 
 CBMCFLAGS +=
 
-DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
-DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
-DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
-DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
-DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_base64.c
-DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
-DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
-DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
-DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
-DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+HARNESS_ENTRY = s2n_stuffer_write_base64_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
 
-ENTRY = s2n_stuffer_write_base64_harness
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_base64.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
-REMOVE_FUNCTION_BODY += --remove-function-body s2n_blob_slice
-REMOVE_FUNCTION_BODY += --remove-function-body s2n_stuffer_wipe_n
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
 
-UNWINDSET += s2n_stuffer_write_base64.2:$(call addone,$(MAX_BLOB_SIZE))
+UNWINDSET += s2n_stuffer_write_base64.10:$(MAX_BLOB_SIZE)
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_base64/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_base64/Makefile
@@ -11,7 +11,7 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Enough to get full coverage with 7 minutes of runtime.
+# Enough to get full coverage with 9 minutes of runtime.
 MAX_BLOB_SIZE = 4
 DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
 

--- a/tests/cbmc/proofs/s2n_stuffer_write_base64/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_base64/Makefile
@@ -41,6 +41,6 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
 
-UNWINDSET += s2n_stuffer_write_base64.10:$(MAX_BLOB_SIZE)
+UNWINDSET += s2n_stuffer_write_base64.16:$(MAX_BLOB_SIZE)
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_base64/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_base64/Makefile
@@ -1,0 +1,45 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+# Enough to get full coverage with 10 seconds of runtime.
+MAX_BLOB_SIZE = 2
+DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
+
+ABSTRACTIONS += $(HELPERDIR)/stubs/mlock.c
+ABSTRACTIONS += $(HELPERDIR)/stubs/munlock.c
+ABSTRACTIONS += $(HELPERDIR)/stubs/s2n_calculate_stacktrace.c
+ABSTRACTIONS += $(HELPERDIR)/stubs/sysconf.c
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_base64.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+
+ENTRY = s2n_stuffer_write_base64_harness
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_blob_slice
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_stuffer_wipe_n
+
+UNWINDSET += s2n_stuffer_write_base64.2:$(call addone,$(MAX_BLOB_SIZE))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_base64/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_write_base64/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_write_base64/s2n_stuffer_write_base64_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_base64/s2n_stuffer_write_base64_harness.c
@@ -46,6 +46,11 @@ void s2n_stuffer_write_base64_harness() {
 
     if (s2n_stuffer_write_base64(stuffer, in) == S2N_SUCCESS) {
         assert(s2n_stuffer_is_valid(stuffer));
+        if(s2n_stuffer_data_available(&old_stuffer) >= 2) {
+	          size_t index;
+	          __CPROVER_assume(index >= old_stuffer.write_cursor && index < stuffer->write_cursor);
+	          assert(s2n_is_base64_char(stuffer->blob.data[index]));
+	      }
     }
 
     assert_stuffer_immutable_fields_after_read(in, &old_in, &old_byte_from_in);

--- a/tests/cbmc/proofs/s2n_stuffer_write_base64/s2n_stuffer_write_base64_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_base64/s2n_stuffer_write_base64_harness.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_mem.h"
+
+#include <assert.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_write_base64_harness() {
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+
+    struct s2n_stuffer *in = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(in));
+    __CPROVER_assume(s2n_blob_is_bounded(&in->blob, MAX_BLOB_SIZE));
+
+    /* Save previous state from stuffer. */
+    struct s2n_stuffer old_stuffer = *stuffer;
+
+    /* Save previous state from out. */
+    struct s2n_stuffer old_in = *in;
+    struct store_byte_from_buffer old_byte_from_in;
+    save_byte_from_blob(&in->blob, &old_byte_from_in);
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    if (s2n_stuffer_write_base64(stuffer, in) == S2N_SUCCESS) {
+        assert(s2n_stuffer_is_valid(stuffer));
+    }
+
+    assert_stuffer_immutable_fields_after_read(in, &old_in, &old_byte_from_in);
+    assert(s2n_stuffer_is_valid(in));
+}

--- a/tests/cbmc/stubs/mlock.c
+++ b/tests/cbmc/stubs/mlock.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "error/s2n_errno.h"
+
+#include <cbmc_proof/nondet.h>
+
+int mlock(const void *addr, size_t len)
+{
+    assert(S2N_MEM_IS_WRITABLE(addr,len));
+    return nondet_int();
+}


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A.

### Description of changes: 

- Adds a proof harness for the `s2n_stuffer_read_base64` function;
- Adds a pre- and post-conditions to the `s2n_stuffer_read_base64` function;
- Adds a proof harness for the `s2n_stuffer_write_base64` function;
- Adds a pre- and post-conditions to the `s2n_stuffer_write_base64` function;
- Adds a stub for the `mlock` function;

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.