### PR TITLE
CBMC proofs for s2n_safety functions

### DIFF
--- a/tests/cbmc/proofs/s2n_align_to/Makefile
+++ b/tests/cbmc/proofs/s2n_align_to/Makefile
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 5 seconds.
+
+CBMCFLAGS +=
+
+HARNESS_ENTRY = s2n_align_to_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_align_to/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_align_to/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_align_to/s2n_align_to_harness.c
+++ b/tests/cbmc/proofs/s2n_align_to/s2n_align_to_harness.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "utils/s2n_safety.h"
+
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+int s2n_align_to_harness()
+{
+    const uint32_t initial;
+    const uint32_t alignment;
+    /* Division and modulo are too slow in CBMC to perform all necessary checks,
+     * so relevant assertions that can't be used currently have been left in comments. */
+    uint32_t *out = can_fail_malloc(sizeof(uint32_t));
+ /* uint64_t result = (uint64_t) alignment * ((((uint64_t) initial - 1) / (uint64_t) alignment) + 1); */
+
+    if (s2n_align_to(initial, alignment, out) == S2N_SUCCESS) {
+        if (initial == 0) {
+            assert(*out == 0);
+        } else {
+         /* assert(*out >= initial); */
+         /* assert(*out < (uint64_t) initial + (uint64_t) alignment); */
+         /* assert(result <= UINT32_MAX); */
+         /* assert(*out % alignment == 0); */
+        }
+    } else {
+     /* assert(*out % alignment != 0 || out == NULL); */
+     /* assert(result > UINT32_MAX || out == NULL); */
+    }
+}

--- a/tests/cbmc/proofs/s2n_constant_time_copy_or_dont/Makefile
+++ b/tests/cbmc/proofs/s2n_constant_time_copy_or_dont/Makefile
@@ -1,0 +1,31 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+
+MAX_ARR_LEN = 10
+DEFINES += -DMAX_ARR_LEN=$(MAX_ARR_LEN)
+
+CBMCFLAGS +=
+
+HARNESS_ENTRY = s2n_constant_time_copy_or_dont_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+UNWINDSET += s2n_constant_time_copy_or_dont.0:$(call addone,$(MAX_ARR_LEN))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_constant_time_copy_or_dont/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_constant_time_copy_or_dont/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_constant_time_copy_or_dont/s2n_constant_time_copy_or_dont_harness.c
+++ b/tests/cbmc/proofs/s2n_constant_time_copy_or_dont/s2n_constant_time_copy_or_dont_harness.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "utils/s2n_safety.h"
+
+#include <sys/param.h>
+#include <assert.h>
+
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_constant_time_copy_or_dont_harness() {
+    /* Non-deterministic inputs. */
+    const uint32_t len;
+    const uint32_t destlen;
+    const uint32_t srclen;
+    const uint8_t dont;
+    __CPROVER_assume(len < MAX_ARR_LEN);
+    __CPROVER_assume(destlen >= len);
+    __CPROVER_assume(srclen >= len);
+    uint8_t * dest = can_fail_malloc(destlen);
+    uint8_t * src = can_fail_malloc(srclen);
+    uint8_t old_src_byte;
+    uint8_t old_dest_byte;
+    uint32_t index;
+
+    /* Pre-conditions. */
+    if (len != 0) {
+        __CPROVER_assume(dest != NULL);
+        __CPROVER_assume(src != NULL);
+        __CPROVER_assume(index < len);
+        old_src_byte = src[index];
+        old_dest_byte = dest[index];
+    }
+
+    s2n_constant_time_copy_or_dont(dest, src, len, dont);
+
+    if (dont == 0) {
+        if (src != NULL) {
+            if (len != 0) {
+                assert(src[index] == old_src_byte);
+            }
+            if(dest != NULL) {
+                uint32_t rand;
+                __CPROVER_assume(rand < len);
+                assert(dest[rand] == src[rand]);
+            }
+        }
+    } else {
+        if (src != NULL && len != 0) {
+            assert(src[index] == old_src_byte);
+        }
+        if (dest != NULL && len != 0) {
+            assert(dest[index] == old_dest_byte);
+        }
+    }
+}

