### PR TITLE
Add initial QUIC setup

### DIFF
--- a/error/s2n_errno.c
+++ b/error/s2n_errno.c
@@ -88,7 +88,7 @@ static const char *no_such_error = "Internal s2n error";
     ERR_ENTRY(S2N_ERR_CERT_TYPE_UNSUPPORTED, "Certificate Type is unsupported") \
     ERR_ENTRY(S2N_ERR_INVALID_MAX_FRAG_LEN, "invalid Maximum Fragmentation Length encountered") \
     ERR_ENTRY(S2N_ERR_MAX_FRAG_LEN_MISMATCH, "Negotiated Maximum Fragmentation Length from server does not match the requested length by client") \
-    ERR_ENTRY(S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED, "TLS protocol version is not supported by selected cipher suite") \
+    ERR_ENTRY(S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED, "TLS protocol version is not supported by configuration") \
     ERR_ENTRY(S2N_ERR_BAD_KEY_SHARE, "Bad key share received") \
     ERR_ENTRY(S2N_ERR_CANCELLED, "handshake was cancelled") \
     ERR_ENTRY(S2N_ERR_PROTOCOL_DOWNGRADE_DETECTED, "Protocol downgrade detected by client") \

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -231,8 +231,8 @@ int main(int argc, char **argv)
     /* Test that negotiating TLS1.2 with QUIC-enabled server fails */
     {
         struct s2n_config *config = s2n_config_new();
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "test_all"));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, ecdsa_chain_and_key));
 
         /* Succeeds when negotiating TLS1.3 */
         {
@@ -241,11 +241,12 @@ int main(int argc, char **argv)
             struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
             EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
             EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS13);
-            EXPECT_SUCCESS(s2n_connection_enable_quic(server_conn));
 
             struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
             EXPECT_EQUAL(client_conn->client_protocol_version, S2N_TLS13);
+
+            EXPECT_SUCCESS(s2n_connection_enable_quic(server_conn));
 
             EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
             EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io,
@@ -258,16 +259,17 @@ int main(int argc, char **argv)
 
         /* Fails when negotiating TLS1.2 */
         {
-            EXPECT_SUCCESS(s2n_enable_tls13());
-            struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
-            EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
-            EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS13);
-            EXPECT_SUCCESS(s2n_connection_enable_quic(server_conn));
-
             EXPECT_SUCCESS(s2n_disable_tls13());
             struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
             EXPECT_EQUAL(client_conn->client_protocol_version, S2N_TLS12);
+
+            EXPECT_SUCCESS(s2n_enable_tls13());
+            struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+            EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS13);
+
+            EXPECT_SUCCESS(s2n_connection_enable_quic(server_conn));
 
             EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
             EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io,

