### PR TITLE
Add proof harnesses for s2n_stuffer_*_fd functions

### DIFF
--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -96,8 +96,8 @@ extern void *s2n_stuffer_raw_write(struct s2n_stuffer *stuffer, const uint32_t d
 extern void *s2n_stuffer_raw_read(struct s2n_stuffer *stuffer, uint32_t data_len);
 
 /* Send/receive stuffer to/from a file descriptor */
-extern int s2n_stuffer_recv_from_fd(struct s2n_stuffer *stuffer, int rfd, uint32_t len, ssize_t *bytes_written);
-extern int s2n_stuffer_send_to_fd(struct s2n_stuffer *stuffer, int wfd, uint32_t len, ssize_t *bytes_sent);
+extern int s2n_stuffer_recv_from_fd(struct s2n_stuffer *stuffer, const int rfd, const uint32_t len, uint32_t *bytes_written);
+extern int s2n_stuffer_send_to_fd(struct s2n_stuffer *stuffer, const int wfd, const uint32_t len, uint32_t *bytes_sent);
 
 /* Read and write integers in network order */
 extern int s2n_stuffer_read_uint8(struct s2n_stuffer *stuffer, uint8_t * u);

--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -96,8 +96,8 @@ extern void *s2n_stuffer_raw_write(struct s2n_stuffer *stuffer, const uint32_t d
 extern void *s2n_stuffer_raw_read(struct s2n_stuffer *stuffer, uint32_t data_len);
 
 /* Send/receive stuffer to/from a file descriptor */
-extern int s2n_stuffer_recv_from_fd(struct s2n_stuffer *stuffer, int rfd, uint32_t len);
-extern int s2n_stuffer_send_to_fd(struct s2n_stuffer *stuffer, int wfd, uint32_t len);
+extern int s2n_stuffer_recv_from_fd(struct s2n_stuffer *stuffer, int rfd, uint32_t len, ssize_t *bytes_written);
+extern int s2n_stuffer_send_to_fd(struct s2n_stuffer *stuffer, int wfd, uint32_t len, ssize_t *bytes_sent);
 
 /* Read and write integers in network order */
 extern int s2n_stuffer_read_uint8(struct s2n_stuffer *stuffer, uint8_t * u);

--- a/stuffer/s2n_stuffer_file.c
+++ b/stuffer/s2n_stuffer_file.c
@@ -26,7 +26,7 @@
 
 #include "utils/s2n_safety.h"
 
-int s2n_stuffer_recv_from_fd(struct s2n_stuffer *stuffer, int rfd, uint32_t len, ssize_t *bytes_written)
+int s2n_stuffer_recv_from_fd(struct s2n_stuffer *stuffer, const int rfd, const uint32_t len, uint32_t *bytes_written)
 {
     PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     /* Make sure we have enough space to write */
@@ -48,7 +48,7 @@ int s2n_stuffer_recv_from_fd(struct s2n_stuffer *stuffer, int rfd, uint32_t len,
     return S2N_SUCCESS;
 }
 
-int s2n_stuffer_send_to_fd(struct s2n_stuffer *stuffer, int wfd, uint32_t len, ssize_t *bytes_sent)
+int s2n_stuffer_send_to_fd(struct s2n_stuffer *stuffer, const int wfd, const uint32_t len, uint32_t *bytes_sent)
 {
     PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
 

--- a/stuffer/s2n_stuffer_file.c
+++ b/stuffer/s2n_stuffer_file.c
@@ -26,7 +26,7 @@
 
 #include "utils/s2n_safety.h"
 
-int s2n_stuffer_recv_from_fd(struct s2n_stuffer *stuffer, int rfd, uint32_t len)
+int s2n_stuffer_recv_from_fd(struct s2n_stuffer *stuffer, int rfd, uint32_t len, ssize_t *bytes_written)
 {
     PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     /* Make sure we have enough space to write */
@@ -44,12 +44,11 @@ int s2n_stuffer_recv_from_fd(struct s2n_stuffer *stuffer, int rfd, uint32_t len)
     /* Record just how many bytes we have written */
     S2N_ERROR_IF(r > UINT32_MAX, S2N_ERR_INTEGER_OVERFLOW);
     GUARD(s2n_stuffer_skip_write(stuffer, (uint32_t)r));
-
-    S2N_ERROR_IF(r > INT_MAX, S2N_ERR_INTEGER_OVERFLOW);
-    return r;
+    if (bytes_written != NULL) *bytes_written = r;
+    return S2N_SUCCESS;
 }
 
-int s2n_stuffer_send_to_fd(struct s2n_stuffer *stuffer, int wfd, uint32_t len)
+int s2n_stuffer_send_to_fd(struct s2n_stuffer *stuffer, int wfd, uint32_t len, ssize_t *bytes_sent)
 {
     PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
 
@@ -67,9 +66,8 @@ int s2n_stuffer_send_to_fd(struct s2n_stuffer *stuffer, int wfd, uint32_t len)
 
     S2N_ERROR_IF(w > UINT32_MAX - stuffer->read_cursor, S2N_ERR_INTEGER_OVERFLOW);
     stuffer->read_cursor += w;
-
-    S2N_ERROR_IF(w > INT_MAX, S2N_ERR_INTEGER_OVERFLOW);
-    return w;
+    if (bytes_sent != NULL) *bytes_sent = w;
+    return S2N_SUCCESS;
 }
 
 int s2n_stuffer_alloc_ro_from_fd(struct s2n_stuffer *stuffer, int rfd)

--- a/tests/cbmc/include/cbmc_proof/nondet.h
+++ b/tests/cbmc/include/cbmc_proof/nondet.h
@@ -19,6 +19,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 
 /**
  * These functions provide a way to get unconstrained values of the correct types for use in CBMC proofs
@@ -36,3 +37,4 @@ uint64_t nondet_uint64_t();
 uint8_t nondet_uint8_t();
 void *nondet_voidp();
 off_t nondet_off_t();
+ssize_t nondet_ssize_t();

--- a/tests/cbmc/proofs/s2n_stuffer_recv_from_fd/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_recv_from_fd/Makefile
@@ -1,0 +1,42 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enough to get full coverage with 30 seconds of runtime.
+MAX_BLOB_SIZE = 2
+DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
+
+ABSTRACTIONS += $(HELPERDIR)/stubs/read.c
+ABSTRACTIONS += $(HELPERDIR)/stubs/s2n_calculate_stacktrace.c
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/cbmc_utils.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_datastructures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/error/s2n_errno.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer.c
+DEPENDENCIES += $(SRCDIR)/stuffer/s2n_stuffer_file.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_blob.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_ensure.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+DEPENDENCIES += $(SRCDIR)/utils/s2n_safety.c
+
+ENTRY = s2n_stuffer_recv_from_fd_harness
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_blob_slice
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_stuffer_wipe_n
+
+UNWINDSET += s2n_stuffer_recv_from_fd.7:$(call addone,$(MAX_BLOB_SIZE))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_recv_from_fd/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_recv_from_fd/Makefile
@@ -11,9 +11,7 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Enough to get full coverage with 1 minute of runtime.
-MAX_BLOB_SIZE = 2
-DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
+# Expected runtime of 2 minutes.
 
 CBMCFLAGS +=
 
@@ -24,6 +22,7 @@ PROOF_SOURCES += $(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
 PROOF_SOURCES += $(PROOF_STUB)/read.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
@@ -41,6 +40,6 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
 
-UNWINDSET += s2n_stuffer_recv_from_fd.7:$(call addone,$(MAX_BLOB_SIZE))
+UNWINDSET += s2n_stuffer_recv_from_fd.7:3
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_recv_from_fd/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_recv_from_fd/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_recv_from_fd/s2n_stuffer_recv_from_fd_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_recv_from_fd/s2n_stuffer_recv_from_fd_harness.c
@@ -25,7 +25,6 @@ void s2n_stuffer_recv_from_fd_harness() {
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
-    __CPROVER_assume(s2n_blob_is_bounded(&stuffer->blob, MAX_BLOB_SIZE));
     int rfd;
     uint32_t len;
 

--- a/tests/cbmc/proofs/s2n_stuffer_recv_from_fd/s2n_stuffer_recv_from_fd_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_recv_from_fd/s2n_stuffer_recv_from_fd_harness.c
@@ -27,6 +27,7 @@ void s2n_stuffer_recv_from_fd_harness() {
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
     int rfd;
     uint32_t len;
+    ssize_t bytes_written;
 
     /* Non-deterministically set initialized (in s2n_mem) to true. */
     if(nondet_bool()) {
@@ -39,11 +40,12 @@ void s2n_stuffer_recv_from_fd_harness() {
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
     /* Operation under verification. */
-    int rc = s2n_stuffer_recv_from_fd(stuffer, rfd, len);
-
-    /* Post-conditions. */
-    if(rc >= 0 && rc < UINT32_MAX) assert(stuffer->write_cursor == old_stuffer.write_cursor + rc);
-    assert(stuffer->alloced == old_stuffer.alloced);
-    assert(stuffer->growable == old_stuffer.growable);
-    assert(stuffer->tainted == old_stuffer.tainted);
+    if (s2n_stuffer_recv_from_fd(stuffer, rfd, len, &bytes_written) == S2N_SUCCESS) {
+       assert(stuffer->write_cursor == old_stuffer.write_cursor + bytes_written);
+       assert(s2n_stuffer_is_valid(stuffer));
+   }
+   assert(stuffer->read_cursor == old_stuffer.read_cursor);
+   assert(stuffer->alloced == old_stuffer.alloced);
+   assert(stuffer->growable == old_stuffer.growable);
+   assert(stuffer->tainted == old_stuffer.tainted);
 }

--- a/tests/cbmc/proofs/s2n_stuffer_recv_from_fd/s2n_stuffer_recv_from_fd_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_recv_from_fd/s2n_stuffer_recv_from_fd_harness.c
@@ -27,7 +27,7 @@ void s2n_stuffer_recv_from_fd_harness() {
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
     int rfd;
     uint32_t len;
-    ssize_t bytes_written;
+    uint32_t bytes_written;
 
     /* Non-deterministically set initialized (in s2n_mem) to true. */
     if(nondet_bool()) {

--- a/tests/cbmc/proofs/s2n_stuffer_recv_from_fd/s2n_stuffer_recv_from_fd_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_recv_from_fd/s2n_stuffer_recv_from_fd_harness.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_mem.h"
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_stuffer_recv_from_fd_harness() {
+    /* Non-deterministic inputs. */
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    __CPROVER_assume(s2n_blob_is_bounded(&stuffer->blob, MAX_BLOB_SIZE));
+    int rfd;
+    uint32_t len;
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    /* Save previous state. */
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    /* Operation under verification. */
+    int rc = s2n_stuffer_recv_from_fd(stuffer, rfd, len);
+
+    /* Post-conditions. */
+    if(rc >= 0 && rc < UINT32_MAX) assert(stuffer->write_cursor == old_stuffer.write_cursor + rc);
+    assert(stuffer->alloced == old_stuffer.alloced);
+    assert(stuffer->growable == old_stuffer.growable);
+    assert(stuffer->tainted == old_stuffer.tainted);
+}

--- a/tests/cbmc/proofs/s2n_stuffer_send_to_fd/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_send_to_fd/Makefile
@@ -11,23 +11,22 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Enough to get full coverage with 1 minute of runtime.
-MAX_BLOB_SIZE = 2
+# Enough to get full coverage with 10 seconds of runtime.
+MAX_BLOB_SIZE = 10
 DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
 
 CBMCFLAGS +=
 
-HARNESS_ENTRY = s2n_stuffer_recv_from_fd_harness
+HARNESS_ENTRY = s2n_stuffer_send_to_fd_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
 
 PROOF_SOURCES += $(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
-PROOF_SOURCES += $(PROOF_STUB)/munlock.c
-PROOF_SOURCES += $(PROOF_STUB)/read.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+PROOF_SOURCES += $(PROOF_STUB)/write.c
 
 PROJECT_SOURCES += $(SRCDIR)/error/s2n_errno.c
 PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
@@ -37,10 +36,6 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
-# We abstract these functions because manual inspection demonstrates they are unreachable.
-REMOVE_FUNCTION_BODY += s2n_blob_slice
-REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
-
-UNWINDSET += s2n_stuffer_recv_from_fd.7:$(call addone,$(MAX_BLOB_SIZE))
+UNWINDSET += s2n_stuffer_send_to_fd.7:$(call addone,$(MAX_BLOB_SIZE))
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_send_to_fd/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_send_to_fd/Makefile
@@ -11,9 +11,7 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Enough to get full coverage with 10 seconds of runtime.
-MAX_BLOB_SIZE = 10
-DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
+# Expected runtime is 30 seconds.
 
 CBMCFLAGS +=
 
@@ -36,6 +34,6 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
-UNWINDSET += s2n_stuffer_send_to_fd.7:$(call addone,$(MAX_BLOB_SIZE))
+UNWINDSET += s2n_stuffer_send_to_fd.7:3
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_send_to_fd/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_send_to_fd/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_send_to_fd/s2n_stuffer_send_to_fd_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_send_to_fd/s2n_stuffer_send_to_fd_harness.c
@@ -27,7 +27,7 @@ void s2n_stuffer_send_to_fd_harness() {
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
     int wfd;
     uint32_t len;
-    ssize_t bytes_sent;
+    uint32_t bytes_sent;
 
     /* Non-deterministically set initialized (in s2n_mem) to true. */
     if(nondet_bool()) {

--- a/tests/cbmc/proofs/s2n_stuffer_send_to_fd/s2n_stuffer_send_to_fd_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_send_to_fd/s2n_stuffer_send_to_fd_harness.c
@@ -25,7 +25,6 @@ void s2n_stuffer_send_to_fd_harness() {
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
-    __CPROVER_assume(s2n_blob_is_bounded(&stuffer->blob, MAX_BLOB_SIZE));
     int wfd;
     uint32_t len;
 

--- a/tests/cbmc/proofs/s2n_stuffer_send_to_fd/s2n_stuffer_send_to_fd_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_send_to_fd/s2n_stuffer_send_to_fd_harness.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_mem.h"
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_stuffer_send_to_fd_harness() {
+    /* Non-deterministic inputs. */
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    __CPROVER_assume(s2n_blob_is_bounded(&stuffer->blob, MAX_BLOB_SIZE));
+    int wfd;
+    uint32_t len;
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    /* Save previous state. */
+    struct s2n_stuffer old_stuffer = *stuffer;
+    struct store_byte_from_buffer old_byte_from_stuffer;
+    save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
+
+    /* Operation under verification. */
+    int rc = s2n_stuffer_send_to_fd(stuffer, wfd, len);
+
+    /* Post-conditions. */
+    if(rc >= 0 && rc < UINT32_MAX) assert(stuffer->read_cursor == old_stuffer.read_cursor + rc);
+    assert(stuffer->write_cursor == old_stuffer.write_cursor);
+    assert(stuffer->alloced == old_stuffer.alloced);
+    assert(stuffer->growable == old_stuffer.growable);
+    assert(stuffer->tainted == old_stuffer.tainted);
+}

--- a/tests/cbmc/stubs/read.c
+++ b/tests/cbmc/stubs/read.c
@@ -20,14 +20,13 @@
 static bool loop_flag = false;
 
 ssize_t read(int fd, void *buf, size_t nbyte) {
-    ssize_t rval = 0;
     errno = nondet_int();
     if(loop_flag) {
         __CPROVER_assume(errno != EINTR);
-        return rval;
+        return 0;
     }
     loop_flag = true;
-    rval = nondet_ssize_t();
+    ssize_t rval;
     __CPROVER_assume(rval <= (ssize_t)nbyte);
     return rval;
 }

--- a/tests/cbmc/stubs/read.c
+++ b/tests/cbmc/stubs/read.c
@@ -14,11 +14,19 @@
  */
 
 #include <cbmc_proof/nondet.h>
+#include <errno.h>
 #include <unistd.h>
 
-static ssize_t round = MAX_BLOB_SIZE;
+static bool loop_flag = false;
 
-ssize_t read(int fildes, void *buf, size_t nbyte) {
-    round--;
-    return (round > 0) ? nondet_ssize_t() : round;
+ssize_t read(int fd, void *buf, size_t nbyte) {
+    ssize_t rval = 0;
+    errno = nondet_int();
+    if(loop_flag) {
+        __CPROVER_assume(errno != EINTR);
+        return rval;
+    }
+    loop_flag = true;
+    rval = nondet_ssize_t();
+    return rval;
 }

--- a/tests/cbmc/stubs/read.c
+++ b/tests/cbmc/stubs/read.c
@@ -28,5 +28,6 @@ ssize_t read(int fd, void *buf, size_t nbyte) {
     }
     loop_flag = true;
     rval = nondet_ssize_t();
+    __CPROVER_assume(rval <= (ssize_t)nbyte);
     return rval;
 }

--- a/tests/cbmc/stubs/read.c
+++ b/tests/cbmc/stubs/read.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cbmc_proof/nondet.h>
+#include <unistd.h>
+
+static ssize_t round = MAX_BLOB_SIZE;
+
+ssize_t read(int fildes, void *buf, size_t nbyte) {
+    round--;
+    return (round > 0) ? nondet_ssize_t() : round;
+}

--- a/tests/cbmc/stubs/write.c
+++ b/tests/cbmc/stubs/write.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cbmc_proof/nondet.h>
+#include <unistd.h>
+
+static ssize_t round = MAX_BLOB_SIZE;
+
+ssize_t write(int fildes, const void *buf, size_t nbyte) {
+    round--;
+    return (round > 0) ? nondet_ssize_t() : round;
+}

--- a/tests/cbmc/stubs/write.c
+++ b/tests/cbmc/stubs/write.c
@@ -13,12 +13,23 @@
  * limitations under the License.
  */
 
+#include <error/s2n_errno.h>
+
+#include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/nondet.h>
+#include <errno.h>
 #include <unistd.h>
 
-static ssize_t round = MAX_BLOB_SIZE;
+static bool loop_flag = false;
 
 ssize_t write(int fildes, const void *buf, size_t nbyte) {
-    round--;
-    return (round > 0) ? nondet_ssize_t() : round;
+    ssize_t rval = 0;
+    errno = nondet_int();
+    if(loop_flag) {
+        __CPROVER_assume(errno != EINTR);
+        return rval;
+    }
+    loop_flag = true;
+    rval = nondet_ssize_t();
+    return rval;
 }

--- a/tests/cbmc/stubs/write.c
+++ b/tests/cbmc/stubs/write.c
@@ -31,5 +31,6 @@ ssize_t write(int fildes, const void *buf, size_t nbyte) {
     }
     loop_flag = true;
     rval = nondet_ssize_t();
+    __CPROVER_assume(rval <= (ssize_t)nbyte);
     return rval;
 }

--- a/tests/cbmc/stubs/write.c
+++ b/tests/cbmc/stubs/write.c
@@ -23,14 +23,13 @@
 static bool loop_flag = false;
 
 ssize_t write(int fildes, const void *buf, size_t nbyte) {
-    ssize_t rval = 0;
     errno = nondet_int();
     if(loop_flag) {
         __CPROVER_assume(errno != EINTR);
-        return rval;
+        return 0;
     }
     loop_flag = true;
-    rval = nondet_ssize_t();
+    ssize_t rval;
     __CPROVER_assume(rval <= (ssize_t)nbyte);
     return rval;
 }

--- a/tests/fuzz/LD_PRELOAD/global_overrides.c
+++ b/tests/fuzz/LD_PRELOAD/global_overrides.c
@@ -37,7 +37,7 @@ int s2n_drbg_generate(struct s2n_drbg *drbg, struct s2n_blob *blob) {
     return S2N_SUCCESS;
 }
 
-int s2n_stuffer_send_to_fd(struct s2n_stuffer *stuffer, int wfd, uint32_t len)
+int s2n_stuffer_send_to_fd(struct s2n_stuffer *stuffer, int wfd, uint32_t len, ssize_t *bytes_sent)
 {
     /* Override the original s2n_stuffer_send_to_fd to check if the write file descriptor is -1, and if so, skip
      * writing anything. This is to speed up fuzz tests that write unnecessary data that is never actually read.
@@ -48,10 +48,11 @@ int s2n_stuffer_send_to_fd(struct s2n_stuffer *stuffer, int wfd, uint32_t len)
     }
 
     /* Otherwise, call the original s2n_stuffer_send_to_fd() */
-    typedef int (*orig_s2n_stuffer_send_to_fd_func_type)(struct s2n_stuffer *stuffer, int wfd, uint32_t len);
+    typedef int (*orig_s2n_stuffer_send_to_fd_func_type)(struct s2n_stuffer *stuffer, int wfd, uint32_t len, ssize_t *bytes_sent);
     orig_s2n_stuffer_send_to_fd_func_type orig_s2n_stuffer_send_to_fd;
     orig_s2n_stuffer_send_to_fd = (orig_s2n_stuffer_send_to_fd_func_type) dlsym(RTLD_NEXT, "s2n_stuffer_send_to_fd");
-    return orig_s2n_stuffer_send_to_fd(stuffer, wfd, len);
+    GUARD(orig_s2n_stuffer_send_to_fd(stuffer, wfd, len, bytes_sent));
+    return S2N_SUCCESS;
 }
 
 S2N_RESULT s2n_get_urandom_data(struct s2n_blob *blob){

--- a/tests/unit/s2n_release_non_empty_buffers_test.c
+++ b/tests/unit/s2n_release_non_empty_buffers_test.c
@@ -144,7 +144,7 @@ int main(int argc, char **argv)
     /* Receive only 100 bytes of the record and try to call s2n_recv */
     n = 0;
     while (n < 100) {
-        s2n_stuffer_recv_from_fd(&in, io_pair.server, 100 - n, &ret);
+        ret = s2n_stuffer_recv_from_fd(&in, io_pair.server, 100 - n, &n);
 
         if (ret < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
             continue;

--- a/tests/unit/s2n_release_non_empty_buffers_test.c
+++ b/tests/unit/s2n_release_non_empty_buffers_test.c
@@ -146,7 +146,11 @@ int main(int argc, char **argv)
     while (n < 100) {
         ret = s2n_stuffer_recv_from_fd(&in, io_pair.server, 100 - n, &n);
 
-        if (ret < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK) {
+            continue;
+        } else {
+            GUARD(ret);
+        }
             continue;
         }
 

--- a/tests/unit/s2n_release_non_empty_buffers_test.c
+++ b/tests/unit/s2n_release_non_empty_buffers_test.c
@@ -83,7 +83,8 @@ int main(int argc, char **argv)
     struct s2n_cert_chain_and_key *chain_and_key;
     struct s2n_stuffer in, out;
     uint8_t buf[sizeof(buf_to_send)];
-    ssize_t n = 0, ret = 0;
+    uint32_t n = 0;
+    ssize_t ret = 0;
 
     BEGIN_TEST();
 
@@ -142,7 +143,6 @@ int main(int argc, char **argv)
     } while (blocked);
 
     /* Receive only 100 bytes of the record and try to call s2n_recv */
-    n = 0;
     while (n < 100) {
         ret = s2n_stuffer_recv_from_fd(&in, io_pair.server, 100 - n, &n);
 
@@ -151,11 +151,6 @@ int main(int argc, char **argv)
         } else {
             GUARD(ret);
         }
-            continue;
-        }
-
-        EXPECT_TRUE(ret > 0);
-        n += ret;
     }
 
     /* s2n_recv should fail as we received only part of the record */
@@ -167,10 +162,12 @@ int main(int argc, char **argv)
 
     /* Read the rest of the buffer and expect s2n_recv to succeed */
     do {
-        s2n_stuffer_recv_from_fd(&in, io_pair.server, MAX_BUF_SIZE, &ret);
+        ret = s2n_stuffer_recv_from_fd(&in, io_pair.server, MAX_BUF_SIZE, NULL);
 
-        if (ret < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK) {
             continue;
+        } else {
+            GUARD(ret);
         }
 
         ret = s2n_recv(conn, buf, sizeof(buf), &blocked);

--- a/tests/unit/s2n_self_talk_custom_io_test.c
+++ b/tests/unit/s2n_self_talk_custom_io_test.c
@@ -66,7 +66,7 @@ int mock_client(struct s2n_test_io_pair *io_pair)
  * This test creates a server, client, and a pair of pipes. The client uses the
  * pipes directly for I/O in s2n. The server copies data from the pipes into
  * stuffers and manages s2n I/O with a set of I/O callbacks that read and write
- * from the stuffers. 
+ * from the stuffers.
  */
 int main(int argc, char **argv)
 {
@@ -132,7 +132,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&in, 0));
     EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));
     EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&in, &out, conn));
-    
+
     /* Make our pipes non-blocking */
     EXPECT_SUCCESS(s2n_fd_set_non_blocking(io_pair.server));
     EXPECT_SUCCESS(s2n_fd_set_non_blocking(io_pair.server));
@@ -143,29 +143,29 @@ int main(int argc, char **argv)
 
         ret = s2n_negotiate(conn, &blocked);
         EXPECT_TRUE(ret == 0 || (blocked && (errno == EAGAIN || errno == EWOULDBLOCK)));
-        
+
         /* check to see if we need to copy more over from the pipes to the buffers
          * to continue the handshake
          */
-        s2n_stuffer_recv_from_fd(&in, io_pair.server, MAX_BUF_SIZE);
-        s2n_stuffer_send_to_fd(&out, io_pair.server, s2n_stuffer_data_available(&out));
+        s2n_stuffer_recv_from_fd(&in, io_pair.server, MAX_BUF_SIZE, NULL);
+        s2n_stuffer_send_to_fd(&out, io_pair.server, s2n_stuffer_data_available(&out), NULL);
     } while (blocked);
-   
+
     /* Shutdown after negotiating */
     uint8_t server_shutdown=0;
     do {
         int ret;
-        
+
         ret = s2n_shutdown(conn, &blocked);
         EXPECT_TRUE(ret == 0 || (blocked && (errno == EAGAIN || errno == EWOULDBLOCK)));
         if (ret == 0) {
             server_shutdown = 1;
         }
 
-        s2n_stuffer_recv_from_fd(&in, io_pair.server, MAX_BUF_SIZE);
-        s2n_stuffer_send_to_fd(&out, io_pair.server, s2n_stuffer_data_available(&out));
+        s2n_stuffer_recv_from_fd(&in, io_pair.server, MAX_BUF_SIZE, NULL);
+        s2n_stuffer_send_to_fd(&out, io_pair.server, s2n_stuffer_data_available(&out), NULL);
     } while (!server_shutdown);
-    
+
     EXPECT_SUCCESS(s2n_connection_free(conn));
 
     /* Clean up */
@@ -186,4 +186,3 @@ int main(int argc, char **argv)
 
     return 0;
 }
-


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A.

### Description of changes: 

- Adds a proof harness for the `s2n_stuffer_recv_from_fd` function;
- Adds a pre- and post-conditions to the `s2n_stuffer_recv_from_fd` function;
- Adds a proof harness for the `s2n_stuffer_send_to_fd` function;
- Adds a pre- and post-conditions to the `s2n_stuffer_send_to_fd` function;
- Adds a stub for the `read` function;
- Adds a stub for the `write` function;

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.