### PR TITLE
Add Kyber Round 2 TLS Security Policy

### DIFF
--- a/tests/integration/s2n_pq_handshake_test.py
+++ b/tests/integration/s2n_pq_handshake_test.py
@@ -27,17 +27,32 @@ pq_handshake_test_vectors = [
     # The first set of vectors specify client and server cipher preference versions that are compatible for a successful PQ handshake
     {"client_ciphers": "KMS-PQ-TLS-1-0-2019-06", "server_ciphers": "KMS-PQ-TLS-1-0-2019-06", "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384", "expected_kem": "BIKE1r1-Level1"},
     {"client_ciphers": "KMS-PQ-TLS-1-0-2019-06", "server_ciphers": "KMS-PQ-TLS-1-0-2020-02", "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384", "expected_kem": "BIKE1r1-Level1"},
-    {"client_ciphers": "KMS-PQ-TLS-1-0-2020-02", "server_ciphers": "KMS-PQ-TLS-1-0-2020-02", "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384", "expected_kem": "BIKE1r2-Level1"},
+    {"client_ciphers": "KMS-PQ-TLS-1-0-2019-06", "server_ciphers": "KMS-PQ-TLS-1-0-2020-07", "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384", "expected_kem": "BIKE1r1-Level1"},
+
     {"client_ciphers": "KMS-PQ-TLS-1-0-2020-02", "server_ciphers": "KMS-PQ-TLS-1-0-2019-06", "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384", "expected_kem": "BIKE1r1-Level1"},
+    {"client_ciphers": "KMS-PQ-TLS-1-0-2020-02", "server_ciphers": "KMS-PQ-TLS-1-0-2020-02", "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384", "expected_kem": "BIKE1r2-Level1"},
+    {"client_ciphers": "KMS-PQ-TLS-1-0-2020-02", "server_ciphers": "KMS-PQ-TLS-1-0-2020-07", "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384", "expected_kem": "BIKE1r2-Level1"},
+
+    {"client_ciphers": "KMS-PQ-TLS-1-0-2020-07", "server_ciphers": "KMS-PQ-TLS-1-0-2019-06", "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384", "expected_kem": "BIKE1r1-Level1"},
+    {"client_ciphers": "KMS-PQ-TLS-1-0-2020-07", "server_ciphers": "KMS-PQ-TLS-1-0-2020-02", "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384", "expected_kem": "BIKE1r2-Level1"},
+    {"client_ciphers": "KMS-PQ-TLS-1-0-2020-07", "server_ciphers": "KMS-PQ-TLS-1-0-2020-07", "expected_cipher": "ECDHE-KYBER-RSA-AES256-GCM-SHA384", "expected_kem": "kyber512r2"},
+
     {"client_ciphers": "PQ-SIKE-TEST-TLS-1-0-2019-11", "server_ciphers": "KMS-PQ-TLS-1-0-2019-06", "expected_cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384", "expected_kem": "SIKEp503r1-KEM"},
     {"client_ciphers": "PQ-SIKE-TEST-TLS-1-0-2019-11", "server_ciphers": "KMS-PQ-TLS-1-0-2020-02", "expected_cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384", "expected_kem": "SIKEp503r1-KEM"},
+    {"client_ciphers": "PQ-SIKE-TEST-TLS-1-0-2019-11", "server_ciphers": "KMS-PQ-TLS-1-0-2020-07", "expected_cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384", "expected_kem": "SIKEp503r1-KEM"},
+
     {"client_ciphers": "PQ-SIKE-TEST-TLS-1-0-2020-02", "server_ciphers": "KMS-PQ-TLS-1-0-2019-06", "expected_cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384", "expected_kem": "SIKEp503r1-KEM"},
     {"client_ciphers": "PQ-SIKE-TEST-TLS-1-0-2020-02", "server_ciphers": "KMS-PQ-TLS-1-0-2020-02", "expected_cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384", "expected_kem": "SIKEp434r2-KEM"},
+    {"client_ciphers": "PQ-SIKE-TEST-TLS-1-0-2020-02", "server_ciphers": "KMS-PQ-TLS-1-0-2020-07", "expected_cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384", "expected_kem": "SIKEp434r2-KEM"},
+
     # The last set of vectors specify a "mismatch" between PQ cipher preferences - a classic handshake should be completed
     {"client_ciphers": "KMS-PQ-TLS-1-0-2019-06", "server_ciphers": "KMS-TLS-1-0-2018-10", "expected_cipher": "ECDHE-RSA-AES256-GCM-SHA384", "expected_kem": "NONE"},
     {"client_ciphers": "KMS-PQ-TLS-1-0-2020-02", "server_ciphers": "KMS-TLS-1-0-2018-10", "expected_cipher": "ECDHE-RSA-AES256-GCM-SHA384", "expected_kem": "NONE"},
+    {"client_ciphers": "KMS-PQ-TLS-1-0-2020-07", "server_ciphers": "KMS-TLS-1-0-2018-10", "expected_cipher": "ECDHE-RSA-AES256-GCM-SHA384", "expected_kem": "NONE"},
+
     {"client_ciphers": "KMS-TLS-1-0-2018-10", "server_ciphers": "KMS-PQ-TLS-1-0-2019-06", "expected_cipher": "ECDHE-RSA-AES256-GCM-SHA384", "expected_kem": "NONE"},
     {"client_ciphers": "KMS-TLS-1-0-2018-10", "server_ciphers": "KMS-PQ-TLS-1-0-2020-02", "expected_cipher": "ECDHE-RSA-AES256-GCM-SHA384", "expected_kem": "NONE"},
+    {"client_ciphers": "KMS-TLS-1-0-2018-10", "server_ciphers": "KMS-PQ-TLS-1-0-2020-07", "expected_cipher": "ECDHE-RSA-AES256-GCM-SHA384", "expected_kem": "NONE"},
 ]
 
 def print_result(result_prefix, return_code):

--- a/tests/integrationv2/common.py
+++ b/tests/integrationv2/common.py
@@ -233,6 +233,7 @@ class Ciphers(object):
     KMS_TLS_1_0_2018_10 = Cipher("KMS-TLS-1-0-2018-10", Protocols.TLS10, False, False)
     KMS_PQ_TLS_1_0_2019_06 = Cipher("KMS-PQ-TLS-1-0-2019-06", Protocols.TLS10, False, False)
     KMS_PQ_TLS_1_0_2020_02 = Cipher("KMS-PQ-TLS-1-0-2020-02", Protocols.TLS10, False, False)
+    KMS_PQ_TLS_1_0_2020_07 = Cipher("KMS-PQ-TLS-1-0-2020-07", Protocols.TLS10, False, False)
     PQ_SIKE_TEST_TLS_1_0_2019_11 = Cipher("PQ-SIKE-TEST-TLS-1-0-2019-11", Protocols.TLS10, False, False)
     PQ_SIKE_TEST_TLS_1_0_2020_02 = Cipher("PQ-SIKE-TEST-TLS-1-0-2020-02", Protocols.TLS10, False, False)
 

