### PR TITLE
pkcs3 to dh params CBMC proof

### DIFF
--- a/tests/cbmc/include/openssl/dh.h
+++ b/tests/cbmc/include/openssl/dh.h
@@ -1,0 +1,68 @@
+/*
+ * Changes to OpenSSL version 1.1.1.
+ * Copyright Amazon.com, Inc. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <stdint.h>
+#include <openssl/ffc.h>
+#include <openssl/bn.h>
+#include <cbmc_proof/nondet.h>
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+#ifndef OPENSSL_DH_H
+# define OPENSSL_DH_H
+# pragma once
+
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+#  define HEADER_DH_H
+# endif
+
+/*
+ * The structs dh_st and dh_method have been cut down to contain
+ * only the parts relevant to the s2n_pkcs3_to_dh_params proof.
+ */
+
+struct dh_st{
+    /*
+     * This first argument is used to pick up errors when a DH is passed
+     * instead of a EVP_PKEY
+     */
+    int pad;
+    int version;
+    FFC_PARAMS params;
+    /* max generated private key length (can be less than len(q)) */
+    int32_t length;
+    BIGNUM *pub_key;            /* g^x % p */
+    BIGNUM *priv_key;           /* x */
+    int flags;
+    BIGNUM *p;
+    BIGNUM *g;
+
+    /* Provider data */
+    size_t dirty_cnt; /* If any key material changes, increment this */
+};
+
+struct dh_method {
+    char *name;
+};
+
+void DH_free(DH *dh);
+int DH_size(const DH *dh);
+DH *d2i_DHparams(DH **a, unsigned char **pp, long length);
+
+#endif

--- a/tests/cbmc/include/openssl/ffc.h
+++ b/tests/cbmc/include/openssl/ffc.h
@@ -1,0 +1,48 @@
+/*
+ * Changes to OpenSSL version 1.1.1.
+ * Copyright Amazon.com, Inc. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <openssl/bn.h>
+
+#ifndef OSSL_INTERNAL_FFC_H
+# define OSSL_INTERNAL_FFC_H
+
+typedef struct ffc_params_st {
+    /* Primes */
+    BIGNUM *p;
+    BIGNUM *q;
+    /* Generator */
+    BIGNUM *g;
+    /* DH X9.42 Optional Subgroup factor j >= 2 where p = j * q + 1 */
+    BIGNUM *j;
+
+    /* Required for FIPS186_4 validation of p, q and optionally canonical g */
+    unsigned char *seed;
+    /* If this value is zero the hash size is used as the seed length */
+    size_t seedlen;
+    /* Required for FIPS186_4 validation of p and q */
+    int pcounter;
+    int nid; /* The identity of a named group */
+
+    /*
+     * Required for FIPS186_4 generation & validation of canonical g.
+     * It uses unverifiable g if this value is -1.
+     */
+    int gindex;
+    int h; /* loop counter for unverifiable g */
+} FFC_PARAMS;
+
+#endif

--- a/tests/cbmc/include/openssl/ossl_typ.h
+++ b/tests/cbmc/include/openssl/ossl_typ.h
@@ -31,6 +31,9 @@ typedef struct asn1_string_st ASN1_STRING;
 typedef struct bio_st BIO;
 typedef struct bignum_st BIGNUM;
 
+typedef struct dh_st DH;
+typedef struct dh_method DH_METHOD;
+
 typedef struct ec_key_st EC_KEY;
 
 typedef struct evp_pkey_ctx_st EVP_PKEY_CTX;
@@ -43,5 +46,8 @@ typedef struct evp_md_ctx_st EVP_MD_CTX;
 typedef struct evp_pkey_st EVP_PKEY;
 
 typedef struct engine_st ENGINE;
+
+/* This empty definition is required for BIGNUM to function properly in CBMC. */
+struct bignum_st{};
 
 #endif

--- a/tests/cbmc/proofs/s2n_pkcs3_to_dh_params/Makefile
+++ b/tests/cbmc/proofs/s2n_pkcs3_to_dh_params/Makefile
@@ -1,0 +1,46 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+MAX_BLOB_SIZE = 10
+DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
+
+CHECKFLAGS +=
+
+HARNESS_ENTRY = s2n_pkcs3_to_dh_params_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/openssl/dh_overrides.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_dhe.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+
+UNWINDSET +=
+
+# These functions are unnecessary for the proof, as the first is an OpenSSL
+# function and the second interacts with OpenSSL functions. Since OpenSSL
+# is not emulated by CBMC, these do not fall within the scope of the proof.
+REMOVE_FUNCTION_BODY += DECLARE_ASN1_ITEM
+REMOVE_FUNCTION_BODY += s2n_check_p_g_dh_params
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_pkcs3_to_dh_params/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_pkcs3_to_dh_params/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_pkcs3_to_dh_params/s2n_pkcs3_to_dh_params_harness.c
+++ b/tests/cbmc/proofs/s2n_pkcs3_to_dh_params/s2n_pkcs3_to_dh_params_harness.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include "crypto/s2n_dhe.h"
+
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/nondet.h>
+
+/*
+ * Since this function largely serves as a way to call specific OpenSSL
+ * functions (which we do not fully emulate in CBMC), all we can assert
+ * is memory safety. As such, several OpenSSL functions have been stubbed,
+ * and a few functions have been left omitted since they do not affect
+ * the proof.
+ */
+void s2n_pkcs3_to_dh_params_harness() {
+    /* Non-deterministic inputs. */
+    struct s2n_dh_params dh_params = {0};
+    struct s2n_blob *pkcs3 = cbmc_allocate_s2n_blob();
+    __CPROVER_assume(s2n_blob_is_valid(pkcs3));
+    uint8_t *old_data = pkcs3->data;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_blob(pkcs3, &old_byte);
+    __CPROVER_assume(s2n_blob_is_bounded(pkcs3, MAX_BLOB_SIZE));
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    if(nondet_bool()) {
+        s2n_mem_init();
+    }
+
+    /* Operation under verification. */
+    if (s2n_pkcs3_to_dh_params(&dh_params, pkcs3) == S2N_SUCCESS) {
+        assert(pkcs3->data == old_data);
+        assert_byte_from_blob_matches(pkcs3, &old_byte);
+    }
+}

--- a/tests/cbmc/sources/openssl/dh_overrides.c
+++ b/tests/cbmc/sources/openssl/dh_overrides.c
@@ -1,0 +1,39 @@
+/*
+ * Changes to OpenSSL version 1.1.1.
+ * Copyright Amazon.com, Inc. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <cbmc_proof/nondet.h>
+#include <openssl/dh.h>
+#include <openssl/ossl_typ.h>
+
+int DH_size(const DH *dh)
+{
+    return nondet_int();
+}
+
+void DH_free(DH *dh)
+{
+    return;
+}
+
+DH *d2i_DHparams(DH **a,const unsigned char **pp, long length)
+{
+    DH *dummy_dh;
+    if(nondet_bool() && *pp != NULL) {
+        *pp = *pp + length;
+    }
+    return dummy_dh;
+}


### PR DESCRIPTION
### Description of changes: 

This proof is for the s2n_pkcs3_to_dh_params function. Since the function mostly calls existing OpenSSL functions (which are not emulated by CBMC), the proof checks just that the only s2n code that modifies data in the function (resetting the pointer if it succeeds) functions properly.

### Call-outs:

Three functions are omitted when the test runs. These functions are either OpenSSL functions or s2n functions that are not relevant to this proof, all of which should not affect the result of the proof. Regardless, I've opened an issue https://github.com/awslabs/s2n/issues/2183.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
