### PR TITLE
AFL Fuzz Testing

### DIFF
--- a/codebuild/bin/install_default_dependencies.sh
+++ b/codebuild/bin/install_default_dependencies.sh
@@ -26,7 +26,7 @@ fi
 # Download and Install LibFuzzer with latest clang
 if [[ "$TESTS" == "fuzz" || "$TESTS" == "ALL" ]]; then
     mkdir -p "$LIBFUZZER_INSTALL_DIR" || true
-    PATH=$LATEST_CLANG_INSTALL_DIR/bin:$PATH codebuild/bin/install_libFuzzer.sh "$(mktemp -d)" "$LIBFUZZER_INSTALL_DIR" "$OS_NAME" > /dev/null ;
+    PATH=$LATEST_CLANG_INSTALL_DIR/bin:$PATH codebuild/bin/install_libFuzzer.sh "$(mktemp -d)" "$LIBFUZZER_INSTALL_DIR" "$OS_NAME" ;
 fi
 
 # Download and Install Openssl 1.1.1

--- a/codebuild/bin/install_libFuzzer.sh
+++ b/codebuild/bin/install_libFuzzer.sh
@@ -12,7 +12,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 #
-set -e
+set -ex
 
 usage() {
 	echo "install_libFuzzer.sh download_dir install_dir os_name"
@@ -42,3 +42,10 @@ ar ruv libFuzzer.a Fuzzer*.o
 echo "Copying libFuzzer.a to $LIBFUZZER_INSTALL_DIR"
 mkdir -p "$LIBFUZZER_INSTALL_DIR"/lib && cp libFuzzer.a "$LIBFUZZER_INSTALL_DIR"/lib
 
+if [ ! -z "$AFL_FUZZ" && -z "$FUZZ_COVERAGE" ]; then
+	mkdir -p "$LIBFUZZER_INSTALL_DIR" && curl https://raw.githubusercontent.com/google/clusterfuzz/master/docs/setting-up-fuzzing/build_afl.bash > "$LIBFUZZER_INSTALL_DIR"/build_afl.bash
+	chmod +x "$LIBFUZZER_INSTALL_DIR"/build_afl.bash
+	cd "$LIBFUZZER_INSTALL_DIR"
+	"$LIBFUZZER_INSTALL_DIR"/build_afl.bash
+	cd -
+fi

--- a/tests/fuzz/Makefile
+++ b/tests/fuzz/Makefile
@@ -45,6 +45,13 @@ LDFLAGS += ${CRYPTO_LDFLAGS} ${LIBS} ${CRYPTO_LIBS} -lm -ldl -lrt -pthread
 DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH"
 LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH"
 
+ifdef AFL_FUZZ
+    ifndef FUZZ_COVERAGE
+        CFLAGS += $(LIBFUZZER_ROOT)/FuzzingEngine.a
+    endif
+endif
+
+
 ld-preload :
 	${MAKE} -C LD_PRELOAD
 


### PR DESCRIPTION
### Description of changes: 

This PR enables AFL instrumentation and execution. To run AFL tests, simply set the AFL_FUZZ environment variable alongside standard fuzz test environment variables (sans coverage and codecov) and build as usual.

### Call-outs:

Since AFL is being used as a wrapper around the libfuzzer-style fuzz tests, the libfuzzer install script is currently what installs AFL. AFL is also placed in the libfuzzer directory for this reason.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
