### PR TITLE
Adding integrationv2 tests for HRR client side

### DIFF
--- a/tests/integrationv2/configuration.py
+++ b/tests/integrationv2/configuration.py
@@ -34,6 +34,12 @@ ALL_TEST_CURVES = [
     Curves.P384,
 ]
 
+# List of keyshares for Hello Retr Requests test.
+HRR_CLIENT_KEYSHARES = [
+    ["-K", "none"],
+    ["-K", "secp256r1"],
+    ["-K", "secp256r1:secp384r1"],
+]
 
 # List of all certificates that will be tested.
 ALL_TEST_CERTS = [

--- a/tests/integrationv2/configuration.py
+++ b/tests/integrationv2/configuration.py
@@ -92,6 +92,12 @@ ALL_TEST_CIPHERS = [
     Ciphers.CHACHA20_POLY1305_SHA256,
 ]
 
+# List of TLS13 Ciphers
+TLS13_CIPHERS = [
+    Ciphers.CHACHA20_POLY1305_SHA256,
+    Ciphers.AES128_GCM_SHA256,
+    Ciphers.AES256_GCM_SHA384,
+]
 
 # List of providers that will be tested.
 PROVIDERS = [S2N, OpenSSL]

--- a/tests/integrationv2/configuration.py
+++ b/tests/integrationv2/configuration.py
@@ -34,13 +34,6 @@ ALL_TEST_CURVES = [
     Curves.P384,
 ]
 
-# List of keyshares for Hello Retr Requests test.
-HRR_CLIENT_KEYSHARES = [
-    ["-K", "none"],
-    ["-K", "secp256r1"],
-    ["-K", "secp256r1:secp384r1"],
-]
-
 # List of all certificates that will be tested.
 ALL_TEST_CERTS = [
     Certificates.RSA_1024_SHA256,

--- a/tests/integrationv2/configuration.py
+++ b/tests/integrationv2/configuration.py
@@ -34,6 +34,7 @@ ALL_TEST_CURVES = [
     Curves.P384,
 ]
 
+
 # List of all certificates that will be tested.
 ALL_TEST_CERTS = [
     Certificates.RSA_1024_SHA256,

--- a/tests/integrationv2/test_hello_retry_requests.py
+++ b/tests/integrationv2/test_hello_retry_requests.py
@@ -8,13 +8,15 @@ from common import ProviderOptions, Protocols, data_bytes, Curves
 from fixtures import managed_process
 from providers import Provider, S2N, OpenSSL
 from utils import invalid_test_parameters, get_parameter_name
-   
+
+
 # List of keyshares for hello retry requests client side test.
 HRR_CLIENT_KEYSHARES = [
     ["-K", "none"],
     ["-K", "secp256r1"],
     ["-K", "secp256r1:secp384r1"],
 ]
+
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)

--- a/tests/integrationv2/test_hello_retry_requests.py
+++ b/tests/integrationv2/test_hello_retry_requests.py
@@ -1,0 +1,160 @@
+import copy
+import os
+import pytest
+import time
+
+from configuration import available_ports, TLS13_CIPHERS, ALL_TEST_CURVES, ALL_TEST_CERTS, PROVIDERS, PROTOCOLS
+from common import Certificates, ProviderOptions, Protocols, data_bytes, Ciphers, Curves
+from fixtures import managed_process
+from providers import Provider, S2N, OpenSSL
+from utils import invalid_test_parameters, get_parameter_name
+
+def verify_hello_retry_request(server):  
+    marker_found = False
+    client_hello_count = 0
+    server_hello_count = 0 
+    finished_count = 0
+    marker = b"cf 21 ad 74 e5 9a 61 11 be 1d"
+
+    for results in server.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+
+        if marker in results.stdout:
+            marker_found = True
+        if b'client hello' in results.stdout:
+            client_hello_count += 1
+        if b'server hello' in results.stdout:
+            server_hello_count += 1
+        if b'finished' in results.stdout:
+            finished_count += 1
+        if marker_found and client_hello_count == 2 and server_hello_count == 2 and finished_count == 2:
+            return True
+
+    return False
+
+@pytest.mark.uncollect_if(func=invalid_test_parameters)
+@pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
+@pytest.mark.parametrize("provider", [OpenSSL])
+@pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
+@pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
+@pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
+def test_hrr_with_empty_keyshare(managed_process, cipher, provider, curve, protocol, certificate):
+    port = next(available_ports)
+
+    bytes_to_send = data_bytes(24)
+    client_options = ProviderOptions(
+        mode=Provider.ClientMode,
+        host="localhost",
+        port=port,
+        cipher=cipher,
+        data_to_send=bytes_to_send,
+        insecure=True,
+        curve=curve,
+        extra_flags=["-K", "none"],
+        protocol=protocol)
+
+    server_options = copy.copy(client_options)
+    server_options.data_to_send = None
+    server_options.mode = Provider.ServerMode
+    server_options.key = certificate.key
+    server_options.cert = certificate.cert
+    server_options.extra_flags = None
+
+    # Passing the type of client and server as a parameter will
+    # allow us to use a fixture to enumerate all possibilities.
+    server = managed_process(provider, server_options, timeout=5)
+    client = managed_process(S2N, client_options, timeout=5)
+
+    # The client should connect and return without error
+    for results in client.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+
+    assert verify_hello_retry_request(server) is True
+
+@pytest.mark.uncollect_if(func=invalid_test_parameters)
+@pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
+@pytest.mark.parametrize("provider", [OpenSSL])
+@pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
+@pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
+def test_hrr_with_single_keyshare(managed_process, cipher, provider, curve, protocol, certificate):
+    port = next(available_ports)
+
+    random_bytes = data_bytes(64)
+    client_options = ProviderOptions(
+        mode=Provider.ClientMode,
+        host="localhost",
+        port=port,
+        cipher=cipher,
+        data_to_send=random_bytes,
+        insecure=True,
+        extra_flags=["-K","secp256r1"],
+        protocol=protocol)
+    
+    server_options = ProviderOptions(
+        mode=Provider.ServerMode,
+        host="localhost",
+        port=port,
+        cipher=cipher,
+        curve=Curves.X25519,
+        protocol=protocol,
+        data_to_send=None,
+        insecure=True,
+        key=certificate.key,
+        cert=certificate.cert)
+
+    # Passing the type of client and server as a parameter will
+    # allow us to use a fixture to enumerate all possibilities.
+    server = managed_process(provider, server_options, timeout=5)
+    client = managed_process(S2N, client_options, timeout=5)
+
+    # The client should connect and return without error
+    for results in client.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+
+    assert verify_hello_retry_request(server) is True
+
+@pytest.mark.uncollect_if(func=invalid_test_parameters)
+@pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
+@pytest.mark.parametrize("provider", [OpenSSL])
+@pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
+@pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
+def test_hrr_with_multiple_keyshare(managed_process, cipher, provider, curve, protocol, certificate):
+    port = next(available_ports)
+
+    random_bytes = data_bytes(64)
+    client_options = ProviderOptions(
+        mode=Provider.ClientMode,
+        host="localhost",
+        port=port,
+        cipher=cipher,
+        data_to_send=random_bytes,
+        insecure=True,
+        extra_flags=["-K","secp256r1:secp384r1"],
+        protocol=protocol)
+    
+    server_options = ProviderOptions(
+        mode=Provider.ServerMode,
+        host="localhost",
+        port=port,
+        cipher=cipher,
+        curve=Curves.X25519,
+        protocol=protocol,
+        data_to_send=None,
+        insecure=True,
+        key=certificate.key,
+        cert=certificate.cert)
+
+    # Passing the type of client and server as a parameter will
+    # allow us to use a fixture to enumerate all possibilities.
+    server = managed_process(provider, server_options, timeout=5)
+    client = managed_process(S2N, client_options, timeout=5)
+
+    # The client should connect and return without error
+    for results in client.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+
+    assert verify_hello_retry_request(server) is True

--- a/tests/integrationv2/test_hello_retry_requests.py
+++ b/tests/integrationv2/test_hello_retry_requests.py
@@ -31,7 +31,7 @@ def verify_hello_retry_request(server):
             finished_count += 1
         if server.data_to_send in results.stdout:
             bytes_found = True
-        if marker_found and client_hello_count == 2 and server_hello_count == 2 and finished_count == 2 and bytes_to_send:
+        if marker_found and client_hello_count == 2 and server_hello_count == 2 and finished_count == 2 and bytes_found:
             return True
 
     return False

--- a/tests/integrationv2/test_hello_retry_requests.py
+++ b/tests/integrationv2/test_hello_retry_requests.py
@@ -3,62 +3,20 @@ import os
 import pytest
 import time
 
-from configuration import available_ports, TLS13_CIPHERS, ALL_TEST_CURVES, ALL_TEST_CERTS
+from configuration import available_ports, TLS13_CIPHERS, ALL_TEST_CURVES, ALL_TEST_CERTS, HRR_CLIENT_KEYSHARES
 from common import ProviderOptions, Protocols, data_bytes, Curves
 from fixtures import managed_process
 from providers import Provider, S2N, OpenSSL
 from utils import invalid_test_parameters, get_parameter_name
-
-def get_curve_name(curve):
-    if curve.name == "X25519":
-       return "x25519"
-    elif curve.name == "P-256":
-        return "secp256r1"
-    elif curve.name == "P-384":
-        return "secp384r1"
-    else:
-       return None
    
-def verify_hello_retry_request_client(curve_name, client):
-    # The client should connect and return without error
-    for results in client.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
-        if bytes("Curve: {}".format(curve_name).encode('utf-8')) in results.stdout:
-            return True 
-    return False 
-
-def verify_hello_retry_request_server(random_bytes, curve, server):
-    marker_found = False
-    supported_groups_found = False
-    shared_group_found = False  
-    data_to_send_found = False 
-    marker_part1 = b"cf 21 ad 74 e5"
-    marker_part2 = b"9a 61 11 be 1d"
-
-    for results in server.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
-
-        if marker_part1 in results.stdout and marker_part2 in results.stdout:
-           marker_found = True
-        if b'Supported Elliptic Groups: X25519:P-256:P-384' in results.stdout:
-            supported_groups_found = True 
-        if bytes("Shared Elliptic groups: {}".format(curve).encode('utf-8')) in results.stdout:
-            shared_group_found = True 
-        if random_bytes in results.stdout:
-            data_to_send_found = True 
-        if marker_found and supported_groups_found and shared_group_found and data_to_send_found:
-            return True 
-    return False 
-
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL])
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
-def test_hrr_with_empty_keyshare(managed_process, cipher, provider, curve, protocol, certificate):
+@pytest.mark.parametrize("keyshare", HRR_CLIENT_KEYSHARES, ids=get_parameter_name)
+def test_hrr_with_s2n_as_client(managed_process, cipher, provider, curve, protocol, certificate, keyshare):
     port = next(available_ports)
 
     random_bytes = data_bytes(64)
