### PR TITLE
Enable xdist in the integv2 framework

### DIFF
--- a/tests/integrationv2/conftest.py
+++ b/tests/integrationv2/conftest.py
@@ -28,21 +28,3 @@ def pytest_collection_modifyitems(config, items):
     if removed:
         config.hook.pytest_deselected(items=removed)
         items[:] = kept
-
-
-def pytest_xdist_node_collection_finished(node, ids):
-    """
-    NOTE: Unimplemented. This is a placeholder for an xdist hook
-    that will help distribute port numbers when tests are run
-    in parallel.
-    """
-    pass
-
-
-def pytest_configure_node(node):
-    """
-    NOTE: Unimplemented. This is a placeholder for an xdist hook
-    that will help distribute port numbers when tests are run
-    in parallel.
-    """
-    pass

--- a/tests/integrationv2/tox.ini
+++ b/tests/integrationv2/tox.ini
@@ -11,4 +11,4 @@ deps =
     pytest==5.3.5
     pytest-xdist
 commands =
-    pytest --cache-clear -rpfsq {env:TOX_TEST_NAME:""}
+    pytest -n8 --cache-clear -rpfsq {env:TOX_TEST_NAME:""}


### PR DESCRIPTION
### Description of changes: 

Enable the xdist plugin in pytest. This reduces the runtime by about half.

### Call-outs:
 
`-n8` gives us 8 parallel test workers. Using 16 didn't give us any speed improvements but 8 was a bit faster than 4 in the limited test runs I performed.

We can experiment with this setting and get better data on the proper setting.

### Testing:

Integration tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
