### PR TITLE
Add client-side support for PQ HRR

### DIFF
--- a/tests/unit/s2n_client_hello_retry_test.c
+++ b/tests/unit/s2n_client_hello_retry_test.c
@@ -170,7 +170,6 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_free(client_conn));
             EXPECT_SUCCESS(s2n_cert_chain_and_key_free(tls13_chain_and_key));
         }
-
 #if !defined(S2N_NO_PQ)
         {
             const struct s2n_kem_group *test_kem_groups[] = {
@@ -245,7 +244,6 @@ int main(int argc, char **argv)
                     EXPECT_SUCCESS(s2n_free(&client_params->kem_params.public_key));
                     EXPECT_SUCCESS(s2n_connection_free(conn));
                 }
-
                 /* s2n_server_hello_retry_recv must fail if the server chose a PQ KEM
                  * that wasn't in the client's supported_groups */
                 {

--- a/tests/unit/s2n_client_hello_retry_test.c
+++ b/tests/unit/s2n_client_hello_retry_test.c
@@ -25,6 +25,7 @@
 #include "tls/s2n_tls13.h"
 #include "tls/s2n_tls13_handshake.h"
 #include "tls/s2n_connection.h"
+#include "crypto/s2n_fips.h"
 
 /* This include is required to access static function s2n_server_hello_parse */
 #include "tls/s2n_server_hello.c"
@@ -106,7 +107,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }
 
-        /* Test success case for s2n_server_hello_retry_recv */
+        /* Test ECC success case for s2n_server_hello_retry_recv */
         {
             struct s2n_config *server_config;
             struct s2n_config *client_config;
@@ -168,8 +169,166 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
             EXPECT_SUCCESS(s2n_connection_free(client_conn));
             EXPECT_SUCCESS(s2n_cert_chain_and_key_free(tls13_chain_and_key));
-
         }
+
+#if !defined(S2N_NO_PQ)
+        {
+            const struct s2n_kem_group *test_kem_groups[] = {
+                &s2n_secp256r1_sike_p434_r2,
+                &s2n_secp256r1_bike1_l1_r2,
+            };
+
+            const struct s2n_kem_preferences test_kem_prefs = {
+                .kem_count = 0,
+                .kems = NULL,
+                .tls13_kem_group_count = s2n_array_len(test_kem_groups),
+                .tls13_kem_groups = test_kem_groups,
+            };
+
+            const struct s2n_security_policy test_security_policy = {
+                .minimum_protocol_version = S2N_SSLv3,
+                .cipher_preferences = &cipher_preferences_test_all_tls13,
+                .kem_preferences = &test_kem_prefs,
+                .signature_preferences = &s2n_signature_preferences_20200207,
+                .ecc_preferences = &s2n_ecc_preferences_20200310,
+            };
+
+            if (s2n_is_in_fips_mode()) {
+                struct s2n_connection *conn;
+                EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+                conn->actual_protocol_version = S2N_TLS13;
+                conn->security_policy_override = &test_security_policy;
+
+                const struct s2n_kem_preferences *kem_pref = NULL;
+                GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
+                EXPECT_NOT_NULL(kem_pref);
+
+                conn->secure.server_kem_group_params.kem_group = kem_pref->tls13_kem_groups[0];
+                EXPECT_NULL(conn->secure.server_ecc_evp_params.negotiated_curve);
+
+                EXPECT_FAILURE_WITH_ERRNO(s2n_server_hello_retry_recv(conn), S2N_ERR_PQ_KEMS_DISALLOWED_IN_FIPS);
+
+                EXPECT_SUCCESS(s2n_connection_free(conn));
+            } else {
+                /* s2n_server_hello_retry_recv must fail when a keyshare for a matching PQ KEM was already present */
+                {
+                    struct s2n_connection *conn;
+                    EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+                    conn->actual_protocol_version = S2N_TLS13;
+                    conn->security_policy_override = &test_security_policy;
+
+                    const struct s2n_kem_preferences *kem_pref = NULL;
+                    GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
+                    EXPECT_NOT_NULL(kem_pref);
+
+                    conn->secure.server_kem_group_params.kem_group = kem_pref->tls13_kem_groups[0];
+                    EXPECT_NULL(conn->secure.server_ecc_evp_params.negotiated_curve);
+
+                    struct s2n_kem_group_params *client_params = &conn->secure.client_kem_group_params[0];
+                    client_params->kem_group = kem_pref->tls13_kem_groups[0];
+                    client_params->kem_params.kem = kem_pref->tls13_kem_groups[0]->kem;
+                    client_params->ecc_params.negotiated_curve = kem_pref->tls13_kem_groups[0]->curve;
+
+                    EXPECT_NULL(client_params->ecc_params.evp_pkey);
+                    EXPECT_NULL(client_params->kem_params.private_key.data);
+
+                    kem_public_key_size public_key_size = kem_pref->tls13_kem_groups[0]->kem->public_key_length;
+                    EXPECT_SUCCESS(s2n_alloc(&client_params->kem_params.public_key, public_key_size));
+
+                    EXPECT_SUCCESS(s2n_kem_generate_keypair(&client_params->kem_params));
+                    EXPECT_NOT_NULL(client_params->kem_params.private_key.data);
+                    EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_params->ecc_params));
+                    EXPECT_NOT_NULL(client_params->ecc_params.evp_pkey);
+
+                    EXPECT_FAILURE_WITH_ERRNO(s2n_server_hello_retry_recv(conn), S2N_ERR_INVALID_HELLO_RETRY);
+
+                    EXPECT_SUCCESS(s2n_free(&client_params->kem_params.public_key));
+                    EXPECT_SUCCESS(s2n_connection_free(conn));
+                }
+
+                /* s2n_server_hello_retry_recv must fail if the server chose a PQ KEM
+                 * that wasn't in the client's supported_groups */
+                {
+                    struct s2n_connection *conn;
+                    EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+                    conn->actual_protocol_version = S2N_TLS13;
+                    conn->security_policy_override = &test_security_policy;
+
+                    /* test_security_policy does not include kyber */
+                    conn->secure.server_kem_group_params.kem_group = &s2n_secp256r1_kyber_512_r2;
+                    EXPECT_NULL(conn->secure.server_ecc_evp_params.negotiated_curve);
+
+                    EXPECT_FAILURE_WITH_ERRNO(s2n_server_hello_retry_recv(conn), S2N_ERR_INVALID_HELLO_RETRY);
+
+                    EXPECT_SUCCESS(s2n_connection_free(conn));
+                }
+                /* Test failure if exactly one of {named_curve, kem_group} isn't non-null */
+                {
+                    struct s2n_connection *conn;
+                    EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+                    conn->actual_protocol_version = S2N_TLS13;
+                    conn->security_policy_override = &test_security_policy;
+
+                    conn->secure.server_kem_group_params.kem_group = &s2n_secp256r1_sike_p434_r2;
+                    conn->secure.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
+
+                    EXPECT_FAILURE_WITH_ERRNO(s2n_server_hello_retry_recv(conn), S2N_ERR_INVALID_HELLO_RETRY);
+
+                    conn->secure.server_kem_group_params.kem_group = NULL;
+                    conn->secure.server_ecc_evp_params.negotiated_curve = NULL;
+
+                    EXPECT_FAILURE_WITH_ERRNO(s2n_server_hello_retry_recv(conn), S2N_ERR_INVALID_HELLO_RETRY);
+
+                    EXPECT_SUCCESS(s2n_connection_free(conn));
+                }
+                /* Test PQ KEM success case for s2n_server_hello_retry_recv. */
+                {
+                    struct s2n_config *config;
+                    struct s2n_connection *conn;
+
+                    struct s2n_cert_chain_and_key *tls13_chain_and_key;
+                    char tls13_cert_chain[S2N_MAX_TEST_PEM_SIZE] = {0};
+                    char tls13_private_key[S2N_MAX_TEST_PEM_SIZE] = {0};
+
+                    EXPECT_NOT_NULL(config = s2n_config_new());
+                    EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+                    conn->security_policy_override = &test_security_policy;
+
+                    EXPECT_NOT_NULL(tls13_chain_and_key = s2n_cert_chain_and_key_new());
+                    EXPECT_SUCCESS(s2n_read_test_pem(S2N_ECDSA_P384_PKCS1_CERT_CHAIN, tls13_cert_chain, S2N_MAX_TEST_PEM_SIZE));
+                    EXPECT_SUCCESS(s2n_read_test_pem(S2N_ECDSA_P384_PKCS1_KEY, tls13_private_key, S2N_MAX_TEST_PEM_SIZE));
+                    EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(tls13_chain_and_key, tls13_cert_chain, tls13_private_key));
+                    EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, tls13_chain_and_key));
+
+                    /* Client sends ClientHello containing key share for p256+SIKE
+                     * (but indicates support for p256+BIKE in supported_groups) */
+                    EXPECT_SUCCESS(s2n_client_hello_send(conn));
+
+                    EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->handshake.io));
+
+                    /* Server responds with HRR indicating p256+BIKE as choice for negotiation;
+                     * the last 6 bytes (0033 0002 2F23) are the key share extension with p256+BIKE */
+                    DEFER_CLEANUP(struct s2n_stuffer hrr = {0}, s2n_stuffer_free);
+                    EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&hrr,
+                            "0303CF21AD74E59A6111BE1D8C021E65B891C2A211167ABB8C5E079E09E2C8A8339C00130200000C002B00020304003300022F23"));
+
+                    EXPECT_SUCCESS(s2n_stuffer_copy(&hrr, &conn->handshake.io, s2n_stuffer_data_available(&hrr)));
+                    conn->handshake.message_number = HELLO_RETRY_MSG_NO;
+                    /* Read the message off the wire */
+                    EXPECT_SUCCESS(s2n_server_hello_parse(conn));
+                    conn->actual_protocol_version_established = 1;
+
+                    EXPECT_SUCCESS(s2n_conn_set_handshake_type(conn));
+                    /* Client receives the HelloRetryRequest message */
+                    EXPECT_SUCCESS(s2n_server_hello_retry_recv(conn));
+
+                    EXPECT_SUCCESS(s2n_config_free(config));
+                    EXPECT_SUCCESS(s2n_connection_free(conn));
+                    EXPECT_SUCCESS(s2n_cert_chain_and_key_free(tls13_chain_and_key));
+                }
+            }
+        }
+#endif
     }
 
     /* Verify that the hash transcript recreation function is called correctly,

--- a/tests/unit/s2n_client_key_share_extension_test.c
+++ b/tests/unit/s2n_client_key_share_extension_test.c
@@ -31,6 +31,8 @@
 #include "utils/s2n_safety.h"
 #include "crypto/s2n_fips.h"
 
+#define HELLO_RETRY_MSG_NO 1
+
 #define S2N_SIZE_OF_CLIENT_SHARE_SIZE   2
 
 #define S2N_PREPARE_DATA_LENGTH( stuffer )   \
@@ -939,7 +941,8 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(S2N_SUPPORTED_KEM_GROUPS_COUNT, s2n_array_len(all_kem_groups));
 
         if (s2n_is_in_fips_mode()) {
-            /* Test that s2n_client_key_share_extension.send sends only ECC key shares when in FIPS mode */
+            /* Test that s2n_client_key_share_extension.send sends only ECC key shares when in FIPS mode,
+             * even if tls13_kem_groups is non-null. */
             const struct s2n_kem_preferences test_kem_prefs = {
                 .kem_count = 0,
                 .kems = NULL,
@@ -955,7 +958,6 @@ int main(int argc, char **argv)
                 .ecc_preferences = &s2n_ecc_preferences_20200310,
             };
 
