### PR TITLE
Remove deprecated methods for encrypted_extensions extensions

### DIFF
--- a/tests/unit/s2n_encrypted_extensions_test.c
+++ b/tests/unit/s2n_encrypted_extensions_test.c
@@ -19,6 +19,7 @@
 #include "tls/s2n_tls.h"
 #include "tls/s2n_tls13.h"
 
+#include "tls/extensions/s2n_extension_type.h"
 #include "tls/extensions/s2n_server_alpn.h"
 #include "tls/extensions/s2n_server_max_fragment_length.h"
 #include "tls/extensions/s2n_server_server_name.h"
@@ -33,175 +34,143 @@ int main(int argc, char **argv)
     BEGIN_TEST();
 
     EXPECT_SUCCESS(s2n_enable_tls13());
-    uint8_t latest_version = S2N_TLS13;
 
-    struct s2n_config *config;
-    EXPECT_NOT_NULL(config = s2n_config_new());
-
-    const uint8_t ENCRYPTED_EXTENSIONS_HEADER_SIZE = 2;
-
-    /* Server successfully sends empty encrypted extension */
+    /* Test s2n_encrypted_extensions_send */
     {
-        struct s2n_connection *server_conn;
-        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        /* Safety checks */
+        EXPECT_FAILURE(s2n_encrypted_extensions_send(NULL));
 
-        const uint8_t encrypted_extensions_expected_size = 2;
-        const uint16_t encrypted_extensions_expected_length = 0;
+        /* Should fail for pre-TLS1.3 */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(conn));
 
-        /* Fail sending because encrypted extensions requires TLS 1.3 */
-        EXPECT_FAILURE_WITH_ERRNO(s2n_encrypted_extensions_send(server_conn), S2N_ERR_BAD_MESSAGE);
+            /* Fails for TLS1.2 */
+            conn->actual_protocol_version = S2N_TLS12;
+            EXPECT_FAILURE_WITH_ERRNO(s2n_encrypted_extensions_send(conn), S2N_ERR_BAD_MESSAGE);
 
-        /* Send success because encrypted extensions requires TLS 1.3 */
-        server_conn->actual_protocol_version = S2N_TLS13;
-        EXPECT_SUCCESS(s2n_encrypted_extensions_send(server_conn));
-        EXPECT_EQUAL(s2n_stuffer_data_available(&server_conn->handshake.io), ENCRYPTED_EXTENSIONS_HEADER_SIZE);
+            /* Succeeds for TLS1.3 */
+            conn->actual_protocol_version = S2N_TLS13;
+            EXPECT_SUCCESS(s2n_encrypted_extensions_send(conn));
 
-        /* Check that size and data in server_conn->handshake.io are correct */
-        struct s2n_stuffer *server_out = &server_conn->handshake.io;
-        uint16_t encrypted_extensions_actual_length;
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
 
-        EXPECT_EQUAL(encrypted_extensions_expected_size, s2n_stuffer_data_available(server_out));
-        s2n_stuffer_read_uint16(server_out, &encrypted_extensions_actual_length);
-        EXPECT_EQUAL(encrypted_extensions_expected_length, encrypted_extensions_actual_length);
-        EXPECT_EQUAL(encrypted_extensions_actual_length, s2n_stuffer_data_available(server_out));
+        /* Should send no extensions by default */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(conn));
+            conn->actual_protocol_version = S2N_TLS13;
 
-        /* Clean up */
-        EXPECT_SUCCESS(s2n_stuffer_free(server_out));
-        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+            struct s2n_stuffer *stuffer = &conn->handshake.io;
+
+            EXPECT_SUCCESS(s2n_encrypted_extensions_send(conn));
+
+            uint16_t extension_list_size;
+            EXPECT_SUCCESS(s2n_stuffer_read_uint16(stuffer, &extension_list_size));
+            EXPECT_EQUAL(extension_list_size, 0);
+            EXPECT_EQUAL(s2n_stuffer_data_available(stuffer), 0);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Should send a requested extension */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(conn));
+            conn->actual_protocol_version = S2N_TLS13;
+
+            struct s2n_stuffer *stuffer = &conn->handshake.io;
+
+            conn->server_name_used = 1;
+            EXPECT_SUCCESS(s2n_encrypted_extensions_send(conn));
+
+            uint16_t extension_list_size;
+            EXPECT_SUCCESS(s2n_stuffer_read_uint16(stuffer, &extension_list_size));
+            EXPECT_NOT_EQUAL(extension_list_size, 0);
+            EXPECT_EQUAL(s2n_stuffer_data_available(stuffer), extension_list_size);
+
+            uint16_t extension_type;
+            EXPECT_SUCCESS(s2n_stuffer_read_uint16(stuffer, &extension_type));
+            EXPECT_EQUAL(extension_type, s2n_server_server_name_extension.iana_value);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
     }
 
