### PR TITLE
Prevent failures on 2 subsequent warning alerts if S2N_ALERT_IGNORE_WARNINGS is set

### DIFF
--- a/tests/unit/s2n_self_talk_alerts_test.c
+++ b/tests/unit/s2n_self_talk_alerts_test.c
@@ -38,6 +38,7 @@
 struct alert_ctx {
     int write_fd;
     int invoked;
+    int count;
 
     uint8_t level;
     uint8_t code;
@@ -111,16 +112,18 @@ int mock_nanoseconds_since_epoch(void *data, uint64_t *nanoseconds)
     return 0;
 }
 
-int client_hello_send_alert(struct s2n_connection *conn, void *ctx)
+int client_hello_send_alerts(struct s2n_connection *conn, void *ctx)
 {
     struct alert_ctx *alert = ctx;
     uint8_t alert_msg[] = { TLS_ALERT, TLS_ALERT_VERSION, TLS_ALERT_LENGTH, alert->level, alert->code };
 
-    if (write(alert->write_fd, alert_msg, sizeof(alert_msg)) != sizeof(alert_msg)) {
-        _exit(100);
-    }
+    for (int i = 0; i < alert->count; i++) {
+        if (write(alert->write_fd, alert_msg, sizeof(alert_msg)) != sizeof(alert_msg)) {
+            _exit(100);
+        }
 
-    alert->invoked = 1;
+        alert->invoked++;
+    }
 
     return 0;
 }
@@ -158,8 +161,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_io_pair_init(&io_pair));
 
         /* Set up the callback to send an alert after receiving ClientHello */
-        struct alert_ctx warning_alert = {.write_fd = io_pair.server, .invoked = 0, .level = TLS_ALERT_LEVEL_WARNING, .code = TLS_ALERT_UNRECOGNIZED_NAME};
-        EXPECT_SUCCESS(s2n_config_set_client_hello_cb(config, client_hello_send_alert, &warning_alert));
+        struct alert_ctx warning_alert = {.write_fd = io_pair.server, .invoked = 0, .count = 2, .level = TLS_ALERT_LEVEL_WARNING, .code = TLS_ALERT_UNRECOGNIZED_NAME};
+        EXPECT_SUCCESS(s2n_config_set_client_hello_cb(config, client_hello_send_alerts, &warning_alert));
 
         /* Create a child process */
         pid = fork();
@@ -184,7 +187,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_negotiate(conn, &blocked));
 
         /* Ensure that callback was invoked */
-        EXPECT_EQUAL(warning_alert.invoked, 1);
+        EXPECT_EQUAL(warning_alert.invoked, 2);
 
         for (int i = 1; i < 0xffff; i += 100) {
             char * ptr = buffer;
@@ -223,8 +226,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_io_pair_init(&io_pair));
 
         /* Set up the callback to send an alert after receiving ClientHello */
-        struct alert_ctx fatal_alert = {.write_fd = io_pair.server, .invoked = 0, .level = TLS_ALERT_LEVEL_FATAL, .code = TLS_ALERT_UNRECOGNIZED_NAME};
-        EXPECT_SUCCESS(s2n_config_set_client_hello_cb(config, client_hello_send_alert, &fatal_alert));
+        struct alert_ctx fatal_alert = {.write_fd = io_pair.server, .invoked = 0, .count = 1, .level = TLS_ALERT_LEVEL_FATAL, .code = TLS_ALERT_UNRECOGNIZED_NAME};
+        EXPECT_SUCCESS(s2n_config_set_client_hello_cb(config, client_hello_send_alerts, &fatal_alert));
 
         /* Create a child process */
         pid = fork();
@@ -269,8 +272,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_io_pair_init(&io_pair));
 
         /* Set up the callback to send an alert after receiving ClientHello */
-        struct alert_ctx warning_alert = {.write_fd = io_pair.server, .invoked = 0, .level = TLS_ALERT_LEVEL_WARNING, .code = TLS_ALERT_UNRECOGNIZED_NAME};
-        EXPECT_SUCCESS(s2n_config_set_client_hello_cb(config, client_hello_send_alert, &warning_alert));
+        struct alert_ctx warning_alert = {.write_fd = io_pair.server, .invoked = 0, .count = 1, .level = TLS_ALERT_LEVEL_WARNING, .code = TLS_ALERT_UNRECOGNIZED_NAME};
+        EXPECT_SUCCESS(s2n_config_set_client_hello_cb(config, client_hello_send_alerts, &warning_alert));
 
         /* Create a child process */
         pid = fork();

--- a/tls/s2n_alerts.c
+++ b/tls/s2n_alerts.c
@@ -84,6 +84,7 @@ int s2n_process_alert_fragment(struct s2n_connection *conn)
             /* Ignore warning-level alerts if we're in warning-tolerant mode */
             if (conn->config->alert_behavior == S2N_ALERT_IGNORE_WARNINGS &&
                     conn->alert_in_data[0] == S2N_TLS_ALERT_LEVEL_WARNING) {
+                GUARD(s2n_stuffer_wipe(&conn->alert_in));
                 return 0;
             }
 


### PR DESCRIPTION
### Description of changes: 

Previously when mode was set to `S2N_ALERT_IGNORE_WARNINGS` and warning was ignored, we did not clean up the `conn->alert_in` buffer, so when we received a second warning we would fail the connection with `S2N_ERR_ALERT_PRESENT` at the beginning of `s2n_process_alert_fragment` function.

### Call-outs:

One drawback is that we won't be able to fetch all warning alerts we received from the peer through `s2n_connection_get_alert` and only the fatal ones will get there. However, I think we can tackle that separately by introducing a different api to get multiple alerts.

### Testing:

Extended existing unit test to send 2 alerts and check that connection still works in `S2N_ALERT_IGNORE_WARNINGS` mode. The test fails without the change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
