### PR TITLE
Add a notnull_check in s2n_kem_encapsulate()

### DIFF
--- a/tls/s2n_kem.c
+++ b/tls/s2n_kem.c
@@ -177,6 +177,7 @@ int s2n_kem_encapsulate(struct s2n_kem_params *kem_params, struct s2n_blob *ciph
 int s2n_kem_decapsulate(struct s2n_kem_params *kem_params, const struct s2n_blob *ciphertext)
 {
     notnull_check(kem_params);
+    notnull_check(kem_params->kem);
     const struct s2n_kem *kem = kem_params->kem;
     notnull_check(kem->decapsulate);
 

--- a/tls/s2n_kem.c
+++ b/tls/s2n_kem.c
@@ -157,6 +157,7 @@ int s2n_kem_generate_keypair(struct s2n_kem_params *kem_params)
 int s2n_kem_encapsulate(struct s2n_kem_params *kem_params, struct s2n_blob *ciphertext)
 {
     notnull_check(kem_params);
+    notnull_check(kem_params->kem);
     const struct s2n_kem *kem = kem_params->kem;
     notnull_check(kem->encapsulate);
 


### PR DESCRIPTION
### Resolved issues:

 Small stability check to be sure the element is not NULL.  Found by manual review.

### Description of changes: 

int s2n_kem_encapsulate(struct s2n_kem_params *kem_params, const struct s2n_blob *ciphertext)
{
    notnull_check(kem_params);
    const struct s2n_kem *kem = kem_params->kem;
    notnull_check(kem->decapsulate);

The notnull_check only checks the received pointer, so in this case if key_params->kem=NULL the app will crash.  Adding the notnull_check before the assignment (the crash would happen in the dereference at the notnull_check, but adding it before the assignment is a little cleaner).

### Call-outs:

There is a similar one in s2n_kem_decapsulate, sending as a separate PR.

### Testing:

This was found by manual code review and the change is minimal, so no additional tests performed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
