### PR TITLE
Check if S2N_COVERAGE and FUZZ_COVERAGE are true

### DIFF
--- a/codebuild/bin/install_clang.sh
+++ b/codebuild/bin/install_clang.sh
@@ -54,7 +54,7 @@ echo "Installed Clang Version: "
 "$CLANG_DOWNLOAD_DIR"/third_party/llvm-build/Release+Asserts/bin/clang --version
 
 # Install matching LLVM if FUZZ_COVERAGE is enabled
-if [[ ! -z "$FUZZ_COVERAGE" ]]; then
+if [[ "$FUZZ_COVERAGE" == "true" ]]; then
 	LLVM_INSTALL_DIR="$CLANG_INSTALL_DIR"/../llvm
 	mkdir -p "$LLVM_INSTALL_DIR"
 	python3 "$CLANG_DOWNLOAD_DIR"/clang/scripts/update.py --package="coverage_tools" --output-dir="$LLVM_INSTALL_DIR"

--- a/codebuild/bin/install_libFuzzer.sh
+++ b/codebuild/bin/install_libFuzzer.sh
@@ -42,7 +42,7 @@ ar ruv libFuzzer.a Fuzzer*.o
 echo "Copying libFuzzer.a to $LIBFUZZER_INSTALL_DIR"
 mkdir -p "$LIBFUZZER_INSTALL_DIR"/lib && cp libFuzzer.a "$LIBFUZZER_INSTALL_DIR"/lib
 
-if [ ! -z "$AFL_FUZZ" && -z "$FUZZ_COVERAGE" ]; then
+if [ ! -z "$AFL_FUZZ" && "$FUZZ_COVERAGE" != "true" ]; then
 	mkdir -p "$LIBFUZZER_INSTALL_DIR" && curl https://raw.githubusercontent.com/google/clusterfuzz/master/docs/setting-up-fuzzing/build_afl.bash > "$LIBFUZZER_INSTALL_DIR"/build_afl.bash
 	chmod +x "$LIBFUZZER_INSTALL_DIR"/build_afl.bash
 	cd "$LIBFUZZER_INSTALL_DIR"

--- a/codebuild/bin/s2n_after_codebuild.sh
+++ b/codebuild/bin/s2n_after_codebuild.sh
@@ -16,8 +16,8 @@
 set -ex
 
 # Upload Code Coverage Information to CodeCov.io
