### PR TITLE
Fix legacy_session_id for middlebox compat mode

### DIFF
--- a/tests/unit/s2n_client_hello_retry_test.c
+++ b/tests/unit/s2n_client_hello_retry_test.c
@@ -303,6 +303,7 @@ int main(int argc, char **argv)
                     EXPECT_SUCCESS(s2n_client_hello_send(conn));
 
                     EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->handshake.io));
+                    conn->session_id_len = 0; /* Wipe the session id to match the HRR hex */
 
                     /* Server responds with HRR indicating p256+BIKE as choice for negotiation;
                      * the last 6 bytes (0033 0002 2F23) are the key share extension with p256+BIKE */

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -40,7 +40,9 @@
 #define ZERO_TO_THIRTY_ONE 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, \
                             0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F
 
-#define LENGTH_TO_CIPHER_LIST (S2N_TLS_PROTOCOL_VERSION_LEN + S2N_TLS_RANDOM_DATA_LEN + 1)
+#define LENGTH_TO_SESSION_ID (S2N_TLS_PROTOCOL_VERSION_LEN + S2N_TLS_RANDOM_DATA_LEN)
+#define TLS12_LENGTH_TO_CIPHER_LIST (LENGTH_TO_SESSION_ID + 1)
+#define TLS13_LENGTH_TO_CIPHER_LIST (TLS12_LENGTH_TO_CIPHER_LIST + S2N_TLS_SESSION_ID_MAX_LEN)
 
 int main(int argc, char **argv)
 {
@@ -130,6 +132,122 @@ int main(int argc, char **argv)
         s2n_disable_tls13();
     }
 
