### PR TITLE
Add s2n_config_set_cert_req_legacy_dss_enabled api to turn on DSS sign in certificate request

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -433,6 +433,13 @@ extern int s2n_async_pkey_op_apply(struct s2n_async_pkey_op *op, struct s2n_conn
 S2N_API
 extern int s2n_async_pkey_op_free(struct s2n_async_pkey_op *op);
 
+/* s2n_config_enable_cert_req_dss_legacy_compat adds a dss cert type in the server certificate request when being called.
+ * It only sends the dss cert type in the cert request but does not succeed the handshake if a dss cert is received.
+ * Please DO NOT call this api unless you know you actually need legacy DSS certificate type compatibility
+ */
+S2N_API
+extern int s2n_config_enable_cert_req_dss_legacy_compat(struct s2n_config *config);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/unit/s2n_server_cert_request_test.c
+++ b/tests/unit/s2n_server_cert_request_test.c
@@ -1,0 +1,111 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <s2n.h>
+
+#include "tls/s2n_config.h"
+#include "tls/s2n_tls.h"
+#include "stuffer/s2n_stuffer.h"
+#include "s2n_test.h"
+
+/*
+ * Definitions in s2n_server_cert_request.c
+ */
+typedef enum {
+    S2N_CERT_TYPE_RSA_SIGN = 1,
+    S2N_CERT_TYPE_DSS_SIGN = 2,
+    S2N_CERT_TYPE_RSA_FIXED_DH = 3,
+    S2N_CERT_TYPE_DSS_FIXED_DH = 4,
+    S2N_CERT_TYPE_RSA_EPHEMERAL_DH_RESERVED = 5,
+    S2N_CERT_TYPE_DSS_EPHEMERAL_DH_RESERVED = 6,
+    S2N_CERT_TYPE_FORTEZZA_DMS_RESERVED = 20,
+    S2N_CERT_TYPE_ECDSA_SIGN = 64,
+    S2N_CERT_TYPE_RSA_FIXED_ECDH = 65,
+    S2N_CERT_TYPE_ECDSA_FIXED_ECDH = 66,
+} s2n_cert_type;
+
+static uint8_t s2n_cert_type_preference_list[] = {
+    S2N_CERT_TYPE_RSA_SIGN,
+    S2N_CERT_TYPE_ECDSA_SIGN
+};
+
+static uint8_t s2n_cert_type_preference_list_legacy_dss[] = {
+    S2N_CERT_TYPE_RSA_SIGN,
+    S2N_CERT_TYPE_DSS_SIGN,
+    S2N_CERT_TYPE_ECDSA_SIGN
+};
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Test server cert request default behavior when s2n_config_enable_cert_req_dss_legacy_compat is not called
+     * Certificate types enabled should be in s2n_cert_type_preference_list */
+    {
+        struct s2n_connection *server_conn;
+        struct s2n_config *server_config;
+
+        EXPECT_NOT_NULL(server_config = s2n_config_new());
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
+
+        s2n_cert_req_send(server_conn);
+        struct s2n_stuffer *in = &server_conn->handshake.io;
+        uint8_t cert_types_len;
+
+        s2n_stuffer_read_uint8(in, &cert_types_len);
+
+        uint8_t *their_cert_type_pref_list = s2n_stuffer_raw_read(in, cert_types_len);
+
+        EXPECT_EQUAL(cert_types_len, sizeof(s2n_cert_type_preference_list));
+        for (int idx = 0; idx < sizeof(s2n_cert_type_preference_list); idx++) {
+            EXPECT_EQUAL(their_cert_type_pref_list[idx], s2n_cert_type_preference_list[idx]);
+        }
+
+        EXPECT_SUCCESS(s2n_config_free(server_config));
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+    }
+
+    /* Test certificate types in server cert request when s2n_config_enable_cert_req_dss_legacy_compat is called
+     * Certificate types enabled should be in s2n_cert_type_preference_list_legacy_dss */
+    {
+        struct s2n_connection *server_conn;
+        struct s2n_config *server_config;
+
+        EXPECT_NOT_NULL(server_config = s2n_config_new());
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
+        EXPECT_SUCCESS(s2n_config_enable_cert_req_dss_legacy_compat(server_config));
+
+        s2n_cert_req_send(server_conn);
+        struct s2n_stuffer *in = &server_conn->handshake.io;
+        uint8_t cert_types_len;
+
+        s2n_stuffer_read_uint8(in, &cert_types_len);
+
+        uint8_t *their_cert_type_pref_list = s2n_stuffer_raw_read(in, cert_types_len);
+
+        EXPECT_EQUAL(cert_types_len, sizeof(s2n_cert_type_preference_list_legacy_dss));
+        for (int idx = 0; idx < sizeof(s2n_cert_type_preference_list_legacy_dss); idx++) {
+            EXPECT_EQUAL(their_cert_type_pref_list[idx], s2n_cert_type_preference_list_legacy_dss[idx]);
+        }
+
+        EXPECT_SUCCESS(s2n_config_free(server_config));
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+    }
+
+    END_TEST();
+    return 0;
+}

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -123,6 +123,7 @@ static int s2n_config_init(struct s2n_config *config)
     config->max_verify_cert_chain_depth_set = 0;
     config->cert_tiebreak_cb = NULL;
     config->async_pkey_cb = NULL;
