### PR TITLE
s2n_alloc and s2n_sub_overflow proofs

### DIFF
--- a/tests/cbmc/proofs/s2n_alloc/Makefile
+++ b/tests/cbmc/proofs/s2n_alloc/Makefile
@@ -1,0 +1,42 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 20 seconds.
+
+CHECKFLAGS +=
+
+HARNESS_ENTRY = s2n_alloc_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/madvise.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+REMOVE_FUNCTION_BODY += s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_ensure_memcpy_trace
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_alloc/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_alloc/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_alloc/s2n_alloc_harness.c
+++ b/tests/cbmc/proofs/s2n_alloc/s2n_alloc_harness.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+#include "api/s2n.h"
+#include "utils/s2n_blob.h"
+#include "utils/s2n_safety.h"
+
+void s2n_alloc_harness()
+{
+    struct s2n_blob *blob = cbmc_allocate_s2n_blob();
+    __CPROVER_assume(S2N_IMPLIES(blob != NULL, s2n_blob_is_valid(blob)));
+    uint32_t size;
+
+    /* Non-deterministically set initialized (in s2n_mem) to true. */
+    nondet_s2n_mem_init();
+
+    if (s2n_alloc(blob, size) == S2N_SUCCESS) {
+        assert(blob->allocated >= size);
+        assert(blob->size == size);
+        if (size != 0) {
+            assert(__CPROVER_w_ok(blob->data, blob->allocated));
+        }
+        assert(s2n_blob_is_valid(blob));
+    } else {
+        assert(blob == NULL || s2n_blob_is_valid(blob));
+    }
+}

--- a/tests/cbmc/proofs/s2n_sub_overflow/Makefile
+++ b/tests/cbmc/proofs/s2n_sub_overflow/Makefile
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+
+CBMCFLAGS +=
+
+HARNESS_ENTRY = s2n_sub_overflow_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_sub_overflow/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_sub_overflow/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_sub_overflow/s2n_sub_overflow_harness.c
+++ b/tests/cbmc/proofs/s2n_sub_overflow/s2n_sub_overflow_harness.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "utils/s2n_safety.h"
+
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+
+int s2n_sub_overflow_harness()
+{
+    uint32_t a;
+    uint32_t b;
+    uint32_t *out = can_fail_malloc(sizeof(uint32_t));
+
+    if (s2n_sub_overflow(a, b, out) == S2N_SUCCESS) {
+        assert(*out == a - b);
+    } else {
+        assert(((uint64_t) UINT32_MAX + (uint64_t) a) - (uint64_t) b < UINT32_MAX || out == NULL);
+    }
+}


### PR DESCRIPTION
### Description of changes:
Adds a proof for s2n_alloc, with the proof for s2n_sub_overflow included because it's small and doesn't deserve a full PR.

### Call-outs:
The s2n_alloc proof is relatively light because s2n_alloc already calls s2n_realloc which has its own proof, so we shouldn't need to re-prove any of those properties.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.