### PR TITLE
Adds proof harnesses for s2n_array_free* functions

### DIFF
--- a/tests/cbmc/proofs/s2n_array_free/Makefile
+++ b/tests/cbmc/proofs/s2n_array_free/Makefile
@@ -30,6 +30,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract this function because manual inspection demonstrates it is unreachable.
 REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl

--- a/tests/cbmc/proofs/s2n_array_free/Makefile
+++ b/tests/cbmc/proofs/s2n_array_free/Makefile
@@ -1,0 +1,39 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 10 seconds.
+
+CBMCFLAGS +=
+
+HARNESS_ENTRY = s2n_array_free_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_array_free/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_array_free/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_array_free/s2n_array_free_harness.c
+++ b/tests/cbmc/proofs/s2n_array_free/s2n_array_free_harness.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "utils/s2n_array.h"
+#include "utils/s2n_result.h"
+
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_array_free_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_array *array = cbmc_allocate_s2n_array();
+    __CPROVER_assume(s2n_array_is_valid(array));
+
+    nondet_s2n_mem_init();
+
+    struct s2n_array old_array = *array;
+
+    /* Operation under verification. */
+    if(s2n_result_is_ok(s2n_array_free(array))) {
+        /* If the call worked, assert all bytes in the blob struct are zero. */
+        assert_all_zeroes(array, sizeof(*array));
+    }
+#pragma CPROVER check push
+#pragma CPROVER check disable "pointer"
+    /*
+     * Regardless of the result of s2n_free, verify that the
+     * data pointed to in the blob was zeroed.
+     */
+    if (old_array.mem.size > 0 && old_array.mem.data != NULL) {
+        size_t i;
+        __CPROVER_assume(i < old_array.mem.size);
+        assert(old_array.mem.data[i] == 0);
+    }
+#pragma CPROVER check pop
+}

--- a/tests/cbmc/proofs/s2n_array_free/s2n_array_free_harness.c
+++ b/tests/cbmc/proofs/s2n_array_free/s2n_array_free_harness.c
@@ -25,7 +25,7 @@ void s2n_array_free_harness()
 {
     /* Non-deterministic inputs. */
     struct s2n_array *array = cbmc_allocate_s2n_array();
-    __CPROVER_assume(s2n_array_is_valid(array));
+    __CPROVER_assume(s2n_result_is_ok(s2n_array_validate(array)));
 
     nondet_s2n_mem_init();
 

--- a/tests/cbmc/proofs/s2n_array_free/s2n_array_free_harness.c
+++ b/tests/cbmc/proofs/s2n_array_free/s2n_array_free_harness.c
@@ -14,6 +14,7 @@
  */
 
 #include "api/s2n.h"
+#include "error/s2n_errno.h"
 #include "utils/s2n_array.h"
 #include "utils/s2n_result.h"
 
@@ -32,10 +33,8 @@ void s2n_array_free_harness()
     struct s2n_array old_array = *array;
 
     /* Operation under verification. */
-    if(s2n_result_is_ok(s2n_array_free(array))) {
-        /* If the call worked, assert all bytes in the blob struct are zero. */
-        assert_all_zeroes(array, sizeof(*array));
-    }
+    s2n_array_free(array);
+
 #pragma CPROVER check push
 #pragma CPROVER check disable "pointer"
     /*

--- a/tests/cbmc/proofs/s2n_array_free_p/Makefile
+++ b/tests/cbmc/proofs/s2n_array_free_p/Makefile
@@ -1,0 +1,39 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 10 seconds.
+
+CBMCFLAGS +=
+
+HARNESS_ENTRY = s2n_array_free_p_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_array_free_p/Makefile
+++ b/tests/cbmc/proofs/s2n_array_free_p/Makefile
@@ -30,6 +30,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract this function because manual inspection demonstrates it is unreachable.
 REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl

--- a/tests/cbmc/proofs/s2n_array_free_p/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_array_free_p/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_array_free_p/s2n_array_free_p_harness.c
+++ b/tests/cbmc/proofs/s2n_array_free_p/s2n_array_free_p_harness.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "utils/s2n_array.h"
+#include "utils/s2n_result.h"
+
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_array_free_p_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_array *array = cbmc_allocate_s2n_array();
+    __CPROVER_assume(s2n_array_is_valid(array));
+
+    nondet_s2n_mem_init();
+
+    struct s2n_array old_array = *array;
+
+    /* Operation under verification. */
+    if(s2n_result_is_ok(s2n_array_free_p(&array))) {
+        /* If the call worked, assert all bytes in the blob struct are zero. */
+        assert_all_zeroes(array, sizeof(*array));
+    }
+#pragma CPROVER check push
+#pragma CPROVER check disable "pointer"
+    /*
+     * Regardless of the result of s2n_free, verify that the
+     * data pointed to in the blob was zeroed.
+     */
+    if (old_array.mem.size > 0 && old_array.mem.data != NULL) {
+        size_t i;
+        __CPROVER_assume(i < old_array.mem.size);
+        assert(old_array.mem.data[i] == 0);
+    }
+#pragma CPROVER check pop
+}

