### PR TITLE
ci: buildspec for alternate file structure (codecommit)

### DIFF
--- a/codebuild/spec/buildspec_sidetrail.yml
+++ b/codebuild/spec/buildspec_sidetrail.yml
@@ -13,6 +13,11 @@
 # limitations under the License.
 version: 0.2
 
+env:
+  variables:
+    # CODEBUILD_ is a reserved namespace.
+    CB_BIN_DIR: "./codebuild/bin"
+
 phases:
   install:
     runtime-versions:
@@ -35,9 +40,15 @@ phases:
   build:
     commands:
       - printenv
-      - codebuild/bin/run_sidetrail.sh /sidetrail-install-dir ${CODEBUILD_SRC_DIR}
+      - |
+        if [ -d "third-party-src" ]; then
+          cd third-party-src
+          $CB_BIN_DIR/run_sidetrail.sh /sidetrail-install-dir ${CODEBUILD_SRC_DIR}/third-party-src;
+        else
+         $CB_BIN_DIR/run_sidetrail.sh /sidetrail-install-dir ${CODEBUILD_SRC_DIR};
+        fi
   post_build:
     commands:
       - echo Build completed on `date`
       - echo Uploading CodeCov.io artifacts
-      - codebuild/bin/s2n_after_codebuild.sh
+      - $CB_BIN_DIR/s2n_after_codebuild.sh

--- a/codebuild/spec/buildspec_ubuntu.yml
+++ b/codebuild/spec/buildspec_ubuntu.yml
@@ -13,6 +13,11 @@
 # limitations under the License.
 version: 0.2
 
+env:
+  variables:
+    # CODEBUILD_ is a reserved namespace.
+    CB_BIN_DIR: "./codebuild/bin"
+
 phases:
   install:
     runtime-versions:
@@ -40,13 +45,17 @@ phases:
       - apt-get install -y --no-install-recommends indent kwstyle lcov libssl-dev m4 make net-tools nettle-bin nettle-dev pkg-config psmisc python3-pip shellcheck sudo tcpdump unzip valgrind zlib1g-dev zlibc cmake tox libtool ninja-build
   pre_build:
     commands:
-      - codebuild/bin/install_default_dependencies.sh
+      - |
+        if [ -d "third-party-src" ]; then
+          cd third-party-src;
+        fi
+      - $CB_BIN_DIR/install_default_dependencies.sh
   build:
     commands:
       - printenv
-      - codebuild/bin/s2n_codebuild.sh
+      - $CB_BIN_DIR/s2n_codebuild.sh
   post_build:
     commands:
       - echo Build completed on `date`
       - echo Uploading CodeCov.io artifacts
-      - codebuild/bin/s2n_after_codebuild.sh
+      - $CB_BIN_DIR/s2n_after_codebuild.sh

--- a/codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
+++ b/codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
@@ -13,6 +13,11 @@
 # limitations under the License.
 version: 0.2
 
+env:
+  variables:
+    # CODEBUILD_ is a reserved namespace.
+    CB_BIN_DIR: "./codebuild/bin"
+
 phases:
   install:
     runtime-versions:
@@ -39,17 +44,21 @@ phases:
       - apt-get install -y --no-install-recommends indent kwstyle lcov libssl-dev m4 make net-tools nettle-bin nettle-dev pkg-config psmisc python3-pip shellcheck sudo tcpdump unzip valgrind zlib1g-dev zlibc cmake
   pre_build:
     commands:
-      - codebuild/bin/install_default_dependencies.sh
-      - touch tests/fuzz/placeholder_results.txt tests/fuzz/placeholder_output.txt 
+      - |
+        if [ -d "third-party-src" ]; then
+          cd third-party-src;
+        fi
+      - $CB_BIN_DIR/install_default_dependencies.sh
+      - touch tests/fuzz/placeholder_results.txt tests/fuzz/placeholder_output.txt
   build:
     commands:
       - printenv
-      - codebuild/bin/s2n_codebuild.sh
+      - $CB_BIN_DIR/bin/s2n_codebuild.sh
   post_build:
     commands:
       - echo Build completed on `date`
       - echo Uploading CodeCov.io artifacts
-      - codebuild/bin/s2n_after_codebuild.sh
+      - $CB_BIN_DIR/bin/s2n_after_codebuild.sh
 artifacts:
   files:
     - "./tests/fuzz/corpus/$FUZZ_TESTS/*"

--- a/codebuild/spec/buildspec_ubuntu_integ_boringlibre.yml
+++ b/codebuild/spec/buildspec_ubuntu_integ_boringlibre.yml
@@ -13,6 +13,11 @@
 # limitations under the License.
 version: 0.2
 
