### PR TITLE
Adds a proof harness for s2n_stuffer_skip_read_until

### DIFF
--- a/stuffer/s2n_stuffer_text.c
+++ b/stuffer/s2n_stuffer_text.c
@@ -78,6 +78,8 @@ int s2n_stuffer_read_expected_str(struct s2n_stuffer *stuffer, const char *expec
 /* Read from stuffer until the target string is found, or until there is no more data. */
 int s2n_stuffer_skip_read_until(struct s2n_stuffer *stuffer, const char *target)
 {
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
+    notnull_check(target);
     int len = strlen(target);
     while (s2n_stuffer_data_available(stuffer) >= len) {
         GUARD(s2n_stuffer_skip_to_char(stuffer, target[0]));
@@ -85,15 +87,15 @@ int s2n_stuffer_skip_read_until(struct s2n_stuffer *stuffer, const char *target)
         notnull_check(actual);
 
         if (strncmp(actual, target, len) == 0){
-            return 0;
+            return S2N_SUCCESS;
         } else {
             /* If string doesn't match, rewind stuffer to 1 byte after last read */
             GUARD(s2n_stuffer_rewind_read(stuffer, len - 1));
             continue;
         }
     }
-
-    return 0;
+    POSTCONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
+    return S2N_SUCCESS;
 
 }
 

--- a/stuffer/s2n_stuffer_text.c
+++ b/stuffer/s2n_stuffer_text.c
@@ -80,13 +80,14 @@ int s2n_stuffer_skip_read_until(struct s2n_stuffer *stuffer, const char *target)
 {
     PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     notnull_check(target);
-    int len = strlen(target);
+    const int len = strlen(target);
     while (s2n_stuffer_data_available(stuffer) >= len) {
         GUARD(s2n_stuffer_skip_to_char(stuffer, target[0]));
-        char *actual = s2n_stuffer_raw_read(stuffer, len);
+        GUARD(s2n_stuffer_skip_read(stuffer, len));
+        uint8_t *actual = stuffer->blob.data + stuffer->read_cursor - len;
         notnull_check(actual);
 
-        if (strncmp(actual, target, len) == 0){
+        if (strncmp((char*)actual, target, len) == 0){
             return S2N_SUCCESS;
         } else {
             /* If string doesn't match, rewind stuffer to 1 byte after last read */
@@ -96,7 +97,6 @@ int s2n_stuffer_skip_read_until(struct s2n_stuffer *stuffer, const char *target)
     }
     POSTCONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     return S2N_SUCCESS;
-
 }
 
 /* Skips the stuffer until the first instance of the target character or until there is no more data. */

--- a/tests/cbmc/proofs/s2n_stuffer_skip_read_until/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_read_until/Makefile
@@ -35,7 +35,7 @@ PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
 
-UNWINDSET += s2n_stuffer_skip_read_until.11:$(call addone,$(MAX_BLOB_SIZE))
+UNWINDSET += s2n_stuffer_skip_read_until.12:$(call addone,$(MAX_BLOB_SIZE))
 UNWINDSET += s2n_stuffer_skip_to_char.3:$(call addone,$(MAX_BLOB_SIZE))
 UNWINDSET += strlen.0:$(call addone,$(MAX_STRING_LEN))
 UNWINDSET += strncmp.0:$(call addone,$(MAX_STRING_LEN))

--- a/tests/cbmc/proofs/s2n_stuffer_skip_read_until/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_read_until/Makefile
@@ -1,0 +1,43 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enough to get full coverage with 10 seconds of runtime.
+MAX_BLOB_SIZE = 5
+DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
+
+MAX_STRING_LEN = 5
+DEFINES += -DMAX_STRING_LEN=$(MAX_STRING_LEN)
+
+CBMCFLAGS +=
+
+HARNESS_ENTRY = s2n_stuffer_skip_read_until_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+
+UNWINDSET += s2n_stuffer_skip_read_until.11:$(call addone,$(MAX_BLOB_SIZE))
+UNWINDSET += s2n_stuffer_skip_to_char.3:$(call addone,$(MAX_BLOB_SIZE))
+UNWINDSET += strlen.0:$(call addone,$(MAX_STRING_LEN))
+UNWINDSET += strncmp.0:$(call addone,$(MAX_STRING_LEN))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_skip_read_until/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_read_until/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_skip_read_until/s2n_stuffer_skip_read_until_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_read_until/s2n_stuffer_skip_read_until_harness.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+#include <assert.h>
+#include <string.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_stuffer_skip_read_until_harness() {
+    /* Non-deterministic inputs. */
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    __CPROVER_assume(s2n_blob_is_bounded(&stuffer->blob, MAX_BLOB_SIZE));
+    char *target = nondet_bool() ? ensure_c_str_is_allocated(MAX_STRING_LEN) : NULL;
+
+    /* Save previous state from stuffer. */
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    /* Operation under verification. */
+    s2n_stuffer_skip_read_until(stuffer, target);
+
+    assert(stuffer->write_cursor == old_stuffer.write_cursor);
+    assert(stuffer->high_water_mark == old_stuffer.high_water_mark);
+    assert(stuffer->alloced == old_stuffer.alloced);
+    assert(stuffer->growable == old_stuffer.growable);
+    assert_blob_equivalence(&stuffer->blob, &old_stuffer.blob, &old_byte_from_stuffer);
+    assert(s2n_stuffer_is_valid(stuffer));
+}


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A.

### Description of changes: 

- Adds a proof harness for the `s2n_stuffer_skip_read_until` function;
- Adds a pre- and post-conditions to the `s2n_stuffer_skip_read_until` function;

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.