### PR TITLE
Update s2n to compile on FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,9 @@ include(CheckCSourceCompiles)
 check_c_source_compiles("
     #include <execinfo.h>
     int main() {
+        void *array[20];
+        int backtrace_size = backtrace(array, 20);
+        backtrace_symbols(array, backtrace_size);
         return 0;
     }" S2N_HAVE_EXECINFO)
 

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -747,7 +747,9 @@ int main(int argc, char *const *argv)
         struct sigaction sa;
 
         sa.sa_handler = SIG_IGN;
+#if defined(SA_NOCLDWAIT)
         sa.sa_flags = SA_NOCLDWAIT;
+#endif
         sigemptyset(&sa.sa_mask);
         sigaction(SIGCHLD, &sa, NULL);
     }

--- a/tests/unit/s2n_rfc5952_test.c
+++ b/tests/unit/s2n_rfc5952_test.c
@@ -17,6 +17,12 @@
 
 #include <arpa/inet.h>
 
+#if defined(__FreeBSD__)
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#endif
+
 #include "utils/s2n_rfc5952.h"
 
 int main(int argc, char **argv)

--- a/tests/unit/s2n_stacktrace_test.c
+++ b/tests/unit/s2n_stacktrace_test.c
@@ -27,6 +27,7 @@ int raises_error()
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
+#ifdef S2N_HAVE_EXECINFO
     EXPECT_SUCCESS(s2n_stack_traces_enabled_set(true));
     struct s2n_stacktrace trace;
     /* If nothing has errored yet, we have no stacktrace */
@@ -48,4 +49,7 @@ int main(int argc, char **argv)
     /* Free the stacktrace to avoid memory leaks */
     EXPECT_SUCCESS(s2n_free_stacktrace());
     END_TEST();
+#else
+    END_TEST();
+#endif
 }

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -14,7 +14,7 @@
  */
 
 #define  _DEFAULT_SOURCE 1
-#if !defined(__APPLE__)
+#if !defined(__APPLE__) && !defined(__FreeBSD__)
 #include <features.h>
 #endif
 


### PR DESCRIPTION
### Resolved issues:

Partially Resolves: https://github.com/awslabs/s2n/issues/2270

### Description of changes: 
Fixes various incompatibilities introduced to s2n in the last few months that causes s2n to fail to compile on FreeBSD. 

### Call-outs:
s2n is now successfully compiles on FreeBSD, but 2 unit tests are still failing: `s2n_self_talk_nonblocking_test` and `s2n_self_talk_broken_pipe_test`. I am still researching these failures, but wanted to get the changes that are ready merged in since they fix the majority of the issues on FreeBSD. 

`s2n_self_talk_nonblocking_test` deadlocks and hangs forever.

`s2n_self_talk_broken_pipe_test` test is failing [on this line](https://github.com/awslabs/s2n/blob/f6c371495b7531c7cba458b097b469df45907df4/tests/unit/s2n_self_talk_broken_pipe_test.c#L155) with `w` equal to `1`.

### Testing:
Started up FreeBSD-12 EC2 instance, and compiled s2n using CMake. All unit tests are passing except the 2 mentioned above, which I am still researching.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
