### PR TITLE
Removing tls13 wikipedia and yahoo tests temporarily

### DIFF
--- a/tests/integration/s2n_client_endpoint_handshake_test.py
+++ b/tests/integration/s2n_client_endpoint_handshake_test.py
@@ -138,12 +138,10 @@ def well_known_endpoints_test(use_corked_io, tls13_enabled):
             if ret is 0:
                 break
             else:
-                if endpoint in allowed_endpoints_failures:
-                    break
                 time.sleep(i)
 
         print_result("Endpoint: %-35sExpected Cipher: %-40s... " % (endpoint, expected_cipher if expected_cipher else "Any"), ret)
-        if ret != 0 and endpoint not in allowed_endpoints_failures:
+        if ret != 0:
             failed += 1
 
     return failed

--- a/tests/integration/s2n_client_endpoint_handshake_test.py
+++ b/tests/integration/s2n_client_endpoint_handshake_test.py
@@ -56,9 +56,9 @@ if os.getenv("S2N_NO_PQ") is None:
     well_known_endpoints.extend(pq_endpoints)
 
 
-# Make an exception to allow failure (if CI is having issues)
+# This can be removed when https://github.com/awslabs/s2n/issues/2220 is fixed.
 allowed_endpoints_failures = [
-    'wikipedia.org'
+    'wikipedia.org', 'yahoo.com'
 ]
 
 def print_result(result_prefix, return_code):
@@ -125,6 +125,8 @@ def well_known_endpoints_test(use_corked_io, tls13_enabled):
     for endpoint_config in well_known_endpoints:
 
         endpoint = endpoint_config["endpoint"]
+        if endpoint in allowed_endpoints_failures and tls13_enabled:
+            continue
         expected_cipher = endpoint_config.get("expected_cipher")
 
         if "cipher_preference_version" in endpoint_config:


### PR DESCRIPTION
### Resolved issues:

### Description of changes: 

s2n is not able to verify status request responses in server certificate extensions. Temporarily, we have removed the two endpoints that send this extension in tls1.3. Once this issue is fixed: #2220 , we can add the endpoints back into the test.
### Call-outs:

Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
### Testing:

 Integ tests pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
