### PR TITLE
Adds proof harnesses for s2n_array_* functions

### DIFF
--- a/tests/cbmc/proofs/s2n_array_get/Makefile
+++ b/tests/cbmc/proofs/s2n_array_get/Makefile
@@ -1,0 +1,39 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 10 seconds.
+
+MAX_ARRAY_LEN = 100
+DEFINES += -DMAX_ARRAY_LEN=$(MAX_ARRAY_LEN)
+
+MAX_ARRAY_ELEMENT_SIZE = 100
+DEFINES += -DMAX_ARRAY_ELEMENT_SIZE=$(MAX_ARRAY_ELEMENT_SIZE)
+
+CBMCFLAGS +=
+
+HARNESS_ENTRY = s2n_array_get_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_array_get/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_array_get/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_array_get/s2n_array_get_harness.c
+++ b/tests/cbmc/proofs/s2n_array_get/s2n_array_get_harness.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "utils/s2n_array.h"
+#include "utils/s2n_result.h"
+
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_array_get_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_array *array = cbmc_allocate_s2n_array();
+    __CPROVER_assume(s2n_array_is_valid(array));
+    __CPROVER_assume(s2n_array_is_bounded(array, MAX_ARRAY_LEN, MAX_ARRAY_ELEMENT_SIZE));
+    uint32_t index;
+    void **element = can_fail_malloc(sizeof(void *));
+
+    /* Operation under verification. */
+    if(s2n_result_is_ok(s2n_array_get(array, index, element))) {
+       /*
+        * In the case s2n_array_get is successful, we can ensure the array isn't empty
+        * and index is within bounds.
+        */
+        assert(array->mem.data != NULL);
+        assert(array->len != 0);
+        assert(index < array->len);
+        assert(*element == (array->mem.data + (array->element_size * index)));
+    }
+
+    /* Post-condition. */
+    assert(s2n_array_is_valid(array));
+}

--- a/tests/cbmc/proofs/s2n_array_get/s2n_array_get_harness.c
+++ b/tests/cbmc/proofs/s2n_array_get/s2n_array_get_harness.c
@@ -25,7 +25,7 @@ void s2n_array_get_harness()
 {
     /* Non-deterministic inputs. */
     struct s2n_array *array = cbmc_allocate_s2n_array();
-    __CPROVER_assume(s2n_array_is_valid(array));
+    __CPROVER_assume(s2n_result_is_ok(s2n_array_validate(array)));
     __CPROVER_assume(s2n_array_is_bounded(array, MAX_ARRAY_LEN, MAX_ARRAY_ELEMENT_SIZE));
     uint32_t index;
     void **element = can_fail_malloc(sizeof(void *));
@@ -43,5 +43,5 @@ void s2n_array_get_harness()
     }
 
     /* Post-condition. */
-    assert(s2n_array_is_valid(array));
+    assert(s2n_result_is_ok(s2n_array_validate(array)));
 }

--- a/tests/cbmc/proofs/s2n_array_insert/Makefile
+++ b/tests/cbmc/proofs/s2n_array_insert/Makefile
@@ -19,6 +19,8 @@ DEFINES += -DMAX_ARRAY_LEN=$(MAX_ARRAY_LEN)
 MAX_ARRAY_ELEMENT_SIZE = 10
 DEFINES += -DMAX_ARRAY_ELEMENT_SIZE=$(MAX_ARRAY_ELEMENT_SIZE)
 
+DEFINES += -DMADV_DONTDUMP=1
+
 CBMCFLAGS +=
 
 HARNESS_ENTRY = s2n_array_insert_harness
