### PR TITLE
Install python3-testresources on Ubuntu hosts

### DIFF
--- a/codebuild/bin/install_ubuntu_dependencies.sh
+++ b/codebuild/bin/install_ubuntu_dependencies.sh
@@ -21,7 +21,7 @@ set -ex
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 sudo apt-get update -o Acquire::CompressionTypes::Order::=gz
 
-DEPENDENCIES="unzip make indent kwstyle libssl-dev tcpdump valgrind lcov m4 nettle-dev nettle-bin pkg-config gcc g++ zlibc zlib1g-dev python3-pip llvm curl git tox"
+DEPENDENCIES="unzip make indent kwstyle libssl-dev tcpdump valgrind lcov m4 nettle-dev nettle-bin pkg-config gcc g++ zlibc zlib1g-dev python3-pip python3-testresources llvm curl git tox"
 
 
 if [[ -n "$GCC_VERSION" ]] && [[ "$GCC_VERSION" != "NONE" ]]; then


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

Installs `python3-testresources` in Ubuntu needed for v2 Integration Tests on Ubuntu.

### Call-outs:
None

### Testing:

Tried running `make integrationv2` and got an error about a missing dependency on `testresources`. I no longer get the error after this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
