### PR TITLE
Set default visibility to hidden

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,14 +183,14 @@ file(GLOB S2N_SRC
     ${UTILS_SRC}
 )
 
-add_library(${PROJECT_NAME} ${S2N_HEADERS} ${S2N_SRC})
+add_library(${PROJECT_NAME} STATIC ${S2N_HEADERS} ${S2N_SRC})
 set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE C)
 
 set(CMAKE_C_FLAGS_DEBUGOPT "")
 
 target_compile_options(${PROJECT_NAME} PRIVATE -pedantic -std=gnu99 -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-subscripts
         -Wuninitialized -Wshadow -Wcast-qual -Wcast-align -Wwrite-strings -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security
-        -Wno-missing-braces)
+        -Wno-missing-braces -fvisibility=hidden -DS2N_EXPORTS)
 
 if(S2N_NO_PQ_ASM)
     target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_NO_PQ_ASM)
@@ -240,7 +240,7 @@ if (BUILD_TESTING)
     file(GLOB TESTLIB_SRC "tests/testlib/*.c")
     file(GLOB TESTLIB_HEADERS "tests/testlib/*.h" "tests/s2n_test.h")
 
-    add_library(testss2n ${TESTLIB_HEADERS} ${TESTLIB_SRC})
+    add_library(testss2n STATIC ${TESTLIB_HEADERS} ${TESTLIB_SRC})
     target_include_directories(testss2n PUBLIC tests)
     target_compile_options(testss2n PRIVATE -std=gnu99)
     target_link_libraries(testss2n PUBLIC ${PROJECT_NAME})

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -15,6 +15,12 @@
 
 #pragma once
 
+#if ((__GNUC__ >= 4) || defined(__clang__)) && defined(S2N_EXPORTS)
+#    define S2N_API __attribute__((visibility("default")))
+#else
+#    define S2N_API
+#endif /* __GNUC__ >= 4 || defined(__clang__) */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -42,6 +48,7 @@ extern "C" {
 #define S2N_TLS13 34
 #define S2N_UNKNOWN_PROTOCOL_VERSION 0
 