@@ -28,6 +30,7 @@ PROOF_SOURCES += $(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/madvise.c
 PROOF_SOURCES += $(PROOF_STUB)/memmove_havoc.c
 PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
@@ -40,7 +43,6 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
-
 
 # We abstract this function because manual inspection demonstrates it is unreachable.
 REMOVE_FUNCTION_BODY += s2n_blob_slice

--- a/tests/cbmc/proofs/s2n_array_insert/Makefile
+++ b/tests/cbmc/proofs/s2n_array_insert/Makefile
@@ -1,0 +1,51 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 10 seconds.
+
+MAX_ARRAY_LEN = 10
+DEFINES += -DMAX_ARRAY_LEN=$(MAX_ARRAY_LEN)
+
+MAX_ARRAY_ELEMENT_SIZE = 10
+DEFINES += -DMAX_ARRAY_ELEMENT_SIZE=$(MAX_ARRAY_ELEMENT_SIZE)
+
+CBMCFLAGS +=
+
+HARNESS_ENTRY = s2n_array_insert_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/memmove_havoc.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_array_insert/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_array_insert/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_array_insert/s2n_array_insert_harness.c
+++ b/tests/cbmc/proofs/s2n_array_insert/s2n_array_insert_harness.c
@@ -34,9 +34,11 @@ void s2n_array_insert_harness()
     nondet_s2n_mem_init();
 
     struct s2n_array old_array = *array;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_array(array->mem.data, array->len, &old_byte);
 
     /* Operation under verification. */
-    if(s2n_result_is_ok(s2n_array_insert(array, index, element))) {
+    if (s2n_result_is_ok(s2n_array_insert(array, index, element))) {
        /*
         * In the case s2n_array_insert is successful, we can ensure the array isn't empty
         * and index is within bounds.
@@ -46,5 +48,13 @@ void s2n_array_insert_harness()
         assert(index < array->len);
         assert(*element == (array->mem.data + (array->element_size * index)));
         assert(s2n_result_is_ok(s2n_array_validate(array)));
+        if (old_array.len != 0 && index == old_array.len) {
+            assert_byte_from_blob_matches(&array->mem, &old_byte);
+        }
+        uint32_t old_capacity = old_array.mem.size / old_array.element_size;
+        if (old_array.len >= old_capacity) {
+            uint32_t new_capacity = array->mem.size;
+            assert(array->mem.size == (2 * old_capacity * array->element_size));
+        }
     }
 }

--- a/tests/cbmc/proofs/s2n_array_insert/s2n_array_insert_harness.c
+++ b/tests/cbmc/proofs/s2n_array_insert/s2n_array_insert_harness.c
@@ -26,7 +26,7 @@ void s2n_array_insert_harness()
 {
     /* Non-deterministic inputs. */
     struct s2n_array *array = cbmc_allocate_s2n_array();
-    __CPROVER_assume(s2n_array_is_valid(array));
+    __CPROVER_assume(s2n_result_is_ok(s2n_array_validate(array)));
     __CPROVER_assume(s2n_array_is_bounded(array, MAX_ARRAY_LEN, MAX_ARRAY_ELEMENT_SIZE));
     uint32_t index;
     void **element = can_fail_malloc(sizeof(void *));
@@ -45,6 +45,6 @@ void s2n_array_insert_harness()
         assert(array->len == (old_array.len + 1));
         assert(index < array->len);
         assert(*element == (array->mem.data + (array->element_size * index)));
-        assert(s2n_array_is_valid(array));
+        assert(s2n_result_is_ok(s2n_array_validate(array)));
     }
 }

--- a/tests/cbmc/proofs/s2n_array_insert/s2n_array_insert_harness.c
+++ b/tests/cbmc/proofs/s2n_array_insert/s2n_array_insert_harness.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "error/s2n_errno.h"
+#include "utils/s2n_array.h"
+#include "utils/s2n_result.h"
+
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_array_insert_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_array *array = cbmc_allocate_s2n_array();
+    __CPROVER_assume(s2n_array_is_valid(array));
+    __CPROVER_assume(s2n_array_is_bounded(array, MAX_ARRAY_LEN, MAX_ARRAY_ELEMENT_SIZE));
+    uint32_t index;
+    void **element = can_fail_malloc(sizeof(void *));
+
+    nondet_s2n_mem_init();
+
+    struct s2n_array old_array = *array;
+
+    /* Operation under verification. */
+    if(s2n_result_is_ok(s2n_array_insert(array, index, element))) {
+       /*
+        * In the case s2n_array_insert is successful, we can ensure the array isn't empty
+        * and index is within bounds.
+        */
+        assert(array->mem.data != NULL);
+        assert(array->len == (old_array.len + 1));
+        assert(index < array->len);
+        assert(*element == (array->mem.data + (array->element_size * index)));
+        assert(s2n_array_is_valid(array));
+    }
+}

