### PR TITLE
fuzz: add S2N_FUZZ_TARGET macro

### DIFF
--- a/tests/fuzz/LD_PRELOAD/global_overrides.c
+++ b/tests/fuzz/LD_PRELOAD/global_overrides.c
@@ -33,7 +33,7 @@ int s2n_drbg_generate(struct s2n_drbg *drbg, struct s2n_blob *blob) {
      */
     GUARD_AS_POSIX(s2n_get_urandom_data(blob));
     drbg->bytes_used += blob->size;
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_stuffer_send_to_fd(struct s2n_stuffer *stuffer, int wfd, uint32_t len)

--- a/tests/fuzz/LD_PRELOAD/global_overrides.c
+++ b/tests/fuzz/LD_PRELOAD/global_overrides.c
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <dlfcn.h>
 
+#include "api/s2n.h"
 #include "crypto/s2n_drbg.h"
 
 #include "stuffer/s2n_stuffer.h"

--- a/tests/fuzz/LD_PRELOAD/s2n_client_cert_verify_recv_test_overrides.c
+++ b/tests/fuzz/LD_PRELOAD/s2n_client_cert_verify_recv_test_overrides.c
@@ -35,5 +35,5 @@ int s2n_pkey_verify(const struct s2n_pkey *key, s2n_signature_algorithm sig_alg,
     orig_s2n_pkey_verify(key, sig_alg, digest, signature);
 
     /* Always assume that pkey_verify passes */
-    return 0;
+    return S2N_SUCCESS;
 }

--- a/tests/fuzz/LD_PRELOAD/s2n_memory_leak_negative_test_overrides.c
+++ b/tests/fuzz/LD_PRELOAD/s2n_memory_leak_negative_test_overrides.c
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 
+#include "api/s2n.h"
 #include "utils/s2n_blob.h"
 
 int s2n_free(struct s2n_blob *b)

--- a/tests/fuzz/LD_PRELOAD/s2n_memory_leak_negative_test_overrides.c
+++ b/tests/fuzz/LD_PRELOAD/s2n_memory_leak_negative_test_overrides.c
@@ -20,5 +20,5 @@ int s2n_free(struct s2n_blob *b)
     /* This will cause large amounts of memory leaks. This should be caught by LibFuzzer as a negative fuzz test to
      * ensure that LibFuzzer will catch these memory leaks.
      */
-    return 0;
+    return S2N_SUCCESS;
 }

--- a/tests/fuzz/Makefile
+++ b/tests/fuzz/Makefile
@@ -50,7 +50,7 @@ ld-preload :
 $(TESTS)::
 	@${CC} ${CFLAGS} $@.c -o $@  ${LDFLAGS} > /dev/null
 
-run_tests:: $(TESTS) ld-preload
+run_tests:: $(FUZZ_TESTS) ld-preload
 	@( fail_count=0; for test_name in ${FUZZ_TESTS} ; do \
 	export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}; \
 	export DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}; \