@@ -70,47 +28,9 @@ def test_hrr_with_empty_keyshare(managed_process, cipher, provider, curve, proto
         data_to_send=random_bytes,
         insecure=True,
         curve=curve,
-        extra_flags=["-K", "none"],
+        extra_flags=keyshare,
         protocol=protocol)
 
-    server_options = copy.copy(client_options)
-    server_options.data_to_send = None
-    server_options.mode = Provider.ServerMode
-    server_options.key = certificate.key
-    server_options.cert = certificate.cert
-    server_options.extra_flags = None
-
-    # Passing the type of client and server as a parameter will
-    # allow us to use a fixture to enumerate all possibilities.
-    server = managed_process(provider, server_options, timeout=5)
-    client = managed_process(S2N, client_options, timeout=5)
-
-    curve_name = get_curve_name(curve)
-    assert verify_hello_retry_request_client(curve_name, client) is True 
-    assert verify_hello_retry_request_server(random_bytes, curve, server) is True 
- 
-    for results in server.get_results():
-        assert b'"key share" (id=51), len=2\n0000 - 00 00' in results.stdout
-
-@pytest.mark.uncollect_if(func=invalid_test_parameters)
-@pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
-@pytest.mark.parametrize("provider", [OpenSSL])
-@pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
-@pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
-def test_hrr_with_single_and_multiple_keyshares(managed_process, cipher, provider, protocol, certificate):
-    port = next(available_ports)
-
-    random_bytes = data_bytes(64)
-    client_options = ProviderOptions(
-        mode=Provider.ClientMode,
-        host="localhost",
-        port=port,
-        cipher=cipher,
-        data_to_send=random_bytes,
-        insecure=True,
-        extra_flags=["-K","secp256r1"],
-        protocol=protocol)
-    
     server_options = copy.copy(client_options)
     server_options.data_to_send = None
     server_options.mode = Provider.ServerMode
