### PR TITLE
Fix build breaking change that was made from v0.9 to v0.10

### DIFF
--- a/crypto/s2n_composite_cipher_aes_sha.c
+++ b/crypto/s2n_composite_cipher_aes_sha.c
@@ -30,7 +30,11 @@
  * should define a separate s2n_cipher struct for LibreSSL and BoringSSL.
  */
 #if S2N_OPENSSL_VERSION_AT_LEAST(1,0,1) && !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_IS_BORINGSSL)
-#define S2N_AES_SHA_COMPOSITE_AVAILABLE
+#define S2N_SHA1_COMPOSITE_AVAILABLE
+#endif
+
+#if S2N_OPENSSL_VERSION_AT_LEAST(1,0,2) && !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_IS_BORINGSSL)
+#define S2N_AES_SHA256_COMPOSITE_AVAILABLE
 #endif
 
 /* Silly accessors, but we avoid using version macro guards in multiple places */
@@ -39,7 +43,7 @@ static const EVP_CIPHER *s2n_evp_aes_128_cbc_hmac_sha1(void)
     /* Symbols for AES-SHA1-CBC composite ciphers were added in Openssl 1.0.1:
      * See https://www.openssl.org/news/cl101.txt.
      */
-    #if defined(S2N_AES_SHA_COMPOSITE_AVAILABLE)
+    #if defined(S2N_AES_SHA1_COMPOSITE_AVAILABLE)
         return EVP_aes_128_cbc_hmac_sha1();
     #else
         return NULL;
