### PR TITLE
Updates s2n_stuffer_write* proofs

### DIFF
--- a/tests/cbmc/proofs/s2n_safety_constant_time_equals/Makefile
+++ b/tests/cbmc/proofs/s2n_safety_constant_time_equals/Makefile
@@ -26,6 +26,6 @@ PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
 
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
-UNWINDSET += s2n_constant_time_equals.0:$(call addone,$(MAX_ARR_LEN))
+UNWINDSET += s2n_constant_time_equals.3:$(call addone,$(MAX_ARR_LEN))
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_read_line/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_line/Makefile
@@ -24,6 +24,7 @@ PROOF_SOURCES += $(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
@@ -37,8 +38,8 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += s2n_blob_slice
-REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 
-UNWINDSET += s2n_stuffer_read_token.0:$(call addone,$(MAX_BLOB_SIZE))
+UNWINDSET += s2n_stuffer_read_token.6:$(call addone,$(MAX_BLOB_SIZE))
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_reservation/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_reservation/Makefile
@@ -14,6 +14,10 @@
 # Expected runtime is 29 minutes.
 DEFINES += -DMADV_DONTDUMP=1
 
+# This the the maximum number of iterations to unroll
+# the loop in s2n_stuffer_write_network_order
+MAX_WRITE_NETWORK_ORDER = 9
+
 CBMCFLAGS +=
 
 HARNESS_ENTRY = s2n_stuffer_write_reservation_harness
@@ -41,13 +45,13 @@ REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
 
-UNWINDSET += s2n_stuffer_write_network_order.0:9
-UNWINDSET += s2n_stuffer_write_network_order.1:9
-UNWINDSET += s2n_stuffer_write_network_order.2:9
-UNWINDSET += s2n_stuffer_write_network_order.3:9
-UNWINDSET += s2n_stuffer_write_network_order.4:9
-UNWINDSET += s2n_stuffer_write_network_order.5:9
-UNWINDSET += s2n_stuffer_write_network_order.6:9
-UNWINDSET += s2n_stuffer_write_network_order.7:9
+UNWINDSET += s2n_stuffer_write_network_order.0:$(MAX_WRITE_NETWORK_ORDER)
+UNWINDSET += s2n_stuffer_write_network_order.1:$(MAX_WRITE_NETWORK_ORDER)
+UNWINDSET += s2n_stuffer_write_network_order.2:$(MAX_WRITE_NETWORK_ORDER)
+UNWINDSET += s2n_stuffer_write_network_order.3:$(MAX_WRITE_NETWORK_ORDER)
+UNWINDSET += s2n_stuffer_write_network_order.4:$(MAX_WRITE_NETWORK_ORDER)
+UNWINDSET += s2n_stuffer_write_network_order.5:$(MAX_WRITE_NETWORK_ORDER)
+UNWINDSET += s2n_stuffer_write_network_order.6:$(MAX_WRITE_NETWORK_ORDER)
+UNWINDSET += s2n_stuffer_write_network_order.7:$(MAX_WRITE_NETWORK_ORDER)
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_reservation/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_reservation/Makefile
@@ -11,9 +11,8 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Expected runtime is 23 minutes.
-MAX_LENGTH = 3
-DEFINES += -DMAX_LENGTH=$(MAX_LENGTH)
+# Expected runtime is 29 minutes.
+DEFINES += -DMADV_DONTDUMP=1
 
 CBMCFLAGS +=
 
@@ -24,6 +23,7 @@ PROOF_SOURCES += $(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/madvise.c
 PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
@@ -38,16 +38,16 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
 
-UNWINDSET += s2n_stuffer_write_network_order.0:$(shell echo $$((1 + $(MAX_LENGTH))))
-UNWINDSET += s2n_stuffer_write_network_order.1:$(shell echo $$((1 + $(MAX_LENGTH))))
-UNWINDSET += s2n_stuffer_write_network_order.2:$(shell echo $$((1 + $(MAX_LENGTH))))
-UNWINDSET += s2n_stuffer_write_network_order.3:$(shell echo $$((1 + $(MAX_LENGTH))))
-UNWINDSET += s2n_stuffer_write_network_order.4:$(shell echo $$((1 + $(MAX_LENGTH))))
-UNWINDSET += s2n_stuffer_write_network_order.5:$(shell echo $$((1 + $(MAX_LENGTH))))
-UNWINDSET += s2n_stuffer_write_network_order.6:$(shell echo $$((1 + $(MAX_LENGTH))))
-UNWINDSET += s2n_stuffer_write_network_order.7:$(shell echo $$((1 + $(MAX_LENGTH))))
-UNWINDSET += s2n_stuffer_write_reservation_harness.0:$(shell echo $$((1 + $(MAX_LENGTH))))
+UNWINDSET += s2n_stuffer_write_network_order.0:9
+UNWINDSET += s2n_stuffer_write_network_order.1:9
+UNWINDSET += s2n_stuffer_write_network_order.2:9
+UNWINDSET += s2n_stuffer_write_network_order.3:9
+UNWINDSET += s2n_stuffer_write_network_order.4:9
+UNWINDSET += s2n_stuffer_write_network_order.5:9
+UNWINDSET += s2n_stuffer_write_network_order.6:9
+UNWINDSET += s2n_stuffer_write_network_order.7:9
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_reservation/s2n_stuffer_write_reservation_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_reservation/s2n_stuffer_write_reservation_harness.c
@@ -29,7 +29,6 @@ void s2n_stuffer_write_reservation_harness() {
     /* Non-deterministic inputs. */
     struct s2n_stuffer_reservation *reservation = cbmc_allocate_s2n_stuffer_reservation();
     __CPROVER_assume(s2n_stuffer_reservation_is_valid(reservation));
-    //__CPROVER_assume(reservation->length < MAX_LENGTH);
     uint32_t u;
 
     /* Non-deterministically set initialized (in s2n_mem) to true. */

--- a/tests/cbmc/proofs/s2n_stuffer_write_reservation/s2n_stuffer_write_reservation_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_reservation/s2n_stuffer_write_reservation_harness.c
@@ -29,7 +29,7 @@ void s2n_stuffer_write_reservation_harness() {
     /* Non-deterministic inputs. */
     struct s2n_stuffer_reservation *reservation = cbmc_allocate_s2n_stuffer_reservation();
     __CPROVER_assume(s2n_stuffer_reservation_is_valid(reservation));
-    __CPROVER_assume(reservation->length < MAX_LENGTH);
+    //__CPROVER_assume(reservation->length < MAX_LENGTH);
     uint32_t u;
 
     /* Non-deterministically set initialized (in s2n_mem) to true. */

--- a/tests/cbmc/proofs/s2n_stuffer_write_vector_size/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_vector_size/Makefile
@@ -12,8 +12,6 @@
 # limitations under the License.
 
 # Expected runtime is 18 minutes.
-MAX_LENGTH = 3
-DEFINES += -DMAX_LENGTH=$(MAX_LENGTH)
 
 CBMCFLAGS +=
 
@@ -40,6 +38,6 @@ REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += s2n_stuffer_resize
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
 
- UNWINDSET += s2n_stuffer_write_network_order.4:$(shell echo $$((1 + $(MAX_LENGTH))))
+UNWINDSET += s2n_stuffer_write_network_order.4:9
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_vector_size/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_vector_size/Makefile
@@ -13,6 +13,10 @@
 
 # Expected runtime is 18 minutes.
 
+# This the the maximum number of iterations to unroll
+# the loop in s2n_stuffer_write_network_order
+MAX_WRITE_NETWORK_ORDER = 9
+
 CBMCFLAGS +=
 
 HARNESS_ENTRY = s2n_stuffer_write_vector_size_harness
@@ -38,6 +42,13 @@ REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += s2n_stuffer_resize
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
 
-UNWINDSET += s2n_stuffer_write_network_order.4:9
+UNWINDSET += s2n_stuffer_write_network_order.0:$(MAX_WRITE_NETWORK_ORDER)
+UNWINDSET += s2n_stuffer_write_network_order.1:$(MAX_WRITE_NETWORK_ORDER)
+UNWINDSET += s2n_stuffer_write_network_order.2:$(MAX_WRITE_NETWORK_ORDER)
+UNWINDSET += s2n_stuffer_write_network_order.3:$(MAX_WRITE_NETWORK_ORDER)
+UNWINDSET += s2n_stuffer_write_network_order.4:$(MAX_WRITE_NETWORK_ORDER)
+UNWINDSET += s2n_stuffer_write_network_order.5:$(MAX_WRITE_NETWORK_ORDER)
+UNWINDSET += s2n_stuffer_write_network_order.6:$(MAX_WRITE_NETWORK_ORDER)
+UNWINDSET += s2n_stuffer_write_network_order.7:$(MAX_WRITE_NETWORK_ORDER)
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_vector_size/s2n_stuffer_write_vector_size_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_vector_size/s2n_stuffer_write_vector_size_harness.c
@@ -29,7 +29,6 @@ void s2n_stuffer_write_vector_size_harness() {
     /* Non-deterministic inputs. */
     struct s2n_stuffer_reservation *reservation = cbmc_allocate_s2n_stuffer_reservation();
     __CPROVER_assume(s2n_stuffer_reservation_is_valid(reservation));
-    __CPROVER_assume(reservation->length < MAX_LENGTH);
 
     /* Non-deterministically set initialized (in s2n_mem) to true. */
     if(nondet_bool()) {

--- a/tests/cbmc/proofs/s2n_stuffer_writev_bytes/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_writev_bytes/Makefile
@@ -11,9 +11,10 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Enough to get full coverage with 22 minutes of runtime.
+# Enough to get full coverage with 8 minutes of runtime.
 MAX_IOVEC_SIZE = 3
 DEFINES += -DMAX_IOVEC_SIZE=$(MAX_IOVEC_SIZE)
+DEFINES += -DMADV_DONTDUMP=1
 
 CBMCFLAGS +=
 
@@ -24,6 +25,8 @@ PROOF_SOURCES += $(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/madvise.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
@@ -36,6 +39,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
 
 UNWINDSET += s2n_stuffer_writev_bytes.20:$(call addone,$(MAX_IOVEC_SIZE))

--- a/tests/cbmc/stubs/madvise.c
+++ b/tests/cbmc/stubs/madvise.c
@@ -14,8 +14,16 @@
  */
 
 #include <cbmc_proof/nondet.h>
+#include <errno.h>
+
+#include "error/s2n_errno.h"
 
 int madvise(void *addr, size_t length, int advice)
 {
-    return nondet_int();
+    assert(S2N_MEM_IS_WRITABLE(addr,length));
+    if(nondet_bool()) {
+        return 0;
+    }
+    errno = nondet_int();
+    return -1;
 }


### PR DESCRIPTION
### Resolved issues:

N/A.

### Description of changes: 

- Updates the version of `aws-templates-for-cbmc-proofs` used by CBMC proofs;
- Updates `s2n_stuffer_write_reservation`, `s2n_stuffer_write_vector_size`, `s2n_stuffer_writev_bytes`proof harnesses to work with unbounded data structures;
- Updates `madvise` stubs for CBMC proofs.

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