-            struct s2n_stuffer key_share_extension;
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             conn->security_policy_override = &test_security_policy;
@@ -969,6 +971,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_preferences));
             EXPECT_NOT_NULL(ecc_preferences);
 
+            DEFER_CLEANUP(struct s2n_stuffer key_share_extension = { 0 }, s2n_stuffer_free);
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&key_share_extension, 1024));
             EXPECT_SUCCESS(s2n_client_key_share_extension.send(conn, &key_share_extension));
 
@@ -978,7 +981,7 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(sent_key_shares_size, s2n_stuffer_data_available(&key_share_extension));
 
             /* ECC key shares should have the format: IANA ID || size || share. Only one ECC key share
-             * should be sent (as per defualt s2n behavior). */
+             * should be sent (as per default s2n behavior). */
             uint16_t iana_value, share_size;
             EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &iana_value));
             EXPECT_EQUAL(iana_value, ecc_preferences->ecc_curves[0]->iana_id);
@@ -989,7 +992,6 @@ int main(int argc, char **argv)
             /* If all the sizes/bytes were correctly written, there should be nothing left over */
             EXPECT_EQUAL(s2n_stuffer_data_available(&key_share_extension), 0);
 
-            EXPECT_SUCCESS(s2n_stuffer_free(&key_share_extension));
             EXPECT_SUCCESS(s2n_connection_free(conn));
         } else {
             /* Test that s2n_client_key_share_extension.send generates and sends PQ hybrid and ECC shares correctly
@@ -1019,96 +1021,235 @@ int main(int argc, char **argv)
                     .ecc_preferences = &s2n_ecc_preferences_20200310,
                 };
 
-                struct s2n_stuffer key_share_extension;
+                /* Test sending of default hybrid key share (non-HRR) */
+                {
+                    struct s2n_connection *conn;
+                    EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+                    conn->security_policy_override = &test_security_policy;
+
+                    const struct s2n_ecc_preferences *ecc_pref = NULL;
+                    EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+                    EXPECT_NOT_NULL(ecc_pref);
+
+                    const struct s2n_kem_preferences *kem_pref = NULL;
+                    EXPECT_SUCCESS(s2n_connection_get_kem_preferences(conn, &kem_pref));
+                    EXPECT_NOT_NULL(kem_pref);
+                    EXPECT_EQUAL(kem_pref->tls13_kem_group_count, S2N_SUPPORTED_KEM_GROUPS_COUNT);
+                    EXPECT_EQUAL(test_kem_groups[0], kem_pref->tls13_kem_groups[0]);
+                    const struct s2n_kem_group *test_kem_group = kem_pref->tls13_kem_groups[0];
+
+                    DEFER_CLEANUP(struct s2n_stuffer key_share_extension = { 0 }, s2n_stuffer_free);
+                    EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&key_share_extension, 4096));
+                    EXPECT_SUCCESS(s2n_client_key_share_extension.send(conn, &key_share_extension));
+
+                    /* First, assert that the client saved its private keys correctly in the connection state
+                     * for both hybrid PQ and classic ECC */
+                    struct s2n_kem_group_params *kem_group_params = &conn->secure.client_kem_group_params[0];
+                    EXPECT_EQUAL(kem_group_params->kem_group, test_kem_group);
+                    EXPECT_EQUAL(kem_group_params->kem_params.kem, test_kem_group->kem);
+                    EXPECT_NOT_NULL(kem_group_params->kem_params.private_key.data);
+                    EXPECT_EQUAL(kem_group_params->kem_params.private_key.size,test_kem_group->kem->private_key_length);
+                    EXPECT_EQUAL(kem_group_params->ecc_params.negotiated_curve, test_kem_group->curve);
+                    EXPECT_NOT_NULL(kem_group_params->ecc_params.evp_pkey);
+
+                    struct s2n_ecc_evp_params *ecc_params = &conn->secure.client_ecc_evp_params[0];
+                    EXPECT_EQUAL(ecc_params->negotiated_curve, ecc_pref->ecc_curves[0]);
+                    EXPECT_NOT_NULL(ecc_params->evp_pkey);
+
+                    /* Next, assert that the client didn't generate/save any hybrid or ECC params that it shouldn't have */
+                    for (size_t kem_group_index = 1; kem_group_index < S2N_SUPPORTED_KEM_GROUPS_COUNT; kem_group_index++) {
+                        EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_index].kem_group);
+                        EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_index].kem_params.kem);
+                        EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_index].kem_params.private_key.data);
+                        EXPECT_EQUAL(conn->secure.client_kem_group_params[kem_group_index].kem_params.private_key.size,0);
+                        EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_index].ecc_params.negotiated_curve);
+                        EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_index].ecc_params.evp_pkey);
+                    }
+                    for (size_t ecc_index = 1; ecc_index < S2N_ECC_EVP_SUPPORTED_CURVES_COUNT; ecc_index++) {
+                        EXPECT_NULL(conn->secure.client_ecc_evp_params[ecc_index].negotiated_curve);
+                        EXPECT_NULL(conn->secure.client_ecc_evp_params[ecc_index].evp_pkey);
+                    }
+
+                    /* Now, assert that the client sent the correct bytes over the wire for the key share extension */
+                    /* Assert total key shares extension size is correct */
+                    uint16_t sent_key_shares_size;
+                    EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &sent_key_shares_size));
+                    EXPECT_EQUAL(sent_key_shares_size, s2n_stuffer_data_available(&key_share_extension));
+
+                    /* Assert that the hybrid key share is correct:
+                     * IANA ID || total hybrid share size || ECC share size || ECC share || PQ share size || PQ share */
+                    uint16_t sent_hybrid_iana_id;
+                    EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &sent_hybrid_iana_id));
+                    EXPECT_EQUAL(sent_hybrid_iana_id, kem_pref->tls13_kem_groups[0]->iana_id);
+
+                    uint16_t expected_hybrid_share_size =
+                            S2N_SIZE_OF_KEY_SHARE_SIZE
+                            + test_kem_group->curve->share_size
+                            + S2N_SIZE_OF_KEY_SHARE_SIZE
+                            + test_kem_group->kem->public_key_length;
+                    uint16_t sent_hybrid_share_size;
+                    EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &sent_hybrid_share_size));
+                    EXPECT_EQUAL(sent_hybrid_share_size, expected_hybrid_share_size);
+
+                    uint16_t hybrid_ecc_share_size;
+                    EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &hybrid_ecc_share_size));
+                    EXPECT_EQUAL(hybrid_ecc_share_size, test_kem_group->curve->share_size);
+                    EXPECT_SUCCESS(s2n_stuffer_skip_read(&key_share_extension, hybrid_ecc_share_size));
+
+                    uint16_t hybrid_pq_share_size;
+                    EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &hybrid_pq_share_size));
+                    EXPECT_EQUAL(hybrid_pq_share_size, test_kem_group->kem->public_key_length);
+                    EXPECT_SUCCESS(s2n_stuffer_skip_read(&key_share_extension, hybrid_pq_share_size));
+
+                    /* Assert that the ECC key share is correct: IANA ID || size || share */
+                    uint16_t ecc_iana_value, ecc_share_size;
+                    EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &ecc_iana_value));
+                    EXPECT_EQUAL(ecc_iana_value, ecc_pref->ecc_curves[0]->iana_id);
+                    EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &ecc_share_size));
+                    EXPECT_EQUAL(ecc_share_size, ecc_pref->ecc_curves[0]->share_size);
+                    EXPECT_SUCCESS(s2n_stuffer_skip_read(&key_share_extension, ecc_share_size));
+
+                    /* If all the sizes/bytes were correctly written, there should be nothing left over */
+                    EXPECT_EQUAL(s2n_stuffer_data_available(&key_share_extension), 0);
+
+                    EXPECT_SUCCESS(s2n_connection_free(conn));
+                }
+
+                /* Test sending key share in response to HRR */
+                {
+                    struct s2n_connection *conn;
+                    EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+                    conn->security_policy_override = &test_security_policy;
+                    conn->actual_protocol_version = S2N_TLS13;
+
+                    const struct s2n_ecc_preferences *ecc_pref = NULL;
+                    EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+                    EXPECT_NOT_NULL(ecc_pref);
+
+                    const struct s2n_kem_preferences *kem_pref = NULL;
+                    EXPECT_SUCCESS(s2n_connection_get_kem_preferences(conn, &kem_pref));
+                    EXPECT_NOT_NULL(kem_pref);
+
+                    /* This is for pre-HRR set up; force the client to generate it's default hybrid key share
+                     * so that we can confirm that s2n_send_hrr_pq_hybrid_keyshare wipes it correctly. */
+                    DEFER_CLEANUP(struct s2n_stuffer key_share_extension = { 0 }, s2n_stuffer_free);
+                    EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&key_share_extension, 4096));
+                    EXPECT_SUCCESS(s2n_client_key_share_extension.send(conn, &key_share_extension));
+                    EXPECT_SUCCESS(s2n_stuffer_wipe(&key_share_extension));
+                    /* Quick sanity check */
+                    EXPECT_NOT_NULL(conn->secure.client_kem_group_params[0].kem_params.private_key.data);
+                    EXPECT_NOT_NULL(conn->secure.client_kem_group_params[0].ecc_params.evp_pkey);
+
+                    /* Prepare client for HRR. Client would have sent a key share for kem_pref->tls13_kem_groups[0],
+                     * but server selects something else for negotiation. */
+                    conn->handshake.handshake_type = HELLO_RETRY_REQUEST;
+                    conn->handshake.message_number = HELLO_RETRY_MSG_NO;
+                    conn->actual_protocol_version_established = 1;
+                    uint8_t chosen_index = kem_pref->tls13_kem_group_count - 1;
+                    EXPECT_NOT_EQUAL(chosen_index, 0);
+                    const struct s2n_kem_group *negotiated_kem_group = kem_pref->tls13_kem_groups[chosen_index];
+                    conn->secure.server_kem_group_params.kem_group = negotiated_kem_group;
+
+                    EXPECT_SUCCESS(s2n_client_key_share_extension.send(conn, &key_share_extension));
+
+                    /* Assert that the client saved its private keys correctly in the connection state for hybrid */
+                    struct s2n_kem_group_params *kem_group_params = &conn->secure.client_kem_group_params[chosen_index];
+                    EXPECT_EQUAL(kem_group_params->kem_group, negotiated_kem_group);
+                    EXPECT_EQUAL(kem_group_params->kem_params.kem, negotiated_kem_group->kem);
+                    EXPECT_NOT_NULL(kem_group_params->kem_params.private_key.data);
+                    EXPECT_EQUAL(kem_group_params->kem_params.private_key.size,negotiated_kem_group->kem->private_key_length);
+                    EXPECT_EQUAL(kem_group_params->ecc_params.negotiated_curve, negotiated_kem_group->curve);
+                    EXPECT_NOT_NULL(kem_group_params->ecc_params.evp_pkey);
+
+                    /* Assert that the client didn't generate/save any key shares that it wasn't supposed to */
+                    for (size_t kem_group_index = 0; kem_group_index < kem_pref->tls13_kem_group_count; kem_group_index++) {
+                        if (kem_group_index == chosen_index) {
+                            continue;
+                        }
+                        EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_index].kem_group);
+                        EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_index].kem_params.kem);
+                        EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_index].kem_params.private_key.data);
+                        EXPECT_EQUAL(conn->secure.client_kem_group_params[kem_group_index].kem_params.private_key.size, 0);
+                        EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_index].ecc_params.negotiated_curve);
+                        EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_index].ecc_params.evp_pkey);
+                    }
+                    for (size_t ecc_index = 0; ecc_index < S2N_ECC_EVP_SUPPORTED_CURVES_COUNT; ecc_index++) {
+                        EXPECT_NULL(conn->secure.client_ecc_evp_params[ecc_index].negotiated_curve);
+                        EXPECT_NULL(conn->secure.client_ecc_evp_params[ecc_index].evp_pkey);
+                    }
+
+                    /* Assert that the client sent the correct bytes over the wire for the key share extension */
+                    /* Assert total key shares extension size is correct */
+                    uint16_t sent_key_shares_size;
+                    EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &sent_key_shares_size));
+                    EXPECT_EQUAL(sent_key_shares_size, s2n_stuffer_data_available(&key_share_extension));
+
+                    /* Assert that the hybrid key share is correct:
+                     * IANA ID || total hybrid share size || ECC share size || ECC share || PQ share size || PQ share */
+                    uint16_t sent_hybrid_iana_id;
+                    EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &sent_hybrid_iana_id));
+                    EXPECT_EQUAL(sent_hybrid_iana_id, kem_pref->tls13_kem_groups[chosen_index]->iana_id);
+
+                    uint16_t expected_hybrid_share_size =
+                              S2N_SIZE_OF_KEY_SHARE_SIZE
+                            + negotiated_kem_group->curve->share_size
+                            + S2N_SIZE_OF_KEY_SHARE_SIZE
+                            + negotiated_kem_group->kem->public_key_length;
+                    uint16_t sent_hybrid_share_size;
+                    EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &sent_hybrid_share_size));
+                    EXPECT_EQUAL(sent_hybrid_share_size, expected_hybrid_share_size);
+
+                    uint16_t hybrid_ecc_share_size;
+                    EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &hybrid_ecc_share_size));
+                    EXPECT_EQUAL(hybrid_ecc_share_size, negotiated_kem_group->curve->share_size);
+                    EXPECT_SUCCESS(s2n_stuffer_skip_read(&key_share_extension, hybrid_ecc_share_size));
+
+                    uint16_t hybrid_pq_share_size;
+                    EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &hybrid_pq_share_size));
+                    EXPECT_EQUAL(hybrid_pq_share_size, negotiated_kem_group->kem->public_key_length);
+                    EXPECT_SUCCESS(s2n_stuffer_skip_read(&key_share_extension, hybrid_pq_share_size));
+
+                    /* If all the sizes/bytes were correctly written, there should be nothing left over */
+                    EXPECT_EQUAL(s2n_stuffer_data_available(&key_share_extension), 0);
+
+                    EXPECT_SUCCESS(s2n_connection_free(conn));
+                }
+            }
+
+            /* Test failure when server chooses a KEM group that is not in the client's preferences */
+            {
+                const struct s2n_kem_group *sike_kem_group[] = {
+                        &s2n_secp256r1_sike_p434_r2,
+                };
+                const struct s2n_kem_preferences sike_kem_prefs = {
+                        .kem_count = 0,
+                        .kems = NULL,
+                        .tls13_kem_group_count = s2n_array_len(sike_kem_group),
+                        .tls13_kem_groups = all_kem_groups,
+                };
+
+                const struct s2n_security_policy sike_security_policy = {
+                        .minimum_protocol_version = S2N_SSLv3,
+                        .cipher_preferences = &cipher_preferences_test_all_tls13,
+                        .kem_preferences = &sike_kem_prefs,
+                        .signature_preferences = &s2n_signature_preferences_20200207,
+                        .ecc_preferences = &s2n_ecc_preferences_20200310,
+                };
+
                 struct s2n_connection *conn;
                 EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
-                conn->security_policy_override = &test_security_policy;
+                conn->security_policy_override = &sike_security_policy;
+                conn->actual_protocol_version = S2N_TLS13;
+                conn->handshake.handshake_type = HELLO_RETRY_REQUEST;
+                conn->handshake.message_number = HELLO_RETRY_MSG_NO;
+                conn->actual_protocol_version_established = 1;
 
-                const struct s2n_ecc_preferences *ecc_pref = NULL;
-                EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
-                EXPECT_NOT_NULL(ecc_pref);
+                conn->secure.server_kem_group_params.kem_group = &s2n_secp256r1_bike1_l1_r2;
 
-                const struct s2n_kem_preferences *kem_pref = NULL;
-                EXPECT_SUCCESS(s2n_connection_get_kem_preferences(conn, &kem_pref));
-                EXPECT_NOT_NULL(kem_pref);
-                EXPECT_EQUAL(kem_pref->tls13_kem_group_count, S2N_SUPPORTED_KEM_GROUPS_COUNT);
-                EXPECT_EQUAL(test_kem_groups[0], kem_pref->tls13_kem_groups[0]);
-                const struct s2n_kem_group *test_kem_group = kem_pref->tls13_kem_groups[0];
-
+                DEFER_CLEANUP(struct s2n_stuffer key_share_extension = { 0 }, s2n_stuffer_free);
                 EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&key_share_extension, 4096));
