### PR TITLE
ci: GH action to mark a release

### DIFF
--- a/.github/workflows/mkrelease.yml
+++ b/.github/workflows/mkrelease.yml
@@ -1,0 +1,28 @@
+on:
+  push:
+    tags:
+      - v0.*  #Caveat: if you tag a personal branch with this format, it _will_ be marked for release.
+
+name: Create Release
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Get current date; set as env variable
+        run: echo "::set-env name=NOW::$(date +'%Y-%m-%d')"
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: |
+            Weekly release for ${{env.NOW}}
+          draft: false
+          prerelease: false


### PR DESCRIPTION
### Resolved issues:

 resolves #1837 

### Description of changes: 

A GitHub Action that will mark for release, any tag matching the pattern `v0.*`

### Call-outs:

Waiting to merge this until some release scripting refactors are done.

The tag pattern is pretty simple and will need updating after v1.

### Testing:

Personal fork: https://github.com/dougch/s2n/releases/tag/v0.0.03

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
