### PR TITLE
ci: add CodeCommit readonly permissions to CodeBuild roles.

### DIFF
--- a/codebuild/README.md
+++ b/codebuild/README.md
@@ -41,9 +41,7 @@ General flow of the CodeBuild Test Projects
 
 Using your favorite virtualenv, install the following dependencies:
 ```
-pip install boto3
-pip install awacs
-pip install troposphere
+pip install -r requirements.txt
 ```
 
 To bootstrap the CodeBuild jobs, the python script:

--- a/codebuild/create_project.py
+++ b/codebuild/create_project.py
@@ -266,7 +266,20 @@ def build_codebuild_role(config, template=Template(), project_name: str = None, 
                         "arn:aws:logs:{region}:{account_number}:log-group:/aws/codebuild/{project}:*".format(
                             region=region, account_number=account_number, project=project_name),
                     ]
-                )
+                ),
+                Statement(
+                    Effect=Allow,
+                    Action=[
+                        Action("codecommit", "BatchGet*"),
+                        Action("codecommit", "BatchDescribe*"),
+                        Action("codecommit", "Describe*"),
+                        Action("codecommit", "EvaluatePullRequestApprovalRules"),
+                        Action("codecommit", "Get*"),
+                        Action("codecommit", "List*"),
+                        Action("codecommit", "GitPull"),
+                    ],
+                    Resource=["*"],
+                ),
             ]
         )
     )]

--- a/codebuild/requirements.txt
+++ b/codebuild/requirements.txt
@@ -1,0 +1,4 @@
+boto3
+troposphere
+awacs
+black


### PR DESCRIPTION
### Resolved issues:

resolves #2116 

### Description of changes: 

Some of our internal workflows can benefit from running CodeBuild jobs against private CodeCommit repos.

### Call-outs:

More scripting will be required to build successful from CodeCommit

### Testing:

These policies have been applied by hand to validate; also CloudFormation change set verified to only touch the roles.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