--- a/tests/cbmc/proofs/s2n_constant_time_pkcs1_unpad_or_dont/Makefile
+++ b/tests/cbmc/proofs/s2n_constant_time_pkcs1_unpad_or_dont/Makefile
@@ -1,0 +1,39 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+
+MAX_ARR_LEN = 10
+
+# Bound for copy or dont must be at at least three higher than the maximum array length
+BOUND = $(MAX_ARR_LEN) + 3
+
+DEFINES += -DMAX_ARR_LEN=$(MAX_ARR_LEN)
+DEFINES += -DBOUND=$(BOUND)
+
+
+CBMCFLAGS +=
+
+HARNESS_ENTRY = s2n_constant_time_pkcs1_unpad_or_dont_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+UNWINDSET += s2n_constant_time_copy_or_dont.0:$(call addone,$(BOUND))
+UNWINDSET += s2n_constant_time_pkcs1_unpad_or_dont.0:$(call addone,$(MAX_ARR_LEN))
+UNWINDSET += s2n_constant_time_pkcs1_unpad_or_dont_harness.0:$(call addone,$(MAX_ARR_LEN))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_constant_time_pkcs1_unpad_or_dont/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_constant_time_pkcs1_unpad_or_dont/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_constant_time_pkcs1_unpad_or_dont/s2n_constant_time_pkcs1_unpad_or_dont_harness.c
+++ b/tests/cbmc/proofs/s2n_constant_time_pkcs1_unpad_or_dont/s2n_constant_time_pkcs1_unpad_or_dont_harness.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "utils/s2n_safety.h"
+
+#include <sys/param.h>
+#include <assert.h>
+
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_constant_time_pkcs1_unpad_or_dont_harness() {
+    /* Non-deterministic inputs. */
+    const uint32_t len;
+    const uint32_t destlen;
+    const uint32_t srclen;
+    const uint8_t dont;
+    __CPROVER_assume(len < MAX_ARR_LEN);
+    __CPROVER_assume(destlen >= len);
+
+    /* This bound is required for our loop unwindings to be reasonably bound. */
+    __CPROVER_assume(srclen >= len + 1 && srclen <= BOUND);
+    uint8_t * dest = can_fail_malloc(destlen);
+    uint8_t * src = can_fail_malloc(srclen);
+    uint8_t old_src_byte;
+    uint8_t old_dest_byte;
+    uint32_t index;
+
+    /* Pre-conditions. */
+    __CPROVER_assume(dest != NULL);
+    __CPROVER_assume(src != NULL);
+    if (len != 0) {
+        __CPROVER_assume(index < len);
+        old_src_byte = src[srclen - len + index];
+        old_dest_byte = dest[index];
+    }
+
+    s2n_constant_time_pkcs1_unpad_or_dont(dest, src, srclen, len);
+
+    if (len != 0) {
+        bool has_zero = false;
+        for (uint32_t i = 2; i < srclen - len - 1; i++) {
+            if(src[i] == 0x00) {
+                has_zero = true;
+            }
+        }
+
+        /* This statement is the inverse of the failure checks found in s2n_constant_time_pkcs1_unpad_or_dont. */
+        if (srclen >= (len + 3) && src[0] == 0x00 && src[1] == 0x02 && src[srclen - len - 1] == 0x00 && has_zero == false) {
+            assert(dest[index] == old_src_byte);
+        } else {
+            assert(dest[index] == old_dest_byte);
+        }
+        assert(src[srclen - len + index] == old_src_byte);
+    }
+}

--- a/tests/sidetrail/working/patches/safety.patch
+++ b/tests/sidetrail/working/patches/safety.patch
@@ -1,5 +1,5 @@
 diff --git a/utils/s2n_safety.c b/utils/s2n_safety.c
-index 66cadaf0..b9a045f9 100644
+index 107bdb78..242ba7a5 100644
 --- a/utils/s2n_safety.c
 +++ b/utils/s2n_safety.c
 @@ -57,16 +57,10 @@ pid_t s2n_actual_getpid()
@@ -27,6 +27,6 @@ index 66cadaf0..b9a045f9 100644
 -    S2N_PUBLIC_INPUT(src);
 -    S2N_PUBLIC_INPUT(len);
 -
