### PR TITLE
docs: Add security comment to ISSUE_TEMPLATE

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,6 +1,22 @@
+
+---
+name: S2N Issue
+about: Template
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### Security issue notifications
+
+If you discover a potential security issue in s2n we ask that you notify
+AWS Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
+
 ### Problem:
 
 A short description of what the problem is and why we need to fix it. Add reproduction steps if necessary.
+
 ### Solution:
 
 A description of the possible solution in terms of S2N architecture. Highlight and explain any potentially controversial design decisions taken.
@@ -8,9 +24,10 @@ A description of the possible solution in terms of S2N architecture. Highlight a
 * **Does this change what S2N sends over the wire?** If yes, explain.
 * **Does this change any public APIs?** If yes, explain.
 * **Which versions of TLS will this impact?**
+
 ### Requirements / Acceptance Criteria:
 
- What must a solution address in order to solve the problem? How do we know the solution is complete?
+What must a solution address in order to solve the problem? How do we know the solution is complete?
 
 * **RFC links:** Links to relevant RFC(s)
 * **Related Issues:** Link any relevant issues


### PR DESCRIPTION

### Resolved issues:

Internal

### Description of changes: 

Copy the security reporting wording from the README to the issue template.

Also, Update to newer [GitHub template format](https://docs.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository).

### Call-outs:

There is the option of creating distinct issue templates for Bugs vs Features, for now, just went with Custom to reduce confusion and duplication.

### Testing:

Added to my fork.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