--- a/tests/fuzz/Readme.md
+++ b/tests/fuzz/Readme.md
@@ -9,8 +9,9 @@ By default, every test in this directory will be run as a fuzz test for several 
     2. If the test ends with `*_negative_test.c` the test is expected to fail in some way or return a non-zero integer (hereafter referred to as a "Negative test").
 2. Strive to be deterministic (Eg. shouldn't depend on the time or on the output of a RNG). Each test should either always pass if a Positive Test, or always fail if a Negative Test.
 3. If a Positive Fuzz test, it should have a non-empty corpus directory with inputs that have a relatively high branch coverage.
-4. Have a function `int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)` that will perform any initialization that will be run only once at startup.
-5. Have a function `int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)` that will pass `buf` to one of s2n's API's
+4. Have a function `int s2n_fuzz_init(int *argc, char **argv[])` that will perform any initialization that will be run only once at startup.
+5. Have a function `int s2n_fuzz_test(const uint8_t *buf, size_t len)` that will pass `buf` to one of s2n's API's
+6. Call `S2N_FUZZ_TARGET(s2n_fuzz_init, s2n_fuzz_test)` at the bottom of the test to initialize the fuzz target
 
 ## Fuzz Test Coverage
 To generate coverage reports for fuzz tests, simply set the FUZZ_COVERAGE environment variable to any non-null value and run `make fuzz`. This will report the target function coverage and overall S2N coverage when running the tests. In order to define target functions for a fuzz test, simply add the following line to your fuzz test below the copyright notice:
@@ -36,7 +37,7 @@ For a test with name `$TEST_NAME`, its files should be laid out with the followi
 > `s2n/tests/fuzz/LD_PRELOAD/${TEST_NAME}_overrides.c`
 
 # Corpus
-A Corpus is a directory of "interesting" inputs that result in a good branch/code coverage. These inputs will be permuted in random ways and checked to see if this permutation results in greater branch coverage or in a failure (Segfault, Memory Leak, Buffer Overflow, Non-zero return code, etc). If the permutation results in greater branch coverage, then it will be added to the Corpus directory. If a Memory leak or a Crash is detected, that file will **not** be added to the corpus for that test, and will instead be written to the current directory (`s2n/tests/fuzz/crash-*` or `s2n/tests/fuzz/leak-*`). These files will be automatically deleted for any Negative Fuzz tests that are expected to crash or leak memory so as to not clutter the directory. 
+A Corpus is a directory of "interesting" inputs that result in a good branch/code coverage. These inputs will be permuted in random ways and checked to see if this permutation results in greater branch coverage or in a failure (Segfault, Memory Leak, Buffer Overflow, Non-zero return code, etc). If the permutation results in greater branch coverage, then it will be added to the Corpus directory. If a Memory leak or a Crash is detected, that file will **not** be added to the corpus for that test, and will instead be written to the current directory (`s2n/tests/fuzz/crash-*` or `s2n/tests/fuzz/leak-*`). These files will be automatically deleted for any Negative Fuzz tests that are expected to crash or leak memory so as to not clutter the directory.
 
 # LD_PRELOAD
 The `LD_PRELOAD` directory contains function overrides for each Fuzz test that will be used **instead** of the original functions defined elsewhere. These function overrides will only be used during fuzz tests, and will not effect the rest of the s2n codebase when not fuzzing. Using `LD_PRELOAD` instead of C Preprocessor `#ifdef`'s is preferable in the following ways:

--- a/tests/fuzz/Readme.md
+++ b/tests/fuzz/Readme.md
@@ -11,7 +11,8 @@ By default, every test in this directory will be run as a fuzz test for several 
 3. If a Positive Fuzz test, it should have a non-empty corpus directory with inputs that have a relatively high branch coverage.
 4. Have a function `int s2n_fuzz_init(int *argc, char **argv[])` that will perform any initialization that will be run only once at startup.
 5. Have a function `int s2n_fuzz_test(const uint8_t *buf, size_t len)` that will pass `buf` to one of s2n's API's
-6. Call `S2N_FUZZ_TARGET(s2n_fuzz_init, s2n_fuzz_test)` at the bottom of the test to initialize the fuzz target
+5. Optionally add a function `void s2n_fuzz_cleanup()` which cleans up any global state.
+6. Call `S2N_FUZZ_TARGET(s2n_fuzz_init, s2n_fuzz_test, s2n_fuzz_cleanup)` at the bottom of the test to initialize the fuzz target
 
 ## Fuzz Test Coverage
 To generate coverage reports for fuzz tests, simply set the FUZZ_COVERAGE environment variable to any non-null value and run `make fuzz`. This will report the target function coverage and overall S2N coverage when running the tests. In order to define target functions for a fuzz test, simply add the following line to your fuzz test below the copyright notice:

--- a/tests/fuzz/s2n_bike_r1_fuzz_test.c
+++ b/tests/fuzz/s2n_bike_r1_fuzz_test.c
@@ -30,17 +30,8 @@
 
 static struct s2n_kem_params server_kem_params = {.kem = &s2n_bike1_l1_r1};
 
-static void s2n_fuzz_atexit()
+int s2n_fuzz_init(int *argc, char **argv[])
 {
-    s2n_kem_free(&server_kem_params);
-    s2n_cleanup();
-}
-
-int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
-{
-    GUARD(s2n_init());
-    GUARD_POSIX_STRICT(atexit(s2n_fuzz_atexit));
-
     GUARD(s2n_alloc(&server_kem_params.private_key, s2n_bike1_l1_r1.private_key_length));
 
     FILE *kat_file = fopen(RSP_FILE_NAME, "r");
@@ -49,10 +40,10 @@ int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
 
     fclose(kat_file);
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
-int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
+int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     struct s2n_blob ciphertext = {0};
     GUARD(s2n_alloc(&ciphertext, len));
@@ -69,5 +60,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     if (server_kem_params.shared_secret.allocated) {
         GUARD(s2n_free(&(server_kem_params.shared_secret)));
     }
-    return 0;
+    return S2N_SUCCESS;
 }
+
+static void s2n_fuzz_cleanup()
+{
+    s2n_kem_free(&server_kem_params);
+}
+
+S2N_FUZZ_TARGET(s2n_fuzz_init, s2n_fuzz_test, s2n_fuzz_cleanup)

--- a/tests/fuzz/s2n_bike_r2_fuzz_test.c
+++ b/tests/fuzz/s2n_bike_r2_fuzz_test.c
@@ -30,17 +30,8 @@
 
 static struct s2n_kem_params server_kem_params = {.kem = &s2n_bike1_l1_r2};
 
-static void s2n_fuzz_atexit()
+int s2n_fuzz_init(int *argc, char **argv[])
 {
-    s2n_kem_free(&server_kem_params);
-    s2n_cleanup();
-}
-
-int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
-{
-    GUARD(s2n_init());
-    GUARD_POSIX_STRICT(atexit(s2n_fuzz_atexit));
-
     GUARD(s2n_alloc(&server_kem_params.private_key, s2n_bike1_l1_r2.private_key_length));
 
     FILE *kat_file = fopen(RSP_FILE_NAME, "r");
@@ -49,10 +40,10 @@ int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
 
     fclose(kat_file);
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
-int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
+int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     struct s2n_blob ciphertext = {0};
     GUARD(s2n_alloc(&ciphertext, len));
@@ -69,5 +60,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     if (server_kem_params.shared_secret.allocated) {
         GUARD(s2n_free(&(server_kem_params.shared_secret)));
     }
-    return 0;
+    return S2N_SUCCESS;
 }
+
+static void s2n_fuzz_cleanup()
+{
+    s2n_kem_free(&server_kem_params);
+}
+
+S2N_FUZZ_TARGET(s2n_fuzz_init, s2n_fuzz_test, s2n_fuzz_cleanup)

--- a/tests/fuzz/s2n_certificate_extensions_parse_test.c
+++ b/tests/fuzz/s2n_certificate_extensions_parse_test.c
@@ -74,24 +74,13 @@ static uint8_t verify_host_accept_everything(const char *host_name, size_t host_
 /* This test is for TLS versions 1.3 and up only */
 static const uint8_t TLS_VERSIONS[] = {S2N_TLS13};
 
-static void s2n_fuzz_atexit()
+int s2n_fuzz_init(int *argc, char **argv[])
 {
-    s2n_cleanup();
-}
-
-int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
-{
-#ifdef S2N_TEST_IN_FIPS_MODE
-    S2N_TEST_ENTER_FIPS_MODE();
-#endif
-
-    GUARD(s2n_init());
-    GUARD_POSIX_STRICT(atexit(s2n_fuzz_atexit));
     GUARD(s2n_enable_tls13());
-    return 0;
+    return S2N_SUCCESS;
 }
 
-int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
+int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     /* We need at least one byte of input to set parameters */
     S2N_FUZZ_ENSURE_MIN_LEN(len, 1);
@@ -149,5 +138,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     GUARD(s2n_connection_free(client_conn));
     GUARD(s2n_stuffer_free(&fuzz_stuffer));
 
-    return 0;
+    return S2N_SUCCESS;
 }
+
+S2N_FUZZ_TARGET(s2n_fuzz_init, s2n_fuzz_test, NULL)

--- a/tests/fuzz/s2n_client_cert_recv_test.c
+++ b/tests/fuzz/s2n_client_cert_recv_test.c
@@ -55,23 +55,7 @@ static uint8_t verify_host_accept_everything(const char *host_name, size_t host_
 
 static const uint8_t TLS_VERSIONS[] = {S2N_TLS10, S2N_TLS11, S2N_TLS12, S2N_TLS13};
 
-static void s2n_fuzz_atexit()
-{
-    s2n_cleanup();
-}
-
-int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
-{
-#ifdef S2N_TEST_IN_FIPS_MODE
-    S2N_TEST_ENTER_FIPS_MODE();
-#endif
-
-    GUARD(s2n_init());
-    GUARD_POSIX_STRICT(atexit(s2n_fuzz_atexit));
-    return 0;
-}
-
-int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
+int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     /* We need at least one byte of input to set parameters */
     S2N_FUZZ_ENSURE_MIN_LEN(len, 1);
@@ -114,5 +98,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
 
     GUARD(s2n_connection_free(server_conn));
 
-    return 0;
+    return S2N_SUCCESS;
 }
+
+S2N_FUZZ_TARGET(NULL, s2n_fuzz_test, NULL)

--- a/tests/fuzz/s2n_client_fuzz_test.c
+++ b/tests/fuzz/s2n_client_fuzz_test.c
@@ -140,7 +140,7 @@ int buffer_read(void *io_context, uint8_t *buf, uint32_t len)
     int n_read, n_avail;
 
     if (buf == NULL) {
-        return 0;
+        return S2N_SUCCESS;
     }
 
     in_buf = (struct s2n_stuffer *) io_context;
@@ -169,26 +169,17 @@ int buffer_write(void *io_context, const uint8_t *buf, uint32_t len)
 
 static struct s2n_config *client_config;
 
-static void s2n_server_fuzz_atexit()
+int s2n_fuzz_init(int *argc, char **argv[])
 {
-    s2n_config_free(client_config);
-    s2n_cleanup();
-}
-
-int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
-{
-    GUARD(s2n_init());
-    GUARD_POSIX_STRICT(atexit(s2n_server_fuzz_atexit));
-
     /* Set up Server Config */
     notnull_check(client_config = s2n_config_new());
     GUARD(s2n_config_add_cert_chain_and_key(client_config, certificate_chain, private_key));
     GUARD(s2n_config_add_dhparams(client_config, dhparams));
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
-int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
+int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     S2N_FUZZ_ENSURE_MIN_LEN(len, S2N_TLS_RECORD_HEADER_LENGTH);
 
@@ -219,5 +210,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     GUARD(s2n_connection_free(client_conn));
     GUARD(s2n_stuffer_free(&in));
 
-    return 0;
+    return S2N_SUCCESS;
 }
+
+static void s2n_fuzz_cleanup()
+{
+    s2n_config_free(client_config);
+}
+
+S2N_FUZZ_TARGET(s2n_fuzz_init, s2n_fuzz_test, s2n_fuzz_cleanup)

--- a/tests/fuzz/s2n_encrypted_extensions_recv_test.c
+++ b/tests/fuzz/s2n_encrypted_extensions_recv_test.c
@@ -34,24 +34,13 @@
 /* This test is for TLS versions 1.3 and up only */
 static const uint8_t TLS_VERSIONS[] = {S2N_TLS13};
 
-static void s2n_fuzz_atexit()
+int s2n_fuzz_init(int *argc, char **argv[])
 {
-    s2n_cleanup();
-}
-
-int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
-{
-#ifdef S2N_TEST_IN_FIPS_MODE
-    S2N_TEST_ENTER_FIPS_MODE();
-#endif
-
-    GUARD(s2n_init());
-    GUARD_POSIX_STRICT(atexit(s2n_fuzz_atexit));
     GUARD(s2n_enable_tls13());
-    return 0;
+    return S2N_SUCCESS;
 }
 
-int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
+int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     /* We need at least one byte of input to set parameters */
     S2N_FUZZ_ENSURE_MIN_LEN(len, 1);
@@ -74,5 +63,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     /* Cleanup */
     GUARD(s2n_connection_free(client_conn));
 
-    return 0;
+    return S2N_SUCCESS;
 }
