### PR TITLE
PQ shared secret will be stored based on Client/Server mode

### DIFF
--- a/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
@@ -209,14 +209,13 @@ int main(int argc, char **argv) {
 
     {
         /* Happy cases for computing the hybrid shared secret and client & server traffic secrets */
-        struct s2n_connection *client_conn;
-        struct s2n_connection *server_conn;
-
         for (int i = 0; i < s2n_array_len(all_test_vectors); i++) {
             const struct hybrid_test_vector *test_vector = all_test_vectors[i];
             const struct s2n_kem_group *kem_group = test_vector->kem_group;
 
             /* Set up connections */
+            struct s2n_connection *client_conn = NULL;
+            struct s2n_connection *server_conn = NULL;
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
 
@@ -272,11 +271,11 @@ int main(int argc, char **argv) {
         /* Various failure cases for s2n_tls13_compute_shared_secret() */
         const struct hybrid_test_vector *test_vector = &aes_128_sha_256_secp256r1_sikep434r2_vector;
         s2n_mode modes[] = { S2N_SERVER, S2N_CLIENT };
-        struct s2n_connection *conn;
 
         for (size_t i = 0; i < s2n_array_len(modes); i++) {
             /* Failures because of NULL arguments */
             EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(NULL, NULL), S2N_ERR_NULL);
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(modes[i]));
             EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, NULL), S2N_ERR_NULL);
             DEFER_CLEANUP(struct s2n_blob calculated_shared_secret = {0}, s2n_free);

--- a/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
@@ -279,35 +279,35 @@ int main(int argc, char **argv) {
             EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(NULL, NULL), S2N_ERR_NULL);
             EXPECT_NOT_NULL(conn = s2n_connection_new(modes[i]));
             EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, NULL), S2N_ERR_NULL);
-            DEFER_CLEANUP(struct s2n_blob client_calculated_shared_secret = {0}, s2n_free);
-            EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(NULL, &client_calculated_shared_secret), S2N_ERR_NULL);
+            DEFER_CLEANUP(struct s2n_blob calculated_shared_secret = {0}, s2n_free);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(NULL, &calculated_shared_secret), S2N_ERR_NULL);
 
             /* Failures because classic (non-hybrid) parameters were configured */
             conn->secure.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
-            EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &client_calculated_shared_secret), S2N_ERR_SAFETY);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &calculated_shared_secret), S2N_ERR_SAFETY);
             conn->secure.server_ecc_evp_params.negotiated_curve = NULL;
             EXPECT_SUCCESS(read_priv_ecc(&conn->secure.server_ecc_evp_params.evp_pkey, test_vector->client_ecc_key));
-            EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &client_calculated_shared_secret), S2N_ERR_SAFETY);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &calculated_shared_secret), S2N_ERR_SAFETY);
             EXPECT_SUCCESS(s2n_ecc_evp_params_free(&conn->secure.server_ecc_evp_params));
 
             /* Failure because the chosen_client_kem_group_params is NULL */
-            EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &client_calculated_shared_secret), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &calculated_shared_secret), S2N_ERR_NULL);
             conn->secure.chosen_client_kem_group_params = &conn->secure.client_kem_group_params[0];
 
             /* Failures because the kem_group_params aren't set */
-            EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &client_calculated_shared_secret), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &calculated_shared_secret), S2N_ERR_NULL);
             conn->secure.server_kem_group_params.ecc_params.negotiated_curve = test_vector->kem_group->curve;
-            EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &client_calculated_shared_secret), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &calculated_shared_secret), S2N_ERR_NULL);
             conn->secure.chosen_client_kem_group_params->ecc_params.negotiated_curve = test_vector->kem_group->curve;
 
             /* Failures because the ECC private keys are NULL */
-            EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &client_calculated_shared_secret), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &calculated_shared_secret), S2N_ERR_NULL);
             EXPECT_SUCCESS(read_priv_ecc(&conn->secure.chosen_client_kem_group_params->ecc_params.evp_pkey, test_vector->client_ecc_key));