+S2N_API
 extern __thread int s2n_errno;
 
 typedef enum {
@@ -55,17 +62,25 @@ typedef enum {
     S2N_ERR_T_USAGE
 } s2n_error_type;
 
+S2N_API
 extern int s2n_error_get_type(int error);
 
 struct s2n_config;
 struct s2n_connection;
 
+S2N_API
 extern unsigned long s2n_get_openssl_version(void);
+S2N_API
 extern int s2n_init(void);
+S2N_API
 extern int s2n_cleanup(void);
+S2N_API
 extern struct s2n_config *s2n_config_new(void);
+S2N_API
 extern int s2n_config_free(struct s2n_config *config);
+S2N_API
 extern int s2n_config_free_dhparams(struct s2n_config *config);
+S2N_API
 extern int s2n_config_free_cert_chain_and_key(struct s2n_config *config);
 
 typedef int (*s2n_clock_time_nanoseconds) (void *, uint64_t *);
@@ -73,23 +88,37 @@ typedef int (*s2n_cache_retrieve_callback) (struct s2n_connection *conn, void *,
 typedef int (*s2n_cache_store_callback) (struct s2n_connection *conn, void *, uint64_t ttl_in_seconds, const void *key, uint64_t key_size, const void *value, uint64_t value_size);
 typedef int (*s2n_cache_delete_callback) (struct s2n_connection *conn,  void *, const void *key, uint64_t key_size);
 
+S2N_API
 extern int s2n_config_set_wall_clock(struct s2n_config *config, s2n_clock_time_nanoseconds clock_fn, void *ctx);
+S2N_API
 extern int s2n_config_set_monotonic_clock(struct s2n_config *config, s2n_clock_time_nanoseconds clock_fn, void *ctx);
 
+S2N_API
 extern const char *s2n_strerror(int error, const char *lang);
+S2N_API
 extern const char *s2n_strerror_debug(int error, const char *lang);
+S2N_API
 extern const char *s2n_strerror_name(int error); 
 
 struct s2n_stacktrace;
+S2N_API
 extern bool s2n_stack_traces_enabled(void);
+S2N_API
 extern int s2n_stack_traces_enabled_set(bool newval);
+S2N_API
 extern int s2n_calculate_stacktrace(void);
+S2N_API
 extern int s2n_print_stacktrace(FILE *fptr);
+S2N_API
 extern int s2n_free_stacktrace(void);
+S2N_API
 extern int s2n_get_stacktrace(struct s2n_stacktrace *trace);
 
+S2N_API
 extern int s2n_config_set_cache_store_callback(struct s2n_config *config, s2n_cache_store_callback cache_store_callback, void *data);
+S2N_API
 extern int s2n_config_set_cache_retrieve_callback(struct s2n_config *config, s2n_cache_retrieve_callback cache_retrieve_callback, void *data);
+S2N_API
 extern int s2n_config_set_cache_delete_callback(struct s2n_config *config, s2n_cache_delete_callback cache_delete_callback, void *data);
 
 typedef int (*s2n_mem_init_callback)(void);
@@ -97,6 +126,7 @@ typedef int (*s2n_mem_cleanup_callback)(void);
 typedef int (*s2n_mem_malloc_callback)(void **ptr, uint32_t requested, uint32_t *allocated);
 typedef int (*s2n_mem_free_callback)(void *ptr, uint32_t size);
 
+S2N_API
 extern int s2n_mem_set_callbacks(s2n_mem_init_callback mem_init_callback, s2n_mem_cleanup_callback mem_cleanup_callback,
                                  s2n_mem_malloc_callback mem_malloc_callback, s2n_mem_free_callback mem_free_callback);
 
@@ -124,163 +154,272 @@ struct s2n_pkey;
 typedef struct s2n_pkey s2n_cert_public_key;
 typedef struct s2n_pkey s2n_cert_private_key;
 
+S2N_API
 extern struct s2n_cert_chain_and_key *s2n_cert_chain_and_key_new(void);
+S2N_API
 extern int s2n_cert_chain_and_key_load_pem(struct s2n_cert_chain_and_key *chain_and_key, const char *chain_pem, const char *private_key_pem);
+S2N_API
 extern int s2n_cert_chain_and_key_free(struct s2n_cert_chain_and_key *cert_and_key);
+S2N_API
 extern int s2n_cert_chain_and_key_set_ctx(struct s2n_cert_chain_and_key *cert_and_key, void *ctx);
+S2N_API
 extern void *s2n_cert_chain_and_key_get_ctx(struct s2n_cert_chain_and_key *cert_and_key);
+S2N_API
 extern s2n_cert_private_key *s2n_cert_chain_and_key_get_private_key(struct s2n_cert_chain_and_key *cert_and_key);
 
 typedef struct s2n_cert_chain_and_key* (*s2n_cert_tiebreak_callback) (struct s2n_cert_chain_and_key *cert1, struct s2n_cert_chain_and_key *cert2, uint8_t *name, uint32_t name_len);
+S2N_API
 extern int s2n_config_set_cert_tiebreak_callback(struct s2n_config *config, s2n_cert_tiebreak_callback cert_tiebreak_cb);
 
+S2N_API
 extern int s2n_config_add_cert_chain_and_key(struct s2n_config *config, const char *cert_chain_pem, const char *private_key_pem);
+S2N_API
 extern int s2n_config_add_cert_chain_and_key_to_store(struct s2n_config *config, struct s2n_cert_chain_and_key *cert_key_pair);
+S2N_API
 extern int s2n_config_set_cert_chain_and_key_defaults(struct s2n_config *config,
                                                       struct s2n_cert_chain_and_key **cert_key_pairs,
                                                       uint32_t num_cert_key_pairs);
 
+S2N_API
 extern int s2n_config_set_verification_ca_location(struct s2n_config *config, const char *ca_pem_filename, const char *ca_dir);
+S2N_API
 extern int s2n_config_add_pem_to_trust_store(struct s2n_config *config, const char *pem);
 
 typedef uint8_t (*s2n_verify_host_fn) (const char *host_name, size_t host_name_len, void *data);
 /* will be inherited by s2n_connection. If s2n_connection specifies a callback, that callback will be used for that connection. */
+S2N_API
 extern int s2n_config_set_verify_host_callback(struct s2n_config *config, s2n_verify_host_fn, void *data);
 
+S2N_API
 extern int s2n_config_set_check_stapled_ocsp_response(struct s2n_config *config, uint8_t check_ocsp);
+S2N_API
 extern int s2n_config_disable_x509_verification(struct s2n_config *config);
+S2N_API
 extern int s2n_config_set_max_cert_chain_depth(struct s2n_config *config, uint16_t max_depth);
 
+S2N_API
 extern int s2n_config_add_dhparams(struct s2n_config *config, const char *dhparams_pem);
+S2N_API
 extern int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *version);
+S2N_API
 extern int s2n_config_set_protocol_preferences(struct s2n_config *config, const char * const *protocols, int protocol_count);
 typedef enum { S2N_STATUS_REQUEST_NONE = 0, S2N_STATUS_REQUEST_OCSP = 1 } s2n_status_request_type;
+S2N_API
 extern int s2n_config_set_status_request_type(struct s2n_config *config, s2n_status_request_type type);
 typedef enum { S2N_CT_SUPPORT_NONE = 0, S2N_CT_SUPPORT_REQUEST = 1 } s2n_ct_support_level;
+S2N_API
 extern int s2n_config_set_ct_support_level(struct s2n_config *config, s2n_ct_support_level level);
 typedef enum { S2N_ALERT_FAIL_ON_WARNINGS = 0, S2N_ALERT_IGNORE_WARNINGS = 1 } s2n_alert_behavior;
+S2N_API
 extern int s2n_config_set_alert_behavior(struct s2n_config *config, s2n_alert_behavior alert_behavior);
+S2N_API
 extern int s2n_config_set_extension_data(struct s2n_config *config, s2n_tls_extension_type type, const uint8_t *data, uint32_t length);
+S2N_API
 extern int s2n_config_send_max_fragment_length(struct s2n_config *config, s2n_max_frag_len mfl_code);
+S2N_API
 extern int s2n_config_accept_max_fragment_length(struct s2n_config *config);
 
+S2N_API
 extern int s2n_config_set_session_state_lifetime(struct s2n_config *config, uint64_t lifetime_in_secs);
 
+S2N_API
 extern int s2n_config_set_session_tickets_onoff(struct s2n_config *config, uint8_t enabled);
+S2N_API
 extern int s2n_config_set_session_cache_onoff(struct s2n_config *config, uint8_t enabled);
+S2N_API
 extern int s2n_config_set_ticket_encrypt_decrypt_key_lifetime(struct s2n_config *config, uint64_t lifetime_in_secs);
+S2N_API
 extern int s2n_config_set_ticket_decrypt_key_lifetime(struct s2n_config *config, uint64_t lifetime_in_secs);
+S2N_API
 extern int s2n_config_add_ticket_crypto_key(struct s2n_config *config,
                                             const uint8_t *name, uint32_t name_len,
                                             uint8_t *key, uint32_t key_len,
                                             uint64_t intro_time_in_seconds_from_epoch);
 
 typedef enum { S2N_SERVER, S2N_CLIENT } s2n_mode;
+S2N_API
 extern struct s2n_connection *s2n_connection_new(s2n_mode mode);
+S2N_API
 extern int s2n_connection_set_config(struct s2n_connection *conn, struct s2n_config *config);
 
+S2N_API
 extern int s2n_connection_set_ctx(struct s2n_connection *conn, void *ctx);
+S2N_API
 extern void *s2n_connection_get_ctx(struct s2n_connection *conn);
 
 typedef int s2n_client_hello_fn(struct s2n_connection *conn, void *ctx);
+S2N_API
 extern int s2n_config_set_client_hello_cb(struct s2n_config *config, s2n_client_hello_fn client_hello_callback, void *ctx);
 
 struct s2n_client_hello;
+S2N_API
 extern struct s2n_client_hello *s2n_connection_get_client_hello(struct s2n_connection *conn);
+S2N_API
 extern ssize_t s2n_client_hello_get_raw_message_length(struct s2n_client_hello *ch);
+S2N_API
 extern ssize_t s2n_client_hello_get_raw_message(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);
+S2N_API
 extern ssize_t s2n_client_hello_get_cipher_suites_length(struct s2n_client_hello *ch);
+S2N_API
 extern ssize_t s2n_client_hello_get_cipher_suites(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);
+S2N_API
 extern ssize_t s2n_client_hello_get_extensions_length(struct s2n_client_hello *ch);
+S2N_API
 extern ssize_t s2n_client_hello_get_extensions(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);
+S2N_API
 extern ssize_t s2n_client_hello_get_extension_length(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type);
+S2N_API
 extern ssize_t s2n_client_hello_get_extension_by_id(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type, uint8_t *out, uint32_t max_length);
 
+S2N_API
 extern int s2n_connection_set_fd(struct s2n_connection *conn, int fd);
+S2N_API
 extern int s2n_connection_set_read_fd(struct s2n_connection *conn, int readfd);
+S2N_API
 extern int s2n_connection_set_write_fd(struct s2n_connection *conn, int writefd);
+S2N_API
 extern int s2n_connection_use_corked_io(struct s2n_connection *conn);
 
 typedef int s2n_recv_fn(void *io_context, uint8_t *buf, uint32_t len);
 typedef int s2n_send_fn(void *io_context, const uint8_t *buf, uint32_t len);
+S2N_API
 extern int s2n_connection_set_recv_ctx(struct s2n_connection *conn, void *ctx);
+S2N_API
 extern int s2n_connection_set_send_ctx(struct s2n_connection *conn, void *ctx);
+S2N_API
 extern int s2n_connection_set_recv_cb(struct s2n_connection *conn, s2n_recv_fn recv);
+S2N_API
 extern int s2n_connection_set_send_cb(struct s2n_connection *conn, s2n_send_fn send);
 
+S2N_API
 extern int s2n_connection_prefer_throughput(struct s2n_connection *conn);
+S2N_API
 extern int s2n_connection_prefer_low_latency(struct s2n_connection *conn);
+S2N_API
 extern int s2n_connection_set_dynamic_record_threshold(struct s2n_connection *conn, uint32_t resize_threshold, uint16_t timeout_threshold);
 
 /* If you don't want to use the configuration wide callback, you can set this per connection and it will be honored. */
+S2N_API
 extern int s2n_connection_set_verify_host_callback(struct s2n_connection *config, s2n_verify_host_fn host_fn, void *data);
 
 typedef enum { S2N_BUILT_IN_BLINDING, S2N_SELF_SERVICE_BLINDING } s2n_blinding;
+S2N_API
 extern int s2n_connection_set_blinding(struct s2n_connection *conn, s2n_blinding blinding);
+S2N_API
 extern uint64_t s2n_connection_get_delay(struct s2n_connection *conn);
 
+S2N_API
 extern int s2n_connection_set_cipher_preferences(struct s2n_connection *conn, const char *version);
+S2N_API
 extern int s2n_connection_set_protocol_preferences(struct s2n_connection *conn, const char * const *protocols, int protocol_count);
+S2N_API
 extern int s2n_set_server_name(struct s2n_connection *conn, const char *server_name);
+S2N_API
 extern const char *s2n_get_server_name(struct s2n_connection *conn);
+S2N_API
 extern const char *s2n_get_application_protocol(struct s2n_connection *conn);
+S2N_API
 extern const uint8_t *s2n_connection_get_ocsp_response(struct s2n_connection *conn, uint32_t *length);
+S2N_API
 extern const uint8_t *s2n_connection_get_sct_list(struct s2n_connection *conn, uint32_t *length);
 
 typedef enum { S2N_NOT_BLOCKED = 0, S2N_BLOCKED_ON_READ, S2N_BLOCKED_ON_WRITE, S2N_BLOCKED_ON_APPLICATION_INPUT } s2n_blocked_status;
+S2N_API
 extern int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status *blocked);