--- a/tests/unit/s2n_quic_support_test.c
+++ b/tests/unit/s2n_quic_support_test.c
@@ -31,25 +31,17 @@ int main(int argc, char **argv)
         /* Check error handling */
         {
             EXPECT_SUCCESS(s2n_disable_tls13());
-            EXPECT_SUCCESS(s2n_in_unit_test_set(true));
             EXPECT_FAILURE_WITH_ERRNO(s2n_connection_enable_quic(conn), S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
             EXPECT_FALSE(conn->quic_enabled);
 
             EXPECT_SUCCESS(s2n_enable_tls13());
-            EXPECT_SUCCESS(s2n_in_unit_test_set(true));
             EXPECT_FAILURE_WITH_ERRNO(s2n_connection_enable_quic(NULL), S2N_ERR_NULL);
-            EXPECT_FALSE(conn->quic_enabled);
-
-            EXPECT_SUCCESS(s2n_enable_tls13());
-            EXPECT_SUCCESS(s2n_in_unit_test_set(false));
-            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_enable_quic(conn), S2N_ERR_NOT_IN_TEST);
             EXPECT_FALSE(conn->quic_enabled);
         }
 
         /* Check success */
         {
             EXPECT_SUCCESS(s2n_enable_tls13());
-            EXPECT_SUCCESS(s2n_in_unit_test_set(true));
             EXPECT_SUCCESS(s2n_connection_enable_quic(conn));
             EXPECT_TRUE(conn->quic_enabled);
 

--- a/tests/unit/s2n_quic_support_test.c
+++ b/tests/unit/s2n_quic_support_test.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "tls/s2n_quic_support.h"
+
+#include "tls/s2n_connection.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Test s2n_connection_enable_quic */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(conn);
+        EXPECT_FALSE(conn->quic_enabled);
+
+        /* Check error handling */
+        {
+            EXPECT_SUCCESS(s2n_disable_tls13());
+            EXPECT_SUCCESS(s2n_in_unit_test_set(true));
+            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_enable_quic(conn), S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
+            EXPECT_FALSE(conn->quic_enabled);
+
+            EXPECT_SUCCESS(s2n_enable_tls13());
+            EXPECT_SUCCESS(s2n_in_unit_test_set(true));
+            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_enable_quic(NULL), S2N_ERR_NULL);
+            EXPECT_FALSE(conn->quic_enabled);
+
+            EXPECT_SUCCESS(s2n_enable_tls13());
+            EXPECT_SUCCESS(s2n_in_unit_test_set(false));
+            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_enable_quic(conn), S2N_ERR_NOT_IN_TEST);
+            EXPECT_FALSE(conn->quic_enabled);
+        }
+
+        /* Check success */
+        {
+            EXPECT_SUCCESS(s2n_enable_tls13());
+            EXPECT_SUCCESS(s2n_in_unit_test_set(true));
+            EXPECT_SUCCESS(s2n_connection_enable_quic(conn));
+            EXPECT_TRUE(conn->quic_enabled);
+
+            /* Enabling QUIC again still succeeds */
+            EXPECT_SUCCESS(s2n_connection_enable_quic(conn));
+            EXPECT_TRUE(conn->quic_enabled);
+        }
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    END_TEST();
+}

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -228,7 +228,8 @@ int s2n_process_client_hello(struct s2n_connection *conn)
     }
 
     /* for pre TLS 1.3 connections, protocol selection is not done in supported_versions extensions, so do it here */
