### PR TITLE
Add non-blocking mode to s2nc and s2nd

### DIFF
--- a/bin/common.h
+++ b/bin/common.h
@@ -33,7 +33,7 @@
 
 void print_s2n_error(const char *app_error);
 int echo(struct s2n_connection *conn, int sockfd);
-int negotiate(struct s2n_connection *conn);
+int negotiate(struct s2n_connection *conn, int sockfd);
 int https(struct s2n_connection *conn, uint32_t bench);
 
 char *load_file_to_cstring(const char *path);

--- a/bin/echo.c
+++ b/bin/echo.c
@@ -59,7 +59,6 @@ static int wait_for_event(int fd, s2n_blocked_status blocked)
         /* This case is not encountered by the s2nc/s2nd applications,
          * but is detected for completeness */
         return S2N_SUCCESS;
-        break;
     }
 
     if (poll(&reader, 1, -1) < 0) {

--- a/bin/echo.c
+++ b/bin/echo.c
@@ -48,7 +48,6 @@ static int wait_for_event(int fd, s2n_blocked_status blocked)
     switch (blocked) {
     case S2N_NOT_BLOCKED:
         return S2N_SUCCESS;
-        break;
     case S2N_BLOCKED_ON_READ:
         reader.events |= POLLIN;
         break;

--- a/bin/echo.c
+++ b/bin/echo.c
@@ -40,18 +40,53 @@ void print_s2n_error(const char *app_error)
             s2n_strerror_debug(s2n_errno, "EN"));
 }
 
