### PR TITLE
Adds a nondet_s2n_mem_init() predicate for CBMC proofs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test-deps/*
 .idea/*
 CMakeCache.txt
 CMakeFiles/*
+.project

--- a/tests/cbmc/include/cbmc_proof/cbmc_utils.h
+++ b/tests/cbmc/include/cbmc_proof/cbmc_utils.h
@@ -141,6 +141,11 @@ uint64_t nondet_hasher(const void *a);
 uint64_t uninterpreted_hasher(const void *a);
 
 /**
- * Standard stub function of a predicate
+ * Standard stub function of a predicate.
  */
 bool uninterpreted_predicate_fn(uint8_t value);
+
+/**
+ * Non-deterministically set initialized (in s2n_mem) to true.
+ */
+void nondet_s2n_mem_init();

--- a/tests/cbmc/include/cbmc_proof/cbmc_utils.h
+++ b/tests/cbmc/include/cbmc_proof/cbmc_utils.h
@@ -15,18 +15,17 @@
 
 #pragma once
 
-#include <stddef.h>
-#include <stdint.h>
-
 #include <cbmc_proof/nondet.h>
 #include <cbmc_proof/proof_allocators.h>
+#include <stddef.h>
+#include <stdint.h>
 #include <stuffer/s2n_stuffer.h>
 #include <utils/s2n_blob.h>
 
 #define IMPLIES(a, b) (!(a) || (b))
 
 struct store_byte_from_buffer {
-    size_t index;
+    size_t  index;
     uint8_t byte;
 };
 
@@ -39,9 +38,8 @@ struct store_byte_from_buffer {
  * rhs s2n_blob instance (use save_byte_from_blob function), so it can properly
  * assert all bytes from blob.data match.
  */
- void assert_stuffer_immutable_fields_after_read(const struct s2n_stuffer *lhs,
-                                                 const struct s2n_stuffer *rhs,
-                                                 const struct store_byte_from_buffer *stored_byte_from_rhs);
+void assert_stuffer_immutable_fields_after_read(const struct s2n_stuffer *lhs, const struct s2n_stuffer *rhs,
+                                                const struct store_byte_from_buffer *stored_byte_from_rhs);
 
 /**
  * Asserts two s2n_blob instances are equivalent. In order to be considered equivalent,
@@ -50,9 +48,8 @@ struct store_byte_from_buffer {
  * a non-deterministic byte from the rhs s2n_blob instance (use save_byte_from_blob function),
  * so it can properly assert all bytes from *data match.
  */
- void assert_blob_equivalence(const struct s2n_blob *lhs,
-                              const struct s2n_blob *rhs,
-                              const struct store_byte_from_buffer *stored_byte_from_rhs);
+void assert_blob_equivalence(const struct s2n_blob *lhs, const struct s2n_blob *rhs,
+                             const struct store_byte_from_buffer *stored_byte_from_rhs);
 
 /**
  * Asserts two s2n_stuffer instances are equivalent. In order to be considered equivalent,
@@ -61,9 +58,8 @@ struct store_byte_from_buffer {
  * a non-deterministic byte from the rhs s2n_blob instance (use save_byte_from_blob function),
  * so it can properly assert all bytes from blob.data match.
  */
- void assert_stuffer_equivalence(const struct s2n_stuffer *lhs,
-                                 const struct s2n_stuffer *rhs,
-                                 const struct store_byte_from_buffer *stored_byte_from_rhs);
+void assert_stuffer_equivalence(const struct s2n_stuffer *lhs, const struct s2n_stuffer *rhs,
+                                const struct store_byte_from_buffer *stored_byte_from_rhs);
 
 /**
  * Asserts whether all bytes from two arrays of same length match.
@@ -102,7 +98,7 @@ void save_byte_from_array(const uint8_t *const array, const size_t size, struct 
  * structure. Afterwards, one can prove using the assert_byte_from_blob_matches function
  * whether no byte in the blob has changed.
  */
-void save_byte_from_blob(const struct s2n_blob *blob, struct store_byte_from_buffer * storage);
+void save_byte_from_blob(const struct s2n_blob *blob, struct store_byte_from_buffer *storage);
 
 /**
  * Standard stub function to compare two items.

--- a/tests/cbmc/include/cbmc_proof/endian.h
+++ b/tests/cbmc/include/cbmc_proof/endian.h
@@ -14,39 +14,39 @@
  */
 
 #if __BYTE_ORDER == __LITTLE_ENDIAN
-# define __LONG_LONG_PAIR(HI, LO) LO, HI
+#    define __LONG_LONG_PAIR(HI, LO) LO, HI
 #elif __BYTE_ORDER == __BIG_ENDIAN
-# define __LONG_LONG_PAIR(HI, LO) HI, LO
+#    define __LONG_LONG_PAIR(HI, LO) HI, LO
 #endif
 
 #if __BYTE_ORDER == __LITTLE_ENDIAN
-# define htobe16(x) __builtin_bswap16 (x)
-# define htole16(x) (x)
-# define be16toh(x) __builtin_bswap16 (x)
-# define le16toh(x) (x)
+#    define htobe16(x) __builtin_bswap16(x)
+#    define htole16(x) (x)
+#    define be16toh(x) __builtin_bswap16(x)
+#    define le16toh(x) (x)
 
-# define htobe32(x) __builtin_bswap32 (x)
-# define htole32(x) (x)
-# define be32toh(x) __builtin_bswap32 (x)
-# define le32toh(x) (x)
+#    define htobe32(x) __builtin_bswap32(x)
+#    define htole32(x) (x)
+#    define be32toh(x) __builtin_bswap32(x)
+#    define le32toh(x) (x)
 
-# define htobe64(x) __builtin_bswap64 (x)
-# define htole64(x) (x)
-# define be64toh(x) __builtin_bswap64 (x)
-# define le64toh(x) (x)
+#    define htobe64(x) __builtin_bswap64(x)
+#    define htole64(x) (x)
+#    define be64toh(x) __builtin_bswap64(x)
+#    define le64toh(x) (x)
 #else
-# define htobe16(x) (x)
-# define htole16(x) __builtin_bswap16 (x)
-# define be16toh(x) (x)
-# define le16toh(x) __builtin_bswap16 (x)
+#    define htobe16(x) (x)
+#    define htole16(x) __builtin_bswap16(x)
+#    define be16toh(x) (x)
+#    define le16toh(x) __builtin_bswap16(x)
 
-# define htobe32(x) (x)
-# define htole32(x) __builtin_bswap32 (x)
-# define be32toh(x) (x)
-# define le32toh(x) __builtin_bswap32 (x)
+#    define htobe32(x) (x)
+#    define htole32(x) __builtin_bswap32(x)
+#    define be32toh(x) (x)
+#    define le32toh(x) __builtin_bswap32(x)
 
-# define htobe64(x) (x)
-# define htole64(x) __builtin_bswap64 (x)
-# define be64toh(x) (x)
-# define le64toh(x) __builtin_bswap64 (x)
+#    define htobe64(x) (x)
+#    define htole64(x) __builtin_bswap64(x)
+#    define be64toh(x) (x)
+#    define le64toh(x) __builtin_bswap64(x)
 #endif

--- a/tests/cbmc/include/cbmc_proof/make_common_datastructures.h
+++ b/tests/cbmc/include/cbmc_proof/make_common_datastructures.h
@@ -17,38 +17,39 @@
 
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/proof_allocators.h>
+
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
 
 /*
  * Checks whether s2n_blob is bounded by max_size.
  */
-bool s2n_blob_is_bounded(const struct s2n_blob* blob, const size_t max_size);
+bool s2n_blob_is_bounded(const struct s2n_blob *blob, const size_t max_size);
 
 /*
  * Checks whether s2n_blob is bounded by max_size.
  */
-bool s2n_stuffer_is_bounded(const struct s2n_stuffer* stuffer, const size_t max_size);
+bool s2n_stuffer_is_bounded(const struct s2n_stuffer *stuffer, const size_t max_size);
 
 /*
  * Ensures s2n_blob has a proper allocated data member.
  */
-void ensure_s2n_blob_has_allocated_fields(struct s2n_blob* blob);
+void ensure_s2n_blob_has_allocated_fields(struct s2n_blob *blob);
 
 /*
  * Properly allocates s2n_blob for CBMC proofs.
  */
-struct s2n_blob* cbmc_allocate_s2n_blob();
+struct s2n_blob *cbmc_allocate_s2n_blob();
 
 /*
  * Ensures s2n_stuffer has a proper allocated blob member.
  */
-void ensure_s2n_stuffer_has_allocated_fields(struct s2n_stuffer* stuffer);
+void ensure_s2n_stuffer_has_allocated_fields(struct s2n_stuffer *stuffer);
 
 /*
  * Properly allocates s2n_stuffer for CBMC proofs.
  */
-struct s2n_stuffer* cbmc_allocate_s2n_stuffer();
+struct s2n_stuffer *cbmc_allocate_s2n_stuffer();
 
 /*
  * Ensures a valid const string is allocated,
@@ -65,4 +66,4 @@ const char *nondet_c_str_is_allocated(size_t max_size);
 /*
  * Properly allocates s2n_stuffer_reservation for CBMC proofs.
  */
-struct s2n_stuffer_reservation* cbmc_allocate_s2n_stuffer_reservation();
+struct s2n_stuffer_reservation *cbmc_allocate_s2n_stuffer_reservation();

--- a/tests/cbmc/include/cbmc_proof/nondet.h
+++ b/tests/cbmc/include/cbmc_proof/nondet.h
@@ -27,15 +27,15 @@
  * For example, each call to nondet_uint8_t() will return a different unconstrained value which can be used
  * in CBMC proofs.
  */
-bool nondet_bool();
-int nondet_int();
+bool         nondet_bool();
+int          nondet_int();
 unsigned int nondet_unsigned_int();
-size_t nondet_size_t();
-long nondet_long();
-uint16_t nondet_uint16_t();
-uint32_t nondet_uint32_t();
-uint64_t nondet_uint64_t();
-uint8_t nondet_uint8_t();
-void *nondet_voidp();
-off_t nondet_off_t();
-ssize_t nondet_ssize_t();
+size_t       nondet_size_t();
+long         nondet_long();
+uint16_t     nondet_uint16_t();
+uint32_t     nondet_uint32_t();
+uint64_t     nondet_uint64_t();
+uint8_t      nondet_uint8_t();
+void *       nondet_voidp();
+off_t        nondet_off_t();
+ssize_t      nondet_ssize_t();

--- a/tests/cbmc/include/openssl/asn1.h
+++ b/tests/cbmc/include/openssl/asn1.h
@@ -20,10 +20,10 @@
 
 #include <openssl/ossl_typ.h>
 
-void ASN1_STRING_clear_free(ASN1_STRING *a);
-BIGNUM *ASN1_INTEGER_to_BN(const ASN1_INTEGER *ai, BIGNUM *bn);
+void          ASN1_STRING_clear_free(ASN1_STRING *a);
+BIGNUM *      ASN1_INTEGER_to_BN(const ASN1_INTEGER *ai, BIGNUM *bn);
 ASN1_INTEGER *BN_to_ASN1_INTEGER(const BIGNUM *bn, ASN1_INTEGER *ai);
 ASN1_INTEGER *d2i_ASN1_INTEGER(ASN1_INTEGER **a, unsigned char **ppin, long length);
-int i2d_ASN1_INTEGER(ASN1_INTEGER *a, unsigned char **ppout);
+int           i2d_ASN1_INTEGER(ASN1_INTEGER *a, unsigned char **ppout);
 
 #endif /* HEADER_ASN1_H */

--- a/tests/cbmc/include/openssl/bn.h
+++ b/tests/cbmc/include/openssl/bn.h
@@ -22,8 +22,8 @@
 
 BIGNUM *BN_new(void);
 BIGNUM *BN_dup(const BIGNUM *from);
-int BN_sub(BIGNUM *r, const BIGNUM *a, const BIGNUM *b);
-void BN_clear_free(BIGNUM *a);
-void BN_free(BIGNUM *a);
+int     BN_sub(BIGNUM *r, const BIGNUM *a, const BIGNUM *b);
+void    BN_clear_free(BIGNUM *a);
+void    BN_free(BIGNUM *a);
 
 #endif

--- a/tests/cbmc/include/openssl/dh.h
+++ b/tests/cbmc/include/openssl/dh.h
@@ -15,41 +15,41 @@
  * permissions and limitations under the License.
  */
 
-#include <stdint.h>
-#include <openssl/ffc.h>
-#include <openssl/bn.h>
 #include <cbmc_proof/nondet.h>
+#include <openssl/bn.h>
+#include <openssl/ffc.h>
+#include <stdint.h>
 
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_safety.h"
 
 #ifndef OPENSSL_DH_H
-# define OPENSSL_DH_H
-# pragma once
+#    define OPENSSL_DH_H
+#    pragma once
 
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define HEADER_DH_H
-# endif
+#    ifndef OPENSSL_NO_DEPRECATED_3_0
+#        define HEADER_DH_H
+#    endif
 
 /*
  * The structs dh_st and dh_method have been cut down to contain
  * only the parts relevant to the s2n_pkcs3_to_dh_params proof.
  */
 
-struct dh_st{
+struct dh_st {
     /*
      * This first argument is used to pick up errors when a DH is passed
      * instead of a EVP_PKEY
      */
-    int pad;
-    int version;
+    int        pad;
+    int        version;
     FFC_PARAMS params;
     /* max generated private key length (can be less than len(q)) */
     int32_t length;
-    BIGNUM *pub_key;            /* g^x % p */
-    BIGNUM *priv_key;           /* x */
-    int flags;
+    BIGNUM *pub_key;  /* g^x % p */
+    BIGNUM *priv_key; /* x */
+    int     flags;
     BIGNUM *p;
     BIGNUM *g;
 
@@ -62,7 +62,7 @@ struct dh_method {
 };
 
 void DH_free(DH *dh);
-int DH_size(const DH *dh);
-DH *d2i_DHparams(DH **a, unsigned char **pp, long length);
+int  DH_size(const DH *dh);
+DH * d2i_DHparams(DH **a, unsigned char **pp, long length);
 
 #endif

--- a/tests/cbmc/include/openssl/ec.h
+++ b/tests/cbmc/include/openssl/ec.h
@@ -38,31 +38,31 @@ typedef enum {
 
 typedef struct ec_group_st EC_GROUP;
 
-EC_GROUP *EC_GROUP_new_by_curve_name(int nid);
-void EC_GROUP_set_point_conversion_form(EC_GROUP *group, point_conversion_form_t form);
+EC_GROUP *    EC_GROUP_new_by_curve_name(int nid);
+void          EC_GROUP_set_point_conversion_form(EC_GROUP *group, point_conversion_form_t form);
 const BIGNUM *EC_GROUP_get0_order(const EC_GROUP *group);
-void EC_GROUP_free(EC_GROUP *group);
+void          EC_GROUP_free(EC_GROUP *group);
 
 typedef struct ECDSA_SIG_st ECDSA_SIG;
 
-EC_KEY *EC_KEY_new(void);
-int EC_KEY_set_group(EC_KEY *key, const EC_GROUP *group);
-void EC_KEY_set_conv_form(EC_KEY *eckey, point_conversion_form_t cform);
-int EC_KEY_set_private_key(EC_KEY *key, const BIGNUM *prv);
-int EC_KEY_generate_key(EC_KEY *key);
-int EC_KEY_up_ref(EC_KEY *r);
+EC_KEY *        EC_KEY_new(void);
+int             EC_KEY_set_group(EC_KEY *key, const EC_GROUP *group);
+void            EC_KEY_set_conv_form(EC_KEY *eckey, point_conversion_form_t cform);
+int             EC_KEY_set_private_key(EC_KEY *key, const BIGNUM *prv);
+int             EC_KEY_generate_key(EC_KEY *key);
+int             EC_KEY_up_ref(EC_KEY *r);
 const EC_GROUP *EC_KEY_get0_group(const EC_KEY *key);
-const BIGNUM *EC_KEY_get0_private_key(const EC_KEY *key);
-int EC_KEY_generate_key(EC_KEY *key);
-void EC_KEY_free(EC_KEY *key);
+const BIGNUM *  EC_KEY_get0_private_key(const EC_KEY *key);
+int             EC_KEY_generate_key(EC_KEY *key);
+void            EC_KEY_free(EC_KEY *key);
 
 EC_KEY *o2i_ECPublicKey(EC_KEY **key, const unsigned char **in, long len);
-int i2o_ECPublicKey(EC_KEY *key, unsigned char **out);
+int     i2o_ECPublicKey(EC_KEY *key, unsigned char **out);
 
-void ECDSA_SIG_get0(const ECDSA_SIG *sig, const BIGNUM **pr, const BIGNUM **ps);
-int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s);
-void ECDSA_SIG_free(ECDSA_SIG *sig);
+void       ECDSA_SIG_get0(const ECDSA_SIG *sig, const BIGNUM **pr, const BIGNUM **ps);
+int        ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s);
+void       ECDSA_SIG_free(ECDSA_SIG *sig);
 ECDSA_SIG *d2i_ECDSA_SIG(ECDSA_SIG **sig, const unsigned char **pp, long len);
-int i2d_ECDSA_SIG(const ECDSA_SIG *sig, unsigned char **pp);
+int        i2d_ECDSA_SIG(const ECDSA_SIG *sig, unsigned char **pp);
 
 #endif

--- a/tests/cbmc/include/openssl/evp.h
+++ b/tests/cbmc/include/openssl/evp.h
@@ -18,63 +18,57 @@
 #ifndef HEADER_EVP_H
 #define HEADER_EVP_H
 
-#include <stddef.h>
-
 #include <openssl/ec.h>
 #include <openssl/ossl_typ.h>
+#include <stddef.h>
 
 #define EVP_MAX_MD_SIZE 64  /* longest known is SHA512 */
 #define EVP_PKEY_HKDF 1036  // reference from obj_mac.h
 
-EVP_PKEY *EVP_PKEY_new(void);
-EC_KEY *EVP_PKEY_get0_EC_KEY(EVP_PKEY *pkey);
-int EVP_PKEY_set1_EC_KEY(EVP_PKEY *pkey, EC_KEY *key);
-void EVP_PKEY_free(EVP_PKEY *pkey);
+EVP_PKEY *    EVP_PKEY_new(void);
+EC_KEY *      EVP_PKEY_get0_EC_KEY(EVP_PKEY *pkey);
+int           EVP_PKEY_set1_EC_KEY(EVP_PKEY *pkey, EC_KEY *key);
+void          EVP_PKEY_free(EVP_PKEY *pkey);
 EVP_PKEY_CTX *EVP_PKEY_CTX_new(EVP_PKEY *pkey, ENGINE *e);
 EVP_PKEY_CTX *EVP_PKEY_CTX_new_id(int id, ENGINE *e);
-int EVP_PKEY_derive_init(EVP_PKEY_CTX *ctx);
-int EVP_PKEY_sign_init(EVP_PKEY_CTX *ctx);
-int EVP_PKEY_sign(EVP_PKEY_CTX *ctx, unsigned char *sig, size_t *siglen, const unsigned char *tbs, size_t tbslen);
+int           EVP_PKEY_derive_init(EVP_PKEY_CTX *ctx);
+int           EVP_PKEY_sign_init(EVP_PKEY_CTX *ctx);
+int  EVP_PKEY_sign(EVP_PKEY_CTX *ctx, unsigned char *sig, size_t *siglen, const unsigned char *tbs, size_t tbslen);
 void EVP_PKEY_CTX_free(EVP_PKEY_CTX *ctx);
-int EVP_PKEY_CTX_ctrl(EVP_PKEY_CTX *ctx, int keytype, int optype, int cmd, int p1, void *p2);
-int EVP_PKEY_derive(EVP_PKEY_CTX *ctx, unsigned char *key, size_t *keylen);
-int EVP_PKEY_encrypt_init(EVP_PKEY_CTX *ctx);
-int EVP_PKEY_decrypt_init(EVP_PKEY_CTX *ctx);
-int EVP_PKEY_CTX_set_rsa_padding(EVP_PKEY_CTX *ctx, int pad);
-int EVP_PKEY_CTX_set_rsa_oaep_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
-int EVP_PKEY_CTX_set_rsa_mgf1_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
-int EVP_PKEY_encrypt(EVP_PKEY_CTX *ctx, unsigned char *out, size_t *outlen, const unsigned char *in, size_t inlen);
-int EVP_PKEY_decrypt(EVP_PKEY_CTX *ctx, unsigned char *out, size_t *outlen, const unsigned char *in, size_t inlen);
+int  EVP_PKEY_CTX_ctrl(EVP_PKEY_CTX *ctx, int keytype, int optype, int cmd, int p1, void *p2);
+int  EVP_PKEY_derive(EVP_PKEY_CTX *ctx, unsigned char *key, size_t *keylen);
+int  EVP_PKEY_encrypt_init(EVP_PKEY_CTX *ctx);
+int  EVP_PKEY_decrypt_init(EVP_PKEY_CTX *ctx);
+int  EVP_PKEY_CTX_set_rsa_padding(EVP_PKEY_CTX *ctx, int pad);
+int  EVP_PKEY_CTX_set_rsa_oaep_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
+int  EVP_PKEY_CTX_set_rsa_mgf1_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
+int  EVP_PKEY_encrypt(EVP_PKEY_CTX *ctx, unsigned char *out, size_t *outlen, const unsigned char *in, size_t inlen);
+int  EVP_PKEY_decrypt(EVP_PKEY_CTX *ctx, unsigned char *out, size_t *outlen, const unsigned char *in, size_t inlen);
 
 EVP_MD_CTX *EVP_MD_CTX_new(void);
-int EVP_MD_CTX_size(const EVP_MD_CTX *ctx);
-void EVP_MD_CTX_free(EVP_MD_CTX *ctx);
-int EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl);
-int EVP_DigestUpdate(EVP_MD_CTX *ctx, const void *d, size_t cnt);
-int EVP_DigestFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s);
-int EVP_DigestFinal(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s);
-int EVP_DigestVerifyInit(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx, const EVP_MD *type, ENGINE *e, EVP_PKEY *pkey);
-int EVP_DigestVerifyFinal(EVP_MD_CTX *ctx, const unsigned char *sig, size_t siglen);
+int         EVP_MD_CTX_size(const EVP_MD_CTX *ctx);
+void        EVP_MD_CTX_free(EVP_MD_CTX *ctx);
+int         EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl);
+int         EVP_DigestUpdate(EVP_MD_CTX *ctx, const void *d, size_t cnt);
+int         EVP_DigestFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s);
+int         EVP_DigestFinal(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s);
+int         EVP_DigestVerifyInit(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx, const EVP_MD *type, ENGINE *e, EVP_PKEY *pkey);
+int         EVP_DigestVerifyFinal(EVP_MD_CTX *ctx, const unsigned char *sig, size_t siglen);
 
 EVP_CIPHER_CTX *EVP_CIPHER_CTX_new(void);