+    /* Test generating session id */
+    {
+        const uint8_t test_session_id[S2N_TLS_SESSION_ID_MAX_LEN] = { 7 };
+
+        /* Use session id if already generated */
+        for(uint8_t i = S2N_TLS10; i <= S2N_TLS13; i++) {
+            if (i >= S2N_TLS13) {
+                EXPECT_SUCCESS(s2n_enable_tls13());
+            }
+
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
+
+            conn->session_id_len = S2N_TLS_SESSION_ID_MAX_LEN;
+            EXPECT_MEMCPY_SUCCESS(conn->session_id, test_session_id, S2N_TLS_SESSION_ID_MAX_LEN);
+
+            EXPECT_SUCCESS(s2n_client_hello_send(conn));
+            EXPECT_SUCCESS(s2n_stuffer_skip_read(hello_stuffer, LENGTH_TO_SESSION_ID));
+
+            uint8_t session_id_length = 0;
+            EXPECT_SUCCESS(s2n_stuffer_read_uint8(hello_stuffer, &session_id_length));
+            EXPECT_EQUAL(session_id_length, S2N_TLS_SESSION_ID_MAX_LEN);
+
+            uint8_t *session_id;
+            EXPECT_NOT_NULL(session_id = s2n_stuffer_raw_read(hello_stuffer, S2N_TLS_SESSION_ID_MAX_LEN));
+            EXPECT_BYTEARRAY_EQUAL(session_id, test_session_id, S2N_TLS_SESSION_ID_MAX_LEN);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+        EXPECT_SUCCESS(s2n_disable_tls13());
+
+        /* With TLS1.3 */
+        {
+            EXPECT_SUCCESS(s2n_enable_tls13());
+
+            /* Generate a session id by default */
+            {
+                struct s2n_connection *conn;
+                EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+                struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
+
+                EXPECT_SUCCESS(s2n_client_hello_send(conn));
+                EXPECT_SUCCESS(s2n_stuffer_skip_read(hello_stuffer, LENGTH_TO_SESSION_ID));
+
+                uint8_t session_id_length = 0;
+                EXPECT_SUCCESS(s2n_stuffer_read_uint8(hello_stuffer, &session_id_length));
+                EXPECT_EQUAL(session_id_length, S2N_TLS_SESSION_ID_MAX_LEN);
+
+                EXPECT_SUCCESS(s2n_connection_free(conn));
+            }
+
+            /* Do NOT generate a session id if middlebox compatibility mode is disabled.
+             * For now, middlebox compatibility mode is only disabled by QUIC.
+             */
+            {
+                struct s2n_connection *conn;
+                EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+                EXPECT_SUCCESS(s2n_connection_enable_quic(conn));
+                struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
+
+                EXPECT_SUCCESS(s2n_client_hello_send(conn));
+                EXPECT_SUCCESS(s2n_stuffer_skip_read(hello_stuffer, LENGTH_TO_SESSION_ID));
+
+                uint8_t session_id_length = 0;
+                EXPECT_SUCCESS(s2n_stuffer_read_uint8(hello_stuffer, &session_id_length));
+                EXPECT_EQUAL(session_id_length, 0);
+
+                EXPECT_SUCCESS(s2n_connection_free(conn));
+            }
+
+            EXPECT_SUCCESS(s2n_disable_tls13());
+        }
+
+        /* With TLS1.2 */
+        {
+            /* Do NOT generate a session id by default */
+            {
+                struct s2n_connection *conn;
+                EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+                struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
+
+                EXPECT_SUCCESS(s2n_client_hello_send(conn));
+                EXPECT_SUCCESS(s2n_stuffer_skip_read(hello_stuffer, LENGTH_TO_SESSION_ID));
+
+                uint8_t session_id_length = 0;
+                EXPECT_SUCCESS(s2n_stuffer_read_uint8(hello_stuffer, &session_id_length));
+                EXPECT_EQUAL(session_id_length, 0);
+
+                EXPECT_SUCCESS(s2n_connection_free(conn));
+            }
+
+            /* Generate a session id if using tickets */
+            {
+                struct s2n_config *config;
+                EXPECT_NOT_NULL(config = s2n_config_new());
+                EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(config, true));
+
+                struct s2n_connection *conn;
+                EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+                EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+                struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
+
+                EXPECT_SUCCESS(s2n_client_hello_send(conn));
+                EXPECT_SUCCESS(s2n_stuffer_skip_read(hello_stuffer, LENGTH_TO_SESSION_ID));
+
+                uint8_t session_id_length = 0;
+                EXPECT_SUCCESS(s2n_stuffer_read_uint8(hello_stuffer, &session_id_length));
+                EXPECT_EQUAL(session_id_length, S2N_TLS_SESSION_ID_MAX_LEN);
+
+                EXPECT_SUCCESS(s2n_connection_free(conn));
+                EXPECT_SUCCESS(s2n_config_free(config));
+            }
+        }
+    }
+
     /* Test cipher suites list */
     {
         /* When TLS 1.3 NOT supported */
@@ -142,7 +260,8 @@ int main(int argc, char **argv)
                 struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
 
                 EXPECT_SUCCESS(s2n_client_hello_send(conn));
-                EXPECT_SUCCESS(s2n_stuffer_skip_read(hello_stuffer, LENGTH_TO_CIPHER_LIST));
+                EXPECT_TRUE(conn->client_protocol_version < S2N_TLS13);
+                EXPECT_SUCCESS(s2n_stuffer_skip_read(hello_stuffer, TLS12_LENGTH_TO_CIPHER_LIST));
 
                 uint16_t list_length = 0;
                 EXPECT_SUCCESS(s2n_stuffer_read_uint16(hello_stuffer, &list_length));
@@ -167,7 +286,8 @@ int main(int argc, char **argv)
                 struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
 
                 EXPECT_SUCCESS(s2n_client_hello_send(conn));
-                EXPECT_SUCCESS(s2n_stuffer_skip_read(hello_stuffer, LENGTH_TO_CIPHER_LIST));
+                EXPECT_TRUE(conn->client_protocol_version < S2N_TLS13);
+                EXPECT_SUCCESS(s2n_stuffer_skip_read(hello_stuffer, TLS12_LENGTH_TO_CIPHER_LIST));
 
                 uint16_t list_length = 0;
                 EXPECT_SUCCESS(s2n_stuffer_read_uint16(hello_stuffer, &list_length));
@@ -202,8 +322,8 @@ int main(int argc, char **argv)
 
                 EXPECT_SUCCESS(s2n_client_hello_send(conn));
 
-                EXPECT_SUCCESS(s2n_stuffer_skip_read(hello_stuffer, LENGTH_TO_CIPHER_LIST));
-                EXPECT_EQUAL(conn->actual_protocol_version, S2N_TLS13);
+                EXPECT_TRUE(conn->actual_protocol_version >= S2N_TLS13);
+                EXPECT_SUCCESS(s2n_stuffer_skip_read(hello_stuffer, TLS13_LENGTH_TO_CIPHER_LIST));
 
                 uint16_t list_length = 0;
                 EXPECT_SUCCESS(s2n_stuffer_read_uint16(hello_stuffer, &list_length));


### PR DESCRIPTION
### Resolved issues:

Related to https://github.com/awslabs/s2n/issues/2289

### Description of changes: 

When I went to update middlebox compatibility mode for QUIC, I found out that we weren't following TLS1.3 middlebox compatibility mode rules for the session_id/legacy_session_id field in the ClientHello. We never generated session_ids for TLS1.3, but the RFC requires that we always generate a session_id in middlebox compatibility mode in order to look more like a TLS1.2 session resumption.

From https://tools.ietf.org/html/rfc8446#section-4.1.3:

> legacy_session_id:  Versions of TLS before TLS 1.3 supported a
      "session resumption" feature which has been merged with pre-shared
      keys in this version (see Section 2.2).  A client which has a
      cached session ID set by a pre-TLS 1.3 server SHOULD set this
      field to that value.  In compatibility mode (see Appendix D.4),
      this field MUST be non-empty, so a client not offering a
      pre-TLS 1.3 session MUST generate a new 32-byte value.  This value
      need not be random but SHOULD be unpredictable to avoid
      implementations fixating on a specific value (also known as
      ossification).  Otherwise, it MUST be set as a zero-length vector
      (i.e., a zero-valued single byte length field).

This change corrects the behavior for non-QUIC TLS1.3.

### Testing:

New unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
