### PR TITLE
Add KEM FIPS checks to *set_cipher_preferences() functions

### DIFF
--- a/tests/unit/s2n_client_key_share_extension_test.c
+++ b/tests/unit/s2n_client_key_share_extension_test.c
@@ -939,7 +939,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(S2N_SUPPORTED_KEM_GROUPS_COUNT, s2n_array_len(all_kem_groups));
 
         if (s2n_is_in_fips_mode()) {
-            /* s2n_client_key_share_extension.send should error if in FIPS mode */
+            /* s2n_client_key_share_extension.send should error when attempting to send PQ shares in FIPS mode */
             const struct s2n_kem_preferences test_kem_prefs = {
                 .kem_count = 0,
                 .kems = NULL,

--- a/tests/unit/s2n_client_record_version_test.c
+++ b/tests/unit/s2n_client_record_version_test.c
@@ -29,6 +29,7 @@
 #include "tls/s2n_connection.h"
 #include "tls/s2n_handshake.h"
 #include "tls/s2n_tls_parameters.h"
+#include "crypto/s2n_fips.h"
 
 #define ZERO_TO_THIRTY_ONE  0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, \
                             0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F
@@ -90,7 +91,11 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
 
         EXPECT_NOT_NULL(client_config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "test_all"));
+        if (s2n_is_in_fips_mode()) {
+            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "test_all_fips"));
+        } else {
+            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "test_all"));
+        }
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
 
         /* Send the client hello */
@@ -175,136 +180,139 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
     }
 
-    /* Server negotiates SSLv3 */
+    /* Server negotiates SSLv3 (SSLv3 not is not supported in FIPS mode) */
     {
-        struct s2n_connection *client_conn;
-        struct s2n_config *client_config;
-        s2n_blocked_status client_blocked;
+        if (!s2n_is_in_fips_mode()) {
+            struct s2n_connection *client_conn;
+            struct s2n_config *client_config;
+            s2n_blocked_status client_blocked;
 
-        uint8_t server_hello_message[] = {
-            /* Protocol version SSLv3 */
-            0x03, 0x00,
-            /* Server random */
-            ZERO_TO_THIRTY_ONE,
-            /* SessionID len - 32 bytes */
-            0x20,
-            /* Session ID */
-            ZERO_TO_THIRTY_ONE,
-            /* Cipher suite - DES-CBC3-SHA */
-            0x00, 0x0A,
-            /* Compression method - none */
-            0x00,
-            /* Extensions len */
-            0x00, 0x00
-        };
-        int body_len = sizeof(server_hello_message);
-        uint8_t message_header[] = {
-            /* Handshake message type SERVER HELLO */
-            0x02,
-            /* Body len */
-            (body_len >> 16) & 0xff, (body_len >> 8) & 0xff, (body_len & 0xff),
-        };
-        int message_len = sizeof(message_header) + body_len;
-        uint8_t record_header[] = {
-            /* Record type HANDSHAKE */
-            0x16,
-            /* Protocol version SSLv3 */
-            0x03, 0x00,
-            /* Message len */
-            (message_len >> 8) & 0xff, (message_len & 0xff),
-        };
+            uint8_t server_hello_message[] = {
+                    /* Protocol version SSLv3 */
+                    0x03, 0x00,
+                    /* Server random */
+                    ZERO_TO_THIRTY_ONE,
+                    /* SessionID len - 32 bytes */
+                    0x20,
+                    /* Session ID */
+                    ZERO_TO_THIRTY_ONE,
+                    /* Cipher suite - DES-CBC3-SHA */
+                    0x00, 0x0A,
+                    /* Compression method - none */
+                    0x00,
+                    /* Extensions len */
+                    0x00, 0x00
+            };
+            int body_len = sizeof(server_hello_message);
+            uint8_t message_header[] = {
+                    /* Handshake message type SERVER HELLO */
+                    0x02,
+                    /* Body len */
+                    (body_len >> 16) & 0xff, (body_len >> 8) & 0xff, (body_len & 0xff),
+            };
+            int message_len = sizeof(message_header) + body_len;
+            uint8_t record_header[] = {
+                    /* Record type HANDSHAKE */
+                    0x16,
+                    /* Protocol version SSLv3 */
+                    0x03, 0x00,
+                    /* Message len */
+                    (message_len >> 8) & 0xff, (message_len & 0xff),
+            };
 
-        /* Create nonblocking pipes */
-        struct s2n_test_io_pair io_pair;
-        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+            /* Create nonblocking pipes */
+            struct s2n_test_io_pair io_pair;
+            EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
 
-        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
+            EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
 
-        EXPECT_NOT_NULL(client_config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "test_all"));
-        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
+            EXPECT_NOT_NULL(client_config = s2n_config_new());
+            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "test_all"));
+            EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
 