+
+S2N_FUZZ_TARGET(s2n_fuzz_init, s2n_fuzz_test, NULL)

--- a/tests/fuzz/s2n_extensions_client_key_share_recv_test.c
+++ b/tests/fuzz/s2n_extensions_client_key_share_recv_test.c
@@ -35,24 +35,13 @@
 /* This test is for TLS versions 1.3 and up only */
 static const uint8_t TLS_VERSIONS[] = {S2N_TLS13};
 
-static void s2n_fuzz_atexit()
+int s2n_fuzz_init(int *argc, char **argv[])
 {
-    s2n_cleanup();
-}
-
-int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
-{
-#ifdef S2N_TEST_IN_FIPS_MODE
-    S2N_TEST_ENTER_FIPS_MODE();
-#endif
-
-    GUARD(s2n_init());
-    GUARD_POSIX_STRICT(atexit(s2n_fuzz_atexit));
     GUARD(s2n_enable_tls13());
-    return 0;
+    return S2N_SUCCESS;
 }
 
-int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
+int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     /* We need at least one byte of input to set parameters */
     S2N_FUZZ_ENSURE_MIN_LEN(len, 1);
@@ -79,5 +68,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     GUARD(s2n_connection_free(server_conn));
     GUARD(s2n_stuffer_free(&fuzz_stuffer));
 
