### PR TITLE
Fix macro usage, indexing and magic numbers

### DIFF
--- a/tests/unit/s2n_aead_aes_test.c
+++ b/tests/unit/s2n_aead_aes_test.c
@@ -100,7 +100,8 @@ int main(int argc, char **argv)
         predicted_length += conn->initial.cipher_suite->record_alg->cipher->io.aead.record_iv_size;
         predicted_length += conn->initial.cipher_suite->record_alg->cipher->io.aead.tag_size;
 
-        const int overhead = 8 /* IV */ + 16 /* TAG */;
+        const int overhead = S2N_TLS_GCM_EXPLICIT_IV_LEN /* Explicit IV */
+            + S2N_TLS_GCM_TAG_LEN /* TAG */;
         EXPECT_EQUAL(predicted_length, bytes_written + overhead);
 
         EXPECT_EQUAL(conn->out.blob.data[0], TLS_APPLICATION_DATA);
@@ -187,7 +188,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
-            conn->in.blob.data[5 + j] ++;
+            conn->in.blob.data[j] ++;
             EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
             EXPECT_FAILURE(s2n_record_parse(conn));
             EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
@@ -239,7 +240,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
-            conn->in.blob.data[S2N_TLS_GCM_IV_LEN + j]++;
+            conn->in.blob.data[S2N_TLS_GCM_EXPLICIT_IV_LEN + j] ++;
             EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
             EXPECT_FAILURE(s2n_record_parse(conn));
             EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
@@ -285,7 +286,8 @@ int main(int argc, char **argv)
         predicted_length += conn->initial.cipher_suite->record_alg->cipher->io.aead.record_iv_size;
         predicted_length += conn->initial.cipher_suite->record_alg->cipher->io.aead.tag_size;
 
-        const int overhead = 8 /* IV */ + 16 /* TAG */;
+        const int overhead = S2N_TLS_GCM_EXPLICIT_IV_LEN /* Explicit IV */
+            + S2N_TLS_GCM_TAG_LEN /* TAG */;
         EXPECT_EQUAL(predicted_length, bytes_written + overhead);
 
         EXPECT_EQUAL(conn->out.blob.data[0], TLS_APPLICATION_DATA);
@@ -343,7 +345,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
 
         /* Tamper with the IV and ensure decryption fails */
-        for (int j = 0; j < S2N_TLS_GCM_IV_LEN; j++) {
+        for (int j = 0; j < S2N_TLS_GCM_EXPLICIT_IV_LEN; j++) {
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
             conn->actual_protocol_version_established = 1;
             conn->server_protocol_version = S2N_TLS12;
@@ -360,7 +362,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
-            conn->in.blob.data[5 + j] ++;
+            conn->in.blob.data[j] ++;
             EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
             EXPECT_FAILURE(s2n_record_parse(conn));
             EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
@@ -397,7 +399,7 @@ int main(int argc, char **argv)
         }
 
         /* Tamper with the ciphertext and ensure decryption fails */
-        for (int j = S2N_TLS_GCM_IV_LEN; j < i - S2N_TLS_GCM_TAG_LEN; j++) {
+        for (int j = S2N_TLS_GCM_EXPLICIT_IV_LEN; j < i - S2N_TLS_GCM_TAG_LEN; j++) {
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
             conn->actual_protocol_version_established = 1;
             conn->server_protocol_version = S2N_TLS12;
@@ -414,7 +416,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
-            conn->in.blob.data[j]++;
+            conn->in.blob.data[j] ++;
             EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
             EXPECT_FAILURE(s2n_record_parse(conn));
             EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);

--- a/tests/unit/s2n_aead_aes_test.c
+++ b/tests/unit/s2n_aead_aes_test.c
@@ -112,13 +112,13 @@ int main(int argc, char **argv)
 
         /* The data should be encrypted */
         if (bytes_written > 10) {
-            EXPECT_NOT_EQUAL(memcmp(conn->out.blob.data + 5, random_data, bytes_written), 0);
+            EXPECT_NOT_EQUAL(memcmp(conn->out.blob.data + S2N_TLS_RECORD_HEADER_LENGTH, random_data, bytes_written), 0);
         }
 
         /* Copy the encrypted out data to the in data */
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
-        EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
+        EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, S2N_TLS_RECORD_HEADER_LENGTH));
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
         /* Let's decrypt it */