+S2N_API
 extern ssize_t s2n_send(struct s2n_connection *conn, const void *buf, ssize_t size, s2n_blocked_status *blocked);
+S2N_API
 extern ssize_t s2n_sendv(struct s2n_connection *conn, const struct iovec *bufs, ssize_t count, s2n_blocked_status *blocked);
+S2N_API
 extern ssize_t s2n_sendv_with_offset(struct s2n_connection *conn, const struct iovec *bufs, ssize_t count, ssize_t offs, s2n_blocked_status *blocked);
+S2N_API
 extern ssize_t s2n_recv(struct s2n_connection *conn,  void *buf, ssize_t size, s2n_blocked_status *blocked);
+S2N_API
 extern uint32_t s2n_peek(struct s2n_connection *conn);
 
+S2N_API
 extern int s2n_connection_free_handshake(struct s2n_connection *conn);
+S2N_API
 extern int s2n_connection_release_buffers(struct s2n_connection *conn);
+S2N_API
 extern int s2n_connection_wipe(struct s2n_connection *conn);
+S2N_API
 extern int s2n_connection_free(struct s2n_connection *conn);
+S2N_API
 extern int s2n_shutdown(struct s2n_connection *conn, s2n_blocked_status *blocked);
 
 typedef enum { S2N_CERT_AUTH_NONE, S2N_CERT_AUTH_REQUIRED, S2N_CERT_AUTH_OPTIONAL } s2n_cert_auth_type;
 