--- a/tests/cbmc/proofs/s2n_array_insert_and_copy/Makefile
+++ b/tests/cbmc/proofs/s2n_array_insert_and_copy/Makefile
@@ -19,6 +19,8 @@ DEFINES += -DMAX_ARRAY_LEN=$(MAX_ARRAY_LEN)
 MAX_ARRAY_ELEMENT_SIZE = 10
 DEFINES += -DMAX_ARRAY_ELEMENT_SIZE=$(MAX_ARRAY_ELEMENT_SIZE)
 
+DEFINES += -DMADV_DONTDUMP=1
+
 CBMCFLAGS +=
 
 HARNESS_ENTRY = s2n_array_insert_and_copy_harness
@@ -28,6 +30,7 @@ PROOF_SOURCES += $(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/madvise.c
 PROOF_SOURCES += $(PROOF_STUB)/memmove_havoc.c
 PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
@@ -40,7 +43,6 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
-
 
 # We abstract this function because manual inspection demonstrates it is unreachable.
 REMOVE_FUNCTION_BODY += s2n_blob_slice

--- a/tests/cbmc/proofs/s2n_array_insert_and_copy/Makefile
+++ b/tests/cbmc/proofs/s2n_array_insert_and_copy/Makefile
@@ -1,0 +1,51 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 10 seconds.
+
+MAX_ARRAY_LEN = 10
+DEFINES += -DMAX_ARRAY_LEN=$(MAX_ARRAY_LEN)
+
+MAX_ARRAY_ELEMENT_SIZE = 10
+DEFINES += -DMAX_ARRAY_ELEMENT_SIZE=$(MAX_ARRAY_ELEMENT_SIZE)
+
+CBMCFLAGS +=
+
+HARNESS_ENTRY = s2n_array_insert_and_copy_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/memmove_havoc.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_array_insert_and_copy/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_array_insert_and_copy/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_array_insert_and_copy/s2n_array_insert_and_copy_harness.c
+++ b/tests/cbmc/proofs/s2n_array_insert_and_copy/s2n_array_insert_and_copy_harness.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "error/s2n_errno.h"
+#include "utils/s2n_array.h"
+#include "utils/s2n_result.h"
+
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_array_insert_and_copy_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_array *array = cbmc_allocate_s2n_array();
+    __CPROVER_assume(s2n_array_is_valid(array));
+    __CPROVER_assume(s2n_array_is_bounded(array, MAX_ARRAY_LEN, MAX_ARRAY_ELEMENT_SIZE));
+    uint32_t index;
+    void *element = can_fail_malloc(array->element_size);
+
+    nondet_s2n_mem_init();
+
+    struct s2n_array old_array = *array;
+
+    /* Operation under verification. */
+    if(s2n_result_is_ok(s2n_array_insert_and_copy(array, index, element))) {
+       /*
+        * In the case s2n_array_insert_and_copy is successful, we can ensure the array isn't empty
+        * and index is within bounds.
+        */
+        assert(array->mem.data != NULL);
+        assert(array->len == (old_array.len + 1));
+        assert(index < array->len);
+        assert(s2n_array_is_valid(array));
+    }
+}

