### PR TITLE
Adds proof harnesses for s2n_stuffer_*_pem functions

### DIFF
--- a/stuffer/s2n_stuffer_pem.c
+++ b/stuffer/s2n_stuffer_pem.c
@@ -57,8 +57,7 @@ static int s2n_stuffer_pem_read_encapsulation_line(struct s2n_stuffer *pem, cons
     }
 
     /* Skip newlines and other whitepsace that may be after the dashes */
-    GUARD(s2n_stuffer_skip_whitespace(pem));
-    return S2N_SUCCESS;
+    return s2n_stuffer_skip_whitespace(pem, NULL);
 }
 
 static int s2n_stuffer_pem_read_begin(struct s2n_stuffer *pem, const char *keyword)
@@ -73,8 +72,7 @@ static int s2n_stuffer_pem_read_end(struct s2n_stuffer *pem, const char *keyword
 
 static int s2n_stuffer_pem_read_contents(struct s2n_stuffer *pem, struct s2n_stuffer *asn1)
 {
-    uint8_t base64_buf[64] = { 0 };
-    struct s2n_blob base64__blob = { .data = base64_buf, .size = sizeof(base64_buf) };
+    s2n_stack_blob(base64__blob, 64, 64);
     struct s2n_stuffer base64_stuffer = {0};
     GUARD(s2n_stuffer_init(&base64_stuffer, &base64__blob));
 
@@ -116,6 +114,7 @@ static int s2n_stuffer_data_from_pem(struct s2n_stuffer *pem, struct s2n_stuffer
 {
     PRECONDITION_POSIX(s2n_stuffer_is_valid(pem));
     PRECONDITION_POSIX(s2n_stuffer_is_valid(asn1));
+    notnull_check(keyword);
 
     GUARD(s2n_stuffer_pem_read_begin(pem, keyword));
     GUARD(s2n_stuffer_pem_read_contents(pem, asn1));

--- a/tests/cbmc/include/cbmc_proof/make_common_datastructures.h
+++ b/tests/cbmc/include/cbmc_proof/make_common_datastructures.h
@@ -26,6 +26,11 @@
 bool s2n_blob_is_bounded(const struct s2n_blob* blob, const size_t max_size);
 
 /*
+ * Checks whether s2n_blob is bounded by max_size.
+ */
+bool s2n_stuffer_is_bounded(const struct s2n_stuffer* stuffer, const size_t max_size);
+
+/*
  * Ensures s2n_blob has a proper allocated data member.
  */
 void ensure_s2n_blob_has_allocated_fields(struct s2n_blob* blob);

--- a/tests/cbmc/include/cbmc_proof/nondet.h
+++ b/tests/cbmc/include/cbmc_proof/nondet.h
@@ -31,6 +31,7 @@ bool nondet_bool();
 int nondet_int();
 unsigned int nondet_unsigned_int();
 size_t nondet_size_t();
+long nondet_long();
 uint16_t nondet_uint16_t();
 uint32_t nondet_uint32_t();
 uint64_t nondet_uint64_t();

--- a/tests/cbmc/proofs/s2n_stuffer_certificate_from_pem/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_certificate_from_pem/Makefile
@@ -26,12 +26,11 @@ PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
-
 PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_read_expected_str.c
-PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_skip_expected_char.c # S2N_PEM_DELIMITER_MAX_COUNT
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_skip_expected_char.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_skip_to_char.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_skip_whitespace.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_read_base64.c
-
 PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
 PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_pem.c
 PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
@@ -44,10 +43,12 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract this function because manual inspection demonstrates it is unreachable.
 REMOVE_FUNCTION_BODY += s2n_stuffer_resize
+REMOVE_FUNCTION_BODY += s2n_stuffer_rewrite
+REMOVE_FUNCTION_BODY += s2n_add_overflow
 
 UNWINDSET += strlen.0:5 # size of S2N_PEM_PKCS1_RSA_PRIVATE_KEY
 UNWINDSET += strncmp.0:5 # size of S2N_PEM_END_TOKEN
-UNWINDSET += __CPROVER_file_local_s2n_stuffer_pem_c_s2n_stuffer_pem_read_contents.7:$(call addone,$(MAX_BLOB_SIZE))
+UNWINDSET += __CPROVER_file_local_s2n_stuffer_pem_c_s2n_stuffer_pem_read_contents.11:$(call addone,$(MAX_BLOB_SIZE))
 UNWINDSET += s2n_stuffer_skip_to_char.3:$(call addone,$(MAX_BLOB_SIZE))
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_certificate_from_pem/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_certificate_from_pem/Makefile
@@ -1,0 +1,53 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enough to get full coverage with 7 minutes of runtime.
+MAX_BLOB_SIZE = 10
+DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
+
+CHECKFLAGS +=
+
+HARNESS_ENTRY = s2n_stuffer_certificate_from_pem_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_read_expected_str.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_skip_expected_char.c # S2N_PEM_DELIMITER_MAX_COUNT
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_skip_whitespace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_read_base64.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_pem.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_base64.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += s2n_stuffer_resize
+
+UNWINDSET += strlen.0:5 # size of S2N_PEM_PKCS1_RSA_PRIVATE_KEY
+UNWINDSET += strncmp.0:5 # size of S2N_PEM_END_TOKEN
+UNWINDSET += __CPROVER_file_local_s2n_stuffer_pem_c_s2n_stuffer_pem_read_contents.7:$(call addone,$(MAX_BLOB_SIZE))
+UNWINDSET += s2n_stuffer_skip_to_char.3:$(call addone,$(MAX_BLOB_SIZE))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_certificate_from_pem/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_certificate_from_pem/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_certificate_from_pem/s2n_stuffer_certificate_from_pem_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_certificate_from_pem/s2n_stuffer_certificate_from_pem_harness.c
@@ -28,7 +28,7 @@ void s2n_stuffer_certificate_from_pem_harness() {
     /* Non-deterministic inputs. */
     struct s2n_stuffer *pem = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(pem));
-    __CPROVER_assume(s2n_blob_is_bounded(&pem->blob, MAX_BLOB_SIZE));
+    __CPROVER_assume(s2n_stuffer_is_bounded(pem, MAX_BLOB_SIZE));
 
     struct s2n_stuffer *asn1 = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(asn1));

--- a/tests/cbmc/proofs/s2n_stuffer_certificate_from_pem/s2n_stuffer_certificate_from_pem_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_certificate_from_pem/s2n_stuffer_certificate_from_pem_harness.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_mem.h"
+
+#include <assert.h>
+#include <string.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_stuffer_certificate_from_pem_harness() {
+    /* Non-deterministic inputs. */
+    struct s2n_stuffer *pem = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(pem));
+    __CPROVER_assume(s2n_blob_is_bounded(&pem->blob, MAX_BLOB_SIZE));
+
+    struct s2n_stuffer *asn1 = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(asn1));
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    /* Operation under verification. */
+    s2n_stuffer_certificate_from_pem(pem, asn1);
+
+    /* Post-conditions. */
+    assert(s2n_stuffer_is_valid(pem));
+    assert(s2n_stuffer_is_valid(asn1));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_dhparams_from_pem/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_dhparams_from_pem/Makefile
@@ -26,12 +26,11 @@ PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
-
 PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_read_expected_str.c
-PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_skip_expected_char.c # S2N_PEM_DELIMITER_MAX_COUNT
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_skip_expected_char.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_skip_to_char.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_skip_whitespace.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_read_base64.c
-
 PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
 PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_pem.c
 PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
@@ -42,12 +41,14 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
-# We abstract this function because manual inspection demonstrates it is unreachable.
+# We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += s2n_stuffer_resize
+REMOVE_FUNCTION_BODY += s2n_stuffer_rewrite
+REMOVE_FUNCTION_BODY += s2n_add_overflow
 
 UNWINDSET += strlen.0:5 # size of S2N_PEM_PKCS1_RSA_PRIVATE_KEY
 UNWINDSET += strncmp.0:5 # size of S2N_PEM_END_TOKEN
-UNWINDSET += __CPROVER_file_local_s2n_stuffer_pem_c_s2n_stuffer_pem_read_contents.7:$(call addone,$(MAX_BLOB_SIZE))
+UNWINDSET += __CPROVER_file_local_s2n_stuffer_pem_c_s2n_stuffer_pem_read_contents.11:$(call addone,$(MAX_BLOB_SIZE))
 UNWINDSET += s2n_stuffer_skip_to_char.3:$(call addone,$(MAX_BLOB_SIZE))
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_dhparams_from_pem/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_dhparams_from_pem/Makefile
@@ -1,0 +1,53 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enough to get full coverage with 7 minutes of runtime.
+MAX_BLOB_SIZE = 10
+DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
+
+CHECKFLAGS +=
+
+HARNESS_ENTRY = s2n_stuffer_dhparams_from_pem_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_read_expected_str.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_skip_expected_char.c # S2N_PEM_DELIMITER_MAX_COUNT
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_skip_whitespace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_read_base64.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_pem.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_base64.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += s2n_stuffer_resize
+
+UNWINDSET += strlen.0:5 # size of S2N_PEM_PKCS1_RSA_PRIVATE_KEY
+UNWINDSET += strncmp.0:5 # size of S2N_PEM_END_TOKEN
+UNWINDSET += __CPROVER_file_local_s2n_stuffer_pem_c_s2n_stuffer_pem_read_contents.7:$(call addone,$(MAX_BLOB_SIZE))
+UNWINDSET += s2n_stuffer_skip_to_char.3:$(call addone,$(MAX_BLOB_SIZE))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_dhparams_from_pem/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_dhparams_from_pem/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_dhparams_from_pem/s2n_stuffer_dhparams_from_pem_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_dhparams_from_pem/s2n_stuffer_dhparams_from_pem_harness.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_mem.h"
+
+#include <assert.h>
+#include <string.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_stuffer_dhparams_from_pem_harness() {
+    /* Non-deterministic inputs. */
+    struct s2n_stuffer *pem = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(pem));
+    __CPROVER_assume(s2n_blob_is_bounded(&pem->blob, MAX_BLOB_SIZE));
+
+    struct s2n_stuffer *asn1 = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(asn1));
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    /* Operation under verification. */
+    s2n_stuffer_dhparams_from_pem(pem, asn1);
+
+    /* Post-conditions. */
+    assert(s2n_stuffer_is_valid(pem));
+    assert(s2n_stuffer_is_valid(asn1));
+}

