### PR TITLE
Add kem_group structure to s2n_kem_preferences

### DIFF
--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -399,6 +399,11 @@ int main(int argc, char **argv)
 
     /* Positive and negative cases for s2n_validate_kem_preferences() */
     {
+        EXPECT_FAILURE_WITH_ERRNO(s2n_validate_kem_preferences(NULL, 0), S2N_ERR_NULL);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_validate_kem_preferences(&kem_preferences_null, 1), S2N_ERR_INVALID_SECURITY_POLICY);
+        EXPECT_SUCCESS(s2n_validate_kem_preferences(&kem_preferences_null, 0));
+
+#if !defined(S2N_NO_PQ)
         const struct s2n_kem_group *test_kem_group_list[] = {
                 &s2n_secp256r1_sike_p434_r2
         };
@@ -434,9 +439,9 @@ int main(int argc, char **argv)
             EXPECT_FAILURE_WITH_ERRNO(s2n_validate_kem_preferences(&invalid_kem_prefs[i], 1), S2N_ERR_INVALID_SECURITY_POLICY);
         }
 
-        EXPECT_FAILURE_WITH_ERRNO(s2n_validate_kem_preferences(&kem_preferences_null, 1), S2N_ERR_INVALID_SECURITY_POLICY);
         EXPECT_FAILURE_WITH_ERRNO(s2n_validate_kem_preferences(&kem_preferences_kms_pq_tls_1_0_2020_07, 0), S2N_ERR_INVALID_SECURITY_POLICY);
         EXPECT_SUCCESS(s2n_validate_kem_preferences(&kem_preferences_kms_pq_tls_1_0_2020_07, 1));
+#endif
     }
 
     END_TEST();

--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -30,6 +30,8 @@ int main(int argc, char **argv)
         EXPECT_FALSE(s2n_pq_kem_is_extension_required(security_policy));
         EXPECT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(0, security_policy->kem_preferences->kem_count);
+        EXPECT_NULL(security_policy->kem_preferences->kem_groups);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_group_count);
         EXPECT_FALSE(s2n_security_policy_supports_tls13(security_policy));
 
         security_policy = NULL;
@@ -38,6 +40,8 @@ int main(int argc, char **argv)
         EXPECT_FALSE(s2n_pq_kem_is_extension_required(security_policy));
         EXPECT_TRUE(s2n_security_policy_supports_tls13(security_policy));
         EXPECT_EQUAL(0, security_policy->kem_preferences->kems);
+        EXPECT_NULL(security_policy->kem_preferences->kem_groups);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_group_count);
         EXPECT_NULL(security_policy->kem_preferences->kems);
 
         security_policy = NULL;
@@ -48,10 +52,14 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(5, security_policy->kem_preferences->kem_count);
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_r2r1_2020_07);
+        EXPECT_NULL(security_policy->kem_preferences->kem_groups);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_group_count);
 #else
         EXPECT_FALSE(s2n_pq_kem_is_extension_required(security_policy));
         EXPECT_EQUAL(0, security_policy->kem_preferences->kem_count);
         EXPECT_NULL(security_policy->kem_preferences->kems);
+        EXPECT_NULL(security_policy->kem_preferences->kem_groups);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_group_count);
 #endif
 
         security_policy = NULL;
@@ -60,6 +68,8 @@ int main(int argc, char **argv)
         EXPECT_FALSE(s2n_pq_kem_is_extension_required(security_policy));
         EXPECT_EQUAL(0, security_policy->kem_preferences->kem_count);
         EXPECT_NULL(security_policy->kem_preferences->kems);
+        EXPECT_NULL(security_policy->kem_preferences->kem_groups);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_group_count);
 
 #if !defined(S2N_NO_PQ)
         security_policy = NULL;
@@ -69,6 +79,8 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(2, security_policy->kem_preferences->kem_count);
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_r1);
+        EXPECT_NULL(security_policy->kem_preferences->kem_groups);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_group_count);
 
         security_policy = NULL;
         EXPECT_SUCCESS(s2n_find_security_policy_from_version("PQ-SIKE-TEST-TLS-1-0-2019-11", &security_policy));
