### PR TITLE
Fixed processing issue with status request extension

### DIFF
--- a/tests/integration/s2n_client_endpoint_handshake_test.py
+++ b/tests/integration/s2n_client_endpoint_handshake_test.py
@@ -55,12 +55,6 @@ if os.getenv("S2N_NO_PQ") is None:
 
     well_known_endpoints.extend(pq_endpoints)
 
-
-# This can be removed when https://github.com/awslabs/s2n/issues/2220 is fixed.
-allowed_endpoints_failures = [
-    'wikipedia.org', 'yahoo.com'
-]
-
 def print_result(result_prefix, return_code):
     print(result_prefix, end="")
     if return_code == 0:
@@ -125,8 +119,6 @@ def well_known_endpoints_test(use_corked_io, tls13_enabled):
     for endpoint_config in well_known_endpoints:
 
         endpoint = endpoint_config["endpoint"]
-        if endpoint in allowed_endpoints_failures and tls13_enabled:
-            continue
         expected_cipher = endpoint_config.get("expected_cipher")
 
         if "cipher_preference_version" in endpoint_config:

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -339,6 +339,7 @@ s2n_cert_validation_code s2n_x509_validator_validate_cert_chain(struct s2n_x509_
 
         certificate_count++;
     }
+
     if (conn->actual_protocol_version >= S2N_TLS13) {
         GUARD(s2n_extension_list_process(S2N_EXTENSION_LIST_CERTIFICATE, conn, &first_certificate_extensions));
     }


### PR DESCRIPTION
### Resolved issues:

 resolves #2220 
### Description of changes: 
Removed the processing of certificate extensions until after we have read in all certificates in the cert chain. Turning on Yahoo and Wikipedia endpoint tests as we can now correctly process the OCSP response in TLS1.3.
### Call-outs:
N/A
### Testing:

Integration tests/unit tests pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