--- a/tests/integrationv2/test_pq_handshake.py
+++ b/tests/integrationv2/test_pq_handshake.py
@@ -9,82 +9,35 @@ from utils import get_expected_s2n_version
 
 
 pq_handshake_test_vectors = [
-    # The first set of vectors verify that PQ handshakes are successful by
-    # specifing client and server cipher preference versions that are compatible for a successful PQ handshake
-    {
-        "client_ciphers": Ciphers.KMS_PQ_TLS_1_0_2019_06,
-        "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2019_06,
-        "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384",
-        "expected_kem": "BIKE1r1-Level1",
-    },
-    {
-        "client_ciphers": Ciphers.KMS_PQ_TLS_1_0_2019_06,
-        "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_02,
-        "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384",
-        "expected_kem": "BIKE1r1-Level1",
-    },
-    {
-        "client_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_02,
-        "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_02,
-        "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384",
-        "expected_kem": "BIKE1r2-Level1",
-    },
-    {
-        "client_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_02,
-        "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2019_06,
-        "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384",
-        "expected_kem": "BIKE1r1-Level1",
-    },
-    {
-        "client_ciphers": Ciphers.PQ_SIKE_TEST_TLS_1_0_2019_11,
-        "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2019_06,
-        "expected_cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384",
-        "expected_kem": "SIKEp503r1-KEM",
-    },
-    {
-        "client_ciphers": Ciphers.PQ_SIKE_TEST_TLS_1_0_2019_11,
-        "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_02,
-        "expected_cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384",
-        "expected_kem": "SIKEp503r1-KEM",
-    },
-    {
-        "client_ciphers": Ciphers.PQ_SIKE_TEST_TLS_1_0_2020_02,
-        "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2019_06,
-        "expected_cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384",
-        "expected_kem": "SIKEp503r1-KEM",
-    },
-    {
-        "client_ciphers": Ciphers.PQ_SIKE_TEST_TLS_1_0_2020_02,
-        "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_02,
-        "expected_cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384",
-        "expected_kem": "SIKEp434r2-KEM",
-    },
-    # The last set of vectors verify that a standard handshake can be completed when only one side supports PQ
-    # by specifing a "mismatch" between PQ cipher preferences
-    {
-        "client_ciphers": Ciphers.KMS_PQ_TLS_1_0_2019_06,
-        "server_ciphers": Ciphers.KMS_TLS_1_0_2018_10,
-        "expected_cipher": "ECDHE-RSA-AES256-GCM-SHA384",
-        "expected_kem": "NONE",
-    },
-    {
-        "client_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_02,
-        "server_ciphers": Ciphers.KMS_TLS_1_0_2018_10,
-        "expected_cipher": "ECDHE-RSA-AES256-GCM-SHA384",
-        "expected_kem": "NONE",
-    },
-    {
-        "client_ciphers": Ciphers.KMS_TLS_1_0_2018_10,
-        "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2019_06,
-        "expected_cipher": "ECDHE-RSA-AES256-GCM-SHA384",
-        "expected_kem": "NONE",
-    },
-    {
-        "client_ciphers": Ciphers.KMS_TLS_1_0_2018_10,
-        "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_02,
-        "expected_cipher": "ECDHE-RSA-AES256-GCM-SHA384",
-        "expected_kem": "NONE",
-    },
+    # The first set of vectors specify client and server cipher preference versions that are compatible for a successful PQ handshake
+    {"client_ciphers": Ciphers.KMS_PQ_TLS_1_0_2019_06, "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2019_06, "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384", "expected_kem": "BIKE1r1-Level1"},
+    {"client_ciphers": Ciphers.KMS_PQ_TLS_1_0_2019_06, "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_02, "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384", "expected_kem": "BIKE1r1-Level1"},
+    {"client_ciphers": Ciphers.KMS_PQ_TLS_1_0_2019_06, "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_07, "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384", "expected_kem": "BIKE1r1-Level1"},
+
+    {"client_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_02, "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2019_06, "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384", "expected_kem": "BIKE1r1-Level1"},
+    {"client_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_02, "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_02, "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384", "expected_kem": "BIKE1r2-Level1"},
+    {"client_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_02, "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_07, "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384", "expected_kem": "BIKE1r2-Level1"},
+
+    {"client_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_07, "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2019_06, "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384", "expected_kem": "BIKE1r1-Level1"},
+    {"client_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_07, "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_02, "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384", "expected_kem": "BIKE1r2-Level1"},
+    {"client_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_07, "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_07, "expected_cipher": "ECDHE-KYBER-RSA-AES256-GCM-SHA384", "expected_kem": "kyber512r2"},
+
+    {"client_ciphers": Ciphers.PQ_SIKE_TEST_TLS_1_0_2019_11, "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2019_06, "expected_cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384", "expected_kem": "SIKEp503r1-KEM"},
+    {"client_ciphers": Ciphers.PQ_SIKE_TEST_TLS_1_0_2019_11, "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_02, "expected_cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384", "expected_kem": "SIKEp503r1-KEM"},
+    {"client_ciphers": Ciphers.PQ_SIKE_TEST_TLS_1_0_2019_11, "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_07, "expected_cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384", "expected_kem": "SIKEp503r1-KEM"},
+
+    {"client_ciphers": Ciphers.PQ_SIKE_TEST_TLS_1_0_2020_02, "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2019_06, "expected_cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384", "expected_kem": "SIKEp503r1-KEM"},
+    {"client_ciphers": Ciphers.PQ_SIKE_TEST_TLS_1_0_2020_02, "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_02, "expected_cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384", "expected_kem": "SIKEp434r2-KEM"},
+    {"client_ciphers": Ciphers.PQ_SIKE_TEST_TLS_1_0_2020_02, "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_07, "expected_cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384", "expected_kem": "SIKEp434r2-KEM"},
+
+    # The last set of vectors specify a "mismatch" between PQ cipher preferences - a classic handshake should be completed
+    {"client_ciphers": Ciphers.KMS_PQ_TLS_1_0_2019_06, "server_ciphers": Ciphers.KMS_TLS_1_0_2018_10, "expected_cipher": "ECDHE-RSA-AES256-GCM-SHA384", "expected_kem": "NONE"},
+    {"client_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_02, "server_ciphers": Ciphers.KMS_TLS_1_0_2018_10, "expected_cipher": "ECDHE-RSA-AES256-GCM-SHA384", "expected_kem": "NONE"},
+    {"client_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_07, "server_ciphers": Ciphers.KMS_TLS_1_0_2018_10, "expected_cipher": "ECDHE-RSA-AES256-GCM-SHA384", "expected_kem": "NONE"},
+
+    {"client_ciphers": Ciphers.KMS_TLS_1_0_2018_10, "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2019_06, "expected_cipher": "ECDHE-RSA-AES256-GCM-SHA384", "expected_kem": "NONE"},
+    {"client_ciphers": Ciphers.KMS_TLS_1_0_2018_10, "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_02, "expected_cipher": "ECDHE-RSA-AES256-GCM-SHA384", "expected_kem": "NONE"},
+    {"client_ciphers": Ciphers.KMS_TLS_1_0_2018_10, "server_ciphers": Ciphers.KMS_PQ_TLS_1_0_2020_07, "expected_cipher": "ECDHE-RSA-AES256-GCM-SHA384", "expected_kem": "NONE"},
 ]
 
 

--- a/tests/unit/s2n_client_pq_kem_extension_test.c
+++ b/tests/unit/s2n_client_pq_kem_extension_test.c
@@ -29,7 +29,7 @@ int main(int argc, char **argv)
             "KMS-PQ-TLS-1-0-2020-07"
     };
 
-    for (int policy_index = 0; policy_index < s2n_array_len(pq_security_policies); policy_index++) {
+    for (size_t policy_index = 0; policy_index < s2n_array_len(pq_security_policies); policy_index++) {
         const char *pq_security_policy = pq_security_policies[policy_index];
         const struct s2n_security_policy *security_policy;
         EXPECT_SUCCESS(s2n_find_security_policy_from_version(pq_security_policy, &security_policy));
@@ -69,7 +69,7 @@ int main(int argc, char **argv)
 
             /* Should write ids */
             uint16_t actual_id;
-            for (int i = 0; i < kem_preferences->kem_count; i++) {
+            for (size_t i = 0; i < kem_preferences->kem_count; i++) {
                 GUARD(s2n_stuffer_read_uint16(&stuffer, &actual_id));
                 EXPECT_EQUAL(actual_id, kem_preferences->kems[i]->kem_extension_id);
             }

--- a/tests/unit/s2n_client_pq_kem_extension_test.c
+++ b/tests/unit/s2n_client_pq_kem_extension_test.c
@@ -24,94 +24,100 @@ int main(int argc, char **argv)
 
 #if !defined(S2N_NO_PQ)
 
-    const char *pq_security_policy = "KMS-PQ-TLS-1-0-2020-02";
-    const struct s2n_security_policy *security_policy;
-    EXPECT_SUCCESS(s2n_find_security_policy_from_version(pq_security_policy, &security_policy));
-    const struct s2n_kem_preferences *kem_preferences = security_policy->kem_preferences;
+    const char* pq_security_policies[] = {
+            "KMS-PQ-TLS-1-0-2020-02",
+            "KMS-PQ-TLS-1-0-2020-07"
+    };
 
-    /* Test should_send */
-    {
-        struct s2n_connection *conn;
-        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+    for (int policy_index = 0; policy_index < s2n_array_len(pq_security_policies); policy_index++) {
+        const char *pq_security_policy = pq_security_policies[policy_index];
+        const struct s2n_security_policy *security_policy;
+        EXPECT_SUCCESS(s2n_find_security_policy_from_version(pq_security_policy, &security_policy));
+        const struct s2n_kem_preferences *kem_preferences = security_policy->kem_preferences;
 
-        /* Default cipher preferences do not include PQ, so extension not sent */
-        EXPECT_FALSE(s2n_client_pq_kem_extension.should_send(conn));
+        /* Test should_send */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
-        /* Use cipher preferences that do include PQ */
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, pq_security_policy));
-        EXPECT_TRUE(s2n_client_pq_kem_extension.should_send(conn));
+            /* Default cipher preferences do not include PQ, so extension not sent */
+            EXPECT_FALSE(s2n_client_pq_kem_extension.should_send(conn));
 
-        EXPECT_SUCCESS(s2n_connection_free(conn));
-    }
+            /* Use cipher preferences that do include PQ */
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, pq_security_policy));
+            EXPECT_TRUE(s2n_client_pq_kem_extension.should_send(conn));
 
-    /* Test send */
-    {
-        struct s2n_connection *conn;
-        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, pq_security_policy));
-
-        struct s2n_stuffer stuffer;
-        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
-
-        EXPECT_SUCCESS(s2n_client_pq_kem_extension.send(conn, &stuffer));
-
-        /* Should write correct size */
-        uint16_t size;
-        EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &size));
-        EXPECT_EQUAL(size, s2n_stuffer_data_available(&stuffer));
-        EXPECT_EQUAL(size, kem_preferences->kem_count * sizeof(kem_extension_size));
-
-        /* Should write ids */
-        uint16_t actual_id;
-        for (int i = 0; i < kem_preferences->kem_count; i++) {
-            GUARD(s2n_stuffer_read_uint16(&stuffer, &actual_id));
-            EXPECT_EQUAL(actual_id, kem_preferences->kems[i]->kem_extension_id);
+            EXPECT_SUCCESS(s2n_connection_free(conn));
         }
 
-        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
-        EXPECT_SUCCESS(s2n_connection_free(conn));
+        /* Test send */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, pq_security_policy));
+
+            struct s2n_stuffer stuffer;
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+            EXPECT_SUCCESS(s2n_client_pq_kem_extension.send(conn, &stuffer));
+
+            /* Should write correct size */
+            uint16_t size;
+            EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &size));
+            EXPECT_EQUAL(size, s2n_stuffer_data_available(&stuffer));
+            EXPECT_EQUAL(size, kem_preferences->kem_count * sizeof(kem_extension_size));
+
+            /* Should write ids */
+            uint16_t actual_id;
+            for (int i = 0; i < kem_preferences->kem_count; i++) {
+                GUARD(s2n_stuffer_read_uint16(&stuffer, &actual_id));
+                EXPECT_EQUAL(actual_id, kem_preferences->kems[i]->kem_extension_id);
+            }
+
+            EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Test receive - malformed length */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, pq_security_policy));
+
+            struct s2n_stuffer stuffer;
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+            EXPECT_SUCCESS(s2n_client_pq_kem_extension.send(conn, &stuffer));
+            EXPECT_SUCCESS(s2n_stuffer_wipe_n(&stuffer, 1));
+
+            EXPECT_SUCCESS(s2n_client_pq_kem_extension.recv(conn, &stuffer));
+            EXPECT_EQUAL(conn->secure.client_pq_kem_extension.size, 0);
+            EXPECT_NULL(conn->secure.client_pq_kem_extension.data);
+
+            EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Test receive */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, pq_security_policy));
+
+            struct s2n_stuffer stuffer;
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+            EXPECT_SUCCESS(s2n_client_pq_kem_extension.send(conn, &stuffer));
+
+            EXPECT_SUCCESS(s2n_client_pq_kem_extension.recv(conn, &stuffer));
+            EXPECT_EQUAL(conn->secure.client_pq_kem_extension.size, kem_preferences->kem_count * sizeof(kem_extension_size));
+            EXPECT_NOT_NULL(conn->secure.client_pq_kem_extension.data);
+            EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
+
+            EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
     }