@@ -77,6 +89,8 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(1, security_policy->kem_preferences->kem_count);
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_sike_r1);
+        EXPECT_NULL(security_policy->kem_preferences->kem_groups);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_group_count);
 
         security_policy = NULL;
         EXPECT_SUCCESS(s2n_find_security_policy_from_version("PQ-SIKE-TEST-TLS-1-0-2020-02", &security_policy));
@@ -85,6 +99,8 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(2, security_policy->kem_preferences->kem_count);
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_sike_r2r1);
+        EXPECT_NULL(security_policy->kem_preferences->kem_groups);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_group_count);
 
         security_policy = NULL;
         EXPECT_SUCCESS(s2n_find_security_policy_from_version("KMS-PQ-TLS-1-0-2020-02", &security_policy));
@@ -93,6 +109,8 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(4, security_policy->kem_preferences->kem_count);
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_r2r1);
+        EXPECT_NULL(security_policy->kem_preferences->kem_groups);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_group_count);
 
         security_policy = NULL;
         EXPECT_SUCCESS(s2n_find_security_policy_from_version("KMS-PQ-TLS-1-0-2020-07", &security_policy));
@@ -101,6 +119,8 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(5, security_policy->kem_preferences->kem_count);
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_r2r1_2020_07);
+        EXPECT_NULL(security_policy->kem_preferences->kem_groups);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_group_count);
 #else
         security_policy = NULL;
         EXPECT_FAILURE_WITH_ERRNO(s2n_find_security_policy_from_version("KMS-PQ-TLS-1-0-2019-06", &security_policy), S2N_ERR_INVALID_SECURITY_POLICY);
@@ -116,6 +136,8 @@ int main(int argc, char **argv)
         EXPECT_FALSE(s2n_pq_kem_is_extension_required(security_policy));
         EXPECT_EQUAL(0, security_policy->kem_preferences->kem_count);
         EXPECT_NULL(security_policy->kem_preferences->kems);
+        EXPECT_NULL(security_policy->kem_preferences->kem_groups);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_group_count);
     }
 
     {
@@ -373,6 +395,48 @@ int main(int argc, char **argv)
         };
 
         EXPECT_FAILURE(s2n_check_ecc_preferences_curves_list(&s2n_ecc_preferences_new_list));
+    }
+
+    /* Positive and negative cases for s2n_validate_kem_preferences() */
+    {
+        const struct s2n_kem_group *test_kem_group_list[] = {
+                &s2n_secp256r1_sike_p434_r2
+        };
+
+        const struct s2n_kem_preferences invalid_kem_prefs[] = {
+            {
+                .kem_count = 1,
+                .kems = NULL,
+                .kem_group_count = 0,
+                .kem_groups = NULL,
+            },
+            {
+                .kem_count = 0,
+                .kems = NULL,
+                .kem_group_count = 1,
+                .kem_groups = NULL,
+            },
+            {
+                .kem_count = 0,
+                .kems = pq_kems_r1,
+                .kem_group_count = 0,
+                .kem_groups = NULL,
+            },
+            {
+                .kem_count = 0,
+                .kems = NULL,
+                .kem_group_count = 0,
+                .kem_groups = test_kem_group_list,
+            },
+        };
+
+        for (size_t i = 0; i < s2n_array_len(invalid_kem_prefs); i++) {
+            EXPECT_FAILURE_WITH_ERRNO(s2n_validate_kem_preferences(&invalid_kem_prefs[i], 1), S2N_ERR_INVALID_SECURITY_POLICY);
+        }
+
+        EXPECT_FAILURE_WITH_ERRNO(s2n_validate_kem_preferences(&kem_preferences_null, 1), S2N_ERR_INVALID_SECURITY_POLICY);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_validate_kem_preferences(&kem_preferences_kms_pq_tls_1_0_2020_07, 0), S2N_ERR_INVALID_SECURITY_POLICY);
+        EXPECT_SUCCESS(s2n_validate_kem_preferences(&kem_preferences_kms_pq_tls_1_0_2020_07, 1));
     }
 
     END_TEST();

--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -30,8 +30,8 @@ int main(int argc, char **argv)
         EXPECT_FALSE(s2n_pq_kem_is_extension_required(security_policy));
         EXPECT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(0, security_policy->kem_preferences->kem_count);
