### PR TITLE
Remove deprecated methods for cert_req extensions

### DIFF
--- a/tests/unit/s2n_server_signature_algorithms_extension_test.c
+++ b/tests/unit/s2n_server_signature_algorithms_extension_test.c
@@ -40,9 +40,9 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
 
         struct s2n_stuffer io;
-        s2n_stuffer_alloc(&io, s2n_extensions_server_signature_algorithms_size(server_conn));
-        EXPECT_SUCCESS(s2n_server_signature_algorithms_extension.send(server_conn, &io));
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&io, 0));
 
+        EXPECT_SUCCESS(s2n_server_signature_algorithms_extension.send(server_conn, &io));
         EXPECT_SUCCESS(s2n_server_signature_algorithms_extension.recv(client_conn, &io));
         EXPECT_EQUAL(s2n_stuffer_data_available(&io), 0);
 

--- a/tests/unit/s2n_tls13_cert_request_extensions_test.c
+++ b/tests/unit/s2n_tls13_cert_request_extensions_test.c
@@ -32,71 +32,7 @@ int main(int argc, char **argv)
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_enable_tls13());
 
-    /* Test client fails to parse certificate request with no extensions */
-    {
-        struct s2n_connection *client_conn;
-        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        client_conn->actual_protocol_version = S2N_TLS13;
-
-        /* Write 0 length request context https://tools.ietf.org/html/rfc8446#section-4.3.2 */
-        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&client_conn->handshake.io, 0));
-        /* write total extension length */
-        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&client_conn->handshake.io, 0));
-
-        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_cert_req_recv(client_conn), S2N_ERR_MISSING_EXTENSION);
-
-        EXPECT_SUCCESS(s2n_connection_free(client_conn));
-    }
-
-    /* Test client fails to parse certificate request with wrong extension type */
-    {
-        struct s2n_connection *client_conn;
-        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        client_conn->actual_protocol_version = S2N_TLS13;
-
-        /* Write supported versions extension instead */
-        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&client_conn->handshake.io, 0));
-        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&client_conn->handshake.io, s2n_extensions_server_supported_versions_size(client_conn)));
-        EXPECT_SUCCESS(s2n_extensions_server_supported_versions_send(client_conn, &client_conn->handshake.io));
-
-        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_cert_req_recv(client_conn), S2N_ERR_BAD_MESSAGE);
-
-        EXPECT_SUCCESS(s2n_connection_free(client_conn));
-    }
-
-    /* Test extension size greater than actual fails */
-    {
-        struct s2n_connection *client_conn;
-        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        client_conn->actual_protocol_version = S2N_TLS13;
-
-        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&client_conn->handshake.io, 0));
-        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&client_conn->handshake.io, s2n_extensions_server_signature_algorithms_size(client_conn) + 3));
-        EXPECT_SUCCESS(s2n_extensions_server_signature_algorithms_send(client_conn, &client_conn->handshake.io));
-
-        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_cert_req_recv(client_conn), S2N_ERR_BAD_MESSAGE);
-
-        EXPECT_SUCCESS(s2n_connection_free(client_conn));
-    }
-
-    /* Test extension size smaller than actual fails */
-    {
-        struct s2n_connection *client_conn;
-        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        client_conn->actual_protocol_version = S2N_TLS13;
-
-        /* Extension size read inside of parsing the extension will be greater than data available 
-         * as overall extension size written here is smaller than was actually written */
-        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&client_conn->handshake.io, 0));
-        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&client_conn->handshake.io, s2n_extensions_server_signature_algorithms_size(client_conn) - 4));
-        EXPECT_SUCCESS(s2n_extensions_server_signature_algorithms_send(client_conn, &client_conn->handshake.io));
-
-        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_cert_req_recv(client_conn), S2N_ERR_BAD_MESSAGE);
-
-        EXPECT_SUCCESS(s2n_connection_free(client_conn));
-    }
-
-    /* Test correct extension (sig_alg) */
+    /* Test correct required extension (sig_alg) sent and received */
     {
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
@@ -110,53 +46,17 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
-    /* Test correct extension (sig alg) with wrong length */
+    /* Test client fails to parse certificate request with no extensions */
     {
         struct s2n_connection *client_conn;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         client_conn->actual_protocol_version = S2N_TLS13;
 
+        /* Write 0 length request context https://tools.ietf.org/html/rfc8446#section-4.3.2 */
         EXPECT_SUCCESS(s2n_stuffer_write_uint8(&client_conn->handshake.io, 0));
-        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&client_conn->handshake.io, s2n_extensions_server_signature_algorithms_size(client_conn)));
-        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&client_conn->handshake.io, TLS_EXTENSION_SIGNATURE_ALGORITHMS));
-        /* From s2n_extensions_server_signature_algorithms_send() */
-        uint16_t total_size = s2n_extensions_server_signature_algorithms_size(client_conn);
-        uint16_t extension_size = total_size - 4;
-        /* Subtract further to make the extension_size smaller than it actually is */
-        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&client_conn->handshake.io, extension_size - 4));
-        EXPECT_SUCCESS(s2n_send_supported_sig_scheme_list(client_conn, &client_conn->handshake.io));
+        EXPECT_SUCCESS(s2n_extension_list_send(S2N_EXTENSION_LIST_EMPTY, client_conn, &client_conn->handshake.io));
 