@@ -147,7 +147,7 @@ int main(int argc, char **argv)
         /* Copy the encrypted out data to the in data */
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
-        EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
+        EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, S2N_TLS_RECORD_HEADER_LENGTH));
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
         /* Tamper the protocol version in the header, and ensure decryption fails, as we use this in the AAD */
@@ -186,7 +186,7 @@ int main(int argc, char **argv)
             /* Copy the encrypted out data to the in data */
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
-            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
+            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, S2N_TLS_RECORD_HEADER_LENGTH));
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
             conn->in.blob.data[j] ++;
             EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
@@ -212,7 +212,7 @@ int main(int argc, char **argv)
             /* Copy the encrypted out data to the in data */
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
-            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
+            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, S2N_TLS_RECORD_HEADER_LENGTH));
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
             conn->in.blob.data[s2n_stuffer_data_available(&conn->in) - j - 1] ++;
             EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
@@ -238,7 +238,7 @@ int main(int argc, char **argv)
             /* Copy the encrypted out data to the in data */
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
-            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
+            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, S2N_TLS_RECORD_HEADER_LENGTH));
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
             conn->in.blob.data[S2N_TLS_GCM_EXPLICIT_IV_LEN + j] ++;
             EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
@@ -298,13 +298,13 @@ int main(int argc, char **argv)
 
         /* The data should be encrypted */
         if (bytes_written > 10) {
-            EXPECT_NOT_EQUAL(memcmp(conn->out.blob.data + 5, random_data, bytes_written), 0);
+            EXPECT_NOT_EQUAL(memcmp(conn->out.blob.data + S2N_TLS_RECORD_HEADER_LENGTH, random_data, bytes_written), 0);
         }
 
         /* Copy the encrypted out data to the in data */
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
-        EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
+        EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, S2N_TLS_RECORD_HEADER_LENGTH));
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
         /* Let's decrypt it */
@@ -332,7 +332,7 @@ int main(int argc, char **argv)
         /* Copy the encrypted out data to the in data */
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
-        EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
+        EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, S2N_TLS_RECORD_HEADER_LENGTH));
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
         /* Tamper with the protocol version in the header, and ensure decryption fails, as we use this in the AAD */
@@ -360,7 +360,7 @@ int main(int argc, char **argv)
             /* Copy the encrypted out data to the in data */
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
-            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
+            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, S2N_TLS_RECORD_HEADER_LENGTH));
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
             conn->in.blob.data[j] ++;
             EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
@@ -387,7 +387,7 @@ int main(int argc, char **argv)
             /* Copy the encrypted out data to the in data */
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
-            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
+            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, S2N_TLS_RECORD_HEADER_LENGTH));
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
             conn->in.blob.data[s2n_stuffer_data_available(&conn->in) - j - 1] ++;
             EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
@@ -414,7 +414,7 @@ int main(int argc, char **argv)
             /* Copy the encrypted out data to the in data */
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
-            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
+            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, S2N_TLS_RECORD_HEADER_LENGTH));
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
             conn->in.blob.data[j] ++;
             EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));

--- a/tests/unit/s2n_aead_chacha20_poly1305_test.c
+++ b/tests/unit/s2n_aead_chacha20_poly1305_test.c
@@ -97,8 +97,8 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(bytes_written, max_fragment);
         }
 
-        static const int overhead = S2N_TLS_CHACHA20_POLY1305_EXPLICIT_IV_LEN   /* Should be 0 */
-            + S2N_TLS_GCM_TAG_LEN; /* TAG */
+        static const int overhead = S2N_TLS_CHACHA20_POLY1305_EXPLICIT_IV_LEN /* Should be 0 */
+            + S2N_TLS_CHACHA20_POLY1305_TAG_LEN; /* TAG */
 
         uint16_t predicted_length = bytes_written;
         predicted_length += conn->initial.cipher_suite->record_alg->cipher->io.aead.record_iv_size;