-    /* Test that server sends Encrypted Extensions  */
+    /* Test s2n_encrypted_extensions_recv */
     {
-        struct s2n_connection *server_conn;
-        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(server_conn));
-        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
-        server_conn->actual_protocol_version = S2N_TLS13;
-        EXPECT_EQUAL(s2n_stuffer_data_available(&server_conn->handshake.io), 0);
+        /* Safety checks */
+        EXPECT_FAILURE(s2n_encrypted_extensions_recv(NULL));
 
-        struct s2n_stuffer *extension_stuffer = &server_conn->handshake.io;
+        /* Should fail for pre-TLS1.3 */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(conn));
 
-        /* Server Name extension */
-        server_conn->server_name_used = 1;
-        const uint8_t EMPTY_SERVER_NAME_EXT_SIZE = 4;
+            /* Fails for TLS1.2 */
+            conn->actual_protocol_version = S2N_TLS12;
+            EXPECT_FAILURE_WITH_ERRNO(s2n_encrypted_extensions_recv(conn), S2N_ERR_BAD_MESSAGE);
 
-        EXPECT_EQUAL(s2n_server_extensions_server_name_send_size(server_conn), EMPTY_SERVER_NAME_EXT_SIZE);
-        EXPECT_SUCCESS(s2n_encrypted_extensions_send(server_conn));
-        S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(extension_stuffer, EMPTY_SERVER_NAME_EXT_SIZE + ENCRYPTED_EXTENSIONS_HEADER_SIZE);
+            /* Succeeds for TLS1.3 */
+            conn->actual_protocol_version = S2N_TLS13;
+            EXPECT_SUCCESS(s2n_encrypted_extensions_recv(conn));
 
-        /* Reset and check */
-        server_conn->server_name_used = 0;
-        EXPECT_SUCCESS(s2n_encrypted_extensions_send(server_conn));
-        S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(extension_stuffer, ENCRYPTED_EXTENSIONS_HEADER_SIZE);
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
 
-        /* Max Fragment Length Extension (MFL) Extension */
-        const uint8_t MFL_EXT_SIZE = 2 + 2 + 1;
-        server_conn->mfl_code = S2N_TLS_MAX_FRAG_LEN_1024;
-        EXPECT_EQUAL(s2n_server_extensions_max_fragment_length_send_size(server_conn), MFL_EXT_SIZE);
-        EXPECT_SUCCESS(s2n_encrypted_extensions_send(server_conn));
-        S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(extension_stuffer, MFL_EXT_SIZE + ENCRYPTED_EXTENSIONS_HEADER_SIZE);
+        /* Should parse an empty list */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(conn));
+            conn->actual_protocol_version = S2N_TLS13;
 
-        /* Reset and check */
-        server_conn->mfl_code = 0;
-        EXPECT_SUCCESS(s2n_encrypted_extensions_send(server_conn));
-        S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(extension_stuffer, ENCRYPTED_EXTENSIONS_HEADER_SIZE);
+            struct s2n_stuffer *stuffer = &conn->handshake.io;
 
-        /* Application Protocol (ALPN) Extension */
-        strcpy(server_conn->application_protocol, "h2");
-        const uint8_t application_protocol_len = strlen(server_conn->application_protocol);
-        const uint8_t ALPN_LEN = 7 + application_protocol_len;
+            /* Parse no data */
+            EXPECT_SUCCESS(s2n_encrypted_extensions_recv(conn));
+            EXPECT_EQUAL(s2n_stuffer_data_available(stuffer), 0);
 
-        EXPECT_SUCCESS(s2n_encrypted_extensions_send(server_conn));
-        S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(extension_stuffer, ALPN_LEN + ENCRYPTED_EXTENSIONS_HEADER_SIZE);
+            /* Parse explicitly empty list */
+            EXPECT_SUCCESS(s2n_extension_list_send(S2N_EXTENSION_LIST_EMPTY, conn, stuffer));
+            EXPECT_SUCCESS(s2n_encrypted_extensions_recv(conn));
+            EXPECT_EQUAL(s2n_stuffer_data_available(stuffer), 0);
 