-    return 0;
+    return S2N_SUCCESS;
 }
+
+S2N_FUZZ_TARGET(s2n_fuzz_init, s2n_fuzz_test, NULL)

--- a/tests/fuzz/s2n_extensions_client_supported_versions_recv_test.c
+++ b/tests/fuzz/s2n_extensions_client_supported_versions_recv_test.c
@@ -36,24 +36,13 @@
 /* This test is for TLS versions 1.3 and up only */
 static const uint8_t TLS_VERSIONS[] = {S2N_TLS13};
 
-static void s2n_fuzz_atexit()
+int s2n_fuzz_init(int *argc, char **argv[])
 {
-    s2n_cleanup();
-}
-
-int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
-{
-#ifdef S2N_TEST_IN_FIPS_MODE
-    S2N_TEST_ENTER_FIPS_MODE();
-#endif
-
-    GUARD(s2n_init());
-    GUARD_POSIX_STRICT(atexit(s2n_fuzz_atexit));
     GUARD(s2n_enable_tls13());
-    return 0;
+    return S2N_SUCCESS;
 }
 
-int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
+int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     /* We need at least one byte of input to set parameters */
     S2N_FUZZ_ENSURE_MIN_LEN(len, 1);
@@ -83,6 +72,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     GUARD(s2n_connection_free(server_conn));
     GUARD(s2n_stuffer_free(&fuzz_stuffer));
 
-    return 0;
+    return S2N_SUCCESS;
 }
+
+S2N_FUZZ_TARGET(s2n_fuzz_init, s2n_fuzz_test, NULL)
 

--- a/tests/fuzz/s2n_extensions_server_key_share_recv_test.c
+++ b/tests/fuzz/s2n_extensions_server_key_share_recv_test.c
@@ -36,24 +36,13 @@
 /* This test is for TLS versions 1.3 and up only */
 static const uint8_t TLS_VERSIONS[] = {S2N_TLS13};
 
-static void s2n_fuzz_atexit()
+int s2n_fuzz_init(int *argc, char **argv[])
 {
-    s2n_cleanup();
-}
-
-int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
-{
-#ifdef S2N_TEST_IN_FIPS_MODE
-    S2N_TEST_ENTER_FIPS_MODE();
-#endif
-
-    GUARD(s2n_init());
-    GUARD_POSIX_STRICT(atexit(s2n_fuzz_atexit));
     GUARD(s2n_enable_tls13());
-    return 0;
+    return S2N_SUCCESS;
 }
 
-int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
+int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     /* We need at least one byte of input to set parameters */
     S2N_FUZZ_ENSURE_MIN_LEN(len, 1);
@@ -90,5 +79,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     GUARD(s2n_connection_free(client_conn));
     GUARD(s2n_stuffer_free(&fuzz_stuffer));
 
-    return 0;
+    return S2N_SUCCESS;
 }
+
+S2N_FUZZ_TARGET(s2n_fuzz_init, s2n_fuzz_test, NULL)

--- a/tests/fuzz/s2n_extensions_server_supported_versions_recv_test.c
+++ b/tests/fuzz/s2n_extensions_server_supported_versions_recv_test.c
@@ -34,24 +34,13 @@
 /* This test is for TLS versions 1.3 and up only */
 static const uint8_t TLS_VERSIONS[] = {S2N_TLS13};
 
-static void s2n_fuzz_atexit()
+int s2n_fuzz_init(int *argc, char **argv[])
 {
-    s2n_cleanup();
-}
-
-int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
-{
-#ifdef S2N_TEST_IN_FIPS_MODE
-    S2N_TEST_ENTER_FIPS_MODE();
-#endif
-
-    GUARD(s2n_init());
-    GUARD_POSIX_STRICT(atexit(s2n_fuzz_atexit));
     GUARD(s2n_enable_tls13());
-    return 0;
+    return S2N_SUCCESS;
 }
 
-int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
+int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     /* We need at least one byte of input to set parameters */
     S2N_FUZZ_ENSURE_MIN_LEN(len, 1);
@@ -80,5 +69,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     GUARD(s2n_connection_free(client_conn));
     GUARD(s2n_stuffer_free(&fuzz_stuffer));
 
-    return 0;
+    return S2N_SUCCESS;
 }
+
+S2N_FUZZ_TARGET(s2n_fuzz_init, s2n_fuzz_test, NULL)

--- a/tests/fuzz/s2n_hybrid_ecdhe_bike_r1_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_bike_r1_fuzz_test.c
@@ -59,29 +59,20 @@ static int setup_connection(struct s2n_connection *server_conn)
     GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->secure.kem_params.private_key));
     GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.server_ecc_evp_params));
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
-static void s2n_fuzz_atexit()
+int s2n_fuzz_init(int *argc, char **argv[])
 {
-    s2n_cleanup();
-    s2n_kem_free(&server_kem_params);
-}
-
-int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
-{
-    GUARD(s2n_init());
-    GUARD_POSIX_STRICT(atexit(s2n_fuzz_atexit));
-
     struct s2n_blob *public_key = &server_kem_params.public_key;
     GUARD(s2n_alloc(public_key, BIKE1_L1_R1_PUBLIC_KEY_BYTES));
     GUARD(s2n_kem_generate_keypair(&server_kem_params));
     GUARD(s2n_free(public_key));
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
-int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
+int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     struct s2n_connection *server_conn;
     notnull_check(server_conn = s2n_connection_new(S2N_SERVER));
@@ -100,5 +91,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
 
     GUARD(s2n_connection_free(server_conn));
 
-    return 0;
+    return S2N_SUCCESS;
 }
+
+static void s2n_fuzz_cleanup()
+{
+    s2n_kem_free(&server_kem_params);
+}
+
+S2N_FUZZ_TARGET(s2n_fuzz_init, s2n_fuzz_test, s2n_fuzz_cleanup)

