### PR TITLE
Use NIST P-256 for key generation when client do not specify curve

### DIFF
--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -193,8 +193,11 @@ static int s2n_parse_client_hello(struct s2n_connection *conn)
     GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
     notnull_check(ecc_pref);
 
-    /* This is going to be our default if the client has no preference. */
-    conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+    /* This is going to be our fallback if the client has no preference. */
+    /* A TLS-compliant application MUST support key exchange with secp256r1 (NIST P-256) */
+    /* and SHOULD support key exchange with X25519 [RFC7748]. */
+    /* - https://tools.ietf.org/html/rfc8446#section-9.1 */
+    conn->secure.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
 
     GUARD(s2n_extension_list_parse(in, &conn->client_hello.extensions));
 

--- a/tls/s2n_ecc_preferences.c
+++ b/tls/s2n_ecc_preferences.c
@@ -84,11 +84,3 @@ bool s2n_ecc_preferences_includes_curve(const struct s2n_ecc_preferences *ecc_pr
     return false;
 }
 
-/* Check that ecc preferences include P-256 */
-S2N_RESULT s2n_ecc_preferences_includes_p256(const struct s2n_ecc_preferences *ecc_preferences) {
-    if (!s2n_ecc_preferences_includes_curve(ecc_preferences, TLS_EC_CURVE_SECP_256_R1)) {
-        return S2N_RESULT_ERROR;
-    }
-
-    return S2N_RESULT_OK;
-}

--- a/tls/s2n_ecc_preferences.c
+++ b/tls/s2n_ecc_preferences.c
@@ -83,3 +83,12 @@ bool s2n_ecc_preferences_includes_curve(const struct s2n_ecc_preferences *ecc_pr
 
     return false;
 }
+
+/* Check that ecc preferences include P-256 */
+S2N_RESULT s2n_ecc_preferences_includes_p256(const struct s2n_ecc_preferences *ecc_preferences) {
+    if (!s2n_ecc_preferences_includes_curve(ecc_preferences, TLS_EC_CURVE_SECP_256_R1)) {
+        return S2N_RESULT_ERROR;
+    }
+
+    return S2N_RESULT_OK;
+}

--- a/tls/s2n_ecc_preferences.h
+++ b/tls/s2n_ecc_preferences.h
@@ -31,3 +31,4 @@ extern const struct s2n_ecc_preferences s2n_ecc_preferences_null;
 
 int s2n_check_ecc_preferences_curves_list(const struct s2n_ecc_preferences *ecc_preferences);
 bool s2n_ecc_preferences_includes_curve(const struct s2n_ecc_preferences *ecc_preferences, uint16_t query_iana_id);
+S2N_RESULT s2n_ecc_preferences_includes_p256(const struct s2n_ecc_preferences *ecc_preferences);

--- a/tls/s2n_ecc_preferences.h
+++ b/tls/s2n_ecc_preferences.h
@@ -31,4 +31,3 @@ extern const struct s2n_ecc_preferences s2n_ecc_preferences_null;
 
 int s2n_check_ecc_preferences_curves_list(const struct s2n_ecc_preferences *ecc_preferences);
 bool s2n_ecc_preferences_includes_curve(const struct s2n_ecc_preferences *ecc_preferences, uint16_t query_iana_id);
-S2N_RESULT s2n_ecc_preferences_includes_p256(const struct s2n_ecc_preferences *ecc_preferences);

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -636,9 +636,10 @@ int s2n_security_policies_init()
         const struct s2n_ecc_preferences *ecc_preference = security_policy->ecc_preferences;
         notnull_check(ecc_preference);
         GUARD(s2n_check_ecc_preferences_curves_list(ecc_preference));
+
         if (security_policy != &security_policy_null) {
             /* catch any offending security policy that does not support P-256 */
-            GUARD_AS_POSIX(s2n_ecc_preferences_includes_p256(ecc_preference));
+            S2N_ERROR_IF(!s2n_ecc_preferences_includes_curve(ecc_preference, TLS_EC_CURVE_SECP_256_R1), S2N_ERR_INVALID_SECURITY_POLICY);
         }
 
         for (int j = 0; j < cipher_preference->count; j++) {

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -636,6 +636,11 @@ int s2n_security_policies_init()
         const struct s2n_ecc_preferences *ecc_preference = security_policy->ecc_preferences;
         notnull_check(ecc_preference);
         GUARD(s2n_check_ecc_preferences_curves_list(ecc_preference));
+        if (security_policy != &security_policy_null) {
+            /* catch any offending security policy that does not support P-256 */
+            GUARD_AS_POSIX(s2n_ecc_preferences_includes_p256(ecc_preference));
+        }
+
         for (int j = 0; j < cipher_preference->count; j++) {
             struct s2n_cipher_suite *cipher = cipher_preference->suites[j];
             notnull_check(cipher);


### PR DESCRIPTION
### Resolved issues:

 resolves #2261 (using solution from option 3)

### Description of changes: 
Use NIST P-256 as the fallback key generation selection when client do not specify curve
Also add tests to ensure P-256 is included in ecc preferences for all
  valid usable security policies

### Testing:

Unit tests along with client hello receive test against a client_hello with no supported_groups extension.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