--- a/tests/cbmc/proofs/s2n_array_free_p/s2n_array_free_p_harness.c
+++ b/tests/cbmc/proofs/s2n_array_free_p/s2n_array_free_p_harness.c
@@ -25,7 +25,7 @@ void s2n_array_free_p_harness()
 {
     /* Non-deterministic inputs. */
     struct s2n_array *array = cbmc_allocate_s2n_array();
-    __CPROVER_assume(s2n_array_is_valid(array));
+    __CPROVER_assume(s2n_result_is_ok(s2n_array_validate(array)));
 
     nondet_s2n_mem_init();
 

--- a/tests/cbmc/proofs/s2n_set_free/Makefile
+++ b/tests/cbmc/proofs/s2n_set_free/Makefile
@@ -1,0 +1,41 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 10 seconds.
+
+CBMCFLAGS +=
+
+HARNESS_ENTRY = s2n_set_free_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_set.c
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_set_free/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_set_free/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_set_free/s2n_set_free_harness.c
+++ b/tests/cbmc/proofs/s2n_set_free/s2n_set_free_harness.c
@@ -14,37 +14,36 @@
  */
 
 #include "api/s2n.h"
-#include "utils/s2n_array.h"
+#include "utils/s2n_set.h"
 #include "utils/s2n_result.h"
 
 #include <assert.h>
 #include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
-void s2n_array_free_p_harness()
+void s2n_set_free_harness()
 {
     /* Non-deterministic inputs. */
-    struct s2n_array *array = cbmc_allocate_s2n_array();
-    __CPROVER_assume(s2n_result_is_ok(s2n_array_validate(array)));
+    struct s2n_set *set = cbmc_allocate_s2n_set();
+    __CPROVER_assume(s2n_result_is_ok(s2n_set_validate(set)));
 
     nondet_s2n_mem_init();
 
-    struct s2n_array old_array = *array;
+    struct s2n_set old_set = *set;
 
     /* Operation under verification. */
-    if(s2n_result_is_ok(s2n_array_free_p(&array))) {
-        assert(array == NULL);
-    }
+    s2n_set_free(set);
+
 #pragma CPROVER check push
 #pragma CPROVER check disable "pointer"
     /*
      * Regardless of the result of s2n_free, verify that the
      * data pointed to in the blob was zeroed.
      */
-    if (old_array.mem.size > 0 && old_array.mem.data != NULL) {
+    if (old_set.data->mem.size > 0 && old_set.data->mem.data != NULL) {
         size_t i;
-        __CPROVER_assume(i < old_array.mem.size);
-        assert(old_array.mem.data[i] == 0);
+        __CPROVER_assume(i < old_set.data->mem.size);
+        assert(old_set.data->mem.data[i] == 0);
     }
 #pragma CPROVER check pop
 }

--- a/tests/cbmc/proofs/s2n_set_free_p/Makefile
+++ b/tests/cbmc/proofs/s2n_set_free_p/Makefile
@@ -1,0 +1,41 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 10 seconds.
+
+CBMCFLAGS +=
+
+HARNESS_ENTRY = s2n_set_free_p_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_set.c
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_set_free_p/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_set_free_p/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_set_free_p/s2n_set_free_p_harness.c
+++ b/tests/cbmc/proofs/s2n_set_free_p/s2n_set_free_p_harness.c
@@ -14,26 +14,26 @@
  */
 
 #include "api/s2n.h"
-#include "utils/s2n_array.h"
+#include "utils/s2n_set.h"
 #include "utils/s2n_result.h"
 
 #include <assert.h>
 #include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
-void s2n_array_free_p_harness()
+void s2n_set_free_p_harness()
 {
     /* Non-deterministic inputs. */
-    struct s2n_array *array = cbmc_allocate_s2n_array();
-    __CPROVER_assume(s2n_result_is_ok(s2n_array_validate(array)));
+    struct s2n_set *set = cbmc_allocate_s2n_set();
+    __CPROVER_assume(s2n_result_is_ok(s2n_set_validate(set)));
 
     nondet_s2n_mem_init();
 
-    struct s2n_array old_array = *array;
+    struct s2n_set old_set = *set;
 
     /* Operation under verification. */
-    if(s2n_result_is_ok(s2n_array_free_p(&array))) {
-        assert(array == NULL);
+    if(s2n_result_is_ok(s2n_set_free_p(&set))) {
+        assert(set == NULL);
     }
 #pragma CPROVER check push
 #pragma CPROVER check disable "pointer"
@@ -41,10 +41,10 @@ void s2n_array_free_p_harness()
      * Regardless of the result of s2n_free, verify that the
      * data pointed to in the blob was zeroed.
      */
-    if (old_array.mem.size > 0 && old_array.mem.data != NULL) {
+    if (old_set.data->mem.size > 0 && old_set.data->mem.data != NULL) {
         size_t i;
-        __CPROVER_assume(i < old_array.mem.size);
-        assert(old_array.mem.data[i] == 0);
+        __CPROVER_assume(i < old_set.data->mem.size);
+        assert(old_set.data->mem.data[i] == 0);
     }
 #pragma CPROVER check pop
 }

--- a/utils/s2n_array.c
+++ b/utils/s2n_array.c
@@ -172,12 +172,13 @@ S2N_RESULT s2n_array_free_p(struct s2n_array **parray)
     GUARD_AS_RESULT(s2n_free(&array->mem));
 
     /* And finally the array */
-    *array = (struct s2n_array) {0};
+    GUARD_AS_RESULT(s2n_free_object((uint8_t **)parray, sizeof(struct s2n_array)));
 
     return S2N_RESULT_OK;
 }
 
 S2N_RESULT s2n_array_free(struct s2n_array *array)
 {
+    ENSURE_REF(array);
     return s2n_array_free_p(&array);
 }

--- a/utils/s2n_array.c
+++ b/utils/s2n_array.c
@@ -172,7 +172,7 @@ S2N_RESULT s2n_array_free_p(struct s2n_array **parray)
     GUARD_AS_RESULT(s2n_free(&array->mem));
 
     /* And finally the array */
-    GUARD_AS_RESULT(s2n_free_object((uint8_t **)parray, sizeof(struct s2n_array)));
+    *array = (struct s2n_array) {0};
 
     return S2N_RESULT_OK;
 }

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -217,7 +217,7 @@ int s2n_free_object(uint8_t **p_data, uint32_t size)
     notnull_check(p_data);
 
     if (*p_data == NULL) {
-        return 0;
+        return S2N_SUCCESS;
     }
     struct s2n_blob b = {.data = *p_data, .allocated = size, .size = size, .growable = 1};
 

--- a/utils/s2n_set.c
+++ b/utils/s2n_set.c
@@ -122,6 +122,8 @@ S2N_RESULT s2n_set_free_p(struct s2n_set **pset)
 
     ENSURE_REF(set);
     GUARD_RESULT(s2n_array_free(set->data));
+
+    /* And finally the set object. */
     GUARD_AS_RESULT(s2n_free_object((uint8_t **)pset, sizeof(struct s2n_set)));
 
     return S2N_RESULT_OK;


### PR DESCRIPTION
### Resolved issues:

N/A.

### Description of changes: 

 - Adds a CBMC-proof harness for `s2n_array_free_p` function;
 - Adds a CBMC-proof harness for `s2n_array_free` function;
 - Adds a CBMC-proof harness for `s2n_set_free_p` function;
 - Adds a CBMC-proof harness for `s2n_set_free` function;

### Call-outs:

This PR depends on PR https://github.com/awslabs/s2n/pull/2193.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
