### PR TITLE
Add quic_transport_parameters extension

### DIFF
--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -246,6 +246,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
             EXPECT_EQUAL(client_conn->client_protocol_version, S2N_TLS13);
 
+            EXPECT_SUCCESS(s2n_connection_enable_quic(client_conn));
             EXPECT_SUCCESS(s2n_connection_enable_quic(server_conn));
 
             EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
@@ -269,6 +270,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
             EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS13);
 
+            client_conn->quic_enabled = true; /* Actual api requires tls1.3, so set flag directly */
             EXPECT_SUCCESS(s2n_connection_enable_quic(server_conn));
 
             EXPECT_SUCCESS(s2n_client_hello_send(client_conn));

--- a/tests/unit/s2n_quic_transport_params_extension_test.c
+++ b/tests/unit/s2n_quic_transport_params_extension_test.c
@@ -1,0 +1,182 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "tests/testlib/s2n_testlib.h"
+
+#include "tls/extensions/s2n_quic_transport_params.h"
+
+#include "tls/s2n_connection.h"
+#include "tls/s2n_quic_support.h"
+#include "tls/s2n_tls13.h"
+
+static const uint8_t TEST_DATA[] = "These are transport parameters";
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    EXPECT_SUCCESS(s2n_enable_tls13());
+
+    /* Test should_send */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+        /* Safety check */
+        EXPECT_FALSE(s2n_quic_transport_parameters_extension.should_send(NULL));
+
+        /* Don't send if quic not enabled (default) */
+        EXPECT_FALSE(s2n_quic_transport_parameters_extension.should_send(conn));
+
+        /* Send if quic enabled */
+        EXPECT_SUCCESS(s2n_connection_enable_quic(conn));
+        EXPECT_TRUE(s2n_quic_transport_parameters_extension.should_send(conn));
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test if_missing */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+        /* Safety check */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_quic_transport_parameters_extension.if_missing(NULL), S2N_ERR_NULL);
+
+        /* Succeeds if quic not enabled (default) */
+        EXPECT_SUCCESS(s2n_quic_transport_parameters_extension.if_missing(conn));
+
+        /* Fails if quic enabled */
+        EXPECT_SUCCESS(s2n_connection_enable_quic(conn));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_quic_transport_parameters_extension.if_missing(conn), S2N_ERR_MISSING_EXTENSION);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test send */
+    {
+        /* Safety checks */
+        {
+            struct s2n_connection conn = { 0 };
+            struct s2n_stuffer out = { 0 };
+            EXPECT_FAILURE_WITH_ERRNO(s2n_quic_transport_parameters_extension.send(NULL, &out), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_quic_transport_parameters_extension.send(&conn, NULL), S2N_ERR_NULL);
+        }
+
+        /* Writes transport parameters */
+        {
+            struct s2n_stuffer out = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));
+
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_SUCCESS(s2n_connection_enable_quic(conn));
+            EXPECT_SUCCESS(s2n_connection_set_quic_transport_parameters(conn, TEST_DATA, sizeof(TEST_DATA)));
+
+            EXPECT_SUCCESS(s2n_quic_transport_parameters_extension.send(conn, &out));
+            EXPECT_BYTEARRAY_EQUAL(out.blob.data, TEST_DATA, sizeof(TEST_DATA));
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_stuffer_free(&out));
+        }
+
+        /* Writes empty transport parameters */
+        {
+            struct s2n_stuffer out = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));
+
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_SUCCESS(s2n_connection_enable_quic(conn));
+
+            EXPECT_SUCCESS(s2n_quic_transport_parameters_extension.send(conn, &out));
+            EXPECT_EQUAL(s2n_stuffer_data_available(&out), 0);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_stuffer_free(&out));
+        }
+    }
+
+    /* Test recv */
+    {
+        /* Safety checks */
+        {
+            struct s2n_connection conn = { 0 };
+            struct s2n_stuffer extension = { 0 };
+            EXPECT_FAILURE_WITH_ERRNO(s2n_quic_transport_parameters_extension.recv(NULL, &extension), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_quic_transport_parameters_extension.recv(&conn, NULL), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_quic_transport_parameters_extension.recv(&conn, &extension),
+                    S2N_ERR_UNSUPPORTED_EXTENSION);
+        }
+
+        /* Save transport parameters */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_SUCCESS(s2n_connection_enable_quic(conn));
+
+            struct s2n_stuffer extension = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&extension, 0));
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&extension, TEST_DATA, sizeof(TEST_DATA)));
+
+            EXPECT_SUCCESS(s2n_quic_transport_parameters_extension.recv(conn, &extension));
+            EXPECT_BYTEARRAY_EQUAL(conn->peer_quic_transport_parameters.data, TEST_DATA, sizeof(TEST_DATA));
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_stuffer_free(&extension));
+        }
+
+        /* Save empty transport parameters */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_SUCCESS(s2n_connection_enable_quic(conn));
+
+            struct s2n_stuffer extension = { 0 };
+
+            EXPECT_SUCCESS(s2n_quic_transport_parameters_extension.recv(conn, &extension));
+            EXPECT_EQUAL(conn->peer_quic_transport_parameters.size, 0);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* recv processes the output of send */
+        {
+            struct s2n_stuffer out = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));
+
+            struct s2n_connection *server_conn;
+            EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+            EXPECT_SUCCESS(s2n_connection_enable_quic(server_conn));
+
+            struct s2n_connection *client_conn;
+            EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_SUCCESS(s2n_connection_enable_quic(client_conn));
+            EXPECT_SUCCESS(s2n_connection_set_quic_transport_parameters(client_conn, TEST_DATA, sizeof(TEST_DATA)));
+
+            EXPECT_SUCCESS(s2n_quic_transport_parameters_extension.send(client_conn, &out));
+            EXPECT_EQUAL(server_conn->peer_quic_transport_parameters.size, 0);
+            EXPECT_SUCCESS(s2n_quic_transport_parameters_extension.recv(server_conn, &out));
+            EXPECT_BYTEARRAY_EQUAL(server_conn->peer_quic_transport_parameters.data, TEST_DATA, sizeof(TEST_DATA));
+
+            EXPECT_SUCCESS(s2n_connection_free(client_conn));
+            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+            EXPECT_SUCCESS(s2n_stuffer_free(&out));
+        }
+    }
+
+    END_TEST();
+}

