### PR TITLE
Improves slow s2n_stuffer CBMC-proofs

### DIFF
--- a/tests/cbmc/proofs/s2n_stuffer_writev_bytes/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_writev_bytes/Makefile
@@ -26,6 +26,7 @@ PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
 PROOF_SOURCES += $(PROOF_STUB)/madvise.c
+PROOF_SOURCES += $(PROOF_STUB)/memcpy_havoc.c
 PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c

--- a/tests/cbmc/stubs/memcpy_havoc.c
+++ b/tests/cbmc/stubs/memcpy_havoc.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ #undef memcpy
+
+ #include <cbmc_proof/nondet.h>
+ #include <stdint.h>
+
+ /**
+  * Override the version of memcpy used by CBMC. Users may not want to pay
+  * for the cost of performing the computation of memcpy in proofs. In that
+  * case, this stub at least checks for the preconditions and make sure to
+  * havoc all elements pointed by *dst up to n.
+  */
+ void *memcpy_impl(void *dst, const void *src, size_t n) {
+     __CPROVER_precondition(
+         __CPROVER_POINTER_OBJECT(dst) != __CPROVER_POINTER_OBJECT(src) ||
+             ((const char *)src >= (const char *)dst + n) || ((const char *)dst >= (const char *)src + n),
+         "memcpy src/dst overlap");
+     __CPROVER_precondition(src != NULL && __CPROVER_r_ok(src, n), "memcpy source region readable");
+     __CPROVER_precondition(dst != NULL && __CPROVER_w_ok(dst, n), "memcpy destination region writeable");
+
+     if (n > 0) {
+         size_t index;
+         __CPROVER_assume(index < n);
+         ((uint8_t *)dst)[index] = nondet_uint8_t();
+     }
+     return dst;
+ }
+
+ void *memcpy(void *dst, const void *src, size_t n) {
+     return memcpy_impl(dst, src, n);
+ }
+
+ void *__builtin___memcpy_chk(void *dst, const void *src, __CPROVER_size_t n, __CPROVER_size_t size) {
+     (void)size;
+     return memcpy_impl(dst, src, n);
+ }

--- a/tests/cbmc/stubs/memcpy_havoc.c
+++ b/tests/cbmc/stubs/memcpy_havoc.c
@@ -19,10 +19,10 @@
  #include <stdint.h>
 
  /**
-  * Override the version of memcpy used by CBMC. Users may not want to pay
-  * for the cost of performing the computation of memcpy in proofs. In that
-  * case, this stub at least checks for the preconditions and make sure to
-  * havoc all elements pointed by *dst up to n.
+  * Overrides the version of memcpy used by CBMC. Users may not want to pay
+  * for the cost of performing the computation of memcpy in proofs.
+  * In that case, this stub at least checks for the preconditions and
+  * assigns arbitrary values to *dst.
   */
  void *memcpy_impl(void *dst, const void *src, size_t n) {
      __CPROVER_precondition(
@@ -32,11 +32,7 @@
      __CPROVER_precondition(src != NULL && __CPROVER_r_ok(src, n), "memcpy source region readable");
      __CPROVER_precondition(dst != NULL && __CPROVER_w_ok(dst, n), "memcpy destination region writeable");
 
-     if (n > 0) {
-         size_t index;
-         __CPROVER_assume(index < n);
-         ((uint8_t *)dst)[index] = nondet_uint8_t();
-     }
+     __CPROVER_havoc_object(dst);
      return dst;
  }
 


### PR DESCRIPTION
### Resolved issues:

N/A.

### Description of changes: 

There are 3 proofs that could take up to 4-6hrs to run:
 - `s2n_stuffer_writev_bytes` needed a stub for memcpy;
 - `s2n_stuffer_write_reservation` and `s2n_stuffer_write_vector_size` proofs had an expensive validity function. More details available in https://github.com/awslabs/s2n/issues/2290.

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
