### PR TITLE
Updates USAGE-GUIDE for s2n_connection_client_cert_used API

### DIFF
--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1226,12 +1226,12 @@ ssize_t s2n_client_hello_get_extension_by_id(struct s2n_client_hello *ch, s2n_tl
 **s2n_client_hello_get_extension_length** returns the number of bytes the given extension type takes on the ClientHello message received by the server; it can be used to allocate the **out** buffer.
 **s2n_client_hello_get_extension_by_id** copies into the **out** buffer **max_length** bytes of a given extension type on the ClienthHello and returns the number of bytes that were copied.
 
-### s2n\_connection\_is\_client\_authenticated
+### s2n\_connection\_client\_cert\_used
 
 ```c
-int s2n_connection_is_client_authenticated(struct s2n_connection *conn);
+int s2n_connection_client_cert_used(struct s2n_connection *conn);
 ```
-**s2n_connection_is_client_authenticated** returns 1 if the handshake completed and Client Auth was 
+**s2n_connection_client_cert_used** returns 1 if the handshake completed and Client Auth was 
 negotiated during the handshake.
 
 ### s2n\_get\_application\_protocol


### PR DESCRIPTION
### Resolved issues:

 resolves  https://github.com/awslabs/s2n/issues/1727

### Description of changes: 

Updates `s2n_connection_is_client_authenticated()`vdescription in USAGE-GUIDE.md to `s2n_connection_client_cert_used` as this  [commit](https://github.com/awslabs/s2n/commit/f6ac8884ae215b11b91f812097098f0d2466bc0e) re-named the API.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