-        EXPECT_NULL(security_policy->kem_preferences->kem_groups);
-        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_group_count);
+        EXPECT_NULL(security_policy->kem_preferences->tls13_kem_groups);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->tls13_kem_group_count);
         EXPECT_FALSE(s2n_security_policy_supports_tls13(security_policy));
 
         security_policy = NULL;
@@ -40,8 +40,8 @@ int main(int argc, char **argv)
         EXPECT_FALSE(s2n_pq_kem_is_extension_required(security_policy));
         EXPECT_TRUE(s2n_security_policy_supports_tls13(security_policy));
         EXPECT_EQUAL(0, security_policy->kem_preferences->kems);
-        EXPECT_NULL(security_policy->kem_preferences->kem_groups);
-        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_group_count);
+        EXPECT_NULL(security_policy->kem_preferences->tls13_kem_groups);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->tls13_kem_group_count);
         EXPECT_NULL(security_policy->kem_preferences->kems);
 
         security_policy = NULL;
@@ -52,14 +52,14 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(5, security_policy->kem_preferences->kem_count);
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_r2r1_2020_07);
-        EXPECT_NULL(security_policy->kem_preferences->kem_groups);
-        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_group_count);
+        EXPECT_NULL(security_policy->kem_preferences->tls13_kem_groups);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->tls13_kem_group_count);
 #else
         EXPECT_FALSE(s2n_pq_kem_is_extension_required(security_policy));
         EXPECT_EQUAL(0, security_policy->kem_preferences->kem_count);
         EXPECT_NULL(security_policy->kem_preferences->kems);
-        EXPECT_NULL(security_policy->kem_preferences->kem_groups);
-        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_group_count);
+        EXPECT_NULL(security_policy->kem_preferences->tls13_kem_groups);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->tls13_kem_group_count);
 #endif
 
         security_policy = NULL;
@@ -68,8 +68,8 @@ int main(int argc, char **argv)
         EXPECT_FALSE(s2n_pq_kem_is_extension_required(security_policy));
         EXPECT_EQUAL(0, security_policy->kem_preferences->kem_count);
         EXPECT_NULL(security_policy->kem_preferences->kems);
-        EXPECT_NULL(security_policy->kem_preferences->kem_groups);
-        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_group_count);
+        EXPECT_NULL(security_policy->kem_preferences->tls13_kem_groups);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->tls13_kem_group_count);
 
 #if !defined(S2N_NO_PQ)
         security_policy = NULL;
@@ -79,8 +79,8 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(2, security_policy->kem_preferences->kem_count);
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_r1);
-        EXPECT_NULL(security_policy->kem_preferences->kem_groups);
-        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_group_count);
+        EXPECT_NULL(security_policy->kem_preferences->tls13_kem_groups);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->tls13_kem_group_count);
 
         security_policy = NULL;
         EXPECT_SUCCESS(s2n_find_security_policy_from_version("PQ-SIKE-TEST-TLS-1-0-2019-11", &security_policy));
@@ -89,8 +89,8 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(1, security_policy->kem_preferences->kem_count);
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_sike_r1);
-        EXPECT_NULL(security_policy->kem_preferences->kem_groups);
-        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_group_count);
+        EXPECT_NULL(security_policy->kem_preferences->tls13_kem_groups);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->tls13_kem_group_count);
 
         security_policy = NULL;
         EXPECT_SUCCESS(s2n_find_security_policy_from_version("PQ-SIKE-TEST-TLS-1-0-2020-02", &security_policy));
@@ -99,8 +99,8 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(2, security_policy->kem_preferences->kem_count);
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_sike_r2r1);
-        EXPECT_NULL(security_policy->kem_preferences->kem_groups);
-        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_group_count);
+        EXPECT_NULL(security_policy->kem_preferences->tls13_kem_groups);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->tls13_kem_group_count);
 
         security_policy = NULL;
         EXPECT_SUCCESS(s2n_find_security_policy_from_version("KMS-PQ-TLS-1-0-2020-02", &security_policy));
