### PR TITLE
Change scheduled Codebuild fuzz job time

### DIFF
--- a/codebuild/fuzz_codebuild.config
+++ b/codebuild/fuzz_codebuild.config
@@ -22,142 +22,142 @@ artifact_s3_bucket: s2n-build-artifacts
 env: TESTS=fuzz FUZZ_TIMEOUT_SEC=28000
 
 [CloudWatchEvent:s2n_bike_r1_fuzz_test]
-start_time: 12:00
+start_time: 05:00
 build_job_name: s2nFuzzScheduled
 input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_bike_r1_fuzz_test"}]}
 
 [CloudWatchEvent:s2n_bike_r2_fuzz_test]
-start_time: 12:00
+start_time: 05:00
 build_job_name: s2nFuzzScheduled
 input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_bike_r2_fuzz_test"}]}
 
 [CloudWatchEvent:s2n_certificate_extensions_parse_test]
-start_time: 12:00
+start_time: 05:00
 build_job_name: s2nFuzzScheduled
 input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_certificate_extensions_parse_test"}]}
 
 [CloudWatchEvent:s2n_client_cert_recv_test]
-start_time: 12:00
+start_time: 05:00
 build_job_name: s2nFuzzScheduled
 input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_client_cert_recv_test"}]}
 
 [CloudWatchEvent:s2n_cert_req_recv_test]
-start_time: 12:00
+start_time: 05:00
 build_job_name: s2nFuzzScheduled
 input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_cert_req_recv_test"}]}
 
 [CloudWatchEvent:s2n_client_cert_verify_recv_test]
-start_time: 12:00
+start_time: 05:00
 build_job_name: s2nFuzzScheduled
 input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_client_cert_verify_recv_test"}]}
 
 [CloudWatchEvent:s2n_client_fuzz_test]
-start_time: 12:00
+start_time: 05:00
 build_job_name: s2nFuzzScheduled
 input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_client_fuzz_test"}]}
 
 [CloudWatchEvent:s2n_client_hello_recv_fuzz_test]
-start_time: 12:00
+start_time: 05:00
 build_job_name: s2nFuzzScheduled
 input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_client_hello_recv_fuzz_test"}]}
 
 [CloudWatchEvent:s2n_client_key_recv_fuzz_test]
-start_time: 12:00
+start_time: 05:00
 build_job_name: s2nFuzzScheduled
 input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_client_key_recv_fuzz_test"}]}
 
 [CloudWatchEvent:s2n_encrypted_extensions_recv_test]
-start_time: 12:00
+start_time: 05:00
 build_job_name: s2nFuzzScheduled
 input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_encrypted_extensions_recv_test"}]}
 
 [CloudWatchEvent:s2n_extensions_client_key_share_recv_test]
-start_time: 12:00
+start_time: 05:00
 build_job_name: s2nFuzzScheduled
 input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_extensions_client_key_share_recv_test"}]}
 
 [CloudWatchEvent:s2ns2n_extensions_client_supported_versions_recv_test_fuzz]
-start_time: 12:00
+start_time: 05:00
 build_job_name: s2nFuzzScheduled
 input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_extensions_client_supported_versions_recv_test"}]}
 
 [CloudWatchEvent:s2n_extensions_server_key_share_recv_test]
-start_time: 12:00
+start_time: 05:00
 build_job_name: s2nFuzzScheduled
 input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_extensions_server_key_share_recv_test"}]}
 
 [CloudWatchEvent:s2n_extensions_server_supported_versions_recv_test]
-start_time: 12:00
+start_time: 05:00
 build_job_name: s2nFuzzScheduled
 input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_extensions_server_supported_versions_recv_test"}]}
 
 [CloudWatchEvent:s2n_hybrid_ecdhe_bike_r1_fuzz_test]
-start_time: 12:00
+start_time: 05:00
 build_job_name: s2nFuzzScheduled
 input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_hybrid_ecdhe_bike_r1_fuzz_test"}]}
 
 [CloudWatchEvent:s2ns2n_hybrid_ecdhe_bike_r2_fuzz_test_fuzz]