-int EVP_CipherInit_ex(
-    EVP_CIPHER_CTX *ctx,
-    const EVP_CIPHER *cipher,
-    ENGINE *impl,
-    const unsigned char *key,
-    const unsigned char *iv,
-    int enc);
-int EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr);
-void EVP_CIPHER_CTX_free(EVP_CIPHER_CTX *ctx);
-int EVP_EncryptInit_ex(
-    EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type, ENGINE *impl, const unsigned char *key, const unsigned char *iv);
-int EVP_DecryptInit_ex(
-    EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type, ENGINE *impl, const unsigned char *key, const unsigned char *iv);
-int EVP_CipherUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl);
-int EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl);
-int EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl);
-int EVP_EncryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl);
-int EVP_DecryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *outm, int *outl);
+int             EVP_CipherInit_ex(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *cipher, ENGINE *impl, const unsigned char *key,
+                                  const unsigned char *iv, int enc);
+int             EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr);
+void            EVP_CIPHER_CTX_free(EVP_CIPHER_CTX *ctx);
+int             EVP_EncryptInit_ex(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type, ENGINE *impl, const unsigned char *key,
+                                   const unsigned char *iv);
+int             EVP_DecryptInit_ex(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type, ENGINE *impl, const unsigned char *key,
+                                   const unsigned char *iv);
+int             EVP_CipherUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl);
+int             EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl);
+int             EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl);
+int             EVP_EncryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl);
+int             EVP_DecryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *outm, int *outl);
 
 #define EVP_MD_CTX_create() EVP_MD_CTX_new()
 #define EVP_MD_CTX_destroy(ctx) EVP_MD_CTX_free((ctx))
@@ -82,9 +76,9 @@ int EVP_DecryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *outm, int *outl);
 const EVP_CIPHER *EVP_aes_128_gcm(void);
 const EVP_CIPHER *EVP_aes_192_gcm(void);
 const EVP_CIPHER *EVP_aes_256_gcm(void);
-const EVP_MD *EVP_sha256(void);
-const EVP_MD *EVP_sha384(void);
-const EVP_MD *EVP_sha512(void);
+const EVP_MD *    EVP_sha256(void);
+const EVP_MD *    EVP_sha384(void);
+const EVP_MD *    EVP_sha512(void);
 
 int EVP_MD_size(const EVP_MD *md);
 

--- a/tests/cbmc/include/openssl/ffc.h
+++ b/tests/cbmc/include/openssl/ffc.h
@@ -18,7 +18,7 @@
 #include <openssl/bn.h>
 
 #ifndef OSSL_INTERNAL_FFC_H
-# define OSSL_INTERNAL_FFC_H
+#    define OSSL_INTERNAL_FFC_H
 
 typedef struct ffc_params_st {
     /* Primes */

--- a/tests/cbmc/include/openssl/hmac.h
+++ b/tests/cbmc/include/openssl/hmac.h
@@ -22,10 +22,10 @@
 
 struct hmac_ctx_st {
     const EVP_MD *md;
-    EVP_MD_CTX *md_ctx;
-    EVP_MD_CTX *i_ctx;
-    EVP_MD_CTX *o_ctx;
-    bool is_initialized;
+    EVP_MD_CTX *  md_ctx;
+    EVP_MD_CTX *  i_ctx;
+    EVP_MD_CTX *  o_ctx;
+    bool          is_initialized;
 };
 
 #endif

--- a/tests/cbmc/include/openssl/kdf.h
+++ b/tests/cbmc/include/openssl/kdf.h
@@ -48,16 +48,16 @@ extern "C" {
 #define EVP_PKEY_HKDEF_MODE_EXPAND_ONLY EVP_KDF_HKDF_MODE_EXPAND_ONLY
 
 #define EVP_PKEY_CTX_set_hkdf_md(pctx, md) \
-    EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, EVP_PKEY_CTRL_HKDF_MD, 0, (void *)(md))
+    EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, EVP_PKEY_CTRL_HKDF_MD, 0, ( void * )(md))
 
 #define EVP_PKEY_CTX_set1_hkdf_salt(pctx, salt, saltlen) \
-    EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, EVP_PKEY_CTRL_HKDF_SALT, saltlen, (void *)(salt))
+    EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, EVP_PKEY_CTRL_HKDF_SALT, saltlen, ( void * )(salt))
 
 #define EVP_PKEY_CTX_set1_hkdf_key(pctx, key, keylen) \
-    EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, EVP_PKEY_CTRL_HKDF_KEY, keylen, (void *)(key))
+    EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, EVP_PKEY_CTRL_HKDF_KEY, keylen, ( void * )(key))
 
 #define EVP_PKEY_CTX_add1_hkdf_info(pctx, info, infolen) \
-    EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, EVP_PKEY_CTRL_HKDF_INFO, infolen, (void *)(info))
+    EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, EVP_PKEY_CTRL_HKDF_INFO, infolen, ( void * )(info))
 
 #define EVP_PKEY_CTX_hkdf_mode(pctx, mode) \
     EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, EVP_PKEY_CTRL_HKDF_MODE, mode, NULL)

--- a/tests/cbmc/include/openssl/md5.h
+++ b/tests/cbmc/include/openssl/md5.h
@@ -16,7 +16,7 @@
  */
 
 #ifndef HEADER_MD5_H
-# define HEADER_MD5_H
+#define HEADER_MD5_H
 
 /*
  * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -26,10 +26,10 @@
  */
 
 #if defined(__LP32__)
-#define MD5_LONG unsigned long
+#    define MD5_LONG unsigned long
 #elif defined(OPENSSL_SYS_CRAY) || defined(__ILP64__)
-#define MD5_LONG unsigned long
-#define MD5_LONG_LOG2 3
+#    define MD5_LONG unsigned long
+#    define MD5_LONG_LOG2 3
 /*
  * _CRAY note. I could declare short, but I have no idea what impact
  * does it have on performance on none-T3E machines. I could declare
@@ -38,19 +38,18 @@
  *					<appro@fy.chalmers.se>
  */
 #else
-#define MD5_LONG unsigned int
+#    define MD5_LONG unsigned int
 #endif
 
-#define MD5_CBLOCK	64
-#define MD5_LBLOCK	(MD5_CBLOCK/4)
+#define MD5_CBLOCK 64
+#define MD5_LBLOCK (MD5_CBLOCK / 4)
 #define MD5_DIGEST_LENGTH 16
 
-typedef struct MD5state_st
-	{
-	MD5_LONG A,B,C,D;
-	MD5_LONG Nl,Nh;
-	MD5_LONG data[MD5_LBLOCK];
-	unsigned int num;
-	} MD5_CTX;
+typedef struct MD5state_st {
+    MD5_LONG     A, B, C, D;
+    MD5_LONG     Nl, Nh;
+    MD5_LONG     data[ MD5_LBLOCK ];
+    unsigned int num;
+} MD5_CTX;
 
 #endif

--- a/tests/cbmc/include/openssl/ossl_typ.h
+++ b/tests/cbmc/include/openssl/ossl_typ.h
@@ -28,26 +28,27 @@ typedef struct asn1_string_st ASN1_STRING;
 #ifdef BIGNUM
 #    undef BIGNUM
 #endif
-typedef struct bio_st BIO;
+typedef struct bio_st    BIO;
 typedef struct bignum_st BIGNUM;
 
-typedef struct dh_st DH;
+typedef struct dh_st     DH;
 typedef struct dh_method DH_METHOD;
 
 typedef struct ec_key_st EC_KEY;
 
 typedef struct evp_pkey_ctx_st EVP_PKEY_CTX;
-typedef struct hmac_ctx_st HMAC_CTX;
+typedef struct hmac_ctx_st     HMAC_CTX;
 
-typedef struct evp_cipher_st EVP_CIPHER;
+typedef struct evp_cipher_st     EVP_CIPHER;
 typedef struct evp_cipher_ctx_st EVP_CIPHER_CTX;
-typedef struct evp_md_st EVP_MD;
-typedef struct evp_md_ctx_st EVP_MD_CTX;
-typedef struct evp_pkey_st EVP_PKEY;
+typedef struct evp_md_st         EVP_MD;
+typedef struct evp_md_ctx_st     EVP_MD_CTX;
+typedef struct evp_pkey_st       EVP_PKEY;
 
 typedef struct engine_st ENGINE;
 
 /* This empty definition is required for BIGNUM to function properly in CBMC. */
-struct bignum_st{};
+struct bignum_st {
+};
 
 #endif

--- a/tests/cbmc/include/openssl/sha.h
+++ b/tests/cbmc/include/openssl/sha.h
@@ -16,7 +16,7 @@
  */
 
 #ifndef HEADER_SHA_H
-# define HEADER_SHA_H
+#define HEADER_SHA_H
 
 /*
  * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -26,76 +26,76 @@
  */
 
 #if defined(__LP32__)
-#define SHA_LONG unsigned long
+#    define SHA_LONG unsigned long
 #elif defined(OPENSSL_SYS_CRAY) || defined(__ILP64__)
-#define SHA_LONG unsigned long
-#define SHA_LONG_LOG2 3
+#    define SHA_LONG unsigned long
+#    define SHA_LONG_LOG2 3
 #else
-#define SHA_LONG unsigned int
+#    define SHA_LONG unsigned int
 #endif
 
-#define SHA_LBLOCK	16
-#define SHA_CBLOCK	(SHA_LBLOCK*4)	/* SHA treats input data as a
+#define SHA_LBLOCK 16
+#define SHA_CBLOCK \
+    (SHA_LBLOCK * 4) /* SHA treats input data as a
 					 * contiguous array of 32 bit
 					 * wide big-endian values. */
-#define SHA_LAST_BLOCK  (SHA_CBLOCK-8)
+#define SHA_LAST_BLOCK (SHA_CBLOCK - 8)
 #define SHA_DIGEST_LENGTH 20
 
-typedef struct SHAstate_st
-	{
-	SHA_LONG h0,h1,h2,h3,h4;
-	SHA_LONG Nl,Nh;
-	SHA_LONG data[SHA_LBLOCK];
-	unsigned int num;
-	} SHA_CTX;
+typedef struct SHAstate_st {
+    SHA_LONG     h0, h1, h2, h3, h4;
+    SHA_LONG     Nl, Nh;
+    SHA_LONG     data[ SHA_LBLOCK ];
+    unsigned int num;
+} SHA_CTX;
 
-  #define SHA256_CBLOCK	(SHA_LBLOCK*4)	/* SHA-256 treats input data as a
+#define SHA256_CBLOCK \
+    (SHA_LBLOCK * 4) /* SHA-256 treats input data as a
   					 * contiguous array of 32 bit
   					 * wide big-endian values. */
-  #define SHA224_DIGEST_LENGTH	28
-  #define SHA256_DIGEST_LENGTH	32
+#define SHA224_DIGEST_LENGTH 28
+#define SHA256_DIGEST_LENGTH 32
 
-  typedef struct SHA256state_st
-  	{
-  	SHA_LONG h[8];
-  	SHA_LONG Nl,Nh;
-  	SHA_LONG data[SHA_LBLOCK];
-  	unsigned int num,md_len;
-  	} SHA256_CTX;
+typedef struct SHA256state_st {
+    SHA_LONG     h[ 8 ];
+    SHA_LONG     Nl, Nh;
+    SHA_LONG     data[ SHA_LBLOCK ];
+    unsigned int num, md_len;
+} SHA256_CTX;
 
-    #define SHA384_DIGEST_LENGTH	48
-    #define SHA512_DIGEST_LENGTH	64
+#define SHA384_DIGEST_LENGTH 48
+#define SHA512_DIGEST_LENGTH 64
 
-    #ifndef OPENSSL_NO_SHA512
-    /*
+#ifndef OPENSSL_NO_SHA512
+/*
      * Unlike 32-bit digest algorithms, SHA-512 *relies* on SHA_LONG64
      * being exactly 64-bit wide. See Implementation Notes in sha512.c
      * for further details.
      */
-    #define SHA512_CBLOCK	(SHA_LBLOCK*8)	/* SHA-512 treats input data as a
+#    define SHA512_CBLOCK \
+        (SHA_LBLOCK * 8) /* SHA-512 treats input data as a
     					 * contiguous array of 64 bit
     					 * wide big-endian values. */
-    #if (defined(_WIN32) || defined(_WIN64)) && !defined(__MINGW32__)
-    #define SHA_LONG64 unsigned __int64
-    #define U64(C)     C##UI64
-    #elif defined(__arch64__)
-    #define SHA_LONG64 unsigned long
-    #define U64(C)     C##UL
-    #else
-    #define SHA_LONG64 unsigned long long
-    #define U64(C)     C##ULL
-    #endif
+#    if (defined(_WIN32) || defined(_WIN64)) && !defined(__MINGW32__)
+#        define SHA_LONG64 unsigned __int64
+#        define U64(C) C##UI64
+#    elif defined(__arch64__)
+#        define SHA_LONG64 unsigned long
+#        define U64(C) C##UL
+#    else
+#        define SHA_LONG64 unsigned long long
+#        define U64(C) C##ULL
+#    endif
 
-    typedef struct SHA512state_st
-    	{
-    	SHA_LONG64 h[8];
-    	SHA_LONG64 Nl,Nh;
-    	union {
-    		SHA_LONG64	d[SHA_LBLOCK];
-    		unsigned char	p[SHA512_CBLOCK];
-    	} u;
-    	unsigned int num,md_len;
-    	} SHA512_CTX;
-    #endif
+typedef struct SHA512state_st {
+    SHA_LONG64 h[ 8 ];
+    SHA_LONG64 Nl, Nh;
+    union {
+        SHA_LONG64    d[ SHA_LBLOCK ];
+        unsigned char p[ SHA512_CBLOCK ];
+    } u;
+    unsigned int num, md_len;
+} SHA512_CTX;
+#endif
 
 #endif

--- a/tests/cbmc/proofs/s2n_add_overflow/s2n_add_overflow_harness.c
+++ b/tests/cbmc/proofs/s2n_add_overflow/s2n_add_overflow_harness.c
@@ -13,22 +13,22 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
 #include "api/s2n.h"
 #include "utils/s2n_safety.h"
 
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
-#include <cbmc_proof/make_common_datastructures.h>
-
 int s2n_add_overflow_harness()
 {
-    uint32_t a;
-    uint32_t b;
+    uint32_t  a;
+    uint32_t  b;
     uint32_t *out = can_fail_malloc(sizeof(uint32_t));
 
     if (s2n_add_overflow(a, b, out) == S2N_SUCCESS) {
         assert(*out == a + b);
     } else {
-        assert((uint64_t) a + (uint64_t) b > UINT32_MAX || out == NULL);
+        assert(( uint64_t )a + ( uint64_t )b > UINT32_MAX || out == NULL);
     }
 }

--- a/tests/cbmc/proofs/s2n_align_to/s2n_align_to_harness.c
+++ b/tests/cbmc/proofs/s2n_align_to/s2n_align_to_harness.c
@@ -13,12 +13,12 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
 #include "api/s2n.h"
 #include "utils/s2n_safety.h"
-
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
-#include <cbmc_proof/make_common_datastructures.h>
 
 int s2n_align_to_harness()
 {
@@ -27,19 +27,19 @@ int s2n_align_to_harness()
     /* Division and modulo are too slow in CBMC to perform all necessary checks,
      * so relevant assertions that can't be used currently have been left in comments. */
     uint32_t *out = can_fail_malloc(sizeof(uint32_t));
- /* uint64_t result = (uint64_t) alignment * ((((uint64_t) initial - 1) / (uint64_t) alignment) + 1); */
+    /* uint64_t result = (uint64_t) alignment * ((((uint64_t) initial - 1) / (uint64_t) alignment) + 1); */
 
     if (s2n_align_to(initial, alignment, out) == S2N_SUCCESS) {
         if (initial == 0) {
             assert(*out == 0);
         } else {
-         /* assert(*out >= initial); */
-         /* assert(*out < (uint64_t) initial + (uint64_t) alignment); */
-         /* assert(result <= UINT32_MAX); */
-         /* assert(*out % alignment == 0); */
+            /* assert(*out >= initial); */
+            /* assert(*out < (uint64_t) initial + (uint64_t) alignment); */
+            /* assert(result <= UINT32_MAX); */
+            /* assert(*out % alignment == 0); */
         }
     } else {
-     /* assert(*out % alignment != 0 || out == NULL); */
-     /* assert(result > UINT32_MAX || out == NULL); */
+        /* assert(*out % alignment != 0 || out == NULL); */
+        /* assert(result > UINT32_MAX || out == NULL); */
     }
 }

--- a/tests/cbmc/proofs/s2n_blob_char_to_lower/s2n_blob_char_to_lower_harness.c
+++ b/tests/cbmc/proofs/s2n_blob_char_to_lower/s2n_blob_char_to_lower_harness.c
@@ -13,13 +13,13 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "utils/s2n_blob.h"
-
 #include <assert.h>
 #include <cbmc_proof/cbmc_utils.h>
