### PR TITLE
CBMC proof for s2n_mem_init

### DIFF
--- a/tests/cbmc/proofs/s2n_mem_init/Makefile
+++ b/tests/cbmc/proofs/s2n_mem_init/Makefile
@@ -1,0 +1,22 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+ABSTRACTIONS += $(HELPERDIR)/stubs/s2n_calculate_stacktrace.c
+
+DEPENDENCIES += $(SRCDIR)/utils/s2n_mem.c
+
+ENTRY = s2n_mem_init_harness
+
+REMOVE_FUNCTION_BODY += --remove-function-body s2n_mem_cleanup_impl
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_mem_init/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_mem_init/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_mem_init/s2n_mem_init_harness.c
+++ b/tests/cbmc/proofs/s2n_mem_init/s2n_mem_init_harness.c
@@ -13,19 +13,19 @@
  * permissions and limitations under the License.
  */
 
-#pragma once
+#include "api/s2n.h"
+#include "utils/s2n_mem.h"
 
-#include "utils/s2n_blob.h"
+#include <assert.h>
 
-#include <stdint.h>
-
-int s2n_mem_init(void);
-bool s2n_mem_is_init(void);
-uint32_t s2n_mem_get_page_size(void);
-int s2n_mem_cleanup(void);
-int s2n_alloc(struct s2n_blob *b, uint32_t size);
-int s2n_realloc(struct s2n_blob *b, uint32_t size);
-int s2n_free(struct s2n_blob *b);
-int s2n_blob_zeroize_free(struct s2n_blob *b);
-int s2n_free_object(uint8_t **p_data, uint32_t size);
-int s2n_dup(struct s2n_blob *from, struct s2n_blob *to);
+void s2n_mem_init_harness()
+{
+    /* Operation under verification. */
+    if( s2n_mem_init( ) == S2N_SUCCESS ) {
+        assert(s2n_mem_is_init());
+        assert(s2n_mem_get_page_size() > 0);
+        assert(s2n_mem_get_page_size() <= UINT32_MAX);
+    } else {
+        assert(!s2n_mem_is_init());
+    }
+}


### PR DESCRIPTION
### Description of changes: 

CBMC proof for s2n_mem_init.
 
### Testing:

Coverage summary:
```
1.00 (25 lines out of 25 statically-reachable lines in 6 functions reached)
1.00 (25 lines out of 25 statically-reachable lines in 6 statically-reachable functions) 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
