### PR TITLE
Fix awslc codebuild hang

### DIFF
--- a/codebuild/bin/install_ubuntu_dependencies.sh
+++ b/codebuild/bin/install_ubuntu_dependencies.sh
@@ -19,7 +19,7 @@
 set -ex
 
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-sudo add-apt-repository ppa:longsleep/golang-backports
+sudo add-apt-repository ppa:longsleep/golang-backports -y
 sudo apt-get update -o Acquire::CompressionTypes::Order::=gz
 
 DEPENDENCIES="unzip make indent kwstyle libssl-dev tcpdump valgrind lcov m4 nettle-dev nettle-bin pkg-config gcc g++ zlibc zlib1g-dev python3-pip python3-testresources llvm curl git tox cmake libtool ninja-build golang-go quilt"

--- a/codebuild/spec/buildspec_ubuntu_integ_awslc.yml
+++ b/codebuild/spec/buildspec_ubuntu_integ_awslc.yml
@@ -29,7 +29,7 @@ phases:
       - echo Entered the install phase...
       - add-apt-repository ppa:ubuntu-toolchain-r/test -y
       # Add repo to get latest golang version. https://github.com/golang/go/wiki/Ubuntu
-      - add-apt-repository ppa:longsleep/golang-backports
+      - add-apt-repository ppa:longsleep/golang-backports -y
       - apt-get update -o Acquire::CompressionTypes::Order::=gz
       - apt-get update -y
       - apt-get install -y --no-install-recommends gcc g++ gcc-4.8 g++-4.8 gcc-6 g++-6 gcc-9 g++-9


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

On Ubuntu the AWS-LC codebuild hangs on command `add-apt-repository` in `codebuild/bin/install_ubuntu_dependencies.sh` and  `buildspec_ubuntu_integ_awslc.yml`.

```
$ codebuild/bin/s2n_install_test_dependencies.sh

[...]

+ codebuild/bin/install_ubuntu_dependencies.sh
+ sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
Hit:1 http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu  bionic InRelease
Hit:2 http://eu-west-2.ec2.archive.ubuntu.com/ubuntu bionic InRelease                      
Get:3 http://eu-west-2.ec2.archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]    
Get:4 http://eu-west-2.ec2.archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]  
Get:5 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]                
Get:6 http://eu-west-2.ec2.archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages [1072 kB]
Get:7 http://eu-west-2.ec2.archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages [1107 kB]
Fetched 2430 kB in 1s (3680 kB/s)                                                          
Reading package lists... Done
+ sudo add-apt-repository ppa:longsleep/golang-backports
 Golang 1.8, 1.9, 1.10, 1.11, 1.12, 1.13, 1.14 and 1.15 PPA for Ubuntu
 More info: https://launchpad.net/~longsleep/+archive/ubuntu/golang-backports
Press [ENTER] to continue or Ctrl-c to cancel adding it.
```

Assuming yes for both prompts fixes the hang.

### Call-outs:

N/A

### Testing:

Tested locally on Ubuntu with the committed changes. No longer hangs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
