### PR TITLE
usage-guide: fix s2n_mode comment about S2N_CLIENT 

### DIFF
--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -277,9 +277,7 @@ an error "category". See [Error Handling](#error-handling) for more detail.
 typedef enum { S2N_SERVER, S2N_CLIENT } s2n_mode;
 ```
 
-**s2n_mode** is used to declare connections as server or client type,
-respectively.  At this time, s2n does not function as a client and only
-S2N_SERVER should be used.
+**s2n_mode** is used to declare connections as server or client type, respectively.
 
 ### s2n_blocked_status
 


### PR DESCRIPTION
### Resolved issues:

None

### Description of changes: 

According to examples in _bin/s2nc.c_  **s2n** can act as a client. now.
So this comment about server only behaviour is no longer correct.

### Call-outs:

None

### Testing:

Generated markdown preview looks correct

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
