### PR TITLE
Enable X25519 for AWS-LC

### DIFF
--- a/crypto/s2n_ecc_evp.c
+++ b/crypto/s2n_ecc_evp.c
@@ -17,6 +17,10 @@
 
 #include <openssl/ecdh.h>
 #include <openssl/evp.h>
+#if defined(OPENSSL_IS_AWSLC)
+#include <openssl/mem.h>
+#endif
+
 #include <stdint.h>
 
 #include "tls/s2n_tls_parameters.h"

--- a/crypto/s2n_ecc_evp.h
+++ b/crypto/s2n_ecc_evp.h
@@ -45,7 +45,7 @@ extern const struct s2n_ecc_named_curve s2n_ecc_curve_x25519;
 /* BoringSSL only supports using EVP_PKEY_X25519 with "modern" EC EVP APIs. BoringSSL has a note to possibly add this in
  * the future. See https://github.com/google/boringssl/blob/master/crypto/evp/p_x25519_asn1.c#L233
  */
-#if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0) && !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
+#if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0) && !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_IS_BORINGSSL)
     #define EVP_APIS_SUPPORTED 1
     #define S2N_ECC_EVP_SUPPORTED_CURVES_COUNT 3
 #else


### PR DESCRIPTION
### Resolved issues:

CryptoAlg-415

### Description of changes: 

s2n currently disables X25519 when using AWS-LC because `EVP_PKEY_{get,set}1_tls_encodedpoint` could not handle `EVP_PKEY_EC` types as input. AWS-LC has recently implemented support for this type for these two functions [see commit](https://github.com/awslabs/aws-lc/commit/50f6f25609a54a8f515d0f8fb5e43b7aa64ca21c). Hence, we can turn on X25519 for AWS-LC.

### Call-outs:

The function `OPENSSL_free` is defined in `openssl/mem.h` in AWS-LC. This header file does not exist in OpenSSL or LibreSSL. This symbol was only present when the `EVP_APIS_SUPPORTED` flag was defined, and was therefore removed during pre-compilation when linking with AWS-LC. Since we now define `EVP_APIS_SUPPORTED` we need this symbol defined.

I scanned unit and integrations tests for cases where X25519 was left out as a test parameter when using AWS-LC. I could not find any such cases.

### Testing:

Current unit tests should cover code-paths since AWS-LC is already a dimension in the CI.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