--- a/tests/cbmc/proofs/s2n_array_insert_and_copy/s2n_array_insert_and_copy_harness.c
+++ b/tests/cbmc/proofs/s2n_array_insert_and_copy/s2n_array_insert_and_copy_harness.c
@@ -34,9 +34,11 @@ void s2n_array_insert_and_copy_harness()
     nondet_s2n_mem_init();
 
     struct s2n_array old_array = *array;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_array(array->mem.data, array->len, &old_byte);
 
     /* Operation under verification. */
-    if(s2n_result_is_ok(s2n_array_insert_and_copy(array, index, element))) {
+    if (s2n_result_is_ok(s2n_array_insert_and_copy(array, index, element))) {
        /*
         * In the case s2n_array_insert_and_copy is successful, we can ensure the array isn't empty
         * and index is within bounds.
@@ -45,5 +47,13 @@ void s2n_array_insert_and_copy_harness()
         assert(array->len == (old_array.len + 1));
         assert(index < array->len);
         assert(s2n_result_is_ok(s2n_array_validate(array)));
+        if (old_array.len != 0 && index == old_array.len) {
+            assert_byte_from_blob_matches(&array->mem, &old_byte);
+        }
+        uint32_t old_capacity = old_array.mem.size / old_array.element_size;
+        if (old_array.len >= old_capacity) {
+            uint32_t new_capacity = array->mem.size;
+            assert(array->mem.size == (2 * old_capacity * array->element_size));
+        }
     }
 }

--- a/tests/cbmc/proofs/s2n_array_insert_and_copy/s2n_array_insert_and_copy_harness.c
+++ b/tests/cbmc/proofs/s2n_array_insert_and_copy/s2n_array_insert_and_copy_harness.c
@@ -26,7 +26,7 @@ void s2n_array_insert_and_copy_harness()
 {
     /* Non-deterministic inputs. */
     struct s2n_array *array = cbmc_allocate_s2n_array();
-    __CPROVER_assume(s2n_array_is_valid(array));
+    __CPROVER_assume(s2n_result_is_ok(s2n_array_validate(array)));
     __CPROVER_assume(s2n_array_is_bounded(array, MAX_ARRAY_LEN, MAX_ARRAY_ELEMENT_SIZE));
     uint32_t index;
     void *element = can_fail_malloc(array->element_size);
@@ -44,6 +44,6 @@ void s2n_array_insert_and_copy_harness()
         assert(array->mem.data != NULL);
         assert(array->len == (old_array.len + 1));
         assert(index < array->len);
-        assert(s2n_array_is_valid(array));
+        assert(s2n_result_is_ok(s2n_array_validate(array)));
     }
 }

--- a/tests/cbmc/proofs/s2n_array_pushback/Makefile
+++ b/tests/cbmc/proofs/s2n_array_pushback/Makefile
@@ -19,6 +19,8 @@ DEFINES += -DMAX_ARRAY_LEN=$(MAX_ARRAY_LEN)
 MAX_ARRAY_ELEMENT_SIZE = 10
 DEFINES += -DMAX_ARRAY_ELEMENT_SIZE=$(MAX_ARRAY_ELEMENT_SIZE)
 
+DEFINES += -DMADV_DONTDUMP=1
+
 CBMCFLAGS +=
 
 HARNESS_ENTRY = s2n_array_pushback_harness