-            EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &client_calculated_shared_secret), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &calculated_shared_secret), S2N_ERR_NULL);
             EXPECT_SUCCESS(read_priv_ecc(&conn->secure.server_kem_group_params.ecc_params.evp_pkey, test_vector->server_ecc_key));
 
             /* Failure because pq_shared_secret is NULL */
-            EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &client_calculated_shared_secret), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &calculated_shared_secret), S2N_ERR_NULL);
             if (conn->mode == S2N_CLIENT) {
                 EXPECT_SUCCESS(s2n_dup(test_vector->pq_secret, &conn->secure.chosen_client_kem_group_params->kem_params.shared_secret));
             } else {
@@ -315,11 +315,11 @@ int main(int argc, char **argv) {
             }
 
             /* Failure because the kem_group is NULL */
-            EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &client_calculated_shared_secret), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &calculated_shared_secret), S2N_ERR_NULL);
             conn->secure.server_kem_group_params.kem_group = test_vector->kem_group;
 
             /* Finally, success */
-            EXPECT_SUCCESS(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &client_calculated_shared_secret));
+            EXPECT_SUCCESS(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &calculated_shared_secret));
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }

--- a/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
@@ -306,10 +306,6 @@ int main(int argc, char **argv) {
             EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &client_calculated_shared_secret), S2N_ERR_NULL);
             EXPECT_SUCCESS(read_priv_ecc(&conn->secure.server_kem_group_params.ecc_params.evp_pkey, test_vector->server_ecc_key));
 