+S2N_API
 extern int s2n_config_get_client_auth_type(struct s2n_config *config, s2n_cert_auth_type *client_auth_type);
+S2N_API
 extern int s2n_config_set_client_auth_type(struct s2n_config *config, s2n_cert_auth_type client_auth_type);
+S2N_API
 extern int s2n_connection_get_client_auth_type(struct s2n_connection *conn, s2n_cert_auth_type *client_auth_type);
+S2N_API
 extern int s2n_connection_set_client_auth_type(struct s2n_connection *conn, s2n_cert_auth_type client_auth_type);
+S2N_API
 extern int s2n_connection_get_client_cert_chain(struct s2n_connection *conn, uint8_t **der_cert_chain_out, uint32_t *cert_chain_len);
 
+S2N_API
 extern int s2n_connection_set_session(struct s2n_connection *conn, const uint8_t *session, size_t length);
+S2N_API
 extern int s2n_connection_get_session(struct s2n_connection *conn, uint8_t *session, size_t max_length);
+S2N_API
 extern int s2n_connection_get_session_ticket_lifetime_hint(struct s2n_connection *conn);
+S2N_API
 extern int s2n_connection_get_session_length(struct s2n_connection *conn);
+S2N_API
 extern int s2n_connection_get_session_id_length(struct s2n_connection *conn);