@@ -109,8 +109,8 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(4, security_policy->kem_preferences->kem_count);
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_r2r1);
-        EXPECT_NULL(security_policy->kem_preferences->kem_groups);
-        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_group_count);
+        EXPECT_NULL(security_policy->kem_preferences->tls13_kem_groups);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->tls13_kem_group_count);
 
         security_policy = NULL;
         EXPECT_SUCCESS(s2n_find_security_policy_from_version("KMS-PQ-TLS-1-0-2020-07", &security_policy));
@@ -119,8 +119,8 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(5, security_policy->kem_preferences->kem_count);
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_r2r1_2020_07);
-        EXPECT_NULL(security_policy->kem_preferences->kem_groups);
-        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_group_count);
+        EXPECT_NULL(security_policy->kem_preferences->tls13_kem_groups);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->tls13_kem_group_count);
 #else
         security_policy = NULL;
         EXPECT_FAILURE_WITH_ERRNO(s2n_find_security_policy_from_version("KMS-PQ-TLS-1-0-2019-06", &security_policy), S2N_ERR_INVALID_SECURITY_POLICY);
@@ -136,8 +136,8 @@ int main(int argc, char **argv)
         EXPECT_FALSE(s2n_pq_kem_is_extension_required(security_policy));
         EXPECT_EQUAL(0, security_policy->kem_preferences->kem_count);
         EXPECT_NULL(security_policy->kem_preferences->kems);
-        EXPECT_NULL(security_policy->kem_preferences->kem_groups);
-        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_group_count);
+        EXPECT_NULL(security_policy->kem_preferences->tls13_kem_groups);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->tls13_kem_group_count);
     }
 
     {
@@ -412,26 +412,26 @@ int main(int argc, char **argv)
             {
                 .kem_count = 1,
                 .kems = NULL,
-                .kem_group_count = 0,
-                .kem_groups = NULL,
+                .tls13_kem_group_count = 0,
+                .tls13_kem_groups = NULL,
             },
             {
                 .kem_count = 0,
                 .kems = NULL,
-                .kem_group_count = 1,
-                .kem_groups = NULL,
+                .tls13_kem_group_count = 1,
+                .tls13_kem_groups = NULL,
             },
             {
                 .kem_count = 0,
                 .kems = pq_kems_r1,
-                .kem_group_count = 0,
-                .kem_groups = NULL,
+                .tls13_kem_group_count = 0,
+                .tls13_kem_groups = NULL,
             },
             {
                 .kem_count = 0,
                 .kems = NULL,
-                .kem_group_count = 0,
-                .kem_groups = test_kem_group_list,
+                .tls13_kem_group_count = 0,
+                .tls13_kem_groups = test_kem_group_list,
             },
         };
 

--- a/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
@@ -155,7 +155,7 @@ int main(int argc, char **argv) {
     };
 
 #if EVP_APIS_SUPPORTED
-    /* All x25519 based kem_groups require EVP_APIS_SUPPORTED */
+    /* All x25519 based tls13_kem_groups require EVP_APIS_SUPPORTED */
     S2N_BLOB_FROM_HEX(x25519_secret, X25519_SHARED_SECRET);
     S2N_BLOB_FROM_HEX(x25519_sikep434r2_hybrid_secret, X25519_SIKEP434R2_HYBRID_SECRET);
 

--- a/tls/s2n_kem.h
+++ b/tls/s2n_kem.h
@@ -67,7 +67,7 @@ struct s2n_kem_group_params {
     struct s2n_ecc_evp_params ecc_params;
 };
 
-/* x25519 based kem_groups require EVP_APIS_SUPPORTED */
+/* x25519 based tls13_kem_groups require EVP_APIS_SUPPORTED */
 #if EVP_APIS_SUPPORTED
 #define S2N_SUPPORTED_KEM_GROUPS_COUNT 2
 #else

