### PR TITLE
Adds proof harnesses for s2n_set_* functions

### DIFF
--- a/tests/cbmc/proofs/s2n_set_add/Makefile
+++ b/tests/cbmc/proofs/s2n_set_add/Makefile
@@ -19,7 +19,9 @@ DEFINES += -DMAX_ARRAY_LEN=$(MAX_ARRAY_LEN)
 MAX_ARRAY_ELEMENT_SIZE = 10
 DEFINES += -DMAX_ARRAY_ELEMENT_SIZE=$(MAX_ARRAY_ELEMENT_SIZE)
 
-BINARY_SEACRH_BOUND = $(shell echo $(MAX_ARRAY_LEN)/2 | bc)
+BINARY_SEARCH_BOUND = 5
+
+DEFINES += -DMADV_DONTDUMP=1
 
 CBMCFLAGS +=
 
@@ -30,6 +32,7 @@ PROOF_SOURCES += $(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/madvise.c
 PROOF_SOURCES += $(PROOF_STUB)/memmove_havoc.c
 PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
@@ -48,6 +51,17 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_set.c
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 
-UNWINDSET += __CPROVER_file_local_s2n_set_c_s2n_set_binary_search.11:$(call addone,$(BINARY_SEACRH_BOUND))
+UNWINDSET += __CPROVER_file_local_s2n_set_c_s2n_set_binary_search.0:$(call addone,$(BINARY_SEARCH_BOUND))
+UNWINDSET += __CPROVER_file_local_s2n_set_c_s2n_set_binary_search.1:$(call addone,$(BINARY_SEARCH_BOUND))
+UNWINDSET += __CPROVER_file_local_s2n_set_c_s2n_set_binary_search.2:$(call addone,$(BINARY_SEARCH_BOUND))
+UNWINDSET += __CPROVER_file_local_s2n_set_c_s2n_set_binary_search.3:$(call addone,$(BINARY_SEARCH_BOUND))
+UNWINDSET += __CPROVER_file_local_s2n_set_c_s2n_set_binary_search.4:$(call addone,$(BINARY_SEARCH_BOUND))
+UNWINDSET += __CPROVER_file_local_s2n_set_c_s2n_set_binary_search.5:$(call addone,$(BINARY_SEARCH_BOUND))
+UNWINDSET += __CPROVER_file_local_s2n_set_c_s2n_set_binary_search.6:$(call addone,$(BINARY_SEARCH_BOUND))
+UNWINDSET += __CPROVER_file_local_s2n_set_c_s2n_set_binary_search.7:$(call addone,$(BINARY_SEARCH_BOUND))
+UNWINDSET += __CPROVER_file_local_s2n_set_c_s2n_set_binary_search.8:$(call addone,$(BINARY_SEARCH_BOUND))
+UNWINDSET += __CPROVER_file_local_s2n_set_c_s2n_set_binary_search.9:$(call addone,$(BINARY_SEARCH_BOUND))
+UNWINDSET += __CPROVER_file_local_s2n_set_c_s2n_set_binary_search.10:$(call addone,$(BINARY_SEARCH_BOUND))
+UNWINDSET += __CPROVER_file_local_s2n_set_c_s2n_set_binary_search.11:$(call addone,$(BINARY_SEARCH_BOUND))
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_set_add/Makefile
+++ b/tests/cbmc/proofs/s2n_set_add/Makefile
@@ -1,0 +1,53 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 50 seconds.
+
+MAX_ARRAY_LEN = 10
+DEFINES += -DMAX_ARRAY_LEN=$(MAX_ARRAY_LEN)
+
+MAX_ARRAY_ELEMENT_SIZE = 10
+DEFINES += -DMAX_ARRAY_ELEMENT_SIZE=$(MAX_ARRAY_ELEMENT_SIZE)
+
+BINARY_SEACRH_BOUND = $(shell echo $(MAX_ARRAY_LEN)/2 | bc)
+
+CBMCFLAGS +=
+
+HARNESS_ENTRY = s2n_set_add_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/memmove_havoc.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_set.c
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET += __CPROVER_file_local_s2n_set_c_s2n_set_binary_search.11:$(call addone,$(BINARY_SEACRH_BOUND))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_set_add/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_set_add/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_set_add/s2n_set_add_harness.c
+++ b/tests/cbmc/proofs/s2n_set_add/s2n_set_add_harness.c
@@ -37,7 +37,7 @@ void s2n_set_add_harness()
     /* Operation under verification. */
     if(s2n_result_is_ok(s2n_set_add(set, element))) {
         /*
-         * In the case s2n_array_insert_and_copy is successful, we can ensure the array isn't empty
+         * In the case s2n_set_add is successful, we can ensure the array isn't empty
          * and index is within bounds.
          */
          assert(set->data->mem.data != NULL);

--- a/tests/cbmc/proofs/s2n_set_add/s2n_set_add_harness.c
+++ b/tests/cbmc/proofs/s2n_set_add/s2n_set_add_harness.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "utils/s2n_set.h"
+#include "utils/s2n_result.h"
+
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_set_add_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_set *set = cbmc_allocate_s2n_set();
+    __CPROVER_assume(s2n_result_is_ok(s2n_set_validate(set)));
+    __CPROVER_assume(s2n_set_is_bounded(set, MAX_ARRAY_LEN, MAX_ARRAY_ELEMENT_SIZE));
+    uint32_t index;
+    void *element = can_fail_malloc(set->data->element_size);
+
+    nondet_s2n_mem_init();
+
+    struct s2n_array old_array = *(set->data);
+
+    /* Operation under verification. */
+    if(s2n_result_is_ok(s2n_set_add(set, element))) {
+        /*
+         * In the case s2n_array_insert_and_copy is successful, we can ensure the array isn't empty
+         * and index is within bounds.
+         */
+         assert(set->data->mem.data != NULL);
+         assert(set->data->len == (old_array.len + 1));
+         assert(s2n_result_is_ok(s2n_set_validate(set)));
+    }
+}

--- a/tests/cbmc/proofs/s2n_set_get/Makefile
+++ b/tests/cbmc/proofs/s2n_set_get/Makefile
@@ -1,0 +1,40 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 10 seconds.
+
+MAX_ARRAY_LEN = 10
+DEFINES += -DMAX_ARRAY_LEN=$(MAX_ARRAY_LEN)
+
+MAX_ARRAY_ELEMENT_SIZE = 10
+DEFINES += -DMAX_ARRAY_ELEMENT_SIZE=$(MAX_ARRAY_ELEMENT_SIZE)
+
+CBMCFLAGS +=
+
+HARNESS_ENTRY = s2n_set_get_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_set.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_set_get/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_set_get/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_set_get/s2n_set_get_harness.c
+++ b/tests/cbmc/proofs/s2n_set_get/s2n_set_get_harness.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "utils/s2n_set.h"
+#include "utils/s2n_result.h"
+
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_set_get_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_set *set = cbmc_allocate_s2n_set();
+    __CPROVER_assume(s2n_result_is_ok(s2n_set_validate(set)));
+    __CPROVER_assume(s2n_set_is_bounded(set, MAX_ARRAY_LEN, MAX_ARRAY_ELEMENT_SIZE));
+    uint32_t index;
+    void **element = can_fail_malloc(sizeof(void *));
+
+    /* Operation under verification. */
+    if(s2n_result_is_ok(s2n_set_get(set, index, element))) {
+        /*
+         * In the case s2n_array_get is successful, we can ensure the array isn't empty
+         * and index is within bounds.
+         */
+         assert(set->data->mem.data != NULL);
+         assert(set->data->len != 0);
+         assert(index < set->data->len);
+         assert(*element == (set->data->mem.data + (set->data->element_size * index)));
+    }
+
+    /* Post-condition. */
+    assert(s2n_result_is_ok(s2n_set_validate(set)));
+}