@@ -217,7 +217,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
-            conn->in.blob.data[S2N_TLS_GCM_IV_LEN + j]++;
+            conn->in.blob.data[S2N_TLS_CHACHA20_POLY1305_IV_LEN + j] ++;
             EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
             EXPECT_FAILURE(s2n_record_parse(conn));
             EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);

--- a/tests/unit/s2n_aead_chacha20_poly1305_test.c
+++ b/tests/unit/s2n_aead_chacha20_poly1305_test.c
@@ -76,9 +76,19 @@ int main(int argc, char **argv)
     GUARD(setup_server_keys(conn, &chacha20_poly1305_key));
 
     int max_fragment = S2N_SMALL_FRAGMENT_LENGTH;
-    for (int i = 0; i <= max_fragment + 1; i++) {
+    for (size_t i = 0; i <= max_fragment + 1; i++) {
         struct s2n_blob in = {.data = random_data,.size = i };
         int bytes_written;
+
+        /* TLS packet on the wire using ChaCha20-Poly1305:
+         * https://tools.ietf.org/html/rfc5246#section-6.2.3.3
+         * https://tools.ietf.org/html/rfc7905#section-2
+         * ----------------------------------
+         * |TLS header|encrypted payload|TAG|
+         * ----------------------------------
+         * Length:
+         * S2N_TLS_RECORD_HEADER_LENGTH + i + S2N_TLS_CHACHA20_POLY1305_TAG_LEN
+         */
 
         EXPECT_SUCCESS(s2n_connection_wipe(conn));
         EXPECT_SUCCESS(s2n_connection_prefer_low_latency(conn));
@@ -175,7 +185,7 @@ int main(int argc, char **argv)
         GUARD(conn->initial.cipher_suite->record_alg->cipher->destroy_key(&conn->initial.client_key));
 
         /* Tamper with the TAG and ensure decryption fails */
-        for (int j = 0; j < S2N_TLS_CHACHA20_POLY1305_TAG_LEN; j++) {
+        for (size_t j = 0; j < S2N_TLS_CHACHA20_POLY1305_TAG_LEN; j++) {
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
             conn->actual_protocol_version_established = 1;
             conn->server_protocol_version = S2N_TLS12;
@@ -201,8 +211,8 @@ int main(int argc, char **argv)
             GUARD(conn->initial.cipher_suite->record_alg->cipher->destroy_key(&conn->initial.client_key));
         }
 
-        /* Tamper with the ciphertext and ensure decryption fails */
-        for (int j = 0; j < i - S2N_TLS_CHACHA20_POLY1305_TAG_LEN; j++) {
+        /* Tamper with the encrypted payload in the ciphertext and ensure decryption fails */
+        for (size_t j = 0; j < i; j++) {
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
             conn->actual_protocol_version_established = 1;
             conn->server_protocol_version = S2N_TLS12;
@@ -217,7 +227,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
-            conn->in.blob.data[S2N_TLS_CHACHA20_POLY1305_IV_LEN + j] ++;
+            conn->in.blob.data[j] ++;
             EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
             EXPECT_FAILURE(s2n_record_parse(conn));
             EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);

--- a/tests/unit/s2n_aes_sha_composite_test.c
+++ b/tests/unit/s2n_aes_sha_composite_test.c
@@ -112,7 +112,7 @@ int main(int argc, char **argv)
 
             /* The data should be encrypted */
             if (bytes_written > 10) {
-                EXPECT_NOT_EQUAL(memcmp(conn->out.blob.data + 5, random_data, bytes_written), 0);
+                EXPECT_NOT_EQUAL(memcmp(conn->out.blob.data + S2N_TLS_RECORD_HEADER_LENGTH, random_data, bytes_written), 0);
             }
 
             /* Copy the encrypted out data to the in data */
@@ -317,7 +317,7 @@ int main(int argc, char **argv)
             /* Copy the encrypted out data to the in data */
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
-            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
+            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, S2N_TLS_RECORD_HEADER_LENGTH));
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
             /* Let's decrypt it */

--- a/tests/unit/s2n_aes_sha_composite_test.c
+++ b/tests/unit/s2n_aes_sha_composite_test.c
@@ -118,7 +118,7 @@ int main(int argc, char **argv)
             /* Copy the encrypted out data to the in data */
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
-            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
+            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, S2N_TLS_RECORD_HEADER_LENGTH));
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
             /* Let's decrypt it */
