### PR TITLE
Optimize pem parsing

### DIFF
--- a/stuffer/s2n_stuffer_base64.c
+++ b/stuffer/s2n_stuffer_base64.c
@@ -118,23 +118,27 @@ int s2n_stuffer_read_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *out
             value4 = 0;
         }
 
+        /* Advance by bytes_this_round, and then fill in the data */
+        GUARD(s2n_stuffer_skip_write(out, bytes_this_round));
+        uint8_t *ptr = out->blob.data + out->write_cursor - bytes_this_round;
+
         /* value1 maps to the first 6 bits of the first data byte */
         /* value2's top two bits are the rest */
-        uint8_t c = ((value1 << 2) & 0xfc) | ((value2 >> 4) & 0x03);
-        GUARD(s2n_stuffer_write_uint8(out, c));
+        *ptr = ((value1 << 2) & 0xfc) | ((value2 >> 4) & 0x03);
+        ptr++;
 
         if (bytes_this_round > 1) {
             /* Put the next four bits in the second data byte */
             /* Put the next four bits in the third data byte */
-            c = ((value2 << 4) & 0xf0) | ((value3 >> 2) & 0x0f);
-            GUARD(s2n_stuffer_write_uint8(out, c));
+            *ptr = ((value2 << 4) & 0xf0) | ((value3 >> 2) & 0x0f);
+            ptr++;
         }
 
         if (bytes_this_round > 2) {
             /* Put the next two bits in the third data byte */
             /* Put the next six bits in the fourth data byte */
-            c = ((value3 << 6) & 0xc0) | (value4 & 0x3f);
-            GUARD(s2n_stuffer_write_uint8(out, c));
+            *ptr = ((value3 << 6) & 0xc0) | (value4 & 0x3f);
+            ptr++;
         }
 
     } while (bytes_this_round == 3);

--- a/stuffer/s2n_stuffer_pem.c
+++ b/stuffer/s2n_stuffer_pem.c
@@ -79,16 +79,18 @@ static int s2n_stuffer_pem_read_contents(struct s2n_stuffer *pem, struct s2n_stu
     struct s2n_stuffer base64_stuffer = {0};
     GUARD(s2n_stuffer_init(&base64_stuffer, &base64__blob));
 
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(pem));
     while (1) {
-        char c;
+        /* We need a byte... */
+        ENSURE_POSIX(s2n_stuffer_data_available(pem) >= 1, S2N_ERR_STUFFER_OUT_OF_DATA);
+
         /* Peek to see if the next char is a dash, meaning end of pem_contents */
-        GUARD(s2n_stuffer_peek_char(pem, &c));
+        char c = pem->blob.data[pem->read_cursor];
         if (c == '-') {
             break;
-        } else {
-            /* Else, move read pointer forward by 1 byte since we will be consuming it. */
-             GUARD(s2n_stuffer_skip_read(pem, 1));
         }
+        /* Else, move read pointer forward by 1 byte since we will be consuming it. */
+        pem->read_cursor += 1;
 
          /* Skip non-base64 characters */
         if (!s2n_is_base64_char(c)) {

--- a/stuffer/s2n_stuffer_text.c
+++ b/stuffer/s2n_stuffer_text.c
@@ -96,14 +96,12 @@ int s2n_stuffer_skip_read_until(struct s2n_stuffer *stuffer, const char *target)
 /* Skips the stuffer until the first instance of the target character or until there is no more data. */
 int s2n_stuffer_skip_to_char(struct s2n_stuffer *stuffer, const char target)
 {
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     while (s2n_stuffer_data_available(stuffer) > 0) {
-        char c;
-        GUARD(s2n_stuffer_peek_char(stuffer, &c));
-        if (c == target) {
+        if (stuffer->blob.data[stuffer->read_cursor] == target) {
             break;
         }
-
-        GUARD(s2n_stuffer_skip_read(stuffer, 1));
+        stuffer->read_cursor += 1;
     }
 
     return 0;


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

When analyzing performance of s2n, we notice that pem parsing takes more
CPU time than ECDHE processing. This is largely due to using single byte
read and write operations.

It is possible to safely access the data blob using the read and write
cursors while ensuring we maintain data integrity and gain a 20% speed
improvement.

### Call-outs:

N/A

### Testing:

Covered by existing unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