@@ -28,6 +30,7 @@ PROOF_SOURCES += $(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/madvise.c
 PROOF_SOURCES += $(PROOF_STUB)/memmove_havoc.c
 PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
@@ -40,7 +43,6 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
-
 
 # We abstract this function because manual inspection demonstrates it is unreachable.
 REMOVE_FUNCTION_BODY += s2n_blob_slice

--- a/tests/cbmc/proofs/s2n_array_pushback/Makefile
+++ b/tests/cbmc/proofs/s2n_array_pushback/Makefile
@@ -1,0 +1,51 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 25 seconds.
+
+MAX_ARRAY_LEN = 10
+DEFINES += -DMAX_ARRAY_LEN=$(MAX_ARRAY_LEN)
+
+MAX_ARRAY_ELEMENT_SIZE = 10
+DEFINES += -DMAX_ARRAY_ELEMENT_SIZE=$(MAX_ARRAY_ELEMENT_SIZE)
+
+CBMCFLAGS +=
+
+HARNESS_ENTRY = s2n_array_pushback_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/memmove_havoc.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_array_pushback/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_array_pushback/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_array_pushback/s2n_array_pushback_harness.c
+++ b/tests/cbmc/proofs/s2n_array_pushback/s2n_array_pushback_harness.c
@@ -26,7 +26,7 @@ void s2n_array_pushback_harness()
 {
     /* Non-deterministic inputs. */
     struct s2n_array *array = cbmc_allocate_s2n_array();
-    __CPROVER_assume(s2n_array_is_valid(array));
+    __CPROVER_assume(s2n_result_is_ok(s2n_array_validate(array)));
     __CPROVER_assume(s2n_array_is_bounded(array, MAX_ARRAY_LEN, MAX_ARRAY_ELEMENT_SIZE));
     void **element = can_fail_malloc(sizeof(void *));
 
@@ -43,6 +43,6 @@ void s2n_array_pushback_harness()
         assert(array->mem.data != NULL);
         assert(array->len == (old_array.len + 1));
         assert(*element == (array->mem.data + (array->element_size * old_array.len)));
-        assert(s2n_array_is_valid(array));
+        assert(s2n_result_is_ok(s2n_array_validate(array)));
     }
 }

--- a/tests/cbmc/proofs/s2n_array_pushback/s2n_array_pushback_harness.c
+++ b/tests/cbmc/proofs/s2n_array_pushback/s2n_array_pushback_harness.c
@@ -33,16 +33,26 @@ void s2n_array_pushback_harness()
     nondet_s2n_mem_init();
 
     struct s2n_array old_array = *array;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_array(array->mem.data, array->len, &old_byte);
 
     /* Operation under verification. */
     if(s2n_result_is_ok(s2n_array_pushback(array, element))) {
        /*
-        * In the case s2n_array_insert is successful, we can ensure the array isn't empty
+        * In the case s2n_array_pushback is successful, we can ensure the array isn't empty
         * and index is within bounds.
         */
         assert(array->mem.data != NULL);
         assert(array->len == (old_array.len + 1));
         assert(*element == (array->mem.data + (array->element_size * old_array.len)));
         assert(s2n_result_is_ok(s2n_array_validate(array)));
+        if (old_array.len != 0) {
+            assert_byte_from_blob_matches(&array->mem, &old_byte);
+        }
+        uint32_t old_capacity = old_array.mem.size / old_array.element_size;
+        if (old_array.len >= old_capacity) {
+            uint32_t new_capacity = array->mem.size;
+            assert(array->mem.size == (2 * old_capacity * array->element_size));
+        }
     }
 }

--- a/tests/cbmc/proofs/s2n_array_pushback/s2n_array_pushback_harness.c
+++ b/tests/cbmc/proofs/s2n_array_pushback/s2n_array_pushback_harness.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "error/s2n_errno.h"
+#include "utils/s2n_array.h"
+#include "utils/s2n_result.h"
+
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_array_pushback_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_array *array = cbmc_allocate_s2n_array();
+    __CPROVER_assume(s2n_array_is_valid(array));
+    __CPROVER_assume(s2n_array_is_bounded(array, MAX_ARRAY_LEN, MAX_ARRAY_ELEMENT_SIZE));
+    void **element = can_fail_malloc(sizeof(void *));
+
+    nondet_s2n_mem_init();
+
+    struct s2n_array old_array = *array;
+
+    /* Operation under verification. */
+    if(s2n_result_is_ok(s2n_array_pushback(array, element))) {
+       /*
+        * In the case s2n_array_insert is successful, we can ensure the array isn't empty
+        * and index is within bounds.
+        */
+        assert(array->mem.data != NULL);
+        assert(array->len == (old_array.len + 1));
+        assert(*element == (array->mem.data + (array->element_size * old_array.len)));
+        assert(s2n_array_is_valid(array));
+    }
+}

