### PR TITLE
Add client/server share size fields to s2n_kem_group

### DIFF
--- a/crypto/s2n_ecc_evp.c
+++ b/crypto/s2n_ecc_evp.c
@@ -34,15 +34,13 @@ DEFINE_POINTER_CLEANUP_FUNC(EC_POINT *, EC_POINT_free);
 #endif
 
 /* IANA values can be found here: https://tools.ietf.org/html/rfc8446#appendix-B.3.1.4 */
-/* Share sizes are described here: https://tools.ietf.org/html/rfc8446#section-4.2.8.2
- * and include the extra "legacy_form" byte */
 
 const struct s2n_ecc_named_curve s2n_ecc_curve_secp256r1 =
 {
         .iana_id = TLS_EC_CURVE_SECP_256_R1,
         .libcrypto_nid = NID_X9_62_prime256v1,
         .name = "secp256r1",
-        .share_size = ( 32 * 2 ) + 1
+        .share_size = SECP256R1_SHARE_SIZE,
 };
 
 const struct s2n_ecc_named_curve s2n_ecc_curve_secp384r1 =
@@ -50,7 +48,7 @@ const struct s2n_ecc_named_curve s2n_ecc_curve_secp384r1 =
         .iana_id = TLS_EC_CURVE_SECP_384_R1,
         .libcrypto_nid = NID_secp384r1,
         .name = "secp384r1",
-        .share_size = ( 48 * 2 ) + 1
+        .share_size = SECP384R1_SHARE_SIZE,
 };
 
 #if EVP_APIS_SUPPORTED
@@ -58,7 +56,7 @@ const struct s2n_ecc_named_curve s2n_ecc_curve_x25519 = {
     .iana_id = TLS_EC_CURVE_ECDH_X25519,
     .libcrypto_nid = NID_X25519,
     .name = "x25519",
-    .share_size = 32
+    .share_size = X25519_SHARE_SIZE,
 };
 #else
 const struct s2n_ecc_named_curve s2n_ecc_curve_x25519 = {0};

--- a/crypto/s2n_ecc_evp.h
+++ b/crypto/s2n_ecc_evp.h
@@ -23,6 +23,12 @@
 #include "tls/s2n_tls_parameters.h"
 #include "utils/s2n_safety.h"
 
