### PR TITLE
Implements client-side sending of PQ key shares for 1.3

### DIFF
--- a/tests/unit/s2n_client_key_share_extension_test.c
+++ b/tests/unit/s2n_client_key_share_extension_test.c
@@ -29,6 +29,7 @@
 #include "testlib/s2n_testlib.h"
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_safety.h"
+#include "crypto/s2n_fips.h"
 
 #define S2N_SIZE_OF_CLIENT_SHARE_SIZE   2
 
@@ -920,6 +921,199 @@ int main(int argc, char **argv)
             }
         }
     }
+
+#if !defined(S2N_NO_PQ)
+    /* PQ hybrid tests for s2n_client_key_share_extension */
+    {
+        const struct s2n_kem_group *all_kem_groups[] = {
+            &s2n_secp256r1_sike_p434_r2,
+            &s2n_secp256r1_bike1_l1_r2,
+            &s2n_secp256r1_kyber_512_r2,
+#if EVP_APIS_SUPPORTED
+            &s2n_x25519_sike_p434_r2,
+            &s2n_x25519_bike1_l1_r2,
+            &s2n_x25519_kyber_512_r2,
+#endif
+        };
+
+        EXPECT_EQUAL(S2N_SUPPORTED_KEM_GROUPS_COUNT, s2n_array_len(all_kem_groups));
+
+        if (s2n_is_in_fips_mode()) {
+            /* Test that s2n_client_key_share_extension.send sends only ECC key shares when in FIPS mode */
+            const struct s2n_kem_preferences test_kem_prefs = {
+                .kem_count = 0,
+                .kems = NULL,
+                .tls13_kem_group_count = s2n_array_len(all_kem_groups),
+                .tls13_kem_groups = all_kem_groups,
+            };
+
+            const struct s2n_security_policy test_security_policy = {
+                .minimum_protocol_version = S2N_SSLv3,
+                .cipher_preferences = &cipher_preferences_test_all_tls13,
+                .kem_preferences = &test_kem_prefs,
+                .signature_preferences = &s2n_signature_preferences_20200207,
+                .ecc_preferences = &s2n_ecc_preferences_20200310,
+            };
+
+            struct s2n_stuffer key_share_extension;
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            conn->security_policy_override = &test_security_policy;
+
+            const struct s2n_kem_preferences *kem_pref = NULL;
+            EXPECT_SUCCESS(s2n_connection_get_kem_preferences(conn, &kem_pref));
+            EXPECT_NOT_NULL(kem_pref);
+            EXPECT_EQUAL(kem_pref->tls13_kem_group_count, S2N_SUPPORTED_KEM_GROUPS_COUNT);
+
+            const struct s2n_ecc_preferences *ecc_preferences = NULL;
+            EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_preferences));
+            EXPECT_NOT_NULL(ecc_preferences);
+
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&key_share_extension, 1024));
+            EXPECT_SUCCESS(s2n_client_key_share_extension.send(conn, &key_share_extension));
+
+            /* Assert total key shares extension size is correct */
+            uint16_t sent_key_shares_size;
+            EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &sent_key_shares_size));
+            EXPECT_EQUAL(sent_key_shares_size, s2n_stuffer_data_available(&key_share_extension));
+
+            /* ECC key shares should have the format: IANA ID || size || share. Only one ECC key share
+             * should be sent (as per defualt s2n behavior). */
+            uint16_t iana_value, share_size;
+            EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &iana_value));
+            EXPECT_EQUAL(iana_value, ecc_preferences->ecc_curves[0]->iana_id);
+            EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &share_size));
+            EXPECT_EQUAL(share_size, ecc_preferences->ecc_curves[0]->share_size);
+            EXPECT_SUCCESS(s2n_stuffer_skip_read(&key_share_extension, share_size));
+
+            /* If all the sizes/bytes were correctly written, there should be nothing left over */
+            EXPECT_EQUAL(s2n_stuffer_data_available(&key_share_extension), 0);
+
+            EXPECT_SUCCESS(s2n_stuffer_free(&key_share_extension));
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        } else {
+            /* Test that s2n_client_key_share_extension.send generates and sends PQ hybrid and ECC shares correctly
+             * when not in FIPS mode. */
+            for (size_t i = 0; i < S2N_SUPPORTED_KEM_GROUPS_COUNT; i++) {
+                /* The PQ hybrid key share send function only sends the highest priority PQ key share. On each
+                 * iteration of the outer loop of this test (index i), we populate test_kem_groups[] with a
+                 * different permutation of all_kem_groups[] to ensure we handle each kem_group key share
+                 * correctly. */
+                const struct s2n_kem_group *test_kem_groups[S2N_SUPPORTED_KEM_GROUPS_COUNT];
+                for (size_t j = 0; j < S2N_SUPPORTED_KEM_GROUPS_COUNT; j++) {
+                    test_kem_groups[j] = all_kem_groups[(j + i) % S2N_SUPPORTED_KEM_GROUPS_COUNT];
+                }
+
+                const struct s2n_kem_preferences test_kem_prefs = {
+                    .kem_count = 0,
+                    .kems = NULL,
+                    .tls13_kem_group_count = s2n_array_len(test_kem_groups),
+                    .tls13_kem_groups = test_kem_groups,
+                };
+
+                const struct s2n_security_policy test_security_policy = {
+                    .minimum_protocol_version = S2N_SSLv3,
+                    .cipher_preferences = &cipher_preferences_test_all_tls13,
+                    .kem_preferences = &test_kem_prefs,
+                    .signature_preferences = &s2n_signature_preferences_20200207,
+                    .ecc_preferences = &s2n_ecc_preferences_20200310,
+                };
+
+                struct s2n_stuffer key_share_extension;
+                struct s2n_connection *conn;
+                EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+                conn->security_policy_override = &test_security_policy;
+
+                const struct s2n_ecc_preferences *ecc_pref = NULL;
+                EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+                EXPECT_NOT_NULL(ecc_pref);
+
+                const struct s2n_kem_preferences *kem_pref = NULL;
+                EXPECT_SUCCESS(s2n_connection_get_kem_preferences(conn, &kem_pref));
+                EXPECT_NOT_NULL(kem_pref);
+                EXPECT_EQUAL(kem_pref->tls13_kem_group_count, S2N_SUPPORTED_KEM_GROUPS_COUNT);
+                EXPECT_EQUAL(test_kem_groups[0], kem_pref->tls13_kem_groups[0]);
+                const struct s2n_kem_group *test_kem_group = kem_pref->tls13_kem_groups[0];
+
+                EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&key_share_extension, 4096));
+                EXPECT_SUCCESS(s2n_client_key_share_extension.send(conn, &key_share_extension));
+
+                /* First, assert that the client saved its private keys correctly in the connection state
+                 * for both hybrid PQ and classic ECC */
+                struct s2n_kem_group_params *kem_group_params = &conn->secure.client_kem_group_params[0];
+                EXPECT_EQUAL(kem_group_params->kem_group, test_kem_group);
+                EXPECT_EQUAL(kem_group_params->kem_params.kem, test_kem_group->kem);
+                EXPECT_NOT_NULL(kem_group_params->kem_params.private_key.data);
+                EXPECT_EQUAL(kem_group_params->kem_params.private_key.size, test_kem_group->kem->private_key_length);
+                EXPECT_EQUAL(kem_group_params->ecc_params.negotiated_curve, test_kem_group->curve);
+                EXPECT_NOT_NULL(kem_group_params->ecc_params.evp_pkey);
+
+                struct s2n_ecc_evp_params *ecc_params = &conn->secure.client_ecc_evp_params[0];
+                EXPECT_EQUAL(ecc_params->negotiated_curve, ecc_pref->ecc_curves[0]);
+                EXPECT_NOT_NULL(ecc_params->evp_pkey);
+
+                /* Next, assert that the client didn't generate/save any hybrid or ECC params that it shouldn't have */
+                for (size_t kem_group_index = 1; kem_group_index < S2N_SUPPORTED_KEM_GROUPS_COUNT; kem_group_index++) {
+                    EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_index].kem_group);
+                    EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_index].kem_params.kem);
+                    EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_index].kem_params.private_key.data);
+                    EXPECT_EQUAL(conn->secure.client_kem_group_params[kem_group_index].kem_params.private_key.size, 0);
+                    EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_index].ecc_params.negotiated_curve);
+                    EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_index].ecc_params.evp_pkey);
+                }
+                for (size_t ecc_index = 1; ecc_index < S2N_ECC_EVP_SUPPORTED_CURVES_COUNT; ecc_index++) {
+                    EXPECT_NULL(conn->secure.client_ecc_evp_params[ecc_index].negotiated_curve);
+                    EXPECT_NULL(conn->secure.client_ecc_evp_params[ecc_index].evp_pkey);
+                }
+
+                /* Now, assert that the client sent the correct bytes over the wire for the key share extension */
+                /* Assert total key shares extension size is correct */
+                uint16_t sent_key_shares_size;
+                EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &sent_key_shares_size));
+                EXPECT_EQUAL(sent_key_shares_size, s2n_stuffer_data_available(&key_share_extension));
+
+                /* Assert that the hybrid key share is correct:
+                 * IANA ID || total hybrid share size || ECC share size || ECC share || PQ share size || PQ share */
+                uint16_t sent_hybrid_iana_id;
+                EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &sent_hybrid_iana_id));
+                EXPECT_EQUAL(sent_hybrid_iana_id, kem_pref->tls13_kem_groups[0]->iana_id);
+
+                uint16_t expected_hybrid_share_size =
+                          S2N_SIZE_OF_KEY_SHARE_SIZE
+                        + test_kem_group->curve->share_size
+                        + S2N_SIZE_OF_KEY_SHARE_SIZE
+                        + test_kem_group->kem->public_key_length;
+                uint16_t sent_hybrid_share_size;
+                EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &sent_hybrid_share_size));
+                EXPECT_EQUAL(sent_hybrid_share_size, expected_hybrid_share_size);
+
+                uint16_t hybrid_ecc_share_size;
+                EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &hybrid_ecc_share_size));
+                EXPECT_EQUAL(hybrid_ecc_share_size, test_kem_group->curve->share_size);
+                EXPECT_SUCCESS(s2n_stuffer_skip_read(&key_share_extension, hybrid_ecc_share_size));
+
+                uint16_t hybrid_pq_share_size;
+                EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &hybrid_pq_share_size));
+                EXPECT_EQUAL(hybrid_pq_share_size, test_kem_group->kem->public_key_length);
+                EXPECT_SUCCESS(s2n_stuffer_skip_read(&key_share_extension, hybrid_pq_share_size));
+
+                /* Assert that the ECC key share is correct: IANA ID || size || share */
+                uint16_t ecc_iana_value, ecc_share_size;
+                EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &ecc_iana_value));
+                EXPECT_EQUAL(ecc_iana_value, ecc_pref->ecc_curves[0]->iana_id);
+                EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &ecc_share_size));
+                EXPECT_EQUAL(ecc_share_size, ecc_pref->ecc_curves[0]->share_size);
+                EXPECT_SUCCESS(s2n_stuffer_skip_read(&key_share_extension, ecc_share_size));
+
+                /* If all the sizes/bytes were correctly written, there should be nothing left over */
+                EXPECT_EQUAL(s2n_stuffer_data_available(&key_share_extension), 0);
+
+                EXPECT_SUCCESS(s2n_stuffer_free(&key_share_extension));
+                EXPECT_SUCCESS(s2n_connection_free(conn));
+            }
+        }
+    }
+#endif
 
     END_TEST();
     return 0;