-     uint8_t mask = ((uint_fast16_t)((uint_fast16_t)(dont) - 1)) >> 8;
- 
-     /* dont = 0 : mask = 0xff */
+ /* This underflows a value of 0 to the maximum value via arithmetic underflow,
+  * so the check for arithmetic overflow/underflow needs to be disabled for CBMC.
+  * Additionally, uint_fast16_t is defined as the fastest available unsigned

--- a/utils/s2n_safety.c
+++ b/utils/s2n_safety.c
@@ -90,12 +90,21 @@ int s2n_constant_time_copy_or_dont(uint8_t * dest, const uint8_t * src, uint32_t
     S2N_PUBLIC_INPUT(src);
     S2N_PUBLIC_INPUT(len);
 
+/* This underflows a value of 0 to the maximum value via arithmetic underflow,
+ * so the check for arithmetic overflow/underflow needs to be disabled for CBMC.
+ * Additionally, uint_fast16_t is defined as the fastest available unsigned
+ * integer with 16 bits or greater, and is not guaranteed to be 16 bits long.
+ * To handle this, the conversion overflow check also needs to be enabled. */
+#pragma CPROVER check push
+#pragma CPROVER check disable "conversion"
+#pragma CPROVER check disable "unsigned-overflow"
     uint8_t mask = ((uint_fast16_t)((uint_fast16_t)(dont) - 1)) >> 8;
+#pragma CPROVER check pop
 
     /* dont = 0 : mask = 0xff */
     /* dont > 0 : mask = 0x00 */
 
-    for (int i = 0; i < len; i++) {
+    for (uint32_t i = 0; i < len; i++) {
         uint8_t old = dest[i];
         uint8_t diff = (old ^ src[i]) & mask;
         dest[i] = old ^ diff;
@@ -134,8 +143,21 @@ int s2n_constant_time_pkcs1_unpad_or_dont(uint8_t * dst, const uint8_t * src, ui
 
     dont_copy |= src[0] ^ 0x00;
     dont_copy |= src[1] ^ 0x02;
-    dont_copy |= start_of_data[-1] ^ 0x00;
 
+/* Since -1 is being used, we need to disable the pointer overflow check for CBMC. */
+#pragma CPROVER check push
+#pragma CPROVER check disable "pointer-overflow"
+    dont_copy |= start_of_data[-1] ^ 0x00;
+#pragma CPROVER check pop
+
+/* This underflows a value of 0 to the maximum value via arithmetic underflow,
+ * so the check for arithmetic overflow/underflow needs to be disabled for CBMC.
+ * Additionally, uint_fast16_t is defined as the fastest available unsigned
+ * integer with 16 bits or greater, and is not guaranteed to be 16 bits long.
+ * To handle this, the conversion overflow check also needs to be enabled. */
+#pragma CPROVER check push
+#pragma CPROVER check disable "conversion"
+#pragma CPROVER check disable "unsigned-overflow"
     for (uint32_t i = 2; i < srclen - expectlen - 1; i++) {
         /* Note! We avoid using logical NOT (!) here; while in practice
          * many compilers will use constant-time sequences for this operator,
@@ -147,6 +169,7 @@ int s2n_constant_time_pkcs1_unpad_or_dont(uint8_t * dst, const uint8_t * src, ui
         /* src[i] > 0 : mask = 0x00 */
         dont_copy |= mask;
     }
+#pragma CPROVER check pop
 
     s2n_constant_time_copy_or_dont(dst, start_of_data, expectlen, dont_copy);
 
@@ -168,6 +191,7 @@ int s2n_in_unit_test_set(bool newval)
 
 int s2n_align_to(uint32_t initial, uint32_t alignment, uint32_t* out)
 {
+    notnull_check(out);
     PRECONDITION_POSIX(alignment != 0);
     if (initial == 0) {
         *out = 0;


### PR DESCRIPTION
### Description of changes: 

This PR adds two proofs for constant time safety functions in S2N along with s2n_align_to. The file s2n_safety.c has been modified for both functions to disable CBMC checks in specific places when the intended behavior is to underflow an integer. The proof for s2n_align_to is also included because it required a change to s2n_safety.c as well. 

### Call outs:

The proof of s2n_align_to, much like the existing proof of s2n_mul_overflow, cannot currently perform full testing due to CBMC performance issues. The multiplication and division required cause it to run hours at a minimum. As a result, the offending lines have been commented out but left in for future use. Once the CBMC team has improved the performance of CBMC, these lines can be enabled again.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