-int negotiate(struct s2n_connection *conn)
+/* Poll the given file descriptor for an event determined by the blocked status */
+static int wait_for_event(int fd, s2n_blocked_status blocked)
+{
+    struct pollfd reader = { .fd = fd, .events = 0 };
+
+    switch (blocked) {
+    case S2N_NOT_BLOCKED:
+        return S2N_SUCCESS;
+        break;
+    case S2N_BLOCKED_ON_READ:
+        reader.events |= POLLIN;
+        break;
+    case S2N_BLOCKED_ON_WRITE:
+        reader.events |= POLLOUT;
+        break;
+    case S2N_BLOCKED_ON_APPLICATION_INPUT:
+        /* This case is not encountered by the s2nc/s2nd applications,
+         * but is detected for completeness */
+        return S2N_SUCCESS;
+        break;
+    }
+
+    if (poll(&reader, 1, -1) < 0) {
+        fprintf(stderr, "Failed to poll connection: %s\n", strerror(errno));
+        S2N_ERROR_PRESERVE_ERRNO();
+    }
+
+    return S2N_SUCCESS;
+}
+
+int negotiate(struct s2n_connection *conn, int fd)
 {
     s2n_blocked_status blocked;
-    do {
-        if (s2n_negotiate(conn, &blocked) < 0) {
-            if (s2n_error_get_type(s2n_errno) != S2N_ERR_T_BLOCKED) {
-                fprintf(stderr, "Failed to negotiate: '%s'. %s\n", s2n_strerror(s2n_errno, "EN"), s2n_strerror_debug(s2n_errno, "EN"));
-                fprintf(stderr, "Alert: %d\n", s2n_connection_get_alert(conn));
-                S2N_ERROR_PRESERVE_ERRNO();
-            }
+    while (s2n_negotiate(conn, &blocked) != S2N_SUCCESS) {
+        if (s2n_error_get_type(s2n_errno) != S2N_ERR_T_BLOCKED) {
+            fprintf(stderr, "Failed to negotiate: '%s'. %s\n",
+                    s2n_strerror(s2n_errno, "EN"),
+                    s2n_strerror_debug(s2n_errno, "EN"));
+            fprintf(stderr, "Alert: %d\n",
+                    s2n_connection_get_alert(conn));
+            S2N_ERROR_PRESERVE_ERRNO();
         }
-    } while (blocked);
+
+        if (wait_for_event(fd, blocked) != S2N_SUCCESS) {
+            S2N_ERROR_PRESERVE_ERRNO();
+        }
+    }
 
     /* Now that we've negotiated, print some parameters */
     int client_hello_version;
@@ -183,13 +218,15 @@ int echo(struct s2n_connection *conn, int sockfd)
                         s2n_errno = S2N_ERR_T_OK;
                         bytes_written = s2n_send(conn, buf_ptr, bytes_read, &blocked);
                         if (bytes_written < 0) {
-                            if (s2n_error_get_type(s2n_errno) == S2N_ERR_T_BLOCKED) {
-                                /* If blocked just try again */
-                                continue;
+                            if (s2n_error_get_type(s2n_errno) != S2N_ERR_T_BLOCKED) {
+                                fprintf(stderr, "Error writing to connection: '%s'\n",
+                                        s2n_strerror(s2n_errno, "EN"));
+                                exit(1);
                             }
 
-                            fprintf(stderr, "Error writing to connection: '%s'\n", s2n_strerror(s2n_errno, "EN"));
-                            exit(1);
+                            if (wait_for_event(sockfd, blocked) != S2N_SUCCESS) {
+                                S2N_ERROR_PRESERVE_ERRNO();
+                            }
                         }
 
                         bytes_read -= bytes_written;

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -28,6 +28,7 @@
 #include <getopt.h>
 #include <strings.h>
 #include <errno.h>
+#include <fcntl.h>
 
 #include <s2n.h>
 #include "common.h"
@@ -86,6 +87,8 @@ void usage()
     fprintf(stderr, "    Turn on corked io\n");
     fprintf(stderr, "  --tls13\n");
     fprintf(stderr, "    Turn on experimental TLS1.3 support.\n");
+    fprintf(stderr, "  --non-blocking\n");
+    fprintf(stderr, "    Set the non-blocking flag on the connection's socket.\n");
     fprintf(stderr, "  -K ,--keyshares\n");
     fprintf(stderr, "    Colon separated list of curve names.\n"
                     "    The client will generate keyshares only for the curve names present in the ecc_preferences list configured in the security_policy.\n"
@@ -248,6 +251,7 @@ int main(int argc, char *const *argv)
     int echo_input = 0;
     int use_corked_io = 0;
     int use_tls13 = 0;
+    uint8_t non_blocking = 0;
     int keyshares_count = 0;
     char keyshares[S2N_ECC_EVP_SUPPORTED_CURVES_COUNT][S2N_MAX_ECC_CURVE_NAME_LENGTH];
     char *input = NULL;
@@ -273,11 +277,12 @@ int main(int argc, char *const *argv)
         {"corked-io", no_argument, 0, 'C'},
         {"tls13", no_argument, 0, '3'},
         {"keyshares", required_argument, 0, 'K'},
+        {"non-blocking", no_argument, 0, 'B'},
     };
 
     while (1) {
         int option_index = 0;
-        int c = getopt_long(argc, argv, "a:c:ehn:sf:d:l:k:D:t:irTCK:", long_options, &option_index);
+        int c = getopt_long(argc, argv, "a:c:ehn:sf:d:l:k:D:t:irTCK:B", long_options, &option_index);
         if (c == -1) {
             break;
         }
@@ -353,6 +358,9 @@ int main(int argc, char *const *argv)
         case '3':
             use_tls13 = 1;
             break;
+        case 'B':
+            non_blocking = 1;
+            break;
         case '?':
         default:
             usage();
@@ -418,6 +426,14 @@ int main(int argc, char *const *argv)
         if (connected == 0) {
             fprintf(stderr, "Failed to connect to %s:%s\n", host, port);
             exit(1);
+        }
+
+        if (non_blocking) {
+            int flags = fcntl(sockfd, F_GETFL, 0);
+            if (fcntl(sockfd, F_SETFL, flags | O_NONBLOCK) < 0) {
+                fprintf(stderr, "fcntl error: %s\n", strerror(errno));
+                exit(1);
+            }
         }
 
         struct s2n_config *config = s2n_config_new();

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -493,8 +493,7 @@ int main(int argc, char *const *argv)
         }
 
         /* See echo.c */
-        if (negotiate(conn) != 0)
-        {
+        if (negotiate(conn, sockfd) != 0) {
             /* Error is printed in negotiate */
             S2N_ERROR_PRESERVE_ERRNO();
         }

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -282,7 +282,7 @@ int main(int argc, char *const *argv)
 
     while (1) {
         int option_index = 0;
-        int c = getopt_long(argc, argv, "a:c:ehn:sf:d:l:k:D:t:irTCK:B", long_options, &option_index);
+        int c = getopt_long(argc, argv, "a:c:ehn:sf:d:l:k:D:t:irTCK:", long_options, &option_index);
         if (c == -1) {
             break;
         }

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -354,7 +354,10 @@ int handle_connection(int fd, struct s2n_config *config, struct conn_settings se
         GUARD_RETURN(s2n_connection_use_corked_io(conn), "Error setting corked io");
     }
 
-    negotiate(conn);
+    if (negotiate(conn, fd) != S2N_SUCCESS) {
+        /* Error is printed in negotiate */
+        S2N_ERROR_PRESERVE_ERRNO();
+    }
 
     if (settings.mutual_auth) {
         if (!s2n_connection_client_cert_used(conn)) {

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -283,6 +283,8 @@ void usage()
     fprintf(stderr, "    Turn on corked io\n");
     fprintf(stderr, "  --tls13\n");
     fprintf(stderr, "    Turn on experimental TLS1.3 support.\n");
+    fprintf(stderr, "  --non-blocking\n");
+    fprintf(stderr, "    Set the non-blocking flag on the connection's socket.\n");
     fprintf(stderr, "  -w --https-server\n");
     fprintf(stderr, "    Run s2nd in a simple https server mode.\n");
     fprintf(stderr, "  -b --https-bench <bytes>\n");
@@ -404,6 +406,7 @@ int main(int argc, char *const *argv)
     int fips_mode = 0;
     int parallelize = 0;
     int use_tls13 = 0;
+    int non_blocking = 0;
     long int bytes = 0;
     conn_settings.session_ticket = 1;
     conn_settings.session_cache = 1;
@@ -434,12 +437,13 @@ int main(int argc, char *const *argv)
         {"https-server", no_argument, 0, 'w'},
         {"https-bench", required_argument, 0, 'b'},
         {"alpn", required_argument, 0, 'A'},
+        {"non-blocking", no_argument, 0, 'B'},
         /* Per getopt(3) the last element of the array has to be filled with all zeros */
         { 0 },
     };
     while (1) {
         int option_index = 0;
-        int c = getopt_long(argc, argv, "c:hmnst:d:iTCX::wb:A:", long_options, &option_index);
+        int c = getopt_long(argc, argv, "c:hmnst:d:iTCX::wb:A:B", long_options, &option_index);
         if (c == -1) {
             break;
         }
@@ -533,6 +537,9 @@ int main(int argc, char *const *argv)
             break;
         case 'A':
             alpn = optarg;
+            break;
+        case 'B':
+            non_blocking = 1;
             break;
         case '?':
         default:
@@ -751,6 +758,14 @@ int main(int argc, char *const *argv)
     int fd;
     while ((fd = accept(sockfd, ai->ai_addr, &ai->ai_addrlen)) > 0) {
 
+        if (non_blocking) {
+            int flags = fcntl(sockfd, F_GETFL, 0);
+            if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0) {
+                fprintf(stderr, "fcntl error: %s\n", strerror(errno));
+                exit(1);
+            }
+        }
+
         if (!parallelize) {
             int rc = handle_connection(fd, config, conn_settings);
             close(fd);
@@ -785,7 +800,6 @@ int main(int argc, char *const *argv)
                 continue;
             }
         }
-
     }
 
     GUARD_EXIT(s2n_cleanup(),  "Error running s2n_cleanup()");

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -443,7 +443,7 @@ int main(int argc, char *const *argv)
     };
     while (1) {
         int option_index = 0;
-        int c = getopt_long(argc, argv, "c:hmnst:d:iTCX::wb:A:B", long_options, &option_index);
+        int c = getopt_long(argc, argv, "c:hmnst:d:iTCX::wb:A:", long_options, &option_index);
         if (c == -1) {
             break;
         }

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -109,7 +109,7 @@ class S2N(Provider):
         """
         Using the passed ProviderOptions, create a command line.
         """
-        cmd_line = ['s2nc', '-e']
+        cmd_line = ['s2nc', '-e', '--non-blocking']
 
         # This is the last thing printed by s2nc before it is ready to send/receive data
         self.ready_to_send_input_marker = 'Cipher negotiated:'
@@ -160,7 +160,7 @@ class S2N(Provider):
         """
         Using the passed ProviderOptions, create a command line.
         """
-        cmd_line = ['s2nd', '-X', '--self-service-blinding']
+        cmd_line = ['s2nd', '-X', '--self-service-blinding', '--non-blocking']
 
         if self.options.key is not None:
             cmd_line.extend(['--key', self.options.key])


### PR DESCRIPTION
### Resolved issues:

 resolves #2028

### Description of changes: 

Add a command line argument to s2nc/s2nd which enabled non-blocking on the socket handling the connection.

### Call-outs:

In this PR the defaults for the new integration test framework will be non-blocking mode. The existing integ tests cover blocking mode. We can iterate on this as well.

### Testing:

Integration testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