--- a/tls/extensions/s2n_client_key_share.c
+++ b/tls/extensions/s2n_client_key_share.c
@@ -102,7 +102,7 @@ static int s2n_generate_default_ecc_key_share(struct s2n_connection *conn, struc
     return S2N_SUCCESS;
 }
 
-static int s2n_generate_preferred_pq_hybrid_key_share(struct s2n_connection *conn, struct s2n_stuffer *out) {
+static int s2n_generate_default_pq_hybrid_key_share(struct s2n_connection *conn, struct s2n_stuffer *out) {
     notnull_check(conn);
     notnull_check(out);
 
@@ -231,7 +231,7 @@ static int s2n_client_key_share_send(struct s2n_connection *conn, struct s2n_stu
     if (s2n_is_hello_retry_handshake(conn)) {
         GUARD(s2n_send_hrr_keyshare(conn, out));
     } else {
-        GUARD(s2n_generate_preferred_pq_hybrid_key_share(conn, out));
+        GUARD(s2n_generate_default_pq_hybrid_key_share(conn, out));
         GUARD(s2n_ecdhe_supported_curves_send(conn, out));
     }
 

--- a/tls/extensions/s2n_client_key_share.c
+++ b/tls/extensions/s2n_client_key_share.c
@@ -21,6 +21,7 @@
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_safety.h"
 #include "tls/s2n_tls13.h"
+#include "crypto/s2n_fips.h"
 
 #define S2N_IS_KEY_SHARE_LIST_EMPTY(preferred_key_shares) (preferred_key_shares & 1)
 #define S2N_IS_KEY_SHARE_REQUESTED(preferred_key_shares, i) ((preferred_key_shares >> (i + 1)) & 1)
@@ -59,7 +60,7 @@ const s2n_extension_type s2n_client_key_share_extension = {
     .if_missing = s2n_extension_noop_if_missing,
 };
 
-static int s2n_generate_preferred_key_shares(struct s2n_connection *conn, struct s2n_stuffer *out)
+static int s2n_generate_preferred_ecc_key_shares(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
     notnull_check(conn);
     uint8_t preferred_key_shares = conn->preferred_key_shares;
@@ -86,7 +87,7 @@ static int s2n_generate_preferred_key_shares(struct s2n_connection *conn, struct
     return S2N_SUCCESS;
 }
 
-static int s2n_generate_default_key_share(struct s2n_connection *conn, struct s2n_stuffer *out)
+static int s2n_generate_default_ecc_key_share(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
     notnull_check(conn);
     const struct s2n_ecc_preferences *ecc_pref = NULL;
@@ -101,7 +102,58 @@ static int s2n_generate_default_key_share(struct s2n_connection *conn, struct s2
     return S2N_SUCCESS;
 }
 
-static int s2n_send_hrr_keyshare(struct s2n_connection *conn, struct s2n_stuffer *out)
+static int s2n_generate_preferred_pq_hybrid_key_share(struct s2n_connection *conn, struct s2n_stuffer *out) {
+    notnull_check(conn);
+    notnull_check(out);
+
+    if (s2n_is_in_fips_mode()) {
+        /* PQ KEMs are not supported in FIPS mode */
+        return S2N_SUCCESS;
+    }
+
+    const struct s2n_kem_preferences *kem_pref = NULL;
+    GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
+    notnull_check(kem_pref);
+
+    if (kem_pref->tls13_kem_group_count == 0) {
+        return S2N_SUCCESS;
+    }
+
+    /* We only send a single PQ key share - the highest preferred one */
+    const struct s2n_kem_group *kem_group = kem_pref->tls13_kem_groups[0];
+
+    /* The structure of the PQ share is:
+     *    IANA ID (2 bytes)
+     * || total share size (2 bytes)
+     * || size of ECC key share (2 bytes)
+     * || ECC key share (variable bytes)
+     * || size of PQ key share (2 bytes)
+     * || PQ key share (variable bytes) */
+    GUARD(s2n_stuffer_write_uint16(out, kem_group->iana_id));
+    uint16_t total_share_size =
+              S2N_SIZE_OF_KEY_SHARE_SIZE
+            + kem_group->curve->share_size
+            + S2N_SIZE_OF_KEY_SHARE_SIZE
+            + kem_group->kem->public_key_length;
+    GUARD(s2n_stuffer_write_uint16(out, total_share_size));
+
+    struct s2n_kem_group_params *kem_group_params = &conn->secure.client_kem_group_params[0];
+    kem_group_params->kem_group = kem_group;
+
+    struct s2n_ecc_evp_params *ecc_params = &kem_group_params->ecc_params;
+    ecc_params->negotiated_curve = kem_group->curve;
+    GUARD(s2n_stuffer_write_uint16(out, ecc_params->negotiated_curve->share_size));
+    GUARD(s2n_ecc_evp_generate_ephemeral_key(ecc_params));
+    GUARD(s2n_ecc_evp_write_params_point(ecc_params, out));
+
+    struct s2n_kem_params *kem_params = &kem_group_params->kem_params;
+    kem_params->kem = kem_group->kem;
+    GUARD(s2n_kem_send_public_key(out, kem_params));
+
+    return S2N_SUCCESS;
+}
+
+static int s2n_send_hrr_ecc_keyshare(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
     notnull_check(conn);
     const struct s2n_ecc_named_curve *server_negotiated_curve = NULL;
@@ -136,23 +188,38 @@ static int s2n_send_hrr_keyshare(struct s2n_connection *conn, struct s2n_stuffer
     return S2N_SUCCESS;
 }
 
+static int s2n_send_hrr_pq_hybrid_keyshare(struct s2n_connection *conn, struct s2n_stuffer *out) {
+    notnull_check(conn);
+    notnull_check(out);
+
+    S2N_ERROR(S2N_ERR_UNIMPLEMENTED);
+}
+
+/* From https://tools.ietf.org/html/rfc8446#section-4.1.2
+ * If a "key_share" extension was supplied in the HelloRetryRequest,
+ * replace the list of shares with a list containing a single
+ * KeyShareEntry from the indicated group.*/
+static int s2n_send_hrr_keyshare(struct s2n_connection *conn, struct s2n_stuffer *out) {
+    notnull_check(conn);
+    notnull_check(out);
+
+    if (conn->secure.server_kem_group_params.kem_group != NULL) {
+        GUARD(s2n_send_hrr_pq_hybrid_keyshare(conn, out));
+    } else {
+        GUARD(s2n_send_hrr_ecc_keyshare(conn, out));
+    }
+
+    return S2N_SUCCESS;
+}
+
 static int s2n_ecdhe_supported_curves_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    /* From https://tools.ietf.org/html/rfc8446#section-4.1.2
-     * If a "key_share" extension was supplied in the HelloRetryRequest,
-     * replace the list of shares with a list containing a single
-     * KeyShareEntry from the indicated group.*/
-    if (s2n_is_hello_retry_handshake(conn)) {
-        GUARD(s2n_send_hrr_keyshare(conn, out));
-        return S2N_SUCCESS;
-    }
-
     if (!conn->preferred_key_shares) {
-        GUARD(s2n_generate_default_key_share(conn, out));
+        GUARD(s2n_generate_default_ecc_key_share(conn, out));
         return S2N_SUCCESS;
     }
 
-    GUARD(s2n_generate_preferred_key_shares(conn, out));
+    GUARD(s2n_generate_preferred_ecc_key_shares(conn, out));
     return S2N_SUCCESS;
 }
 
@@ -161,7 +228,12 @@ static int s2n_client_key_share_send(struct s2n_connection *conn, struct s2n_stu
     struct s2n_stuffer_reservation shares_size = {0};
     GUARD(s2n_stuffer_reserve_uint16(out, &shares_size));
 
-    GUARD(s2n_ecdhe_supported_curves_send(conn, out));
+    if (s2n_is_hello_retry_handshake(conn)) {
+        GUARD(s2n_send_hrr_keyshare(conn, out));
+    } else {
+        GUARD(s2n_generate_preferred_pq_hybrid_key_share(conn, out));
+        GUARD(s2n_ecdhe_supported_curves_send(conn, out));
+    }
 
     GUARD(s2n_stuffer_write_vector_size(&shares_size));
 


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

Implements client-side sending of hybrid PQ key shares for TLS 1.3.

### Call-outs:

* We are only sending a single hybrid key share (corresponding to the most preferred `tls13_kem_group` in the preferences)
  * It would be fairly straightforward to implement a preferred hybrid key shares functionality that is analogous to what currently exists for ECC. There are no plans to do that right now; given the large size of the PQ key shares, we don't plan on sending multiples.
* PQ-aware HRR support is not included in this PR
* Currently, all KEM preferences have `tls13_kem_group_count == 0` and `tls13_kem_groups == NULL`. This is an effective way to feature-gate the new code paths until all client and server functionality has been implemented. 

### Testing:

* Unit test added
* No integration tests yet (will have to wait until after we add new KEM preferences for PQ 1.3)
* Built locally with `S2N_NO_PQ=1` to verify that build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