-        /* Reset and check */
-        strcpy(server_conn->application_protocol, "");
-        EXPECT_SUCCESS(s2n_encrypted_extensions_send(server_conn));
-        S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(extension_stuffer, ENCRYPTED_EXTENSIONS_HEADER_SIZE);
+            /* Parse empty result of default s2n_encrypted_extensions_send */
+            EXPECT_SUCCESS(s2n_encrypted_extensions_send(conn));
+            EXPECT_SUCCESS(s2n_encrypted_extensions_recv(conn));
+            EXPECT_EQUAL(s2n_stuffer_data_available(stuffer), 0);
 
-        /* Test a combination of 2 encrypted extensions sent */
-        server_conn->server_name_used = 1;
-        server_conn->mfl_code = S2N_TLS_MAX_FRAG_LEN_1024;
-        EXPECT_SUCCESS(s2n_encrypted_extensions_send(server_conn));
-        S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(extension_stuffer, EMPTY_SERVER_NAME_EXT_SIZE + MFL_EXT_SIZE + ENCRYPTED_EXTENSIONS_HEADER_SIZE);
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
 
-        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        /* Should parse a requested extension */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(conn));
+            conn->actual_protocol_version = S2N_TLS13;
+
+            struct s2n_stuffer *stuffer = &conn->handshake.io;
+
+            conn->server_name_used = 1;
+            EXPECT_SUCCESS(s2n_encrypted_extensions_send(conn));
+
+            /* Reset server_name_used */
+            conn->server_name_used = 0;
+
+            EXPECT_SUCCESS(s2n_encrypted_extensions_recv(conn));
+            EXPECT_EQUAL(s2n_stuffer_data_available(stuffer), 0);
+            EXPECT_EQUAL(conn->server_name_used, 1);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
     }
-
-    /* Self talk tests: Encrypted extensions send recv round trips */
-    {
-        struct s2n_connection *client_conn;
-        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(client_conn));
-        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
-        client_conn->actual_protocol_version = S2N_TLS13;
-
-        /* Client successfully receives empty encrypted extension */
-        EXPECT_SUCCESS(s2n_encrypted_extensions_send(client_conn));
-        EXPECT_SUCCESS(s2n_encrypted_extensions_recv(client_conn));
-
-        /* Client successfully receives all supported (server name, mfl, alpn) encrypted extensions */
-        client_conn->server_name_used = 1;
-        client_conn->mfl_code = S2N_TLS_MAX_FRAG_LEN_1024;
-        config->mfl_code = S2N_TLS_MAX_FRAG_LEN_1024;
-        strcpy(client_conn->application_protocol, "h2");
-        EXPECT_SUCCESS(s2n_encrypted_extensions_send(client_conn));
-        EXPECT_SUCCESS(s2n_encrypted_extensions_recv(client_conn));
-
-        EXPECT_SUCCESS(s2n_connection_free(client_conn));
-    }
-
-    /* Client successfully parses a non-empty encrypted extension */
-    {
-        struct s2n_connection *client_conn;
-        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(client_conn));
-        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
-        client_conn->actual_protocol_version = S2N_TLS13;;
-
-        /* Write length of ALPN extension, then write the extension itself */
-        strcpy(client_conn->application_protocol, "h2");
-        const uint8_t application_protocol_len = strlen(client_conn->application_protocol);
-        uint16_t alpn_extension_length = 7 + application_protocol_len;
-        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&client_conn->handshake.io, alpn_extension_length));
-
-        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&client_conn->handshake.io, TLS_EXTENSION_ALPN));
-        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&client_conn->handshake.io, application_protocol_len + 3));
-        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&client_conn->handshake.io, application_protocol_len + 1));
-        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&client_conn->handshake.io, application_protocol_len));
-        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&client_conn->handshake.io, (uint8_t *) client_conn->application_protocol, application_protocol_len));
-
-        /* Client parses encrypted extensions */
-        strcpy(client_conn->application_protocol, "");
-        EXPECT_SUCCESS(s2n_encrypted_extensions_recv(client_conn));
-        EXPECT_SUCCESS(strcmp(client_conn->application_protocol, "h2"));
-
-        EXPECT_SUCCESS(s2n_connection_free(client_conn));
-    }
-
-    /* Client does not parse a non-EE extension */
-    {
-        struct s2n_connection *client_conn;
-        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
-        client_conn->server_protocol_version = latest_version;
-
-        /* write length of supported versions extension (6) then write the extension itself */
-        uint16_t supported_versions_extension_length = 6;
-        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&client_conn->handshake.io, supported_versions_extension_length));
-        EXPECT_SUCCESS(s2n_extensions_server_supported_versions_send(client_conn, &client_conn->handshake.io));
-
-        client_conn->server_protocol_version = 0;
-        EXPECT_FAILURE_WITH_ERRNO(s2n_encrypted_extensions_recv(client_conn), S2N_ERR_BAD_MESSAGE);
-
-        EXPECT_EQUAL(client_conn->client_protocol_version, latest_version);
-        EXPECT_NOT_EQUAL(client_conn->server_protocol_version, latest_version);
-
-        EXPECT_SUCCESS(s2n_connection_free(client_conn));
-    }
-
-    EXPECT_SUCCESS(s2n_config_free(config));
 
     END_TEST();
 }