+S2N_API
 extern int s2n_connection_get_session_id(struct s2n_connection *conn, uint8_t *session_id, size_t max_length);
+S2N_API
 extern int s2n_connection_is_session_resumed(struct s2n_connection *conn);
+S2N_API
 extern int s2n_connection_is_ocsp_stapled(struct s2n_connection *conn);
 
+S2N_API
 extern struct s2n_cert_chain_and_key *s2n_connection_get_selected_cert(struct s2n_connection *conn);
 
+S2N_API
 extern uint64_t s2n_connection_get_wire_bytes_in(struct s2n_connection *conn);
+S2N_API
 extern uint64_t s2n_connection_get_wire_bytes_out(struct s2n_connection *conn);
+S2N_API
 extern int s2n_connection_get_client_protocol_version(struct s2n_connection *conn);
+S2N_API
 extern int s2n_connection_get_server_protocol_version(struct s2n_connection *conn);
+S2N_API
 extern int s2n_connection_get_actual_protocol_version(struct s2n_connection *conn);
+S2N_API
 extern int s2n_connection_get_client_hello_version(struct s2n_connection *conn);
+S2N_API
 extern int s2n_connection_client_cert_used(struct s2n_connection *conn);
+S2N_API
 extern const char *s2n_connection_get_cipher(struct s2n_connection *conn);
+S2N_API
 extern int s2n_connection_is_valid_for_cipher_preferences(struct s2n_connection *conn, const char *version);
+S2N_API
 extern const char *s2n_connection_get_curve(struct s2n_connection *conn);
+S2N_API
 extern const char *s2n_connection_get_kem_name(struct s2n_connection *conn);
+S2N_API
 extern int s2n_connection_get_alert(struct s2n_connection *conn);