-        /* Send the client hello */
-        EXPECT_EQUAL(s2n_negotiate(client_conn, &client_blocked), -1);
-        EXPECT_EQUAL(s2n_errno, S2N_ERR_IO_BLOCKED);
-        EXPECT_EQUAL(client_blocked, S2N_BLOCKED_ON_READ);
+            /* Send the client hello */
+            EXPECT_EQUAL(s2n_negotiate(client_conn, &client_blocked), -1);
+            EXPECT_EQUAL(s2n_errno, S2N_ERR_IO_BLOCKED);
+            EXPECT_EQUAL(client_blocked, S2N_BLOCKED_ON_READ);
 
-        /* Read ClientHello s2n wrote */
-        uint8_t buf[1024];
-        size_t buf_occupied = 0;
+            /* Read ClientHello s2n wrote */
+            uint8_t buf[1024];
+            size_t buf_occupied = 0;
 
-        /* we need only first 10 bytes to get to ClientHello protocol version */
-        while (buf_occupied < 10) {
-            ssize_t n = read(io_pair.server, buf + buf_occupied, sizeof(buf) - buf_occupied);
+            /* we need only first 10 bytes to get to ClientHello protocol version */
+            while (buf_occupied < 10) {
+                ssize_t n = read(io_pair.server, buf + buf_occupied, sizeof(buf) - buf_occupied);
 
-            /* We should be able to read 10 bytes without blocking */
-            EXPECT_TRUE(n > 0);
-            buf_occupied += n;
-        }
-        /* Record Type is Handshake */
-        EXPECT_EQUAL(buf[0], 0x16);
-        /* Protocol version is TLS1.0 */
-        EXPECT_EQUAL(buf[1], 0x03);
-        EXPECT_EQUAL(buf[2], 0x01);
-        /* Handshake Type is ClientHello */
-        EXPECT_EQUAL(buf[5], 0x01);
-        /* Handshake Protocol Version is TLS1.2 */
-        EXPECT_EQUAL(buf[9], 0x03);
-        EXPECT_EQUAL(buf[10], 0x03);
+                /* We should be able to read 10 bytes without blocking */
+                EXPECT_TRUE(n > 0);
+                buf_occupied += n;
+            }
+            /* Record Type is Handshake */
+            EXPECT_EQUAL(buf[0], 0x16);
+            /* Protocol version is TLS1.0 */
+            EXPECT_EQUAL(buf[1], 0x03);
+            EXPECT_EQUAL(buf[2], 0x01);
+            /* Handshake Type is ClientHello */
+            EXPECT_EQUAL(buf[5], 0x01);
+            /* Handshake Protocol Version is TLS1.2 */
+            EXPECT_EQUAL(buf[9], 0x03);
+            EXPECT_EQUAL(buf[10], 0x03);
 