--- a/tests/unit/s2n_server_alpn_extension_test.c
+++ b/tests/unit/s2n_server_alpn_extension_test.c
@@ -16,6 +16,7 @@
 #include "s2n_test.h"
 
 #include "tls/extensions/s2n_server_alpn.h"
+#include "tls/s2n_connection.h"
 
 int main(int argc, char **argv)
 {

--- a/tests/unit/s2n_server_server_name_extension_test.c
+++ b/tests/unit/s2n_server_server_name_extension_test.c
@@ -16,6 +16,8 @@
 #include "s2n_test.h"
 
 #include "tls/extensions/s2n_server_server_name.h"
+#include "tls/s2n_connection.h"
+#include "tls/s2n_handshake.h"
 
 #define S2N_TEST_RESUMPTION_HANDSHAKE (NEGOTIATED)
 #define S2N_TEST_NOT_RESUMPTION_HANDSHAKE (NEGOTIATED | FULL_HANDSHAKE)

--- a/tls/extensions/s2n_server_alpn.c
+++ b/tls/extensions/s2n_server_alpn.c
@@ -79,26 +79,3 @@ static int s2n_alpn_recv(struct s2n_connection *conn, struct s2n_stuffer *extens
 
     return S2N_SUCCESS;
 }
-
-/* Old-style extension functions -- remove after extensions refactor is complete */
-
-int s2n_server_extensions_alpn_send_size(struct s2n_connection *conn)
-{
-    const uint8_t application_protocol_len = strlen(conn->application_protocol);
-
-    if (!application_protocol_len) {
-        return 0;
-    }
-
-    return 3 * sizeof(uint16_t) + 1 * sizeof(uint8_t) + application_protocol_len;
-}
-
-int s2n_server_extensions_alpn_send(struct s2n_connection *conn, struct s2n_stuffer *out)
-{
-    return s2n_extension_send(&s2n_server_alpn_extension, conn, out);
-}
-
-int s2n_recv_server_alpn(struct s2n_connection *conn, struct s2n_stuffer *extension)
-{
-    return s2n_extension_recv(&s2n_server_alpn_extension, conn, extension);
-}

--- a/tls/extensions/s2n_server_alpn.h
+++ b/tls/extensions/s2n_server_alpn.h
@@ -16,12 +16,5 @@
 #pragma once
 
 #include "tls/extensions/s2n_extension_type.h"
-#include "tls/s2n_connection.h"
-#include "stuffer/s2n_stuffer.h"
 
 extern const s2n_extension_type s2n_server_alpn_extension;
-
-/* Old-style extension functions -- remove after extensions refactor is complete */
-int s2n_server_extensions_alpn_send_size(struct s2n_connection *conn);
-int s2n_server_extensions_alpn_send(struct s2n_connection *conn, struct s2n_stuffer *out);
-int s2n_recv_server_alpn(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_server_max_fragment_length.c
+++ b/tls/extensions/s2n_server_max_fragment_length.c
@@ -59,23 +59,3 @@ static int s2n_max_fragment_length_recv(struct s2n_connection *conn, struct s2n_
     S2N_ERROR_IF(mfl_code != conn->config->mfl_code, S2N_ERR_MAX_FRAG_LEN_MISMATCH);
     return S2N_SUCCESS;
 }
-
-/* Old-style extension functions -- remove after extensions refactor is complete */
-
-int s2n_server_extensions_max_fragment_length_send_size(struct s2n_connection *conn)
-{
-    if (!conn->mfl_code) {
-        return 0;
-    }
-    return 2 * sizeof(uint16_t) + 1 * sizeof(uint8_t);
-}
-
-int s2n_server_extensions_max_fragment_length_send(struct s2n_connection *conn, struct s2n_stuffer *out)
-{
-    return s2n_extension_send(&s2n_server_max_fragment_length_extension, conn, out);
-}
-
-int s2n_recv_server_max_fragment_length(struct s2n_connection *conn, struct s2n_stuffer *extension)
-{
-    return s2n_extension_recv(&s2n_server_max_fragment_length_extension, conn, extension);
-}

--- a/tls/extensions/s2n_server_max_fragment_length.h
+++ b/tls/extensions/s2n_server_max_fragment_length.h
@@ -16,12 +16,5 @@
 #pragma once
 
 #include "tls/extensions/s2n_extension_type.h"
-#include "tls/s2n_connection.h"
-#include "stuffer/s2n_stuffer.h"
 
 extern const s2n_extension_type s2n_server_max_fragment_length_extension;
-
-/* Old-style extension functions -- remove after extensions refactor is complete */
-int s2n_server_extensions_max_fragment_length_send_size(struct s2n_connection *conn);
-int s2n_server_extensions_max_fragment_length_send(struct s2n_connection *conn, struct s2n_stuffer *out);
-int s2n_recv_server_max_fragment_length(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/extensions/s2n_server_server_name.c
+++ b/tls/extensions/s2n_server_server_name.c
@@ -49,23 +49,3 @@ static int s2n_server_name_recv(struct s2n_connection *conn, struct s2n_stuffer 
     conn->server_name_used = 1;
     return S2N_SUCCESS;
 }
-
-/* Old-style extension functions -- remove after extensions refactor is complete */
-
-int s2n_server_extensions_server_name_send_size(struct s2n_connection *conn) {
-    if (!s2n_server_name_should_send(conn)) {
-        return 0;
-    }
-
-    return 2 * sizeof(uint16_t);
-}
-
-int s2n_server_extensions_server_name_send(struct s2n_connection *conn, struct s2n_stuffer *out)
-{
-    return s2n_extension_send(&s2n_server_server_name_extension, conn, out);
-}
-
-int s2n_recv_server_server_name(struct s2n_connection *conn, struct s2n_stuffer *extension)
-{
-    return s2n_extension_recv(&s2n_server_server_name_extension, conn, extension);
-}

--- a/tls/extensions/s2n_server_server_name.h
+++ b/tls/extensions/s2n_server_server_name.h
@@ -16,12 +16,5 @@
 #pragma once
 
 #include "tls/extensions/s2n_extension_type.h"
-#include "tls/s2n_connection.h"
-#include "stuffer/s2n_stuffer.h"
 
 extern const s2n_extension_type s2n_server_server_name_extension;
-
-/* Old-style extension functions -- remove after extensions refactor is complete */
-int s2n_server_extensions_server_name_send_size(struct s2n_connection *conn);
-int s2n_server_extensions_server_name_send(struct s2n_connection *conn, struct s2n_stuffer *out);
-int s2n_recv_server_server_name(struct s2n_connection *conn, struct s2n_stuffer *extension);

--- a/tls/s2n_encrypted_extensions.c
+++ b/tls/s2n_encrypted_extensions.c
@@ -36,7 +36,8 @@
 
 int s2n_encrypted_extensions_send(struct s2n_connection *conn)
 {
-    S2N_ERROR_IF(conn->actual_protocol_version != S2N_TLS13, S2N_ERR_BAD_MESSAGE);
+    notnull_check(conn);
+    ENSURE_POSIX(conn->actual_protocol_version >= S2N_TLS13, S2N_ERR_BAD_MESSAGE);
 
     struct s2n_stuffer *out = &conn->handshake.io;
     GUARD(s2n_extension_list_send(S2N_EXTENSION_LIST_ENCRYPTED_EXTENSIONS, conn, out));
@@ -45,6 +46,9 @@ int s2n_encrypted_extensions_send(struct s2n_connection *conn)
 
 int s2n_encrypted_extensions_recv(struct s2n_connection *conn)
 {
+    notnull_check(conn);
+    ENSURE_POSIX(conn->actual_protocol_version >= S2N_TLS13, S2N_ERR_BAD_MESSAGE);
+
     struct s2n_stuffer *in = &conn->handshake.io;
     GUARD(s2n_extension_list_recv(S2N_EXTENSION_LIST_ENCRYPTED_EXTENSIONS, conn, in));
     return S2N_SUCCESS;


### PR DESCRIPTION
### Description of changes: 

To prove the extensions refactor didn't change behavior, the tests were left largely untouched and the old methods were kept as wrappers around the new methods. We now need to clean this up.

### Call-outs:

s2n_encrypted_extensions_test.c is a completely new test, as the code the old version tested no longer exists. It'll probably be easier to review the test by reading the file directly, not as part of the diff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