-    if (conn->actual_protocol_version != S2N_TLS13) {
+    if (conn->actual_protocol_version < S2N_TLS13) {
+        ENSURE_POSIX(!conn->quic_enabled, S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
         conn->actual_protocol_version = MIN(conn->server_protocol_version, conn->client_protocol_version);
     }
 

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -105,8 +105,6 @@ struct s2n_connection {
 
     /* If write fd is broken */
     unsigned write_fd_broken:1;
-    
-    unsigned quic_enabled:1;
 
     /* Track request extensions to ensure correct response extension behavior.
      *
@@ -306,6 +304,10 @@ struct s2n_connection {
 
     /* Key update data */
     unsigned key_update_pending:1;
+
+    /* Whether this connection can be used by a QUIC implementation.
+     * See s2n_quic_support.h */
+    unsigned quic_enabled:1;
 
     /* Bitmap to represent preferred list of keyshare for client to generate and send keyshares in the ClientHello message.
      * The least significant bit (lsb), if set, indicates that the client must send an empty keyshare list.

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -94,15 +94,6 @@ struct s2n_connection {
     /* Was the EC point formats sent by the client */
     unsigned ec_point_formats:1;
 
-    /* Track request extensions to ensure correct response extension behavior.
-     *
-     * We need to track client and server extensions separately because some
-     * extensions (like request_status and other Certificate extensions) can
-     * be requested by the client, the server, or both.
-     */
-    s2n_extension_bitfield extension_requests_sent;
-    s2n_extension_bitfield extension_requests_received;
-
     /* whether the connection address is ipv6 or not */
     unsigned ipv6:1;
 
@@ -115,6 +106,17 @@ struct s2n_connection {
     /* If write fd is broken */
     unsigned write_fd_broken:1;
     
+    unsigned quic_enabled:1;
+
+    /* Track request extensions to ensure correct response extension behavior.
+     *
+     * We need to track client and server extensions separately because some
+     * extensions (like request_status and other Certificate extensions) can
+     * be requested by the client, the server, or both.
+     */
+    s2n_extension_bitfield extension_requests_sent;
+    s2n_extension_bitfield extension_requests_received;
+
     /* Is this connection a client or a server connection */
     s2n_mode mode;
 

--- a/tls/s2n_quic_support.c
+++ b/tls/s2n_quic_support.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "tls/s2n_quic_support.h"
+
+#include "tls/s2n_connection.h"
+#include "tls/s2n_tls13.h"
+#include "utils/s2n_safety.h"
+
+int s2n_connection_enable_quic(struct s2n_connection *conn)
+{
+    /* The QUIC RFC is not yet finalized, so all QUIC APIs are
+     * considered experimental and subject to change.
+     * They should only be used for testing purposes.
+     */
+    ENSURE_POSIX(S2N_IN_TEST, S2N_ERR_NOT_IN_TEST);
+
+    /* The QUIC protocol doesn't use pre-1.3 TLS */
+    ENSURE_POSIX(s2n_is_tls13_enabled(), S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
+
+    notnull_check(conn);
+    conn->quic_enabled = true;
+    return S2N_SUCCESS;
+}

--- a/tls/s2n_quic_support.c
+++ b/tls/s2n_quic_support.c
@@ -21,12 +21,6 @@
 
 int s2n_connection_enable_quic(struct s2n_connection *conn)
 {
-    /* The QUIC RFC is not yet finalized, so all QUIC APIs are
-     * considered experimental and subject to change.
-     * They should only be used for testing purposes.
-     */
-    ENSURE_POSIX(S2N_IN_TEST, S2N_ERR_NOT_IN_TEST);
-
     /* The QUIC protocol doesn't use pre-1.3 TLS */
     ENSURE_POSIX(s2n_is_tls13_enabled(), S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
 

--- a/tls/s2n_quic_support.h
+++ b/tls/s2n_quic_support.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include "api/s2n.h"
+
+/*
+ * APIs intended to support the QUIC protocol: https://datatracker.ietf.org/wg/quic/about/
+ *
+ * QUIC requires access to parts of S2N not usually surfaced to customers. These APIs change
+ * the behavior of S2N in potentially dangerous ways and should only be used by implementations
+ * of the QUIC protocol.
+ *
+ * Additionally, the QUIC RFC is not yet finalized, so all QUIC APIs are considered experimental
+ * and are subject to change. They should only be used for testing purposes, and can only be called
+ * from S2N unit tests or with the "S2N_INTEG_TEST" environmental variable set.
+ */
+
+S2N_API int s2n_connection_enable_quic(struct s2n_connection *conn);

--- a/tls/s2n_quic_support.h
+++ b/tls/s2n_quic_support.h
@@ -18,15 +18,15 @@
 #include "api/s2n.h"
 
 /*
- * APIs intended to support the QUIC protocol: https://datatracker.ietf.org/wg/quic/about/
+ * APIs intended to support an external implementation of the QUIC protocol:
+ * https://datatracker.ietf.org/wg/quic/about/
  *
  * QUIC requires access to parts of S2N not usually surfaced to customers. These APIs change
  * the behavior of S2N in potentially dangerous ways and should only be used by implementations
  * of the QUIC protocol.
  *
  * Additionally, the QUIC RFC is not yet finalized, so all QUIC APIs are considered experimental
- * and are subject to change. They should only be used for testing purposes, and can only be called
- * from S2N unit tests or with the "S2N_INTEG_TEST" environmental variable set.
+ * and are subject to change without notice. They should only be used for testing purposes.
  */
 
 S2N_API int s2n_connection_enable_quic(struct s2n_connection *conn);

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -140,6 +140,7 @@ static int s2n_server_hello_parse(struct s2n_connection *conn)
         conn->server_protocol_version = (uint8_t)(protocol_version[0] * 10) + protocol_version[1];
 
         S2N_ERROR_IF(s2n_client_detect_downgrade_mechanism(conn), S2N_ERR_PROTOCOL_DOWNGRADE_DETECTED);
+        ENSURE_POSIX(!conn->quic_enabled, S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
 
         const struct s2n_security_policy *security_policy;
         GUARD(s2n_connection_get_security_policy(conn, &security_policy));


### PR DESCRIPTION
### Resolved issues:

 resolves https://github.com/awslabs/s2n/issues/2278

### Description of changes: 

Add new method to enable QUIC when using TLS1.3.

### Call-outs:

I considered putting the header file in "api" instead of "tls" to make it clearer that it's a new API, but decided against it for now to avoid advertising the APIs before they're useable. However, we will probably want to move the public QUIC APIs to "api" once they are out of development.

Also:
- I changed the S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED error message because "selected cipher suite" wasn't even really accurate to how we used it pre-QUIC. We threw "S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED" only when our security policy didn't support the negotiated version. The new wording should be more accurate and also include the QUIC error cases.
- In the connection structure, I moved the extension bitfields to keep all our standalone bitflags together.

### Testing:

New unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
