### PR TITLE
CBMC proof for s2n_strcpy 

### DIFF
--- a/tests/cbmc/proofs/s2n_strcpy/Makefile
+++ b/tests/cbmc/proofs/s2n_strcpy/Makefile
@@ -1,0 +1,40 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Expected runtime is 10 seconds.
+
+MAX_STRING_LEN = 100
+DEFINES += -DMAX_STRING_LEN=$(MAX_STRING_LEN)
+
+CHECKFLAGS +=
+
+HARNESS_ENTRY = s2n_strcpy_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_str.c
+
+UNWINDSET += strlen.0:$(call addone,$(MAX_STRING_LEN))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_strcpy/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_strcpy/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_strcpy/s2n_strcpy_harness.c
+++ b/tests/cbmc/proofs/s2n_strcpy/s2n_strcpy_harness.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "utils/s2n_str.h"
+
+#include <assert.h>
+#include <string.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <sys/param.h>
+
+void s2n_strcpy_harness() {
+    char *str = ensure_c_str_is_allocated(MAX_STRING_LEN);
+    const uint32_t slen = strlen(str);
+    const uint32_t buflen;
+    const uint32_t index;
+    __CPROVER_assume(buflen < MAX_STRING_LEN);
+    __CPROVER_assume(slen == 0 || index < slen);
+    char buf[buflen];
+
+    /* Last must point to a valid position in buf. */
+    const uint32_t last_offset;
+    __CPROVER_assume(last_offset < buflen);
+    char* last = &buf[last_offset];
+    struct store_byte_from_buffer str_byte;
+    save_byte_from_array(str, slen, &str_byte);
+    char *result;
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if (nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    /* Non-deterministically set str to NULL. */
+    bool nullstr = nondet_bool();
+    result = s2n_strcpy(buf, last, nullstr ? NULL : str);
+
+    if (buf >= last) {
+        assert(result == buf);
+    } else if (nullstr) {
+        assert(result == buf);
+        assert(*buf == '\0');
+    } else if (slen > 0) {
+        uint32_t rand;
+        __CPROVER_assume(rand < MIN(last - buf - 1, slen));
+        assert(buf[rand] == str[rand]);
+        assert_byte_from_buffer_matches(str, &str_byte);
+        assert(*result == '\0');
+    }
+}

--- a/utils/s2n_str.c
+++ b/utils/s2n_str.c
@@ -17,9 +17,17 @@
 #include <sys/param.h>
 
 char *s2n_strcpy(char *buf, char *last, const char *str) {
+
+/* CBMC pointer checks need to be disabled to compare buf and last for
+ * the case where they are the same. */
+#pragma CPROVER check push
+#pragma CPROVER check disable "pointer"
+
     if (buf >= last) {
         return buf;
     }
+
+#pragma CPROVER check pop
 
     if (NULL == str) {
         *buf = '\0';


### PR DESCRIPTION
### Description of changes: 

This PR adds a CBMC proof for the function s2n_strcpy. The proof validates that the string copy is completed successfully when provided a valid C string, an allocated buffer, and a pointer to somewhere in that buffer.

### Call-outs:

This doesn't test for cases where the provided string is not a valid C string, or where the destination buffer is not allocated, or where the "last" pointer points at a memory address greater than that of the buffer's allocated memory. This is because the s2n_strcpy does not check for these cases. This function is based on the standard functions memcpy and strcpy, which also do not check for these edge cases, so the similarity seems to be intended functionality to increase speed when used securely.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