--- a/tls/s2n_kem_preferences.c
+++ b/tls/s2n_kem_preferences.c
@@ -55,39 +55,39 @@ const struct s2n_kem *pq_kems_sike_r2r1[2] = {
 const struct s2n_kem_preferences kem_preferences_kms_pq_tls_1_0_2019_06 = {
     .kem_count = s2n_array_len(pq_kems_r1),
     .kems = pq_kems_r1,
-    .kem_group_count = 0,
-    .kem_groups = NULL,
+    .tls13_kem_group_count = 0,
+    .tls13_kem_groups = NULL,
 };
 
 /* Includes round 1 and round 2 PQ KEM params. */
 const struct s2n_kem_preferences kem_preferences_kms_pq_tls_1_0_2020_02 = {
     .kem_count = s2n_array_len(pq_kems_r2r1),
     .kems = pq_kems_r2r1,
-    .kem_group_count = 0,
-    .kem_groups = NULL,
+    .tls13_kem_group_count = 0,
+    .tls13_kem_groups = NULL,
 };
 
 const struct s2n_kem_preferences kem_preferences_kms_pq_tls_1_0_2020_07 = {
     .kem_count = s2n_array_len(pq_kems_r2r1_2020_07),
     .kems = pq_kems_r2r1_2020_07,
-    .kem_group_count = 0,
-    .kem_groups = NULL,
+    .tls13_kem_group_count = 0,
+    .tls13_kem_groups = NULL,
 };
 
 /* Includes only SIKE round 1 (for integration tests) */
 const struct s2n_kem_preferences kem_preferences_pq_sike_test_tls_1_0_2019_11 = {
     .kem_count = s2n_array_len(pq_kems_sike_r1),
     .kems = pq_kems_sike_r1,
-    .kem_group_count = 0,
-    .kem_groups = NULL,
+    .tls13_kem_group_count = 0,
+    .tls13_kem_groups = NULL,
 };
 
 /* Includes only SIKE round 1 and round 2 (for integration tests). */
 const struct s2n_kem_preferences kem_preferences_pq_sike_test_tls_1_0_2020_02 = {
     .kem_count = s2n_array_len(pq_kems_sike_r2r1),
     .kems = pq_kems_sike_r2r1,
-    .kem_group_count = 0,
-    .kem_groups = NULL,
+    .tls13_kem_group_count = 0,
+    .tls13_kem_groups = NULL,
 };
 
 #endif
@@ -95,6 +95,6 @@ const struct s2n_kem_preferences kem_preferences_pq_sike_test_tls_1_0_2020_02 = 
 const struct s2n_kem_preferences kem_preferences_null = {
     .kem_count = 0,
     .kems = NULL,
-    .kem_group_count = 0,
-    .kem_groups = NULL,
+    .tls13_kem_group_count = 0,
+    .tls13_kem_groups = NULL,
 };

--- a/tls/s2n_kem_preferences.c
+++ b/tls/s2n_kem_preferences.c
@@ -55,29 +55,39 @@ const struct s2n_kem *pq_kems_sike_r2r1[2] = {
 const struct s2n_kem_preferences kem_preferences_kms_pq_tls_1_0_2019_06 = {
     .kem_count = s2n_array_len(pq_kems_r1),
     .kems = pq_kems_r1,
+    .kem_group_count = 0,
+    .kem_groups = NULL,
 };
 
 /* Includes round 1 and round 2 PQ KEM params. */
 const struct s2n_kem_preferences kem_preferences_kms_pq_tls_1_0_2020_02 = {
     .kem_count = s2n_array_len(pq_kems_r2r1),
     .kems = pq_kems_r2r1,
+    .kem_group_count = 0,
+    .kem_groups = NULL,
 };
 
 const struct s2n_kem_preferences kem_preferences_kms_pq_tls_1_0_2020_07 = {
     .kem_count = s2n_array_len(pq_kems_r2r1_2020_07),
     .kems = pq_kems_r2r1_2020_07,
+    .kem_group_count = 0,
+    .kem_groups = NULL,
 };
 
 /* Includes only SIKE round 1 (for integration tests) */
 const struct s2n_kem_preferences kem_preferences_pq_sike_test_tls_1_0_2019_11 = {
     .kem_count = s2n_array_len(pq_kems_sike_r1),
     .kems = pq_kems_sike_r1,
+    .kem_group_count = 0,
+    .kem_groups = NULL,
 };
 
 /* Includes only SIKE round 1 and round 2 (for integration tests). */
 const struct s2n_kem_preferences kem_preferences_pq_sike_test_tls_1_0_2020_02 = {
     .kem_count = s2n_array_len(pq_kems_sike_r2r1),
     .kems = pq_kems_sike_r2r1,
+    .kem_group_count = 0,
+    .kem_groups = NULL,
 };
 
 #endif
@@ -85,4 +95,6 @@ const struct s2n_kem_preferences kem_preferences_pq_sike_test_tls_1_0_2020_02 = 
 const struct s2n_kem_preferences kem_preferences_null = {
     .kem_count = 0,
     .kems = NULL,
+    .kem_group_count = 0,
+    .kem_groups = NULL,
 };

--- a/tls/s2n_kem_preferences.h
+++ b/tls/s2n_kem_preferences.h
@@ -19,8 +19,13 @@
 #include "tls/s2n_kex.h"
 
 struct s2n_kem_preferences {
+    /* kems used for hybrid TLS 1.2 */
     uint8_t kem_count;
     const struct s2n_kem **kems;
+
+    /* kem_groups used for hybrid TLS 1.3 */
+    uint8_t kem_group_count;
+    const struct s2n_kem_group **kem_groups;
 };
 
 #if !defined(S2N_NO_PQ)

--- a/tls/s2n_kem_preferences.h
+++ b/tls/s2n_kem_preferences.h
@@ -23,9 +23,9 @@ struct s2n_kem_preferences {
     uint8_t kem_count;
     const struct s2n_kem **kems;
 
-    /* kem_groups used for hybrid TLS 1.3 */
-    uint8_t kem_group_count;
-    const struct s2n_kem_group **kem_groups;
+    /* tls13_kem_groups used for hybrid TLS 1.3 */
+    uint8_t tls13_kem_group_count;
+    const struct s2n_kem_group **tls13_kem_groups;
 };
 
 #if !defined(S2N_NO_PQ)

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -693,18 +693,18 @@ int s2n_validate_kem_preferences(const struct s2n_kem_preferences *kem_preferenc
     notnull_check(kem_preferences);
 
     /* Basic sanity checks to assert that the count is 0 if and only if the associated list is NULL */
-    S2N_ERROR_IF(!S2N_IFF(kem_preferences->kem_group_count == 0, kem_preferences->kem_groups == NULL),
+    ENSURE_POSIX(S2N_IFF(kem_preferences->kem_group_count == 0, kem_preferences->kem_groups == NULL),
                  S2N_ERR_INVALID_SECURITY_POLICY);
-    S2N_ERROR_IF(!S2N_IFF(kem_preferences->kem_count == 0, kem_preferences->kems == NULL),
+    ENSURE_POSIX(S2N_IFF(kem_preferences->kem_count == 0, kem_preferences->kems == NULL),
                  S2N_ERR_INVALID_SECURITY_POLICY);
 
     /* The PQ KEM extension is applicable only to TLS 1.2 */
     if (pq_kem_extension_required) {
-        S2N_ERROR_IF(kem_preferences->kem_count == 0, S2N_ERR_INVALID_SECURITY_POLICY);
-        S2N_ERROR_IF(kem_preferences->kems == NULL, S2N_ERR_INVALID_SECURITY_POLICY);
+        ENSURE_POSIX(kem_preferences->kem_count > 0, S2N_ERR_INVALID_SECURITY_POLICY);
+        ENSURE_POSIX(kem_preferences->kems != NULL, S2N_ERR_INVALID_SECURITY_POLICY);
     } else {
-        S2N_ERROR_IF(kem_preferences->kem_count != 0, S2N_ERR_INVALID_SECURITY_POLICY);
-        S2N_ERROR_IF(kem_preferences->kems!= NULL, S2N_ERR_INVALID_SECURITY_POLICY);
+        ENSURE_POSIX(kem_preferences->kem_count == 0, S2N_ERR_INVALID_SECURITY_POLICY);
+        ENSURE_POSIX(kem_preferences->kems == NULL, S2N_ERR_INVALID_SECURITY_POLICY);
     }
 
     return S2N_SUCCESS;

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -600,13 +600,7 @@ int s2n_security_policies_init()
             }
         }
 
-        if (security_policy_selection[i].pq_kem_extension_required == 1) {
-            S2N_ERROR_IF(kem_preference->kem_count == 0, S2N_ERR_INVALID_SECURITY_POLICY);
-            S2N_ERROR_IF(kem_preference->kems == NULL, S2N_ERR_INVALID_SECURITY_POLICY);
-        } else {
-            S2N_ERROR_IF(kem_preference->kem_count != 0, S2N_ERR_INVALID_SECURITY_POLICY);
-            S2N_ERROR_IF(kem_preference->kems!= NULL, S2N_ERR_INVALID_SECURITY_POLICY);
-        }
+        GUARD(s2n_validate_kem_preferences(kem_preference, security_policy_selection[i].pq_kem_extension_required));
     }
     return 0;
 }
@@ -693,4 +687,25 @@ int s2n_connection_is_valid_for_cipher_preferences(struct s2n_connection *conn, 
     }
 
     return 0;
+}
+
+int s2n_validate_kem_preferences(const struct s2n_kem_preferences *kem_preferences, bool pq_kem_extension_required) {
+    notnull_check(kem_preferences);
+
+    /* Basic sanity checks to assert that the count is 0 if and only if the associated list is NULL */
+    S2N_ERROR_IF(!S2N_IFF(kem_preferences->kem_group_count == 0, kem_preferences->kem_groups == NULL),
+                 S2N_ERR_INVALID_SECURITY_POLICY);
+    S2N_ERROR_IF(!S2N_IFF(kem_preferences->kem_count == 0, kem_preferences->kems == NULL),
+                 S2N_ERR_INVALID_SECURITY_POLICY);
+
+    /* The PQ KEM extension is applicable only to TLS 1.2 */
+    if (pq_kem_extension_required) {
+        S2N_ERROR_IF(kem_preferences->kem_count == 0, S2N_ERR_INVALID_SECURITY_POLICY);
+        S2N_ERROR_IF(kem_preferences->kems == NULL, S2N_ERR_INVALID_SECURITY_POLICY);
+    } else {
+        S2N_ERROR_IF(kem_preferences->kem_count != 0, S2N_ERR_INVALID_SECURITY_POLICY);
+        S2N_ERROR_IF(kem_preferences->kems!= NULL, S2N_ERR_INVALID_SECURITY_POLICY);
+    }
+
+    return S2N_SUCCESS;
 }

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -693,7 +693,7 @@ int s2n_validate_kem_preferences(const struct s2n_kem_preferences *kem_preferenc
     notnull_check(kem_preferences);
 
     /* Basic sanity checks to assert that the count is 0 if and only if the associated list is NULL */
-    ENSURE_POSIX(S2N_IFF(kem_preferences->kem_group_count == 0, kem_preferences->kem_groups == NULL),
+    ENSURE_POSIX(S2N_IFF(kem_preferences->tls13_kem_group_count == 0, kem_preferences->tls13_kem_groups == NULL),
                  S2N_ERR_INVALID_SECURITY_POLICY);
     ENSURE_POSIX(S2N_IFF(kem_preferences->kem_count == 0, kem_preferences->kems == NULL),
                  S2N_ERR_INVALID_SECURITY_POLICY);

--- a/tls/s2n_security_policies.h
+++ b/tls/s2n_security_policies.h
@@ -109,3 +109,4 @@ bool s2n_ecc_is_extension_required(const struct s2n_security_policy *security_po
 bool s2n_pq_kem_is_extension_required(const struct s2n_security_policy *security_policy);
 bool s2n_security_policy_supports_tls13(const struct s2n_security_policy *security_policy);
 int s2n_find_security_policy_from_version(const char *version, const struct s2n_security_policy **security_policy);
+int s2n_validate_kem_preferences(const struct s2n_kem_preferences *kem_preferences, bool pq_kem_extension_required);


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

* Adds `kem_group_count` and `kem_groups` to the `s2n_kem_preferences` structure
* Adds `s2n_validate_kem_preferences()` to perform basic sanity checks on KEM preferences that are used in security policies

### Call-outs:

For now, all of the `kem_group_count`s are 0, and all of the `kem_groups` are `NULL`. We need the structure to be present in the KEM preferences in order to implement client/server functionality, but we haven't defined any pq-tls 1.3 KEM preferences yet.

### Testing:

* Updated existing security policy tests
* Added test cases for `s2n_validate_kem_preferences()`
* Ran unit tests locally with `S2N_NO_PQ=1`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.