+S2N_API
 extern const char *s2n_connection_get_handshake_type_name(struct s2n_connection *conn);
+S2N_API
 extern const char *s2n_connection_get_last_message_name(struct s2n_connection *conn);
 
 struct s2n_async_pkey_op;
 
 typedef int (*s2n_async_pkey_fn)(struct s2n_connection *conn, struct s2n_async_pkey_op *op);
+S2N_API
 extern int s2n_config_set_async_pkey_callback(struct s2n_config *config, s2n_async_pkey_fn fn);
+S2N_API
 extern int s2n_async_pkey_op_perform(struct s2n_async_pkey_op *op, s2n_cert_private_key *key);
+S2N_API
 extern int s2n_async_pkey_op_apply(struct s2n_async_pkey_op *op, struct s2n_connection *conn);
+S2N_API
 extern int s2n_async_pkey_op_free(struct s2n_async_pkey_op *op);
 
 #ifdef __cplusplus

--- a/bin/Makefile
+++ b/bin/Makefile
@@ -17,7 +17,7 @@
 all: s2nc s2nd
 include ../s2n.mk
 
-LDFLAGS += -L../lib/ -L${LIBCRYPTO_ROOT}/lib -ls2n ${LIBS} ${CRYPTO_LIBS}
+LDFLAGS += -L../lib/ -L${LIBCRYPTO_ROOT}/lib ../lib/libs2n.a ${CRYPTO_LIBS} ${LIBS}
 CRUFT += s2nc s2nd
 
 s2nc: s2nc.c echo.c

--- a/s2n.mk
+++ b/s2n.mk
@@ -10,13 +10,13 @@
 #
 
 ifeq ($(PLATFORM),Darwin)
-    LIBS = -lc -lpthread
+    LIBS = -lc -pthread
 else ifeq ($(PLATFORM),FreeBSD)
     LIBS = -lthr
 else ifeq ($(PLATFORM),NetBSD)
-    LIBS = -lpthread
+    LIBS = -pthread
 else
-    LIBS = -lpthread -ldl -lrt
+    LIBS = -pthread -ldl -lrt
 endif
 
 CRYPTO_LIBS = -lcrypto
@@ -43,7 +43,7 @@ DEFAULT_CFLAGS += -pedantic -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-s
                  -Wshadow  -Wcast-align -Wwrite-strings -fPIC -Wno-missing-braces\
                  -D_POSIX_C_SOURCE=200809L -O2 -I$(LIBCRYPTO_ROOT)/include/ \
                  -I$(S2N_ROOT)/api/ -I$(S2N_ROOT) -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security \
-                 -D_FORTIFY_SOURCE=2 -fgnu89-inline 
+                 -D_FORTIFY_SOURCE=2 -fgnu89-inline -fvisibility=hidden -DS2N_EXPORTS
 
 COVERAGE_CFLAGS = -fprofile-arcs -ftest-coverage
 COVERAGE_LDFLAGS = --coverage
@@ -145,6 +145,15 @@ ifeq ($(S2N_UNSAFE_FUZZING_MODE),1)
     # Turn on debugging and fuzzing flags when S2N_UNSAFE_FUZZING_MODE is enabled to give detailed stack traces in case
     # an error occurs while fuzzing.
     CFLAGS += ${DEFAULT_CFLAGS} ${DEBUG_CFLAGS} ${FUZZ_CFLAGS}
+
+    # Filter out the visibility settings if we are fuzzing
+    CFLAGS := $(filter-out -fvisibility=hidden,$(CFLAGS))
+    CFLAGS := $(filter-out -DS2N_EXPORTS,$(CFLAGS))
+    DEFAULT_CFLAGS := $(filter-out -fvisibility=hidden,$(DEFAULT_CFLAGS))
+    DEFAULT_CFLAGS := $(filter-out -DS2N_EXPORTS,$(DEFAULT_CFLAGS))
+    CPPFLAGS := $(filter-out -fvisibility=hidden,$(CPPFLAGS))
+    CPPFLAGS := $(filter-out -DS2N_EXPORTS,$(CPPFLAGS))
+
 endif
 
 # If COV_TOOL isn't set, pick a default COV_TOOL depending on if the LLVM Marker File was created.