-
-    /* Test receive - malformed length */
-    {
-        struct s2n_connection *conn;
-        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, pq_security_policy));
-
-        struct s2n_stuffer stuffer;
-        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
-
-        EXPECT_SUCCESS(s2n_client_pq_kem_extension.send(conn, &stuffer));
-        EXPECT_SUCCESS(s2n_stuffer_wipe_n(&stuffer, 1));
-
-        EXPECT_SUCCESS(s2n_client_pq_kem_extension.recv(conn, &stuffer));
-        EXPECT_EQUAL(conn->secure.client_pq_kem_extension.size, 0);
-        EXPECT_NULL(conn->secure.client_pq_kem_extension.data);
-
-        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
-        EXPECT_SUCCESS(s2n_connection_free(conn));
-    }
-
-    /* Test receive */
-    {
-        struct s2n_connection *conn;
-        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, pq_security_policy));
-
-        struct s2n_stuffer stuffer;
-        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
-
-        EXPECT_SUCCESS(s2n_client_pq_kem_extension.send(conn, &stuffer));
-
-        EXPECT_SUCCESS(s2n_client_pq_kem_extension.recv(conn, &stuffer));
-        EXPECT_EQUAL(conn->secure.client_pq_kem_extension.size, kem_preferences->kem_count * sizeof(kem_extension_size));
-        EXPECT_NOT_NULL(conn->secure.client_pq_kem_extension.data);
-        EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
-
-        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
-        EXPECT_SUCCESS(s2n_connection_free(conn));
-    }
-
 #endif
 
     END_TEST();