--- a/tls/extensions/s2n_extension_type.h
+++ b/tls/extensions/s2n_extension_type.h
@@ -60,6 +60,7 @@ static const uint16_t s2n_supported_extensions[] = {
     TLS_EXTENSION_SUPPORTED_VERSIONS,
     TLS_EXTENSION_KEY_SHARE,
     TLS_EXTENSION_COOKIE,
+    TLS_QUIC_TRANSPORT_PARAMETERS,
 };
 
 typedef char s2n_extension_bitfield[S2N_SUPPORTED_EXTENSIONS_BITFIELD_LEN];

--- a/tls/extensions/s2n_extension_type_lists.c
+++ b/tls/extensions/s2n_extension_type_lists.c
@@ -32,6 +32,7 @@
 #include "tls/extensions/s2n_client_pq_kem.h"
 #include "tls/extensions/s2n_client_renegotiation_info.h"
 #include "tls/extensions/s2n_ec_point_format.h"
+#include "tls/extensions/s2n_quic_transport_params.h"
 #include "tls/extensions/s2n_server_certificate_status.h"
 #include "tls/extensions/s2n_server_renegotiation_info.h"
 #include "tls/extensions/s2n_server_alpn.h"
@@ -59,6 +60,7 @@ static const s2n_extension_type *const client_hello_extensions[] = {
         &s2n_client_pq_kem_extension,
         &s2n_client_renegotiation_info_extension,
         &s2n_client_cookie_extension,
+        &s2n_quic_transport_parameters_extension,
 };
 
 static const s2n_extension_type *const tls12_server_hello_extensions[] = {
@@ -83,6 +85,7 @@ static const s2n_extension_type *const encrypted_extensions[] = {
         &s2n_server_server_name_extension,
         &s2n_server_max_fragment_length_extension,
         &s2n_server_alpn_extension,
+        &s2n_quic_transport_parameters_extension,
 };
 
 static const s2n_extension_type *const cert_req_extensions[] = {

--- a/tls/extensions/s2n_quic_transport_params.c
+++ b/tls/extensions/s2n_quic_transport_params.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "tls/extensions/s2n_quic_transport_params.h"
+
+#include "tls/s2n_connection.h"
+#include "tls/s2n_tls.h"
+
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+/*
+ * The quic_transport_params extension is required by the QUIC protocol to
+ * negotiate additional connection parameters when using S2N.
+ *
+ * This extension should not be sent or received unless using S2N with QUIC.
+ * S2N treats the extension data as opaque bytes and performs no validation.
+ */
+
+static bool s2n_quic_transport_params_should_send(struct s2n_connection *conn)
+{
+    return conn && conn->quic_enabled;
+}
+
+static int s2n_quic_transport_params_if_missing(struct s2n_connection *conn)
+{
+    notnull_check(conn);
+    ENSURE_POSIX(!conn->quic_enabled, S2N_ERR_MISSING_EXTENSION);
+    return S2N_SUCCESS;
+}
+
+static int s2n_quic_transport_params_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    notnull_check(conn);
+    notnull_check(out);
+
+    if (conn->our_quic_transport_parameters.size) {
+        GUARD(s2n_stuffer_write(out, &conn->our_quic_transport_parameters));
+    }
+    return S2N_SUCCESS;
+}
+
+static int s2n_quic_transport_params_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    notnull_check(conn);
+    notnull_check(extension);
+    ENSURE_POSIX(conn->quic_enabled, S2N_ERR_UNSUPPORTED_EXTENSION);
+
+    if (s2n_stuffer_data_available(extension)) {
+        GUARD(s2n_alloc(&conn->peer_quic_transport_parameters, s2n_stuffer_data_available(extension)));
+        GUARD(s2n_stuffer_read(extension, &conn->peer_quic_transport_parameters));
+    }
+    return S2N_SUCCESS;
+}
+
+const s2n_extension_type s2n_quic_transport_parameters_extension = {
+    .iana_value = TLS_QUIC_TRANSPORT_PARAMETERS,
+    .is_response = false,
+    .send = s2n_quic_transport_params_send,
+    .recv = s2n_quic_transport_params_recv,
+    .should_send = s2n_quic_transport_params_should_send,
+    .if_missing = s2n_quic_transport_params_if_missing,
+};