--- a/tests/fuzz/s2n_hybrid_ecdhe_bike_r2_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_bike_r2_fuzz_test.c
@@ -59,29 +59,20 @@ static int setup_connection(struct s2n_connection *server_conn)
     GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->secure.kem_params.private_key));
     GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.server_ecc_evp_params));
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
-static void s2n_fuzz_atexit()
+int s2n_fuzz_init(int *argc, char **argv[])
 {
-    s2n_cleanup();
-    s2n_kem_free(&server_kem_params);
-}
-
-int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
-{
-    GUARD(s2n_init());
-    GUARD_POSIX_STRICT(atexit(s2n_fuzz_atexit));
-
     struct s2n_blob *public_key = &server_kem_params.public_key;
     GUARD(s2n_alloc(public_key, BIKE1_L1_R2_PUBLIC_KEY_BYTES));
     GUARD(s2n_kem_generate_keypair(&server_kem_params));
     GUARD(s2n_free(public_key));
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
-int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
+int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     struct s2n_connection *server_conn;
     notnull_check(server_conn = s2n_connection_new(S2N_SERVER));
@@ -100,5 +91,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
 
     GUARD(s2n_connection_free(server_conn));
 
-    return 0;
+    return S2N_SUCCESS;
 }
+
+static void s2n_fuzz_cleanup()
+{
+    s2n_kem_free(&server_kem_params);
+}
+
+S2N_FUZZ_TARGET(s2n_fuzz_init, s2n_fuzz_test, s2n_fuzz_cleanup)

--- a/tests/fuzz/s2n_hybrid_ecdhe_sike_r1_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_sike_r1_fuzz_test.c
@@ -59,29 +59,20 @@ static int setup_connection(struct s2n_connection *server_conn)
     GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->secure.kem_params.private_key));
     GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.server_ecc_evp_params));
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
-static void s2n_fuzz_atexit()
+int s2n_fuzz_init(int *argc, char **argv[])
 {
-    s2n_cleanup();
-    s2n_kem_free(&server_kem_params);
-}
-
-int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
-{
-    GUARD(s2n_init());
-    GUARD_POSIX_STRICT(atexit(s2n_fuzz_atexit));
-
     struct s2n_blob *public_key = &server_kem_params.public_key;
     GUARD(s2n_alloc(public_key, SIKE_P503_R1_PUBLIC_KEY_BYTES));
     GUARD(s2n_kem_generate_keypair(&server_kem_params));
     GUARD(s2n_free(public_key));
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
-int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
+int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     struct s2n_connection *server_conn;
     notnull_check(server_conn = s2n_connection_new(S2N_SERVER));
@@ -100,5 +91,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
 
     GUARD(s2n_connection_free(server_conn));
 
-    return 0;
+    return S2N_SUCCESS;
 }
+
+static void s2n_fuzz_cleanup()
+{
+    s2n_kem_free(&server_kem_params);
+}
+
+S2N_FUZZ_TARGET(s2n_fuzz_init, s2n_fuzz_test, s2n_fuzz_cleanup)

--- a/tests/fuzz/s2n_hybrid_ecdhe_sike_r2_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_sike_r2_fuzz_test.c
@@ -59,29 +59,20 @@ static int setup_connection(struct s2n_connection *server_conn)
     GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->secure.kem_params.private_key));
     GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.server_ecc_evp_params));
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
-static void s2n_fuzz_atexit()
+int s2n_fuzz_init(int *argc, char **argv[])
 {
-    s2n_cleanup();
-    s2n_kem_free(&server_kem_params);
-}
-
-int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
-{
-    GUARD(s2n_init());
-    GUARD(atexit(s2n_fuzz_atexit));
-
     struct s2n_blob *public_key = &server_kem_params.public_key;
     GUARD(s2n_alloc(public_key, SIKE_P434_R2_PUBLIC_KEY_BYTES));
     GUARD(s2n_kem_generate_keypair(&server_kem_params));
     GUARD(s2n_free(public_key));
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
-int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
+int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     struct s2n_connection *server_conn;
     notnull_check(server_conn = s2n_connection_new(S2N_SERVER));
@@ -100,5 +91,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
 
     GUARD(s2n_connection_free(server_conn));
 
-    return 0;
+    return S2N_SUCCESS;
 }
+
+static void s2n_fuzz_cleanup()
+{
+    s2n_kem_free(&server_kem_params);
+}
+
+S2N_FUZZ_TARGET(s2n_fuzz_init, s2n_fuzz_test, s2n_fuzz_cleanup)

--- a/tests/fuzz/s2n_memory_leak_negative_test.c
+++ b/tests/fuzz/s2n_memory_leak_negative_test.c
@@ -133,17 +133,7 @@ static char dhparams[] =
 
 static int MAX_NEGOTIATION_ATTEMPTS = 10;
 
-int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
-{
-#ifdef S2N_TEST_IN_FIPS_MODE
-    S2N_TEST_ENTER_FIPS_MODE();
-#endif
-
-    GUARD(s2n_init());
-    return 0;
-}
-
-int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
+int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     S2N_FUZZ_ENSURE_MIN_LEN(len, S2N_TLS_RECORD_HEADER_LENGTH);
 
@@ -210,5 +200,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     GUARD(s2n_connection_free(client_conn));
     GUARD(s2n_config_free(client_config));
 
-    return 0;
+    return S2N_SUCCESS;
 }
+
+S2N_FUZZ_TARGET(NULL, s2n_fuzz_test, NULL)

--- a/tests/fuzz/s2n_recv_client_supported_groups_test.c
+++ b/tests/fuzz/s2n_recv_client_supported_groups_test.c
@@ -34,24 +34,13 @@
 /* This test is for TLS versions 1.3 and up only */
 static const uint8_t TLS_VERSIONS[] = {S2N_TLS13};
 
