### PR TITLE
build: fix cmake shared lib build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,7 +183,7 @@ file(GLOB S2N_SRC
     ${UTILS_SRC}
 )
 
-add_library(${PROJECT_NAME} STATIC ${S2N_HEADERS} ${S2N_SRC})
+add_library(${PROJECT_NAME} ${S2N_HEADERS} ${S2N_SRC})
 set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE C)
 
 set(CMAKE_C_FLAGS_DEBUGOPT "")


### PR DESCRIPTION
### Description of changes: 

In #2082 it explicitly added `STATIC` to the `add_library` call in `CMakeLists.txt`. From my understanding, this completely disables the ability to compile s2n dynamically. According to the [`add_library` docs](https://cmake.org/cmake/help/latest/command/add_library.html#id2):

> If no type is given explicitly the type is STATIC or SHARED based on whether the current value of the variable BUILD_SHARED_LIBS is ON.

This change removes the `STATIC` argument and allows consumers to pass `BUILD_SHARED_LIBS`.

### Testing:

I tested this change locally and was able to build s2n both statically and dynamically, whereas before the change only static compilation was possible.

### Open questions:

@baldwinmatt does this affect the changes made in #2082? What's the best way to test that it doesn't?

By submitting this pull request, I confirm that my contribution is `made under the terms of the Apache 2.0 license.