-#include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+#include "api/s2n.h"
+#include "utils/s2n_blob.h"
 
 void s2n_blob_char_to_lower_harness()
 {
@@ -29,16 +29,15 @@ void s2n_blob_char_to_lower_harness()
     __CPROVER_assume(s2n_blob_is_bounded(blob, BLOB_SIZE));
 
     /* Save previous state. */
-    struct s2n_blob old_blob = *blob;
+    struct s2n_blob               old_blob = *blob;
     struct store_byte_from_buffer old_byte_from_blob;
     save_byte_from_blob(blob, &old_byte_from_blob);
 
     /* Operation under verification. */
-    if(s2n_blob_char_to_lower(blob) == S2N_SUCCESS) {
-        if (blob->size != 0){
-            if(old_byte_from_blob.byte >= 'A' && old_byte_from_blob.byte <= 'Z')
-            {
-                assert(blob->data[old_byte_from_blob.index] == (old_byte_from_blob.byte + ('a' - 'A')));
+    if (s2n_blob_char_to_lower(blob) == S2N_SUCCESS) {
+        if (blob->size != 0) {
+            if (old_byte_from_blob.byte >= 'A' && old_byte_from_blob.byte <= 'Z') {
+                assert(blob->data[ old_byte_from_blob.index ] == (old_byte_from_blob.byte + ('a' - 'A')));
             }
         }
     }

--- a/tests/cbmc/proofs/s2n_blob_init/s2n_blob_init_harness.c
+++ b/tests/cbmc/proofs/s2n_blob_init/s2n_blob_init_harness.c
@@ -13,27 +13,24 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "utils/s2n_blob.h"
-#include "error/s2n_errno.h"
-
 #include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+#include "api/s2n.h"
+#include "error/s2n_errno.h"
+#include "utils/s2n_blob.h"
 
 void s2n_blob_init_harness()
 {
     /* Non-deterministic inputs. */
-    struct s2n_blob * blob = can_fail_malloc( sizeof( *blob ) );
-    uint32_t size;
-    uint8_t * data = can_fail_malloc( size );
+    struct s2n_blob *blob = can_fail_malloc(sizeof(*blob));
+    uint32_t         size;
+    uint8_t *        data = can_fail_malloc(size);
 
     /* Pre-conditions. */
     __CPROVER_assume(S2N_IMPLIES(size != 0, data != NULL));
 
     /* Operation under verification. */
-    if( s2n_blob_init( blob, data, size ) == S2N_SUCCESS )
-    {
-        assert( s2n_blob_is_valid( blob ) );
-    }
+    if (s2n_blob_init(blob, data, size) == S2N_SUCCESS) { assert(s2n_blob_is_valid(blob)); }
 }

--- a/tests/cbmc/proofs/s2n_blob_is_growable/s2n_blob_is_growable_harness.c
+++ b/tests/cbmc/proofs/s2n_blob_is_growable/s2n_blob_is_growable_harness.c
@@ -13,27 +13,25 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
 #include "api/s2n.h"
 #include "error/s2n_errno.h"
 #include "utils/s2n_blob.h"
 
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
-#include <cbmc_proof/make_common_datastructures.h>
-
-void s2n_blob_is_growable_harness() {
+void s2n_blob_is_growable_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_blob *blob = cbmc_allocate_s2n_blob();
-    __CPROVER_assume(S2N_IMPLIES(blob!= NULL, s2n_blob_is_valid(blob)));
+    __CPROVER_assume(S2N_IMPLIES(blob != NULL, s2n_blob_is_valid(blob)));
 
     /* Operation under verification. */
-    if(s2n_blob_is_growable(blob)) {
-        assert(blob->growable ||
-		           (blob->data == NULL &&
-		            blob->size == 0 &&
-		            blob->allocated == 0));
+    if (s2n_blob_is_growable(blob)) {
+        assert(blob->growable || (blob->data == NULL && blob->size == 0 && blob->allocated == 0));
     }
 
     /* Post-condition. */
-    if(blob != NULL) assert(s2n_blob_is_valid(blob));
+    if (blob != NULL) assert(s2n_blob_is_valid(blob));
 }

--- a/tests/cbmc/proofs/s2n_blob_slice/s2n_blob_slice_harness.c
+++ b/tests/cbmc/proofs/s2n_blob_slice/s2n_blob_slice_harness.c
@@ -13,13 +13,13 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "utils/s2n_blob.h"
-
 #include <assert.h>
 #include <cbmc_proof/cbmc_utils.h>
-#include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+#include "api/s2n.h"
+#include "utils/s2n_blob.h"
 
 void s2n_blob_slice_harness()
 {
@@ -32,20 +32,20 @@ void s2n_blob_slice_harness()
     uint32_t size;
 
     /* Save previous state. */
-    struct s2n_blob old_blob = *blob;
+    struct s2n_blob               old_blob = *blob;
     struct store_byte_from_buffer old_byte_from_blob;
     save_byte_from_blob(blob, &old_byte_from_blob);
-    struct s2n_blob old_slice = *slice;
+    struct s2n_blob               old_slice = *slice;
     struct store_byte_from_buffer old_byte_from_slice;
     save_byte_from_blob(slice, &old_byte_from_slice);
 
     /* Operation under verification. */
-    if(s2n_blob_slice(blob, slice, offset, size) == S2N_SUCCESS) {
+    if (s2n_blob_slice(blob, slice, offset, size) == S2N_SUCCESS) {
         assert(blob->size >= offset + size);
         assert(slice->size == size);
         assert(slice->growable == 0);
         assert(slice->allocated == 0);
-        assert_bytes_match(blob->data+offset, slice->data, slice->size);
+        assert_bytes_match(blob->data + offset, slice->data, slice->size);
     } else {
         assert_blob_equivalence(slice, &old_slice, &old_byte_from_slice);
     }

--- a/tests/cbmc/proofs/s2n_blob_zero/s2n_blob_zero_harness.c
+++ b/tests/cbmc/proofs/s2n_blob_zero/s2n_blob_zero_harness.c
@@ -13,13 +13,13 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "utils/s2n_blob.h"
-
 #include <assert.h>
 #include <cbmc_proof/cbmc_utils.h>
-#include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+#include "api/s2n.h"
+#include "utils/s2n_blob.h"
 
 void s2n_blob_zero_harness()
 {
@@ -28,9 +28,6 @@ void s2n_blob_zero_harness()
     __CPROVER_assume(s2n_blob_is_valid(blob));
 
     /* Operation under verification. */
-    if(s2n_blob_zero(blob) == S2N_SUCCESS && blob->size != 0)
-    {
-        assert_all_zeroes(blob->data, blob->size);
-    }
+    if (s2n_blob_zero(blob) == S2N_SUCCESS && blob->size != 0) { assert_all_zeroes(blob->data, blob->size); }
     assert(s2n_blob_is_valid(blob));
 }

--- a/tests/cbmc/proofs/s2n_blob_zeroize_free/s2n_blob_zeroize_free_harness.c
+++ b/tests/cbmc/proofs/s2n_blob_zeroize_free/s2n_blob_zeroize_free_harness.c
@@ -13,23 +13,21 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "utils/s2n_blob.h"
-#include "error/s2n_errno.h"
-
 #include <assert.h>
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
 
-void s2n_blob_zeroize_free_harness() {
+#include "api/s2n.h"
+#include "error/s2n_errno.h"
+#include "utils/s2n_blob.h"
+
+void s2n_blob_zeroize_free_harness()
+{
     struct s2n_blob *blob = cbmc_allocate_s2n_blob();
     __CPROVER_assume(s2n_blob_is_valid(blob));
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
     const struct s2n_blob old_blob = *blob;
 
@@ -37,8 +35,8 @@ void s2n_blob_zeroize_free_harness() {
         /* If the call worked, assert all bytes in the blob struct
            are zero */
         assert_all_zeroes(blob->data, old_blob.size);
-        if(old_blob.size != 0 && s2n_blob_is_growable(&old_blob)) {
-            assert(!S2N_MEM_IS_READABLE(blob->data,old_blob.size));
+        if (old_blob.size != 0 && s2n_blob_is_growable(&old_blob)) {
+            assert(!S2N_MEM_IS_READABLE(blob->data, old_blob.size));
         }
     }
 }

--- a/tests/cbmc/proofs/s2n_constant_time_copy_or_dont/s2n_constant_time_copy_or_dont_harness.c
+++ b/tests/cbmc/proofs/s2n_constant_time_copy_or_dont/s2n_constant_time_copy_or_dont_harness.c
@@ -13,27 +13,27 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <sys/param.h>
+
 #include "api/s2n.h"
 #include "utils/s2n_safety.h"
 
-#include <sys/param.h>
-#include <assert.h>
-
-#include <cbmc_proof/proof_allocators.h>
-
-void s2n_constant_time_copy_or_dont_harness() {
+void s2n_constant_time_copy_or_dont_harness()
+{
     /* Non-deterministic inputs. */
     const uint32_t len;
     const uint32_t destlen;
     const uint32_t srclen;
-    const uint8_t dont;
+    const uint8_t  dont;
     __CPROVER_assume(len < MAX_ARR_LEN);
     __CPROVER_assume(destlen >= len);
     __CPROVER_assume(srclen >= len);
-    uint8_t * dest = can_fail_malloc(destlen);
-    uint8_t * src = can_fail_malloc(srclen);
-    uint8_t old_src_byte;
-    uint8_t old_dest_byte;
+    uint8_t *dest = can_fail_malloc(destlen);
+    uint8_t *src  = can_fail_malloc(srclen);
+    uint8_t  old_src_byte;
+    uint8_t  old_dest_byte;
     uint32_t index;
 
     /* Pre-conditions. */
@@ -41,29 +41,23 @@ void s2n_constant_time_copy_or_dont_harness() {
         __CPROVER_assume(dest != NULL);
         __CPROVER_assume(src != NULL);
         __CPROVER_assume(index < len);
-        old_src_byte = src[index];
-        old_dest_byte = dest[index];
+        old_src_byte  = src[ index ];
+        old_dest_byte = dest[ index ];
     }
 
     s2n_constant_time_copy_or_dont(dest, src, len, dont);
 
     if (dont == 0) {
         if (src != NULL) {
-            if (len != 0) {
-                assert(src[index] == old_src_byte);
-            }
-            if(dest != NULL) {
+            if (len != 0) { assert(src[ index ] == old_src_byte); }
+            if (dest != NULL) {
                 uint32_t rand;
                 __CPROVER_assume(rand < len);
-                assert(dest[rand] == src[rand]);
+                assert(dest[ rand ] == src[ rand ]);
             }
         }
     } else {
-        if (src != NULL && len != 0) {
-            assert(src[index] == old_src_byte);
-        }
-        if (dest != NULL && len != 0) {
-            assert(dest[index] == old_dest_byte);
-        }
+        if (src != NULL && len != 0) { assert(src[ index ] == old_src_byte); }
+        if (dest != NULL && len != 0) { assert(dest[ index ] == old_dest_byte); }
     }
 }

--- a/tests/cbmc/proofs/s2n_constant_time_pkcs1_unpad_or_dont/s2n_constant_time_pkcs1_unpad_or_dont_harness.c
+++ b/tests/cbmc/proofs/s2n_constant_time_pkcs1_unpad_or_dont/s2n_constant_time_pkcs1_unpad_or_dont_harness.c
@@ -13,29 +13,29 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <sys/param.h>
+
 #include "api/s2n.h"
 #include "utils/s2n_safety.h"
 
-#include <sys/param.h>
-#include <assert.h>
-
-#include <cbmc_proof/proof_allocators.h>
-
-void s2n_constant_time_pkcs1_unpad_or_dont_harness() {
+void s2n_constant_time_pkcs1_unpad_or_dont_harness()
+{
     /* Non-deterministic inputs. */
     const uint32_t len;
     const uint32_t destlen;
     const uint32_t srclen;
-    const uint8_t dont;
+    const uint8_t  dont;
     __CPROVER_assume(len < MAX_ARR_LEN);
     __CPROVER_assume(destlen >= len);
 
     /* This bound is required for our loop unwindings to be reasonably bound. */
     __CPROVER_assume(srclen >= len + 1 && srclen <= BOUND);
-    uint8_t * dest = can_fail_malloc(destlen);
-    uint8_t * src = can_fail_malloc(srclen);
-    uint8_t old_src_byte;
-    uint8_t old_dest_byte;
+    uint8_t *dest = can_fail_malloc(destlen);
+    uint8_t *src  = can_fail_malloc(srclen);
+    uint8_t  old_src_byte;
+    uint8_t  old_dest_byte;
     uint32_t index;
 
     /* Pre-conditions. */
@@ -43,8 +43,8 @@ void s2n_constant_time_pkcs1_unpad_or_dont_harness() {
     __CPROVER_assume(src != NULL);
     if (len != 0) {
         __CPROVER_assume(index < len);
-        old_src_byte = src[srclen - len + index];
-        old_dest_byte = dest[index];
+        old_src_byte  = src[ srclen - len + index ];
+        old_dest_byte = dest[ index ];
     }
 
     s2n_constant_time_pkcs1_unpad_or_dont(dest, src, srclen, len);
@@ -52,17 +52,16 @@ void s2n_constant_time_pkcs1_unpad_or_dont_harness() {
     if (len != 0) {
         bool has_zero = false;
         for (uint32_t i = 2; i < srclen - len - 1; i++) {
-            if(src[i] == 0x00) {
-                has_zero = true;
-            }
+            if (src[ i ] == 0x00) { has_zero = true; }
         }
 
         /* This statement is the inverse of the failure checks found in s2n_constant_time_pkcs1_unpad_or_dont. */
-        if (srclen >= (len + 3) && src[0] == 0x00 && src[1] == 0x02 && src[srclen - len - 1] == 0x00 && has_zero == false) {
-            assert(dest[index] == old_src_byte);
+        if (srclen >= (len + 3) && src[ 0 ] == 0x00 && src[ 1 ] == 0x02 && src[ srclen - len - 1 ] == 0x00
+            && has_zero == false) {
+            assert(dest[ index ] == old_src_byte);
         } else {
-            assert(dest[index] == old_dest_byte);
+            assert(dest[ index ] == old_dest_byte);
         }
-        assert(src[srclen - len + index] == old_src_byte);
+        assert(src[ srclen - len + index ] == old_src_byte);
     }
 }

--- a/tests/cbmc/proofs/s2n_dup/s2n_dup_harness.c
+++ b/tests/cbmc/proofs/s2n_dup/s2n_dup_harness.c
@@ -13,13 +13,13 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "utils/s2n_blob.h"
-
 #include <assert.h>
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
+
+#include "api/s2n.h"
+#include "utils/s2n_blob.h"
 
 /*
  * There's unreachable code in the CBMC output because s2n_dup calls
@@ -28,19 +28,18 @@
  * many branches of s2n_realloc cannot be executed. This is intentional behavior.
  */
 
-void s2n_dup_harness() {
+void s2n_dup_harness()
+{
     struct s2n_blob *from = cbmc_allocate_s2n_blob();
-    struct s2n_blob *to = cbmc_allocate_s2n_blob();
+    struct s2n_blob *to   = cbmc_allocate_s2n_blob();
     __CPROVER_assume(s2n_blob_is_valid(from));
     __CPROVER_assume(s2n_blob_is_valid(to));
-    const struct s2n_blob old_from = *from;
-    const struct s2n_blob old_to = *to;
+    const struct s2n_blob         old_from = *from;
+    const struct s2n_blob         old_to   = *to;
     struct store_byte_from_buffer old_byte;
     save_byte_from_blob(from, &old_byte);
     /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if (nondet_bool()) {
-        s2n_mem_init();
-    }
+    if (nondet_bool()) { s2n_mem_init(); }
 
     if (s2n_dup(from, to) == S2N_SUCCESS) {
         assert(old_from.size != 0);
@@ -51,7 +50,7 @@ void s2n_dup_harness() {
 
         uint32_t index;
         __CPROVER_assume(index < from->size);
-        assert(from->data[index] == to->data[index]);
+        assert(from->data[ index ] == to->data[ index ]);
     }
     assert(s2n_blob_is_valid(from));
     assert(s2n_blob_is_valid(to));

--- a/tests/cbmc/proofs/s2n_free/s2n_free_harness.c
+++ b/tests/cbmc/proofs/s2n_free/s2n_free_harness.c
@@ -13,23 +13,20 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "utils/s2n_blob.h"
-
 #include <assert.h>
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
 
-void s2n_free_harness() {
+#include "api/s2n.h"
+#include "utils/s2n_blob.h"
+
+void s2n_free_harness()
+{
     struct s2n_blob *blob = cbmc_allocate_s2n_blob();
+    __CPROVER_assume(s2n_blob_is_valid(blob));
 
-    __CPROVER_assume(s2n_blob_is_valid( blob ));
-
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
     struct s2n_blob old_blob = *blob;
 
@@ -46,8 +43,7 @@ void s2n_free_harness() {
     if (old_blob.size > 0 && old_blob.data != NULL) {
         size_t i;
         __CPROVER_assume(i < old_blob.size);
-        assert(old_blob.data[i] == 0);
+        assert(old_blob.data[ i ] == 0);
     }
 #pragma CPROVER check pop
-
 }

--- a/tests/cbmc/proofs/s2n_free_object/s2n_free_object_harness.c
+++ b/tests/cbmc/proofs/s2n_free_object/s2n_free_object_harness.c
@@ -13,26 +13,22 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-
 #include <assert.h>
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
 
-void s2n_free_object_harness() {
+#include "api/s2n.h"
+
+void s2n_free_object_harness()
+{
     uint32_t size;
-    uint8_t * data = can_fail_malloc( size );
-    uint8_t * old_data = data;
+    uint8_t *data     = can_fail_malloc(size);
+    uint8_t *old_data = data;
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
-    if (s2n_free_object(&data, size) == S2N_SUCCESS) {
-        assert(data == NULL);
-    }
+    if (s2n_free_object(&data, size) == S2N_SUCCESS) { assert(data == NULL); }
 
 #pragma CPROVER check push
 #pragma CPROVER check disable "pointer"
@@ -40,7 +36,7 @@ void s2n_free_object_harness() {
     if (size > 0 && old_data != NULL) {
         size_t i;
         __CPROVER_assume(i < size);
-        assert(old_data[i] == 0);
+        assert(old_data[ i ] == 0);
     }
 #pragma CPROVER check pop
 }

--- a/tests/cbmc/proofs/s2n_hex_string_to_bytes/s2n_hex_string_to_bytes_harness.c
+++ b/tests/cbmc/proofs/s2n_hex_string_to_bytes/s2n_hex_string_to_bytes_harness.c
@@ -13,14 +13,14 @@
  * permissions and limitations under the License.
  */
 
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <string.h>
+
 #include "api/s2n.h"
 #include "error/s2n_errno.h"
 #include "utils/s2n_blob.h"
-
-#include <cbmc_proof/cbmc_utils.h>
-#include <cbmc_proof/proof_allocators.h>
-#include <cbmc_proof/make_common_datastructures.h>
-#include <string.h>
 
 void s2n_hex_string_to_bytes_harness()
 {
@@ -30,12 +30,12 @@ void s2n_hex_string_to_bytes_harness()
     char *str = ensure_c_str_is_allocated(MAX_STRING_LEN);
 
     /* Save previous state. */
-    struct s2n_blob old_blob = *blob;
+    struct s2n_blob               old_blob = *blob;
     struct store_byte_from_buffer old_byte_from_blob;
     save_byte_from_blob(blob, &old_byte_from_blob);
 
     /* Operation under verification. */
-    if(s2n_hex_string_to_bytes(str, blob) == S2N_SUCCESS) {
+    if (s2n_hex_string_to_bytes(str, blob) == S2N_SUCCESS) {
         size_t strLength = strlen(str);
         assert(blob->size >= (strLength / 2));
         assert(strLength % 2 == 0);

--- a/tests/cbmc/proofs/s2n_is_base64_char/s2n_is_base64_char_harness.c
+++ b/tests/cbmc/proofs/s2n_is_base64_char/s2n_is_base64_char_harness.c
@@ -13,17 +13,15 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-
-#include "stuffer/s2n_stuffer.h"
-
 #include <assert.h>
 
-void s2n_is_base64_char_harness() {
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+void s2n_is_base64_char_harness()
+{
     unsigned char c;
-    bool is_base_64 = ('A' <= c && c <= 'Z') ||
-                      ('a' <= c && c <= 'z') ||
-                      ('0' <= c && c <= '9') ||
-                      c == '+' || c == '/' || c == '=';
+    bool          is_base_64 =
+        ('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z') || ('0' <= c && c <= '9') || c == '+' || c == '/' || c == '=';
     assert(is_base_64 == s2n_is_base64_char(c));
 }

--- a/tests/cbmc/proofs/s2n_mem_cleanup/s2n_mem_cleanup_harness.c
+++ b/tests/cbmc/proofs/s2n_mem_cleanup/s2n_mem_cleanup_harness.c
@@ -13,21 +13,18 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "utils/s2n_blob.h"
-#include "utils/s2n_mem.h"
-
 #include <assert.h>
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
 
-void s2n_mem_cleanup_harness() {
+#include "api/s2n.h"
+#include "utils/s2n_blob.h"
+#include "utils/s2n_mem.h"
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+void s2n_mem_cleanup_harness()
+{
+    nondet_s2n_mem_init();
 
     bool old_init = s2n_mem_is_init();
 

--- a/tests/cbmc/proofs/s2n_mem_init/s2n_mem_init_harness.c
+++ b/tests/cbmc/proofs/s2n_mem_init/s2n_mem_init_harness.c
@@ -13,15 +13,15 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
+
 #include "api/s2n.h"
 #include "utils/s2n_mem.h"
-
-#include <assert.h>
 
 void s2n_mem_init_harness()
 {
     /* Operation under verification. */
-    if( s2n_mem_init( ) == S2N_SUCCESS ) {
+    if (s2n_mem_init() == S2N_SUCCESS) {
         assert(s2n_mem_is_init());
         assert(s2n_mem_get_page_size() > 0);
         assert(s2n_mem_get_page_size() <= UINT32_MAX);

--- a/tests/cbmc/proofs/s2n_mul_overflow_harness/s2n_mul_overflow_harness.c
+++ b/tests/cbmc/proofs/s2n_mul_overflow_harness/s2n_mul_overflow_harness.c
@@ -13,17 +13,17 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
 #include "api/s2n.h"
 #include "utils/s2n_safety.h"
 
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
-#include <cbmc_proof/make_common_datastructures.h>
-
 int s2n_mul_overflow_harness()
 {
-    uint32_t a;
-    uint32_t b;
+    uint32_t  a;
+    uint32_t  b;
     uint32_t *out = can_fail_malloc(sizeof(uint32_t));
 
     /* a check on *out == a*b should be added here but the CBMC checking is too slow */

--- a/tests/cbmc/proofs/s2n_pkcs3_to_dh_params/s2n_pkcs3_to_dh_params_harness.c
+++ b/tests/cbmc/proofs/s2n_pkcs3_to_dh_params/s2n_pkcs3_to_dh_params_harness.c
@@ -13,15 +13,15 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "stuffer/s2n_stuffer.h"
-#include "crypto/s2n_dhe.h"
-
 #include <assert.h>
 #include <cbmc_proof/cbmc_utils.h>
-#include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/nondet.h>
+#include <cbmc_proof/proof_allocators.h>
+
+#include "api/s2n.h"
+#include "crypto/s2n_dhe.h"
+#include "stuffer/s2n_stuffer.h"
 
 /*
  * Since this function largely serves as a way to call specific OpenSSL
@@ -30,20 +30,18 @@
  * and a few functions have been left omitted since they do not affect
  * the proof.
  */
-void s2n_pkcs3_to_dh_params_harness() {
+void s2n_pkcs3_to_dh_params_harness()
+{
     /* Non-deterministic inputs. */
-    struct s2n_dh_params dh_params = {0};
-    struct s2n_blob *pkcs3 = cbmc_allocate_s2n_blob();
+    struct s2n_dh_params dh_params = { 0 };
+    struct s2n_blob *    pkcs3     = cbmc_allocate_s2n_blob();
     __CPROVER_assume(s2n_blob_is_valid(pkcs3));
-    uint8_t *old_data = pkcs3->data;
+    uint8_t *                     old_data = pkcs3->data;
     struct store_byte_from_buffer old_byte;
     save_byte_from_blob(pkcs3, &old_byte);
     __CPROVER_assume(s2n_blob_is_bounded(pkcs3, MAX_BLOB_SIZE));
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
     /* Operation under verification. */
     if (s2n_pkcs3_to_dh_params(&dh_params, pkcs3) == S2N_SUCCESS) {

--- a/tests/cbmc/proofs/s2n_safety_constant_time_equals/Makefile
+++ b/tests/cbmc/proofs/s2n_safety_constant_time_equals/Makefile
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 
-# Expected runtime is 40 seconds.
+# Expected runtime is 6 seconds.
 MAX_ARR_LEN = 10
 DEFINES += -DMAX_ARR_LEN=$(MAX_ARR_LEN)
 

--- a/tests/cbmc/proofs/s2n_safety_constant_time_equals/s2n_safety_constant_time_equals_harness.c
+++ b/tests/cbmc/proofs/s2n_safety_constant_time_equals/s2n_safety_constant_time_equals_harness.c
@@ -13,15 +13,15 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <sys/param.h>
+
 #include "api/s2n.h"
 #include "utils/s2n_safety.h"
 
-#include <sys/param.h>
-#include <assert.h>
-
-#include <cbmc_proof/proof_allocators.h>
-
-void s2n_safety_constant_time_equals_harness() {
+void s2n_safety_constant_time_equals_harness()
+{
     /* Non-deterministic inputs. */
     uint32_t len;
     uint32_t alen;
@@ -29,14 +29,16 @@ void s2n_safety_constant_time_equals_harness() {
     __CPROVER_assume(len < MAX_ARR_LEN);
     __CPROVER_assume(alen >= len);
     __CPROVER_assume(blen >= len);
-    uint8_t * a = can_fail_malloc(alen);
-    uint8_t * b = can_fail_malloc(blen);
+    uint8_t *a = can_fail_malloc(alen);
+    uint8_t *b = can_fail_malloc(blen);
 
     /* Pre-conditions. */
     __CPROVER_assume(S2N_IMPLIES(len != 0, a != NULL && b != NULL));
-    
+
     /* Check logical equivalence of s2n_constant_time_equals against element equality */
-    if(s2n_constant_time_equals(a, b, len)) {
-        assert(__CPROVER_forall {size_t i; (i >=0 && i < len) ==> (a[i] == b[i])});
+    if (s2n_constant_time_equals(a, b, len)) {
+        /* clang-format off */
+        assert(__CPROVER_forall { size_t i; (i >=0 && i < len) ==> (a[i] == b[i]) });
+        /* clang-format on */
     }
 }

--- a/tests/cbmc/proofs/s2n_strcpy/s2n_strcpy_harness.c
+++ b/tests/cbmc/proofs/s2n_strcpy/s2n_strcpy_harness.c
@@ -13,41 +13,40 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "utils/s2n_str.h"
-
 #include <assert.h>
-#include <string.h>
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
+#include <string.h>
 #include <sys/param.h>
 
-void s2n_strcpy_harness() {
-    char *str = ensure_c_str_is_allocated(MAX_STRING_LEN);
+#include "api/s2n.h"
+#include "utils/s2n_str.h"
+
+void s2n_strcpy_harness()
+{
+    char *         str  = ensure_c_str_is_allocated(MAX_STRING_LEN);
     const uint32_t slen = strlen(str);
     const uint32_t buflen;
     const uint32_t index;
     __CPROVER_assume(buflen < MAX_STRING_LEN);
     __CPROVER_assume(slen == 0 || index < slen);
-    char buf[buflen];
+    char buf[ buflen ];
 
     /* Last must point to a valid position in buf. */
     const uint32_t last_offset;
     __CPROVER_assume(last_offset < buflen);
-    char* last = &buf[last_offset];
+    char *                        last = &buf[ last_offset ];
     struct store_byte_from_buffer str_byte;
     save_byte_from_array(str, slen, &str_byte);
     char *result;
 
     /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if (nondet_bool()) {
-        s2n_mem_init();
-    }
+    if (nondet_bool()) { s2n_mem_init(); }
 
     /* Non-deterministically set str to NULL. */
     bool nullstr = nondet_bool();
-    result = s2n_strcpy(buf, last, nullstr ? NULL : str);
+    result       = s2n_strcpy(buf, last, nullstr ? NULL : str);
 
     if (buf >= last) {
         assert(result == buf);
@@ -57,7 +56,7 @@ void s2n_strcpy_harness() {
     } else if (slen > 0) {
         uint32_t rand;
         __CPROVER_assume(rand < MIN(last - buf - 1, slen));
-        assert(buf[rand] == str[rand]);
+        assert(buf[ rand ] == str[ rand ]);
         assert_byte_from_buffer_matches(str, &str_byte);
         assert(*result == '\0');
     }

--- a/tests/cbmc/proofs/s2n_stuffer_alloc/s2n_stuffer_alloc_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc/s2n_stuffer_alloc_harness.c
@@ -13,15 +13,16 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_mem.h"
 
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
-#include <cbmc_proof/make_common_datastructures.h>
-
-void s2n_stuffer_alloc_harness() {
+void s2n_stuffer_alloc_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
@@ -30,10 +31,7 @@ void s2n_stuffer_alloc_harness() {
     /* Save previous state from stuffer. */
     struct s2n_stuffer old_stuffer = *stuffer;
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
     /* Operation under verification. */
     if (s2n_stuffer_alloc(stuffer, size) == S2N_SUCCESS) {

--- a/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_fd/s2n_stuffer_alloc_ro_from_fd_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_fd/s2n_stuffer_alloc_ro_from_fd_harness.c
@@ -13,25 +13,25 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "error/s2n_errno.h"
-#include "stuffer/s2n_stuffer.h"
-
 #include <assert.h>
-
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
 
-void s2n_stuffer_alloc_ro_from_fd_harness() {
+#include "api/s2n.h"
+#include "error/s2n_errno.h"
+#include "stuffer/s2n_stuffer.h"
+
+void s2n_stuffer_alloc_ro_from_fd_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
-    int rfd;
+    int                 rfd;
 
     /* Store a byte from the stuffer to compare if the write fails */
-    struct s2n_stuffer old_stuffer;
+    struct s2n_stuffer            old_stuffer;
     struct store_byte_from_buffer old_byte_from_stuffer;
-    if(s2n_stuffer_is_valid(stuffer)) {
+    if (s2n_stuffer_is_valid(stuffer)) {
         old_stuffer = *stuffer;
         save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
     }

--- a/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_file/s2n_stuffer_alloc_ro_from_file_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_file/s2n_stuffer_alloc_ro_from_file_harness.c
@@ -13,26 +13,26 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <errno.h>
+
 #include "api/s2n.h"
 #include "error/s2n_errno.h"
 #include "stuffer/s2n_stuffer.h"
 
-#include <assert.h>
-#include <errno.h>
-
-#include <cbmc_proof/cbmc_utils.h>
-#include <cbmc_proof/make_common_datastructures.h>
-#include <cbmc_proof/proof_allocators.h>
-
-void s2n_stuffer_alloc_ro_from_file_harness() {
+void s2n_stuffer_alloc_ro_from_file_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
-    char *file = nondet_c_str_is_allocated(MAX_STRING_LEN);
+    char *              file    = nondet_c_str_is_allocated(MAX_STRING_LEN);
 
     /* Store a byte from the stuffer to compare if the write fails */
-    struct s2n_stuffer old_stuffer;
+    struct s2n_stuffer            old_stuffer;
     struct store_byte_from_buffer old_byte_from_stuffer;
-    if(s2n_stuffer_is_valid(stuffer)) {
+    if (s2n_stuffer_is_valid(stuffer)) {
         old_stuffer = *stuffer;
         save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
     }
@@ -41,10 +41,9 @@ void s2n_stuffer_alloc_ro_from_file_harness() {
     if (s2n_stuffer_alloc_ro_from_file(stuffer, file) == S2N_SUCCESS) {
         assert(s2n_stuffer_is_valid(stuffer));
     } else {
-        if (s2n_stuffer_is_valid(stuffer) &&
-            errno != EBADF && /* The stuffer might not be equivalent if close() fails. */
-            errno != EINTR &&
-            errno != EIO) {
+        if (s2n_stuffer_is_valid(stuffer) && errno != EBADF
+            && /* The stuffer might not be equivalent if close() fails. */
+            errno != EINTR && errno != EIO) {
             assert_stuffer_equivalence(stuffer, &old_stuffer, &old_byte_from_stuffer);
         }
     }

--- a/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_string/s2n_stuffer_alloc_ro_from_string_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_string/s2n_stuffer_alloc_ro_from_string_harness.c
@@ -13,38 +13,35 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <string.h>
+
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_mem.h"
 
-#include <assert.h>
-#include <string.h>
-
-#include <cbmc_proof/cbmc_utils.h>
-#include <cbmc_proof/proof_allocators.h>
-#include <cbmc_proof/make_common_datastructures.h>
-
-void s2n_stuffer_alloc_ro_from_string_harness() {
+void s2n_stuffer_alloc_ro_from_string_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
     char *str = ensure_c_str_is_allocated(MAX_STRING_LEN);
 
     /* Save previous state from stuffer. */
-    struct s2n_stuffer old_stuffer = *stuffer;
+    struct s2n_stuffer            old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte_from_stuffer;
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
     /* Operation under verification. */
     if (s2n_stuffer_alloc_ro_from_string(stuffer, str) == S2N_SUCCESS) {
         /* Post-conditions. */
         uint32_t length = strlen(str);
-        assert_bytes_match(stuffer->blob.data, (const uint8_t *)str, length);
+        assert_bytes_match(stuffer->blob.data, ( const uint8_t * )str, length);
         assert(stuffer->alloced);
         assert(stuffer->blob.size == length + 1);
         assert(stuffer->write_cursor == length);

--- a/tests/cbmc/proofs/s2n_stuffer_certificate_from_pem/s2n_stuffer_certificate_from_pem_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_certificate_from_pem/s2n_stuffer_certificate_from_pem_harness.c
@@ -13,18 +13,18 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <string.h>
+
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_mem.h"
 
-#include <assert.h>
-#include <string.h>
-
-#include <cbmc_proof/cbmc_utils.h>
-#include <cbmc_proof/proof_allocators.h>
-#include <cbmc_proof/make_common_datastructures.h>
-
-void s2n_stuffer_certificate_from_pem_harness() {
+void s2n_stuffer_certificate_from_pem_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *pem = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(pem));
@@ -33,10 +33,7 @@ void s2n_stuffer_certificate_from_pem_harness() {
     struct s2n_stuffer *asn1 = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(asn1));
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
     /* Operation under verification. */
     s2n_stuffer_certificate_from_pem(pem, asn1);

--- a/tests/cbmc/proofs/s2n_stuffer_copy/s2n_stuffer_copy_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_copy/s2n_stuffer_copy_harness.c
@@ -13,19 +13,20 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <error/s2n_errno.h>
 
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
-#include <cbmc_proof/cbmc_utils.h>
-#include <cbmc_proof/make_common_datastructures.h>
-#include <error/s2n_errno.h>
 
-void s2n_stuffer_copy_harness() {
+void s2n_stuffer_copy_harness()
+{
     struct s2n_stuffer *from = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(from));
-    struct s2n_stuffer old_stuffer = *from;
+    struct s2n_stuffer            old_stuffer = *from;
     struct store_byte_from_buffer old_byte;
     save_byte_from_blob(&from->blob, &old_byte);
     struct s2n_stuffer *to = cbmc_allocate_s2n_stuffer();
@@ -44,5 +45,4 @@ void s2n_stuffer_copy_harness() {
     assert(from->tainted == old_stuffer.tainted);
     assert_byte_from_blob_matches(&from->blob, &old_byte);
     assert(s2n_stuffer_is_valid(from));
-
 }

--- a/tests/cbmc/proofs/s2n_stuffer_dhparams_from_pem/s2n_stuffer_dhparams_from_pem_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_dhparams_from_pem/s2n_stuffer_dhparams_from_pem_harness.c
@@ -13,19 +13,19 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/nondet.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <string.h>
+
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_mem.h"
 
-#include <assert.h>
-#include <string.h>
-
-#include <cbmc_proof/cbmc_utils.h>
-#include <cbmc_proof/proof_allocators.h>
-#include <cbmc_proof/make_common_datastructures.h>
-#include <cbmc_proof/nondet.h>
-
-void s2n_stuffer_dhparams_from_pem_harness() {
+void s2n_stuffer_dhparams_from_pem_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *pem = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(pem));
@@ -34,10 +34,7 @@ void s2n_stuffer_dhparams_from_pem_harness() {
     struct s2n_stuffer *asn1 = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(asn1));
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
     /* Operation under verification. */
     s2n_stuffer_dhparams_from_pem(pem, asn1);

--- a/tests/cbmc/proofs/s2n_stuffer_erase_and_read/s2n_stuffer_erase_and_read_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_erase_and_read/s2n_stuffer_erase_and_read_harness.c
@@ -13,25 +13,25 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-
-#include "stuffer/s2n_stuffer.h"
-
 #include <assert.h>
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
 
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
 void s2n_calculate_stacktrace() {}
 
-void s2n_stuffer_erase_and_read_harness() {
+void s2n_stuffer_erase_and_read_harness()
+{
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
-    struct s2n_blob *blob = cbmc_allocate_s2n_blob();
+    struct s2n_blob *   blob    = cbmc_allocate_s2n_blob();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
     __CPROVER_assume(s2n_blob_is_valid(blob));
 
     struct s2n_stuffer old_stuffer = *stuffer;
-    struct s2n_blob old_blob = *blob;
+    struct s2n_blob    old_blob    = *blob;
 
     /* Store a byte from the stuffer to compare if the copy fails */
     struct store_byte_from_buffer old_byte_from_stuffer;
@@ -39,14 +39,14 @@ void s2n_stuffer_erase_and_read_harness() {
 
     /* Store a byte from the stuffer to compare if the copy succeeds */
     struct store_byte_from_buffer copied_byte;
-    if(s2n_stuffer_data_available(stuffer) >= blob->size) {
-        save_byte_from_array(&stuffer->blob.data[old_stuffer.read_cursor], blob->size, &copied_byte);
+    if (s2n_stuffer_data_available(stuffer) >= blob->size) {
+        save_byte_from_array(&stuffer->blob.data[ old_stuffer.read_cursor ], blob->size, &copied_byte);
     }
 
     if (s2n_stuffer_erase_and_read(stuffer, blob) == S2N_SUCCESS) {
         assert(stuffer->read_cursor == old_stuffer.read_cursor + old_blob.size);
-        assert_all_zeroes(&(old_stuffer.blob.data[old_stuffer.read_cursor]), old_blob.size);
-        assert_byte_from_blob_matches(blob, &copied_byte); 
+        assert_all_zeroes(&(old_stuffer.blob.data[ old_stuffer.read_cursor ]), old_blob.size);
+        assert_byte_from_blob_matches(blob, &copied_byte);
     } else {
         assert(stuffer->read_cursor == old_stuffer.read_cursor);
         assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);

--- a/tests/cbmc/proofs/s2n_stuffer_erase_and_read_bytes/s2n_stuffer_erase_and_read_bytes_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_erase_and_read_bytes/s2n_stuffer_erase_and_read_bytes_harness.c
@@ -13,31 +13,33 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "stuffer/s2n_stuffer.h"
 #include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
 
-void s2n_stuffer_erase_and_read_bytes_harness() {
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+void s2n_stuffer_erase_and_read_bytes_harness()
+{
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
-    struct s2n_blob *blob = cbmc_allocate_s2n_blob();
+    struct s2n_blob *   blob    = cbmc_allocate_s2n_blob();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
     __CPROVER_assume(s2n_blob_is_valid(blob));
-    struct s2n_stuffer old_stuffer = *stuffer;
-    struct s2n_blob old_blob = *blob;
+    struct s2n_stuffer            old_stuffer = *stuffer;
+    struct s2n_blob               old_blob    = *blob;
     struct store_byte_from_buffer old_byte;
     save_byte_from_blob(&stuffer->blob, &old_byte);
 
     struct store_byte_from_buffer copied_byte;
-    if(s2n_stuffer_data_available(stuffer) >= blob->size) {
-        save_byte_from_array(&stuffer->blob.data[old_stuffer.read_cursor], blob->size, &copied_byte);
+    if (s2n_stuffer_data_available(stuffer) >= blob->size) {
+        save_byte_from_array(&stuffer->blob.data[ old_stuffer.read_cursor ], blob->size, &copied_byte);
     }
 
     if (s2n_stuffer_erase_and_read_bytes(stuffer, blob->data, blob->size) == S2N_SUCCESS) {
         assert(stuffer->read_cursor == old_stuffer.read_cursor + old_blob.size);
-        assert_all_zeroes(&(stuffer->blob.data[old_stuffer.read_cursor]), old_blob.size);
+        assert_all_zeroes(&(stuffer->blob.data[ old_stuffer.read_cursor ]), old_blob.size);
         assert_byte_from_blob_matches(blob, &copied_byte);
     } else {
         assert(stuffer->read_cursor == old_stuffer.read_cursor);

--- a/tests/cbmc/proofs/s2n_stuffer_extract_blob/s2n_stuffer_extract_blob_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_extract_blob/s2n_stuffer_extract_blob_harness.c
@@ -13,30 +13,28 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
 #include "api/s2n.h"
 #include "error/s2n_errno.h"
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_mem.h"
 
-#include <assert.h>
-#include <cbmc_proof/cbmc_utils.h>
-#include <cbmc_proof/proof_allocators.h>
-#include <cbmc_proof/make_common_datastructures.h>
-
-void s2n_stuffer_extract_blob_harness() {
+void s2n_stuffer_extract_blob_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
     struct s2n_blob *blob = cbmc_allocate_s2n_blob();
     __CPROVER_assume(s2n_blob_is_valid(blob));
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
     /* Save previous state. */
-    struct s2n_stuffer old_stuffer = *stuffer;
+    struct s2n_stuffer            old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte_from_stuffer;
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
@@ -47,7 +45,7 @@ void s2n_stuffer_extract_blob_harness() {
         if (blob->size > 0) {
             uint32_t index;
             __CPROVER_assume(index < blob->size);
-            assert(blob->data[index] == stuffer->blob.data[stuffer->read_cursor + index]);
+            assert(blob->data[ index ] == stuffer->blob.data[ stuffer->read_cursor + index ]);
         }
     }
 

--- a/tests/cbmc/proofs/s2n_stuffer_free/s2n_stuffer_free_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_free/s2n_stuffer_free_harness.c
@@ -13,20 +13,20 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
-#include <cbmc_proof/make_common_datastructures.h>
-#include <cbmc_proof/cbmc_utils.h>
 
 void s2n_calculate_stacktrace() {}
 
-void s2n_stuffer_free_harness() {
+void s2n_stuffer_free_harness()
+{
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
 
-    if (s2n_stuffer_free(stuffer) == 0) {
-        assert_all_zeroes(stuffer, sizeof(*stuffer));
-    }
+    if (s2n_stuffer_free(stuffer) == 0) { assert_all_zeroes(stuffer, sizeof(*stuffer)); }
 }

--- a/tests/cbmc/proofs/s2n_stuffer_growable_alloc/s2n_stuffer_growable_alloc_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_growable_alloc/s2n_stuffer_growable_alloc_harness.c
@@ -13,16 +13,17 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
 #include "api/s2n.h"
 #include "error/s2n_errno.h"
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_mem.h"
 
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
-#include <cbmc_proof/make_common_datastructures.h>
-
-void s2n_stuffer_growable_alloc_harness() {
+void s2n_stuffer_growable_alloc_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
@@ -31,10 +32,7 @@ void s2n_stuffer_growable_alloc_harness() {
     /* Save previous state from stuffer. */
     struct s2n_stuffer old_stuffer = *stuffer;
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
     /* Operation under verification. */
     if (s2n_stuffer_growable_alloc(stuffer, size) == S2N_SUCCESS) {

--- a/tests/cbmc/proofs/s2n_stuffer_init/s2n_stuffer_init_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_init/s2n_stuffer_init_harness.c
@@ -13,17 +13,19 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
-#include <cbmc_proof/make_common_datastructures.h>
 
-void s2n_stuffer_init_harness() {
-  struct s2n_stuffer *stuffer = can_fail_malloc(sizeof(*stuffer));
-  struct s2n_blob* in = cbmc_allocate_s2n_blob();
-  if (s2n_stuffer_init(stuffer, in) == S2N_SUCCESS){
-    assert(s2n_stuffer_is_valid(stuffer));
-    assert(s2n_blob_is_valid(in));
-  };
+void s2n_stuffer_init_harness()
+{
+    struct s2n_stuffer *stuffer = can_fail_malloc(sizeof(*stuffer));
+    struct s2n_blob *   in      = cbmc_allocate_s2n_blob();
+    if (s2n_stuffer_init(stuffer, in) == S2N_SUCCESS) {
+        assert(s2n_stuffer_is_valid(stuffer));
+        assert(s2n_blob_is_valid(in));
+    };
 }

--- a/tests/cbmc/proofs/s2n_stuffer_is_consumed/s2n_stuffer_is_consumed_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_is_consumed/s2n_stuffer_is_consumed_harness.c
@@ -13,20 +13,21 @@
  * permissions and limitations under the License.
  */
 
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
 
-#include <cbmc_proof/cbmc_utils.h>
-#include <cbmc_proof/proof_allocators.h>
-#include <cbmc_proof/make_common_datastructures.h>
-
-void s2n_stuffer_is_consumed_harness() {
+void s2n_stuffer_is_consumed_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
 
     /* Save previous state. */
-    struct s2n_stuffer old_stuffer = *stuffer;
+    struct s2n_stuffer            old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte_from_stuffer;
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 

--- a/tests/cbmc/proofs/s2n_stuffer_peek_char/s2n_stuffer_peek_char_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_peek_char/s2n_stuffer_peek_char_harness.c
@@ -13,31 +13,30 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-
-#include "stuffer/s2n_stuffer.h"
-
 #include <assert.h>
-
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
 
-void s2n_stuffer_peek_char_harness() {
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+void s2n_stuffer_peek_char_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
     uint8_t dest;
 
     /* Store a byte from the stuffer to compare after the read */
-    struct s2n_stuffer old_stuffer = *stuffer;
+    struct s2n_stuffer            old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte_from_stuffer;
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
     /* Operation under verification. */
     if (s2n_stuffer_peek_char(stuffer, &dest) == S2N_SUCCESS) {
         /* If successful, ensure uint was assembled correctly from stuffer */
-        assert(stuffer->blob.data[old_stuffer.read_cursor] == dest);
+        assert(stuffer->blob.data[ old_stuffer.read_cursor ] == dest);
         assert_stuffer_immutable_fields_after_read(stuffer, &old_stuffer, &old_byte_from_stuffer);
     } else {
         assert_stuffer_equivalence(stuffer, &old_stuffer, &old_byte_from_stuffer);

--- a/tests/cbmc/proofs/s2n_stuffer_peek_check_for_str/s2n_stuffer_peek_check_for_str_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_peek_check_for_str/s2n_stuffer_peek_check_for_str_harness.c
@@ -13,31 +13,30 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-
-#include "stuffer/s2n_stuffer.h"
-
 #include <assert.h>
-#include <string.h>
-
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
+#include <string.h>
 
-void s2n_stuffer_peek_check_for_str_harness() {
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+void s2n_stuffer_peek_check_for_str_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
     char *expected = ensure_c_str_is_allocated(MAX_STRING_LEN);
 
     /* Store a byte from the stuffer to compare after the read */
-    struct s2n_stuffer old_stuffer = *stuffer;
+    struct s2n_stuffer            old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte_from_stuffer;
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
     /* Operation under verification. */
     if (s2n_stuffer_peek_check_for_str(stuffer, expected) == S2N_SUCCESS) {
-        uint8_t* actual = stuffer->blob.data + stuffer->read_cursor;
+        uint8_t *actual = stuffer->blob.data + stuffer->read_cursor;
         assert(!memcmp(actual, expected, strlen(expected)));
     }
     assert_stuffer_equivalence(stuffer, &old_stuffer, &old_byte_from_stuffer);

--- a/tests/cbmc/proofs/s2n_stuffer_private_key_from_pem/s2n_stuffer_private_key_from_pem_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_private_key_from_pem/s2n_stuffer_private_key_from_pem_harness.c
@@ -13,18 +13,18 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <string.h>
+
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_mem.h"
 
-#include <assert.h>
-#include <string.h>
-
-#include <cbmc_proof/cbmc_utils.h>
-#include <cbmc_proof/proof_allocators.h>
-#include <cbmc_proof/make_common_datastructures.h>
-
-void s2n_stuffer_private_key_from_pem_harness() {
+void s2n_stuffer_private_key_from_pem_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *pem = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(pem));
@@ -33,10 +33,7 @@ void s2n_stuffer_private_key_from_pem_harness() {
     struct s2n_stuffer *asn1 = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(asn1));
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
     /* Operation under verification. */
     s2n_stuffer_private_key_from_pem(pem, asn1);

--- a/tests/cbmc/proofs/s2n_stuffer_raw_read/s2n_stuffer_raw_read_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_raw_read/s2n_stuffer_raw_read_harness.c
@@ -13,18 +13,20 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
 #include "api/s2n.h"
 #include "error/s2n_errno.h"
 #include "stuffer/s2n_stuffer.h"
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
-#include <cbmc_proof/cbmc_utils.h>
-#include <cbmc_proof/make_common_datastructures.h>
 
-void s2n_stuffer_raw_read_harness() {
+void s2n_stuffer_raw_read_harness()
+{
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
-    struct s2n_stuffer old_stuffer = *stuffer;
+    struct s2n_stuffer            old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte;
     save_byte_from_blob(&stuffer->blob, &old_byte);
     uint32_t size;

--- a/tests/cbmc/proofs/s2n_stuffer_raw_write/s2n_stuffer_raw_write_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_raw_write/s2n_stuffer_raw_write_harness.c
@@ -13,27 +13,24 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
 #include <sys/param.h>
 
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_mem.h"
 
-#include <assert.h>
-#include <cbmc_proof/cbmc_utils.h>
-#include <cbmc_proof/make_common_datastructures.h>
-#include <cbmc_proof/proof_allocators.h>
-
-void s2n_stuffer_raw_write_harness() {
+void s2n_stuffer_raw_write_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
     uint32_t data_len;
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
     /* Save previous state from stuffer. */
     struct s2n_stuffer old_stuffer = *stuffer;
@@ -49,9 +46,7 @@ void s2n_stuffer_raw_write_harness() {
         assert(retval == stuffer->blob.data + old_stuffer.write_cursor);
         assert(stuffer->high_water_mark == MAX(old_stuffer.write_cursor + data_len, old_stuffer.high_water_mark));
         assert(stuffer->tainted == 1);
-        if(old_stuffer.blob.size > 0) {
-            assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
-        }
+        if (old_stuffer.blob.size > 0) { assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer); }
         assert(s2n_stuffer_is_valid(stuffer));
     } else {
         assert(stuffer->write_cursor == old_stuffer.write_cursor);

--- a/tests/cbmc/proofs/s2n_stuffer_read/s2n_stuffer_read_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read/s2n_stuffer_read_harness.c
@@ -13,23 +13,25 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "stuffer/s2n_stuffer.h"
 #include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
 
-void s2n_stuffer_read_harness() {
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+void s2n_stuffer_read_harness()
+{
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
-    struct s2n_blob *blob = cbmc_allocate_s2n_blob();
+    struct s2n_blob *   blob    = cbmc_allocate_s2n_blob();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
     __CPROVER_assume(s2n_blob_is_valid(blob));
-    struct s2n_stuffer old_stuffer = *stuffer;
-    struct s2n_blob old_blob = *blob;
+    struct s2n_stuffer            old_stuffer = *stuffer;
+    struct s2n_blob               old_blob    = *blob;
     struct store_byte_from_buffer old_byte;
     save_byte_from_blob(&stuffer->blob, &old_byte);
-   
+
     /* int s2n_stuffer_read(struct s2n_stuffer *stuffer, struct s2n_blob *out) */
     if (s2n_stuffer_read(stuffer, blob) == S2N_SUCCESS) {
         assert(stuffer->read_cursor == old_stuffer.read_cursor + old_blob.size);

--- a/tests/cbmc/proofs/s2n_stuffer_read_base64/s2n_stuffer_read_base64_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_base64/s2n_stuffer_read_base64_harness.c
@@ -13,17 +13,17 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "stuffer/s2n_stuffer.h"
-#include "utils/s2n_mem.h"
-
 #include <assert.h>
-
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
 
-void s2n_stuffer_read_base64_harness() {
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_mem.h"
+
+void s2n_stuffer_read_base64_harness()
+{
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
     __CPROVER_assume(s2n_blob_is_bounded(&stuffer->blob, MAX_BLOB_SIZE));
@@ -32,25 +32,22 @@ void s2n_stuffer_read_base64_harness() {
     __CPROVER_assume(s2n_stuffer_is_valid(out));
 
     /* Save previous state from stuffer. */
-    struct s2n_stuffer old_stuffer = *stuffer;
+    struct s2n_stuffer            old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte_from_stuffer;
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
     /* Save previous state from out. */
     struct s2n_stuffer old_out = *out;
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
     if (s2n_stuffer_read_base64(stuffer, out) == S2N_SUCCESS) {
         assert(s2n_stuffer_is_valid(out));
-	      if(s2n_stuffer_data_available(&old_stuffer) >= 4) {
-	          size_t index;
-	          __CPROVER_assume(index >= old_stuffer.read_cursor && index < old_stuffer.write_cursor);
-	          assert(s2n_is_base64_char(stuffer->blob.data[index]));
-	      }
+        if (s2n_stuffer_data_available(&old_stuffer) >= 4) {
+            size_t index;
+            __CPROVER_assume(index >= old_stuffer.read_cursor && index < old_stuffer.write_cursor);
+            assert(s2n_is_base64_char(stuffer->blob.data[ index ]));
+        }
     }
 
     assert_stuffer_immutable_fields_after_read(stuffer, &old_stuffer, &old_byte_from_stuffer);

--- a/tests/cbmc/proofs/s2n_stuffer_read_bytes/s2n_stuffer_read_bytes_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_bytes/s2n_stuffer_read_bytes_harness.c
@@ -13,26 +13,25 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-
-#include "stuffer/s2n_stuffer.h"
-
 #include <assert.h>
-
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
 
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
 void s2n_calculate_stacktrace() {}
 
-void s2n_stuffer_read_bytes_harness() {
+void s2n_stuffer_read_bytes_harness()
+{
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
-    struct s2n_blob *blob = cbmc_allocate_s2n_blob();
+    struct s2n_blob *   blob    = cbmc_allocate_s2n_blob();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
     __CPROVER_assume(s2n_blob_is_valid(blob));
 
     struct s2n_stuffer old_stuffer = *stuffer;
-    struct s2n_blob old_blob = *blob;
+    struct s2n_blob    old_blob    = *blob;
 
     /* Store a byte from the stuffer to compare if the copy fails */
     struct store_byte_from_buffer old_byte_from_stuffer;
@@ -40,17 +39,17 @@ void s2n_stuffer_read_bytes_harness() {
 
     /* Store a byte from the stuffer to compare if the copy succeeds */
     struct store_byte_from_buffer copied_byte;
-    if(s2n_stuffer_data_available(stuffer) >= blob->size) {
-        save_byte_from_array(&stuffer->blob.data[old_stuffer.read_cursor], blob->size, &copied_byte);
+    if (s2n_stuffer_data_available(stuffer) >= blob->size) {
+        save_byte_from_array(&stuffer->blob.data[ old_stuffer.read_cursor ], blob->size, &copied_byte);
     }
 
     if (s2n_stuffer_read_bytes(stuffer, blob->data, blob->size) == S2N_SUCCESS) {
         assert(stuffer->read_cursor == old_stuffer.read_cursor + blob->size);
         assert_byte_from_blob_matches(blob, &copied_byte);
     } else {
-	    assert(stuffer->read_cursor == old_stuffer.read_cursor);
+        assert(stuffer->read_cursor == old_stuffer.read_cursor);
     }
 
-    assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer); 
+    assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
     assert(s2n_stuffer_is_valid(stuffer));
 }

--- a/tests/cbmc/proofs/s2n_stuffer_read_expected_str/s2n_stuffer_read_expected_str_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_expected_str/s2n_stuffer_read_expected_str_harness.c
@@ -13,31 +13,30 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-
-#include "stuffer/s2n_stuffer.h"
-
 #include <assert.h>
-#include <string.h>
-
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
+#include <string.h>
 
-void s2n_stuffer_read_expected_str_harness() {
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+void s2n_stuffer_read_expected_str_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
     char *expected = ensure_c_str_is_allocated(MAX_STRING_LEN);
 
     /* Store a byte from the stuffer to compare after the read */
-    struct s2n_stuffer old_stuffer = *stuffer;
+    struct s2n_stuffer            old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte_from_stuffer;
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
     /* Operation under verification. */
     if (s2n_stuffer_read_expected_str(stuffer, expected) == S2N_SUCCESS) {
-        uint8_t* actual = stuffer->blob.data + stuffer->read_cursor - strlen(expected);
+        uint8_t *actual = stuffer->blob.data + stuffer->read_cursor - strlen(expected);
         assert(!memcmp(actual, expected, strlen(expected)));
         assert(stuffer->read_cursor == old_stuffer.read_cursor + strlen(expected));
     } else {

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint16/s2n_stuffer_read_uint16_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint16/s2n_stuffer_read_uint16_harness.c
@@ -13,22 +13,21 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-
-#include "stuffer/s2n_stuffer.h"
-
 #include <assert.h>
-
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
 
-void s2n_stuffer_read_uint16_harness() {
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+void s2n_stuffer_read_uint16_harness()
+{
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
 
     struct s2n_stuffer old_stuffer = *stuffer;
-    uint16_t *dest = can_fail_malloc(sizeof(uint16_t*));
+    uint16_t *         dest        = can_fail_malloc(sizeof(uint16_t *));
 
     /* Store a byte from the stuffer to compare after the read */
     struct store_byte_from_buffer old_byte_from_stuffer;
@@ -37,8 +36,8 @@ void s2n_stuffer_read_uint16_harness() {
     if (s2n_stuffer_read_uint16(stuffer, dest) == S2N_SUCCESS) {
         assert(stuffer->read_cursor == old_stuffer.read_cursor + sizeof(uint16_t));
         /* If successful, ensure uint was assembled correctly from stuffer */
-        assert(((uint16_t) stuffer->blob.data[old_stuffer.read_cursor]) << 8
-             | ((uint16_t) stuffer->blob.data[old_stuffer.read_cursor + 1]) == *dest);
+        assert((( uint16_t )stuffer->blob.data[ old_stuffer.read_cursor ]) << 8
+               | (( uint16_t )stuffer->blob.data[ old_stuffer.read_cursor + 1 ]) == *dest);
     } else {
         assert(stuffer->read_cursor == old_stuffer.read_cursor);
     }

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint24/s2n_stuffer_read_uint24_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint24/s2n_stuffer_read_uint24_harness.c
@@ -13,22 +13,21 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-
-#include "stuffer/s2n_stuffer.h"
-
 #include <assert.h>
-
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
 
-void s2n_stuffer_read_uint24_harness() {
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+void s2n_stuffer_read_uint24_harness()
+{
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
 
     struct s2n_stuffer old_stuffer = *stuffer;
-    uint32_t *dest = can_fail_malloc(sizeof(uint32_t*));
+    uint32_t *         dest        = can_fail_malloc(sizeof(uint32_t *));
 
     /* Store a byte from the stuffer to compare after the read */
     struct store_byte_from_buffer old_byte_from_stuffer;
@@ -37,10 +36,9 @@ void s2n_stuffer_read_uint24_harness() {
     if (s2n_stuffer_read_uint24(stuffer, dest) == S2N_SUCCESS) {
         assert(stuffer->read_cursor == old_stuffer.read_cursor + SIZEOF_UINT24);
         /* If successful, ensure uint was assembled correctly from stuffer */
-        assert(((uint32_t) stuffer->blob.data[old_stuffer.read_cursor]) << 16
-             | ((uint32_t) stuffer->blob.data[old_stuffer.read_cursor + 1]) << 8
-             | ((uint32_t) stuffer->blob.data[old_stuffer.read_cursor + 2]) == *dest
-             | *dest < (1 << (24 - 1)));
+        assert((( uint32_t )stuffer->blob.data[ old_stuffer.read_cursor ]) << 16
+               | (( uint32_t )stuffer->blob.data[ old_stuffer.read_cursor + 1 ]) << 8
+               | (( uint32_t )stuffer->blob.data[ old_stuffer.read_cursor + 2 ]) == *dest | *dest < (1 << (24 - 1)));
     } else {
         assert(stuffer->read_cursor == old_stuffer.read_cursor);
     }

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint32/s2n_stuffer_read_uint32_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint32/s2n_stuffer_read_uint32_harness.c
@@ -13,22 +13,21 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-
-#include "stuffer/s2n_stuffer.h"
-
 #include <assert.h>
-
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
 
-void s2n_stuffer_read_uint32_harness() {
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+void s2n_stuffer_read_uint32_harness()
+{
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
 
     struct s2n_stuffer old_stuffer = *stuffer;
-    uint32_t *dest = can_fail_malloc(sizeof(uint32_t*));
+    uint32_t *         dest        = can_fail_malloc(sizeof(uint32_t *));
 
     /* Store a byte from the stuffer to compare after the read */
     struct store_byte_from_buffer old_byte_from_stuffer;
@@ -37,10 +36,10 @@ void s2n_stuffer_read_uint32_harness() {
     if (s2n_stuffer_read_uint32(stuffer, dest) == S2N_SUCCESS) {
         assert(stuffer->read_cursor == old_stuffer.read_cursor + sizeof(uint32_t));
         /* If successful, ensure uint was assembled correctly from stuffer */
-        assert(((uint32_t) stuffer->blob.data[old_stuffer.read_cursor]) << 24
-             | ((uint32_t) stuffer->blob.data[old_stuffer.read_cursor + 1]) << 16
-             | ((uint32_t) stuffer->blob.data[old_stuffer.read_cursor + 2]) << 8
-             | ((uint32_t) stuffer->blob.data[old_stuffer.read_cursor + 3]) == *dest);
+        assert((( uint32_t )stuffer->blob.data[ old_stuffer.read_cursor ]) << 24
+               | (( uint32_t )stuffer->blob.data[ old_stuffer.read_cursor + 1 ]) << 16
+               | (( uint32_t )stuffer->blob.data[ old_stuffer.read_cursor + 2 ]) << 8
+               | (( uint32_t )stuffer->blob.data[ old_stuffer.read_cursor + 3 ]) == *dest);
     } else {
         assert(stuffer->read_cursor == old_stuffer.read_cursor);
     }

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint64/s2n_stuffer_read_uint64_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint64/s2n_stuffer_read_uint64_harness.c
@@ -13,22 +13,21 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-
-#include "stuffer/s2n_stuffer.h"
-
 #include <assert.h>
-
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
 
-void s2n_stuffer_read_uint64_harness() {
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+void s2n_stuffer_read_uint64_harness()
+{
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
 
     struct s2n_stuffer old_stuffer = *stuffer;
-    uint64_t *dest = can_fail_malloc(sizeof(uint64_t*));
+    uint64_t *         dest        = can_fail_malloc(sizeof(uint64_t *));
 
     /* Store a byte from the stuffer to compare after the read */
     struct store_byte_from_buffer old_byte_from_stuffer;
@@ -37,14 +36,14 @@ void s2n_stuffer_read_uint64_harness() {
     if (s2n_stuffer_read_uint64(stuffer, dest) == S2N_SUCCESS) {
         assert(stuffer->read_cursor == old_stuffer.read_cursor + sizeof(uint64_t));
         /* If successful, ensure uint was assembled correctly from stuffer */
-        assert(((uint64_t) stuffer->blob.data[old_stuffer.read_cursor]) << 56
-             | ((uint64_t) stuffer->blob.data[old_stuffer.read_cursor + 1]) << 48
-             | ((uint64_t) stuffer->blob.data[old_stuffer.read_cursor + 2]) << 40
-             | ((uint64_t) stuffer->blob.data[old_stuffer.read_cursor + 3]) << 32
-             | ((uint64_t) stuffer->blob.data[old_stuffer.read_cursor + 4]) << 24
-             | ((uint64_t) stuffer->blob.data[old_stuffer.read_cursor + 5]) << 16
-             | ((uint64_t) stuffer->blob.data[old_stuffer.read_cursor + 6]) << 8
-             | ((uint64_t) stuffer->blob.data[old_stuffer.read_cursor + 7]) == *dest);
+        assert((( uint64_t )stuffer->blob.data[ old_stuffer.read_cursor ]) << 56
+               | (( uint64_t )stuffer->blob.data[ old_stuffer.read_cursor + 1 ]) << 48
+               | (( uint64_t )stuffer->blob.data[ old_stuffer.read_cursor + 2 ]) << 40
+               | (( uint64_t )stuffer->blob.data[ old_stuffer.read_cursor + 3 ]) << 32
+               | (( uint64_t )stuffer->blob.data[ old_stuffer.read_cursor + 4 ]) << 24
+               | (( uint64_t )stuffer->blob.data[ old_stuffer.read_cursor + 5 ]) << 16
+               | (( uint64_t )stuffer->blob.data[ old_stuffer.read_cursor + 6 ]) << 8
+               | (( uint64_t )stuffer->blob.data[ old_stuffer.read_cursor + 7 ]) == *dest);
     } else {
         assert(stuffer->read_cursor == old_stuffer.read_cursor);
     }

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint8/s2n_stuffer_read_uint8_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint8/s2n_stuffer_read_uint8_harness.c
@@ -13,22 +13,21 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-
-#include "stuffer/s2n_stuffer.h"
-
 #include <assert.h>
-
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
 
-void s2n_stuffer_read_uint8_harness() {
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+void s2n_stuffer_read_uint8_harness()
+{
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
 
     struct s2n_stuffer old_stuffer = *stuffer;
-    uint8_t *dest = can_fail_malloc(sizeof(uint8_t*));
+    uint8_t *          dest        = can_fail_malloc(sizeof(uint8_t *));
 
     /* Store a byte from the stuffer to compare after the read. */
     struct store_byte_from_buffer old_byte_from_stuffer;
@@ -37,7 +36,7 @@ void s2n_stuffer_read_uint8_harness() {
     if (s2n_stuffer_read_uint8(stuffer, dest) == S2N_SUCCESS) {
         assert(stuffer->read_cursor == old_stuffer.read_cursor + sizeof(uint8_t));
         /* If successful, ensure uint was assembled correctly from stuffer */
-        assert(stuffer->blob.data[old_stuffer.read_cursor] == *dest);
+        assert(stuffer->blob.data[ old_stuffer.read_cursor ] == *dest);
     } else {
         assert(stuffer->read_cursor == old_stuffer.read_cursor);
     }

--- a/tests/cbmc/proofs/s2n_stuffer_recv_from_fd/s2n_stuffer_recv_from_fd_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_recv_from_fd/s2n_stuffer_recv_from_fd_harness.c
@@ -13,39 +13,37 @@
  * permissions and limitations under the License.
  */
 
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_mem.h"
 
-#include <cbmc_proof/cbmc_utils.h>
-#include <cbmc_proof/proof_allocators.h>
-#include <cbmc_proof/make_common_datastructures.h>
-
-void s2n_stuffer_recv_from_fd_harness() {
+void s2n_stuffer_recv_from_fd_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
-    int rfd;
+    int      rfd;
     uint32_t len;
     uint32_t bytes_written;
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
     /* Save previous state. */
-    struct s2n_stuffer old_stuffer = *stuffer;
+    struct s2n_stuffer            old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte_from_stuffer;
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
     /* Operation under verification. */
     if (s2n_stuffer_recv_from_fd(stuffer, rfd, len, &bytes_written) == S2N_SUCCESS) {
-       assert(stuffer->write_cursor == old_stuffer.write_cursor + bytes_written);
-       assert(s2n_stuffer_is_valid(stuffer));
-   }
-   assert(stuffer->read_cursor == old_stuffer.read_cursor);
-   assert(stuffer->alloced == old_stuffer.alloced);
-   assert(stuffer->growable == old_stuffer.growable);
-   assert(stuffer->tainted == old_stuffer.tainted);
+        assert(stuffer->write_cursor == old_stuffer.write_cursor + bytes_written);
+        assert(s2n_stuffer_is_valid(stuffer));
+    }
+    assert(stuffer->read_cursor == old_stuffer.read_cursor);
+    assert(stuffer->alloced == old_stuffer.alloced);
+    assert(stuffer->growable == old_stuffer.growable);
+    assert(stuffer->tainted == old_stuffer.tainted);
 }

--- a/tests/cbmc/proofs/s2n_stuffer_reread/s2n_stuffer_reread_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_reread/s2n_stuffer_reread_harness.c
@@ -13,17 +13,19 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "stuffer/s2n_stuffer.h"
 #include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
 
-void s2n_stuffer_reread_harness() {
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+void s2n_stuffer_reread_harness()
+{
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
-    struct s2n_stuffer old_stuffer = *stuffer;
+    struct s2n_stuffer            old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte;
     save_byte_from_blob(&stuffer->blob, &old_byte);
 

--- a/tests/cbmc/proofs/s2n_stuffer_reserve/s2n_stuffer_reserve_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve/s2n_stuffer_reserve_harness.c
@@ -13,29 +13,27 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/nondet.h>
+#include <cbmc_proof/proof_allocators.h>
 #include <sys/param.h>
 
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_mem.h"
 
-#include <assert.h>
-#include <cbmc_proof/cbmc_utils.h>
-#include <cbmc_proof/make_common_datastructures.h>
-#include <cbmc_proof/nondet.h>
-#include <cbmc_proof/proof_allocators.h>
-
-void s2n_stuffer_reserve_harness() {
+void s2n_stuffer_reserve_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
     struct s2n_stuffer_reservation *reservation = cbmc_allocate_s2n_stuffer_reservation();
-    const uint8_t length;
+    const uint8_t                   length;
 
     /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if (nondet_bool()) {
-        s2n_mem_init();
-    }
+    if (nondet_bool()) { s2n_mem_init(); }
 
     /* Save previous state from stuffer. */
     struct s2n_stuffer old_stuffer = *stuffer;
@@ -50,10 +48,10 @@ void s2n_stuffer_reserve_harness() {
         assert(reservation->length == length);
         if (old_stuffer.blob.size > 0 && reservation->length > 0) {
             size_t index;
-            __CPROVER_assume(index >= reservation->write_cursor &&
-                             index < (reservation->write_cursor + reservation->length));
-            assert(stuffer->blob.data[index] == S2N_WIPE_PATTERN);
-            assert(reservation->stuffer->blob.data[index] == S2N_WIPE_PATTERN);
+            __CPROVER_assume(index >= reservation->write_cursor
+                             && index < (reservation->write_cursor + reservation->length));
+            assert(stuffer->blob.data[ index ] == S2N_WIPE_PATTERN);
+            assert(reservation->stuffer->blob.data[ index ] == S2N_WIPE_PATTERN);
         }
         assert(stuffer == reservation->stuffer);
         assert(s2n_stuffer_is_valid(stuffer));

--- a/tests/cbmc/proofs/s2n_stuffer_reserve_space/s2n_stuffer_reserve_space_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve_space/s2n_stuffer_reserve_space_harness.c
@@ -13,40 +13,38 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <sys/param.h>
+
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_mem.h"
 
-#include <sys/param.h>
-#include <assert.h>
-
-#include <cbmc_proof/cbmc_utils.h>
-#include <cbmc_proof/proof_allocators.h>
-#include <cbmc_proof/make_common_datastructures.h>
-
-void s2n_stuffer_reserve_space_harness() {
+void s2n_stuffer_reserve_space_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
     uint32_t size;
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
     /* Save previous state. */
-    struct s2n_stuffer old_stuffer = *stuffer;
+    struct s2n_stuffer            old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte_from_stuffer;
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
     /* Operation under verification. */
     if (s2n_stuffer_reserve_space(stuffer, size) == S2N_SUCCESS) {
         assert(s2n_stuffer_is_valid(stuffer));
-        if(s2n_stuffer_space_remaining(&old_stuffer) < size) {
+        if (s2n_stuffer_space_remaining(&old_stuffer) < size) {
             /* Always grow a stuffer by at least 1k */
-            assert(stuffer->blob.size == (MAX(size - s2n_stuffer_space_remaining(&old_stuffer), S2N_MIN_STUFFER_GROWTH_IN_BYTES) +
-                                          old_stuffer.blob.size));
+            assert(stuffer->blob.size
+                   == (MAX(size - s2n_stuffer_space_remaining(&old_stuffer), S2N_MIN_STUFFER_GROWTH_IN_BYTES)
+                       + old_stuffer.blob.size));
             assert(stuffer->blob.allocated >= size);
         } else {
             assert_stuffer_equivalence(stuffer, &old_stuffer, &old_byte_from_stuffer);

--- a/tests/cbmc/proofs/s2n_stuffer_reserve_uint24/s2n_stuffer_reserve_uint24_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve_uint24/s2n_stuffer_reserve_uint24_harness.c
@@ -13,27 +13,24 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
 #include <sys/param.h>
 
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_mem.h"
 
-#include <assert.h>
-#include <cbmc_proof/cbmc_utils.h>
-#include <cbmc_proof/make_common_datastructures.h>
-#include <cbmc_proof/proof_allocators.h>
-
-void s2n_stuffer_reserve_uint24_harness() {
+void s2n_stuffer_reserve_uint24_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
     struct s2n_stuffer_reservation *reservation = cbmc_allocate_s2n_stuffer_reservation();
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
     /* Save previous state from stuffer. */
     struct s2n_stuffer old_stuffer = *stuffer;
@@ -46,12 +43,12 @@ void s2n_stuffer_reserve_uint24_harness() {
         assert(stuffer->write_cursor == old_stuffer.write_cursor + SIZEOF_UINT24);
         assert(stuffer->high_water_mark == MAX(old_stuffer.write_cursor + SIZEOF_UINT24, old_stuffer.high_water_mark));
         assert(reservation->length == SIZEOF_UINT24);
-        if(old_stuffer.blob.size > 0) {
+        if (old_stuffer.blob.size > 0) {
             size_t index;
-            __CPROVER_assume(index >= reservation->write_cursor &&
-                             index < (reservation->write_cursor + reservation->length));
-            assert(stuffer->blob.data[index] == S2N_WIPE_PATTERN);
-            assert(reservation->stuffer->blob.data[index] == S2N_WIPE_PATTERN);
+            __CPROVER_assume(index >= reservation->write_cursor
+                             && index < (reservation->write_cursor + reservation->length));
+            assert(stuffer->blob.data[ index ] == S2N_WIPE_PATTERN);
+            assert(reservation->stuffer->blob.data[ index ] == S2N_WIPE_PATTERN);
         }
         assert(stuffer == reservation->stuffer);
         assert(s2n_stuffer_is_valid(stuffer));

--- a/tests/cbmc/proofs/s2n_stuffer_resize_if_empty/s2n_stuffer_resize_if_empty_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_resize_if_empty/s2n_stuffer_resize_if_empty_harness.c
@@ -13,37 +13,34 @@
  * permissions and limitations under the License.
  */
 
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_mem.h"
-
-#include <cbmc_proof/cbmc_utils.h>
-#include <cbmc_proof/proof_allocators.h>
-#include <cbmc_proof/make_common_datastructures.h>
 
 /*
  * The reason we don't have full coverage is that we only call s2n_realloc
  * with blob-data == NULL.
  */
-void s2n_stuffer_resize_if_empty_harness() {
+void s2n_stuffer_resize_if_empty_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
     uint32_t size;
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
     /* Save previous state. */
-    struct s2n_stuffer old_stuffer = *stuffer;
+    struct s2n_stuffer            old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte;
     save_byte_from_blob(&stuffer->blob, &old_byte);
 
     /* Operation under verification. */
-    if (s2n_stuffer_resize_if_empty(stuffer, size) == S2N_SUCCESS &&
-        size != 0 && old_stuffer.blob.data == NULL) {
+    if (s2n_stuffer_resize_if_empty(stuffer, size) == S2N_SUCCESS && size != 0 && old_stuffer.blob.data == NULL) {
         assert(stuffer->blob.growable);
         assert(stuffer->blob.size == size);
         assert(stuffer->blob.allocated >= size);

--- a/tests/cbmc/proofs/s2n_stuffer_rewind_read/s2n_stuffer_rewind_read_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_rewind_read/s2n_stuffer_rewind_read_harness.c
@@ -13,17 +13,16 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-
-#include "stuffer/s2n_stuffer.h"
-
 #include <assert.h>
-
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
 
-void s2n_stuffer_rewind_read_harness() {
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+void s2n_stuffer_rewind_read_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
@@ -36,11 +35,10 @@ void s2n_stuffer_rewind_read_harness() {
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
     /* Operation under verification. */
-    if(s2n_stuffer_rewind_read(stuffer, size) == S2N_SUCCESS) {
+    if (s2n_stuffer_rewind_read(stuffer, size) == S2N_SUCCESS) {
         assert(old_stuffer.read_cursor >= size);
         assert(stuffer->read_cursor == old_stuffer.read_cursor - size);
-    }
-    else {
+    } else {
         assert(old_stuffer.read_cursor < size);
         assert(stuffer->read_cursor == old_stuffer.read_cursor);
     }

--- a/tests/cbmc/proofs/s2n_stuffer_rewrite/s2n_stuffer_rewrite_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_rewrite/s2n_stuffer_rewrite_harness.c
@@ -13,17 +13,16 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-
-#include "stuffer/s2n_stuffer.h"
-
 #include <assert.h>
-
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
 
-void s2n_stuffer_rewrite_harness() {
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+void s2n_stuffer_rewrite_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));

--- a/tests/cbmc/proofs/s2n_stuffer_send_to_fd/s2n_stuffer_send_to_fd_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_send_to_fd/s2n_stuffer_send_to_fd_harness.c
@@ -13,34 +13,32 @@
  * permissions and limitations under the License.
  */
 
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_mem.h"
 
-#include <cbmc_proof/cbmc_utils.h>
-#include <cbmc_proof/proof_allocators.h>
-#include <cbmc_proof/make_common_datastructures.h>
-
-void s2n_stuffer_send_to_fd_harness() {
+void s2n_stuffer_send_to_fd_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
-    int wfd;
+    int      wfd;
     uint32_t len;
     uint32_t bytes_sent;
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
     /* Save previous state. */
-    struct s2n_stuffer old_stuffer = *stuffer;
+    struct s2n_stuffer            old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte_from_stuffer;
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
     /* Operation under verification. */
-    if(s2n_stuffer_send_to_fd(stuffer, wfd, len, &bytes_sent) == S2N_SUCCESS) {
+    if (s2n_stuffer_send_to_fd(stuffer, wfd, len, &bytes_sent) == S2N_SUCCESS) {
         assert(stuffer->read_cursor == old_stuffer.read_cursor + bytes_sent);
     }
     assert_stuffer_immutable_fields_after_read(stuffer, &old_stuffer, &old_byte_from_stuffer);

--- a/tests/cbmc/proofs/s2n_stuffer_skip_expected_char/s2n_stuffer_skip_expected_char_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_expected_char/s2n_stuffer_skip_expected_char_harness.c
@@ -13,28 +13,28 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "stuffer/s2n_stuffer.h"
-
 #include <assert.h>
-
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
 
-void s2n_stuffer_skip_expected_char_harness() {
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+void s2n_stuffer_skip_expected_char_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
     __CPROVER_assume(s2n_blob_is_bounded(&stuffer->blob, BLOB_SIZE));
     const char expected;
-    uint32_t min;
-    uint32_t max;
-    uint32_t skipped;
-    uint32_t index;
+    uint32_t   min;
+    uint32_t   max;
+    uint32_t   skipped;
+    uint32_t   index;
 
     /* Save previous state from stuffer. */
-    struct s2n_stuffer old_stuffer = *stuffer;
+    struct s2n_stuffer            old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte_from_stuffer;
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
@@ -43,10 +43,10 @@ void s2n_stuffer_skip_expected_char_harness() {
         assert(skipped >= min && skipped <= max);
         /* The read_cursor will move the number of skipped positions. */
         assert(stuffer->read_cursor == old_stuffer.read_cursor + skipped);
-        if(stuffer->blob.size > 0) {
+        if (stuffer->blob.size > 0) {
             /* The skipped bytes should match the expected element. */
             __CPROVER_assume(index >= old_stuffer.read_cursor && index < (old_stuffer.read_cursor + skipped));
-            assert(stuffer->blob.data[index] == expected);
+            assert(stuffer->blob.data[ index ] == expected);
         }
     }
     assert_stuffer_immutable_fields_after_read(stuffer, &old_stuffer, &old_byte_from_stuffer);

--- a/tests/cbmc/proofs/s2n_stuffer_skip_read/s2n_stuffer_skip_read_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_read/s2n_stuffer_skip_read_harness.c
@@ -13,25 +13,27 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "stuffer/s2n_stuffer.h"
 #include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
 
-void s2n_stuffer_skip_read_harness() {
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+void s2n_stuffer_skip_read_harness()
+{
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
-    struct s2n_stuffer old_stuffer = *stuffer;
+    struct s2n_stuffer            old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte;
     save_byte_from_blob(&stuffer->blob, &old_byte);
     uint32_t n;
-   
+
     if (s2n_stuffer_skip_read(stuffer, n) == S2N_SUCCESS) {
-	assert(stuffer->read_cursor == old_stuffer.read_cursor + n);
+        assert(stuffer->read_cursor == old_stuffer.read_cursor + n);
     } else {
-	assert(stuffer->read_cursor == old_stuffer.read_cursor);
+        assert(stuffer->read_cursor == old_stuffer.read_cursor);
     }
 
     /* These assertions should always hold, regardless of whether the test succeeded */

--- a/tests/cbmc/proofs/s2n_stuffer_skip_read_until/s2n_stuffer_skip_read_until_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_read_until/s2n_stuffer_skip_read_until_harness.c
@@ -13,17 +13,17 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "stuffer/s2n_stuffer.h"
-
 #include <assert.h>
-#include <string.h>
-
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
+#include <string.h>
 
-void s2n_stuffer_skip_read_until_harness() {
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+void s2n_stuffer_skip_read_until_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
@@ -31,7 +31,7 @@ void s2n_stuffer_skip_read_until_harness() {
     char *target = nondet_bool() ? ensure_c_str_is_allocated(MAX_STRING_LEN) : NULL;
 
     /* Save previous state from stuffer. */
-    struct s2n_stuffer old_stuffer = *stuffer;
+    struct s2n_stuffer            old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte_from_stuffer;
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
@@ -39,8 +39,8 @@ void s2n_stuffer_skip_read_until_harness() {
     if (s2n_stuffer_skip_read_until(stuffer, target) == S2N_SUCCESS) {
         const int len = strlen(target);
         if (s2n_stuffer_data_available(stuffer) >= len) {
-              uint8_t *actual = stuffer->blob.data + stuffer->read_cursor - len;
-              assert((strncmp((char*)actual, target, len) == 0) || (s2n_stuffer_data_available(stuffer) < len));
+            uint8_t *actual = stuffer->blob.data + stuffer->read_cursor - len;
+            assert((strncmp(( char * )actual, target, len) == 0) || (s2n_stuffer_data_available(stuffer) < len));
         }
     }
 

--- a/tests/cbmc/proofs/s2n_stuffer_skip_to_char/s2n_stuffer_skip_to_char_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_to_char/s2n_stuffer_skip_to_char_harness.c
@@ -13,16 +13,17 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "error/s2n_errno.h"
-#include "stuffer/s2n_stuffer.h"
-
 #include <assert.h>
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
 
-void s2n_stuffer_skip_to_char_harness() {
+#include "api/s2n.h"
+#include "error/s2n_errno.h"
+#include "stuffer/s2n_stuffer.h"
+
+void s2n_stuffer_skip_to_char_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
@@ -30,18 +31,19 @@ void s2n_stuffer_skip_to_char_harness() {
     const char target;
 
     /* Save previous state from stuffer. */
-    struct s2n_stuffer old_stuffer = *stuffer;
+    struct s2n_stuffer            old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte_from_stuffer;
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
     /* Operation under verification. */
     if (s2n_stuffer_skip_to_char(stuffer, target) == S2N_SUCCESS) {
-        assert(S2N_IMPLIES(s2n_stuffer_data_available(&old_stuffer) == 0, stuffer->read_cursor == old_stuffer.read_cursor));
-        if(s2n_stuffer_data_available(stuffer) > 0) {
-            assert(stuffer->blob.data[stuffer->read_cursor] == target);
+        assert(S2N_IMPLIES(s2n_stuffer_data_available(&old_stuffer) == 0,
+                           stuffer->read_cursor == old_stuffer.read_cursor));
+        if (s2n_stuffer_data_available(stuffer) > 0) {
+            assert(stuffer->blob.data[ stuffer->read_cursor ] == target);
             size_t index;
             __CPROVER_assume(index >= old_stuffer.read_cursor && index < stuffer->read_cursor);
-            assert(stuffer->blob.data[index] != target);
+            assert(stuffer->blob.data[ index ] != target);
         }
     }
     assert_stuffer_immutable_fields_after_read(stuffer, &old_stuffer, &old_byte_from_stuffer);

--- a/tests/cbmc/proofs/s2n_stuffer_skip_whitespace/s2n_stuffer_skip_whitespace_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_whitespace/s2n_stuffer_skip_whitespace_harness.c
@@ -13,15 +13,16 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "stuffer/s2n_stuffer.h"
-
 #include <assert.h>
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
 
-void s2n_stuffer_skip_whitespace_harness() {
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+void s2n_stuffer_skip_whitespace_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
@@ -29,26 +30,24 @@ void s2n_stuffer_skip_whitespace_harness() {
     uint32_t skipped;
 
     /* Save previous state from stuffer. */
-    struct s2n_stuffer old_stuffer = *stuffer;
+    struct s2n_stuffer            old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte_from_stuffer;
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
     /* Operation under verification. */
-    if(s2n_stuffer_skip_whitespace(stuffer, &skipped) == S2N_SUCCESS) {
+    if (s2n_stuffer_skip_whitespace(stuffer, &skipped) == S2N_SUCCESS) {
         size_t index;
         if (skipped > 0) {
             assert(stuffer->read_cursor == old_stuffer.read_cursor + skipped);
             __CPROVER_assume(index >= old_stuffer.read_cursor && index < stuffer->read_cursor);
-            assert(stuffer->blob.data[index] == ' '  ||
-                   stuffer->blob.data[index] == '\t' ||
-                   stuffer->blob.data[index] == '\n' ||
-                   stuffer->blob.data[index] == '\r');
+            assert(stuffer->blob.data[ index ] == ' ' || stuffer->blob.data[ index ] == '\t'
+                   || stuffer->blob.data[ index ] == '\n' || stuffer->blob.data[ index ] == '\r');
         } else {
-            assert((stuffer->read_cursor >= stuffer->write_cursor) ||
-                   (stuffer->blob.data[old_stuffer.read_cursor] != ' '  &&
-                    stuffer->blob.data[old_stuffer.read_cursor] != '\t' &&
-                    stuffer->blob.data[old_stuffer.read_cursor] != '\n' &&
-                    stuffer->blob.data[old_stuffer.read_cursor] != '\r'));
+            assert((stuffer->read_cursor >= stuffer->write_cursor)
+                   || (stuffer->blob.data[ old_stuffer.read_cursor ] != ' '
+                       && stuffer->blob.data[ old_stuffer.read_cursor ] != '\t'
+                       && stuffer->blob.data[ old_stuffer.read_cursor ] != '\n'
+                       && stuffer->blob.data[ old_stuffer.read_cursor ] != '\r'));
         }
     }
     assert_stuffer_immutable_fields_after_read(stuffer, &old_stuffer, &old_byte_from_stuffer);

--- a/tests/cbmc/proofs/s2n_stuffer_skip_write/s2n_stuffer_skip_write_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_write/s2n_stuffer_skip_write_harness.c
@@ -13,26 +13,23 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
 #include <sys/param.h>
 
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
 
-#include <assert.h>
-#include <cbmc_proof/cbmc_utils.h>
-#include <cbmc_proof/make_common_datastructures.h>
-#include <cbmc_proof/proof_allocators.h>
-
-void s2n_stuffer_skip_write_harness() {
+void s2n_stuffer_skip_write_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
     uint32_t data_len;
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
     /* Save previous state from stuffer. */
     struct s2n_stuffer old_stuffer = *stuffer;
@@ -44,9 +41,7 @@ void s2n_stuffer_skip_write_harness() {
     if (s2n_stuffer_skip_write(stuffer, data_len) == S2N_SUCCESS) {
         assert(stuffer->write_cursor == old_stuffer.write_cursor + data_len);
         assert(stuffer->high_water_mark == MAX(old_stuffer.write_cursor + data_len, old_stuffer.high_water_mark));
-        if(old_stuffer.blob.size > 0) {
-            assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer);
-        }
+        if (old_stuffer.blob.size > 0) { assert_byte_from_blob_matches(&stuffer->blob, &old_byte_from_stuffer); }
         assert(s2n_stuffer_is_valid(stuffer));
     } else {
         assert(stuffer->write_cursor == old_stuffer.write_cursor);

--- a/tests/cbmc/proofs/s2n_stuffer_wipe/s2n_stuffer_wipe_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_wipe/s2n_stuffer_wipe_harness.c
@@ -13,23 +13,25 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
-#include <cbmc_proof/make_common_datastructures.h>
 
-void s2n_stuffer_wipe_harness() {
-  struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+void s2n_stuffer_wipe_harness()
+{
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
 
-  __CPROVER_assume( s2n_stuffer_is_valid(stuffer) );
-  __CPROVER_assume( stuffer->high_water_mark );
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
+    __CPROVER_assume(stuffer->high_water_mark);
 
-  if ( s2n_stuffer_wipe(stuffer) == S2N_SUCCESS ){
-    assert( s2n_stuffer_is_valid(stuffer) );
-    assert( stuffer->high_water_mark == 0 );
-    assert( stuffer->tainted == 0 );
-    assert( stuffer->write_cursor == 0 );
-    assert( stuffer->read_cursor == 0);
-  };
+    if (s2n_stuffer_wipe(stuffer) == S2N_SUCCESS) {
+        assert(s2n_stuffer_is_valid(stuffer));
+        assert(stuffer->high_water_mark == 0);
+        assert(stuffer->tainted == 0);
+        assert(stuffer->write_cursor == 0);
+        assert(stuffer->read_cursor == 0);
+    };
 }

--- a/tests/cbmc/proofs/s2n_stuffer_wipe_n/s2n_stuffer_wipe_n_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_wipe_n/s2n_stuffer_wipe_n_harness.c
@@ -13,19 +13,19 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
-#include <cbmc_proof/make_common_datastructures.h>
 
-void s2n_stuffer_wipe_n_harness() {
-  struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
-  uint32_t n;
+void s2n_stuffer_wipe_n_harness()
+{
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    uint32_t            n;
 
-  __CPROVER_assume( s2n_stuffer_is_valid(stuffer) );
+    __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
 
-  if (s2n_stuffer_wipe_n(stuffer, n) == S2N_SUCCESS){
-    assert(s2n_stuffer_is_valid(stuffer));
-  };
+    if (s2n_stuffer_wipe_n(stuffer, n) == S2N_SUCCESS) { assert(s2n_stuffer_is_valid(stuffer)); };
 }

--- a/tests/cbmc/proofs/s2n_stuffer_write/s2n_stuffer_write_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write/s2n_stuffer_write_harness.c
@@ -13,16 +13,17 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "stuffer/s2n_stuffer.h"
-
 #include <assert.h>
-#include <sys/param.h>
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
+#include <sys/param.h>
 
-void s2n_stuffer_write_harness() {
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+void s2n_stuffer_write_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
@@ -30,32 +31,29 @@ void s2n_stuffer_write_harness() {
     __CPROVER_assume(s2n_blob_is_valid(blob));
     uint32_t index;
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
     /* Save previous state from stuffer. */
     struct s2n_stuffer old_stuffer = *stuffer;
 
     /* Store a byte from the stuffer that wont be overwritten to compare if the write succeeds. */
     __CPROVER_assume(index < stuffer->blob.size);
-    if(__CPROVER_overflow_plus(old_stuffer.write_cursor, blob->size)) {
+    if (__CPROVER_overflow_plus(old_stuffer.write_cursor, blob->size)) {
         __CPROVER_assume(index < old_stuffer.write_cursor);
     } else {
         __CPROVER_assume(index < old_stuffer.write_cursor || index >= old_stuffer.write_cursor + blob->size);
     }
-    uint8_t untouched_byte = stuffer->blob.data[index];
+    uint8_t untouched_byte = stuffer->blob.data[ index ];
 
     /* Store a byte from the blob to compare. */
-    struct s2n_blob old_blob = *blob;
+    struct s2n_blob               old_blob = *blob;
     struct store_byte_from_buffer old_byte_from_blob;
     save_byte_from_blob(blob, &old_byte_from_blob);
 
     /* Operation under verification. */
     if (s2n_stuffer_write(stuffer, blob) == S2N_SUCCESS) {
         assert(stuffer->write_cursor == old_stuffer.write_cursor + blob->size);
-        assert(stuffer->blob.data[index] == untouched_byte);
+        assert(stuffer->blob.data[ index ] == untouched_byte);
         assert(stuffer->high_water_mark == MAX(old_stuffer.write_cursor + blob->size, old_stuffer.high_water_mark));
         assert(s2n_stuffer_is_valid(stuffer));
     } else {

--- a/tests/cbmc/proofs/s2n_stuffer_write_base64/s2n_stuffer_write_base64_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_base64/s2n_stuffer_write_base64_harness.c
@@ -13,17 +13,17 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "stuffer/s2n_stuffer.h"
-#include "utils/s2n_mem.h"
-
 #include <assert.h>
-
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
 
-void s2n_stuffer_write_base64_harness() {
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_mem.h"
+
+void s2n_stuffer_write_base64_harness()
+{
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
 
@@ -35,22 +35,19 @@ void s2n_stuffer_write_base64_harness() {
     struct s2n_stuffer old_stuffer = *stuffer;
 
     /* Save previous state from out. */
-    struct s2n_stuffer old_in = *in;
+    struct s2n_stuffer            old_in = *in;
     struct store_byte_from_buffer old_byte_from_in;
     save_byte_from_blob(&in->blob, &old_byte_from_in);
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
     if (s2n_stuffer_write_base64(stuffer, in) == S2N_SUCCESS) {
         assert(s2n_stuffer_is_valid(stuffer));
-        if(s2n_stuffer_data_available(&old_stuffer) >= 2) {
-	          size_t index;
-	          __CPROVER_assume(index >= old_stuffer.write_cursor && index < stuffer->write_cursor);
-	          assert(s2n_is_base64_char(stuffer->blob.data[index]));
-	      }
+        if (s2n_stuffer_data_available(&old_stuffer) >= 2) {
+            size_t index;
+            __CPROVER_assume(index >= old_stuffer.write_cursor && index < stuffer->write_cursor);
+            assert(s2n_is_base64_char(stuffer->blob.data[ index ]));
+        }
     }
 
     assert_stuffer_immutable_fields_after_read(in, &old_in, &old_byte_from_in);

--- a/tests/cbmc/proofs/s2n_stuffer_write_bytes/s2n_stuffer_write_bytes_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_bytes/s2n_stuffer_write_bytes_harness.c
@@ -13,17 +13,17 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "stuffer/s2n_stuffer.h"
-
-#include <sys/param.h>
 #include <assert.h>
-
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
+#include <sys/param.h>
 
-void s2n_stuffer_write_bytes_harness() {
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+void s2n_stuffer_write_bytes_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
@@ -31,27 +31,24 @@ void s2n_stuffer_write_bytes_harness() {
     uint32_t size;
     uint8_t *data = can_fail_malloc(size);
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
     /* Save previous state from stuffer. */
     struct s2n_stuffer old_stuffer = *stuffer;
 
     /* Store a byte from the stuffer that wont be overwritten to compare if the write succeeds. */
     __CPROVER_assume(index < stuffer->blob.size);
-    if(__CPROVER_overflow_plus(old_stuffer.write_cursor, size)) {
+    if (__CPROVER_overflow_plus(old_stuffer.write_cursor, size)) {
         __CPROVER_assume(index < old_stuffer.write_cursor);
     } else {
         __CPROVER_assume(index < old_stuffer.write_cursor || index >= old_stuffer.write_cursor + size);
     }
-    uint8_t untouched_byte = stuffer->blob.data[index];
+    uint8_t untouched_byte = stuffer->blob.data[ index ];
 
     /* Operation under verification. */
     if (s2n_stuffer_write_bytes(stuffer, data, size) == S2N_SUCCESS) {
         assert(stuffer->write_cursor == old_stuffer.write_cursor + size);
-        assert(stuffer->blob.data[index] == untouched_byte);
+        assert(stuffer->blob.data[ index ] == untouched_byte);
         assert(stuffer->high_water_mark == MAX(old_stuffer.write_cursor + size, old_stuffer.high_water_mark));
         assert(s2n_stuffer_is_valid(stuffer));
     } else {

--- a/tests/cbmc/proofs/s2n_stuffer_write_network_order/s2n_stuffer_write_network_order_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_network_order/s2n_stuffer_write_network_order_harness.c
@@ -13,46 +13,42 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-
-#include "stuffer/s2n_stuffer.h"
-#include "utils/s2n_safety.h"
-
 #include <assert.h>
-
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/endian.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
 
-void s2n_stuffer_write_network_order_harness() {
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+void s2n_stuffer_write_network_order_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
     uint64_t input;
-    uint8_t length;
+    uint8_t  length;
 
     /* Store a byte from the stuffer to compare if the write fails */
-    struct s2n_stuffer old_stuffer = *stuffer;
+    struct s2n_stuffer            old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte_from_stuffer;
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
     /* Operation under verification. */
     if (s2n_stuffer_write_network_order(stuffer, input, length) == S2N_SUCCESS) {
         assert(stuffer->write_cursor == old_stuffer.write_cursor + length);
         assert(s2n_stuffer_is_valid(stuffer));
-        if(length == 0) {
+        if (length == 0) {
             assert_stuffer_equivalence(stuffer, &old_stuffer, &old_byte_from_stuffer);
         } else {
-            uint8_t* data = stuffer->blob.data + old_stuffer.write_cursor;
+            uint8_t *data = stuffer->blob.data + old_stuffer.write_cursor;
             for (int i = 0; i < length; i++) {
                 uint8_t shift = (length - i - 1) * CHAR_BIT;
-                assert(data[i] == ((input >> (shift)) & UINT8_MAX));
+                assert(data[ i ] == ((input >> (shift)) & UINT8_MAX));
             }
         }
     } else {

--- a/tests/cbmc/proofs/s2n_stuffer_write_reservation/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_reservation/Makefile
@@ -44,6 +44,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
+REMOVE_FUNCTION_BODY += s2n_mem_cleanup_impl
 
 UNWINDSET += s2n_stuffer_write_network_order.0:$(MAX_WRITE_NETWORK_ORDER)
 UNWINDSET += s2n_stuffer_write_network_order.1:$(MAX_WRITE_NETWORK_ORDER)

--- a/tests/cbmc/proofs/s2n_stuffer_write_reservation/s2n_stuffer_write_reservation_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_reservation/s2n_stuffer_write_reservation_harness.c
@@ -13,28 +13,25 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/nondet.h>
+#include <cbmc_proof/proof_allocators.h>
 #include <sys/param.h>
 
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_mem.h"
 
-#include <assert.h>
-#include <cbmc_proof/cbmc_utils.h>
-#include <cbmc_proof/make_common_datastructures.h>
-#include <cbmc_proof/nondet.h>
-#include <cbmc_proof/proof_allocators.h>
-
-void s2n_stuffer_write_reservation_harness() {
+void s2n_stuffer_write_reservation_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer_reservation *reservation = cbmc_allocate_s2n_stuffer_reservation();
     __CPROVER_assume(s2n_stuffer_reservation_is_valid(reservation));
     uint32_t u;
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
     /* Save previous state from stuffer_reservation. */
     struct s2n_stuffer_reservation old_stuffer_reservation = *reservation;

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint16/s2n_stuffer_write_uint16_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint16/s2n_stuffer_write_uint16_harness.c
@@ -13,19 +13,18 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-
-#include "stuffer/s2n_stuffer.h"
-#include "utils/s2n_safety.h"
-
 #include <assert.h>
-
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/endian.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
 
-void s2n_stuffer_write_uint16_harness() {
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+void s2n_stuffer_write_uint16_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
@@ -33,26 +32,23 @@ void s2n_stuffer_write_uint16_harness() {
     uint32_t index;
 
     /* Store a byte from the stuffer to compare if the write fails */
-    struct s2n_stuffer old_stuffer = *stuffer;
+    struct s2n_stuffer            old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte_from_stuffer;
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
     /* Store a byte from the stuffer that won't be overwritten to compare if the write succeeds. */
-    __CPROVER_assume(index < stuffer->blob.size && (index < old_stuffer.write_cursor ||
-                                                    index >= old_stuffer.write_cursor + sizeof(uint16_t)));
-    uint8_t untouched_byte = stuffer->blob.data[index];
+    __CPROVER_assume(index < stuffer->blob.size
+                     && (index < old_stuffer.write_cursor || index >= old_stuffer.write_cursor + sizeof(uint16_t)));
+    uint8_t untouched_byte = stuffer->blob.data[ index ];
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
     /* Operation under verification. */
     if (s2n_stuffer_write_uint16(stuffer, src) == S2N_SUCCESS) {
         assert(stuffer->write_cursor == old_stuffer.write_cursor + sizeof(uint16_t));
-        assert(stuffer->blob.data[index] == untouched_byte);
+        assert(stuffer->blob.data[ index ] == untouched_byte);
         /* Ensure uint was correctly written to the stuffer */
-        assert(be16toh(*((uint16_t*)(stuffer->blob.data+old_stuffer.write_cursor))) == src);
+        assert(be16toh(*(( uint16_t * )(stuffer->blob.data + old_stuffer.write_cursor))) == src);
         assert(s2n_stuffer_is_valid(stuffer));
     } else {
         assert(stuffer->write_cursor == old_stuffer.write_cursor);

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint24/s2n_stuffer_write_uint24_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint24/s2n_stuffer_write_uint24_harness.c
@@ -13,18 +13,17 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-
-#include "stuffer/s2n_stuffer.h"
-#include "utils/s2n_safety.h"
-
 #include <assert.h>
-
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
 
-void s2n_stuffer_write_uint24_harness() {
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+void s2n_stuffer_write_uint24_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
@@ -32,28 +31,26 @@ void s2n_stuffer_write_uint24_harness() {
     uint32_t index;
 
     /* Store a byte from the stuffer to compare if the write fails */
-    struct s2n_stuffer old_stuffer = *stuffer;
+    struct s2n_stuffer            old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte_from_stuffer;
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
     /* Store a byte from the stuffer that won't be overwritten to compare if the write succeeds. */
-    __CPROVER_assume(index < stuffer->blob.size && (index < old_stuffer.write_cursor ||
-                                                    index >= old_stuffer.write_cursor + (size_t)SIZEOF_UINT24));
-    uint8_t untouched_byte = stuffer->blob.data[index];
+    __CPROVER_assume(
+        index < stuffer->blob.size
+        && (index < old_stuffer.write_cursor || index >= old_stuffer.write_cursor + ( size_t )SIZEOF_UINT24));
+    uint8_t untouched_byte = stuffer->blob.data[ index ];
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
     /* Operation under verification. */
     if (s2n_stuffer_write_uint24(stuffer, src) == S2N_SUCCESS) {
         assert(stuffer->write_cursor == old_stuffer.write_cursor + SIZEOF_UINT24);
-        assert(stuffer->blob.data[index] == untouched_byte);
+        assert(stuffer->blob.data[ index ] == untouched_byte);
         /* Ensure uint was correctly written to the stuffer */
-        assert(((uint32_t) stuffer->blob.data[old_stuffer.write_cursor]) << 16
-             | ((uint32_t) stuffer->blob.data[old_stuffer.write_cursor + 1]) << 8
-             | ((uint32_t) stuffer->blob.data[old_stuffer.write_cursor + 2]) == (src & 0xFFFFFF));
+        assert((( uint32_t )stuffer->blob.data[ old_stuffer.write_cursor ]) << 16
+               | (( uint32_t )stuffer->blob.data[ old_stuffer.write_cursor + 1 ]) << 8
+               | (( uint32_t )stuffer->blob.data[ old_stuffer.write_cursor + 2 ]) == (src & 0xFFFFFF));
         assert(s2n_stuffer_is_valid(stuffer));
     } else {
         assert(stuffer->write_cursor == old_stuffer.write_cursor);

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint32/s2n_stuffer_write_uint32_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint32/s2n_stuffer_write_uint32_harness.c
@@ -13,19 +13,18 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-
-#include "stuffer/s2n_stuffer.h"
-#include "utils/s2n_safety.h"
-
 #include <assert.h>
-
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/endian.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
 
-void s2n_stuffer_write_uint32_harness() {
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+void s2n_stuffer_write_uint32_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
@@ -33,26 +32,23 @@ void s2n_stuffer_write_uint32_harness() {
     uint32_t index;
 
     /* Store a byte from the stuffer to compare if the write fails */
-    struct s2n_stuffer old_stuffer = *stuffer;
+    struct s2n_stuffer            old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte_from_stuffer;
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
     /* Store a byte from the stuffer that won't be overwritten to compare if the write succeeds. */
-    __CPROVER_assume(index < stuffer->blob.size && (index < old_stuffer.write_cursor ||
-                                                    index >= old_stuffer.write_cursor + sizeof(uint32_t)));
-    uint8_t untouched_byte = stuffer->blob.data[index];
+    __CPROVER_assume(index < stuffer->blob.size
+                     && (index < old_stuffer.write_cursor || index >= old_stuffer.write_cursor + sizeof(uint32_t)));
+    uint8_t untouched_byte = stuffer->blob.data[ index ];
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
     /* Operation under verification. */
     if (s2n_stuffer_write_uint32(stuffer, src) == S2N_SUCCESS) {
         assert(stuffer->write_cursor == old_stuffer.write_cursor + sizeof(uint32_t));
-        assert(stuffer->blob.data[index] == untouched_byte);
+        assert(stuffer->blob.data[ index ] == untouched_byte);
         /* Ensure uint was correctly written to the stuffer */
-        assert(be32toh(*((uint32_t*)(stuffer->blob.data+old_stuffer.write_cursor))) == src);
+        assert(be32toh(*(( uint32_t * )(stuffer->blob.data + old_stuffer.write_cursor))) == src);
         assert(s2n_stuffer_is_valid(stuffer));
     } else {
         assert(stuffer->write_cursor == old_stuffer.write_cursor);

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint64/s2n_stuffer_write_uint64_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint64/s2n_stuffer_write_uint64_harness.c
@@ -13,19 +13,18 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-
-#include "stuffer/s2n_stuffer.h"
-#include "utils/s2n_safety.h"
-
 #include <assert.h>
-
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/endian.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
 
-void s2n_stuffer_write_uint64_harness() {
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+void s2n_stuffer_write_uint64_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
@@ -33,26 +32,23 @@ void s2n_stuffer_write_uint64_harness() {
     uint32_t index;
 
     /* Store a byte from the stuffer to compare if the write fails */
-    struct s2n_stuffer old_stuffer = *stuffer;
+    struct s2n_stuffer            old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte_from_stuffer;
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
     /* Store a byte from the stuffer that won't be overwritten to compare if the write succeeds. */
-    __CPROVER_assume(index < stuffer->blob.size && (index < old_stuffer.write_cursor ||
-                                                    index >= old_stuffer.write_cursor + sizeof(uint64_t)));
-    uint8_t untouched_byte = stuffer->blob.data[index];
+    __CPROVER_assume(index < stuffer->blob.size
+                     && (index < old_stuffer.write_cursor || index >= old_stuffer.write_cursor + sizeof(uint64_t)));
+    uint8_t untouched_byte = stuffer->blob.data[ index ];
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
     /* Operation under verification. */
     if (s2n_stuffer_write_uint64(stuffer, src) == S2N_SUCCESS) {
         assert(stuffer->write_cursor == old_stuffer.write_cursor + sizeof(uint64_t));
-        assert(stuffer->blob.data[index] == untouched_byte);
+        assert(stuffer->blob.data[ index ] == untouched_byte);
         /* Ensure uint was correctly written to the stuffer */
-        assert(be64toh(*((uint64_t*)(stuffer->blob.data+old_stuffer.write_cursor))) == src);
+        assert(be64toh(*(( uint64_t * )(stuffer->blob.data + old_stuffer.write_cursor))) == src);
         assert(s2n_stuffer_is_valid(stuffer));
     }
     assert(stuffer->alloced == old_stuffer.alloced);

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint8/s2n_stuffer_write_uint8_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint8/s2n_stuffer_write_uint8_harness.c
@@ -13,45 +13,41 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-
-#include "stuffer/s2n_stuffer.h"
-#include "utils/s2n_safety.h"
-
 #include <assert.h>
-
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/proof_allocators.h>
 
-void s2n_stuffer_write_uint8_harness() {
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+void s2n_stuffer_write_uint8_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
-    uint8_t src;
+    uint8_t  src;
     uint32_t index;
 
     /* Store a byte from the stuffer to compare if the write fails */
-    struct s2n_stuffer old_stuffer = *stuffer;
+    struct s2n_stuffer            old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte_from_stuffer;
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 
     /* Store a byte from the stuffer that won't be overwritten to compare if the write succeeds. */
-    __CPROVER_assume(index < stuffer->blob.size && (index < old_stuffer.write_cursor ||
-                                                    index >= old_stuffer.write_cursor + sizeof(uint8_t)));
-    uint8_t untouched_byte = stuffer->blob.data[index];
+    __CPROVER_assume(index < stuffer->blob.size
+                     && (index < old_stuffer.write_cursor || index >= old_stuffer.write_cursor + sizeof(uint8_t)));
+    uint8_t untouched_byte = stuffer->blob.data[ index ];
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
     /* Operation under verification. */
     if (s2n_stuffer_write_uint8(stuffer, src) == S2N_SUCCESS) {
         assert(stuffer->write_cursor == old_stuffer.write_cursor + sizeof(uint8_t));
-        assert(stuffer->blob.data[index] == untouched_byte);
+        assert(stuffer->blob.data[ index ] == untouched_byte);
         /* Ensure uint was correctly written to the stuffer */
-        assert(stuffer->blob.data[old_stuffer.write_cursor] == src);
+        assert(stuffer->blob.data[ old_stuffer.write_cursor ] == src);
         assert(s2n_stuffer_is_valid(stuffer));
     } else {
         assert(stuffer->write_cursor == old_stuffer.write_cursor);

--- a/tests/cbmc/proofs/s2n_stuffer_write_vector_size/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_vector_size/Makefile
@@ -41,6 +41,7 @@ REMOVE_FUNCTION_BODY += s2n_add_overflow
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += s2n_stuffer_resize
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
+REMOVE_FUNCTION_BODY += s2n_mem_cleanup_impl
 
 UNWINDSET += s2n_stuffer_write_network_order.0:$(MAX_WRITE_NETWORK_ORDER)
 UNWINDSET += s2n_stuffer_write_network_order.1:$(MAX_WRITE_NETWORK_ORDER)

--- a/tests/cbmc/proofs/s2n_stuffer_write_vector_size/s2n_stuffer_write_vector_size_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_vector_size/s2n_stuffer_write_vector_size_harness.c
@@ -13,27 +13,24 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/nondet.h>
+#include <cbmc_proof/proof_allocators.h>
 #include <sys/param.h>
 
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_mem.h"
 
-#include <assert.h>
-#include <cbmc_proof/cbmc_utils.h>
-#include <cbmc_proof/make_common_datastructures.h>
-#include <cbmc_proof/nondet.h>
-#include <cbmc_proof/proof_allocators.h>
-
-void s2n_stuffer_write_vector_size_harness() {
+void s2n_stuffer_write_vector_size_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer_reservation *reservation = cbmc_allocate_s2n_stuffer_reservation();
     __CPROVER_assume(s2n_stuffer_reservation_is_valid(reservation));
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
     /* Save previous state from stuffer_reservation. */
     struct s2n_stuffer_reservation old_stuffer_reservation = *reservation;

--- a/tests/cbmc/proofs/s2n_stuffer_writev_bytes/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_writev_bytes/Makefile
@@ -41,6 +41,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
+REMOVE_FUNCTION_BODY += s2n_mem_cleanup_impl
 
 UNWINDSET += s2n_stuffer_writev_bytes.20:$(call addone,$(MAX_IOVEC_SIZE))
 UNWINDSET += s2n_stuffer_writev_bytes_harness.0:$(call addone,$(MAX_IOVEC_SIZE))

--- a/tests/cbmc/proofs/s2n_stuffer_writev_bytes/s2n_stuffer_writev_bytes_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_writev_bytes/s2n_stuffer_writev_bytes_harness.c
@@ -13,37 +13,32 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <sys/param.h>
+
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_mem.h"
 
-#include <sys/param.h>
-#include <assert.h>
-
-#include <cbmc_proof/cbmc_utils.h>
-#include <cbmc_proof/make_common_datastructures.h>
-#include <cbmc_proof/proof_allocators.h>
-
-void s2n_stuffer_writev_bytes_harness() {
+void s2n_stuffer_writev_bytes_harness()
+{
     /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
     size_t iov_count;
     __CPROVER_assume(iov_count < MAX_IOVEC_SIZE);
-    struct iovec iov[iov_count];
-    for(int i = 0; i < iov_count; i++) {
-        iov[i].iov_base = can_fail_malloc(iov[i].iov_len);
-    }
+    struct iovec iov[ iov_count ];
+    for (int i = 0; i < iov_count; i++) { iov[ i ].iov_base = can_fail_malloc(iov[ i ].iov_len); }
     uint32_t offs;
     uint32_t size;
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if(nondet_bool()) {
-        s2n_mem_init();
-    }
+    nondet_s2n_mem_init();
 
     /* Save previous state from stuffer. */
-    struct s2n_stuffer old_stuffer = *stuffer;
+    struct s2n_stuffer            old_stuffer = *stuffer;
     struct store_byte_from_buffer old_byte_from_stuffer;
     save_byte_from_blob(&stuffer->blob, &old_byte_from_stuffer);
 

--- a/tests/cbmc/sources/cbmc_utils.c
+++ b/tests/cbmc/sources/cbmc_utils.c
@@ -181,3 +181,7 @@ uint64_t uninterpreted_hasher(const void *a) {
 }
 
 bool uninterpreted_predicate_fn(uint8_t value);
+
+void nondet_s2n_mem_init() {
+    if (nondet_bool()) { s2n_mem_init(); }
+}

--- a/tests/cbmc/sources/cbmc_utils.c
+++ b/tests/cbmc/sources/cbmc_utils.c
@@ -14,12 +14,11 @@
  */
 
 #include <assert.h>
-
 #include <cbmc_proof/cbmc_utils.h>
 
-void assert_stuffer_immutable_fields_after_read(const struct s2n_stuffer *lhs,
-                                                const struct s2n_stuffer *rhs,
-                                                const struct store_byte_from_buffer *stored_byte_from_rhs) {
+void assert_stuffer_immutable_fields_after_read(const struct s2n_stuffer *lhs, const struct s2n_stuffer *rhs,
+                                                const struct store_byte_from_buffer *stored_byte_from_rhs)
+{
     /* In order to be equivalent, either both are NULL or both are non-NULL */
     if (lhs == rhs) {
         return;
@@ -34,9 +33,9 @@ void assert_stuffer_immutable_fields_after_read(const struct s2n_stuffer *lhs,
     assert_blob_equivalence(&lhs->blob, &rhs->blob, stored_byte_from_rhs);
 }
 
-void assert_blob_equivalence(const struct s2n_blob *lhs,
-                             const struct s2n_blob *rhs,
-                             const struct store_byte_from_buffer *stored_byte_from_rhs) {
+void assert_blob_equivalence(const struct s2n_blob *lhs, const struct s2n_blob *rhs,
+                             const struct store_byte_from_buffer *stored_byte_from_rhs)
+{
     /* In order to be equivalent, either both are NULL or both are non-NULL */
     if (lhs == rhs) {
         return;
@@ -46,14 +45,12 @@ void assert_blob_equivalence(const struct s2n_blob *lhs,
     assert(lhs->size == rhs->size);
     assert(lhs->allocated == rhs->allocated);
     assert(lhs->growable == rhs->growable);
-    if (lhs->size > 0) {
-        assert_byte_from_blob_matches(lhs, stored_byte_from_rhs);
-    }
+    if (lhs->size > 0) { assert_byte_from_blob_matches(lhs, stored_byte_from_rhs); }
 }
 
-void assert_stuffer_equivalence(const struct s2n_stuffer *lhs,
-                                const struct s2n_stuffer *rhs,
-                                const struct store_byte_from_buffer *stored_byte_from_rhs) {
+void assert_stuffer_equivalence(const struct s2n_stuffer *lhs, const struct s2n_stuffer *rhs,
+                                const struct store_byte_from_buffer *stored_byte_from_rhs)
+{
     /* In order to be equivalent, either both are NULL or both are non-NULL */
     if (lhs == rhs) {
         return;
@@ -69,59 +66,61 @@ void assert_stuffer_equivalence(const struct s2n_stuffer *lhs,
     assert_blob_equivalence(&lhs->blob, &rhs->blob, stored_byte_from_rhs);
 }
 
-void assert_bytes_match(const uint8_t *const a, const uint8_t *const b, const size_t len) {
+void assert_bytes_match(const uint8_t *const a, const uint8_t *const b, const size_t len)
+{
     assert(!a == !b);
     if (len > 0 && a != NULL && b != NULL) {
         size_t i;
         __CPROVER_assume(i < len && len < MAX_MALLOC); /* prevent spurious pointer overflows */
-        assert(a[i] == b[i]);
+        assert(a[ i ] == b[ i ]);
     }
 }
 
-void assert_all_bytes_are(const uint8_t *const a, const uint8_t c, const size_t len) {
+void assert_all_bytes_are(const uint8_t *const a, const uint8_t c, const size_t len)
+{
     if (len > 0 && a != NULL) {
         size_t i;
         __CPROVER_assume(i < len);
-        assert(a[i] == c);
+        assert(a[ i ] == c);
     }
 }
 
-void assert_all_zeroes(const uint8_t *const a, const size_t len) {
-    assert_all_bytes_are(a, 0, len);
+void assert_all_zeroes(const uint8_t *const a, const size_t len) { assert_all_bytes_are(a, 0, len); }
+
+void assert_byte_from_buffer_matches(const uint8_t *const buffer, const struct store_byte_from_buffer *const b)
+{
+    if (buffer && b) { assert(*(buffer + b->index) == b->byte); }
 }
 
-void assert_byte_from_buffer_matches(const uint8_t *const buffer, const struct store_byte_from_buffer *const b) {
-    if (buffer && b) {
-        assert(*(buffer + b->index) == b->byte);
-    }
+void assert_byte_from_blob_matches(const struct s2n_blob *blob, const struct store_byte_from_buffer *const b)
+{
+    if (blob && blob->size) { assert_byte_from_buffer_matches(blob->data, b); }
 }
 
-void assert_byte_from_blob_matches(const struct s2n_blob *blob, const struct store_byte_from_buffer *const b) {
-    if(blob && blob->size) {
-        assert_byte_from_buffer_matches(blob->data, b);
-    }
-}
-
-void save_byte_from_array(const uint8_t *const array, const size_t size, struct store_byte_from_buffer *const storage) {
+void save_byte_from_array(const uint8_t *const array, const size_t size, struct store_byte_from_buffer *const storage)
+{
     if (size > 0 && array && storage) {
         storage->index = nondet_size_t();
         __CPROVER_assume(storage->index < size);
-        storage->byte = array[storage->index];
+        storage->byte = array[ storage->index ];
     }
 }
 
-void save_byte_from_blob(const struct s2n_blob *blob, struct store_byte_from_buffer * storage) {
+void save_byte_from_blob(const struct s2n_blob *blob, struct store_byte_from_buffer *storage)
+{
     save_byte_from_array(blob->data, blob->size, storage);
 }
 
-int nondet_compare(const void *const a, const void *const b) {
+int nondet_compare(const void *const a, const void *const b)
+{
     assert(a != NULL);
     assert(b != NULL);
     return nondet_int();
 }
 
 int __CPROVER_uninterpreted_compare(const void *const a, const void *const b);
-int uninterpreted_compare(const void *const a, const void *const b) {
+int uninterpreted_compare(const void *const a, const void *const b)
+{
     assert(a != NULL);
     assert(b != NULL);
     int rval = __CPROVER_uninterpreted_compare(a, b);
@@ -130,44 +129,44 @@ int uninterpreted_compare(const void *const a, const void *const b) {
     /* Compare is anti-symmetric*/
     __CPROVER_assume(__CPROVER_uninterpreted_compare(b, a) == -rval);
     /* If two things are equal, their hashes are also equal */
-    if (rval == 0) {
-        __CPROVER_assume(__CPROVER_uninterpreted_hasher(a) == __CPROVER_uninterpreted_hasher(b));
-    }
+    if (rval == 0) { __CPROVER_assume(__CPROVER_uninterpreted_hasher(a) == __CPROVER_uninterpreted_hasher(b)); }
     return rval;
 }
 
-bool nondet_equals(const void *const a, const void *const b) {
+bool nondet_equals(const void *const a, const void *const b)
+{
     assert(a != NULL);
     assert(b != NULL);
     return nondet_bool();
 }
 
-bool __CPROVER_uninterpreted_equals(const void *const a, const void *const b);
+bool     __CPROVER_uninterpreted_equals(const void *const a, const void *const b);
 uint64_t __CPROVER_uninterpreted_hasher(const void *const a);
 /**
  * Add assumptions that equality is reflexive and symmetric. Don't bother with
  * transitivity because it doesn't cause any spurious proof failures on hash-table
  */
-bool uninterpreted_equals(const void *const a, const void *const b) {
+bool uninterpreted_equals(const void *const a, const void *const b)
+{
     bool rval = __CPROVER_uninterpreted_equals(a, b);
     /* Equals is reflexive */
     __CPROVER_assume(IMPLIES(a == b, rval));
     /* Equals is symmetric */
     __CPROVER_assume(__CPROVER_uninterpreted_equals(b, a) == rval);
     /* If two things are equal, their hashes are also equal */
-    if (rval) {
-        __CPROVER_assume(__CPROVER_uninterpreted_hasher(a) == __CPROVER_uninterpreted_hasher(b));
-    }
+    if (rval) { __CPROVER_assume(__CPROVER_uninterpreted_hasher(a) == __CPROVER_uninterpreted_hasher(b)); }
     return rval;
 }
 
-bool uninterpreted_equals_assert_inputs_nonnull(const void *const a, const void *const b) {
+bool uninterpreted_equals_assert_inputs_nonnull(const void *const a, const void *const b)
+{
     assert(a != NULL);
     assert(b != NULL);
     return uninterpreted_equals(a, b);
 }
 
-uint64_t nondet_hasher(const void *a) {
+uint64_t nondet_hasher(const void *a)
+{
     assert(a != NULL);
     return nondet_uint64_t();
 }
@@ -175,13 +174,15 @@ uint64_t nondet_hasher(const void *a) {
 /**
  * Standard stub function to hash one item.
  */
-uint64_t uninterpreted_hasher(const void *a) {
+uint64_t uninterpreted_hasher(const void *a)
+{
     assert(a != NULL);
     return __CPROVER_uninterpreted_hasher(a);
 }
 
 bool uninterpreted_predicate_fn(uint8_t value);
 
-void nondet_s2n_mem_init() {
+void nondet_s2n_mem_init()
+{
     if (nondet_bool()) { s2n_mem_init(); }
 }

--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -15,69 +15,68 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
-bool s2n_blob_is_bounded(const struct s2n_blob* blob, const size_t max_size) {
-    return (blob->size <= max_size);
-}
+bool s2n_blob_is_bounded(const struct s2n_blob *blob, const size_t max_size) { return (blob->size <= max_size); }
 
-bool s2n_stuffer_is_bounded(const struct s2n_stuffer* stuffer, const size_t max_size) {
+bool s2n_stuffer_is_bounded(const struct s2n_stuffer *stuffer, const size_t max_size)
+{
     return (stuffer->blob.size <= max_size);
 }
 
-void ensure_s2n_blob_has_allocated_fields(struct s2n_blob* blob) {
-    if(blob->growable) {
+void ensure_s2n_blob_has_allocated_fields(struct s2n_blob *blob)
+{
+    if (blob->growable) {
         blob->data = (blob->allocated == 0) ? NULL : bounded_malloc(blob->allocated);
     } else {
         blob->data = (blob->size == 0) ? NULL : bounded_malloc(blob->size);
     }
 }
 
-struct s2n_blob* cbmc_allocate_s2n_blob() {
-    struct s2n_blob* blob = can_fail_malloc(sizeof(*blob));
-    if (blob !=  NULL) {
-	      ensure_s2n_blob_has_allocated_fields(blob);
-    }
+struct s2n_blob *cbmc_allocate_s2n_blob()
+{
+    struct s2n_blob *blob = can_fail_malloc(sizeof(*blob));
+    if (blob != NULL) { ensure_s2n_blob_has_allocated_fields(blob); }
     return blob;
 }
 
-void ensure_s2n_stuffer_has_allocated_fields(struct s2n_stuffer* stuffer)
+void ensure_s2n_stuffer_has_allocated_fields(struct s2n_stuffer *stuffer)
 {
     ensure_s2n_blob_has_allocated_fields(&stuffer->blob);
 }
 
-struct s2n_stuffer* cbmc_allocate_s2n_stuffer() {
-    struct s2n_stuffer* stuffer = can_fail_malloc(sizeof(*stuffer));
-    if (stuffer != NULL) {
-        ensure_s2n_stuffer_has_allocated_fields(stuffer);
-    }
+struct s2n_stuffer *cbmc_allocate_s2n_stuffer()
+{
+    struct s2n_stuffer *stuffer = can_fail_malloc(sizeof(*stuffer));
+    if (stuffer != NULL) { ensure_s2n_stuffer_has_allocated_fields(stuffer); }
     return stuffer;
 }
 
-const char *ensure_c_str_is_allocated(size_t max_size) {
+const char *ensure_c_str_is_allocated(size_t max_size)
+{
     size_t cap;
     __CPROVER_assume(cap > 0 && cap <= max_size);
     const char *str = bounded_malloc(cap);
     /* Ensure that its a valid c string. Since all bytes are nondeterminstic, the actual
      * string length is 0..str_cap
      */
-    __CPROVER_assume(str[cap - 1] == 0);
+    __CPROVER_assume(str[ cap - 1 ] == 0);
     return str;
 }
 
-const char *nondet_c_str_is_allocated(size_t max_size) {
+const char *nondet_c_str_is_allocated(size_t max_size)
+{
     size_t cap;
     __CPROVER_assume(cap > 0 && cap <= max_size);
     const char *str = can_fail_malloc(cap);
     /* Ensure that its a valid c string. Since all bytes are nondeterminstic, the actual
      * string length is 0..str_cap
      */
-    __CPROVER_assume(IMPLIES(str != NULL, str[cap - 1] == 0));
+    __CPROVER_assume(IMPLIES(str != NULL, str[ cap - 1 ] == 0));
     return str;
 }
 
-struct s2n_stuffer_reservation* cbmc_allocate_s2n_stuffer_reservation() {
-    struct s2n_stuffer_reservation* reservation = can_fail_malloc(sizeof(*reservation));
-    if (reservation != NULL) {
-        reservation->stuffer = cbmc_allocate_s2n_stuffer();
-    }
+struct s2n_stuffer_reservation *cbmc_allocate_s2n_stuffer_reservation()
+{
+    struct s2n_stuffer_reservation *reservation = can_fail_malloc(sizeof(*reservation));
+    if (reservation != NULL) { reservation->stuffer = cbmc_allocate_s2n_stuffer(); }
     return reservation;
 }

--- a/tests/cbmc/sources/proof_allocators.c
+++ b/tests/cbmc/sources/proof_allocators.c
@@ -17,26 +17,23 @@
 #include <stdarg.h>
 #include <stdlib.h>
 
-void *bounded_calloc(size_t num, size_t size) {
+void *bounded_calloc(size_t num, size_t size)
+{
     size_t required_bytes;
     __CPROVER_assume(!__builtin_mul_overflow(num, size, &required_bytes));
     __CPROVER_assume(required_bytes <= MAX_MALLOC);
     return calloc(num, size);
 }
 
-void *bounded_malloc(size_t size) {
+void *bounded_malloc(size_t size)
+{
     __CPROVER_assume(size <= MAX_MALLOC);
     return malloc(size);
 }
 
+void *can_fail_calloc(size_t num, size_t size) { return nondet_bool() ? NULL : bounded_calloc(num, size); }
 
-void *can_fail_calloc(size_t num, size_t size) {
-    return nondet_bool() ? NULL : bounded_calloc(num, size);
-}
-
-void *can_fail_malloc(size_t size) {
-    return nondet_bool() ? NULL : bounded_malloc(size);
-}
+void *can_fail_malloc(size_t size) { return nondet_bool() ? NULL : bounded_malloc(size); }
 
 /**
  * https://en.cppreference.com/w/c/memory/realloc
@@ -48,14 +45,11 @@ void *can_fail_malloc(size_t size) {
  * memory block may or may not be freed), or some non-null pointer may be returned that may not be used to access
  * storage).
  */
-void *can_fail_realloc(void *ptr, size_t newsize) {
-    if (newsize > MAX_MALLOC) {
-        return NULL;
-    }
+void *can_fail_realloc(void *ptr, size_t newsize)
+{
+    if (newsize > MAX_MALLOC) { return NULL; }
     if (newsize == 0) {
-        if (nondet_bool()) {
-            free(ptr);
-        }
+        if (nondet_bool()) { free(ptr); }
         return nondet_voidp();
     }
     return nondet_bool() ? NULL : realloc(ptr, newsize);

--- a/tests/cbmc/stubs/__tolower.c
+++ b/tests/cbmc/stubs/__tolower.c
@@ -23,9 +23,6 @@
 
 int __tolower(int c)
 {
-    if(c >= 'A' && c <= 'Z')
-    {
-        c = c + ('a' - 'A');
-    }
+    if (c >= 'A' && c <= 'Z') { c = c + ('a' - 'A'); }
     return c;
 }

--- a/tests/cbmc/stubs/abort_override_assert_false.c
+++ b/tests/cbmc/stubs/abort_override_assert_false.c
@@ -21,6 +21,4 @@
 
 #include <assert.h>
 
-void abort() {
-    assert(0);
-}
+void abort() { assert(0); }

--- a/tests/cbmc/stubs/close.c
+++ b/tests/cbmc/stubs/close.c
@@ -21,11 +21,10 @@
 
 static bool loop_flag = false;
 
-int close(int fd) {
+int close(int fd)
+{
     assert(fd >= -1 && fd <= 65536 /* File descriptor limit. */);
-    if(nondet_bool()) {
-        return 0;
-    }
+    if (nondet_bool()) { return 0; }
     __CPROVER_assume(errno == EBADF || errno == EINTR || errno == EIO);
     return -1;
 }

--- a/tests/cbmc/stubs/fstat.c
+++ b/tests/cbmc/stubs/fstat.c
@@ -17,7 +17,8 @@
 #include <cbmc_proof/nondet.h>
 #include <sys/stat.h>
 
-int fstat(int fd, struct stat *buf) {
+int fstat(int fd, struct stat *buf)
+{
     assert(__CPROVER_w_ok(buf, sizeof(*buf)));
     buf->st_size = nondet_off_t();
     return nondet_bool() ? 0 : -1;

--- a/tests/cbmc/stubs/madvise.c
+++ b/tests/cbmc/stubs/madvise.c
@@ -20,10 +20,8 @@
 
 int madvise(void *addr, size_t length, int advice)
 {
-    assert(S2N_MEM_IS_WRITABLE(addr,length));
-    if(nondet_bool()) {
-        return 0;
-    }
+    assert(S2N_MEM_IS_WRITABLE(addr, length));
+    if (nondet_bool()) { return 0; }
     errno = nondet_int();
     return -1;
 }

--- a/tests/cbmc/stubs/mlock.c
+++ b/tests/cbmc/stubs/mlock.c
@@ -13,13 +13,13 @@
  * limitations under the License.
  */
 
+#include <cbmc_proof/nondet.h>
+
 #include "api/s2n.h"
 #include "error/s2n_errno.h"
 
-#include <cbmc_proof/nondet.h>
-
 int mlock(const void *addr, size_t len)
 {
-    assert(S2N_MEM_IS_WRITABLE(addr,len));
+    assert(S2N_MEM_IS_WRITABLE(addr, len));
     return nondet_int();
 }

--- a/tests/cbmc/stubs/mmap.c
+++ b/tests/cbmc/stubs/mmap.c
@@ -18,10 +18,11 @@
 #include <cbmc_proof/proof_allocators.h>
 #include <sys/mman.h>
 
-void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
+void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset)
+{
     assert(addr == NULL);
     assert(length > 0);
-    if(nondet_bool()) {
+    if (nondet_bool()) {
         uint8_t *buf = can_fail_malloc(length);
         return buf;
     }

--- a/tests/cbmc/stubs/munlock.c
+++ b/tests/cbmc/stubs/munlock.c
@@ -13,14 +13,13 @@
  * limitations under the License.
  */
 
+#include <cbmc_proof/nondet.h>
+
 #include "api/s2n.h"
 #include "error/s2n_errno.h"
 
-#include <cbmc_proof/nondet.h>
-
 int munlock(const void *addr, size_t len)
 {
-    assert(S2N_MEM_IS_WRITABLE(addr,len));
+    assert(S2N_MEM_IS_WRITABLE(addr, len));
     return nondet_int();
 }
-

--- a/tests/cbmc/stubs/open.c
+++ b/tests/cbmc/stubs/open.c
@@ -21,17 +21,18 @@
 
 static bool loop_flag = false;
 
-int open(const char *path, int flag, ...) {
+int open(const char *path, int flag, ...)
+{
     assert(path != NULL);
     assert(flag == O_RDONLY || flag == O_WRONLY || flag == O_RDWR);
     int rval = 0;
-    errno = nondet_int();
-    if(loop_flag) {
+    errno    = nondet_int();
+    if (loop_flag) {
         __CPROVER_assume(errno != EINTR);
         return rval;
     }
     loop_flag = true;
-    rval = nondet_int();
+    rval      = nondet_int();
     __CPROVER_assume(rval >= -1 && rval <= 65536 /* File descriptor limit. */);
     return rval;
 }

--- a/tests/cbmc/stubs/read.c
+++ b/tests/cbmc/stubs/read.c
@@ -19,14 +19,15 @@
 
 static bool loop_flag = false;
 
-ssize_t read(int fd, void *buf, size_t nbyte) {
+ssize_t read(int fd, void *buf, size_t nbyte)
+{
     errno = nondet_int();
-    if(loop_flag) {
+    if (loop_flag) {
         __CPROVER_assume(errno != EINTR);
         return 0;
     }
     loop_flag = true;
     ssize_t rval;
-    __CPROVER_assume(rval <= (ssize_t)nbyte);
+    __CPROVER_assume(rval <= ( ssize_t )nbyte);
     return rval;
 }

--- a/tests/cbmc/stubs/s2n_calculate_stacktrace.c
+++ b/tests/cbmc/stubs/s2n_calculate_stacktrace.c
@@ -13,11 +13,8 @@
  * limitations under the License.
  */
 
-#include "api/s2n.h"
-
 #include <cbmc_proof/nondet.h>
 
-int s2n_calculate_stacktrace()
-{
-    return nondet_bool() ? S2N_SUCCESS : S2N_FAILURE;
-}
+#include "api/s2n.h"
+
+int s2n_calculate_stacktrace() { return nondet_bool() ? S2N_SUCCESS : S2N_FAILURE; }

--- a/tests/cbmc/stubs/s2n_stuffer_read_base64.c
+++ b/tests/cbmc/stubs/s2n_stuffer_read_base64.c
@@ -13,11 +13,11 @@
  * limitations under the License.
  */
 
+#include <cbmc_proof/nondet.h>
+
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_safety.h"
-
-#include <cbmc_proof/nondet.h>
 
 int s2n_stuffer_read_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *out)
 {

--- a/tests/cbmc/stubs/s2n_stuffer_read_expected_str.c
+++ b/tests/cbmc/stubs/s2n_stuffer_read_expected_str.c
@@ -13,11 +13,11 @@
  * limitations under the License.
  */
 
+#include <cbmc_proof/nondet.h>
+
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_safety.h"
-
-#include <cbmc_proof/nondet.h>
 
 int s2n_stuffer_read_expected_str(struct s2n_stuffer *s2n_stuffer, const char *expected)
 {

--- a/tests/cbmc/stubs/s2n_stuffer_skip_expected_char.c
+++ b/tests/cbmc/stubs/s2n_stuffer_skip_expected_char.c
@@ -13,14 +13,15 @@
  * limitations under the License.
  */
 
+#include <cbmc_proof/nondet.h>
+
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_safety.h"
 
-#include <cbmc_proof/nondet.h>
-
 /* Skips an expected character in the stuffer between min and max times */
-int s2n_stuffer_skip_expected_char(struct s2n_stuffer *stuffer, const char expected, const uint32_t min, const uint32_t max, uint32_t *skipped)
+int s2n_stuffer_skip_expected_char(struct s2n_stuffer *stuffer, const char expected, const uint32_t min,
+                                   const uint32_t max, uint32_t *skipped)
 {
     PRECONDITION_POSIX(s2n_stuffer_is_valid(stuffer));
     PRECONDITION_POSIX(min <= max);

--- a/tests/cbmc/stubs/s2n_stuffer_skip_to_char.c
+++ b/tests/cbmc/stubs/s2n_stuffer_skip_to_char.c
@@ -13,11 +13,11 @@
  * limitations under the License.
  */
 
+#include <cbmc_proof/nondet.h>
+
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_safety.h"
-
-#include <cbmc_proof/nondet.h>
 
 int s2n_stuffer_skip_to_char(struct s2n_stuffer *stuffer, const char target)
 {

--- a/tests/cbmc/stubs/s2n_stuffer_skip_whitespace.c
+++ b/tests/cbmc/stubs/s2n_stuffer_skip_whitespace.c
@@ -13,11 +13,11 @@
  * limitations under the License.
  */
 
+#include <cbmc_proof/nondet.h>
+
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_safety.h"
-
-#include <cbmc_proof/nondet.h>
 
 int s2n_stuffer_skip_whitespace(struct s2n_stuffer *s2n_stuffer, uint32_t *skipped)
 {

--- a/tests/cbmc/stubs/sysconf.c
+++ b/tests/cbmc/stubs/sysconf.c
@@ -15,7 +15,4 @@
 
 #include <cbmc_proof/nondet.h>
 
-long sysconf(int name)
-{
-    return nondet_long();
-}
+long sysconf(int name) { return nondet_long(); }

--- a/tests/cbmc/stubs/write.c
+++ b/tests/cbmc/stubs/write.c
@@ -13,23 +13,23 @@
  * limitations under the License.
  */
 
-#include <error/s2n_errno.h>
-
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/nondet.h>
 #include <errno.h>
+#include <error/s2n_errno.h>
 #include <unistd.h>
 
 static bool loop_flag = false;
 
-ssize_t write(int fildes, const void *buf, size_t nbyte) {
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
     errno = nondet_int();
-    if(loop_flag) {
+    if (loop_flag) {
         __CPROVER_assume(errno != EINTR);
         return 0;
     }
     loop_flag = true;
     ssize_t rval;
-    __CPROVER_assume(rval <= (ssize_t)nbyte);
+    __CPROVER_assume(rval <= ( ssize_t )nbyte);
     return rval;
 }


### PR DESCRIPTION
### Resolved issues:

Resolves https://github.com/awslabs/s2n/issues/2124.

### Description of changes: 

Creates a `nondet_s2n_mem_init()` macro to make the code cleaner.
- Adds `nondet_s2n_mem_init()` to CBMC proofs;
- Updates `.gitignore`;
- clang-format CBMC proofs.

### Call-outs:

This PR includes the changes from PR https://github.com/awslabs/s2n/pull/2226.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