--- a/tests/cbmc/proofs/s2n_stuffer_dhparams_from_pem/s2n_stuffer_dhparams_from_pem_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_dhparams_from_pem/s2n_stuffer_dhparams_from_pem_harness.c
@@ -23,6 +23,7 @@
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/nondet.h>
 
 void s2n_stuffer_dhparams_from_pem_harness() {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_stuffer_private_key_from_pem/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_private_key_from_pem/Makefile
@@ -26,12 +26,11 @@ PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
-
 PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_read_expected_str.c
-PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_skip_expected_char.c # S2N_PEM_DELIMITER_MAX_COUNT
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_skip_expected_char.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_skip_to_char.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_skip_whitespace.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_read_base64.c
-
 PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
 PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_pem.c
 PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
@@ -44,10 +43,12 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract this function because manual inspection demonstrates it is unreachable.
 REMOVE_FUNCTION_BODY += s2n_stuffer_resize
+REMOVE_FUNCTION_BODY += s2n_stuffer_rewrite
+REMOVE_FUNCTION_BODY += s2n_add_overflow
 
 UNWINDSET += strlen.0:5 # size of S2N_PEM_PKCS1_RSA_PRIVATE_KEY
 UNWINDSET += strncmp.0:5 # size of S2N_PEM_END_TOKEN
-UNWINDSET += __CPROVER_file_local_s2n_stuffer_pem_c_s2n_stuffer_pem_read_contents.7:$(call addone,$(MAX_BLOB_SIZE))
+UNWINDSET += __CPROVER_file_local_s2n_stuffer_pem_c_s2n_stuffer_pem_read_contents.11:$(call addone,$(MAX_BLOB_SIZE))
 UNWINDSET += s2n_stuffer_skip_to_char.3:$(call addone,$(MAX_BLOB_SIZE))
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_private_key_from_pem/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_private_key_from_pem/Makefile
@@ -1,0 +1,53 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enough to get full coverage with 7 minutes of runtime.
+MAX_BLOB_SIZE = 10
+DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
+
+CHECKFLAGS +=
+
+HARNESS_ENTRY = s2n_stuffer_private_key_from_pem_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_read_expected_str.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_skip_expected_char.c # S2N_PEM_DELIMITER_MAX_COUNT
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_skip_whitespace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_read_base64.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_pem.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_base64.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += s2n_stuffer_resize
+
+UNWINDSET += strlen.0:5 # size of S2N_PEM_PKCS1_RSA_PRIVATE_KEY
+UNWINDSET += strncmp.0:5 # size of S2N_PEM_END_TOKEN
+UNWINDSET += __CPROVER_file_local_s2n_stuffer_pem_c_s2n_stuffer_pem_read_contents.7:$(call addone,$(MAX_BLOB_SIZE))
+UNWINDSET += s2n_stuffer_skip_to_char.3:$(call addone,$(MAX_BLOB_SIZE))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_private_key_from_pem/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_stuffer_private_key_from_pem/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_stuffer_private_key_from_pem/s2n_stuffer_private_key_from_pem_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_private_key_from_pem/s2n_stuffer_private_key_from_pem_harness.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_mem.h"
+
+#include <assert.h>
+#include <string.h>
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_stuffer_private_key_from_pem_harness() {
+    /* Non-deterministic inputs. */
+    struct s2n_stuffer *pem = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(pem));
+    __CPROVER_assume(s2n_blob_is_bounded(&pem->blob, MAX_BLOB_SIZE));
+
+    struct s2n_stuffer *asn1 = cbmc_allocate_s2n_stuffer();
+    __CPROVER_assume(s2n_stuffer_is_valid(asn1));
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    /* Operation under verification. */
+    s2n_stuffer_private_key_from_pem(pem, asn1);
+
+    /* Post-conditions. */
+    assert(s2n_stuffer_is_valid(pem));
+    assert(s2n_stuffer_is_valid(asn1));
+}

