### PR TITLE
Improves performance and coverage of s2n_stuffer_* proofs

### DIFF
--- a/tests/cbmc/proofs/s2n_alloc/Makefile
+++ b/tests/cbmc/proofs/s2n_alloc/Makefile
@@ -33,7 +33,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
-REMOVE_FUNCTION_BODY += s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += s2n_ensure_memcpy_trace
 

--- a/tests/cbmc/proofs/s2n_blob_zeroize_free/Makefile
+++ b/tests/cbmc/proofs/s2n_blob_zeroize_free/Makefile
@@ -29,7 +29,7 @@ PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 
-REMOVE_FUNCTION_BODY += s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 
 UNWINDSET +=
 

--- a/tests/cbmc/proofs/s2n_dup/Makefile
+++ b/tests/cbmc/proofs/s2n_dup/Makefile
@@ -10,8 +10,8 @@
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Expected runtime is ten seconds.
+
+# Expected runtime is 20 seconds.
 
 CHECKFLAGS +=
 
@@ -24,7 +24,6 @@ PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
 PROOF_SOURCES += $(PROOF_STUB)/madvise.c
 PROOF_SOURCES += $(PROOF_STUB)/mlock.c
-PROOF_SOURCES += $(PROOF_STUB)/munlock.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 
@@ -33,7 +32,11 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
+# We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_blob_zero
+REMOVE_FUNCTION_BODY += s2n_free
 
 UNWINDSET +=
 

--- a/tests/cbmc/proofs/s2n_dup/Makefile
+++ b/tests/cbmc/proofs/s2n_dup/Makefile
@@ -33,7 +33,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
-REMOVE_FUNCTION_BODY += s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 
 UNWINDSET +=
 

