### PR TITLE
Removed extra cert validator call

### DIFF
--- a/tests/fuzz/s2n_certificate_extensions_parse_test.c
+++ b/tests/fuzz/s2n_certificate_extensions_parse_test.c
@@ -128,10 +128,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
         GUARD(s2n_pkey_zero_init(&public_key_out));
         s2n_pkey_type pkey_type;
 
-        /* Add cert to chain twice to reach codepaths that need 2+ certs */
-        GUARD(s2n_x509_validator_validate_cert_chain(&client_conn->x509_validator, client_conn, chain_data, chain_len, &pkey_type, &public_key_out));
-        GUARD(s2n_pkey_free(&public_key_out));
-        GUARD(s2n_pkey_zero_init(&public_key_out));
         GUARD(s2n_x509_validator_validate_cert_chain(&client_conn->x509_validator, client_conn, chain_data, chain_len, &pkey_type, &public_key_out));
         GUARD(s2n_stuffer_free(&chain_stuffer));
         GUARD(s2n_pkey_free(&public_key_out));


### PR DESCRIPTION


### Description of changes: 

Original fuzz test had a two calls to s2n_x509_validator_validate_cert_chain, which doesn't make sense since there is no reason to validate a cert chain twice.

### Testing:

fuzz test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