-        /* Read the rest of the pipe */
-        while (1) {
-            ssize_t n = read(io_pair.server, buf, sizeof(buf));
+            /* Read the rest of the pipe */
+            while (1) {
+                ssize_t n = read(io_pair.server, buf, sizeof(buf));
 
-            if (n > 0) {
-                continue;
+                if (n > 0) {
+                    continue;
+                }
+
+                EXPECT_EQUAL(n, -1);
+                if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                    break;
+                }
             }
 
-            EXPECT_EQUAL(n, -1);
-            if (errno == EAGAIN || errno == EWOULDBLOCK) {
-                break;
+            /* Write the server hello */
+            EXPECT_EQUAL(write(io_pair.server, record_header, sizeof(record_header)), sizeof(record_header));
+            EXPECT_EQUAL(write(io_pair.server, message_header, sizeof(message_header)), sizeof(message_header));
+            EXPECT_EQUAL(write(io_pair.server, server_hello_message, sizeof(server_hello_message)),
+                    sizeof(server_hello_message));
+
+            /* Verify that we proceed with handshake */
+            EXPECT_EQUAL(s2n_negotiate(client_conn, &client_blocked), -1);
+            EXPECT_EQUAL(s2n_errno, S2N_ERR_IO_BLOCKED);
+            EXPECT_EQUAL(client_blocked, S2N_BLOCKED_ON_READ);
+
+            /* Verify that protocol versions are SSLv3 with the exeption of client which supports TLS1.2 */
+            EXPECT_EQUAL(client_conn->client_protocol_version, S2N_TLS12);
+            EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_SSLv3);
+            EXPECT_EQUAL(client_conn->server_protocol_version, S2N_SSLv3);
+
+            /* Now lets shutdown the connection and verify that alert is sent in record with protocol version SSLv3 */
+            EXPECT_EQUAL(s2n_shutdown(client_conn, &client_blocked), -1);
+            EXPECT_EQUAL(s2n_errno, S2N_ERR_IO_BLOCKED);
+            EXPECT_EQUAL(client_blocked, S2N_BLOCKED_ON_READ);
+
+            /* Receive the next record from client and ensure that record protocol version is SSLv3 */
+            buf_occupied = 0;
+            /* We need only first 5 bytes to get to record protocol version */
+            while (buf_occupied < 5) {
+                ssize_t n = read(io_pair.server, buf + buf_occupied, sizeof(buf) - buf_occupied);
+
+                /* We should be able to read 5 bytes without blocking */
+                EXPECT_TRUE(n > 0);
+                buf_occupied += n;
             }
+            /* Protocol version is SSLv3 now */
+            EXPECT_EQUAL(buf[1], 0x03);
+            EXPECT_EQUAL(buf[2], 0x00);
+
+            EXPECT_SUCCESS(s2n_connection_free(client_conn));
+            EXPECT_SUCCESS(s2n_config_free(client_config));
+
+            EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
         }
-
-        /* Write the server hello */
-        EXPECT_EQUAL(write(io_pair.server, record_header, sizeof(record_header)), sizeof(record_header));
-        EXPECT_EQUAL(write(io_pair.server, message_header, sizeof(message_header)), sizeof(message_header));
-        EXPECT_EQUAL(write(io_pair.server, server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
-
-        /* Verify that we proceed with handshake */
-        EXPECT_EQUAL(s2n_negotiate(client_conn, &client_blocked), -1);
-        EXPECT_EQUAL(s2n_errno, S2N_ERR_IO_BLOCKED);
-        EXPECT_EQUAL(client_blocked, S2N_BLOCKED_ON_READ);
-
-        /* Verify that protocol versions are SSLv3 with the exeption of client which supports TLS1.2 */
-        EXPECT_EQUAL(client_conn->client_protocol_version, S2N_TLS12);
-        EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_SSLv3);
-        EXPECT_EQUAL(client_conn->server_protocol_version, S2N_SSLv3);
-
-        /* Now lets shutdown the connection and verify that alert is sent in record with protocol version SSLv3 */
-        EXPECT_EQUAL(s2n_shutdown(client_conn, &client_blocked), -1);
-        EXPECT_EQUAL(s2n_errno, S2N_ERR_IO_BLOCKED);
-        EXPECT_EQUAL(client_blocked, S2N_BLOCKED_ON_READ);
-
-        /* Receive the next record from client and ensure that record protocol version is SSLv3 */
-        buf_occupied = 0;
-        /* We need only first 5 bytes to get to record protocol version */
-        while (buf_occupied < 5) {
-            ssize_t n = read(io_pair.server, buf + buf_occupied, sizeof(buf) - buf_occupied);
-
-            /* We should be able to read 5 bytes without blocking */
-            EXPECT_TRUE(n > 0);
-            buf_occupied += n;
-        }
-        /* Protocol version is SSLv3 now */
-        EXPECT_EQUAL(buf[1], 0x03);
-        EXPECT_EQUAL(buf[2], 0x00);
-
-        EXPECT_SUCCESS(s2n_connection_free(client_conn));
-        EXPECT_SUCCESS(s2n_config_free(client_config));
-
-        EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
     }
 
     free(cert_chain);

