### PR TITLE
Implements sending PQ named groups for TLS 1.3

### DIFF
--- a/tests/unit/s2n_client_supported_groups_extension_test.c
+++ b/tests/unit/s2n_client_supported_groups_extension_test.c
@@ -24,6 +24,7 @@
 
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_safety.h"
+#include "crypto/s2n_fips.h"
 
 int main()
 {
@@ -43,7 +44,7 @@ int main()
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
-    /* Test send */
+    /* Test send (with default KEM prefs = kem_preferences_null) */
     {
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
@@ -53,12 +54,19 @@ int main()
 
         const struct s2n_ecc_preferences *ecc_pref = NULL;
         EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+        EXPECT_NOT_NULL(ecc_pref);
+
+        const struct s2n_kem_preferences *kem_pref = NULL;
+        EXPECT_SUCCESS(s2n_connection_get_kem_preferences(conn, &kem_pref));
+        EXPECT_NOT_NULL(kem_pref);
+        EXPECT_EQUAL(kem_pref, &kem_preferences_null);
 
         EXPECT_SUCCESS(s2n_client_supported_groups_extension.send(conn, &stuffer));
 
         uint16_t length;
         EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &length));
         EXPECT_EQUAL(length, s2n_stuffer_data_available(&stuffer));
+        EXPECT_EQUAL(length, ecc_pref->count * sizeof(uint16_t));
 
         uint16_t curve_id;
         for (int i = 0; i < ecc_pref->count; i++) {
@@ -69,6 +77,77 @@ int main()
         EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
+
+#if !defined(S2N_NO_PQ)
+    /* Test send with KEM groups */
+    {
+        const struct s2n_kem_group *test_kem_groups[] = {
+                &s2n_secp256r1_sike_p434_r2,
+                &s2n_secp256r1_bike1_l1_r2,
+        };
+
+        const struct s2n_kem_preferences test_kem_prefs = {
+                .kem_count = 0,
+                .kems = NULL,
+                .tls13_kem_group_count = s2n_array_len(test_kem_groups),
+                .tls13_kem_groups = test_kem_groups,
+        };
+
+        const struct s2n_security_policy test_pq_security_policy = {
+                .minimum_protocol_version = S2N_SSLv3,
+                .cipher_preferences = &cipher_preferences_test_all_tls13,
+                .kem_preferences = &test_kem_prefs,
+                .signature_preferences = &s2n_signature_preferences_20200207,
+                .ecc_preferences = &s2n_ecc_preferences_20200310,
+        };
+
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        if (!s2n_is_in_fips_mode()) {
+            conn->security_policy_override = &test_pq_security_policy;
+        }
+        /* If in FIPS mode, the test will proceed using the default KEM preferences (kem_preferences_null) */
+
+        const struct s2n_ecc_preferences *ecc_pref = NULL;
+        EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+        EXPECT_NOT_NULL(ecc_pref);
+
+        const struct s2n_kem_preferences *kem_pref = NULL;
+        EXPECT_SUCCESS(s2n_connection_get_kem_preferences(conn, &kem_pref));
+        EXPECT_NOT_NULL(kem_pref);
+        if (!s2n_is_in_fips_mode()) {
+            EXPECT_EQUAL(kem_pref, &test_kem_prefs);
+        } else {
+            EXPECT_EQUAL(kem_pref, &kem_preferences_null);
+        }
+
+        EXPECT_SUCCESS(s2n_client_supported_groups_extension.send(conn, &stuffer));
+
+        uint16_t length;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &length));
+        EXPECT_EQUAL(length, s2n_stuffer_data_available(&stuffer));
+        EXPECT_EQUAL(length, (ecc_pref->count * sizeof(uint16_t)) + (kem_pref->tls13_kem_group_count * sizeof(uint16_t)));
+
+        uint16_t kem_id;
+        for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
+            EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &kem_id));
+            EXPECT_EQUAL(kem_id, kem_pref->tls13_kem_groups[i]->iana_id);
+        }
+
+        uint16_t curve_id;
+        for (int i = 0; i < ecc_pref->count; i++) {
+            EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &curve_id));
+            EXPECT_EQUAL(curve_id, ecc_pref->ecc_curves[i]->iana_id);
+        }
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+#endif
 
     /* Test recv */
     {


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

Implements client-side sending of PQ named groups for TLS 1.3.

### Call-outs:

* All KEM preferences in s2n currently have tls13_kem_group_count = 0 and tls13_kem_groups = NULL, so this should not change the current behavior for classic handshakes.

### Testing:

* Added unit test.
* No integration testing yet; there is still more client-side work to do.
* I tested locally with `S2N_NO_PQ=1` and `S2N_NO_PQ_ASM=1` to verify those builds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