--- a/tests/cbmc/proofs/s2n_array_remove/Makefile
+++ b/tests/cbmc/proofs/s2n_array_remove/Makefile
@@ -1,0 +1,44 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 10 seconds.
+
+MAX_ARRAY_LEN = 10
+DEFINES += -DMAX_ARRAY_LEN=$(MAX_ARRAY_LEN)
+
+MAX_ARRAY_ELEMENT_SIZE = 10
+DEFINES += -DMAX_ARRAY_ELEMENT_SIZE=$(MAX_ARRAY_ELEMENT_SIZE)
+
+CBMCFLAGS +=
+
+HARNESS_ENTRY = s2n_array_remove_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/memmove_havoc.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_array_remove/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_array_remove/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_array_remove/s2n_array_remove_harness.c
+++ b/tests/cbmc/proofs/s2n_array_remove/s2n_array_remove_harness.c
@@ -26,7 +26,7 @@ void s2n_array_remove_harness()
 {
     /* Non-deterministic inputs. */
     struct s2n_array *array = cbmc_allocate_s2n_array();
-    __CPROVER_assume(s2n_array_is_valid(array));
+    __CPROVER_assume(s2n_result_is_ok(s2n_array_validate(array)));
     __CPROVER_assume(s2n_array_is_bounded(array, MAX_ARRAY_LEN, MAX_ARRAY_ELEMENT_SIZE));
     uint32_t index;
 
@@ -39,5 +39,5 @@ void s2n_array_remove_harness()
         assert(array->len == (old_array.len - 1));
         assert(index < old_array.len);
     }
-    assert(s2n_array_is_valid(array));
+    assert(s2n_result_is_ok(s2n_array_validate(array)));
 }

--- a/tests/cbmc/proofs/s2n_array_remove/s2n_array_remove_harness.c
+++ b/tests/cbmc/proofs/s2n_array_remove/s2n_array_remove_harness.c
@@ -31,6 +31,8 @@ void s2n_array_remove_harness()
     uint32_t index;
 
     struct s2n_array old_array = *array;
+    struct store_byte_from_buffer old_byte;
+    if (array->len != 0) save_byte_from_array(array->mem.data, array->len - 1, &old_byte);
 
     /* Operation under verification. */
     if(s2n_result_is_ok(s2n_array_remove(array, index))) {
@@ -38,6 +40,9 @@ void s2n_array_remove_harness()
         assert(array->mem.data != NULL);
         assert(array->len == (old_array.len - 1));
         assert(index < old_array.len);
+        if(array->len != 0 && index == old_array.len - 1) {
+            assert_byte_from_blob_matches(&array->mem, &old_byte);
+        }
     }
     assert(s2n_result_is_ok(s2n_array_validate(array)));
 }

--- a/tests/cbmc/proofs/s2n_array_remove/s2n_array_remove_harness.c
+++ b/tests/cbmc/proofs/s2n_array_remove/s2n_array_remove_harness.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "error/s2n_errno.h"
+#include "utils/s2n_array.h"
+#include "utils/s2n_result.h"
+
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_array_remove_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_array *array = cbmc_allocate_s2n_array();
+    __CPROVER_assume(s2n_array_is_valid(array));
+    __CPROVER_assume(s2n_array_is_bounded(array, MAX_ARRAY_LEN, MAX_ARRAY_ELEMENT_SIZE));
+    uint32_t index;
+
+    struct s2n_array old_array = *array;
+
+    /* Operation under verification. */
+    if(s2n_result_is_ok(s2n_array_remove(array, index))) {
+       /* Post-conditions. */
+        assert(array->mem.data != NULL);
+        assert(array->len == (old_array.len - 1));
+        assert(index < old_array.len);
+    }
+    assert(s2n_array_is_valid(array));
+}

