### PR TITLE
CBMC proof for s2n_add_overflow

### DIFF
--- a/tests/cbmc/proofs/s2n_add_overflow/Makefile
+++ b/tests/cbmc/proofs/s2n_add_overflow/Makefile
@@ -1,0 +1,29 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+CBMCFLAGS +=
+
+HARNESS_ENTRY = s2n_add_overflow_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_add_overflow/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_add_overflow/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_add_overflow/s2n_add_overflow_harness.c
+++ b/tests/cbmc/proofs/s2n_add_overflow/s2n_add_overflow_harness.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "utils/s2n_safety.h"
+
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+int s2n_add_overflow_harness()
+{
+    uint32_t a;
+    uint32_t b;
+    uint32_t *out = can_fail_malloc(sizeof(uint32_t));
+
+    if (s2n_add_overflow(a, b, out) == S2N_SUCCESS) {
+        assert(*out == a + b);
+    } else {
+        assert((uint64_t) a + (uint64_t) b > UINT32_MAX || out == NULL);
+    }
+}


### PR DESCRIPTION
### Description of changes: 

This PR adds a CBMC proof for the function s2n_add_overflow. It ensures that the function properly checks for integer addition overflows.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
