### PR TITLE
Automatically Check that TLS 1.3 extensions are ignored in TLS 1.2

### DIFF
--- a/tests/unit/s2n_tls13_cookie_test.c
+++ b/tests/unit/s2n_tls13_cookie_test.c
@@ -145,7 +145,7 @@ int main(int argc, char *argv[])
             EXPECT_SUCCESS(s2n_connection_free(client_conn));
         }
 
-        /* Should do nothing if cookie size wrong */
+        /* Should fail if cookie size wrong */
         {
             EXPECT_SUCCESS(s2n_stuffer_write_bytes(&server_conn->cookie_stuffer,
                     test_cookie_data, test_cookie_size));
@@ -160,7 +160,7 @@ int main(int argc, char *argv[])
             EXPECT_SUCCESS(s2n_server_cookie_extension.send(server_conn, &stuffer));
             EXPECT_SUCCESS(s2n_stuffer_wipe_n(&stuffer, 1));
 
-            EXPECT_SUCCESS(s2n_server_cookie_extension.recv(client_conn, &stuffer));
+            EXPECT_FAILURE(s2n_server_cookie_extension.recv(client_conn, &stuffer));
             EXPECT_EQUAL(s2n_stuffer_data_available(&client_conn->cookie_stuffer), 0);
 
             EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));

--- a/tests/unit/s2n_tls13_support_test.c
+++ b/tests/unit/s2n_tls13_support_test.c
@@ -16,6 +16,8 @@
 #include "s2n_test.h"
 #include "testlib/s2n_testlib.h"
 
+#include "tls/extensions/s2n_cookie.h"
+#include "tls/extensions/s2n_extension_type_lists.h"
 #include "tls/extensions/s2n_server_supported_versions.h"
 #include "tls/extensions/s2n_server_key_share.h"
 
@@ -90,6 +92,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_in_unit_test_set(false));
     EXPECT_SUCCESS(s2n_enable_tls13());
     EXPECT_SUCCESS(s2n_disable_tls13());
+    EXPECT_SUCCESS(s2n_in_unit_test_set(true));
 
     /* Test s2n_is_valid_tls13_cipher() */
     {
@@ -116,12 +119,12 @@ int main(int argc, char **argv)
         EXPECT_TRUE(s2n_is_valid_tls13_cipher(s2n_tls13_chacha20_poly1305_sha256.iana_value));
     }
 
-    /* Server does not parse new TLS 1.3 extensions unless TLS 1.3 enabled */
+    /* Server does not parse TLS 1.3 extensions unless TLS 1.3 enabled */
     {
-        const s2n_extension_type *tls13_extensions[] = {
-                &s2n_server_supported_versions_extension,
-                &s2n_server_key_share_extension,
-        };
+        s2n_extension_type_list *tls13_server_hello_extensions = NULL;
+        EXPECT_SUCCESS(s2n_extension_type_list_get(S2N_EXTENSION_LIST_SERVER_HELLO_TLS13, &tls13_server_hello_extensions));
+        EXPECT_NOT_NULL(tls13_server_hello_extensions);
+        EXPECT_EQUAL(tls13_server_hello_extensions->count, 3);
 
         struct s2n_connection *server_conn;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
@@ -135,24 +138,25 @@ int main(int argc, char **argv)
         server_conn->actual_protocol_version = S2N_TLS13;
 
         s2n_parsed_extensions_list parsed_extension_list = { 0 };
-        for (int i=0; i < s2n_array_len(tls13_extensions); i++) {
+        for (int i=0; i < tls13_server_hello_extensions->count; i++) {
+            const s2n_extension_type *tls13_extension_type = tls13_server_hello_extensions->extension_types[i];
             s2n_extension_type_id extension_id;
-            EXPECT_SUCCESS(s2n_extension_supported_iana_value_to_id(tls13_extensions[i]->iana_value, &extension_id));
+            EXPECT_SUCCESS(s2n_extension_supported_iana_value_to_id(tls13_extension_type->iana_value, &extension_id));
             s2n_parsed_extension *parsed_extension = &parsed_extension_list.parsed_extensions[extension_id];
 
             /* Create parsed extension */
             parsed_extension->extension = extension_data.blob;
-            parsed_extension->extension_type = tls13_extensions[i]->iana_value;
+            parsed_extension->extension_type = tls13_extension_type->iana_value;
 
             EXPECT_SUCCESS(s2n_disable_tls13());
-            EXPECT_SUCCESS(s2n_extension_process(tls13_extensions[i], server_conn, &parsed_extension_list));
+            EXPECT_SUCCESS(s2n_extension_process(tls13_extension_type, server_conn, &parsed_extension_list));
 
             /* Create parsed extension again, because s2n_extension_process cleared the last one */
             parsed_extension->extension = extension_data.blob;
-            parsed_extension->extension_type = tls13_extensions[i]->iana_value;
+            parsed_extension->extension_type = tls13_extension_type->iana_value;
 
             EXPECT_SUCCESS(s2n_enable_tls13());
-            EXPECT_FAILURE(s2n_extension_process(tls13_extensions[i], server_conn, &parsed_extension_list));
+            EXPECT_FAILURE(s2n_extension_process(tls13_extension_type, server_conn, &parsed_extension_list));
         }
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));

--- a/tls/extensions/s2n_cookie.c
+++ b/tls/extensions/s2n_cookie.c
@@ -66,10 +66,7 @@ static int s2n_cookie_recv(struct s2n_connection *conn, struct s2n_stuffer *exte
 
     uint16_t cookie_len;
     GUARD(s2n_stuffer_read_uint16(extension, &cookie_len));
-
-    if (s2n_stuffer_data_available(extension) < cookie_len) {
-        return S2N_SUCCESS;
-    }
+    ENSURE_POSIX(s2n_stuffer_data_available(extension) == cookie_len, S2N_ERR_BAD_MESSAGE);
 
     GUARD(s2n_stuffer_wipe(&conn->cookie_stuffer));
     GUARD(s2n_stuffer_resize(&conn->cookie_stuffer, cookie_len));


### PR DESCRIPTION
### Resolved issues:

 Manual review of potential TLS 1.2 and TLS 1.3 interaction edge cases that we don't have tests for.

### Description of changes: 
Updates TLS 1.3 test to ensure the following are true for all TLS 1.3 specific extensions:
 - TLS 1.2 server will ignore any TLS 1.3 extensions received without failing the handshake, even if extension is malformed.
 - TLS 1.3 server receiving a malformed TLS 1.3 extension will reject that extension.

Also updated unit test so that any future TLS 1.3 extensions added to SeverHello processing will automatically be tested as well.

### Call-outs:
Ended up modifying TLS 1.3 Cookie code to be more strict about rejecting malformed data lengths in the extension.

### Testing:
Unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
