### PR TITLE
(Do not merge yet) Changed uint8_t array to be a uint16_t array

### DIFF
--- a/tests/unit/s2n_aes_sha_composite_test.c
+++ b/tests/unit/s2n_aes_sha_composite_test.c
@@ -62,7 +62,7 @@ int main(int argc, char **argv)
     conn->client = &conn->initial;
 
     const int max_aligned_fragment = S2N_DEFAULT_FRAGMENT_LENGTH;
-    const uint8_t proto_versions[3] = { S2N_TLS10, S2N_TLS11, S2N_TLS12 };
+    const uint16_t proto_versions[3] = { S2N_TLS10, S2N_TLS11, S2N_TLS12 };
 
     /* test the composite AES128_SHA1 cipher  */
     conn->initial.cipher_suite->record_alg = &s2n_record_alg_aes128_sha_composite;


### PR DESCRIPTION
### Resolved issues:
N/A

### Description of changes: 

Storing constants in a uint8_t array was causing an overflow issue when run on ubuntu platform. Changed to be a uint16_array to get around this issue.
### Call-outs:

### Testing:


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
