### PR TITLE
Separate project level coverage for fuzz tests

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,6 +12,16 @@ coverage:
   status:
     project:
       default:
+        flags:
+          - asan
+          - integration
+          - integrationv2
+        target: auto
+        threshold: 0.5
+        base: auto
+      fuzz:
+        flags:
+          - fuzz
         target: auto
         threshold: 0.5
         base: auto


### PR DESCRIPTION
### Description of changes: 

Similar to https://github.com/awslabs/s2n/pull/2108, this will separate the fuzz tests for project level coverage due to the bug in LLVM that assigns coverage data to comments (https://bugs.llvm.org/show_bug.cgi?id=45757)

### Testing

Ran the following validation:
 cat codecov.yml | curl --data-binary @- https://codecov.io/validate
   
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
