### PR TITLE
Fix TLS 1.3 server side OCSP metrics

### DIFF
--- a/tests/unit/s2n_client_extensions_test.c
+++ b/tests/unit/s2n_client_extensions_test.c
@@ -818,7 +818,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(server_ocsp_reply = s2n_connection_get_ocsp_response(client_conn, &length));
         EXPECT_EQUAL(length, sizeof(server_ocsp_status));
 
-        for (int i = 0; i < sizeof(server_ocsp_status); i++) {
+        for (size_t i = 0; i < sizeof(server_ocsp_status); i++) {
             EXPECT_EQUAL(server_ocsp_reply[i], server_ocsp_status[i]);
         }
 
@@ -876,7 +876,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(server_ocsp_reply = s2n_connection_get_ocsp_response(client_conn, &length));
         EXPECT_EQUAL(length, sizeof(server_ocsp_status));
 
-        for (int i = 0; i < sizeof(server_ocsp_status); i++) {
+        for (size_t i = 0; i < sizeof(server_ocsp_status); i++) {
             EXPECT_EQUAL(server_ocsp_reply[i], server_ocsp_status[i]);
         }
 
@@ -933,12 +933,13 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(s2n_connection_is_ocsp_stapled(server_conn), 1);
 
         /* Verify that the client received an OCSP response. */
-        /* Currently fails test */ /*EXPECT_EQUAL(s2n_connection_is_ocsp_stapled(client_conn), 1); */
+        /* Currently fails test. Remove when https://github.com/awslabs/s2n/issues/2239 is fixed */
+        /* EXPECT_EQUAL(s2n_connection_is_ocsp_stapled(client_conn), 1); */
 
         EXPECT_NOT_NULL(server_ocsp_reply = s2n_connection_get_ocsp_response(client_conn, &length));
         EXPECT_EQUAL(length, sizeof(server_ocsp_status));
 
-        for (int i = 0; i < sizeof(server_ocsp_status); i++) {
+        for (size_t i = 0; i < sizeof(server_ocsp_status); i++) {
             EXPECT_EQUAL(server_ocsp_reply[i], server_ocsp_status[i]);
         }
 

--- a/tests/unit/s2n_client_extensions_test.c
+++ b/tests/unit/s2n_client_extensions_test.c
@@ -890,7 +890,7 @@ int main(int argc, char **argv)
     }
 
     /* Server and client support the OCSP extension. Test Behavior for TLS 1.3 */
-    if(s2n_x509_ocsp_stapling_supported()) {
+    if(s2n_x509_ocsp_stapling_supported() && s2n_is_tls13_supported()) {
         struct s2n_connection *client_conn;
         struct s2n_connection *server_conn;
         struct s2n_config *server_config;

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -164,7 +164,7 @@ struct s2n_handshake {
 
 /* Handshake needs OCSP status message */
 #define OCSP_STATUS                 0x08
-#define IS_OCSP_STAPLED( type ) ( (type) & OCSP_STATUS )
+#define IS_OCSP_STAPLED( type ) ( ( (type) & OCSP_STATUS ) != 0 )
 
 /* Handshake should request a Client Certificate */
 #define CLIENT_AUTH                 0x10

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -27,6 +27,7 @@
 #include "tls/s2n_connection.h"
 #include "tls/s2n_resume.h"
 #include "tls/s2n_crypto.h"
+#include "tls/s2n_tls.h"
 
 int s2n_allowed_to_cache_connection(struct s2n_connection *conn)
 {
@@ -311,7 +312,11 @@ int s2n_connection_is_session_resumed(struct s2n_connection *conn)
 int s2n_connection_is_ocsp_stapled(struct s2n_connection *conn)
 {
     notnull_check(conn);
-    return IS_OCSP_STAPLED(conn->handshake.handshake_type) ? 1 : 0;
+
+    return
+        conn->actual_protocol_version >= S2N_TLS13 ?
+            (s2n_server_can_send_ocsp(conn) || s2n_server_sent_ocsp(conn)) :
+            IS_OCSP_STAPLED(conn->handshake.handshake_type) ? 1 : 0;
 }
 
 int s2n_config_is_encrypt_decrypt_key_available(struct s2n_config *config)

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -313,10 +313,11 @@ int s2n_connection_is_ocsp_stapled(struct s2n_connection *conn)
 {
     notnull_check(conn);
 
-    return
-        conn->actual_protocol_version >= S2N_TLS13 ?
-            (s2n_server_can_send_ocsp(conn) || s2n_server_sent_ocsp(conn)) :
-            IS_OCSP_STAPLED(conn->handshake.handshake_type) ? 1 : 0;
+    if (conn->actual_protocol_version >= S2N_TLS13) {
+        return (s2n_server_can_send_ocsp(conn) || s2n_server_sent_ocsp(conn));
+    } else {
+        return IS_OCSP_STAPLED(conn->handshake.handshake_type);
+    }
 }
 
 int s2n_config_is_encrypt_decrypt_key_available(struct s2n_config *config)


### PR DESCRIPTION
### Resolved issues:
Fixes server side detection of OCSP stapling used with TLS 1.3 #2212 

### Description of changes: 
Update s2n_connection_is_ocsp_stapled() 

### Call-outs:
Does not address client side OCSP stapling detection in TLS 1.3 (See #2239)

### Testing:
Added unit test for this behavior.

