### PR TITLE
ci: show fuzz test output

### DIFF
--- a/tests/fuzz/Makefile
+++ b/tests/fuzz/Makefile
@@ -56,10 +56,10 @@ ld-preload :
 	${MAKE} -C LD_PRELOAD
 
 $(TESTS)::
-	@${CC} ${CFLAGS} $@.c -o $@  ${LDFLAGS} > /dev/null
+	@${CC} ${CFLAGS} $@.c -o $@  ${LDFLAGS} | tee make_test_output.txt
 
 run_tests:: $(FUZZ_TESTS) ld-preload
-	@( fail_count=0; for test_name in ${FUZZ_TESTS} ; do \
+	( fail_count=0; for test_name in ${FUZZ_TESTS} ; do \
 	export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}; \
 	export DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}; \
 	export LIBCRYPTO_ROOT=${LIBCRYPTO_ROOT}; \


### PR DESCRIPTION
### Resolved issues:

issue #2231 

### Description of changes: 

Some fuzz test output is not currently captured.

### Call-outs:

The longer running jobs are storing artifacts, the new log should get picked up as a build artifact.

### Testing:

Tested with [CodeBuild](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nfuzzerOpenSSL111Coverage/build/s2nfuzzerOpenSSL111Coverage%3A24eaa3cd-e56a-45e5-bbca-8e02a5312b3b/log?region=us-west-2) against my fork.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
