### PR TITLE
Prepare S2N CI for branch name change

### DIFF
--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - master
+      - main
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/private_fork_pr_codebuild.yml
+++ b/.github/workflows/private_fork_pr_codebuild.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - master
+      - main
 jobs:
   fuzz:
     if: startsWith(github.repository, 'private-')

--- a/.github/workflows/private_sync.yml
+++ b/.github/workflows/private_sync.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - main
 jobs:
   build:
     # This should only run in one place.

--- a/codebuild/fuzz_codebuild.config
+++ b/codebuild/fuzz_codebuild.config
@@ -14,7 +14,7 @@ buildspec: codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
 source_location: https://github.com/awslabs/private-s2n-fuzz.git
 source_type : GITHUB
 source_clonedepth: 1
-source_version: master
+source_version:
 # This next value MUST match the buildspec files
 # secondary-artifacts, and can be a comma sep. list
 artifact_secondary_identifiers: logs


### PR DESCRIPTION
### Description of changes: 

Remove any specific reference to S2N's branch name in preparation to change our default branch name.

The documentation for `source_version` says: "If not specified, the default branch's HEAD commit ID is used." We leave `source_version` empty in other CodeBuild configs: https://github.com/awslabs/s2n/blob/master/codebuild/integ_codebuild.config#L29

### Testing:

Example entry in changeset:
```
INFO:root:Summary of changes:
	Action                   Modify
	LogicalResourceId    s2nstufferpemfuzztestRule
	PhysicalResourceId   s2nstufferpemfuzztestEvernt
	ResourceType         AWS::Events::Rule
	Replacement               False
	Scope                ['Properties']
	Details              [{'Target': {'Attribute': 'Properties', 'Name': 'Targets', 'RequiresRecreation': 'Never'}, 'Evaluation': 'Dynamic', 'ChangeSource': 'ResourceAttribute', 'CausingEntity': 's2nFuzzScheduled.Arn'}]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
