### PR TITLE
Add test to verify all handshakes are middlebox compatible

### DIFF
--- a/tests/unit/s2n_tls13_state_machine_handshake_test.c
+++ b/tests/unit/s2n_tls13_state_machine_handshake_test.c
@@ -399,12 +399,12 @@ int main(int argc, char **argv)
 
         /* Test: "If not offering early data, the client sends a dummy change_cipher_spec record immediately before
          *       its second flight. This may either be before its second ClientHello or before its encrypted handshake flight." */
-        for (int i = 0; i < valid_tls13_handshakes_size; i++) {
+        for (size_t i = 0; i < valid_tls13_handshakes_size; i++) {
             change_cipher_spec_found = false;
             handshake_type = valid_tls13_handshakes[i];
             messages = tls13_handshakes[handshake_type];
 
-            for (int j = 1; j < S2N_MAX_HANDSHAKE_LENGTH; j++) {
+            for (size_t j = 1; j < S2N_MAX_HANDSHAKE_LENGTH; j++) {
 
                 /* Ignore initial handshakes */
                 if (!IS_NEGOTIATED(handshake_type)) {
@@ -437,12 +437,12 @@ int main(int argc, char **argv)
 
         /* Test: "The server sends a dummy change_cipher_spec record immediately after its first handshake message.
          *       This may either be after a ServerHello or a HelloRetryRequest." */
-        for (int i = 0; i < valid_tls13_handshakes_size; i++) {
+        for (size_t i = 0; i < valid_tls13_handshakes_size; i++) {
             change_cipher_spec_found = false;
             handshake_type = valid_tls13_handshakes[i];
             messages = tls13_handshakes[handshake_type];
 
-            for (int j = 1; j < S2N_MAX_HANDSHAKE_LENGTH; j++) {
+            for (size_t j = 1; j < S2N_MAX_HANDSHAKE_LENGTH; j++) {
 
                 /* Ignore initial handshakes */
                 if (!IS_NEGOTIATED(handshake_type)) {

--- a/tests/unit/s2n_tls13_state_machine_handshake_test.c
+++ b/tests/unit/s2n_tls13_state_machine_handshake_test.c
@@ -257,7 +257,7 @@ int main(int argc, char **argv)
 
                 EXPECT_SUCCESS(s2n_handshake_read_io(conn));
 
-                if (tls13_handshakes[i][j] == SERVER_CHANGE_CIPHER_SPEC) {
+                if (tls13_handshakes[handshake][j] == SERVER_CHANGE_CIPHER_SPEC) {
                     EXPECT_EQUAL(conn->handshake.message_number, j + 1);
                 } else {
                     EXPECT_EQUAL(conn->handshake.message_number, j);
@@ -298,7 +298,7 @@ int main(int argc, char **argv)
 
                 EXPECT_SUCCESS(s2n_handshake_read_io(conn));
 
-                if (tls13_handshakes[i][j] == CLIENT_CHANGE_CIPHER_SPEC) {
+                if (tls13_handshakes[handshake][j] == CLIENT_CHANGE_CIPHER_SPEC) {
                     EXPECT_EQUAL(conn->handshake.message_number, j + 1);
                 } else {
                     EXPECT_EQUAL(conn->handshake.message_number, j);


### PR DESCRIPTION
### Resolved issues:

 resolves #1823 

### Description of changes: 

Our SAW proofs used to verify that we matched the RFC state machine. The most common mistake they caught was the CCS messages appearing in the wrong place, or not appearing at all. Now that the SAW proofs are disabled for TLS1.3, nothing is verifying middlebox compatibility.

This PR adds a unit test to close that testing gap and verify that all TLS1.3 handshakes match the RFC's CCS message rules.

### Call-outs:

**Were the existing tests broken before?** Despite appearances, no. Our tls13_handshakes array contains a list of messages for every handshake type, even the ones we haven't actually explicitly set a list of messages for. These unused handshake types are assigned an  "empty" message list that's just [client_hello, client_hello, ... client_hello]. The old tests were supposed to filter out those "empty" handshakes for sanity, but didn't due to a bug in identifying the "empty" handshakes. However, the old tests actually ran fine against the "empty handshakes". The old tests really just cared that CCS messages could be received anywhere in a handshake, regardless of the contents of the handshake. However, the new tests DO fail for the "empty" handshakes, because they expect the CCS messages to be part of the message list (as required for middlebox compatibility). Therefore, I had to fix the "filter out empty handshakes" logic.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