+env:
+  variables:
+    # CODEBUILD_ is a reserved namespace.
+    CB_BIN_DIR: "./codebuild/bin"
+
 phases:
   install:
     runtime-versions:
@@ -32,15 +37,19 @@ phases:
       - apt-get install -y --no-install-recommends indent kwstyle lcov libssl-dev m4 make net-tools nettle-bin nettle-dev pkg-config psmisc python3-pip shellcheck sudo tcpdump unzip valgrind zlib1g-dev zlibc cmake tox libtool ninja-build
   pre_build:
     commands:
-      - S2N_LIBCRYPTO=libressl GCC_VERSION=6 codebuild/bin/install_default_dependencies.sh
-      - S2N_LIBCRYPTO=boringssl GCC_VERSION=9 codebuild/bin/install_default_dependencies.sh
+      - |
+        if [ -d "third-party-src" ]; then
+          cd third-party-src;
+        fi
+      - S2N_LIBCRYPTO=libressl GCC_VERSION=6 $CB_BIN_DIR/install_default_dependencies.sh
+      - S2N_LIBCRYPTO=boringssl GCC_VERSION=9 $CB_BIN_DIR/install_default_dependencies.sh
   build:
     commands:
       - printenv
-      - S2N_LIBCRYPTO=libressl GCC_VERSION=6 TESTS=integration codebuild/bin/s2n_codebuild.sh
-      - S2N_LIBCRYPTO=boringssl GCC_VERSION=9 TESTS=integration codebuild/bin/s2n_codebuild.sh
+      - S2N_LIBCRYPTO=libressl GCC_VERSION=6 TESTS=integration  $CB_BIN_DIR/s2n_codebuild.sh
+      - S2N_LIBCRYPTO=boringssl GCC_VERSION=9 TESTS=integration  $CB_BIN_DIR/s2n_codebuild.sh
   post_build:
     commands:
       - echo Build completed on `date`
       - echo Uploading CodeCov.io artifacts
-      - codebuild/bin/s2n_after_codebuild.sh
+      - $CB_BIN_DIR/s2n_after_codebuild.sh

--- a/codebuild/spec/buildspec_ubuntu_integ_openssl102.yml
+++ b/codebuild/spec/buildspec_ubuntu_integ_openssl102.yml
@@ -13,6 +13,11 @@
 # limitations under the License.
 version: 0.2
 
+env:
+  variables:
+    # CODEBUILD_ is a reserved namespace.
+    CB_BIN_DIR: "./codebuild/bin"
+
 phases:
   install:
     runtime-versions:
@@ -32,15 +37,19 @@ phases:
       - apt-get install -y --no-install-recommends indent kwstyle lcov libssl-dev m4 make net-tools nettle-bin nettle-dev pkg-config psmisc python3-pip shellcheck sudo tcpdump unzip valgrind zlib1g-dev zlibc cmake tox libtool ninja-build
   pre_build:
     commands:
-      - S2N_LIBCRYPTO=openssl-1.0.2 codebuild/bin/install_default_dependencies.sh
-      - S2N_LIBCRYPTO=openssl-1.0.2-fips codebuild/bin/install_default_dependencies.sh
+      - |
+        if [ -d "third-party-src" ]; then
+          cd third-party-src;
+        fi
+      - S2N_LIBCRYPTO=openssl-1.0.2 $CB_BIN_DIR/install_default_dependencies.sh
+      - S2N_LIBCRYPTO=openssl-1.0.2-fips $CB_BIN_DIR/install_default_dependencies.sh
   build:
     commands:
       - printenv
-      - S2N_LIBCRYPTO=openssl-1.0.2 TESTS=integration GCC_VERSION=6 codebuild/bin/s2n_codebuild.sh
-      - S2N_LIBCRYPTO=openssl-1.0.2-fips TESTS=integration GCC_VERSION=6 codebuild/bin/s2n_codebuild.sh
+      - S2N_LIBCRYPTO=openssl-1.0.2 TESTS=integration GCC_VERSION=6 $CB_BIN_DIR/s2n_codebuild.sh
+      - S2N_LIBCRYPTO=openssl-1.0.2-fips TESTS=integration GCC_VERSION=6 $CB_BIN_DIR/s2n_codebuild.sh
   post_build:
     commands:
       - echo Build completed on `date`
       - echo Uploading CodeCov.io artifacts
-      - codebuild/bin/s2n_after_codebuild.sh
+      - $CB_BIN_DIR/s2n_after_codebuild.sh

--- a/codebuild/spec/buildspec_ubuntu_integ_openssl102_asanvalgrind.yml
+++ b/codebuild/spec/buildspec_ubuntu_integ_openssl102_asanvalgrind.yml
@@ -13,6 +13,11 @@
 # limitations under the License.
 version: 0.2
 
