### PR TITLE
ci: Remove Travis coverage job

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,3 @@
-_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
 ### Resolved issues:
 
  resolves #ISSUE-NUMBER1, resolves #ISSUE-NUMBER2, etc.

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ cache:
 
 jobs:
   include:
-  - os: linux
-    dist: bionic
-    env: S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=6 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true
-
 # Normal Build Targets
   - os: linux
     dist: bionic

--- a/codebuild/codebuild.config
+++ b/codebuild/codebuild.config
@@ -26,7 +26,7 @@ env: S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=9
 snippet: UbuntuBoilerplate2XL
 env: S2N_LIBCRYPTO=libressl BUILD_S2N=true TESTS=integration GCC_VERSION=9
 
-[CodeBuild:s2nIntegrationOpenSSL111Gcc6]
+[CodeBuild:s2nIntegrationOpenSSL111Gcc6Coverage]
 snippet: UbuntuBoilerplate2XL
 env: S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=6 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true
 
@@ -51,7 +51,7 @@ snippet: UbuntuBoilerplate2XL
 env: S2N_LIBCRYPTO=boringssl BUILD_S2N=true TESTS=integration GCC_VERSION=9
 
 # Asan Test
-[CodeBuild:s2nAsanOpenSSL111Gcc6]
+[CodeBuild:s2nAsanOpenSSL111Gcc6Coverage]
 snippet: UbuntuBoilerplateLarge
 env: S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=asan GCC_VERSION=6 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true
 

--- a/codebuild/integ_codebuild.config
+++ b/codebuild/integ_codebuild.config
@@ -30,7 +30,7 @@ source_version:
 env: TESTS=integration BUILD_S2N=true
 
 # OpenSSL111 + GCC6 + Corked and notCorked + Gcc4.8
-[CodeBuild:s2nIntegrationOpenSSL111Plus]
+[CodeBuild:s2nIntegrationOpenSSL111PlusCoverage]
 image : aws/codebuild/standard:2.0
 env_type: LINUX_CONTAINER
 compute_type: BUILD_GENERAL1_LARGE

--- a/codebuild/spec/buildspec_ubuntu_integ_openssl111.yml
+++ b/codebuild/spec/buildspec_ubuntu_integ_openssl111.yml
@@ -37,7 +37,7 @@ phases:
     commands:
       - printenv
       - S2N_LIBCRYPTO=openssl-1.1.1 GCC_VERSION=4.8 codebuild/bin/s2n_codebuild.sh
-      - S2N_LIBCRYPTO=openssl-1.1.1 TESTS=integration GCC_VERSION=6 codebuild/bin/s2n_codebuild.sh
+      - S2N_LIBCRYPTO=openssl-1.1.1 TESTS=integration GCC_VERSION=6 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true codebuild/bin/s2n_codebuild.sh
       - S2N_LIBCRYPTO=openssl-1.1.1 TESTS=integration GCC_VERSION=6 S2N_CORKED_IO=true codebuild/bin/s2n_codebuild.sh
   post_build:
     commands:


### PR DESCRIPTION
### Resolved issues:

CodeCov.io coverage reports not accurate.

### Description of changes: 
Changes:
- Removes Travis job uploading coverage
- Rename any codebuild job with coverage to include that in the name
- Add coverage back to an Integ test run by PR
- remove this banner:
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._


### Call-outs:

The python script managing CodeBuild job creation will need to be run after this is merged.
Renaming CodeBuild jobs can break in-flight PRs and must be done during slow PR activity windows.

### Testing:

Ad-hoc codebuild jobs with over-ridden environment variables.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