-start_time: 12:00
+start_time: 05:00
 build_job_name: s2nFuzzScheduled
 input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_hybrid_ecdhe_bike_r2_fuzz_test"}]}
 
 [CloudWatchEvent:s2n_hybrid_ecdhe_sike_r1_fuzz_test]
-start_time: 12:00
+start_time: 05:00
 build_job_name: s2nFuzzScheduled
 input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_hybrid_ecdhe_sike_r1_fuzz_test"}]}
 
 [CloudWatchEvent:s2n_hybrid_ecdhe_sike_r2_fuzz_test]
-start_time: 12:00
+start_time: 05:00
 build_job_name: s2nFuzzScheduled
 input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_hybrid_ecdhe_sike_r2_fuzz_test"}]}
 
 [CloudWatchEvent:s2n_openssl_diff_pem_parsing_test]
-start_time: 12:00
+start_time: 05:00
 build_job_name: s2nFuzzScheduled
 input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_openssl_diff_pem_parsing_test"}]}
 
 [CloudWatchEvent:s2n_recv_client_supported_groups_test]
-start_time: 12:00
+start_time: 05:00
 build_job_name: s2nFuzzScheduled
 input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_recv_client_supported_groups_test"}]}
 
 [CloudWatchEvent:s2n_select_server_cert_test]
-start_time: 12:00
+start_time: 05:00
 build_job_name: s2nFuzzScheduled
 input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_select_server_cert_test"}]}
 
 [CloudWatchEvent:s2n_server_cert_recv_test]
-start_time: 12:00
+start_time: 05:00
 build_job_name: s2nFuzzScheduled
 input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_server_cert_recv_test"}]}
 
 [CloudWatchEvent:s2n_server_extensions_recv_test]
-start_time: 12:00
+start_time: 05:00
 build_job_name: s2nFuzzScheduled
 input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_server_extensions_recv_test"}]}
 
 [CloudWatchEvent:s2n_server_fuzz_test]
-start_time: 12:00
+start_time: 05:00
 build_job_name: s2nFuzzScheduled
 input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_server_fuzz_test"}]}
 
 [CloudWatchEvent:s2n_server_hello_recv_test]
-start_time: 12:00
+start_time: 05:00
 build_job_name: s2nFuzzScheduled
 input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_server_hello_recv_test"}]}
 
 [CloudWatchEvent:s2n_sike_r1_fuzz_test]
-start_time: 12:00
+start_time: 05:00
 build_job_name: s2nFuzzScheduled
 input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_sike_r1_fuzz_test"}]}
 
 [CloudWatchEvent:s2n_sike_r2_fuzz_test]
-start_time: 12:00
+start_time: 05:00
 build_job_name: s2nFuzzScheduled
 input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_sike_r2_fuzz_test"}]}
 
 [CloudWatchEvent:s2n_stuffer_pem_fuzz_test]
-start_time: 12:00
+start_time: 05:00
 build_job_name: s2nFuzzScheduled
 input: {"environmentVariablesOverride": [{"name": "FUZZ_TESTS","value": "s2n_stuffer_pem_fuzz_test"}]}
 


### PR DESCRIPTION
### Description of changes: 

Our long-running fuzz tests take ~7hrs. They currently start at 12:00 UTC, which is 5:00 PST or 8:00 EST.
This means that they generally finish running at about 19:00 UTC, which is 12:00 PST or 15:00 EST. This is really too late in the work day to be useful for US developers, especially for anyone on the east coast.

I'm instead changing the tests to start at 05:00 UTC, which is 22:00 PST or 01:00 EST. That should be late enough in the day to catch any new commits. This means that the tests will finish running at about 12:00 UTC, which is 05:00 PST and 08:00 EST. This will make the results of the tests available first thing in the morning for both west and east coast US developers.

### Testing:
None, open to suggestions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