+env:
+  variables:
+    # CODEBUILD_ is a reserved namespace.
+    CB_BIN_DIR: "./codebuild/bin"
+
 phases:
   install:
     runtime-versions:
@@ -32,15 +37,19 @@ phases:
       - apt-get install -y --no-install-recommends indent kwstyle lcov libssl-dev m4 make net-tools nettle-bin nettle-dev pkg-config psmisc python3-pip shellcheck sudo tcpdump unzip valgrind zlib1g-dev zlibc cmake tox libtool ninja-build
   pre_build:
     commands:
-      - S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=asan GCC_VERSION=6 codebuild/bin/install_default_dependencies.sh
-      - S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=valgrind GCC_VERSION=6 codebuild/bin/install_default_dependencies.sh
+      - |
+        if [ -d "third-party-src" ]; then
+          cd third-party-src;
+        fi
+      - S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=asan GCC_VERSION=6 $CB_BIN_DIR/install_default_dependencies.sh
+      - S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=valgrind GCC_VERSION=6 $CB_BIN_DIR/install_default_dependencies.sh
   build:
     commands:
       - printenv
-      - S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=asan GCC_VERSION=6 codebuild/bin/s2n_codebuild.sh
-      - S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=valgrind GCC_VERSION=6 codebuild/bin/s2n_codebuild.sh
+      - S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=asan GCC_VERSION=6 $CB_BIN_DIR/s2n_codebuild.sh
+      - S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=valgrind GCC_VERSION=6 $CB_BIN_DIR/s2n_codebuild.sh
   post_build:
     commands:
       - echo Build completed on `date`
       - echo Uploading CodeCov.io artifacts
-      - codebuild/bin/s2n_after_codebuild.sh
+      - $CB_BIN_DIR/s2n_after_codebuild.sh

--- a/codebuild/spec/buildspec_ubuntu_integ_openssl111.yml
+++ b/codebuild/spec/buildspec_ubuntu_integ_openssl111.yml
@@ -13,6 +13,11 @@
 # limitations under the License.
 version: 0.2
 
+env:
+  variables:
+    # CODEBUILD_ is a reserved namespace.
+    CB_BIN_DIR: "./codebuild/bin"
+
 phases:
   install:
     runtime-versions:
@@ -32,15 +37,19 @@ phases:
       - apt-get install -y --no-install-recommends indent kwstyle lcov libssl-dev m4 make net-tools nettle-bin nettle-dev pkg-config psmisc python3-pip shellcheck sudo tcpdump unzip valgrind zlib1g-dev zlibc cmake tox libtool ninja-build
   pre_build:
     commands:
-      - S2N_LIBCRYPTO=openssl-1.1.1 GCC_VERSION=6 codebuild/bin/install_default_dependencies.sh
+      - |
+        if [ -d "third-party-src" ]; then
+          cd third-party-src;
+        fi
+      - S2N_LIBCRYPTO=openssl-1.1.1 GCC_VERSION=6 $CB_BIN_DIR/install_default_dependencies.sh
   build:
     commands:
       - printenv
-      - S2N_LIBCRYPTO=openssl-1.1.1 GCC_VERSION=4.8 codebuild/bin/s2n_codebuild.sh
-      - S2N_LIBCRYPTO=openssl-1.1.1 TESTS=integration GCC_VERSION=6 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true codebuild/bin/s2n_codebuild.sh
-      - S2N_LIBCRYPTO=openssl-1.1.1 TESTS=integration GCC_VERSION=6 S2N_CORKED_IO=true codebuild/bin/s2n_codebuild.sh
+      - S2N_LIBCRYPTO=openssl-1.1.1 GCC_VERSION=4.8 $CB_BIN_DIR/s2n_codebuild.sh
+      - S2N_LIBCRYPTO=openssl-1.1.1 TESTS=integration GCC_VERSION=6 S2N_COVERAGE=true CODECOV_IO_UPLOAD=true $CB_BIN_DIR/s2n_codebuild.sh
+      - S2N_LIBCRYPTO=openssl-1.1.1 TESTS=integration GCC_VERSION=6 S2N_CORKED_IO=true $CB_BIN_DIR/s2n_codebuild.sh
   post_build:
     commands:
       - echo Build completed on `date`
       - echo Uploading CodeCov.io artifacts
-      - codebuild/bin/s2n_after_codebuild.sh
+      - $CB_BIN_DIR/s2n_after_codebuild.sh


### PR DESCRIPTION
### Resolved issues:

Internal

### Description of changes: 

Path structures differ- use the buildspec to look for `third-party-src` and descend into it if present.

### Call-outs:

Sidetrail is still failing due to patching inconsistencies

### Testing:

Against my fork of s2n.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
