### PR TITLE
Fixed faulty fuzz test

### DIFF
--- a/tests/fuzz/s2n_client_cert_recv_test.c
+++ b/tests/fuzz/s2n_client_cert_recv_test.c
@@ -95,6 +95,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
         GUARD(s2n_connection_set_verify_host_callback(server_conn, verify_host_accept_everything, &verify_data));
     }
 
+    /* Returns void, so can't be guarded */
+    s2n_x509_validator_wipe(&server_conn->x509_validator);
     GUARD(s2n_x509_validator_init(&server_conn->x509_validator, &trust_store, 1));
     server_conn->x509_validator.skip_cert_validation = (randval >> 1) % 2;
     server_conn->actual_protocol_version = TLS_VERSIONS[((randval >> 4) & 0x0f) % s2n_array_len(TLS_VERSIONS)];


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

N/A

### Description of changes: 
conn->x509_validator initialized already when calling s2n_connection_new(), so we need to wipe it before calling s2n_x509_validator_init().
### Call-outs:

N/A
### Testing:
fuzz test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
