### PR TITLE
Add FIPS check as part of s2n_validate_kem_preferences()

### DIFF
--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -18,6 +18,7 @@
 #include "tls/s2n_security_policies.h"
 #include "tls/s2n_connection.h"
 #include "utils/s2n_safety.h"
+#include "crypto/s2n_fips.h"
 
 const struct s2n_security_policy security_policy_20170210 = {
     .minimum_protocol_version = S2N_TLS10,
@@ -705,6 +706,13 @@ int s2n_validate_kem_preferences(const struct s2n_kem_preferences *kem_preferenc
     } else {
         ENSURE_POSIX(kem_preferences->kem_count == 0, S2N_ERR_INVALID_SECURITY_POLICY);
         ENSURE_POSIX(kem_preferences->kems == NULL, S2N_ERR_INVALID_SECURITY_POLICY);
+    }
+
+    if (s2n_is_in_fips_mode()) {
+        ENSURE_POSIX(kem_preferences->kem_count == 0, S2N_ERR_PQ_KEMS_DISALLOWED_IN_FIPS);
+        ENSURE_POSIX(kem_preferences->kems == NULL, S2N_ERR_PQ_KEMS_DISALLOWED_IN_FIPS);
+        ENSURE_POSIX(kem_preferences->tls13_kem_group_count == 0, S2N_ERR_PQ_KEMS_DISALLOWED_IN_FIPS);
+        ENSURE_POSIX(kem_preferences->tls13_kem_groups == NULL, S2N_ERR_PQ_KEMS_DISALLOWED_IN_FIPS);
     }
 
     return S2N_SUCCESS;


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

We do not allow PQ KEMs to be negotiated when s2n is built in FIPS mode. We have checks during the 1.2 handshake to assert that FIPS mode is not active, such as: 

https://github.com/awslabs/s2n/blob/57c79676d9f6b4fba64a64b9c9804a88b7c2a476/tls/s2n_kex.c#L45-L48

However, this still allows s2n to start up, initialize, and attempt to negotiate a connection, only failing during the handshake. This PR adds the FIPS check as part of the security policy initialization. This provides a better overall experience - `s2n_init()` will fail if the peer attempts to start s2n in FIPS mode with anything other than `kem_preferences_null`.

### Call-outs:

N/A

### Testing:

* Added new unit test cases

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