--- a/tests/unit/s2n_malformed_handshake_test.c
+++ b/tests/unit/s2n_malformed_handshake_test.c
@@ -24,6 +24,7 @@
 
 #include "tls/s2n_connection.h"
 #include "tls/s2n_handshake.h"
+#include "crypto/s2n_fips.h"
 
 #define TLS_ALERT              21
 #define TLS_HANDSHAKE          22
@@ -241,7 +242,11 @@ int main(int argc, char **argv)
     EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
     EXPECT_NOT_NULL(config = s2n_config_new());
     EXPECT_SUCCESS(s2n_config_disable_x509_verification(config));
-    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "test_all"));
+    if (s2n_is_in_fips_mode()) {
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "test_all_fips"));
+    } else {
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "test_all"));
+    }
     EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
     /* Test a good certificate list */

--- a/tls/extensions/s2n_server_key_share.c
+++ b/tls/extensions/s2n_server_key_share.c
@@ -64,15 +64,17 @@ static int s2n_server_key_share_recv_pq_hybrid(struct s2n_connection *conn, uint
     notnull_check(conn);
     notnull_check(extension);
 
-    ENSURE_POSIX(s2n_is_in_fips_mode() == false, S2N_ERR_PQ_KEMS_DISALLOWED_IN_FIPS);
-
     const struct s2n_kem_preferences *kem_pref = NULL;
     GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
     notnull_check(kem_pref);
 
     /* This check should have been done higher up, but including it here as well for extra defense.
      * Uses S2N_ERR_ECDHE_UNSUPPORTED_CURVE for backward compatibility. */
-    ENSURE_POSIX(s2n_kem_preferences_includes_tls13_kem_group(kem_pref, named_group_iana), S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
+    ENSURE_POSIX(s2n_kem_preferences_includes_tls13_kem_group(kem_pref, named_group_iana),
+            S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
+    /* Defense in depth; security policy initialization checks should have already enforced KEM
+     * preferences do not include any KEM groups if in FIPS mode */
+    ENSURE_POSIX(s2n_is_in_fips_mode() == false, S2N_ERR_PQ_KEMS_DISALLOWED_IN_FIPS);
 
     size_t kem_group_index = 0;
     for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -18,6 +18,7 @@
 #include "tls/s2n_security_policies.h"
 #include "tls/s2n_connection.h"
 #include "utils/s2n_safety.h"
+#include "crypto/s2n_fips.h"
 
 const struct s2n_security_policy security_policy_20170210 = {
     .minimum_protocol_version = S2N_TLS10,
@@ -611,6 +612,12 @@ int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *ver
     notnull_check(&config->security_policy->kem_preferences);
     notnull_check(&config->security_policy->signature_preferences);
     notnull_check(&config->security_policy->ecc_preferences);
+
+    if (s2n_is_in_fips_mode()) {
+        ENSURE_POSIX(config->security_policy->kem_preferences == &kem_preferences_null,
+                S2N_ERR_PQ_KEMS_DISALLOWED_IN_FIPS);
+    }
+
     return 0;
 }
 
@@ -621,6 +628,12 @@ int s2n_connection_set_cipher_preferences(struct s2n_connection *conn, const cha
     notnull_check(&conn->security_policy_override->kem_preferences);
     notnull_check(&conn->security_policy_override->signature_preferences);
     notnull_check(&conn->security_policy_override->ecc_preferences);
+
+    if (s2n_is_in_fips_mode()) {
+        ENSURE_POSIX(conn->security_policy_override->kem_preferences == &kem_preferences_null,
+                S2N_ERR_PQ_KEMS_DISALLOWED_IN_FIPS);
+    }
+
     return 0;
 }
 

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -607,32 +607,38 @@ int s2n_find_security_policy_from_version(const char *version, const struct s2n_
 
 int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *version)
 {
-    GUARD(s2n_find_security_policy_from_version(version, &config->security_policy));
-    notnull_check(&config->security_policy->cipher_preferences);
-    notnull_check(&config->security_policy->kem_preferences);
-    notnull_check(&config->security_policy->signature_preferences);
-    notnull_check(&config->security_policy->ecc_preferences);
+    const struct s2n_security_policy *temp_policy = NULL;
+    GUARD(s2n_find_security_policy_from_version(version, &temp_policy));
+    notnull_check(temp_policy);
+    notnull_check(&temp_policy->cipher_preferences);
+    notnull_check(&temp_policy->kem_preferences);
+    notnull_check(&temp_policy->signature_preferences);
+    notnull_check(&temp_policy->ecc_preferences);
 
     if (s2n_is_in_fips_mode()) {
-        ENSURE_POSIX(config->security_policy->kem_preferences == &kem_preferences_null,
-                S2N_ERR_PQ_KEMS_DISALLOWED_IN_FIPS);
+        ENSURE_POSIX(temp_policy->kem_preferences == &kem_preferences_null, S2N_ERR_PQ_KEMS_DISALLOWED_IN_FIPS);
     }
+
+    config->security_policy = temp_policy;
 
     return 0;
 }
 
 int s2n_connection_set_cipher_preferences(struct s2n_connection *conn, const char *version)
 {
-    GUARD(s2n_find_security_policy_from_version(version, &conn->security_policy_override));
-    notnull_check(&conn->security_policy_override->cipher_preferences);
-    notnull_check(&conn->security_policy_override->kem_preferences);
-    notnull_check(&conn->security_policy_override->signature_preferences);
-    notnull_check(&conn->security_policy_override->ecc_preferences);
+    const struct s2n_security_policy *temp_policy = NULL;
+    GUARD(s2n_find_security_policy_from_version(version, &temp_policy));
+    notnull_check(temp_policy);
+    notnull_check(&temp_policy->cipher_preferences);
+    notnull_check(&temp_policy->kem_preferences);
+    notnull_check(&temp_policy->signature_preferences);
+    notnull_check(&temp_policy->ecc_preferences);
 
     if (s2n_is_in_fips_mode()) {
-        ENSURE_POSIX(conn->security_policy_override->kem_preferences == &kem_preferences_null,
-                S2N_ERR_PQ_KEMS_DISALLOWED_IN_FIPS);
+        ENSURE_POSIX(temp_policy->kem_preferences == &kem_preferences_null, S2N_ERR_PQ_KEMS_DISALLOWED_IN_FIPS);
     }
+
+    conn->security_policy_override = temp_policy;
 
     return 0;
 }


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

For both TLS 1.2 and 1.3, we disallow negotiation of hybrid/PQ handshakes when operating in FIPS mode. The FIPS checks are performed during the actual handshake, which is not ideal because it allows the peer to choose a security policy that contains PQ KEMs, only to have the handshake unexpectedly fail. This change adds checks in `s2n_config_set_cipher_preferences()` and `s2n_connection_set_cipher_preferences()` to ensure that only non-PQ security policies can be used when operating in FIPS mode.

### Call-outs:

N/A

### Testing:

Adapted current unit tests as necessary.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