@@ -178,13 +178,13 @@ int main(int argc, char **argv)
 
             /* The data should be encrypted */
             if (bytes_written > 10) {
-                EXPECT_NOT_EQUAL(memcmp(conn->out.blob.data + 5, random_data, bytes_written), 0);
+                EXPECT_NOT_EQUAL(memcmp(conn->out.blob.data + S2N_TLS_RECORD_HEADER_LENGTH, random_data, bytes_written), 0);
             }
 
             /* Copy the encrypted out data to the in data */
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
-            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
+            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, S2N_TLS_RECORD_HEADER_LENGTH));
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
             /* Let's decrypt it */
@@ -245,13 +245,13 @@ int main(int argc, char **argv)
 
             /* The data should be encrypted */
             if (bytes_written > 10) {
-                EXPECT_NOT_EQUAL(memcmp(conn->out.blob.data + 5, random_data, bytes_written), 0);
+                EXPECT_NOT_EQUAL(memcmp(conn->out.blob.data + S2N_TLS_RECORD_HEADER_LENGTH, random_data, bytes_written), 0);
             }
 
             /* Copy the encrypted out data to the in data */
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
-            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
+            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, S2N_TLS_RECORD_HEADER_LENGTH));
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
             /* Let's decrypt it */
@@ -311,7 +311,7 @@ int main(int argc, char **argv)
 
             /* The data should be encrypted */
             if (bytes_written > 10) {
-                EXPECT_NOT_EQUAL(memcmp(conn->out.blob.data + 5, random_data, bytes_written), 0);
+                EXPECT_NOT_EQUAL(memcmp(conn->out.blob.data + S2N_TLS_RECORD_HEADER_LENGTH, random_data, bytes_written), 0);
             }
 
             /* Copy the encrypted out data to the in data */


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

This PR fixes four issues + one magic number in the unit testing of AES-GCM and ChaCha20-Poly1305:

1.
The unit test `tests/unit/s2n_aead_chacha20_poly1305_test.c` makes use of the wrong macro, `S2N_TLS_GCM_TAG_LEN`, for the ChaCha20-Poly1305 Tag length at one occasion. The correct macro is: `S2N_TLS_CHACHA20_POLY1305_TAG_LEN`. Similarly, `S2N_TLS_GCM_IV_LEN` is used at one occasion, instead of `S2N_TLS_CHACHA20_POLY1305_IV_LEN`.

2.
The unit test `tests/unit/s2n_aead_aes_test.c` use the macro `S2N_TLS_GCM_IV_LEN` (=12) to point to the start of the TLS packet payload field located immediately after the IV field. However, only the explicit part of the IV is encoded in the IV field (https://tools.ietf.org/html/rfc5246#section-6.2.3.3). For AES-GCM the explicit IV length is 8 and encoded in the macro `S2N_TLS_GCM_EXPLICIT_IV_LEN`.

3.
At two occasions the `conn->in.blob.data` pointer is initially incremented by 5, likely intended to account for the TLS header. However, the header is written to the buffer `conn->header_in`, hence is not present in `conn->in.blob.data`.

4.
When flipping bits in the encrypted payload part of the TLS packet, the index to the encrypted payload was wrongly computed. `i` is the length of the payload / encrypted payload, it is therefore not correct to start the counter `j` at e.g `S2N_TLS_GCM_IV_LEN` or limit the counter to e.g. `i - S2N_TLS_GCM_TAG_LEN`.

5.
Used macro's instead of magic numbers to compute `overhead` in `tests/unit/s2n_aead_aes_test.c`.

### Call-outs:

Included a diagram of a TLS packet on the wire for both AES-GCM and ChaCha20-Poly1305 to facilitate understanding of the indexing done when flipping bits.

### Testing:

N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