-            /* Failure because the kem_group is NULL */
-            EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &client_calculated_shared_secret), S2N_ERR_NULL);
-            conn->secure.server_kem_group_params.kem_group = test_vector->kem_group;
-
             /* Failure because pq_shared_secret is NULL */
             EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &client_calculated_shared_secret), S2N_ERR_NULL);
             if (conn->mode == S2N_CLIENT) {
@@ -317,6 +313,10 @@ int main(int argc, char **argv) {
             } else {
                 EXPECT_SUCCESS(s2n_dup(test_vector->pq_secret, &conn->secure.server_kem_group_params.kem_params.shared_secret));
             }
+
+            /* Failure because the kem_group is NULL */
+            EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &client_calculated_shared_secret), S2N_ERR_NULL);
+            conn->secure.server_kem_group_params.kem_group = test_vector->kem_group;
 
             /* Finally, success */
             EXPECT_SUCCESS(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &client_calculated_shared_secret));

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -119,7 +119,12 @@ int s2n_tls13_compute_pq_hybrid_shared_secret(struct s2n_connection *conn, struc
 
     struct s2n_kem_params *server_kem_params = &server_kem_group_params->kem_params;
     notnull_check(server_kem_params);
-    struct s2n_blob *pq_shared_secret = &server_kem_params->shared_secret;
+    struct s2n_blob *pq_shared_secret;
+    if (conn->mode == S2N_CLIENT) {
+        pq_shared_secret = &client_kem_group_params->kem_params.shared_secret;
+    } else {
+        pq_shared_secret = &server_kem_params->shared_secret;
+    }
     notnull_check(pq_shared_secret);
     notnull_check(pq_shared_secret->data);
     eq_check(pq_shared_secret->size, negotiated_kem_group->kem->shared_secret_key_length);

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -107,16 +107,13 @@ int s2n_tls13_compute_pq_hybrid_shared_secret(struct s2n_connection *conn, struc
     DEFER_CLEANUP(struct s2n_blob ecdhe_shared_secret = { 0 }, s2n_blob_zeroize_free);
     struct s2n_blob *pq_shared_secret;
 
-    struct s2n_kem_params *server_kem_params = &server_kem_group_params->kem_params;
-    notnull_check(server_kem_params);
-
     /* Compute the ECDHE shared secret, and retrieve the PQ shared secret. */
     if (conn->mode == S2N_CLIENT) {
         GUARD(s2n_ecc_evp_compute_shared_secret_from_params(client_ecc_params, server_ecc_params, &ecdhe_shared_secret));
         pq_shared_secret = &client_kem_group_params->kem_params.shared_secret;
     } else {
         GUARD(s2n_ecc_evp_compute_shared_secret_from_params(server_ecc_params, client_ecc_params, &ecdhe_shared_secret));
-        pq_shared_secret = &server_kem_params->shared_secret;
+        pq_shared_secret = &server_kem_group_params->kem_params.shared_secret;
     }
 
     notnull_check(pq_shared_secret);

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -105,7 +105,7 @@ int s2n_tls13_compute_pq_hybrid_shared_secret(struct s2n_connection *conn, struc
     notnull_check(client_ecc_params);
 
     DEFER_CLEANUP(struct s2n_blob ecdhe_shared_secret = { 0 }, s2n_blob_zeroize_free);
-    struct s2n_blob *pq_shared_secret;
+    struct s2n_blob *pq_shared_secret = NULL;
 
     /* Compute the ECDHE shared secret, and retrieve the PQ shared secret. */
     if (conn->mode == S2N_CLIENT) {

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -105,30 +105,31 @@ int s2n_tls13_compute_pq_hybrid_shared_secret(struct s2n_connection *conn, struc
     notnull_check(client_ecc_params);
 
     DEFER_CLEANUP(struct s2n_blob ecdhe_shared_secret = { 0 }, s2n_blob_zeroize_free);
+    struct s2n_blob *pq_shared_secret;
 
+    struct s2n_kem_params *server_kem_params = &server_kem_group_params->kem_params;
+    notnull_check(server_kem_params);
+
+    /* Compute the ECDHE shared secret, and retrieve the PQ shared secret. */
     if (conn->mode == S2N_CLIENT) {
         GUARD(s2n_ecc_evp_compute_shared_secret_from_params(client_ecc_params, server_ecc_params, &ecdhe_shared_secret));
+        pq_shared_secret = &client_kem_group_params->kem_params.shared_secret;
     } else {
         GUARD(s2n_ecc_evp_compute_shared_secret_from_params(server_ecc_params, client_ecc_params, &ecdhe_shared_secret));
+        pq_shared_secret = &server_kem_params->shared_secret;
     }
+
+    notnull_check(pq_shared_secret);
+    notnull_check(pq_shared_secret->data);
 
     const struct s2n_kem_group *negotiated_kem_group = conn->secure.server_kem_group_params.kem_group;
     notnull_check(negotiated_kem_group);
     notnull_check(negotiated_kem_group->kem);
-    uint32_t hybrid_shared_secret_size = ecdhe_shared_secret.size + negotiated_kem_group->kem->shared_secret_key_length;
 
-    struct s2n_kem_params *server_kem_params = &server_kem_group_params->kem_params;
-    notnull_check(server_kem_params);
-    struct s2n_blob *pq_shared_secret;
-    if (conn->mode == S2N_CLIENT) {
-        pq_shared_secret = &client_kem_group_params->kem_params.shared_secret;
-    } else {
-        pq_shared_secret = &server_kem_params->shared_secret;
-    }
-    notnull_check(pq_shared_secret);
-    notnull_check(pq_shared_secret->data);
     eq_check(pq_shared_secret->size, negotiated_kem_group->kem->shared_secret_key_length);
 
+    /* Construct the concatenated/hybrid shared secret */
+    uint32_t hybrid_shared_secret_size = ecdhe_shared_secret.size + negotiated_kem_group->kem->shared_secret_key_length;
     GUARD(s2n_alloc(shared_secret, hybrid_shared_secret_size));
     struct s2n_stuffer stuffer_combiner = { 0 };
     GUARD(s2n_stuffer_init(&stuffer_combiner, shared_secret));


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

Preemptively fixes a bug in the shared secret derivation that surfaced while working on the hybrid 1.3 client. The server will generate the PQ secret and store it in the server KEM params; the client will decapsulate the ciphertext sent by the server and store the shared secret in the client kem params (along with it's private key).

### Call-outs:

N/A

### Testing:

Updated the hybrid shared secret unit test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
