### PR TITLE
Separate different types of tests into separate codecov statuses

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -17,6 +17,15 @@ coverage:
         base: auto
     patch:
       default:
+        flags:
+          - asan
+          - integration
+          - integrationv2
+        target: auto
+        threshold: 0.5
+        base: auto
+      fuzz:
+        flags: fuzz
         target: auto
         threshold: 0.5
         base: auto

--- a/codebuild/bin/s2n_after_codebuild.sh
+++ b/codebuild/bin/s2n_after_codebuild.sh
@@ -18,7 +18,7 @@ set -ex
 # Upload Code Coverage Information to CodeCov.io
 if [[ -n "$CODECOV_IO_UPLOAD" ]]; then
     if [[ -n "$FUZZ_COVERAGE" ]]; then
-        bash <(curl -s https://codecov.io/bash) -f coverage/fuzz/codecov.txt
+        bash <(curl -s https://codecov.io/bash) -f coverage/fuzz/codecov.txt -F ${TESTS};
     else
         bash <(curl -s https://codecov.io/bash) -F ${TESTS};
     fi


### PR DESCRIPTION
### Description of changes: 

Since fuzz test coverage is including comments in coverage due to an apparent bug in LLVM (see https://bugs.llvm.org/show_bug.cgi?id=45757), as a semi-workaround this will separate the fuzz coverage tracking into a separate status.
   

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