--- a/tls/extensions/s2n_quic_transport_params.h
+++ b/tls/extensions/s2n_quic_transport_params.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include "tls/extensions/s2n_extension_type.h"
+
+extern const s2n_extension_type s2n_quic_transport_parameters_extension;

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -465,6 +465,8 @@ int s2n_connection_free(struct s2n_connection *conn)
 
     GUARD(s2n_free(&conn->client_ticket));
     GUARD(s2n_free(&conn->status_response));
+    GUARD(s2n_free(&conn->our_quic_transport_parameters));
+    GUARD(s2n_free(&conn->peer_quic_transport_parameters));
     GUARD(s2n_stuffer_free(&conn->in));
     GUARD(s2n_stuffer_free(&conn->out));
     GUARD(s2n_stuffer_free(&conn->handshake.io));
@@ -580,6 +582,7 @@ int s2n_connection_free_handshake(struct s2n_connection *conn)
     /* We can free extension data we no longer need */
     GUARD(s2n_free(&conn->client_ticket));
     GUARD(s2n_free(&conn->status_response));
+    GUARD(s2n_free(&conn->our_quic_transport_parameters));
     GUARD(s2n_free(&conn->application_protocols_overridden));
     GUARD(s2n_stuffer_free(&conn->cookie_stuffer));
 
@@ -630,6 +633,8 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     GUARD(s2n_free(&conn->client_ticket));
     GUARD(s2n_free(&conn->status_response));
     GUARD(s2n_free(&conn->application_protocols_overridden));
