### PR TITLE
Don't print debug allocation info to stdout during unit tests

### DIFF
--- a/tests/unit/s2n_mem_allocator_test.c
+++ b/tests/unit/s2n_mem_allocator_test.c
@@ -265,6 +265,7 @@ int main(int argc, char **argv)
     free(private_key_pem);
     free(dhparams_pem);
 
+#if defined(S2N_TEST_DEBUG)
     /* Sort our histogram */
     uint32_t spare_value, spare_count;
     for (int i = 0; i < HISTOGRAM_SIZE; i++) {
@@ -291,14 +292,15 @@ int main(int argc, char **argv)
     }
 
     /* Print the histogram values */
-    printf("\n\n");
+    TEST_DEBUG_PRINT("\n\n");
     for (int i = 0; i < HISTOGRAM_SIZE; i++) {
         if (histogram_values[i] == 0) {
             break;
         }
-        printf("Allocated %d bytes %d times\n", histogram_values[i], histogram_counts[i]);
+        TEST_DEBUG_PRINT("Allocated %d bytes %d times\n", histogram_values[i], histogram_counts[i]);
     }
-    printf("\n");
+    TEST_DEBUG_PRINT("\n");
+#endif
 
     END_TEST();
 


### PR DESCRIPTION
### Resolved issues:
Running this unit test prints a lot of unnecessary info: 

```
Running s2n_client_supported_versions_extension_test.c     ... PASSED        114 tests
Running s2n_mem_allocator_test.c                           ...

Allocated 8 bytes 5 times
Allocated 12 bytes 4 times
Allocated 13 bytes 6 times
Allocated 16 bytes 4 times
Allocated 24 bytes 6 times
Allocated 32 bytes 2 times
Allocated 40 bytes 8 times
Allocated 48 bytes 5 times
Allocated 80 bytes 4 times
Allocated 88 bytes 4 times
Allocated 96 bytes 16 times
Allocated 103 bytes 2 times
Allocated 120 bytes 8 times
Allocated 256 bytes 2 times
Allocated 264 bytes 5 times
Allocated 296 bytes 2 times
Allocated 384 bytes 8 times
Allocated 425 bytes 1 times
Allocated 426 bytes 1 times
Allocated 689 bytes 2 times
Allocated 767 bytes 2 times
Allocated 773 bytes 2 times
Allocated 813 bytes 2 times
Allocated 1096 bytes 2 times
Allocated 1680 bytes 2 times
Allocated 1681 bytes 2 times
Allocated 1705 bytes 2 times
Allocated 1706 bytes 2 times
Allocated 2048 bytes 4 times
Allocated 3072 bytes 2 times
Allocated 3249 bytes 2 times
Allocated 16384 bytes 1314 times
Allocated 16872 bytes 2 times
Allocated 18437 bytes 6 times

PASSED   42976725 tests
Running s2n_tls12_handshake_test.c                         ... PASSED      14243 tests
```

### Description of changes: 
Removes code used to generate and print out this debug info.

### Call-outs:
None.

### Testing:

All existing tests are left intact, code for printing out info is removed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