@@ -48,7 +52,7 @@ static const EVP_CIPHER *s2n_evp_aes_128_cbc_hmac_sha1(void)
 
 static const EVP_CIPHER *s2n_evp_aes_256_cbc_hmac_sha1(void)
 {
-    #if defined(S2N_AES_SHA_COMPOSITE_AVAILABLE)
+    #if defined(S2N_AES_SHA1_COMPOSITE_AVAILABLE)
         return EVP_aes_256_cbc_hmac_sha1();
     #else
         return NULL;
@@ -60,7 +64,7 @@ static const EVP_CIPHER *s2n_evp_aes_128_cbc_hmac_sha256(void)
     /* Symbols for AES-SHA256-CBC composite ciphers were added in Openssl 1.0.2:
      * See https://www.openssl.org/news/cl102.txt. Not supported in any LibreSSL releases.
      */
-    #if defined(S2N_AES_SHA_COMPOSITE_AVAILABLE)
+    #if defined(S2N_AES_SHA256_COMPOSITE_AVAILABLE)
         return EVP_aes_128_cbc_hmac_sha256();
     #else
         return NULL;
@@ -69,7 +73,7 @@ static const EVP_CIPHER *s2n_evp_aes_128_cbc_hmac_sha256(void)
 
 static const EVP_CIPHER *s2n_evp_aes_256_cbc_hmac_sha256(void)
 {
-    #if defined(S2N_AES_SHA_COMPOSITE_AVAILABLE)
+    #if defined(S2N_AES_SHA256_COMPOSITE_AVAILABLE)
         return EVP_aes_256_cbc_hmac_sha256();
     #else
         return NULL;

--- a/crypto/s2n_composite_cipher_aes_sha.c
+++ b/crypto/s2n_composite_cipher_aes_sha.c
@@ -30,7 +30,7 @@
  * should define a separate s2n_cipher struct for LibreSSL and BoringSSL.
  */
 #if S2N_OPENSSL_VERSION_AT_LEAST(1,0,1) && !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_IS_BORINGSSL)
-#define S2N_SHA1_COMPOSITE_AVAILABLE
+#define S2N_AES_SHA1_COMPOSITE_AVAILABLE
 #endif
 
 #if S2N_OPENSSL_VERSION_AT_LEAST(1,0,2) && !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_IS_BORINGSSL)

--- a/crypto/s2n_composite_cipher_aes_sha.c
+++ b/crypto/s2n_composite_cipher_aes_sha.c
@@ -30,13 +30,15 @@
  * should define a separate s2n_cipher struct for LibreSSL and BoringSSL.
  */
 #if !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_IS_BORINGSSL)
-/* Symbols for AES-SHA1-CBC composite ciphers were added in Openssl 1.0.1:
+/* Symbols for AES-SHA1-CBC composite ciphers were added in Openssl 1.0.1
+ * These composite ciphers exhibit erratic behavior in LibreSSL releases.
  */
 #if S2N_OPENSSL_VERSION_AT_LEAST(1,0,1) 
 #define S2N_AES_SHA1_COMPOSITE_AVAILABLE
 #endif
-/* Symbols for AES-SHA256-CBC composite ciphers were added in Openssl 1.0.2:
- * See https://www.openssl.org/news/cl102.txt. Not supported in any LibreSSL releases.
+/* Symbols for AES-SHA256-CBC composite ciphers were added in Openssl 1.0.2
+ * See https://www.openssl.org/news/cl102.txt
+ * These composite ciphers exhibit erratic behavior in LibreSSL releases.
  */
 #if S2N_OPENSSL_VERSION_AT_LEAST(1,0,2)
 #define S2N_AES_SHA256_COMPOSITE_AVAILABLE

--- a/crypto/s2n_composite_cipher_aes_sha.c
+++ b/crypto/s2n_composite_cipher_aes_sha.c
@@ -29,12 +29,16 @@
 /* LibreSSL and BoringSSL supports the cipher, but the interface is different from Openssl's. We
  * should define a separate s2n_cipher struct for LibreSSL and BoringSSL.
  */
-#if S2N_OPENSSL_VERSION_AT_LEAST(1,0,1) && !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_IS_BORINGSSL)
+#if !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_IS_BORINGSSL)
+
+#if S2N_OPENSSL_VERSION_AT_LEAST(1,0,1) 
 #define S2N_AES_SHA1_COMPOSITE_AVAILABLE
 #endif
 
-#if S2N_OPENSSL_VERSION_AT_LEAST(1,0,2) && !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_IS_BORINGSSL)
+#if S2N_OPENSSL_VERSION_AT_LEAST(1,0,2)
 #define S2N_AES_SHA256_COMPOSITE_AVAILABLE
+#endif
+
 #endif
 
 /* Silly accessors, but we avoid using version macro guards in multiple places */

--- a/crypto/s2n_composite_cipher_aes_sha.c
+++ b/crypto/s2n_composite_cipher_aes_sha.c
@@ -30,11 +30,15 @@
  * should define a separate s2n_cipher struct for LibreSSL and BoringSSL.
  */
 #if !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_IS_BORINGSSL)
-
+/* Symbols for AES-SHA1-CBC composite ciphers were added in Openssl 1.0.1:
+ * See https://www.openssl.org/news/cl101.txt.
+ */
 #if S2N_OPENSSL_VERSION_AT_LEAST(1,0,1) 
 #define S2N_AES_SHA1_COMPOSITE_AVAILABLE
 #endif
-
+/* Symbols for AES-SHA256-CBC composite ciphers were added in Openssl 1.0.2:
+ * See https://www.openssl.org/news/cl102.txt. Not supported in any LibreSSL releases.
+ */
 #if S2N_OPENSSL_VERSION_AT_LEAST(1,0,2)
 #define S2N_AES_SHA256_COMPOSITE_AVAILABLE
 #endif
@@ -44,9 +48,6 @@
 /* Silly accessors, but we avoid using version macro guards in multiple places */
 static const EVP_CIPHER *s2n_evp_aes_128_cbc_hmac_sha1(void)
 {
-    /* Symbols for AES-SHA1-CBC composite ciphers were added in Openssl 1.0.1:
-     * See https://www.openssl.org/news/cl101.txt.
-     */
     #if defined(S2N_AES_SHA1_COMPOSITE_AVAILABLE)
         return EVP_aes_128_cbc_hmac_sha1();
     #else
@@ -65,9 +66,6 @@ static const EVP_CIPHER *s2n_evp_aes_256_cbc_hmac_sha1(void)
 
 static const EVP_CIPHER *s2n_evp_aes_128_cbc_hmac_sha256(void)
 {
-    /* Symbols for AES-SHA256-CBC composite ciphers were added in Openssl 1.0.2:
-     * See https://www.openssl.org/news/cl102.txt. Not supported in any LibreSSL releases.
-     */
     #if defined(S2N_AES_SHA256_COMPOSITE_AVAILABLE)
         return EVP_aes_128_cbc_hmac_sha256();
     #else

--- a/crypto/s2n_composite_cipher_aes_sha.c
+++ b/crypto/s2n_composite_cipher_aes_sha.c
@@ -31,7 +31,6 @@
  */
 #if !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_IS_BORINGSSL)
 /* Symbols for AES-SHA1-CBC composite ciphers were added in Openssl 1.0.1:
- * See https://www.openssl.org/news/cl101.txt.
  */
 #if S2N_OPENSSL_VERSION_AT_LEAST(1,0,1) 
 #define S2N_AES_SHA1_COMPOSITE_AVAILABLE


### PR DESCRIPTION
### Resolved issues:

 resolves #ISSUE-2194 ( https://github.com/awslabs/s2n/issues/2194 )

### Description of changes: 

This fixes a build breaking change introduced in https://github.com/awslabs/s2n/commit/9802a051850e8bb8dbfe0f03d66fc9f6249d7bb3 ( from v0.9 to v0.10 ).
AES-SHA256-CBC composite ciphers are not present in OpenSSL1.0.1

### Testing:

This was built with OpenSSL1.01
Functionallity was not tested, though.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