+    GUARD(s2n_free(&conn->our_quic_transport_parameters));
+    GUARD(s2n_free(&conn->peer_quic_transport_parameters));
 
     /* Allocate memory for handling handshakes */
     GUARD(s2n_stuffer_resize(&conn->handshake.io, S2N_LARGE_RECORD_LENGTH));

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -275,6 +275,10 @@ struct s2n_connection {
     s2n_ct_support_level ct_level_requested;
     struct s2n_blob ct_response;
 
+    /* QUIC transport parameters data: https://tools.ietf.org/html/draft-ietf-quic-tls-29#section-8.2 */
+    struct s2n_blob our_quic_transport_parameters;
+    struct s2n_blob peer_quic_transport_parameters;
+
     struct s2n_client_hello client_hello;
 
     struct s2n_x509_validator x509_validator;

--- a/tls/s2n_quic_support.c
+++ b/tls/s2n_quic_support.c
@@ -17,6 +17,8 @@
 
 #include "tls/s2n_connection.h"
 #include "tls/s2n_tls13.h"
+
+#include "utils/s2n_mem.h"
 #include "utils/s2n_safety.h"
 
 int s2n_connection_enable_quic(struct s2n_connection *conn)
@@ -26,5 +28,30 @@ int s2n_connection_enable_quic(struct s2n_connection *conn)
 
     notnull_check(conn);
     conn->quic_enabled = true;
+    return S2N_SUCCESS;
+}
+
+int s2n_connection_set_quic_transport_parameters(struct s2n_connection *conn,
+        const uint8_t *data_buffer, uint16_t data_len)
+{
+    notnull_check(conn);
+
+    GUARD(s2n_free(&conn->our_quic_transport_parameters));
+    GUARD(s2n_alloc(&conn->our_quic_transport_parameters, data_len));
+    memcpy_check(conn->our_quic_transport_parameters.data, data_buffer, data_len);
+
+    return S2N_SUCCESS;
+}
+
+int s2n_connection_get_quic_transport_parameters(struct s2n_connection *conn,
+        const uint8_t **data_buffer, uint16_t *data_len)
+{
+    notnull_check(conn);
+    notnull_check(data_buffer);
+    notnull_check(data_len);
+
+    *data_buffer = conn->peer_quic_transport_parameters.data;
+    *data_len = conn->peer_quic_transport_parameters.size;
+
     return S2N_SUCCESS;
 }

--- a/tls/s2n_quic_support.h
+++ b/tls/s2n_quic_support.h
@@ -30,3 +30,20 @@
  */
 
 S2N_API int s2n_connection_enable_quic(struct s2n_connection *conn);
+
+/*
+ * Set the data to be sent in the quic_transport_parameters extension.
+ * The data provided will be copied into a buffer owned by S2N.
+ */
+S2N_API int s2n_connection_set_quic_transport_parameters(struct s2n_connection *conn,
+        const uint8_t *data_buffer, uint16_t data_len);
+
+/*
+ * Retrieve the data from the peer's quic_transport_parameters extension.
+ * data_buffer will be set to a buffer owned by S2N which will be freed when the connection is freed.
+ * data_len will be set to the length of the data returned.
+ *
+ * S2N treats the extension data as opaque bytes and performs no validation.
+ */
+S2N_API int s2n_connection_get_quic_transport_parameters(struct s2n_connection *conn,
+        const uint8_t **data_buffer, uint16_t *data_len);

--- a/tls/s2n_tls_parameters.h
+++ b/tls/s2n_tls_parameters.h
@@ -109,6 +109,9 @@
 #define TLS_EXTENSION_COOKIE               44
 #define TLS_EXTENSION_KEY_SHARE            51
 
+/* QUIC-TLS extension from https://tools.ietf.org/html/draft-ietf-quic-tls-29#section-8.2 */
+#define TLS_QUIC_TRANSPORT_PARAMETERS      65535
+
 /* TLS Signature Algorithms - RFC 5246 7.4.1.4.1 */
 /* https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-16 */
 #define TLS_SIGNATURE_ALGORITHM_ANONYMOUS   0


### PR DESCRIPTION
### Resolved issues:

resolves https://github.com/awslabs/s2n/issues/2279

### Description of changes: 

Adds a new extension required by QUIC and the APIs to configure it.

### Call-outs:

* Changes to s2n_client_hello_test.c: The client needs to have quic enabled so that it will send the required extension, otherwise processing the ClientHello fails on the missing extension instead of on the wrong protocol version.

### Testing:

New unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