+    config->cert_req_dss_legacy_compat_enabled = 0;
 
     GUARD(s2n_config_setup_default(config));
     if (s2n_use_default_tls13_config()) {
@@ -840,4 +841,11 @@ int s2n_config_get_num_default_certs(struct s2n_config *config)
     }
 
     return num_certs;
+}
+
+int s2n_config_enable_cert_req_dss_legacy_compat(struct s2n_config *config)
+{
+    notnull_check(config);
+    config->cert_req_dss_legacy_compat_enabled = 1;
+    return S2N_SUCCESS;
 }

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -41,6 +41,9 @@ struct s2n_config {
     /* Whether a connection can be used by a QUIC implementation.
      * See s2n_quic_support.h */
     unsigned quic_enabled:1;
+    /* Whether to add dss cert type during a server certificate request.
+     * See https://github.com/awslabs/s2n/blob/main/docs/USAGE-GUIDE.md */
+    unsigned cert_req_dss_legacy_compat_enabled:1;
 
     struct s2n_dh_params *dhparams;
     /* Needed until we can deprecate s2n_config_add_cert_chain_and_key. This is

--- a/tls/s2n_server_cert_request.c
+++ b/tls/s2n_server_cert_request.c
@@ -50,6 +50,16 @@ static uint8_t s2n_cert_type_preference_list[] = {
     S2N_CERT_TYPE_ECDSA_SIGN
 };
 
+/*
+ * Include DSS sign certificate type in server certificate request.
+ * Only will be used if cert_req_dss_legacy_compat_enabled is set by calling s2n_config_enable_cert_req_dss_legacy_compat.
+ */
+static uint8_t s2n_cert_type_preference_list_legacy_dss[] = {
+    S2N_CERT_TYPE_RSA_SIGN,
+    S2N_CERT_TYPE_DSS_SIGN,
+    S2N_CERT_TYPE_ECDSA_SIGN
+};
+
 static int s2n_cert_type_to_pkey_type(s2n_cert_type cert_type_in, s2n_pkey_type *pkey_type_out) {
     switch(cert_type_in) {
         case S2N_CERT_TYPE_RSA_SIGN:
@@ -161,10 +171,17 @@ int s2n_cert_req_send(struct s2n_connection *conn)
     struct s2n_stuffer *out = &conn->handshake.io;
 
     uint8_t client_cert_preference_list_size = sizeof(s2n_cert_type_preference_list);
+    if (conn->config->cert_req_dss_legacy_compat_enabled) {
+        client_cert_preference_list_size = sizeof(s2n_cert_type_preference_list_legacy_dss);
+    }
     GUARD(s2n_stuffer_write_uint8(out, client_cert_preference_list_size));
 
     for (int i = 0; i < client_cert_preference_list_size; i++) {
-        GUARD(s2n_stuffer_write_uint8(out, s2n_cert_type_preference_list[i]));
+        if (conn->config->cert_req_dss_legacy_compat_enabled) {
+            GUARD(s2n_stuffer_write_uint8(out, s2n_cert_type_preference_list_legacy_dss[i]));
+        } else {
+            GUARD(s2n_stuffer_write_uint8(out, s2n_cert_type_preference_list[i]));
+        }
     }
 
     if (conn->actual_protocol_version == S2N_TLS12) {


### PR DESCRIPTION
### Resolved issues:

We use s2n in server mode and need to advocate DSS sign in certificate request for special needs.

### Description of changes: 

s2n only include rsa and ecdsa type in the certificate requests, and with this change, s2n used as server can include dss in the certificate request by setting an environment variable

### Call-outs:

The change is only including dss in the certificate request but not adding corresponding algorithms in supported_signature_algorithms which is due to special needs for legacy client.

### Testing:

Add a unit test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
