### PR TITLE
s2n_config_set_security_policy and s2n_connection_set_security_policy

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -153,6 +153,7 @@ extern int s2n_config_set_max_cert_chain_depth(struct s2n_config *config, uint16
 
 extern int s2n_config_add_dhparams(struct s2n_config *config, const char *dhparams_pem);
 extern int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *version);
+extern int s2n_config_set_security_policy(struct s2n_config *config, const char *version);
 extern int s2n_config_set_protocol_preferences(struct s2n_config *config, const char * const *protocols, int protocol_count);
 typedef enum { S2N_STATUS_REQUEST_NONE = 0, S2N_STATUS_REQUEST_OCSP = 1 } s2n_status_request_type;
 extern int s2n_config_set_status_request_type(struct s2n_config *config, s2n_status_request_type type);
@@ -220,6 +221,7 @@ extern int s2n_connection_set_blinding(struct s2n_connection *conn, s2n_blinding
 extern uint64_t s2n_connection_get_delay(struct s2n_connection *conn);
 
 extern int s2n_connection_set_cipher_preferences(struct s2n_connection *conn, const char *version);
+extern int s2n_connection_set_security_policy(struct s2n_connection *conn, const char *version);
 extern int s2n_connection_set_protocol_preferences(struct s2n_connection *conn, const char * const *protocols, int protocol_count);
 extern int s2n_set_server_name(struct s2n_connection *conn, const char *server_name);
 extern const char *s2n_get_server_name(struct s2n_connection *conn);

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -372,9 +372,9 @@ This string is useful to include when reporting issues to the s2n development te
 Example:
 
 ```
-if (s2n_config_set_cipher_preferences(config, prefs) < 0) {
-    printf("Setting cipher prefs failed! %s : %s", s2n_strerror(s2n_errno, "EN"), s2n_strerror_debug(s2n_errno, "EN"));
-    return -1;
+if (s2n_config_set_security_policy(config, prefs) < 0) {
+    printf("Setting security policy failed! %s : %s", s2n_strerror(s2n_errno, "EN"), s2n_strerror_debug(s2n_errno, "EN"));
+    return S2N_FAILURE;
 }
 ```
 
@@ -492,6 +492,18 @@ int s2n_config_free(struct s2n_config *config);
 ```
 
 **s2n_config_free** frees the memory associated with an **s2n_config** object.
+
+### s2n\_config\_set\_security\_policy
+
+```c
+int s2n_config_set_security_policy(struct s2n_config *config,
+                                      const char *version);
+```
+
+**s2n_config_set_security_policy** S2N makes opinionated decisions about which ciphers,
+key encapsualtion mechanisms, signature algorithms, and curves can be used together. These
+combinations are called *security policies*. This function is simply a wrapper for
+*s2n_config_set_cipher_preferences*. The name better describes the behavior behind the scenes.
 
 ### s2n\_config\_set\_cipher\_preferences
 
@@ -1030,6 +1042,18 @@ is supported by a given cipher preferences. It returns
 -  1 if the connection satisfies the cipher suite 
 -  0 if it does not
 - -1 on any other errors
+
+
+### s2n\_connection\_set\_security\_policy
+
+```c
+int s2n_connection_set_security_policy(struct s2n_connection *conn, const char *version);
+```
+
+**s2n_connection_set_security_policy** sets the security policy override for the
+s2n_connection. Calling this function is not necessary unless you want to set the
+security policy on the connection to something different than what is in the s2n_config.
+This function is a wrapper for **s2n_connection_set_cipher_preferences**.
 
 
 ### s2n\_connection\_set\_cipher\_preferences

--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -270,7 +270,7 @@ int main(int argc, char **argv)
         struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
         s2n_connection_set_config(conn, config);
 
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default"));
+        EXPECT_SUCCESS(s2n_connection_set_security_policy(conn, "default"));
         EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
         EXPECT_EQUAL(security_policy, &security_policy_20170210);
         EXPECT_EQUAL(security_policy->cipher_preferences, &cipher_preferences_20170210);
@@ -278,7 +278,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(security_policy->signature_preferences, &s2n_signature_preferences_20140601);
         EXPECT_EQUAL(security_policy->ecc_preferences, &s2n_ecc_preferences_20140601);
 
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "20170210"));
+        EXPECT_SUCCESS(s2n_connection_set_security_policy(conn, "20170210"));
         EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
         EXPECT_EQUAL(security_policy, &security_policy_20170210);
         EXPECT_EQUAL(security_policy->cipher_preferences, &cipher_preferences_20170210);
@@ -286,7 +286,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(security_policy->signature_preferences, &s2n_signature_preferences_20140601);
         EXPECT_EQUAL(security_policy->ecc_preferences, &s2n_ecc_preferences_20140601);
 
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default_tls13"));
+        EXPECT_SUCCESS(s2n_connection_set_security_policy(conn, "default_tls13"));
         EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
         EXPECT_EQUAL(security_policy, &security_policy_20190801);
         EXPECT_EQUAL(security_policy->cipher_preferences, &cipher_preferences_20190801);
@@ -294,7 +294,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(security_policy->signature_preferences, &s2n_signature_preferences_20200207);
         EXPECT_EQUAL(security_policy->ecc_preferences, &s2n_ecc_preferences_20200310);
 
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "20190801"));
+        EXPECT_SUCCESS(s2n_connection_set_security_policy(conn, "20190801"));
         EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
         EXPECT_EQUAL(security_policy, &security_policy_20190801);
         EXPECT_EQUAL(security_policy->cipher_preferences, &cipher_preferences_20190801);
@@ -302,7 +302,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(security_policy->signature_preferences, &s2n_signature_preferences_20200207);
         EXPECT_EQUAL(security_policy->ecc_preferences, &s2n_ecc_preferences_20200310);
 
-        EXPECT_FAILURE_WITH_ERRNO(s2n_connection_set_cipher_preferences(conn, "notathing"),
+        EXPECT_FAILURE_WITH_ERRNO(s2n_connection_set_security_policy(conn, "notathing"),
                 S2N_ERR_INVALID_SECURITY_POLICY);
 
         s2n_config_free(config);

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -535,6 +535,11 @@ int s2n_find_security_policy_from_version(const char *version, const struct s2n_
     S2N_ERROR(S2N_ERR_INVALID_SECURITY_POLICY);
 }
 
+int s2n_config_set_security_policy(struct s2n_config *config, const char *version)
+{
+    return s2n_config_set_cipher_preferences(config, version);
+}
+
 int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *version)
 {
     GUARD(s2n_find_security_policy_from_version(version, &config->security_policy));
@@ -542,7 +547,12 @@ int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *ver
     notnull_check(&config->security_policy->kem_preferences);
     notnull_check(&config->security_policy->signature_preferences);
     notnull_check(&config->security_policy->ecc_preferences);
-    return 0;
+    return S2N_SUCCESS;
+}
+
+int s2n_connection_set_security_policy(struct s2n_connection *conn, const char *version)
+{
+    return s2n_connection_set_cipher_preferences(conn, version);
 }
 
 int s2n_connection_set_cipher_preferences(struct s2n_connection *conn, const char *version)
@@ -552,7 +562,7 @@ int s2n_connection_set_cipher_preferences(struct s2n_connection *conn, const cha
     notnull_check(&conn->security_policy_override->kem_preferences);
     notnull_check(&conn->security_policy_override->signature_preferences);
     notnull_check(&conn->security_policy_override->ecc_preferences);
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_security_policies_init()


### PR DESCRIPTION
### Resolved issues:

 resolves #2079

### Description of changes: 

Add new APIs, s2n_config_set_security_policy and s2n_connection_set_security_policy.

 * Update usage guide
 * Update security policy unit tests to use the new setter

### Call-outs:

This API simply wraps s2n_{config, connection}_set_cipher_preferences. Calling this function makes it clear what is happening behind the scenes (security policy change) opposed to setting only cipher preferences.

### Testing:

Unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