--- a/tests/cbmc/proofs/s2n_dup/s2n_dup_harness.c
+++ b/tests/cbmc/proofs/s2n_dup/s2n_dup_harness.c
@@ -38,8 +38,8 @@ void s2n_dup_harness()
     const struct s2n_blob         old_to   = *to;
     struct store_byte_from_buffer old_byte;
     save_byte_from_blob(from, &old_byte);
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if (nondet_bool()) { s2n_mem_init(); }
+
+    nondet_s2n_mem_init();
 
     if (s2n_dup(from, to) == S2N_SUCCESS) {
         assert(old_from.size != 0);

--- a/tests/cbmc/proofs/s2n_free/Makefile
+++ b/tests/cbmc/proofs/s2n_free/Makefile
@@ -29,7 +29,7 @@ PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 
-REMOVE_FUNCTION_BODY += s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 
 UNWINDSET +=
 

--- a/tests/cbmc/proofs/s2n_free_object/Makefile
+++ b/tests/cbmc/proofs/s2n_free_object/Makefile
@@ -28,7 +28,7 @@ PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 
-REMOVE_FUNCTION_BODY += s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 
 UNWINDSET +=
 

--- a/tests/cbmc/proofs/s2n_mem_cleanup/Makefile
+++ b/tests/cbmc/proofs/s2n_mem_cleanup/Makefile
@@ -30,7 +30,7 @@ PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 
-REMOVE_FUNCTION_BODY += s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 
 UNWINDSET +=
 

--- a/tests/cbmc/proofs/s2n_mem_init/Makefile
+++ b/tests/cbmc/proofs/s2n_mem_init/Makefile
@@ -23,7 +23,7 @@ PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 
 # We abstract this function because manual inspection demonstrates it is unreachable.
-REMOVE_FUNCTION_BODY += s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 
 UNWINDSET +=
 

--- a/tests/cbmc/proofs/s2n_realloc/Makefile
+++ b/tests/cbmc/proofs/s2n_realloc/Makefile
@@ -33,7 +33,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
-REMOVE_FUNCTION_BODY += s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 
 UNWINDSET +=
 

--- a/tests/cbmc/proofs/s2n_stuffer_alloc/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc/Makefile
@@ -11,7 +11,7 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Expected runtime is 20 seconds.
+# Expected runtime is 15 seconds.
 
 CHECKFLAGS +=
 
@@ -19,8 +19,13 @@ HARNESS_ENTRY = s2n_stuffer_alloc_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
 
 PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 
 PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
@@ -29,6 +34,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += s2n_ensure_memcpy_trace
 

--- a/tests/cbmc/proofs/s2n_stuffer_copy/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_copy/Makefile
@@ -11,8 +11,8 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-###########
-#Use the default set of CBMC flags
+# Expected runtime is less than 1 minute.
+
 CHECKFLAGS +=
 
 HARNESS_ENTRY = s2n_stuffer_copy_harness
@@ -22,6 +22,10 @@ PROOF_SOURCES += $(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 
 PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
@@ -29,8 +33,11 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
-#No loops to unwind
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
+
 UNWINDSET +=
-###########
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_copy/s2n_stuffer_copy_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_copy/s2n_stuffer_copy_harness.c
@@ -33,6 +33,8 @@ void s2n_stuffer_copy_harness()
     __CPROVER_assume(s2n_stuffer_is_valid(to));
     uint32_t length;
 
+    nondet_s2n_mem_init();
+
     s2n_stuffer_copy(from, to, length);
 
     /* These assertions should always hold, regardless of whether the test succeeded */

--- a/tests/cbmc/proofs/s2n_stuffer_free/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_free/Makefile
@@ -11,25 +11,28 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-###########
-#Use the default set of CBMC flags
+# Expected runtime is 10 seconds.
+
 CHECKFLAGS +=
 
 HARNESS_ENTRY = s2n_stuffer_free_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
 
 PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
-PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 
 PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
 
-#No loops to unwind
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
 UNWINDSET +=
-###########
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_free/s2n_stuffer_free_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_free/s2n_stuffer_free_harness.c
@@ -28,5 +28,7 @@ void s2n_stuffer_free_harness()
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     __CPROVER_assume(s2n_stuffer_is_valid(stuffer));
 
+    nondet_s2n_mem_init();
+
     if (s2n_stuffer_free(stuffer) == 0) { assert_all_zeroes(stuffer, sizeof(*stuffer)); }
 }

--- a/tests/cbmc/proofs/s2n_stuffer_growable_alloc/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_growable_alloc/Makefile
@@ -19,8 +19,13 @@ HARNESS_ENTRY = s2n_stuffer_growable_alloc_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
 
 PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 
 PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
@@ -29,6 +34,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += s2n_ensure_memcpy_trace
 

--- a/tests/cbmc/proofs/s2n_stuffer_raw_write/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_raw_write/Makefile
@@ -32,7 +32,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 # We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
-REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 
 UNWINDSET +=
 

--- a/tests/cbmc/proofs/s2n_stuffer_raw_write/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_raw_write/Makefile
@@ -31,7 +31,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += s2n_blob_slice
-REMOVE_FUNCTION_BODY += s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
 
 UNWINDSET +=

--- a/tests/cbmc/proofs/s2n_stuffer_read_base64/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_base64/Makefile
@@ -39,7 +39,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += s2n_blob_slice
-REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 
 UNWINDSET += s2n_stuffer_read_base64.23:$(MAX_BLOB_SIZE)
 

--- a/tests/cbmc/proofs/s2n_stuffer_read_token/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_token/Makefile
@@ -37,7 +37,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += s2n_blob_slice
-REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 
 UNWINDSET += s2n_stuffer_read_token.6:$(call addone,$(MAX_BLOB_SIZE))
 

--- a/tests/cbmc/proofs/s2n_stuffer_recv_from_fd/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_recv_from_fd/Makefile
@@ -38,7 +38,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += s2n_blob_slice
-REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 
 UNWINDSET += s2n_stuffer_recv_from_fd.7:3
 

--- a/tests/cbmc/proofs/s2n_stuffer_reserve/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve/Makefile
@@ -36,7 +36,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += s2n_blob_slice
-REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 
 UNWINDSET +=
 

--- a/tests/cbmc/proofs/s2n_stuffer_reserve_space/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve_space/Makefile
@@ -36,7 +36,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 # We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += s2n_calculate_stacktrace
-REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 
 UNWINDSET +=
 

--- a/tests/cbmc/proofs/s2n_stuffer_reserve_uint16/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve_uint16/Makefile
@@ -35,7 +35,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += s2n_blob_slice
-REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 
 UNWINDSET +=
 

--- a/tests/cbmc/proofs/s2n_stuffer_reserve_uint24/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve_uint24/Makefile
@@ -35,7 +35,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += s2n_blob_slice
-REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 
 UNWINDSET +=
 

--- a/tests/cbmc/proofs/s2n_stuffer_resize_if_empty/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_resize_if_empty/Makefile
@@ -35,7 +35,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 REMOVE_FUNCTION_BODY += s2n_calculate_stacktrace
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += s2n_ensure_memcpy_trace
-REMOVE_FUNCTION_BODY += s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 
 UNWINDSET +=
 

--- a/tests/cbmc/proofs/s2n_stuffer_skip_write/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_write/Makefile
@@ -22,6 +22,10 @@ PROOF_SOURCES += $(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 
 PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
@@ -32,7 +36,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 # We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
-REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 
 UNWINDSET +=
 

--- a/tests/cbmc/proofs/s2n_stuffer_skip_write/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_write/Makefile
@@ -31,7 +31,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += s2n_blob_slice
-REMOVE_FUNCTION_BODY += s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
 
 UNWINDSET +=

--- a/tests/cbmc/proofs/s2n_stuffer_write/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write/Makefile
@@ -32,7 +32,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 # We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
-REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 
 UNWINDSET +=
 

--- a/tests/cbmc/proofs/s2n_stuffer_write/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write/Makefile
@@ -31,7 +31,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += s2n_blob_slice
-REMOVE_FUNCTION_BODY += s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
 
 UNWINDSET +=

--- a/tests/cbmc/proofs/s2n_stuffer_write_base64/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_base64/Makefile
@@ -39,7 +39,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += s2n_blob_slice
-REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 
 UNWINDSET += s2n_stuffer_write_base64.16:$(MAX_BLOB_SIZE)
 

--- a/tests/cbmc/proofs/s2n_stuffer_write_bytes/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_bytes/Makefile
@@ -32,7 +32,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 # We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
-REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 
 UNWINDSET +=
 

--- a/tests/cbmc/proofs/s2n_stuffer_write_bytes/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_bytes/Makefile
@@ -31,7 +31,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += s2n_blob_slice
-REMOVE_FUNCTION_BODY += s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
 
 UNWINDSET +=

--- a/tests/cbmc/proofs/s2n_stuffer_write_network_order/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_network_order/Makefile
@@ -34,7 +34,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += s2n_blob_slice
-REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 
 UNWINDSET += s2n_stuffer_write_network_order.4:9
 UNWINDSET += s2n_stuffer_write_network_order_harness.0:9

--- a/tests/cbmc/proofs/s2n_stuffer_write_reservation/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_reservation/Makefile
@@ -44,7 +44,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
-REMOVE_FUNCTION_BODY += s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 
 UNWINDSET += s2n_stuffer_write_network_order.0:$(MAX_WRITE_NETWORK_ORDER)
 UNWINDSET += s2n_stuffer_write_network_order.1:$(MAX_WRITE_NETWORK_ORDER)

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint16/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint16/Makefile
@@ -33,7 +33,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += s2n_blob_slice
-REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 
 UNWINDSET += s2n_stuffer_write_network_order.4:$(shell echo $$((1 + $(SIZEOF_UINT16))))
 

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint24/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint24/Makefile
@@ -33,7 +33,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += s2n_blob_slice
-REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 
 UNWINDSET += s2n_stuffer_write_network_order.4:$(shell echo $$((1 + $(SIZEOF_UINT24))))
 

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint32/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint32/Makefile
@@ -33,7 +33,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += s2n_blob_slice
-REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 
 UNWINDSET += s2n_stuffer_write_network_order.4:$(shell echo $$((1 + $(SIZEOF_UINT32))))
 

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint64/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint64/Makefile
@@ -33,7 +33,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += s2n_blob_slice
-REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 
 UNWINDSET += s2n_stuffer_write_network_order.4:$(shell echo $$((1 + $(SIZEOF_UINT64))))
 

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint8/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint8/Makefile
@@ -33,7 +33,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 # We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
-REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 
 UNWINDSET +=
 

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint8/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint8/Makefile
@@ -32,7 +32,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += s2n_blob_slice
-REMOVE_FUNCTION_BODY += s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
 
 UNWINDSET +=

--- a/tests/cbmc/proofs/s2n_stuffer_write_vector_size/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_vector_size/Makefile
@@ -41,7 +41,7 @@ REMOVE_FUNCTION_BODY += s2n_add_overflow
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += s2n_stuffer_resize
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
-REMOVE_FUNCTION_BODY += s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 
 UNWINDSET += s2n_stuffer_write_network_order.0:$(MAX_WRITE_NETWORK_ORDER)
 UNWINDSET += s2n_stuffer_write_network_order.1:$(MAX_WRITE_NETWORK_ORDER)

--- a/tests/cbmc/proofs/s2n_stuffer_writev_bytes/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_writev_bytes/Makefile
@@ -41,7 +41,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
-REMOVE_FUNCTION_BODY += s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 
 UNWINDSET += s2n_stuffer_writev_bytes.20:$(call addone,$(MAX_IOVEC_SIZE))
 UNWINDSET += s2n_stuffer_writev_bytes_harness.0:$(call addone,$(MAX_IOVEC_SIZE))


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

### Resolved issues:

N/A.

### Description of changes: 

 - Properly remove function body of `s2n_mem_cleanup_impl` in selected proofs to improve performance.
 - Adds nondet initializer for CBMC proofs.
 - Updates Makefiles to improve coverage on proofs.

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