--- a/tests/cbmc/proofs/s2n_set_add/s2n_set_add_harness.c
+++ b/tests/cbmc/proofs/s2n_set_add/s2n_set_add_harness.c
@@ -33,6 +33,7 @@ void s2n_set_add_harness()
     nondet_s2n_mem_init();
 
     struct s2n_array old_array = *(set->data);
+    struct store_byte_from_buffer old_byte;
 
     /* Operation under verification. */
     if(s2n_result_is_ok(s2n_set_add(set, element))) {
@@ -43,5 +44,10 @@ void s2n_set_add_harness()
          assert(set->data->mem.data != NULL);
          assert(set->data->len == (old_array.len + 1));
          assert(s2n_result_is_ok(s2n_set_validate(set)));
+         uint32_t old_capacity = old_array.mem.size / old_array.element_size;
+         if (old_array.len >= old_capacity) {
+             uint32_t new_capacity = set->data->mem.size;
+             assert(set->data->mem.size == (2 * old_capacity * set->data->element_size));
+         }
     }
 }

--- a/tests/cbmc/proofs/s2n_set_remove/s2n_set_remove_harness.c
+++ b/tests/cbmc/proofs/s2n_set_remove/s2n_set_remove_harness.c
@@ -31,6 +31,8 @@ void s2n_set_remove_harness()
     uint32_t index;
 
     struct s2n_array old_array = *(set->data);
