### PR TITLE
Initialize slot variable to fix ARM compiler warning

### DIFF
--- a/utils/s2n_map.c
+++ b/utils/s2n_map.c
@@ -118,7 +118,7 @@ S2N_RESULT s2n_map_add(struct s2n_map *map, struct s2n_blob *key, struct s2n_blo
         GUARD_RESULT(s2n_map_embiggen(map, map->capacity * 2));
     }
 
-    uint32_t slot;
+    uint32_t slot = 0;
     GUARD_RESULT(s2n_map_slot(map, key, &slot));
 
     /* Linear probing until we find an empty slot */
@@ -150,7 +150,7 @@ S2N_RESULT s2n_map_put(struct s2n_map *map, struct s2n_blob *key, struct s2n_blo
         GUARD_RESULT(s2n_map_embiggen(map, map->capacity * 2));
     }
 
-    uint32_t slot;
+    uint32_t slot = 0;
     GUARD_RESULT(s2n_map_slot(map, key, &slot));
 
     /* Linear probing until we find an empty slot */
@@ -194,7 +194,7 @@ S2N_RESULT s2n_map_lookup(struct s2n_map *map, struct s2n_blob *key, struct s2n_
 {
     ENSURE(map->immutable, S2N_ERR_MAP_MUTABLE);
 
-    uint32_t slot;
+    uint32_t slot = 0;
     GUARD_RESULT(s2n_map_slot(map, key, &slot));
     const uint32_t initial_slot = slot;
 


### PR DESCRIPTION
### Resolved issues:
Fixes this ARM CI build failure: https://github.com/awslabs/aws-crt-java/pull/216
Related to: https://github.com/awslabs/s2n/issues/790

### Description of changes: 
Fixes a false positive GCC5 compiler warning on ARM builds about `slot` variable potentially being uninitialized.

```
2020-08-27T22:35:54.2613376Z /work/aws-common-runtime/s2n/utils/s2n_map.c: In function 's2n_map_embiggen':
2020-08-27T22:35:54.2613863Z /work/aws-common-runtime/s2n/utils/s2n_map.c:125:21: error: 'slot' may be used uninitialized in this function [-Werror=maybe-uninitialized]
2020-08-27T22:35:54.2614177Z      while(map->table[slot].key.size) {
2020-08-27T22:35:54.2614312Z                      ^
2020-08-27T22:35:54.2614671Z /work/aws-common-runtime/s2n/utils/s2n_map.c:121:14: note: 'slot' was declared here
2020-08-27T22:35:54.2614817Z      uint32_t slot;
2020-08-27T22:35:54.2614938Z               ^
2020-08-27T22:35:54.2684140Z /work/aws-common-runtime/s2n/utils/s2n_map.c: In function 's2n_map_add':
2020-08-27T22:35:54.2684595Z /work/aws-common-runtime/s2n/utils/s2n_map.c:125:21: error: 'slot' may be used uninitialized in this function [-Werror=maybe-uninitialized]
2020-08-27T22:35:54.2685158Z      while(map->table[slot].key.size) {
2020-08-27T22:35:54.2685291Z                      ^
2020-08-27T22:35:54.2727767Z /work/aws-common-runtime/s2n/utils/s2n_map.c: In function 's2n_map_put':
2020-08-27T22:35:54.2728194Z /work/aws-common-runtime/s2n/utils/s2n_map.c:157:21: error: 'slot' may be used uninitialized in this function [-Werror=maybe-uninitialized]
2020-08-27T22:35:54.2728497Z      while(map->table[slot].key.size) {
2020-08-27T22:35:54.2728610Z                      ^
2020-08-27T22:35:54.2770107Z /work/aws-common-runtime/s2n/utils/s2n_map.c: In function 's2n_map_lookup':
2020-08-27T22:35:54.2770592Z /work/aws-common-runtime/s2n/utils/s2n_map.c:207:16: error: 'slot' may be used uninitialized in this function [-Werror=maybe-uninitialized]
2020-08-27T22:35:54.2770753Z              if (slot == initial_slot) {
2020-08-27T22:35:54.2770880Z                 ^
2020-08-27T22:35:54.2799944Z cc1: all warnings being treated as errors
2020-08-27T22:35:54.2818896Z make[2]: *** [aws-common-runtime/s2n/CMakeFiles/s2n.dir/utils/s2n_map.c.o] Error 1
2020-08-27T22:35:54.2819485Z aws-common-runtime/s2n/CMakeFiles/s2n.dir/build.make:2357: recipe for target 'aws-common-runtime/s2n/CMakeFiles/s2n.dir/utils/s2n_map.c.o' failed
2020-08-27T22:35:54.2819874Z CMakeFiles/Makefile2:323: recipe for target 'aws-common-runtime/s2n/CMakeFiles/s2n.dir/all' failed
```

### Call-outs:
None

### Testing:
Compiled and passes unit tests.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