-static void s2n_fuzz_atexit()
+int s2n_fuzz_init(int *argc, char **argv[])
 {
-    s2n_cleanup();
-}
-
-int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
-{
-#ifdef S2N_TEST_IN_FIPS_MODE
-    S2N_TEST_ENTER_FIPS_MODE();
-#endif
-
-    GUARD(s2n_init());
-    GUARD_POSIX_STRICT(atexit(s2n_fuzz_atexit));
     GUARD(s2n_enable_tls13());
-    return 0;
+    return S2N_SUCCESS;
 }
 
-int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
+int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     /* We need at least one byte of input to set parameters */
     S2N_FUZZ_ENSURE_MIN_LEN(len, 1);
@@ -79,5 +68,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     GUARD(s2n_connection_free(server_conn));
     GUARD(s2n_stuffer_free(&fuzz_stuffer));
 
-    return 0;
+    return S2N_SUCCESS;
 }
+
+S2N_FUZZ_TARGET(s2n_fuzz_init, s2n_fuzz_test, NULL)

--- a/tests/fuzz/s2n_server_cert_recv_test.c
+++ b/tests/fuzz/s2n_server_cert_recv_test.c
@@ -55,23 +55,7 @@ static uint8_t verify_host_accept_everything(const char *host_name, size_t host_
 
 static const uint8_t TLS_VERSIONS[] = {S2N_TLS10, S2N_TLS11, S2N_TLS12, S2N_TLS13};
 
-static void s2n_fuzz_atexit()
-{
-    s2n_cleanup();
-}
-
-int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
-{
-#ifdef S2N_TEST_IN_FIPS_MODE
-    S2N_TEST_ENTER_FIPS_MODE();
-#endif
-
-    GUARD(s2n_init());
-    GUARD_POSIX_STRICT(atexit(s2n_fuzz_atexit));
-    return 0;
-}
-
-int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
+int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     /* We need at least one byte of input to set parameters */
     S2N_FUZZ_ENSURE_MIN_LEN(len, 1);
@@ -112,5 +96,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
 
     GUARD(s2n_connection_free(conn));
 
-    return 0;
+    return S2N_SUCCESS;
 }
+
+S2N_FUZZ_TARGET(NULL, s2n_fuzz_test, NULL)

--- a/tests/fuzz/s2n_server_extensions_recv_test.c
+++ b/tests/fuzz/s2n_server_extensions_recv_test.c
@@ -37,24 +37,13 @@
 /* This test is for TLS versions 1.3 and up only */
 static const uint8_t TLS_VERSIONS[] = {S2N_TLS13};
 
-static void s2n_fuzz_atexit()
+int s2n_fuzz_init(int *argc, char **argv[])
 {
-    s2n_cleanup();
-}
-
-int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
-{
-#ifdef S2N_TEST_IN_FIPS_MODE
-    S2N_TEST_ENTER_FIPS_MODE();
-#endif
-
-    GUARD(s2n_init());
-    GUARD_POSIX_STRICT(atexit(s2n_fuzz_atexit));
     GUARD(s2n_enable_tls13());
-    return 0;
+    return S2N_SUCCESS;
 }
 
-int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
+int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     /* We need at least one byte of input to set parameters */
     S2N_FUZZ_ENSURE_MIN_LEN(len, 1);
@@ -82,5 +71,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     GUARD(s2n_connection_free(client_conn));
     GUARD(s2n_stuffer_free(&fuzz_stuffer));
 
-    return 0;
+    return S2N_SUCCESS;
 }
+
+S2N_FUZZ_TARGET(s2n_fuzz_init, s2n_fuzz_test, NULL)

--- a/tests/fuzz/s2n_server_hello_recv_test.c
+++ b/tests/fuzz/s2n_server_hello_recv_test.c
@@ -31,23 +31,7 @@
 static const uint8_t TLS_VERSIONS[] = {S2N_TLS10, S2N_TLS11, S2N_TLS12, S2N_TLS13};
 struct s2n_config *client_config;
 
-static void s2n_fuzz_atexit()
-{
-    s2n_cleanup();
-}
-
-int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
-{
-#ifdef S2N_TEST_IN_FIPS_MODE
-    S2N_TEST_ENTER_FIPS_MODE();
-#endif
-
-    GUARD(s2n_init());
-    GUARD_POSIX_STRICT(atexit(s2n_fuzz_atexit));
-    return 0;
-}
-
-int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
+int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     /* We need at least one byte of input to set parameters */
     S2N_FUZZ_ENSURE_MIN_LEN(len, 1);
@@ -73,5 +57,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     GUARD(s2n_config_free(client_config));
     GUARD(s2n_connection_free(client_conn));
 
-    return 0;
+    return S2N_SUCCESS;
 }
+
+S2N_FUZZ_TARGET(NULL, s2n_fuzz_test, NULL)

--- a/tests/fuzz/s2n_sike_r1_fuzz_test.c
+++ b/tests/fuzz/s2n_sike_r1_fuzz_test.c
@@ -30,17 +30,8 @@
 
 static struct s2n_kem_params server_kem_params = {.kem = &s2n_sike_p503_r1};
 
-static void s2n_fuzz_atexit()
+int s2n_fuzz_init(int *argc, char **argv[])
 {
-    s2n_kem_free(&server_kem_params);
-    s2n_cleanup();
-}
-
-int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
-{
-    GUARD(s2n_init());
-    GUARD_POSIX_STRICT(atexit(s2n_fuzz_atexit));
-
     GUARD(s2n_alloc(&server_kem_params.private_key, s2n_sike_p503_r1.private_key_length));
 
     FILE *kat_file = fopen(RSP_FILE_NAME, "r");
@@ -49,10 +40,10 @@ int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
 
     fclose(kat_file);
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
-int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
+int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     struct s2n_blob ciphertext = {0};
     GUARD(s2n_alloc(&ciphertext, len));
@@ -69,5 +60,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     if (server_kem_params.shared_secret.allocated) {
         GUARD(s2n_free(&(server_kem_params.shared_secret)));
     }
-    return 0;
+    return S2N_SUCCESS;
 }