-        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_cert_req_recv(client_conn), S2N_ERR_BAD_MESSAGE);
-
-        /* Test again with extension size larger than it actually is */
-        EXPECT_SUCCESS(s2n_stuffer_wipe(&client_conn->handshake.io));
-        EXPECT_TRUE(s2n_stuffer_data_available(&client_conn->handshake.io) == 0);
-
-        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&client_conn->handshake.io, 0));
-        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&client_conn->handshake.io, s2n_extensions_server_signature_algorithms_size(client_conn)));
-        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&client_conn->handshake.io, TLS_EXTENSION_SIGNATURE_ALGORITHMS));
-        total_size = s2n_extensions_server_signature_algorithms_size(client_conn);
-        extension_size = total_size - 4;
-        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&client_conn->handshake.io, extension_size + 4));
-        EXPECT_SUCCESS(s2n_send_supported_sig_scheme_list(client_conn, &client_conn->handshake.io));
-
-        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_cert_req_recv(client_conn), S2N_ERR_BAD_MESSAGE);
-
-        EXPECT_SUCCESS(s2n_connection_free(client_conn));
-    }
-
-    /* Test two of the same extension */
-    {
-        struct s2n_connection *client_conn;
-        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        client_conn->actual_protocol_version = S2N_TLS13;
-
-        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&client_conn->handshake.io, 0));
-        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&client_conn->handshake.io, 2 * s2n_extensions_server_signature_algorithms_size(client_conn)));
-        EXPECT_SUCCESS(s2n_extensions_server_signature_algorithms_send(client_conn, &client_conn->handshake.io));
-        EXPECT_SUCCESS(s2n_extensions_server_signature_algorithms_send(client_conn, &client_conn->handshake.io));
-
-        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_cert_req_recv(client_conn), S2N_ERR_DUPLICATE_EXTENSION);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_cert_req_recv(client_conn), S2N_ERR_MISSING_EXTENSION);
 
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
     }

--- a/tests/unit/s2n_tls13_cert_request_test.c
+++ b/tests/unit/s2n_tls13_cert_request_test.c
@@ -82,10 +82,12 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         client_conn->actual_protocol_version = S2N_TLS13;
 
-        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&client_conn->handshake.io, 2));
-        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&client_conn->handshake.io, s2n_extensions_server_signature_algorithms_size(client_conn)));
-        EXPECT_SUCCESS(s2n_extensions_server_signature_algorithms_send(client_conn, &client_conn->handshake.io));
+        /* Request context correct */
+        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&client_conn->handshake.io, 0));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_cert_req_recv(client_conn), S2N_ERR_MISSING_EXTENSION);
 
+        /* Request context incorrect */
+        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&client_conn->handshake.io, 2));
         EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_cert_req_recv(client_conn), S2N_ERR_BAD_MESSAGE);
 
         EXPECT_SUCCESS(s2n_connection_free(client_conn));

--- a/tls/extensions/s2n_server_signature_algorithms.c
+++ b/tls/extensions/s2n_server_signature_algorithms.c
@@ -17,10 +17,12 @@
 #include <stdint.h>
 
 #include "tls/extensions/s2n_client_signature_algorithms.h"
+#include "tls/s2n_connection.h"
 #include "tls/s2n_tls.h"
 #include "tls/s2n_tls_parameters.h"
 #include "tls/s2n_signature_algorithms.h"
 
+#include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_safety.h"
 
 static int s2n_signature_algorithms_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
@@ -37,22 +39,4 @@ const s2n_extension_type s2n_server_signature_algorithms_extension = {
 static int s2n_signature_algorithms_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
     return s2n_recv_supported_sig_scheme_list(extension, &conn->handshake_params.server_sig_hash_algs);
-}
-
-/* Old-style extension functions -- remove after extensions refactor is complete */
-
-int s2n_extensions_server_signature_algorithms_size(struct s2n_connection *conn)
-{
-    /* extra 6 = 2 from extension type, 2 from extension size, 2 from list length */
-    return s2n_supported_sig_scheme_list_size(conn) + 6;
-}
-
-int s2n_extensions_server_signature_algorithms_send(struct s2n_connection *conn, struct s2n_stuffer *out)
-{
-    return s2n_extension_send(&s2n_server_signature_algorithms_extension, conn, out);
-}
-
-int s2n_extensions_server_signature_algorithms_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
-{
-    return s2n_extension_recv(&s2n_server_signature_algorithms_extension, conn, extension);
 }

--- a/tls/extensions/s2n_server_signature_algorithms.h
+++ b/tls/extensions/s2n_server_signature_algorithms.h
@@ -16,12 +16,5 @@
 #pragma once
 
 #include "tls/extensions/s2n_extension_type.h"
-#include "tls/s2n_connection.h"
-#include "stuffer/s2n_stuffer.h"
 
 extern const s2n_extension_type s2n_server_signature_algorithms_extension;
-
-/* Old-style extension functions -- remove after extensions refactor is complete */
-int s2n_extensions_server_signature_algorithms_send(struct s2n_connection *conn, struct s2n_stuffer *out);
-int s2n_extensions_server_signature_algorithms_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
-int s2n_extensions_server_signature_algorithms_size(struct s2n_connection *conn);


### PR DESCRIPTION
### Description of changes: 

To prove the extensions refactor didn't change behavior, the tests were left largely untouched and the old methods were kept as wrappers around the new methods. We now need to clean this up.

### Call-outs:

I'm deleting most of the tests in s2n_tls13_cert_request_extensions_test.c because those cases are no longer handled by cert_request specifically. Those cases are now handled by (and therefore tested with) s2n_extension_list.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
