### PR TITLE
Removing dot prefix on codecov.yml and fixing validation issue

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -25,7 +25,8 @@ coverage:
         threshold: 0.5
         base: auto
       fuzz:
-        flags: fuzz
+        flags:
+          - fuzz
         target: auto
         threshold: 0.5
         base: auto


### PR DESCRIPTION
### Description of changes: 

According to https://community.codecov.io/t/cannot-disable-codecov-patch-check/682/30, codecov.yml must not have a dot prefix. Additionally, the flags setting must be formatted as a list in order to pass Codecov validation.

### Testing

Ran the following validation:
 cat codecov.yml | curl --data-binary @- https://codecov.io/validate


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