--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -19,6 +19,10 @@ bool s2n_blob_is_bounded(const struct s2n_blob* blob, const size_t max_size) {
     return (blob->size <= max_size);
 }
 
+bool s2n_stuffer_is_bounded(const struct s2n_stuffer* stuffer, const size_t max_size) {
+    return (stuffer->blob.size <= max_size);
+}
+
 void ensure_s2n_blob_has_allocated_fields(struct s2n_blob* blob) {
     if(blob->growable) {
         blob->data = (blob->allocated == 0) ? NULL : bounded_malloc(blob->allocated);

--- a/tests/cbmc/stubs/s2n_stuffer_read_base64.c
+++ b/tests/cbmc/stubs/s2n_stuffer_read_base64.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+#include <cbmc_proof/nondet.h>
+
+int s2n_stuffer_read_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *out)
+{
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(out));
+    return nondet_bool() ? S2N_SUCCESS : S2N_FAILURE;
+}

--- a/tests/cbmc/stubs/s2n_stuffer_read_expected_str.c
+++ b/tests/cbmc/stubs/s2n_stuffer_read_expected_str.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+#include <cbmc_proof/nondet.h>
+
+int s2n_stuffer_read_expected_str(struct s2n_stuffer *s2n_stuffer, const char *expected)
+{
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(s2n_stuffer));
+    notnull_check(expected);
+    return nondet_bool() ? S2N_SUCCESS : S2N_FAILURE;
+}