--- a/tests/unit/s2n_kem_test.c
+++ b/tests/unit/s2n_kem_test.c
@@ -613,7 +613,7 @@ int main(int argc, char **argv)
                 &s2n_kyber_512_r2
         };
 
-        for (int i = 0; i < 5; i++) {
+        for (int i = 0; i < s2n_array_len(kems); i++) {
             kem_extension_size kem_id = kem_extensions[i];
             const struct s2n_kem *returned_kem = NULL;
 

--- a/tests/unit/s2n_kem_test.c
+++ b/tests/unit/s2n_kem_test.c
@@ -35,6 +35,7 @@ const uint8_t TEST_CIPHERTEXT[] = { 5, 5, 5, 5, 5 };
 
 #if !defined(S2N_NO_PQ)
 
+static const uint8_t kyber_iana[S2N_TLS_CIPHER_SUITE_LEN] = { TLS_ECDHE_KYBER_RSA_WITH_AES_256_GCM_SHA384 };
 static const uint8_t bike_iana[S2N_TLS_CIPHER_SUITE_LEN] = { TLS_ECDHE_BIKE_RSA_WITH_AES_256_GCM_SHA384 };
 static const uint8_t sike_iana[S2N_TLS_CIPHER_SUITE_LEN] = { TLS_ECDHE_SIKE_RSA_WITH_AES_256_GCM_SHA384 };
 static const uint8_t classic_ecdhe_iana[S2N_TLS_CIPHER_SUITE_LEN] = { TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA };
@@ -271,6 +272,11 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(negotiated_kem->kem_extension_id, TLS_PQ_KEM_EXTENSION_ID_BIKE1_L1_R2);
             negotiated_kem = NULL;
 
+            EXPECT_SUCCESS(s2n_choose_kem_without_peer_pref_list(bike_iana, pq_kems_r2r1_2020_07, 5, &negotiated_kem));
+            EXPECT_NOT_NULL(negotiated_kem);
+            EXPECT_EQUAL(negotiated_kem->kem_extension_id, TLS_PQ_KEM_EXTENSION_ID_BIKE1_L1_R2);
+            negotiated_kem = NULL;
+
             EXPECT_SUCCESS(s2n_choose_kem_without_peer_pref_list(sike_iana, pq_kems_r1, 2, &negotiated_kem));
             EXPECT_NOT_NULL(negotiated_kem);
             EXPECT_EQUAL(negotiated_kem->kem_extension_id, TLS_PQ_KEM_EXTENSION_ID_SIKE_P503_R1);
@@ -279,6 +285,16 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_choose_kem_without_peer_pref_list(sike_iana, pq_kems_r2r1, 4, &negotiated_kem));
             EXPECT_NOT_NULL(negotiated_kem);
             EXPECT_EQUAL(negotiated_kem->kem_extension_id, TLS_PQ_KEM_EXTENSION_ID_SIKE_P434_R2);
+            negotiated_kem = NULL;
+
+            EXPECT_SUCCESS(s2n_choose_kem_without_peer_pref_list(sike_iana, pq_kems_r2r1_2020_07, 5, &negotiated_kem));
+            EXPECT_NOT_NULL(negotiated_kem);
+            EXPECT_EQUAL(negotiated_kem->kem_extension_id, TLS_PQ_KEM_EXTENSION_ID_SIKE_P434_R2);
+            negotiated_kem = NULL;
+
+            EXPECT_SUCCESS(s2n_choose_kem_without_peer_pref_list(kyber_iana, pq_kems_r2r1_2020_07, 5, &negotiated_kem));
+            EXPECT_NOT_NULL(negotiated_kem);
+            EXPECT_EQUAL(negotiated_kem->kem_extension_id, TLS_PQ_KEM_EXTENSION_ID_KYBER_512_R2);
             negotiated_kem = NULL;
         }
         {
@@ -318,7 +334,14 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(compatible_params->kem_count, 2);
         EXPECT_EQUAL(compatible_params->kems[0]->kem_extension_id, s2n_sike_p503_r1.kem_extension_id);
         EXPECT_EQUAL(compatible_params->kems[1]->kem_extension_id, s2n_sike_p434_r2.kem_extension_id);
+
+        compatible_params = NULL;
+        EXPECT_SUCCESS(s2n_cipher_suite_to_kem(kyber_iana, &compatible_params));
+        EXPECT_NOT_NULL(compatible_params);
+        EXPECT_EQUAL(compatible_params->kem_count, 1);
+        EXPECT_EQUAL(compatible_params->kems[0]->kem_extension_id, s2n_kyber_512_r2.kem_extension_id);
     }
+
     {
         /* Tests for s2n_kem_free() */
         EXPECT_SUCCESS(s2n_kem_free(NULL));
@@ -578,7 +601,8 @@ int main(int argc, char **argv)
                 TLS_PQ_KEM_EXTENSION_ID_BIKE1_L1_R1,
                 TLS_PQ_KEM_EXTENSION_ID_BIKE1_L1_R2,
                 TLS_PQ_KEM_EXTENSION_ID_SIKE_P503_R1,
-                TLS_PQ_KEM_EXTENSION_ID_SIKE_P434_R2
+                TLS_PQ_KEM_EXTENSION_ID_SIKE_P434_R2,
+                TLS_PQ_KEM_EXTENSION_ID_KYBER_512_R2
         };
 
         const struct s2n_kem *kems[] = {
@@ -586,9 +610,10 @@ int main(int argc, char **argv)
                 &s2n_bike1_l1_r2,
                 &s2n_sike_p503_r1,
                 &s2n_sike_p434_r2,
+                &s2n_kyber_512_r2
         };
 