-if [[ -n "$CODECOV_IO_UPLOAD" ]]; then
-    if [[ -n "$FUZZ_COVERAGE" ]]; then
+if [[ "$CODECOV_IO_UPLOAD" == "true" ]]; then
+    if [[ "$FUZZ_COVERAGE" == "true" ]]; then
         bash <(curl -s https://codecov.io/bash) -f coverage/fuzz/codecov.txt -F ${TESTS};
     else
         bash <(curl -s https://codecov.io/bash) -F ${TESTS};

--- a/codebuild/bin/s2n_codebuild.sh
+++ b/codebuild/bin/s2n_codebuild.sh
@@ -82,6 +82,6 @@ if [[ "$TESTS" == "ALL" || "$TESTS" == "sawBIKE" ]]; then make -C tests/saw bike
 
 # Generate *.gcov files that can be picked up by the CodeCov.io Bash helper script. Don't run lcov or genhtml 
 # since those will delete .gcov files as they're processed.
-if [[ -n "$CODECOV_IO_UPLOAD" && -z "$FUZZ_COVERAGE" ]]; then
+if [[ "$CODECOV_IO_UPLOAD" == "true" && "$FUZZ_COVERAGE" != "true" ]]; then
     make run-gcov;
 fi

--- a/codebuild/bin/s2n_setup_env.sh
+++ b/codebuild/bin/s2n_setup_env.sh
@@ -82,7 +82,7 @@ export OS_NAME
 export S2N_CORKED_IO
 
 # S2N_COVERAGE should not be used with fuzz tests, use FUZZ_COVERAGE instead
-if [[ ! -z "$S2N_COVERAGE" && "$TESTS" == "fuzz" ]]; then
+if [[ "$S2N_COVERAGE" == "true" && "$TESTS" == "fuzz" ]]; then
     unset S2N_COVERAGE
     export FUZZ_COVERAGE=true
 fi

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -20,7 +20,7 @@ all: libs2n.a libs2n.so libs2n.dylib
 
 include ../s2n.mk
 
-ifdef FUZZ_COVERAGE
+ifeq ($(FUZZ_COVERAGE), true)
 	FUZZCOV_FLAGS = -fprofile-instr-generate -fcoverage-mapping
 endif
 

--- a/s2n.mk
+++ b/s2n.mk
@@ -52,10 +52,10 @@ FUZZ_CFLAGS = -fsanitize-coverage=trace-pc-guard -fsanitize=address,undefined,le
 
 # Define FUZZ_COVERAGE - to be used for generating coverage reports on fuzz tests
 #                !!! NOT COMPATIBLE WITH S2N_COVERAGE !!!
-ifdef FUZZ_COVERAGE
+ifeq ($(FUZZ_COVERAGE), true)
 	FUZZ_CFLAGS += -fprofile-instr-generate -fcoverage-mapping
 else
-	ifdef S2N_COVERAGE
+	ifeq ($(S2N_COVERAGE), true)
 		DEFAULT_CFLAGS += ${COVERAGE_CFLAGS}
 		LIBS += ${COVERAGE_LDFLAGS}
 	endif

--- a/tests/fuzz/Makefile
+++ b/tests/fuzz/Makefile
@@ -46,7 +46,7 @@ DYLD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_P
 LD_LIBRARY_PATH="../../lib/:../testlib/:$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH"
 
 ifdef AFL_FUZZ
-    ifndef FUZZ_COVERAGE
+    ifneq ($(FUZZ_COVERAGE), true)
         CFLAGS += $(LIBFUZZER_ROOT)/FuzzingEngine.a
     endif
 endif

--- a/tests/fuzz/calcTotalCov.sh
+++ b/tests/fuzz/calcTotalCov.sh
@@ -35,7 +35,7 @@ FUZZCOV_SOURCES="${S2N_ROOT}/api ${S2N_ROOT}/bin ${S2N_ROOT}/crypto ${S2N_ROOT}/
 # Total coverage is overlayed on source code in s2n_cov.html and coverage statistics are available in s2n_cov.txt
 # If using LLVM version 9 or greater, coverage is output in LCOV format instead of HTML
 # All files are stored in the s2n coverage directory
-if [[ ! -z "$FUZZ_COVERAGE" ]]; then
+if [[ "$FUZZ_COVERAGE" == "true" ]]; then
 
     printf "Calculating total s2n coverage... "
 

--- a/tests/fuzz/runFuzzTest.sh
+++ b/tests/fuzz/runFuzzTest.sh
@@ -76,7 +76,7 @@ TEMP_CORPUS_DIR="$(mktemp -d)"
 cp -r ./corpus/${TEST_NAME}/. "${TEMP_CORPUS_DIR}"
 
 # Run AFL instead of libfuzzer if AFL_FUZZ is set. Not compatible with fuzz coverage.
-if [[ ! -z "$AFL_FUZZ" && -z "$FUZZ_COVERAGE" ]]; then
+if [[ ! -z "$AFL_FUZZ" && "$FUZZ_COVERAGE" != "true" ]]; then
     printf "Running %-s %-40s for %5d sec... " "${FIPS_TEST_MSG}" ${TEST_NAME} ${FUZZ_TIMEOUT_SEC}
     mkdir -p results/${TEST_NAME}
     timeout ${FUZZ_TIMEOUT_SEC} afl-fuzz -i corpus/${TEST_NAME} -o results/${TEST_NAME} -m none ./${TEST_NAME}
@@ -98,7 +98,7 @@ else
 fi
 
 # Setup and clean profile structure if FUZZ_COVERAGE is enabled, otherwise run as normal
-if [[ ! -z "$FUZZ_COVERAGE" ]]; then
+if [[ "$FUZZ_COVERAGE" == "true" ]]; then
     mkdir -p "./profiles/${TEST_NAME}"
     rm -f ./profiles/${TEST_NAME}/*.profraw
     LLVM_PROFILE_FILE="./profiles/${TEST_NAME}/${TEST_NAME}.%p.profraw" ./${TEST_NAME} ${LIBFUZZER_ARGS} ${TEMP_CORPUS_DIR} > ${TEST_NAME}_output.txt 2>&1 || ACTUAL_TEST_FAILURE=1
@@ -118,7 +118,7 @@ declare -i TARGET_COV=0
 # Coverage is overlayed on source code in ${TEST_NAME}_cov.html, and coverage statistics are available in ${TEST_NAME}_cov.txt
 # If using LLVM version 9 or greater, coverage is output in LCOV format instead of HTML
 # All files are stored in the s2n coverage directory
-if [[ ! -z "$FUZZ_COVERAGE" ]]; then
+if [[ "$FUZZ_COVERAGE" == "true" ]]; then
     mkdir -p ${COVERAGE_DIR}/fuzz
     llvm-profdata merge -sparse ./profiles/${TEST_NAME}/*.profraw -o ./profiles/${TEST_NAME}/${TEST_NAME}.profdata
     llvm-cov report -instr-profile=./profiles/${TEST_NAME}/${TEST_NAME}.profdata ${S2N_ROOT}/lib/libs2n.so ${FUZZCOV_SOURCES} -show-functions > ${COVERAGE_DIR}/fuzz/${TEST_NAME}_cov.txt
@@ -151,7 +151,7 @@ then
 
     # Output target function coverage percentage if target functions are defined and fuzzing coverage is enabled
     # Otherwise, print number of features covered
-    if [[ ! -z "$FUZZ_COVERAGE" && ! -z "$TARGET_FUNCS" && "$EXPECTED_TEST_FAILURE" != 1 && "$TARGET_TOTAL" != 0 ]];
+    if [[ "$FUZZ_COVERAGE" == "true" && ! -z "$TARGET_FUNCS" && "$EXPECTED_TEST_FAILURE" != 1 && "$TARGET_TOTAL" != 0 ]];
     then
         printf ", %6.2f%% target coverage" "$(( 10000 * ($TARGET_TOTAL - $TARGET_COV) / $TARGET_TOTAL ))e-2"
     else


### PR DESCRIPTION
S2N_COVERAGE is set to false for some builds, but ifdef S2N_COVERAGE returns true in that case. This changes the behavior to only return true if S2N_COVERAGE (and similarly FUZZ_COVERAGE) equals true