### PR TITLE
CBMC proofs that rely on an madvise stub

### DIFF
--- a/tests/cbmc/proofs/s2n_blob_zeroize_free/Makefile
+++ b/tests/cbmc/proofs/s2n_blob_zeroize_free/Makefile
@@ -1,0 +1,36 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Expected runtime is around 5 seconds.
+
+CHECKFLAGS +=
+
+HARNESS_ENTRY = s2n_blob_zeroize_free_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+
+REMOVE_FUNCTION_BODY += s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_blob_zeroize_free/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_blob_zeroize_free/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_blob_zeroize_free/s2n_blob_zeroize_free_harness.c
+++ b/tests/cbmc/proofs/s2n_blob_zeroize_free/s2n_blob_zeroize_free_harness.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "utils/s2n_blob.h"
+#include "error/s2n_errno.h"
+
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_blob_zeroize_free_harness() {
+    struct s2n_blob *blob = cbmc_allocate_s2n_blob();
+    __CPROVER_assume(s2n_blob_is_valid(blob));
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    const struct s2n_blob old_blob = *blob;
+
+    if (s2n_blob_zeroize_free(blob) == S2N_SUCCESS) {
+        /* If the call worked, assert all bytes in the blob struct
+           are zero */
+        assert_all_zeroes(blob->data, old_blob.size);
+        if(old_blob.size != 0 && s2n_blob_is_growable(&old_blob)) {
+            assert(!S2N_MEM_IS_READABLE(blob->data,old_blob.size));
+        }
+    }
+}

--- a/tests/cbmc/proofs/s2n_dup/Makefile
+++ b/tests/cbmc/proofs/s2n_dup/Makefile
@@ -1,0 +1,40 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Expected runtime is ten seconds.
+
+CHECKFLAGS +=
+
+HARNESS_ENTRY = s2n_dup_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/madvise.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+REMOVE_FUNCTION_BODY += s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_dup/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_dup/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_dup/s2n_dup_harness.c
+++ b/tests/cbmc/proofs/s2n_dup/s2n_dup_harness.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "utils/s2n_blob.h"
+
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+/*
+ * There's unreachable code in the CBMC output because s2n_dup calls
+ * s2n_alloc, which itself calls s2n_realloc. Since the to blob must
+ * be size 0 with a null data pointer to pass the first checks in s2n_dup,
+ * many branches of s2n_realloc cannot be executed. This is intentional behavior.
+ */
+
+void s2n_dup_harness() {
+    struct s2n_blob *from = cbmc_allocate_s2n_blob();
+    struct s2n_blob *to = cbmc_allocate_s2n_blob();
+    __CPROVER_assume(s2n_blob_is_valid(from));
+    __CPROVER_assume(s2n_blob_is_valid(to));
+    const struct s2n_blob old_from = *from;
+    const struct s2n_blob old_to = *to;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_blob(from, &old_byte);
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if (nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    if (s2n_dup(from, to) == S2N_SUCCESS) {
+        assert(old_from.size != 0);
+        assert(old_from.data != NULL);
+        assert(old_to.size == 0);
+        assert(old_to.data == NULL);
+        assert(to->size == from->size);
+
+        uint32_t index;
+        __CPROVER_assume(index < from->size);
+        assert(from->data[index] == to->data[index]);
+    }
+    assert(s2n_blob_is_valid(from));
+    assert(s2n_blob_is_valid(to));
+    assert_blob_equivalence(from, &old_from, &old_byte);
+}

--- a/tests/cbmc/proofs/s2n_mem_cleanup/Makefile
+++ b/tests/cbmc/proofs/s2n_mem_cleanup/Makefile
@@ -1,0 +1,37 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Expected runtime is 10 seconds.
+
+
+CHECKFLAGS +=
+
+HARNESS_ENTRY = s2n_mem_cleanup_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+
+REMOVE_FUNCTION_BODY += s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_mem_cleanup/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_mem_cleanup/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_mem_cleanup/s2n_mem_cleanup_harness.c
+++ b/tests/cbmc/proofs/s2n_mem_cleanup/s2n_mem_cleanup_harness.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "utils/s2n_blob.h"
+#include "utils/s2n_mem.h"
+
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_mem_cleanup_harness() {
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    bool old_init = s2n_mem_is_init();
+
+    if (s2n_mem_cleanup() == S2N_SUCCESS) {
+        assert(old_init);
+        assert(!s2n_mem_is_init());
+    }
+}

--- a/tests/cbmc/proofs/s2n_realloc/Makefile
+++ b/tests/cbmc/proofs/s2n_realloc/Makefile
@@ -1,0 +1,40 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Expected runtime is 20 seconds.
+
+CHECKFLAGS +=
+
+HARNESS_ENTRY = s2n_realloc_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/madvise.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+REMOVE_FUNCTION_BODY += s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_realloc/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_realloc/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_realloc/s2n_realloc_harness.c
+++ b/tests/cbmc/proofs/s2n_realloc/s2n_realloc_harness.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "utils/s2n_blob.h"
+
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_realloc_harness() {
+    struct s2n_blob *blob = cbmc_allocate_s2n_blob();
+    __CPROVER_assume(s2n_blob_is_valid(blob));
+    uint32_t size;
+    size_t index;
+    __CPROVER_assume(index < blob->size || (blob->size == 0 && index == 0));
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    const struct s2n_blob old_blob = *blob;
+    uint8_t old_data;
+    if (blob->size > 0) {
+        old_data = blob->data[index];
+    }
+
+    if (s2n_realloc(blob, size) == S2N_SUCCESS) {
+        assert(s2n_blob_is_valid(blob));
+        assert(blob->allocated >= size);
+        assert(blob->size == size);
+        if (size >= old_blob.size) {
+            if(old_blob.size > 0) {
+                assert(blob->data[index] == old_data);
+            }
+
+            /* Check if data at the old memory location was zeroed before freeing */
+#pragma CPROVER check push
+#pragma CPROVER check disable "pointer"
+            if (size > old_blob.allocated) {
+                if (old_blob.size > 0 && old_blob.data != NULL) {
+                    size_t i;
+                    __CPROVER_assume(i < old_blob.size);
+                    assert(old_blob.data[i] == 0);
+                }
+            }
+#pragma CPROVER check pop
+        }
+        else {
+            assert_all_zeroes(blob->data + blob->size, old_blob.size - blob->size);
+        }
+    }
+}

--- a/tests/cbmc/stubs/madvise.c
+++ b/tests/cbmc/stubs/madvise.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cbmc_proof/nondet.h>
+
+int madvise(void *addr, size_t length, int advice)
+{
+    return nondet_int();
+}


### PR DESCRIPTION
### Description of changes: 

This PR adds four CBMC proofs that all require the included madvise.c stub. The proofs are for the functions s2n_mem_cleanup, s2n_realloc, s2n_blob_zeroize_free, and s2n_dup.

### Call outs:

The proof for s2n_mem_cleanup just tests after success that the memory had been set to initialized before the function call and is set to uninitialized now. Since the callback function is set at runtime this is the only behavior that can be meaningfully tested through this function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