--- a/tests/cbmc/proofs/s2n_set_get/s2n_set_get_harness.c
+++ b/tests/cbmc/proofs/s2n_set_get/s2n_set_get_harness.c
@@ -33,7 +33,7 @@ void s2n_set_get_harness()
     /* Operation under verification. */
     if(s2n_result_is_ok(s2n_set_get(set, index, element))) {
         /*
-         * In the case s2n_array_get is successful, we can ensure the array isn't empty
+         * In the case s2n_set_get is successful, we can ensure the array isn't empty
          * and index is within bounds.
          */
          assert(set->data->mem.data != NULL);

--- a/tests/cbmc/proofs/s2n_set_new/Makefile
+++ b/tests/cbmc/proofs/s2n_set_new/Makefile
@@ -1,0 +1,46 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 20 seconds.
+
+CBMCFLAGS +=
+
+HARNESS_ENTRY = s2n_set_new_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/memset_havoc.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_set.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_ensure_memcpy_trace
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_set_new/Makefile
+++ b/tests/cbmc/proofs/s2n_set_new/Makefile
@@ -13,6 +13,8 @@
 
 # Expected runtime is less than 20 seconds.
 
+DEFINES += -DMADV_DONTDUMP=1
+
 CBMCFLAGS +=
 
 HARNESS_ENTRY = s2n_set_new_harness
@@ -22,6 +24,7 @@ PROOF_SOURCES += $(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/madvise.c
 PROOF_SOURCES += $(PROOF_STUB)/memset_havoc.c
 PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c

--- a/tests/cbmc/proofs/s2n_set_new/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_set_new/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_set_new/s2n_set_new_harness.c
+++ b/tests/cbmc/proofs/s2n_set_new/s2n_set_new_harness.c
@@ -26,11 +26,12 @@ void s2n_set_new_harness()
 {
     /* Non-deterministic inputs. */
     uint32_t element_size;
+    int (*nondet_compare_ptr)(void*,void*) = nondet_bool() ? &nondet_compare : NULL;
 
     nondet_s2n_mem_init();
 
     /* Operation under verification. */
-    struct s2n_set *new_set = s2n_set_new(element_size, nondet_compare);
+    struct s2n_set *new_set = s2n_set_new(element_size, nondet_compare_ptr);
 
     /* Post-conditions. */
     assert(S2N_IMPLIES(new_set != NULL, s2n_result_is_ok(s2n_set_validate(new_set))));

--- a/tests/cbmc/proofs/s2n_set_new/s2n_set_new_harness.c
+++ b/tests/cbmc/proofs/s2n_set_new/s2n_set_new_harness.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "error/s2n_errno.h"
+#include "utils/s2n_set.h"
+#include "utils/s2n_mem.h"
+
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_set_new_harness()
+{
+    /* Non-deterministic inputs. */
+    uint32_t element_size;
+
+    nondet_s2n_mem_init();
+
+    /* Operation under verification. */
+    struct s2n_set *new_set = s2n_set_new(element_size, nondet_compare);
+
+    /* Post-conditions. */
+    assert(S2N_IMPLIES(new_set != NULL, s2n_result_is_ok(s2n_set_validate(new_set))));
+}

--- a/tests/cbmc/proofs/s2n_set_remove/Makefile
+++ b/tests/cbmc/proofs/s2n_set_remove/Makefile
@@ -1,0 +1,45 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 10 seconds.
+
+MAX_ARRAY_LEN = 10
+DEFINES += -DMAX_ARRAY_LEN=$(MAX_ARRAY_LEN)
+
+MAX_ARRAY_ELEMENT_SIZE = 10
+DEFINES += -DMAX_ARRAY_ELEMENT_SIZE=$(MAX_ARRAY_ELEMENT_SIZE)
+
+CBMCFLAGS +=
+
+HARNESS_ENTRY = s2n_set_remove_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/memmove_havoc.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_set.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_set_remove/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_set_remove/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_set_remove/s2n_set_remove_harness.c
+++ b/tests/cbmc/proofs/s2n_set_remove/s2n_set_remove_harness.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "error/s2n_errno.h"
+#include "utils/s2n_set.h"
+#include "utils/s2n_result.h"
+
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_set_remove_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_set *set = cbmc_allocate_s2n_set();
+    __CPROVER_assume(s2n_result_is_ok(s2n_set_validate(set)));
+    __CPROVER_assume(s2n_set_is_bounded(set, MAX_ARRAY_LEN, MAX_ARRAY_ELEMENT_SIZE));
+    uint32_t index;
+
+    struct s2n_array old_array = *(set->data);
+
+    /* Operation under verification. */
+    if(s2n_result_is_ok(s2n_set_remove(set, index))) {
+        /* Post-conditions. */
+        assert(set->data->mem.data != NULL);
+        assert(S2N_IMPLIES(old_array.len != 0, set->data->len == (old_array.len - 1)));
+        assert(index < old_array.len);
+    }
+
+    assert(s2n_result_is_ok(s2n_set_validate(set)));
+}

--- a/tests/cbmc/proofs/s2n_set_remove/s2n_set_remove_harness.c
+++ b/tests/cbmc/proofs/s2n_set_remove/s2n_set_remove_harness.c
@@ -38,6 +38,9 @@ void s2n_set_remove_harness()
         assert(set->data->mem.data != NULL);
         assert(S2N_IMPLIES(old_array.len != 0, set->data->len == (old_array.len - 1)));
         assert(index < old_array.len);
+	if(index == old_array.len - 1) {
+            assert_bytes_match(set->data->mem.data, old_array.mem.data, set->data->len);
+        }
     }
 
     assert(s2n_result_is_ok(s2n_set_validate(set)));

--- a/tests/cbmc/stubs/memmove_havoc.c
+++ b/tests/cbmc/stubs/memmove_havoc.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#undef memmove
+
+#include <cbmc_proof/nondet.h>
+#include <stdint.h>
+
+/**
+ * Override the version of memmove used by CBMC. Users may not want to pay
+ * for the cost of performing the computation of memmove in proofs. In that
+ * case, this stub at least checks for the preconditions and make sure to
+ * havoc all elements pointed by *dest up to n.
+ */
+void *memmove_impl(void *dest, const void *src, size_t n) {
+__CPROVER_HIDE:;
+    __CPROVER_precondition(src != NULL && __CPROVER_r_ok(src, n), "memmove source region readable");
+    __CPROVER_precondition(dest != NULL && __CPROVER_w_ok(dest, n), "memmove destination region writeable");
+
+    if (n > 0) {
+        size_t index;
+        __CPROVER_assume(index < n);
+        ((uint8_t *)dest)[index] = nondet_uint8_t();
+    }
+
+    return dest;
+}
+
+void *memmove(void *dest, const void *src, size_t n) {
+__CPROVER_HIDE:;
+    return memmove_impl(dest, src, n);
+}
+
+void *__builtin___memmove_chk(void *dest, const void *src, size_t n, size_t size) {
+  __CPROVER_HIDE:;
+    (void)size;
+    return memmove_impl(dest, src, n);
+}

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -356,7 +356,11 @@ extern int s2n_sub_overflow(uint32_t a, uint32_t b, uint32_t* out);
 /* Note: this macro is replaced by ENSURE_POSIX_REF */
 #define notnull_check( ptr )                        ENSURE_POSIX_REF(ptr)
 /* Note: this macro is replaced by ENSURE_REF_PTR */
-#define notnull_check_ptr( ptr )                    ENSURE_REF_PTR(ptr)
+#ifdef CBMC
+#    define notnull_check_ptr( ptr )                do { if ( ptr == NULL ) { return NULL; } } while (0)
+#else
+#    define notnull_check_ptr( ptr )                ENSURE_REF_PTR(ptr)
+#endif
 
 /* Range check a number */
 #define gte_check( n , min )                        ENSURE_POSIX((n) >= (min), S2N_ERR_SAFETY)

--- a/utils/s2n_set.c
+++ b/utils/s2n_set.c
@@ -32,7 +32,7 @@ S2N_RESULT s2n_set_validate(const struct s2n_set *set)
  * Returns an error if the element already exists */
 static S2N_RESULT s2n_set_binary_search(struct s2n_set *set, void *element, uint32_t* out)
 {
-    ENSURE_REF(set);
+    GUARD_RESULT(s2n_set_validate(set));
     ENSURE_REF(element);
     ENSURE_REF(out);
     struct s2n_array *array = set->data;
@@ -72,9 +72,9 @@ static S2N_RESULT s2n_set_binary_search(struct s2n_set *set, void *element, uint
     return S2N_RESULT_OK;
 }
 
-struct s2n_set *s2n_set_new(size_t element_size, int (*comparator)(const void*, const void*))
+struct s2n_set *s2n_set_new(uint32_t element_size, int (*comparator)(const void*, const void*))
 {
-    ENSURE_REF_PTR(comparator);
+    if (comparator == NULL) return NULL;
     struct s2n_blob mem = {0};
     GUARD_POSIX_PTR(s2n_alloc(&mem, sizeof(struct s2n_set)));
     struct s2n_set *set = (void *) mem.data;
@@ -88,6 +88,8 @@ struct s2n_set *s2n_set_new(size_t element_size, int (*comparator)(const void*, 
 
 S2N_RESULT s2n_set_add(struct s2n_set *set, void *element)
 {
+    GUARD_RESULT(s2n_set_validate(set));
+
     uint32_t index = 0;
     GUARD_RESULT(s2n_set_binary_search(set, element, &index));
     GUARD_RESULT(s2n_array_insert_and_copy(set->data, index, element));
@@ -97,7 +99,7 @@ S2N_RESULT s2n_set_add(struct s2n_set *set, void *element)
 
 S2N_RESULT s2n_set_get(struct s2n_set *set, uint32_t index, void **element)
 {
-    ENSURE_REF(set);
+    GUARD_RESULT(s2n_set_validate(set));
     ENSURE_REF(element);
 
     GUARD_RESULT(s2n_array_get(set->data, index, element));
@@ -107,6 +109,7 @@ S2N_RESULT s2n_set_get(struct s2n_set *set, uint32_t index, void **element)
 
 S2N_RESULT s2n_set_remove(struct s2n_set *set, uint32_t index)
 {
+    GUARD_RESULT(s2n_set_validate(set));
     GUARD_RESULT(s2n_array_remove(set->data, index));
 
     return S2N_RESULT_OK;

--- a/utils/s2n_set.c
+++ b/utils/s2n_set.c
@@ -74,7 +74,7 @@ static S2N_RESULT s2n_set_binary_search(struct s2n_set *set, void *element, uint
 
 struct s2n_set *s2n_set_new(uint32_t element_size, int (*comparator)(const void*, const void*))
 {
-    if (comparator == NULL) return NULL;
+    notnull_check_ptr(comparator);
     struct s2n_blob mem = {0};
     GUARD_POSIX_PTR(s2n_alloc(&mem, sizeof(struct s2n_set)));
     struct s2n_set *set = (void *) mem.data;

--- a/utils/s2n_set.h
+++ b/utils/s2n_set.h
@@ -24,7 +24,7 @@ struct s2n_set {
 };
 
 extern S2N_RESULT s2n_set_validate(const struct s2n_set *set);
-extern struct s2n_set *s2n_set_new(size_t element_size, int (*comparator)(const void*, const void*));
+extern struct s2n_set *s2n_set_new(uint32_t element_size, int (*comparator)(const void*, const void*));
 extern S2N_RESULT s2n_set_add(struct s2n_set *set, void *element);
 extern S2N_RESULT s2n_set_get(struct s2n_set *set, uint32_t index, void **element);
 extern S2N_RESULT s2n_set_remove(struct s2n_set *set, uint32_t index);


### PR DESCRIPTION
### Resolved issues:

N/A.

### Description of changes: 

 - Adds a CBMC-proof harness for `s2n_set_add` function;
 - Adds a CBMC-proof harness for `s2n_set_get` function;
 - Adds a CBMC-proof harness for `s2n_set_new` function;
 - Adds a CBMC-proof harness for `s2n_set_remove` function;
 - Adds a stub for a havoc version of `memmove`;

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