-        for (int i = 0; i < 4; i++) {
+        for (int i = 0; i < 5; i++) {
             kem_extension_size kem_id = kem_extensions[i];
             const struct s2n_kem *returned_kem = NULL;
 

--- a/tests/unit/s2n_kem_test.c
+++ b/tests/unit/s2n_kem_test.c
@@ -613,7 +613,7 @@ int main(int argc, char **argv)
                 &s2n_kyber_512_r2
         };
 
-        for (int i = 0; i < s2n_array_len(kems); i++) {
+        for (size_t i = 0; i < s2n_array_len(kems); i++) {
             kem_extension_size kem_id = kem_extensions[i];
             const struct s2n_kem *returned_kem = NULL;
 

--- a/tests/unit/s2n_kex_with_kem_test.c
+++ b/tests/unit/s2n_kex_with_kem_test.c
@@ -198,27 +198,35 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(do_kex_with_kem(&kyber_test_suite, "KMS-PQ-TLS-1-0-2020-07", &s2n_kyber_512_r2));
 
-        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&sike_test_suite, "KMS-PQ-TLS-1-0-2019-06", &s2n_sike_p434_r2),
-                                  S2N_ERR_KEM_UNSUPPORTED_PARAMS);
-        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&sike_test_suite, "KMS-PQ-TLS-1-0-2019-06", &s2n_bike1_l1_r1),
-                                  S2N_ERR_KEM_UNSUPPORTED_PARAMS);
-        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&sike_test_suite, "KMS-PQ-TLS-1-0-2019-06", &s2n_bike1_l1_r2),
-                                  S2N_ERR_KEM_UNSUPPORTED_PARAMS);
-        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&sike_test_suite, "KMS-PQ-TLS-1-0-2020-02", &s2n_bike1_l1_r1),
-                                  S2N_ERR_KEM_UNSUPPORTED_PARAMS);
-        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&sike_test_suite, "KMS-PQ-TLS-1-0-2020-02", &s2n_bike1_l1_r2),
-                                  S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+        /* Test Failure cases */
+        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&sike_test_suite, "KMS-PQ-TLS-1-0-2019-06", &s2n_sike_p434_r2), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&sike_test_suite, "KMS-PQ-TLS-1-0-2019-06", &s2n_bike1_l1_r1), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&sike_test_suite, "KMS-PQ-TLS-1-0-2019-06", &s2n_bike1_l1_r2), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&sike_test_suite, "KMS-PQ-TLS-1-0-2020-02", &s2n_bike1_l1_r1), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&sike_test_suite, "KMS-PQ-TLS-1-0-2020-02", &s2n_bike1_l1_r2), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
 
-        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&bike_test_suite, "KMS-PQ-TLS-1-0-2019-06", &s2n_bike1_l1_r2),
-                                  S2N_ERR_KEM_UNSUPPORTED_PARAMS);
-        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&bike_test_suite, "KMS-PQ-TLS-1-0-2019-06", &s2n_sike_p434_r2),
-                                  S2N_ERR_KEM_UNSUPPORTED_PARAMS);
-        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&bike_test_suite, "KMS-PQ-TLS-1-0-2019-06", &s2n_sike_p503_r1),
-                                  S2N_ERR_KEM_UNSUPPORTED_PARAMS);
-        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&bike_test_suite, "KMS-PQ-TLS-1-0-2020-02", &s2n_sike_p434_r2),
-                                  S2N_ERR_KEM_UNSUPPORTED_PARAMS);
-        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&bike_test_suite, "KMS-PQ-TLS-1-0-2020-02", &s2n_sike_p503_r1),
-                                  S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&bike_test_suite, "KMS-PQ-TLS-1-0-2019-06", &s2n_bike1_l1_r2), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&bike_test_suite, "KMS-PQ-TLS-1-0-2019-06", &s2n_sike_p434_r2), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&bike_test_suite, "KMS-PQ-TLS-1-0-2019-06", &s2n_sike_p503_r1), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&bike_test_suite, "KMS-PQ-TLS-1-0-2020-02", &s2n_sike_p434_r2), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&bike_test_suite, "KMS-PQ-TLS-1-0-2020-02", &s2n_sike_p503_r1), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+
+        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&kyber_test_suite, "KMS-PQ-TLS-1-0-2019-06", &s2n_bike1_l1_r1), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&kyber_test_suite, "KMS-PQ-TLS-1-0-2019-06", &s2n_bike1_l1_r2), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&kyber_test_suite, "KMS-PQ-TLS-1-0-2019-06", &s2n_sike_p503_r1), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&kyber_test_suite, "KMS-PQ-TLS-1-0-2019-06", &s2n_sike_p434_r2), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&kyber_test_suite, "KMS-PQ-TLS-1-0-2019-06", &s2n_kyber_512_r2), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+
+        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&kyber_test_suite, "KMS-PQ-TLS-1-0-2020-02", &s2n_bike1_l1_r1), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&kyber_test_suite, "KMS-PQ-TLS-1-0-2020-02", &s2n_bike1_l1_r2), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&kyber_test_suite, "KMS-PQ-TLS-1-0-2020-02", &s2n_sike_p503_r1), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&kyber_test_suite, "KMS-PQ-TLS-1-0-2020-02", &s2n_sike_p434_r2), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&kyber_test_suite, "KMS-PQ-TLS-1-0-2020-02", &s2n_kyber_512_r2), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+
+        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&kyber_test_suite, "KMS-PQ-TLS-1-0-2020-07", &s2n_bike1_l1_r1), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&kyber_test_suite, "KMS-PQ-TLS-1-0-2020-07", &s2n_bike1_l1_r2), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&kyber_test_suite, "KMS-PQ-TLS-1-0-2020-07", &s2n_sike_p503_r1), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+        EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&kyber_test_suite, "KMS-PQ-TLS-1-0-2020-07", &s2n_sike_p434_r2), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
     }
 
 #endif

--- a/tests/unit/s2n_kex_with_kem_test.c
+++ b/tests/unit/s2n_kex_with_kem_test.c
@@ -46,6 +46,11 @@ static struct s2n_cipher_suite bike_test_suite = {
         .key_exchange_alg = &s2n_test_kem_kex,
 };
 