--- a/tests/cbmc/stubs/s2n_stuffer_read_expected_str.c
+++ b/tests/cbmc/stubs/s2n_stuffer_read_expected_str.c
@@ -23,5 +23,9 @@ int s2n_stuffer_read_expected_str(struct s2n_stuffer *s2n_stuffer, const char *e
 {
     PRECONDITION_POSIX(s2n_stuffer_is_valid(s2n_stuffer));
     notnull_check(expected);
+    /*
+     * This is stub is incomplete and it needs to update stuffer
+     * cursors appropriately https://github.com/awslabs/s2n/issues/2173.
+     */
     return nondet_bool() ? S2N_SUCCESS : S2N_FAILURE;
 }

--- a/tests/cbmc/stubs/s2n_stuffer_skip_expected_char.c
+++ b/tests/cbmc/stubs/s2n_stuffer_skip_expected_char.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+#include <cbmc_proof/nondet.h>
+
+/* Skips an expected character in the stuffer between min and max times */
+int s2n_stuffer_skip_expected_char(struct s2n_stuffer *stuffer, const char expected, const uint32_t min, const uint32_t max, uint32_t *skipped)
+{
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
+    PRECONDITION_POSIX(min <= max);
+    uint32_t skip;
+    __CPROVER_assume(skip >= min && skip < max && skip < s2n_stuffer_data_available(stuffer));
+    return nondet_bool() ? S2N_SUCCESS : S2N_FAILURE;
+}

--- a/tests/cbmc/stubs/s2n_stuffer_skip_expected_char.c
+++ b/tests/cbmc/stubs/s2n_stuffer_skip_expected_char.c
@@ -24,7 +24,9 @@ int s2n_stuffer_skip_expected_char(struct s2n_stuffer *stuffer, const char expec
 {
     PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     PRECONDITION_POSIX(min <= max);
-    uint32_t skip;
-    __CPROVER_assume(skip >= min && skip < max && skip < s2n_stuffer_data_available(stuffer));
+    /*
+     * This is stub is incomplete and it needs to update stuffer
+     * cursors appropriately https://github.com/awslabs/s2n/issues/2173.
+     */
     return nondet_bool() ? S2N_SUCCESS : S2N_FAILURE;
 }

--- a/tests/cbmc/stubs/s2n_stuffer_skip_to_char.c
+++ b/tests/cbmc/stubs/s2n_stuffer_skip_to_char.c
@@ -19,10 +19,9 @@
 
 #include <cbmc_proof/nondet.h>
 
-int s2n_stuffer_read_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *out)
+int s2n_stuffer_skip_to_char(struct s2n_stuffer *stuffer, const char target)
 {
     PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
-    PRECONDITION_POSIX(s2n_stuffer_is_valid(out));
     /*
      * This is stub is incomplete and it needs to update stuffer
      * cursors appropriately https://github.com/awslabs/s2n/issues/2173.

--- a/tests/cbmc/stubs/s2n_stuffer_skip_whitespace.c
+++ b/tests/cbmc/stubs/s2n_stuffer_skip_whitespace.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+#include <cbmc_proof/nondet.h>
+
+int s2n_stuffer_skip_whitespace(struct s2n_stuffer *s2n_stuffer)
+{
+    PRECONDITION_POSIX(s2n_stuffer_is_valid(s2n_stuffer));
+    return nondet_bool() ? S2N_SUCCESS : S2N_FAILURE;
+}

--- a/tests/cbmc/stubs/s2n_stuffer_skip_whitespace.c
+++ b/tests/cbmc/stubs/s2n_stuffer_skip_whitespace.c
@@ -19,8 +19,12 @@
 
 #include <cbmc_proof/nondet.h>
 
-int s2n_stuffer_skip_whitespace(struct s2n_stuffer *s2n_stuffer)
+int s2n_stuffer_skip_whitespace(struct s2n_stuffer *s2n_stuffer, uint32_t *skipped)
 {
     PRECONDITION_POSIX(s2n_stuffer_is_valid(s2n_stuffer));
+    /*
+     * This is stub is incomplete and it needs to update stuffer
+     * cursors appropriately https://github.com/awslabs/s2n/issues/2173.
+     */
     return nondet_bool() ? S2N_SUCCESS : S2N_FAILURE;
 }


### PR DESCRIPTION
### Resolved issues:

N/A.

### Description of changes: 

- Adds a pre- and post-conditions to the `s2n_stuffer_data_from_pem` function;
- Adds a pre-conditions to the `s2n_stuffer_private_key_from_pem` function;
- Adds a proof harness for the `s2n_stuffer_private_key_from_pem` function;
- Adds a proof harness for the `s2n_stuffer_certificate_from_pem` function;
- Adds a proof harness for the `s2n_stuffer_dhparams_from_pem` function;
- Adds a stub for the `s2n_stuffer_read_base64` function;
- Adds a stub for the `s2n_stuffer_read_expected_str` function;
- Adds a stub for the `s2n_stuffer_skip_expected_char` function;
- Adds a stub for the `s2n_stuffer_skip_whitespace` function;

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