+
+static void s2n_fuzz_cleanup()
+{
+    s2n_kem_free(&server_kem_params);
+}
+
+S2N_FUZZ_TARGET(s2n_fuzz_init, s2n_fuzz_test, s2n_fuzz_cleanup)

--- a/tests/fuzz/s2n_stuffer_pem_fuzz_test.c
+++ b/tests/fuzz/s2n_stuffer_pem_fuzz_test.c
@@ -25,21 +25,10 @@
 
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
+#include "tests/s2n_test.h"
 #include "utils/s2n_safety.h"
 
-static void s2n_fuzz_atexit()
-{
-    s2n_cleanup();
-}
-
-int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
-{
-    GUARD(s2n_init());
-    GUARD_POSIX_STRICT(atexit(s2n_fuzz_atexit));
-    return 0;
-}
-
-int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
+int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     struct s2n_stuffer in = {0};
     struct s2n_stuffer out = {0};
@@ -59,5 +48,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     GUARD(s2n_stuffer_free(&in));
     GUARD(s2n_stuffer_free(&out));
 
-    return 0;
+    return S2N_SUCCESS;
 }
+
+S2N_FUZZ_TARGET(NULL, s2n_fuzz_test, NULL)

--- a/tests/s2n_test.h
+++ b/tests/s2n_test.h
@@ -209,7 +209,7 @@ int LLVMFuzzerInitialize(int *argc, char **argv[]) \
 { \
     S2N_TEST_OPTIONALLY_ENABLE_FIPS_MODE(); \
     EXPECT_SUCCESS_WITHOUT_COUNT(s2n_init()); \
-    EXPECT_SUCCESS_WITHOUT_COUNT(atexit(s2n_test__fuzz_cleanup));
+    EXPECT_SUCCESS_WITHOUT_COUNT(atexit(s2n_test__fuzz_cleanup)); \
     if (!fuzz_init) { \
         return S2N_SUCCESS; \
     } \

--- a/tests/s2n_test.h
+++ b/tests/s2n_test.h
@@ -41,26 +41,17 @@ int test_count;
  * This is a very basic, but functional unit testing framework. All testing should
  * happen in main() and start with a BEGIN_TEST() and end with an END_TEST();
  */
-#ifdef S2N_TEST_IN_FIPS_MODE
-#define BEGIN_TEST()						\
-  do {								\
-    test_count = 0; \
-    EXPECT_SUCCESS_WITHOUT_COUNT(s2n_in_unit_test_set(true));	\
-    EXPECT_NOT_EQUAL_WITHOUT_COUNT(FIPS_mode_set(1), 0);	\
-    EXPECT_SUCCESS_WITHOUT_COUNT(s2n_init());			\
-    fprintf(stdout, "Running FIPS test %-50s ... ", __FILE__);	\
+#define BEGIN_TEST()                                           \
+  do {                                                         \
+    test_count = 0;                                            \
+    EXPECT_SUCCESS_WITHOUT_COUNT(s2n_in_unit_test_set(true));  \
+    S2N_TEST_OPTIONALLY_ENABLE_FIPS_MODE();                    \
+    EXPECT_SUCCESS_WITHOUT_COUNT(s2n_init());                  \
+    fprintf(stdout, "Running %-50s ... ", __FILE__);           \
   } while(0)
-#else
-#define BEGIN_TEST()						\
-  do {					\
-    test_count = 0; \
-    EXPECT_SUCCESS_WITHOUT_COUNT(s2n_in_unit_test_set(true));	\
-    EXPECT_SUCCESS_WITHOUT_COUNT(s2n_init());			\
-    fprintf(stdout, "Running %-50s ... ", __FILE__);		\
-  } while(0)
-#endif
+
 #define END_TEST()   do { \
-                        EXPECT_SUCCESS_WITHOUT_COUNT(s2n_in_unit_test_set(false));		\
+                        EXPECT_SUCCESS_WITHOUT_COUNT(s2n_in_unit_test_set(false));      \
                         EXPECT_SUCCESS_WITHOUT_COUNT(s2n_cleanup());       \
                         if (isatty(fileno(stdout))) { \
                             if (test_count) { \
@@ -84,18 +75,22 @@ int test_count;
 #define FAIL()      FAIL_MSG("")
 
 #define FAIL_MSG( msg ) do { \
-                          s2n_print_stacktrace(stdout); \
+                          FAIL_MSG_PRINT(msg); \
+                          exit(1);  \
+                        } while(0)
+
+#define FAIL_MSG_PRINT( msg ) do { \
+                          s2n_print_stacktrace(stderr); \
                           /* isatty will overwrite errno on failure */ \
                           int real_errno = errno; \
-                          if (isatty(fileno(stdout))) { \
+                          if (isatty(fileno(stderr))) { \
                             errno = real_errno; \
-                            fprintf(stdout, "\033[31;1mFAILED test %d\033[0m\n%s (%s line %d)\nError Message: '%s'\n Debug String: '%s'\n System Error: %s (%d)\n", test_count, (msg), __FILE__, __LINE__, s2n_strerror(s2n_errno, "EN"), s2n_debug_str, strerror(errno), errno); \
+                            fprintf(stderr, "\033[31;1mFAILED test %d\033[0m\n%s (%s line %d)\nError Message: '%s'\n Debug String: '%s'\n System Error: %s (%d)\n", test_count, (msg), __FILE__, __LINE__, s2n_strerror(s2n_errno, "EN"), s2n_debug_str, strerror(errno), errno); \
                           } \
                           else { \
                             errno = real_errno; \
-                            fprintf(stdout, "FAILED test %d\n%s (%s line %d)\nError Message: '%s'\n Debug String: '%s'\n System Error: %s (%d)\n", test_count, (msg), __FILE__, __LINE__, s2n_strerror(s2n_errno, "EN"), s2n_debug_str, strerror(errno), errno); \
+                            fprintf(stderr, "FAILED test %d\n%s (%s line %d)\nError Message: '%s'\n Debug String: '%s'\n System Error: %s (%d)\n", test_count, (msg), __FILE__, __LINE__, s2n_strerror(s2n_errno, "EN"), s2n_debug_str, strerror(errno), errno); \
                           } \
-                          exit(1);  \
                         } while(0)
 
 #define RESET_ERRNO() \
@@ -173,8 +168,14 @@ int test_count;
                                         printf("s2nd entered FIPS mode\n"); \
                                       }
 
+#ifdef S2N_TEST_IN_FIPS_MODE
+#define S2N_TEST_OPTIONALLY_ENABLE_FIPS_MODE() S2N_TEST_ENTER_FIPS_MODE()
+#else
+#define S2N_TEST_OPTIONALLY_ENABLE_FIPS_MODE()
+#endif
+
 /* Ensures fuzz test input length is greater than or equal to the minimum needed for the test */
-#define S2N_FUZZ_ENSURE_MIN_LEN( len , min ) do {if ( (len) < (min) ) return 0;} while (0)
+#define S2N_FUZZ_ENSURE_MIN_LEN( len , min ) do {if ( (len) < (min) ) return S2N_SUCCESS;} while (0)
 
 #define EXPECT_MEMCPY_SUCCESS(d, s, n)                                         \
     do {                                                                       \
@@ -194,3 +195,35 @@ int test_count;
 #else
 #define TEST_DEBUG_PRINT(...)
 #endif
+
+/* Creates a fuzz target */
+#define S2N_FUZZ_TARGET(fuzz_init, fuzz_entry, fuzz_cleanup) \
+int LLVMFuzzerInitialize(int *argc, char **argv[]) \
+{ \
+    S2N_TEST_OPTIONALLY_ENABLE_FIPS_MODE(); \
+    EXPECT_SUCCESS_WITHOUT_COUNT(s2n_init()); \
+    if (!fuzz_init) { \
+        return S2N_SUCCESS; \
+    } \
+    int result = ((int (*)(int *argc, char **argv[])) fuzz_init)(argc, argv); \
+    if (result != S2N_SUCCESS) { \
+        FAIL_MSG_PRINT(#fuzz_init " did not return S2N_SUCCESS"); \
+        if (fuzz_cleanup) { \
+            ((void (*)()) fuzz_cleanup)(); \
+        } \
+        s2n_cleanup(); \
+    } \
+    return result; \
+} \
+int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len) \
+{ \
+    int result = fuzz_entry(buf, len); \
+    if (result != S2N_SUCCESS) { \
+        FAIL_MSG_PRINT(#fuzz_entry " did not return S2N_SUCCESS"); \
+        if (fuzz_cleanup) { \
+            ((void (*)()) fuzz_cleanup)(); \
+        } \
+        s2n_cleanup(); \
+    } \
+    return result; \
+}

--- a/tests/s2n_test.h
+++ b/tests/s2n_test.h
@@ -159,17 +159,20 @@ int test_count;
 #define EXPECT_STRING_EQUAL( p1, p2 ) EXPECT_EQUAL( strcmp( (p1), (p2) ), 0 )
 #define EXPECT_STRING_NOT_EQUAL( p1, p2 ) EXPECT_NOT_EQUAL( strcmp( (p1), (p2) ), 0 )
 
-#define S2N_TEST_ENTER_FIPS_MODE()    { if (FIPS_mode_set(1) == 0) { \
-                                            unsigned long fips_rc = ERR_get_error(); \
-                                            char ssl_error_buf[256]; \
-                                            fprintf(stderr, "s2nd failed to enter FIPS mode with RC: %lu; String: %s\n", fips_rc, ERR_error_string(fips_rc, ssl_error_buf)); \
-                                            return 1; \
-                                        } \
-                                        printf("s2nd entered FIPS mode\n"); \
-                                      }
-
 #ifdef S2N_TEST_IN_FIPS_MODE
-#define S2N_TEST_OPTIONALLY_ENABLE_FIPS_MODE() S2N_TEST_ENTER_FIPS_MODE()
+#include <openssl/err.h>
+
+#define S2N_TEST_OPTIONALLY_ENABLE_FIPS_MODE() \
+    do { \
+        if (FIPS_mode_set(1) == 0) { \
+            unsigned long fips_rc = ERR_get_error(); \
+            char ssl_error_buf[256]; \
+            fprintf(stderr, "s2nd failed to enter FIPS mode with RC: %lu; String: %s\n", fips_rc, ERR_error_string(fips_rc, ssl_error_buf)); \
+            return 1; \
+        } \
+        printf("s2nd entered FIPS mode\n"); \
+    } while (0)
+
 #else
 #define S2N_TEST_OPTIONALLY_ENABLE_FIPS_MODE()
 #endif


### PR DESCRIPTION
### Description of changes: 

This adds a `S2N_FUZZ_TARGET` macro which wraps fuzz target implementations. This enables:

* Stacktraces and error messages are printed on failures - very helpful for debugging
* Consistent initialization and cleanup
* Abstraction for other fuzzing engines in the future (AFL, Honggfuzz, etc.) We just need to update the macro to export a different harness for each. It might even be possible to even make it work with CBMC :)

Defining a fuzz target now looks something like:

```c
int s2n_fuzz_init(int *argc, char **argv[])
{
    // init goes here; s2n_init is automatically done for you
    return S2N_SUCCESS;
}

int s2n_fuzz_test(const uint8_t *buf, size_t len)
{
    // checks go here
    return S2N_SUCCESS;
}

void s2n_fuzz_cleanup()
{
    // cleanup goes here
}

S2N_FUZZ_TARGET(s2n_fuzz_init, s2n_fuzz_test, s2n_fuzz_cleanup)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
