### PR TITLE
Properly decode stdout in integv2

### DIFF
--- a/tests/integrationv2/processes.py
+++ b/tests/integrationv2/processes.py
@@ -307,8 +307,8 @@ class ManagedProcess(threading.Thread):
                 # information no matter where a test fails.
                 print("Command line: {}".format(" ".join(self.cmd_line)))
                 print("Exit code: {}".format(proc.returncode))
-                print("Stdout: {}".format(proc_results[0]))
-                print("Stderr: {}".format(proc_results[1]))
+                print("Stdout: {}".format(proc_results[0].decode("utf-8", "backslashreplace")))
+                print("Stderr: {}".format(proc_results[1].decode("utf-8", "backslashreplace")))
 
     def _process_ready(self):
         """Condition variable predicate"""

--- a/tests/integrationv2/test_happy_path.py
+++ b/tests/integrationv2/test_happy_path.py
@@ -60,6 +60,7 @@ def test_s2n_server_happy_path(managed_process, cipher, provider, curve, protoco
         assert results.exit_code == 0
         assert bytes("Actual protocol version: {}".format(expected_version).encode('utf-8')) in results.stdout
         assert random_bytes in results.stdout
+
         if provider is not S2N:
             assert bytes("Cipher negotiated: {}".format(cipher.name).encode('utf-8')) in results.stdout
 

--- a/tests/integrationv2/test_happy_path.py
+++ b/tests/integrationv2/test_happy_path.py
@@ -60,7 +60,6 @@ def test_s2n_server_happy_path(managed_process, cipher, provider, curve, protoco
         assert results.exit_code == 0
         assert bytes("Actual protocol version: {}".format(expected_version).encode('utf-8')) in results.stdout
         assert random_bytes in results.stdout
-
         if provider is not S2N:
             assert bytes("Cipher negotiated: {}".format(cipher.name).encode('utf-8')) in results.stdout
 


### PR DESCRIPTION
### Linked issues:

#2142 
### Description of changes: 

When an error occurs in an integ test, raw stdout and sterr are printed, without interpreting the newline characters as such. I converted the output to utf-8 so that failed tests would be easier to read.
### Call-outs:

### Testing:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