-                EXPECT_SUCCESS(s2n_client_key_share_extension.send(conn, &key_share_extension));
+                EXPECT_FAILURE_WITH_ERRNO(s2n_client_key_share_extension.send(conn, &key_share_extension), S2N_ERR_INVALID_HELLO_RETRY);
 
-                /* First, assert that the client saved its private keys correctly in the connection state
-                 * for both hybrid PQ and classic ECC */
-                struct s2n_kem_group_params *kem_group_params = &conn->secure.client_kem_group_params[0];
-                EXPECT_EQUAL(kem_group_params->kem_group, test_kem_group);
-                EXPECT_EQUAL(kem_group_params->kem_params.kem, test_kem_group->kem);
-                EXPECT_NOT_NULL(kem_group_params->kem_params.private_key.data);
-                EXPECT_EQUAL(kem_group_params->kem_params.private_key.size, test_kem_group->kem->private_key_length);
-                EXPECT_EQUAL(kem_group_params->ecc_params.negotiated_curve, test_kem_group->curve);
-                EXPECT_NOT_NULL(kem_group_params->ecc_params.evp_pkey);
-
-                struct s2n_ecc_evp_params *ecc_params = &conn->secure.client_ecc_evp_params[0];
-                EXPECT_EQUAL(ecc_params->negotiated_curve, ecc_pref->ecc_curves[0]);
-                EXPECT_NOT_NULL(ecc_params->evp_pkey);
-
-                /* Next, assert that the client didn't generate/save any hybrid or ECC params that it shouldn't have */
-                for (size_t kem_group_index = 1; kem_group_index < S2N_SUPPORTED_KEM_GROUPS_COUNT; kem_group_index++) {
-                    EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_index].kem_group);
-                    EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_index].kem_params.kem);
-                    EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_index].kem_params.private_key.data);
-                    EXPECT_EQUAL(conn->secure.client_kem_group_params[kem_group_index].kem_params.private_key.size, 0);
-                    EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_index].ecc_params.negotiated_curve);
-                    EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_index].ecc_params.evp_pkey);
-                }
-                for (size_t ecc_index = 1; ecc_index < S2N_ECC_EVP_SUPPORTED_CURVES_COUNT; ecc_index++) {
-                    EXPECT_NULL(conn->secure.client_ecc_evp_params[ecc_index].negotiated_curve);
-                    EXPECT_NULL(conn->secure.client_ecc_evp_params[ecc_index].evp_pkey);
-                }
-
-                /* Now, assert that the client sent the correct bytes over the wire for the key share extension */
-                /* Assert total key shares extension size is correct */
-                uint16_t sent_key_shares_size;
-                EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &sent_key_shares_size));
-                EXPECT_EQUAL(sent_key_shares_size, s2n_stuffer_data_available(&key_share_extension));
-
-                /* Assert that the hybrid key share is correct:
-                 * IANA ID || total hybrid share size || ECC share size || ECC share || PQ share size || PQ share */
-                uint16_t sent_hybrid_iana_id;
-                EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &sent_hybrid_iana_id));
-                EXPECT_EQUAL(sent_hybrid_iana_id, kem_pref->tls13_kem_groups[0]->iana_id);
-
-                uint16_t expected_hybrid_share_size =
-                          S2N_SIZE_OF_KEY_SHARE_SIZE
-                        + test_kem_group->curve->share_size
-                        + S2N_SIZE_OF_KEY_SHARE_SIZE
-                        + test_kem_group->kem->public_key_length;
-                uint16_t sent_hybrid_share_size;
-                EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &sent_hybrid_share_size));
-                EXPECT_EQUAL(sent_hybrid_share_size, expected_hybrid_share_size);
-
-                uint16_t hybrid_ecc_share_size;
-                EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &hybrid_ecc_share_size));
-                EXPECT_EQUAL(hybrid_ecc_share_size, test_kem_group->curve->share_size);
-                EXPECT_SUCCESS(s2n_stuffer_skip_read(&key_share_extension, hybrid_ecc_share_size));
-
-                uint16_t hybrid_pq_share_size;
-                EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &hybrid_pq_share_size));
-                EXPECT_EQUAL(hybrid_pq_share_size, test_kem_group->kem->public_key_length);
-                EXPECT_SUCCESS(s2n_stuffer_skip_read(&key_share_extension, hybrid_pq_share_size));
-
-                /* Assert that the ECC key share is correct: IANA ID || size || share */
-                uint16_t ecc_iana_value, ecc_share_size;
-                EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &ecc_iana_value));
-                EXPECT_EQUAL(ecc_iana_value, ecc_pref->ecc_curves[0]->iana_id);
-                EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &ecc_share_size));
-                EXPECT_EQUAL(ecc_share_size, ecc_pref->ecc_curves[0]->share_size);
-                EXPECT_SUCCESS(s2n_stuffer_skip_read(&key_share_extension, ecc_share_size));
-
-                /* If all the sizes/bytes were correctly written, there should be nothing left over */
-                EXPECT_EQUAL(s2n_stuffer_data_available(&key_share_extension), 0);
-
-                EXPECT_SUCCESS(s2n_stuffer_free(&key_share_extension));
                 EXPECT_SUCCESS(s2n_connection_free(conn));
             }
         }


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

* Adds `HelloRetryRequest` support for PQ TLS 1.3

### Call-outs:

* This should complete client-side PQ TLS 1.3 functionality(!)
* Currently, all KEM preferences have `tls13_kem_group_count == 0` and `tls13_kem_groups == NULL`. This is an effective way to feature-gate the new code paths until all client and server functionality has been implemented.
* https://github.com/awslabs/s2n/pull/2267 is related - disables sending of PQ IDs in `supported_groups` when in FIPS mode

### Testing:

* Unit tests added
* No integration tests yet because we are purposefully not adding TLS 1.3 KEM preferences yet
* Tested manually (with locally committed KEM preferences) against `test.openquantumsafe.org` to confirm that 1-RTT and HRR handshakes are correctly performed for appropriate KEM groups
* Built locally with `S2N_NO_PQ=1` to verify that build

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
