### PR TITLE
added unit test for sort order of s2n_all_cipher_suites in IANA order

### DIFF
--- a/tests/unit/s2n_cipher_suite_match_test.c
+++ b/tests/unit/s2n_cipher_suite_match_test.c
@@ -31,6 +31,7 @@ int main(int argc, char **argv)
         struct s2n_connection *conn;
         uint8_t wire[2];
         int count;
+        int cipher_suite_order;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
         char *cert_chain;
@@ -41,6 +42,13 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key(conn->config, cert_chain, private_key));
 
+        /* Test that all cipher suites that s2n negotiates are listed in IANA order */
+        const uint8_t cipher_suite_count = cipher_preferences_test_all.count;
+        for (int i = 0; i < cipher_suite_count-1; ++i) {
+            cipher_suite_order = memcmp(cipher_preferences_test_all.suites[i]->iana_value, cipher_preferences_test_all.suites[i+1]->iana_value, 2);
+            EXPECT_TRUE(cipher_suite_order < 0);
+        }
+        
         count = 0;
         for (int i = 0; i < 0xffff; i++) {
             wire[0] = (i >> 8);


### PR DESCRIPTION
### Resolved issues:

 resolves #2136 Missing unit test for sort order of s2n_all_cipher_suites

### Description of changes: 

- Implements a unit test that verifies that the cipher suites that s2n negotiates have been added in order of IANA value (in the struct s2n_all_cipher_suites[]).
- This is invoked before we first attempt to use the array during the unit tests within s2n_cipher_suite_match_test.c.

### Call-outs:

Uses the structure cipher_preferences_test_all rather than s2n_all_cipher_suites[] as it has already been exposed for testing and contains a count of the cipher suites.

### Testing:

- I tested locally by editing order of the cipher suites in s2n_cipher_suites.c. This included the cases where: only the first byte was out of list order, only the second byte was out of list order, both bytes were out of list order.

- The build test now performs 226 tests that pass when running s2n_cipher_suite_match_test.c as opposed to the 188 previous to this new unit test. The 38 additional tests constitute the pairwise test of the 39 cipher suites in s2n_all_cipher_suites[].

Added alexw91 (assigned this issue to me) and andrewhop (as recently edited this file) as reviewers.

###
References
See https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml for IANA values.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