--- a/tests/benchmark/Makefile
+++ b/tests/benchmark/Makefile
@@ -32,7 +32,7 @@ all: $(BM_TESTS)
 include ../../s2n.mk
 
 CRUFT += $(wildcard *_benchmark)
-LIBS += -L../testlib/ -ltests2n -L../../lib/ -ls2n
+LIBS += ../testlib/libtests2n.a ../../lib/libs2n.a
 
 # Suppress the unreachable code warning, because tests involve what should be
 # unreachable code
@@ -41,8 +41,8 @@ LDFLAGS += ${CRYPTO_LDFLAGS} ${LIBS} ${CRYPTO_LIBS} ${BENCHMARK_LDFLAGS} -lm -ld
 
 $(BM_TESTS)::
 	${CXX} ${CPPFLAGS} -o $@ $@.cc ${LDFLAGS} 2>&1
-	@DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" \
-	LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
+	@DYLD_LIBRARY_PATH="$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" \
+	LD_LIBRARY_PATH="$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
 	./$@
 
 .PHONY : clean

--- a/tests/fuzz/Makefile
+++ b/tests/fuzz/Makefile
@@ -36,10 +36,11 @@ all : run_tests
 include ../../s2n.mk
 
 CRUFT += $(wildcard *_test) $(wildcard fuzz-*.log) $(wildcard *_test_output.txt) $(wildcard *_test_results.txt) $(wildcard LD_PRELOAD/*.so) $(wildcard *.prof*)
-LIBS += -lm -ltests2n
 
 CFLAGS += -Wno-unreachable-code -O0 -I$(LIBCRYPTO_ROOT)/include/ -I../
-LDFLAGS += $(LIBFUZZER_ROOT)/lib/libFuzzer.a -lstdc++ -L../../lib/ ${CRYPTO_LDFLAGS} -L../testlib/ -ls2n ${LIBS} ${CRYPTO_LIBS} -L../testlib/
+LIBS += -L../testlib/ -ltests2n -L../../lib/ -ls2n
+LDFLAGS += $(LIBFUZZER_ROOT)/lib/libFuzzer.a -lstdc++
+LDFLAGS += ${CRYPTO_LDFLAGS} ${LIBS} ${CRYPTO_LIBS} -lm -ldl -lrt -pthread
 
 DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH"
 LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH"

--- a/tests/testlib/Makefile
+++ b/tests/testlib/Makefile
@@ -18,15 +18,20 @@ OBJS=$(SRCS:.c=.o)
 CRYPTO_LDFLAGS = -L$(LIBCRYPTO_ROOT)/lib
 
 .PHONY : all
-all: libtests2n.so libtests2n.dylib
+all: libtests2n.a libtests2n.so libtests2n.dylib
 
 include ../../s2n.mk
 
 CFLAGS += -I../
-LDFLAGS += -L../../lib/ ${CRYPTO_LDFLAGS} -lcrypto -lpthread -ls2n
+LIBS += ../../lib/libs2n.a
+LDFLAGS += ${CRYPTO_LDFLAGS} ${LIBS} ${CRYPTO_LIBS} -lm -ldl -lrt -pthread
 
 libtests2n.so: ${OBJS}
 	${CC} ${CFLAGS} -shared ${LDFLAGS} -o libtests2n.so ${OBJS}
 
 libtests2n.dylib: ${OBJS}
 	test ! -f /usr/lib/libSystem.dylib || libtool ${LDFLAGS} -dynamic -o libtests2n.dylib ${OBJS}
+
+libtests2n.a: ${OBJS}
+	$(AR) cru libtests2n.a ${OBJS}
+	$(RANLIB) libtests2n.a

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -32,32 +32,32 @@ all: $(UNIT_TESTS)
 include ../../s2n.mk
 
 CRUFT += $(wildcard *_test)
-LIBS += -lm -ltests2n -ls2n -ldl
+LIBS += ../testlib/libtests2n.a ../../lib/libs2n.a
 
 # Suppress the unreachable code warning, because tests involve what should be
 # unreachable code
 CFLAGS += -Wno-unreachable-code -I../
-LDFLAGS += -L../../lib/ ${CRYPTO_LDFLAGS} -L../testlib/ ${LIBS} ${CRYPTO_LIBS}
+LDFLAGS += ${CRYPTO_LDFLAGS} ${LIBS} ${CRYPTO_LIBS} -lm -ldl
 
 ifdef S2N_ADDRESS_SANITIZER
 $(UNIT_TESTS)::
 	@${CC} ${CFLAGS} -o $@ $@.c ${LDFLAGS} 2>&1
-	@DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" \
-	LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
+	@DYLD_LIBRARY_PATH="$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" \
+	LD_LIBRARY_PATH="$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
 	./$@
 else
 $(UNIT_TESTS)::
 	@${CC} ${CFLAGS} -o $@ $@.c ${LDFLAGS} 2>&1
-	@DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" \
-	LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
+	@DYLD_LIBRARY_PATH="$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" \
+	LD_LIBRARY_PATH="$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
 	LD_PRELOAD="../LD_PRELOAD/allocator_overrides.so" \
 	./$@
 endif
 
 $(VALGRIND_TESTS)::
 	@${CC} ${CFLAGS} -o $(@:.valgrind=) $(@:.valgrind=.c) ${LDFLAGS} 2>&1
-	@DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" \
-	LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
+	@DYLD_LIBRARY_PATH="$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" \
+	LD_LIBRARY_PATH="$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
 	S2N_VALGRIND=1 \
 	valgrind --leak-check=full --run-libc-freeres=no -q --error-exitcode=9 --gen-suppressions=all --log-fd=2 --num-callers=40 --leak-resolution=high --undef-value-errors=no --trace-children=yes --suppressions=valgrind.suppressions \
 	./$(@:.valgrind=)

--- a/tests/viz/Makefile
+++ b/tests/viz/Makefile
@@ -18,7 +18,7 @@ all: build_viz
 
 include ../../s2n.mk
 
-LDFLAGS += -L../../lib ${LIBS} -ls2n -L$(LIBCRYPTO_ROOT)/lib ${CRYPTO_LIBS}
+LDFLAGS += ../../lib/libs2n.a -L$(LIBCRYPTO_ROOT)/lib ${CRYPTO_LIBS} ${LIBS}
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
@@ -32,8 +32,8 @@ endif
 build_viz::
 	${CC} ${CFLAGS} -o s2n_state_machine_viz s2n_state_machine_viz.c ${LDFLAGS}
 	@[ "${STATE_MACHINE_GRAPHS}" ] && \
-	DYLD_LIBRARY_PATH="../../lib:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" \
-	LD_LIBRARY_PATH="../../lib:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
+	DYLD_LIBRARY_PATH="$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" \
+	LD_LIBRARY_PATH="$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
 	./s2n_state_machine_viz || true
 
 .PHONY : clean

--- a/tls/s2n_tls13.h
+++ b/tls/s2n_tls13.h
@@ -15,14 +15,26 @@
 
 #pragma once
 
+#include "api/s2n.h"
 #include "tls/s2n_crypto.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+S2N_API
+extern int s2n_enable_tls13();
+
+#ifdef __cplusplus
+}
+#endif
+
 
 /* from RFC: https://tools.ietf.org/html/rfc8446#section-4.1.3*/
 extern uint8_t hello_retry_req_random[S2N_TLS_RANDOM_DATA_LEN];
 
 int s2n_is_tls13_supported();
 int s2n_is_tls13_enabled();
-int s2n_enable_tls13();
 int s2n_disable_tls13();
 bool s2n_is_valid_tls13_cipher(const uint8_t version[2]);
 


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

This change sets the default symbol visibility to hidden. The APIs which are to be exported are marked with `S2N_API` such that they are attributed with default visibility.

### Call-outs:

To facilitate this change all tests are now linked to the static library in order to access the internals of s2n.

`s2nc` and `s2nd` are also linked to the static lib as they access private internals.

when running fuzz testing, the previous behavior (default visibility) is used as fuzz testing relies on the `LD_PRELOAD` trick to subvert some s2n APIs.  When statically linking with s2n this doesn't work as the symbols are resolved at link time.

### Testing:

Existing test suites should pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