@@ -124,13 +44,33 @@ def test_hrr_with_single_and_multiple_keyshares(managed_process, cipher, provide
     server = managed_process(provider, server_options, timeout=5)
     client = managed_process(S2N, client_options, timeout=5)
 
-    assert verify_hello_retry_request_client("x25519", client) is True 
-    assert verify_hello_retry_request_server(random_bytes, Curves.X25519, server) is True 
+    # The client should connect and return without error
+    for results in client.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+        assert bytes("Curve: {}".format("x25519").encode('utf-8')) in results.stdout
 
-    client_options.extra_flags = ["-K","secp256r1:secp384r1"]
+    marker_found = False
+    supported_groups_found = False
+    shared_group_found = False  
+    data_to_send_found = False 
+    marker_part1 = b"cf 21 ad 74 e5"
+    marker_part2 = b"9a 61 11 be 1d"
 
-    server = managed_process(provider, server_options, timeout=5)
-    client = managed_process(S2N, client_options, timeout=5)
+    for results in server.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
 
-    assert verify_hello_retry_request_client("x25519", client) is True 
-    assert verify_hello_retry_request_server(random_bytes, Curves.X25519, server) is True
+        if marker_part1 in results.stdout and marker_part2 in results.stdout:
+           marker_found = True
+        if 'none' in keyshare:
+            assert b'"key share" (id=51), len=2\n0000 - 00 00' in results.stdout
+        if b'Supported Elliptic Groups: X25519:P-256:P-384' in results.stdout:
+            supported_groups_found = True 
+        if bytes("Shared Elliptic groups: {}".format(server_options.curve).encode('utf-8')) in results.stdout:
+            shared_group_found = True 
+        if random_bytes in results.stdout:
+            data_to_send_found = True 
+        
+    assert marker_found and supported_groups_found and shared_group_found and data_to_send_found
+


### PR DESCRIPTION
### Resolved issues:

 resolves https://github.com/awslabs/s2n/issues/2049

### Description of changes: 

Add integration tests for Hello Retry Request for the following cases:

- Client sends an empty list of key shares
- Client sends a list of key shares, but the key share(s) present in the list is not supported by the server
   

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
