### PR TITLE
Don't enable OCSP stapling if not available

### DIFF
--- a/tests/unit/s2n_client_extensions_test.c
+++ b/tests/unit/s2n_client_extensions_test.c
@@ -722,6 +722,14 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_free(client_config));
     }
 
+    /* Cannot enable OCSP stapling if there's no support for it */
+    if(!s2n_x509_ocsp_stapling_supported()) {
+        struct s2n_config *client_config;
+        EXPECT_NOT_NULL(client_config = s2n_config_new());
+        EXPECT_FAILURE(s2n_config_set_check_stapled_ocsp_response(client_config, 1));
+        EXPECT_SUCCESS(s2n_config_free(client_config));
+    }
+
     /* Server doesn't support the OCSP extension. We can't run this test if ocsp isn't supported by the client. */
     if(s2n_x509_ocsp_stapling_supported()) {
         struct s2n_connection *client_conn;

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -405,6 +405,7 @@ int s2n_config_set_verify_host_callback(struct s2n_config *config, s2n_verify_ho
 int s2n_config_set_check_stapled_ocsp_response(struct s2n_config *config, uint8_t check_ocsp)
 {
     notnull_check(config);
+    S2N_ERROR_IF(check_ocsp && !s2n_x509_ocsp_stapling_supported(), S2N_ERR_OCSP_NOT_SUPPORTED);
     config->check_ocsp = check_ocsp;
     return 0;
 }


### PR DESCRIPTION
On BoringSSL OCSP stapling is not available, however, it can still be
added to the configuration via s2n_config_set_check_stapled_ocsp_response.
The docs suggest that if this feature cannot be enabled, the return code
should be -1 instead.

Signed-off-by: Petre Eftime <epetre@amazon.com>

### Description

Fixes documentation mismatch here: https://github.com/awslabs/s2n/blob/main/docs/USAGE-GUIDE.md#s2n_config_set_check_stapled_ocsp_response.

### Testing:

Local build + unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