+    struct store_byte_from_buffer old_byte;
+    if (set->data->len != 0) save_byte_from_array(set->data->mem.data, set->data->len - 1, &old_byte);
 
     /* Operation under verification. */
     if(s2n_result_is_ok(s2n_set_remove(set, index))) {
@@ -38,8 +40,8 @@ void s2n_set_remove_harness()
         assert(set->data->mem.data != NULL);
         assert(S2N_IMPLIES(old_array.len != 0, set->data->len == (old_array.len - 1)));
         assert(index < old_array.len);
-	if(index == old_array.len - 1) {
-            assert_bytes_match(set->data->mem.data, old_array.mem.data, set->data->len);
+        if(set->data->len != 0 && index == old_array.len - 1) {
+            assert_byte_from_blob_matches(&set->data->mem, &old_byte);
         }
     }
 

--- a/utils/s2n_array.c
+++ b/utils/s2n_array.c
@@ -121,7 +121,7 @@ S2N_RESULT s2n_array_insert(struct s2n_array *array, uint32_t index, void **elem
 
 S2N_RESULT s2n_array_remove(struct s2n_array *array, uint32_t index)
 {
-    ENSURE_REF(array);
+    PRECONDITION(s2n_array_is_valid(array));
     ENSURE(index < array->len, S2N_ERR_ARRAY_INDEX_OOB);
 
     /* If the removed element is the last one, no need to move anything.
@@ -133,11 +133,18 @@ S2N_RESULT s2n_array_remove(struct s2n_array *array, uint32_t index)
     }
     array->len--;
 
-    /* After shifting, zero the last element */
-    CHECKED_MEMSET(array->mem.data + array->element_size * array->len,
-                   0,
-                   array->element_size);
+    if (array->len == 0) {
+        /* If array is empty, make sure the underline blob is empty too. */
+        s2n_blob_zero(&array->mem);
+        array->mem.size = 0;
+    } else {
+        /* After shifting, zero the last element */
+        CHECKED_MEMSET(array->mem.data + array->element_size * array->len,
+                       0,
+                       array->element_size);
+    }
 
+    PRECONDITION(s2n_array_is_valid(array));
     return S2N_RESULT_OK;
 }
 

--- a/utils/s2n_array.c
+++ b/utils/s2n_array.c
@@ -90,7 +90,7 @@ S2N_RESULT s2n_array_insert_and_copy(struct s2n_array *array, uint32_t index, vo
 
 S2N_RESULT s2n_array_insert(struct s2n_array *array, uint32_t index, void **element)
 {
-    ENSURE_REF(array);
+    PRECONDITION(s2n_array_is_valid(array));
     ENSURE_REF(element);
     /* index == len is ok since we're about to add one element */
     ENSURE(index <= array->len, S2N_ERR_ARRAY_INDEX_OOB);
@@ -98,13 +98,14 @@ S2N_RESULT s2n_array_insert(struct s2n_array *array, uint32_t index, void **elem
     /* We are about to add one more element to the array. Add capacity if necessary */
     uint32_t current_capacity = 0;
     GUARD_RESULT(s2n_array_capacity(array, &current_capacity));
+
     if (array->len >= current_capacity) {
         /* Enlarge the array */
         uint32_t new_capacity;
         GUARD_AS_RESULT(s2n_mul_overflow(current_capacity, 2, &new_capacity));
         GUARD_RESULT(s2n_array_enlarge(array, new_capacity));
     }
-
+#if 0
     /* If we are adding at an existing index, slide everything down. */
     if (index < array->len) {
         memmove(array->mem.data + array->element_size * (index + 1),
@@ -114,7 +115,7 @@ S2N_RESULT s2n_array_insert(struct s2n_array *array, uint32_t index, void **elem
 
     *element = array->mem.data + array->element_size * index;
     array->len++;
-
+#endif
     return S2N_RESULT_OK;
 }
 

--- a/utils/s2n_array.c
+++ b/utils/s2n_array.c
@@ -66,7 +66,7 @@ struct s2n_array *s2n_array_new(uint32_t element_size)
 
 S2N_RESULT s2n_array_pushback(struct s2n_array *array, void **element)
 {
-    ENSURE_REF(array);
+    PRECONDITION(s2n_array_is_valid(array));
     ENSURE_REF(element);
     return s2n_array_insert(array, array->len, element);
 }

--- a/utils/s2n_array.c
+++ b/utils/s2n_array.c
@@ -73,10 +73,10 @@ S2N_RESULT s2n_array_pushback(struct s2n_array *array, void **element)
 
 S2N_RESULT s2n_array_get(struct s2n_array *array, uint32_t index, void **element)
 {
-    ENSURE_REF(array);
+    PRECONDITION(s2n_array_is_valid(array));
     ENSURE_REF(element);
     ENSURE(index < array->len, S2N_ERR_ARRAY_INDEX_OOB);
-    *element = array->mem.data + array->element_size * index;
+    *element = array->mem.data + (array->element_size * index);
     return S2N_RESULT_OK;
 }
 

--- a/utils/s2n_array.c
+++ b/utils/s2n_array.c
@@ -101,7 +101,7 @@ S2N_RESULT s2n_array_insert(struct s2n_array *array, uint32_t index, void **elem
 
     if (array->len >= current_capacity) {
         /* Enlarge the array */
-        uint32_t new_capacity;
+        uint32_t new_capacity = 0;
         GUARD_AS_RESULT(s2n_mul_overflow(current_capacity, 2, &new_capacity));
         GUARD_RESULT(s2n_array_enlarge(array, new_capacity));
     }
@@ -139,7 +139,6 @@ S2N_RESULT s2n_array_remove(struct s2n_array *array, uint32_t index)
                    0,
                    array->element_size);
 
-    GUARD_RESULT(s2n_array_validate(array));
     return S2N_RESULT_OK;
 }
 


### PR DESCRIPTION
### Resolved issues:

N/A.

### Description of changes: 

 - Adds a CBMC-proof harness for `s2n_array_get` function;
 - Adds a CBMC-proof harness for `s2n_array_insert` function;
 - Adds a CBMC-proof harness for `s2n_array_insert_and_copy` function;
 - Adds a CBMC-proof harness for `s2n_array_pushback` function;
 - Adds a CBMC-proof harness for `s2n_array_remove` function;
 - Adds a stub for a havoc version of `memmove`;
 - Updates `s2n_array` validity function;

### Call-outs:

This PR depends on PR https://github.com/awslabs/s2n/pull/2193.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