+static struct s2n_cipher_suite kyber_test_suite = {
+        .iana_value = { TLS_ECDHE_KYBER_RSA_WITH_AES_256_GCM_SHA384 },
+        .key_exchange_alg = &s2n_test_kem_kex,
+};
+
 static int do_kex_with_kem(struct s2n_cipher_suite *cipher_suite, const char *security_policy_version, const struct s2n_kem *negotiated_kem) {
     S2N_ERROR_IF(s2n_is_in_fips_mode(), S2N_ERR_PQ_KEMS_DISALLOWED_IN_FIPS);
 
@@ -174,16 +179,24 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(assert_kex_fips_checks(&bike_test_suite, "KMS-PQ-TLS-1-0-2019-06", &s2n_bike1_l1_r2));
         EXPECT_SUCCESS(assert_kex_fips_checks(&bike_test_suite, "KMS-PQ-TLS-1-0-2020-02", &s2n_bike1_l1_r1));
         EXPECT_SUCCESS(assert_kex_fips_checks(&bike_test_suite, "KMS-PQ-TLS-1-0-2020-02", &s2n_bike1_l1_r2));
+
+        EXPECT_SUCCESS(assert_kex_fips_checks(&kyber_test_suite, "KMS-PQ-TLS-1-0-2020-07", &s2n_kyber_512_r2));
     } else {
         /* KMS-PQ-TLS-1-0-2019-06 supports only Round 1 KEMs
          * KMS-PQ-TLS-1-0-2020-02 supports Round 1 and Round 2 KEMs */
         EXPECT_SUCCESS(do_kex_with_kem(&sike_test_suite, "KMS-PQ-TLS-1-0-2019-06", &s2n_sike_p503_r1));
         EXPECT_SUCCESS(do_kex_with_kem(&sike_test_suite, "KMS-PQ-TLS-1-0-2020-02", &s2n_sike_p503_r1));
         EXPECT_SUCCESS(do_kex_with_kem(&sike_test_suite, "KMS-PQ-TLS-1-0-2020-02", &s2n_sike_p434_r2));
+        EXPECT_SUCCESS(do_kex_with_kem(&sike_test_suite, "KMS-PQ-TLS-1-0-2020-07", &s2n_sike_p503_r1));
+        EXPECT_SUCCESS(do_kex_with_kem(&sike_test_suite, "KMS-PQ-TLS-1-0-2020-07", &s2n_sike_p434_r2));
 
         EXPECT_SUCCESS(do_kex_with_kem(&bike_test_suite, "KMS-PQ-TLS-1-0-2019-06", &s2n_bike1_l1_r1));
         EXPECT_SUCCESS(do_kex_with_kem(&bike_test_suite, "KMS-PQ-TLS-1-0-2020-02", &s2n_bike1_l1_r1));
         EXPECT_SUCCESS(do_kex_with_kem(&bike_test_suite, "KMS-PQ-TLS-1-0-2020-02", &s2n_bike1_l1_r2));
+        EXPECT_SUCCESS(do_kex_with_kem(&bike_test_suite, "KMS-PQ-TLS-1-0-2020-07", &s2n_bike1_l1_r1));
+        EXPECT_SUCCESS(do_kex_with_kem(&bike_test_suite, "KMS-PQ-TLS-1-0-2020-07", &s2n_bike1_l1_r2));
+
+        EXPECT_SUCCESS(do_kex_with_kem(&kyber_test_suite, "KMS-PQ-TLS-1-0-2020-07", &s2n_kyber_512_r2));
 
         EXPECT_FAILURE_WITH_ERRNO(do_kex_with_kem(&sike_test_suite, "KMS-PQ-TLS-1-0-2019-06", &s2n_sike_p434_r2),
                                   S2N_ERR_KEM_UNSUPPORTED_PARAMS);

--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -107,7 +107,7 @@ int main(int argc, char **argv)
         EXPECT_FAILURE_WITH_ERRNO(s2n_find_security_policy_from_version("PQ-SIKE-TEST-TLS-1-0-2019-11", &security_policy), S2N_ERR_INVALID_SECURITY_POLICY);
         EXPECT_FAILURE_WITH_ERRNO(s2n_find_security_policy_from_version("PQ-SIKE-TEST-TLS-1-0-2020-02", &security_policy), S2N_ERR_INVALID_SECURITY_POLICY);
         EXPECT_FAILURE_WITH_ERRNO(s2n_find_security_policy_from_version("KMS-PQ-TLS-1-0-2020-02", &security_policy), S2N_ERR_INVALID_SECURITY_POLICY);
-        EXPECT_FAILURE_WITH_ERRNO(s2n_find_security_policy_from_version("KMS-PQ-TLS-1-0-2020-05", &security_policy), S2N_ERR_INVALID_SECURITY_POLICY);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_find_security_policy_from_version("KMS-PQ-TLS-1-0-2020-07", &security_policy), S2N_ERR_INVALID_SECURITY_POLICY);
 #endif
 
         security_policy = NULL;

--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -45,9 +45,9 @@ int main(int argc, char **argv)
         EXPECT_TRUE(s2n_ecc_is_extension_required(security_policy));
 #if !defined(S2N_NO_PQ)
         EXPECT_TRUE(s2n_pq_kem_is_extension_required(security_policy));
-        EXPECT_EQUAL(4, security_policy->kem_preferences->kem_count);
+        EXPECT_EQUAL(5, security_policy->kem_preferences->kem_count);
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
-        EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_r2r1);
+        EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_r2r1_2020_07);
 #else
         EXPECT_FALSE(s2n_pq_kem_is_extension_required(security_policy));
         EXPECT_EQUAL(0, security_policy->kem_preferences->kem_count);
@@ -93,12 +93,21 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(4, security_policy->kem_preferences->kem_count);
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_r2r1);
+
+        security_policy = NULL;
+        EXPECT_SUCCESS(s2n_find_security_policy_from_version("KMS-PQ-TLS-1-0-2020-07", &security_policy));
+        EXPECT_TRUE(s2n_ecc_is_extension_required(security_policy));
+        EXPECT_TRUE(s2n_pq_kem_is_extension_required(security_policy));
+        EXPECT_EQUAL(5, security_policy->kem_preferences->kem_count);
+        EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
+        EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_r2r1_2020_07);
 #else
         security_policy = NULL;
         EXPECT_FAILURE_WITH_ERRNO(s2n_find_security_policy_from_version("KMS-PQ-TLS-1-0-2019-06", &security_policy), S2N_ERR_INVALID_SECURITY_POLICY);
         EXPECT_FAILURE_WITH_ERRNO(s2n_find_security_policy_from_version("PQ-SIKE-TEST-TLS-1-0-2019-11", &security_policy), S2N_ERR_INVALID_SECURITY_POLICY);
         EXPECT_FAILURE_WITH_ERRNO(s2n_find_security_policy_from_version("PQ-SIKE-TEST-TLS-1-0-2020-02", &security_policy), S2N_ERR_INVALID_SECURITY_POLICY);
         EXPECT_FAILURE_WITH_ERRNO(s2n_find_security_policy_from_version("KMS-PQ-TLS-1-0-2020-02", &security_policy), S2N_ERR_INVALID_SECURITY_POLICY);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_find_security_policy_from_version("KMS-PQ-TLS-1-0-2020-05", &security_policy), S2N_ERR_INVALID_SECURITY_POLICY);
 #endif
 
         security_policy = NULL;
