### PR TITLE
Adds BIKE1L1R2 kem groups

### DIFF
--- a/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
@@ -90,10 +90,13 @@ struct hybrid_test_vector {
 
 /* PQ shared secrets taken from the first entry in the NIST KAT files */
 #define SIKEP434R2_SECRET "35f7f8ff388714dedc41f139078cedc9"
+#define BIKE1L1R2_SECRET "C1C96E2B8B1D23E52F02AD3A766A75ADBEDF7BA1558B94412B4AB534EEDBDE36"
 
 /* Hybrid shared secrets are the concatenation: ECDHE || PQ */
 #define X25519_SIKEP434R2_HYBRID_SECRET      (X25519_SHARED_SECRET      SIKEP434R2_SECRET)
 #define SECP256R1_SIKEP434R2_HYBRID_SECRET   (SECP256R1_SHARED_SECRET   SIKEP434R2_SECRET)
+#define X25519_BIKE1L1R2_HYBRID_SECRET       (X25519_SHARED_SECRET      BIKE1L1R2_SECRET)
+#define SECP256R1_BIKE1L1R2_HYBRID_SECRET    (SECP256R1_SHARED_SECRET   BIKE1L1R2_SECRET)
 
 /* The expected traffic secrets were calculated from an independent implementation,
  * using the ECDHE & PQ secrets defined above. */
@@ -101,10 +104,21 @@ struct hybrid_test_vector {
 #define AES_128_SECP256R1_SIKEP434R2_SERVER_TRAFFIC_SECRET "423dfaf8fd66b17aaf8c919a9318f3a6bd69875aacdf022aa58a953a7b6de806"
 #define AES_256_SECP256R1_SIKEP434R2_CLIENT_TRAFFIC_SECRET "f7d349f364f49ff3ae9c4e9e7aa60c41d6c650d09c03d8c076bc714ab76177045e23e7426dceb872d2fe7c0d07abdefd"
 #define AES_256_SECP256R1_SIKEP434R2_SERVER_TRAFFIC_SECRET "184755801232f7b9b5c42cbdc66c793071f4322079e34307fd60261c0f7a27612b3808918218c4000c12f829d6c19ebf"
+
 #define AES_128_X25519_SIKEP434_CLIENT_TRAFFIC_SECRET "9b9c53221edb5cc1f95ab2ecfc5eb8ec27d6b9fc2159c956333cd90099911dc7"
 #define AES_128_X25519_SIKEP434_SERVER_TRAFFIC_SECRET "29a8786ffc6a48692b95d70ab7e04bcf112afd0a019dff6c15c1d095cfa5ebcc"
 #define AES_256_X25519_SIKEP434_CLIENT_TRAFFIC_SECRET "c7ee90f95fdfd53d97da07e338c7b6aa9e5111864d66d9631048941f45c9fd1a7b119871594140000923a79333040775"
 #define AES_256_X25519_SIKEP434_SERVER_TRAFFIC_SECRET "aff2987e4ed3c2bc55cbd9e3e52db0cc330034dfa709e0a4127c4d74278198720b74a444afa8f0f7dca115797470cef2"
+
+#define AES_128_SECP256R1_BIKE1L1R2_CLIENT_TRAFFIC_SECRET "67ed1aec6227ce924087b4a2224ec697ae164dc8541eee3c3d393dda2bd10958"
+#define AES_128_SECP256R1_BIKE1L1R2_SERVER_TRAFFIC_SECRET "c0d1cf356e224db5fa693b91bad93130915448913fd3509257188a3f064585d1"
+#define AES_256_SECP256R1_BIKE1L1R2_CLIENT_TRAFFIC_SECRET "fd5d731c6454c523dd029a2311346da9969c30ea8cead8a6e19f211762c2bbabd182e6fb599527b26eecf86f3329103c"
+#define AES_256_SECP256R1_BIKE1L1R2_SERVER_TRAFFIC_SECRET "03dcd83c4ae4cd4dd5a76404afd3147e277a748ec3f10e8c1427ae37c1c0cc0eff29149cb14b61da49696510dc0182d2"
+
+#define AES_128_X25519_BIKE1L1R2_CLIENT_TRAFFIC_SECRET "3a0d971f4461ee69688eb1159c1640d429e2255473f2e2668b1cbab4ac80a47f"
+#define AES_128_X25519_BIKE1L1R2_SERVER_TRAFFIC_SECRET "74ea914ef6416dbe16b75a568c00d505c66770b0938539fccbfe3051460ab583"
+#define AES_256_X25519_BIKE1L1R2_CLIENT_TRAFFIC_SECRET "982ea3ccdd83225b6b2bb8a2f623e4f9b9cdcca1f5a11ea2b94f264bbf6785d6c1db3232ceb395eb79ddcae3f754fe7d"
+#define AES_256_X25519_BIKE1L1R2_SERVER_TRAFFIC_SECRET "510970206a3eb187c8ea4ad5f91b738e44dee08616579a16572320e2dac46f6dfa5d072c0f5ac08b9e3480b28d6d8923"
 
 /* A fake transcript string to hash when deriving handshake secrets */
 #define FAKE_TRANSCRIPT "client_hello || server_hello"
@@ -122,7 +136,7 @@ int main(int argc, char **argv) {
     S2N_BLOB_FROM_HEX(sikep434r2_secret, SIKEP434R2_SECRET);
 
     S2N_BLOB_FROM_HEX(secp256r1_secret, SECP256R1_SHARED_SECRET);
-    S2N_BLOB_FROM_HEX(secp256r1_sikep434r2_hybrid_secret,SECP256R1_SIKEP434R2_HYBRID_SECRET);
+    S2N_BLOB_FROM_HEX(secp256r1_sikep434r2_hybrid_secret, SECP256R1_SIKEP434R2_HYBRID_SECRET);
 
     S2N_BLOB_FROM_HEX(aes_128_secp256r1_sikep434r2_client_secret, AES_128_SECP256R1_SIKEP434R2_CLIENT_TRAFFIC_SECRET);
     S2N_BLOB_FROM_HEX(aes_128_secp256r1_sikep434r2_server_secret, AES_128_SECP256R1_SIKEP434R2_SERVER_TRAFFIC_SECRET);
@@ -152,6 +166,38 @@ int main(int argc, char **argv) {
             .expected_hybrid_secret = &secp256r1_sikep434r2_hybrid_secret,
             .expected_client_traffic_secret = &aes_256_secp256r1_sikep434r2_client_secret,
             .expected_server_traffic_secret = &aes_256_secp256r1_sikep434r2_server_secret,
+    };
+
+    S2N_BLOB_FROM_HEX(bike1l1r2_secret, BIKE1L1R2_SECRET);
+    S2N_BLOB_FROM_HEX(secp256r1_bike1l1r2_hybrid_secret, SECP256R1_BIKE1L1R2_HYBRID_SECRET);
+    S2N_BLOB_FROM_HEX(aes_128_secp256r1_bike1l1r2_client_secret, AES_128_SECP256R1_BIKE1L1R2_CLIENT_TRAFFIC_SECRET);
+    S2N_BLOB_FROM_HEX(aes_128_secp256r1_bike1l1r2_server_secret, AES_128_SECP256R1_BIKE1L1R2_SERVER_TRAFFIC_SECRET);
+
+    const struct hybrid_test_vector aes_128_sha_256_secp256r1_bike1l1r2_vector = {
+            .cipher_suite = &s2n_tls13_aes_128_gcm_sha256,
+            .transcript = FAKE_TRANSCRIPT,
+            .kem_group = &s2n_secp256r1_bike1_l1_r2,
+            .client_ecc_key = CLIENT_SECP256R1_PRIV_KEY,
+            .server_ecc_key = SERVER_SECP256R1_PRIV_KEY,
+            .pq_secret = &bike1l1r2_secret,
+            .expected_hybrid_secret = &secp256r1_bike1l1r2_hybrid_secret,
+            .expected_client_traffic_secret = &aes_128_secp256r1_bike1l1r2_client_secret,
+            .expected_server_traffic_secret = &aes_128_secp256r1_bike1l1r2_server_secret,
+    };
+
+    S2N_BLOB_FROM_HEX(aes_256_secp256r1_bike1l1r2_client_secret, AES_256_SECP256R1_BIKE1L1R2_CLIENT_TRAFFIC_SECRET);
+    S2N_BLOB_FROM_HEX(aes_256_secp256r1_bike1l1r2_server_secret, AES_256_SECP256R1_BIKE1L1R2_SERVER_TRAFFIC_SECRET);
+
+    const struct hybrid_test_vector aes_256_sha_384_secp256r1_bike1l1r2_vector = {
+            .cipher_suite = &s2n_tls13_aes_256_gcm_sha384,
+            .transcript = FAKE_TRANSCRIPT,
+            .kem_group = &s2n_secp256r1_bike1_l1_r2,
+            .client_ecc_key = CLIENT_SECP256R1_PRIV_KEY,
+            .server_ecc_key = SERVER_SECP256R1_PRIV_KEY,
+            .pq_secret = &bike1l1r2_secret,
+            .expected_hybrid_secret = &secp256r1_bike1l1r2_hybrid_secret,
+            .expected_client_traffic_secret = &aes_256_secp256r1_bike1l1r2_client_secret,
+            .expected_server_traffic_secret = &aes_256_secp256r1_bike1l1r2_server_secret,
     };
 
 #if EVP_APIS_SUPPORTED
@@ -188,24 +234,62 @@ int main(int argc, char **argv) {
             .expected_client_traffic_secret = &aes_256_x25519_sikep434r2_client_secret,
             .expected_server_traffic_secret = &aes_256_x25519_sikep434r2_server_secret,
     };
+
+    S2N_BLOB_FROM_HEX(x25519_bike1l1r2_hybrid_secret, X25519_BIKE1L1R2_HYBRID_SECRET);
+    S2N_BLOB_FROM_HEX(aes_128_x25519_bike1l1r2_client_secret, AES_128_X25519_BIKE1L1R2_CLIENT_TRAFFIC_SECRET);
+    S2N_BLOB_FROM_HEX(aes_128_x25519_bike1l1r2_server_secret, AES_128_X25519_BIKE1L1R2_SERVER_TRAFFIC_SECRET);
+
+    const struct hybrid_test_vector aes_128_sha_256_x25519_bike1l1r2_vector = {
+            .cipher_suite = &s2n_tls13_aes_128_gcm_sha256,
+            .transcript = FAKE_TRANSCRIPT,
+            .kem_group = &s2n_x25519_bike1_l1_r2,
+            .client_ecc_key = CLIENT_X25519_PRIV_KEY,
+            .server_ecc_key = SERVER_X25519_PRIV_KEY,
+            .pq_secret = &bike1l1r2_secret,
+            .expected_hybrid_secret = &x25519_bike1l1r2_hybrid_secret,
+            .expected_client_traffic_secret = &aes_128_x25519_bike1l1r2_client_secret,
+            .expected_server_traffic_secret = &aes_128_x25519_bike1l1r2_server_secret,
+    };
+
+    S2N_BLOB_FROM_HEX(aes_256_x25519_bike1l1r2_client_secret, AES_256_X25519_BIKE1L1R2_CLIENT_TRAFFIC_SECRET);
+    S2N_BLOB_FROM_HEX(aes_256_x25519_bike1l1r2_server_secret, AES_256_X25519_BIKE1L1R2_SERVER_TRAFFIC_SECRET);
+
+    const struct hybrid_test_vector aes_256_sha_384_x25519_bike1l1r2_vector = {
+            .cipher_suite = &s2n_tls13_aes_256_gcm_sha384,
+            .transcript = FAKE_TRANSCRIPT,
+            .kem_group = &s2n_x25519_bike1_l1_r2,
+            .client_ecc_key = CLIENT_X25519_PRIV_KEY,
+            .server_ecc_key = SERVER_X25519_PRIV_KEY,
+            .pq_secret = &bike1l1r2_secret,
+            .expected_hybrid_secret = &x25519_bike1l1r2_hybrid_secret,
+            .expected_client_traffic_secret = &aes_256_x25519_bike1l1r2_client_secret,
+            .expected_server_traffic_secret = &aes_256_x25519_bike1l1r2_server_secret,
+    };
 #endif
 
 #if EVP_APIS_SUPPORTED
-    EXPECT_EQUAL(2, S2N_SUPPORTED_KEM_GROUPS_COUNT);
+    EXPECT_EQUAL(4, S2N_SUPPORTED_KEM_GROUPS_COUNT);
     const struct hybrid_test_vector *all_test_vectors[] = {
             &aes_128_sha_256_secp256r1_sikep434r2_vector,
             &aes_256_sha_384_secp256r1_sikep434r2_vector,
             &aes_128_sha_256_x25519_sikep434r2_vector,
             &aes_256_sha_284_x25519_sikep434r2_vector,
+            &aes_128_sha_256_secp256r1_bike1l1r2_vector,
+            &aes_256_sha_384_secp256r1_bike1l1r2_vector,
+            &aes_128_sha_256_x25519_bike1l1r2_vector,
+            &aes_256_sha_384_x25519_bike1l1r2_vector,
     };
 #else
-    EXPECT_EQUAL(1, S2N_SUPPORTED_KEM_GROUPS_COUNT);
+    EXPECT_EQUAL(2, S2N_SUPPORTED_KEM_GROUPS_COUNT);
     const struct hybrid_test_vector *all_test_vectors[] = {
             &aes_128_sha_256_secp256r1_sikep434r2_vector,
             &aes_256_sha_384_secp256r1_sikep434r2_vector,
+            &aes_128_sha_256_secp256r1_bike1l1r2_vector,
+            &aes_256_sha_384_secp256r1_bike1l1r2_vector,
     };
 #endif
 
+    EXPECT_EQUAL(2 * S2N_SUPPORTED_KEM_GROUPS_COUNT, s2n_array_len(all_test_vectors));
 
     struct s2n_connection *client_conn;
     struct s2n_connection *server_conn;

--- a/tls/s2n_kem.c
+++ b/tls/s2n_kem.c
@@ -138,6 +138,14 @@ const struct s2n_kem_group s2n_secp256r1_sike_p434_r2 = {
         .kem = &s2n_sike_p434_r2,
 };
 
+const struct s2n_kem_group s2n_secp256r1_bike1_l1_r2 = {
+        /* The name string follows the convention in the above google doc */
+        .name = "secp256r1_bike-1l1fo-r2",
+        .iana_id = TLS_PQ_KEM_GROUP_ID_SECP256R1_BIKE1_L1_R2,
+        .curve = &s2n_ecc_curve_secp256r1,
+        .kem = &s2n_bike1_l1_r2,
+};
+
 #if EVP_APIS_SUPPORTED
 const struct s2n_kem_group s2n_x25519_sike_p434_r2 = {
         .name = "x25519_sike-p434-r2",
@@ -145,8 +153,17 @@ const struct s2n_kem_group s2n_x25519_sike_p434_r2 = {
         .curve = &s2n_ecc_curve_x25519,
         .kem = &s2n_sike_p434_r2,
 };
+
+const struct s2n_kem_group s2n_x25519_bike1_l1_r2 = {
+        /* The name string follows the convention in the above google doc */
+        .name = "x25519_bike-1l1fo-r2",
+        .iana_id = TLS_PQ_KEM_GROUP_ID_X25519_BIKE1_L1_R2,
+        .curve = &s2n_ecc_curve_x25519,
+        .kem = &s2n_bike1_l1_r2,
+};
 #else
 const struct s2n_kem_group s2n_x25519_sike_p434_r2 = { 0 };
+const struct s2n_kem_group s2n_x25519_bike1_l1_r2 = { 0 };
 #endif
 
 #else

--- a/tls/s2n_kem.h
+++ b/tls/s2n_kem.h
@@ -69,9 +69,9 @@ struct s2n_kem_group_params {
 
 /* x25519 based tls13_kem_groups require EVP_APIS_SUPPORTED */
 #if EVP_APIS_SUPPORTED
-#define S2N_SUPPORTED_KEM_GROUPS_COUNT 2
+#define S2N_SUPPORTED_KEM_GROUPS_COUNT 4
 #else
-#define S2N_SUPPORTED_KEM_GROUPS_COUNT 1
+#define S2N_SUPPORTED_KEM_GROUPS_COUNT 2
 #endif
 
 #if !defined(S2N_NO_PQ)
@@ -82,7 +82,9 @@ struct s2n_kem_group_params {
     extern const struct s2n_kem s2n_kyber_512_r2;
 
     extern const struct s2n_kem_group s2n_secp256r1_sike_p434_r2;
+    extern const struct s2n_kem_group s2n_secp256r1_bike1_l1_r2;
     extern const struct s2n_kem_group s2n_x25519_sike_p434_r2;
+    extern const struct s2n_kem_group s2n_x25519_bike1_l1_r2;
 #endif
 
 extern int s2n_kem_generate_keypair(struct s2n_kem_params *kem_params);

--- a/tls/s2n_tls_parameters.h
+++ b/tls/s2n_tls_parameters.h
@@ -74,6 +74,8 @@
  * are defined in https://docs.google.com/spreadsheets/d/12YarzaNv3XQNLnvDsWLlRKwtZFhRrDdWf36YlzwrPeg/edit#gid=0. */
 #define TLS_PQ_KEM_GROUP_ID_X25519_SIKE_P434_R2 0x2F27
 #define TLS_PQ_KEM_GROUP_ID_SECP256R1_SIKE_P434_R2 0x2F1F
+#define TLS_PQ_KEM_GROUP_ID_X25519_BIKE1_L1_R2 0x2F28
+#define TLS_PQ_KEM_GROUP_ID_SECP256R1_BIKE1_L1_R2 0x2F23
 
 /* From https://tools.ietf.org/html/rfc7507 */
 #define TLS_FALLBACK_SCSV                   0x56, 0x00


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

Adds BIKE1L1R2 based KEM groups. 

### Call-outs:

The `.name` strings assigned to the BIKE KEM groups follow a slightly different convention than what we have used in code previously; in particular, the substring `fo` appears. This is intentional, as we want our `.name` to conform to what is listed in the [interoperability doc](https://docs.google.com/spreadsheets/d/12YarzaNv3XQNLnvDsWLlRKwtZFhRrDdWf36YlzwrPeg/edit#gid=0). (FO indicates the Fujisaki-Okamoto transformation.)

### Testing:

`s2n_tls13_hybrid_shared_secret_test.c` was updated with appropriate test vectors. The vectors were generated from an independent implementation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