+/* Share sizes are described here: https://tools.ietf.org/html/rfc8446#section-4.2.8.2
+ * and include the extra "legacy_form" byte */
+#define SECP256R1_SHARE_SIZE ((32 * 2 ) + 1)
+#define SECP384R1_SHARE_SIZE ((48 * 2 ) + 1)
+#define X25519_SHARE_SIZE (32)
+
 struct s2n_ecc_named_curve {
     /* See https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8 */
     uint16_t iana_id;

--- a/tls/extensions/s2n_server_key_share.c
+++ b/tls/extensions/s2n_server_key_share.c
@@ -100,21 +100,9 @@ static int s2n_server_key_share_recv_pq_hybrid(struct s2n_connection *conn, uint
     eq_check(conn->secure.client_kem_group_params[kem_group_index].kem_group->iana_id, named_group_iana);
     conn->secure.chosen_client_kem_group_params = &conn->secure.client_kem_group_params[kem_group_index];
 
-    /* The structure of the PQ share should be:
-     *    total share size (2 bytes)
-     * || size of ECC key share (2 bytes)
-     * || ECC key share (variable bytes)
-     * || size of PQ key share (2 bytes)
-     * || PQ key share (variable bytes) */
     uint16_t received_total_share_size;
     GUARD(s2n_stuffer_read_uint16(extension, &received_total_share_size));
-
-    uint16_t expected_total_share_size =
-            S2N_SIZE_OF_KEY_SHARE_SIZE
-            + server_kem_group_params->kem_group->curve->share_size
-            + S2N_SIZE_OF_KEY_SHARE_SIZE
-            + server_kem_group_params->kem_group->kem->ciphertext_length;
-    ENSURE_POSIX(received_total_share_size == expected_total_share_size, S2N_ERR_BAD_KEY_SHARE);
+    ENSURE_POSIX(received_total_share_size == server_kem_group_params->kem_group->server_share_size, S2N_ERR_BAD_KEY_SHARE);
     ENSURE_POSIX(s2n_stuffer_data_available(extension) == received_total_share_size, S2N_ERR_BAD_KEY_SHARE);
 
     /* Parse ECC key share */

--- a/tls/s2n_kem.c
+++ b/tls/s2n_kem.c
@@ -17,6 +17,7 @@
 
 #include "tls/s2n_tls_parameters.h"
 #include "tls/s2n_kem.h"
+#include "tls/extensions/s2n_key_share.h"
 
 #include "utils/s2n_mem.h"
 #include "utils/s2n_safety.h"
@@ -118,7 +119,7 @@ const struct s2n_kem *sike_kems[] = {
 
 const struct s2n_kem *kyber_kems[] = {
         &s2n_kyber_512_r2,
-	&s2n_kyber_512_90s_r2,
+        &s2n_kyber_512_90s_r2,
 };
 
 const struct s2n_iana_to_kem kem_mapping[3] = {
@@ -132,7 +133,7 @@ const struct s2n_iana_to_kem kem_mapping[3] = {
             .kems = sike_kems,
             .kem_count = s2n_array_len(sike_kems),
         },
-	{
+        {
             .iana_value = { TLS_ECDHE_KYBER_RSA_WITH_AES_256_GCM_SHA384 },
             .kems = kyber_kems,
             .kem_count = s2n_array_len(kyber_kems),
@@ -144,10 +145,20 @@ const struct s2n_iana_to_kem kem_mapping[3] = {
  * community to use values in the proposed reserved range defined in
  * https://tools.ietf.org/html/draft-stebila-tls-hybrid-design.
  * Values for interoperability are defined in
- * https://docs.google.com/spreadsheets/d/12YarzaNv3XQNLnvDsWLlRKwtZFhRrDdWf36YlzwrPeg/edit#gid=0. */
+ * https://docs.google.com/spreadsheets/d/12YarzaNv3XQNLnvDsWLlRKwtZFhRrDdWf36YlzwrPeg/edit#gid=0.
+ *
+ * The structure of the hybrid share is:
+ *    size of ECC key share (2 bytes)
+ * || ECC key share (variable bytes)
+ * || size of PQ key share (2 bytes)
+ * || PQ key share (variable bytes) */
 const struct s2n_kem_group s2n_secp256r1_sike_p434_r2 = {
         .name = "secp256r1_sike-p434-r2",
         .iana_id = TLS_PQ_KEM_GROUP_ID_SECP256R1_SIKE_P434_R2,
+        .client_share_size = (S2N_SIZE_OF_KEY_SHARE_SIZE + SECP256R1_SHARE_SIZE) +
+                (S2N_SIZE_OF_KEY_SHARE_SIZE + SIKE_P434_R2_PUBLIC_KEY_BYTES),
+        .server_share_size = (S2N_SIZE_OF_KEY_SHARE_SIZE + SECP256R1_SHARE_SIZE) +
+                (S2N_SIZE_OF_KEY_SHARE_SIZE + SIKE_P434_R2_CIPHERTEXT_BYTES),
         .curve = &s2n_ecc_curve_secp256r1,
         .kem = &s2n_sike_p434_r2,
 };
@@ -156,6 +167,10 @@ const struct s2n_kem_group s2n_secp256r1_bike1_l1_r2 = {
         /* The name string follows the convention in the above google doc */
         .name = "secp256r1_bike-1l1fo-r2",
         .iana_id = TLS_PQ_KEM_GROUP_ID_SECP256R1_BIKE1_L1_R2,
+        .client_share_size = (S2N_SIZE_OF_KEY_SHARE_SIZE + SECP256R1_SHARE_SIZE) +
+                (S2N_SIZE_OF_KEY_SHARE_SIZE + BIKE1_L1_R2_PUBLIC_KEY_BYTES),
+        .server_share_size = (S2N_SIZE_OF_KEY_SHARE_SIZE + SECP256R1_SHARE_SIZE) +
+                (S2N_SIZE_OF_KEY_SHARE_SIZE + BIKE1_L1_R2_CIPHERTEXT_BYTES),
         .curve = &s2n_ecc_curve_secp256r1,
         .kem = &s2n_bike1_l1_r2,
 };
@@ -163,6 +178,10 @@ const struct s2n_kem_group s2n_secp256r1_bike1_l1_r2 = {
 const struct s2n_kem_group s2n_secp256r1_kyber_512_r2 = {
         .name = "secp256r1_kyber-512-r2",
         .iana_id = TLS_PQ_KEM_GROUP_ID_SECP256R1_KYBER_512_R2,
+        .client_share_size = (S2N_SIZE_OF_KEY_SHARE_SIZE + SECP256R1_SHARE_SIZE) +
+                (S2N_SIZE_OF_KEY_SHARE_SIZE + KYBER_512_R2_PUBLIC_KEY_BYTES),
+        .server_share_size = (S2N_SIZE_OF_KEY_SHARE_SIZE + SECP256R1_SHARE_SIZE) +
+                (S2N_SIZE_OF_KEY_SHARE_SIZE + KYBER_512_R2_CIPHERTEXT_BYTES),
         .curve = &s2n_ecc_curve_secp256r1,
         .kem = &s2n_kyber_512_r2,
 };
@@ -171,6 +190,10 @@ const struct s2n_kem_group s2n_secp256r1_kyber_512_r2 = {
 const struct s2n_kem_group s2n_x25519_sike_p434_r2 = {
         .name = "x25519_sike-p434-r2",
         .iana_id = TLS_PQ_KEM_GROUP_ID_X25519_SIKE_P434_R2,
+        .client_share_size = (S2N_SIZE_OF_KEY_SHARE_SIZE + X25519_SHARE_SIZE) +
+                (S2N_SIZE_OF_KEY_SHARE_SIZE + SIKE_P434_R2_PUBLIC_KEY_BYTES),
+        .server_share_size = (S2N_SIZE_OF_KEY_SHARE_SIZE + X25519_SHARE_SIZE) +
+                (S2N_SIZE_OF_KEY_SHARE_SIZE + SIKE_P434_R2_CIPHERTEXT_BYTES),
         .curve = &s2n_ecc_curve_x25519,
         .kem = &s2n_sike_p434_r2,
 };
@@ -179,6 +202,10 @@ const struct s2n_kem_group s2n_x25519_bike1_l1_r2 = {
         /* The name string follows the convention in the above google doc */
         .name = "x25519_bike-1l1fo-r2",
         .iana_id = TLS_PQ_KEM_GROUP_ID_X25519_BIKE1_L1_R2,
+        .client_share_size = (S2N_SIZE_OF_KEY_SHARE_SIZE + X25519_SHARE_SIZE) +
+                (S2N_SIZE_OF_KEY_SHARE_SIZE + BIKE1_L1_R2_PUBLIC_KEY_BYTES),
+        .server_share_size = (S2N_SIZE_OF_KEY_SHARE_SIZE + X25519_SHARE_SIZE) +
+                (S2N_SIZE_OF_KEY_SHARE_SIZE + BIKE1_L1_R2_CIPHERTEXT_BYTES),
         .curve = &s2n_ecc_curve_x25519,
         .kem = &s2n_bike1_l1_r2,
 };
@@ -186,6 +213,10 @@ const struct s2n_kem_group s2n_x25519_bike1_l1_r2 = {
 const struct s2n_kem_group s2n_x25519_kyber_512_r2 = {
         .name = "x25519_kyber-512-r2",
         .iana_id = TLS_PQ_KEM_GROUP_ID_X25519_KYBER_512_R2,
+        .client_share_size = (S2N_SIZE_OF_KEY_SHARE_SIZE + X25519_SHARE_SIZE) +
+                (S2N_SIZE_OF_KEY_SHARE_SIZE + KYBER_512_R2_PUBLIC_KEY_BYTES),
+        .server_share_size = (S2N_SIZE_OF_KEY_SHARE_SIZE + X25519_SHARE_SIZE) +
+                (S2N_SIZE_OF_KEY_SHARE_SIZE + KYBER_512_R2_CIPHERTEXT_BYTES),
         .curve = &s2n_ecc_curve_x25519,
         .kem = &s2n_kyber_512_r2,
 };

--- a/tls/s2n_kem.h
+++ b/tls/s2n_kem.h
@@ -57,6 +57,8 @@ struct s2n_iana_to_kem {
 struct s2n_kem_group {
     const char *name;
     uint16_t iana_id;
+    uint16_t client_share_size;
+    uint16_t server_share_size;
     const struct s2n_ecc_named_curve *curve;
     const struct s2n_kem *kem;
 };


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

Adds two fields to `s2n_kem_group` for easier parsing of PQ shares in TLS 1.3:
* `client_share_size`
* `server_share_size`

### Call-outs:

N/A

### Testing:

Covered by existing tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