@@ -138,6 +147,7 @@ int main(int argc, char **argv)
 #if !defined(S2N_NO_PQ)
             "KMS-PQ-TLS-1-0-2019-06",
             "KMS-PQ-TLS-1-0-2020-02",
+            "KMS-PQ-TLS-1-0-2020-07",
             "PQ-SIKE-TEST-TLS-1-0-2019-11",
             "PQ-SIKE-TEST-TLS-1-0-2020-02",
 #endif

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -885,6 +885,28 @@ const struct s2n_cipher_preferences cipher_preferences_pq_sike_test_tls_1_0_2020
     .suites = cipher_suites_pq_sike_test_tls_1_0_2019_11,
 };
 
+/* Includes Both Round 2 and Round 1 PQ Ciphers */
+struct s2n_cipher_suite *cipher_suites_kms_pq_tls_1_0_2020_07[] = {
+    &s2n_ecdhe_kyber_rsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_bike_rsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_sike_rsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_rsa_with_3des_ede_cbc_sha,
+    &s2n_dhe_rsa_with_aes_256_cbc_sha256,
+    &s2n_dhe_rsa_with_aes_128_cbc_sha256,
+    &s2n_dhe_rsa_with_aes_256_cbc_sha,
+    &s2n_dhe_rsa_with_aes_128_cbc_sha,
+};
+
+const struct s2n_cipher_preferences cipher_preferences_kms_pq_tls_1_0_2020_07 = {
+    .count = s2n_array_len(cipher_suites_kms_pq_tls_1_0_2020_07),
+    .suites = cipher_suites_kms_pq_tls_1_0_2020_07,
+};
+
 #endif
 
 struct s2n_cipher_suite *cipher_suites_kms_fips_tls_1_2_2018_10[] = {

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -82,6 +82,7 @@ extern const struct s2n_cipher_preferences cipher_preferences_kms_tls_1_0_2018_1
 
 extern const struct s2n_cipher_preferences cipher_preferences_kms_pq_tls_1_0_2019_06;
 extern const struct s2n_cipher_preferences cipher_preferences_kms_pq_tls_1_0_2020_02;
+extern const struct s2n_cipher_preferences cipher_preferences_kms_pq_tls_1_0_2020_07;
 extern const struct s2n_cipher_preferences cipher_preferences_pq_sike_test_tls_1_0_2019_11;
 extern const struct s2n_cipher_preferences cipher_preferences_pq_sike_test_tls_1_0_2020_02;
 

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -679,7 +679,7 @@ struct s2n_cipher_suite s2n_dhe_rsa_with_chacha20_poly1305_sha256 = /* 0xCC,0xAA
     .minimum_required_tls_version = S2N_TLS12,
 };
 
-/* From https://tools.ietf.org/html/draft-campagna-tls-bike-sike-hybrid-01 */
+/* From https://tools.ietf.org/html/draft-campagna-tls-bike-sike-hybrid */
 
 struct s2n_cipher_suite s2n_ecdhe_kyber_rsa_with_aes_256_gcm_sha384 = /* 0xFF, 0x0C */ {
     .available = 0,

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -680,6 +680,21 @@ struct s2n_cipher_suite s2n_dhe_rsa_with_chacha20_poly1305_sha256 = /* 0xCC,0xAA
 };
 
 /* From https://tools.ietf.org/html/draft-campagna-tls-bike-sike-hybrid-01 */
+
+struct s2n_cipher_suite s2n_ecdhe_kyber_rsa_with_aes_256_gcm_sha384 = /* 0xFF, 0x0C */ {
+    .available = 0,
+    .name = "ECDHE-KYBER-RSA-AES256-GCM-SHA384",
+    .iana_value = { TLS_ECDHE_KYBER_RSA_WITH_AES_256_GCM_SHA384 },
+    .key_exchange_alg = &s2n_hybrid_ecdhe_kem,
+    .auth_method = S2N_AUTHENTICATION_RSA,
+    .record_alg = NULL,
+    .all_record_algs = { &s2n_record_alg_aes256_gcm },
+    .num_record_algs = 1,
+    .sslv3_record_alg = NULL,
+    .prf_alg = S2N_HMAC_SHA384,
+    .minimum_required_tls_version = S2N_TLS12,
+};
+
 struct s2n_cipher_suite s2n_ecdhe_bike_rsa_with_aes_256_gcm_sha384 = /* 0xFF, 0x04 */ {
     .available = 0,
     .name = "ECDHE-BIKE-RSA-AES256-GCM-SHA384",
@@ -796,6 +811,7 @@ static struct s2n_cipher_suite *s2n_all_cipher_suites[] = {
 #if !defined(S2N_NO_PQ)
     &s2n_ecdhe_bike_rsa_with_aes_256_gcm_sha384,    /* 0xFF,0x04 */
     &s2n_ecdhe_sike_rsa_with_aes_256_gcm_sha384,    /* 0xFF,0x08 */
+    &s2n_ecdhe_kyber_rsa_with_aes_256_gcm_sha384,   /* 0xFF,0x0C */
 #endif
 };
 
@@ -1057,7 +1073,6 @@ struct s2n_cipher_suite *s2n_cipher_suite_from_wire(const uint8_t cipher_suite[S
 {
     int low = 0;
     int top = (sizeof(s2n_all_cipher_suites) / sizeof(struct s2n_cipher_suite *)) - 1;
-
     /* Perform a textbook binary search */
     while (low <= top) {
         /* Check in the middle */

--- a/tls/s2n_cipher_suites.h
+++ b/tls/s2n_cipher_suites.h
@@ -32,7 +32,7 @@
 
 #define S2N_MAX_POSSIBLE_RECORD_ALGS    2
 #if !defined(S2N_NO_PQ)
-#define S2N_PQ_CIPHER_SUITE_COUNT       2
+#define S2N_PQ_CIPHER_SUITE_COUNT       3
 #else
 #define S2N_PQ_CIPHER_SUITE_COUNT       0
 #endif
@@ -157,6 +157,7 @@ extern struct s2n_cipher_suite s2n_ecdhe_rsa_with_chacha20_poly1305_sha256;
 extern struct s2n_cipher_suite s2n_dhe_rsa_with_chacha20_poly1305_sha256;
 extern struct s2n_cipher_suite s2n_ecdhe_ecdsa_with_chacha20_poly1305_sha256;
 extern struct s2n_cipher_suite s2n_ecdhe_rsa_with_rc4_128_sha;
+extern struct s2n_cipher_suite s2n_ecdhe_kyber_rsa_with_aes_256_gcm_sha384;
 extern struct s2n_cipher_suite s2n_ecdhe_bike_rsa_with_aes_256_gcm_sha384;
 extern struct s2n_cipher_suite s2n_ecdhe_sike_rsa_with_aes_256_gcm_sha384;
 extern struct s2n_cipher_suite s2n_tls13_aes_256_gcm_sha384;

--- a/tls/s2n_kem_preferences.c
+++ b/tls/s2n_kem_preferences.c
@@ -31,6 +31,14 @@ const struct s2n_kem *pq_kems_r2r1[4] = {
     &s2n_sike_p503_r1,
 };
 
+const struct s2n_kem *pq_kems_r2r1_2020_07[5] = {
+    &s2n_kyber_512_r2,
+    &s2n_bike1_l1_r2,
+    &s2n_sike_p434_r2,
+    &s2n_bike1_l1_r1,
+    &s2n_sike_p503_r1,
+};
+
 /* Extension list for SIKE P503 Round 1 only (for testing) */
 const struct s2n_kem *pq_kems_sike_r1[1] = {
     &s2n_sike_p503_r1,
@@ -53,6 +61,11 @@ const struct s2n_kem_preferences kem_preferences_kms_pq_tls_1_0_2019_06 = {
 const struct s2n_kem_preferences kem_preferences_kms_pq_tls_1_0_2020_02 = {
     .kem_count = s2n_array_len(pq_kems_r2r1),
     .kems = pq_kems_r2r1,
+};
+
+const struct s2n_kem_preferences kem_preferences_kms_pq_tls_1_0_2020_07 = {
+    .kem_count = s2n_array_len(pq_kems_r2r1_2020_07),
+    .kems = pq_kems_r2r1_2020_07,
 };
 
 /* Includes only SIKE round 1 (for integration tests) */

--- a/tls/s2n_kem_preferences.h
+++ b/tls/s2n_kem_preferences.h
@@ -27,11 +27,13 @@ struct s2n_kem_preferences {
 
 extern const struct s2n_kem *pq_kems_r1[2];
 extern const struct s2n_kem *pq_kems_r2r1[4];
+extern const struct s2n_kem *pq_kems_r2r1_2020_07[5];
 extern const struct s2n_kem *pq_kems_sike_r1[1];
 extern const struct s2n_kem *pq_kems_sike_r2r1[2];
 
 extern const struct s2n_kem_preferences kem_preferences_kms_pq_tls_1_0_2019_06;
 extern const struct s2n_kem_preferences kem_preferences_kms_pq_tls_1_0_2020_02;
+extern const struct s2n_kem_preferences kem_preferences_kms_pq_tls_1_0_2020_07;
 extern const struct s2n_kem_preferences kem_preferences_pq_sike_test_tls_1_0_2019_11;
 extern const struct s2n_kem_preferences kem_preferences_pq_sike_test_tls_1_0_2020_02;
 

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -263,6 +263,14 @@ const struct s2n_security_policy security_policy_pq_sike_test_tls_1_0_2020_02 = 
     .ecc_preferences = &s2n_ecc_preferences_20140601,
 };
 
+const struct s2n_security_policy security_policy_kms_pq_tls_1_0_2020_07 = {
+    .minimum_protocol_version = S2N_TLS10,
+    .cipher_preferences = &cipher_preferences_kms_pq_tls_1_0_2020_07,
+    .kem_preferences = &kem_preferences_kms_pq_tls_1_0_2020_07,
+    .signature_preferences = &s2n_signature_preferences_20140601,
+    .ecc_preferences = &s2n_ecc_preferences_20140601,
+};
+
 #endif
 const struct s2n_security_policy security_policy_kms_fips_tls_1_2_2018_10 = {
     .minimum_protocol_version = S2N_TLS12,
@@ -388,7 +396,7 @@ const struct s2n_security_policy security_policy_test_all = {
     .minimum_protocol_version = S2N_SSLv3,
     .cipher_preferences = &cipher_preferences_test_all,
 #if !defined(S2N_NO_PQ)
-    .kem_preferences = &kem_preferences_kms_pq_tls_1_0_2020_02,
+    .kem_preferences = &kem_preferences_kms_pq_tls_1_0_2020_07,
 #else
     .kem_preferences = &kem_preferences_null,
 #endif
@@ -400,7 +408,7 @@ const struct s2n_security_policy security_policy_test_all_tls12 = {
     .minimum_protocol_version = S2N_SSLv3,
     .cipher_preferences = &cipher_preferences_test_all_tls12,
 #if !defined(S2N_NO_PQ)
-    .kem_preferences = &kem_preferences_kms_pq_tls_1_0_2020_02,
+    .kem_preferences = &kem_preferences_kms_pq_tls_1_0_2020_07,
 #else
     .kem_preferences = &kem_preferences_null,
 #endif
@@ -486,6 +494,7 @@ struct s2n_security_policy_selection security_policy_selection[] = {
 #if !defined(S2N_NO_PQ)
     { .version="KMS-PQ-TLS-1-0-2019-06", .security_policy=&security_policy_kms_pq_tls_1_0_2019_06, .ecc_extension_required=0, .pq_kem_extension_required=0 },
     { .version="KMS-PQ-TLS-1-0-2020-02", .security_policy=&security_policy_kms_pq_tls_1_0_2020_02, .ecc_extension_required=0, .pq_kem_extension_required=0 },
+    { .version="KMS-PQ-TLS-1-0-2020-07", .security_policy=&security_policy_kms_pq_tls_1_0_2020_07, .ecc_extension_required=0, .pq_kem_extension_required=0 },
     { .version="PQ-SIKE-TEST-TLS-1-0-2019-11", .security_policy=&security_policy_pq_sike_test_tls_1_0_2019_11, .ecc_extension_required=0, .pq_kem_extension_required=0 },
     { .version="PQ-SIKE-TEST-TLS-1-0-2020-02", .security_policy=&security_policy_pq_sike_test_tls_1_0_2020_02, .ecc_extension_required=0, .pq_kem_extension_required=0 },
 #endif

--- a/tls/s2n_security_policies.h
+++ b/tls/s2n_security_policies.h
@@ -77,6 +77,7 @@ extern const struct s2n_security_policy security_policy_elb_fs_1_2_res_2019_08;
 #if !defined(S2N_NO_PQ)
 extern const struct s2n_security_policy security_policy_kms_pq_tls_1_0_2019_06;
 extern const struct s2n_security_policy security_policy_kms_pq_tls_1_0_2020_02;
+extern const struct s2n_security_policy security_policy_kms_pq_tls_1_0_2020_07;
 extern const struct s2n_security_policy security_policy_pq_sike_test_tls_1_0_2019_11;
 extern const struct s2n_security_policy security_policy_pq_sike_test_tls_1_0_2020_02;
 #endif


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

Adds public Security Policy for Kyber PQ Algorithm and adds new Security Policy to existing unit tests.

### Call-outs:

Still missing `s2n_hybrid_ecdhe_kyber_r2_test.c` unit test that other PQ algorithms have, but we will be opening a PR for that unit test at a later time.

### Testing:

New Security Policy added to existing Security Policy and PQ Test suites.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
