### PR TITLE
Updates s2n_stuffer_write_* proof harnesses

### DIFF
--- a/tests/cbmc/proofs/s2n_stuffer_write_reservation/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_reservation/Makefile
@@ -44,6 +44,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
+REMOVE_FUNCTION_BODY += s2n_mem_cleanup_impl
 
 UNWINDSET += s2n_stuffer_write_network_order.0:$(MAX_WRITE_NETWORK_ORDER)
 UNWINDSET += s2n_stuffer_write_network_order.1:$(MAX_WRITE_NETWORK_ORDER)

--- a/tests/cbmc/proofs/s2n_stuffer_write_vector_size/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_vector_size/Makefile
@@ -41,6 +41,7 @@ REMOVE_FUNCTION_BODY += s2n_add_overflow
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += s2n_stuffer_resize
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
+REMOVE_FUNCTION_BODY += s2n_mem_cleanup_impl
 
 UNWINDSET += s2n_stuffer_write_network_order.0:$(MAX_WRITE_NETWORK_ORDER)
 UNWINDSET += s2n_stuffer_write_network_order.1:$(MAX_WRITE_NETWORK_ORDER)

--- a/tests/cbmc/proofs/s2n_stuffer_writev_bytes/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_writev_bytes/Makefile
@@ -41,6 +41,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
+REMOVE_FUNCTION_BODY += s2n_mem_cleanup_impl
 
 UNWINDSET += s2n_stuffer_writev_bytes.20:$(call addone,$(MAX_IOVEC_SIZE))
 UNWINDSET += s2n_stuffer_writev_bytes_harness.0:$(call addone,$(MAX_IOVEC_SIZE))


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

### Resolved issues:

N/A.

### Description of changes: 

Updates the build process for the following CBMC proofs:
 - s2n_stuffer_write_reservation
 - s2n_stuffer_write_vector_size
 - s2n_stuffer_writev_bytes

### Call-outs:

N/A.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
