### PR TITLE
Add server functionality for sending PQ key shares

### DIFF
--- a/tests/unit/s2n_extensions_server_key_share_select_test.c
+++ b/tests/unit/s2n_extensions_server_key_share_select_test.c
@@ -20,106 +20,100 @@
 #include "tls/extensions/s2n_server_key_share.h"
 #include "tls/s2n_security_policies.h"
 
-int main(int argc, char **argv)
-{
-    struct s2n_connection *server_conn;
-
+/* These tests check the server's logic when selecting a keyshare and supporting group. */
+int main() {
     BEGIN_TEST();
 
     EXPECT_SUCCESS(s2n_enable_tls13());
 
-    /* These tests check the server's logic when selecting a keyshare and supporting group. */
-
+    /* If client and server have no mutually supported groups, abort the handshake without sending HRR. */
     {
-        /* If client and server have no mutually supported groups and no mutually supported
-         * keyshares, a Hello Retry Request is not sent. 
-         */
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
-
         EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
 
-        const struct s2n_ecc_preferences *ecc_pref = NULL;
-        EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(server_conn, &ecc_pref));
-        EXPECT_NOT_NULL(ecc_pref);
+        EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+        EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
 
-        for (int i = 0; i < ecc_pref->count; i++) {
-            EXPECT_NULL(server_conn->secure.client_ecc_evp_params[i].evp_pkey);
-            EXPECT_NULL(server_conn->secure.client_ecc_evp_params[i].negotiated_curve);
-            EXPECT_NULL(server_conn->secure.mutually_supported_curves[i]);
-        }
-
-        EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_server_key_share_select(server_conn), S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_server_key_share_select(server_conn),
+                S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
 
         EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
-        EXPECT_FALSE(s2n_is_hello_retry_message(server_conn));
+        EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
+        EXPECT_FALSE(s2n_is_hello_retry_handshake(server_conn));
+
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
     }
 
+    /* If client and server have no mutually supported groups but server received an ECC key share,
+     * a Hello Retry Request flag is not set and the server ignores the mutually supported keyshare. */
     {
-        /* If client and server have no mutually supported groups but client and server have 
-         * found mutually supported keyshares(erroneous behavior), a Hello Retry Request flag is not set and the server
-         * ignores the mutually supported keyshare. 
-         */ 
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
-
         EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
 
         const struct s2n_ecc_preferences *ecc_pref = NULL;
         EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(server_conn, &ecc_pref));
         EXPECT_NOT_NULL(ecc_pref);
 
+        EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+        EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
         server_conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
         EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.client_ecc_evp_params[0]));
 
-        EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_server_key_share_select(server_conn), S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_server_key_share_select(server_conn),
+                S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
 
         EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
-        EXPECT_FALSE(s2n_is_hello_retry_message(server_conn));
-        EXPECT_SUCCESS(s2n_connection_free(server_conn)); 
-    }
+        EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
+        EXPECT_FALSE(s2n_is_hello_retry_handshake(server_conn));
 
-    {
-        /* If client has sent no keys but server and client have found a mutually supported group,
-         * send Hello Retry Request. 
-         */ 
-        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-
-        EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
-
-        const struct s2n_ecc_preferences *ecc_pref = NULL;
-        EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(server_conn, &ecc_pref));
-        EXPECT_NOT_NULL(ecc_pref);
-
-        server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
-        server_conn->secure.mutually_supported_curves[0] = ecc_pref->ecc_curves[0];
-        for (int i = 0; i < ecc_pref->count; i++) {
-            EXPECT_NULL(server_conn->secure.client_ecc_evp_params[i].evp_pkey);
-            EXPECT_NULL(server_conn->secure.client_ecc_evp_params[i].negotiated_curve);
-        }
-        EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
-
-        EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[0]);
-
-        /* Verify that the handshake type was updated correctly */
-        EXPECT_TRUE(s2n_is_hello_retry_handshake(server_conn));
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
     }
 
+    /* If client has sent no keyshares, but server and client have a mutually supported EC curve,
+     * send Hello Retry Request. */
     {
-        /* When client and server mutually supported group 0 and group 1, but client has only sent a keyshare for
-         * group 1, Hello Retry Request is not sent and server chooses group 1.
-         */ 
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
-
         EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
 
         const struct s2n_ecc_preferences *ecc_pref = NULL;
         EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(server_conn, &ecc_pref));
         EXPECT_NOT_NULL(ecc_pref);
 
+        EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
+        server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[1];
+        EXPECT_NULL(server_conn->secure.mutually_supported_curves[0]);
+        server_conn->secure.mutually_supported_curves[1] = ecc_pref->ecc_curves[1];
+        for (size_t i = 0; i < ecc_pref->count; i++) {
+            EXPECT_NULL(server_conn->secure.client_ecc_evp_params[i].evp_pkey);
+            EXPECT_NULL(server_conn->secure.client_ecc_evp_params[i].negotiated_curve);
+        }
+
+        EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
+
+        EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[1]);
+        EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
+        EXPECT_TRUE(s2n_is_hello_retry_handshake(server_conn));
+
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+    }
+
+    /* When client and server mutually support curve 0 and curve 1, but client has only sent a keyshare for
+     * curve 1, Hello Retry Request is not sent and server chooses curve 1. */
+    {
+        struct s2n_connection *server_conn = NULL;
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
+
+        const struct s2n_ecc_preferences *ecc_pref = NULL;
+        EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(server_conn, &ecc_pref));
+        EXPECT_NOT_NULL(ecc_pref);
+
+        /* Server would have initially chosen curve[0] when processing the supported_groups extension */
+        EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
+        server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
         server_conn->secure.mutually_supported_curves[0] = ecc_pref->ecc_curves[0];
         server_conn->secure.mutually_supported_curves[1] = ecc_pref->ecc_curves[1];
 
@@ -130,34 +124,452 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
 
+        /* Server should have updated it's choice to curve[1] after taking received keyshares into account */
         EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[1]);
-        EXPECT_FALSE(s2n_is_hello_retry_message(server_conn));
+        EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
+        EXPECT_FALSE(s2n_is_hello_retry_handshake(server_conn));
+
         EXPECT_SUCCESS(s2n_connection_free(server_conn)); 
     }
 
+    /* When client and server mutually support curve 0 and curve 1 and client has sent keyshares for both,
+     * Hello Retry Request is not sent and server chooses curve 0. */
     {
-        /* When client and server mutually supported group 0 and client has sent a keyshare for group 0,
-         * Hello Retry Request is not sent and server chooses group 0.
-         */
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
-
         EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
 
         const struct s2n_ecc_preferences *ecc_pref = NULL;
         EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(server_conn, &ecc_pref));
         EXPECT_NOT_NULL(ecc_pref);
 
+        /* Server would have initially chosen curve[0] when processing the supported_groups extension */
+        EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
+        server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
         server_conn->secure.mutually_supported_curves[0] = ecc_pref->ecc_curves[0];
+        server_conn->secure.mutually_supported_curves[1] = ecc_pref->ecc_curves[1];
+
         server_conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
         EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.client_ecc_evp_params[0]));
+        server_conn->secure.client_ecc_evp_params[1].negotiated_curve = ecc_pref->ecc_curves[1];
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.client_ecc_evp_params[1]));
 
         EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
 
+        /* Server should still prefer curve[0] after taking received keyshares into account */
         EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[0]);
-        EXPECT_FALSE(s2n_is_hello_retry_message(server_conn));
-        EXPECT_SUCCESS(s2n_connection_free(server_conn)); 
-    } 
+        EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
+        EXPECT_FALSE(s2n_is_hello_retry_handshake(server_conn));
+
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+    }
+
+#if !defined(S2N_NO_PQ)
+    {
+        const struct s2n_kem_group *test_kem_groups[] = {
+                &s2n_secp256r1_sike_p434_r2,
+                &s2n_secp256r1_bike1_l1_r2,
+                &s2n_secp256r1_kyber_512_r2
+        };
+
+        const struct s2n_kem_preferences test_kem_pref = {
+                .kem_count = 0,
+                .kems = NULL,
+                .tls13_kem_group_count = s2n_array_len(test_kem_groups),
+                .tls13_kem_groups = test_kem_groups,
+        };
+
+        const struct s2n_security_policy test_security_policy = {
+                .minimum_protocol_version = S2N_SSLv3,
+                .cipher_preferences = &cipher_preferences_test_all_tls13,
+                .kem_preferences = &test_kem_pref,
+                .signature_preferences = &s2n_signature_preferences_20200207,
+                .ecc_preferences = &s2n_ecc_preferences_20200310,
+        };
+
+        /* If both server_curve and server_kem_group are set (erroneous behavior), we should
+         * error and abort the handshake. */
+        {
+            struct s2n_connection *server_conn = NULL;
+            EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+            server_conn->security_policy_override = &test_security_policy;
+            EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
+
+            const struct s2n_ecc_preferences *ecc_pref = NULL;
+            EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(server_conn, &ecc_pref));
+            EXPECT_NOT_NULL(ecc_pref);
+
+            const struct s2n_kem_preferences *kem_pref = NULL;
+            EXPECT_SUCCESS(s2n_connection_get_kem_preferences(server_conn, &kem_pref));
+            EXPECT_NOT_NULL(kem_pref);
+
+            server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+            server_conn->secure.server_kem_group_params.kem_group = kem_pref->tls13_kem_groups[0];
+
+            EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_server_key_share_select(server_conn),
+                    S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
+
+            EXPECT_FALSE(s2n_is_hello_retry_handshake(server_conn));
+
+            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        }
+
+        /* If client and server have no mutually supported groups but server received a KEM group key share,
+         * a Hello Retry Request flag is not set and the server ignores the keyshare. */
+        {
+            struct s2n_connection *server_conn = NULL;
+            EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+            server_conn->security_policy_override = &test_security_policy;
+            EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
+
+            const struct s2n_kem_preferences *kem_pref = NULL;
+            EXPECT_SUCCESS(s2n_connection_get_kem_preferences(server_conn, &kem_pref));
+            EXPECT_NOT_NULL(kem_pref);
+
+            /* Server would have not chosen any group when processing the supported_groups extension */
+            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
+
+            /* Received an erroneous keyshare for kem group 0 */
+            struct s2n_kem_group_params *client_params0 = &server_conn->secure.client_kem_group_params[0];
+            const struct s2n_kem_group *kem_group0 = kem_pref->tls13_kem_groups[0];
+            client_params0->kem_group = kem_group0;
+            client_params0->kem_params.kem = kem_group0->kem;
+            client_params0->ecc_params.negotiated_curve = kem_group0->curve;
+            EXPECT_SUCCESS(s2n_alloc(&client_params0->kem_params.public_key, kem_group0->kem->public_key_length));
+            EXPECT_SUCCESS(s2n_kem_generate_keypair(&client_params0->kem_params));
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_params0->ecc_params));
+
+            EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_server_key_share_select(server_conn),
+                    S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
+
+            /* Nothing selected, no HRR */
+            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
+            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_params.kem);
+            EXPECT_NULL(server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
+            EXPECT_NULL(server_conn->secure.chosen_client_kem_group_params);
+            EXPECT_FALSE(s2n_is_hello_retry_handshake(server_conn));
+
+            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        }
+
+        /* If client has sent no keyshares but server and client mutually support KEM group 1,
+         * select KEM group 1 and send Hello Retry Request. */
+        {
+            struct s2n_connection *server_conn = NULL;
+            EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+            server_conn->security_policy_override = &test_security_policy;
+            EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
+
+            const struct s2n_kem_preferences *kem_pref = NULL;
+            EXPECT_SUCCESS(s2n_connection_get_kem_preferences(server_conn, &kem_pref));
+            EXPECT_NOT_NULL(kem_pref);
+
+            /* Server would have initially chosen kem_group[1] when processing the supported_groups extension */
+            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+            struct s2n_kem_group_params *server_params = &server_conn->secure.server_kem_group_params;
+            const struct s2n_kem_group *kem_group1 = kem_pref->tls13_kem_groups[1];
+            server_params->kem_group = kem_group1;
+            server_params->kem_params.kem = kem_group1->kem;
+            server_params->ecc_params.negotiated_curve = kem_group1->curve;
+
+            /* 0 is not supported, 1 is */
+            EXPECT_NULL(server_conn->secure.mutually_supported_kem_groups[0]);
+            server_conn->secure.mutually_supported_kem_groups[1] = kem_group1;
+
+            /* No keyshares received */
+            for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
+                EXPECT_NULL(server_conn->secure.client_kem_group_params[i].kem_group);
+                EXPECT_NULL(server_conn->secure.client_kem_group_params[i].kem_params.kem);
+                EXPECT_NULL(server_conn->secure.client_kem_group_params[i].kem_params.public_key.data);
+                EXPECT_NULL(server_conn->secure.client_kem_group_params[i].ecc_params.negotiated_curve);
+                EXPECT_NULL(server_conn->secure.client_kem_group_params[i].ecc_params.evp_pkey);
+            }
+
+            EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
+
+            /* Server maintains its selection of KEM group 1, sends HRR */
+            EXPECT_EQUAL(server_params->kem_group, kem_group1);
+            EXPECT_EQUAL(server_params->kem_params.kem, kem_group1->kem);
+            EXPECT_EQUAL(server_params->ecc_params.negotiated_curve, kem_group1->curve);
+            EXPECT_NULL(server_conn->secure.chosen_client_kem_group_params);
+            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+            EXPECT_TRUE(s2n_is_hello_retry_handshake(server_conn));
+
+            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        }
+
+        /* When client and server mutually support KEM groups 0 and 1, but client has only sent a keyshare for
+         * KEM group 1, Hello Retry Request is not sent and server chooses group 1. */
+        {
+            struct s2n_connection *server_conn = NULL;
+            EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+            server_conn->security_policy_override = &test_security_policy;
+            EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
+
+            const struct s2n_kem_preferences *kem_pref = NULL;
+            EXPECT_SUCCESS(s2n_connection_get_kem_preferences(server_conn, &kem_pref));
+            EXPECT_NOT_NULL(kem_pref);
+
+            /* Server would have initially chosen kem_group[0] when processing the supported_groups extension */
+            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+            struct s2n_kem_group_params *server_params = &server_conn->secure.server_kem_group_params;
+            const struct s2n_kem_group *kem_group0 = kem_pref->tls13_kem_groups[0];
+            const struct s2n_kem_group *kem_group1 = kem_pref->tls13_kem_groups[1];
+            server_params->kem_group = kem_group0;
+            server_params->kem_params.kem = kem_group0->kem;
+            server_params->ecc_params.negotiated_curve = kem_group0->curve;
+
+            /* Both 0 and 1 supported */
+            server_conn->secure.mutually_supported_kem_groups[0] = kem_group0;
+            server_conn->secure.mutually_supported_kem_groups[1] = kem_group1;
+
+            /* Received a keyshare for 1 only */
+            EXPECT_NULL(server_conn->secure.client_kem_group_params[0].kem_group);
+            struct s2n_kem_group_params *client_params1 = &server_conn->secure.client_kem_group_params[1];
+            client_params1->kem_group = kem_group1;
+            client_params1->kem_params.kem = kem_group1->kem;
+            client_params1->ecc_params.negotiated_curve = kem_group1->curve;
+            EXPECT_SUCCESS(s2n_alloc(&client_params1->kem_params.public_key, kem_group1->kem->public_key_length));
+            EXPECT_SUCCESS(s2n_kem_generate_keypair(&client_params1->kem_params));
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_params1->ecc_params));
+
+            EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
+
+            /* Server should have updated it's choice to kem_group[1] after taking received keyshares into account */
+            EXPECT_EQUAL(server_params->kem_group, kem_group1);
+            EXPECT_EQUAL(server_params->kem_params.kem, kem_group1->kem);
+            EXPECT_EQUAL(server_params->ecc_params.negotiated_curve, kem_group1->curve);
+            EXPECT_EQUAL(server_conn->secure.chosen_client_kem_group_params, client_params1);
+            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+            EXPECT_FALSE(s2n_is_hello_retry_handshake(server_conn));
+
+            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        }
+
+        /* When client and server mutually support KEM groups 0,1,2 and client has sent keyshares for all,
+         * Hello Retry Request is not sent and server chooses group 0. */
+        {
+            struct s2n_connection *server_conn = NULL;
+            EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+            server_conn->security_policy_override = &test_security_policy;
+            EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
+
+            const struct s2n_kem_preferences *kem_pref = NULL;
+            EXPECT_SUCCESS(s2n_connection_get_kem_preferences(server_conn, &kem_pref));
+            EXPECT_NOT_NULL(kem_pref);
+
+            /* Server would have initially chosen kem_group[0] when processing the supported_groups extension */
+            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+            struct s2n_kem_group_params *server_params = &server_conn->secure.server_kem_group_params;
+            const struct s2n_kem_group *kem_group0 = kem_pref->tls13_kem_groups[0];
+            server_params->kem_group = kem_group0;
+            server_params->kem_params.kem = kem_group0->kem;
+            server_params->ecc_params.negotiated_curve = kem_group0->curve;
+
+            /* Support all KEM Groups; received key shares for all KEM groups */
+            for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
+                struct s2n_kem_group_params *client_params = &server_conn->secure.client_kem_group_params[i];
+                const struct s2n_kem_group *kem_group = kem_pref->tls13_kem_groups[i];
+
+                server_conn->secure.mutually_supported_kem_groups[i] = kem_group;
+
+                client_params->kem_group = kem_group;
+                client_params->kem_params.kem = kem_group->kem;
+                client_params->ecc_params.negotiated_curve = kem_group->curve;
+                EXPECT_SUCCESS(s2n_alloc(&client_params->kem_params.public_key, kem_group->kem->public_key_length));
+                EXPECT_SUCCESS(s2n_kem_generate_keypair(&client_params->kem_params));
+                EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_params->ecc_params));
+            }
+
+            EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
+
+            /* Server should still prefer kem_group[0] after taking received keyshares into account */
+            EXPECT_EQUAL(server_params->kem_group, kem_group0);
+            EXPECT_EQUAL(server_params->kem_params.kem, kem_group0->kem);
+            EXPECT_EQUAL(server_params->ecc_params.negotiated_curve, kem_group0->curve);
+            EXPECT_EQUAL(server_conn->secure.chosen_client_kem_group_params, &server_conn->secure.client_kem_group_params[0]);
+            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+            EXPECT_FALSE(s2n_is_hello_retry_handshake(server_conn));
+
+            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        }
+
+        /* When client and server mutually support all KEM groups and all curves, but client sent no keyshares,
+         * server should choose kem_group[0] and send HRR. */
+        {
+            struct s2n_connection *server_conn = NULL;
+            EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+            server_conn->security_policy_override = &test_security_policy;
+            EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
+
+            const struct s2n_ecc_preferences *ecc_pref = NULL;
+            EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(server_conn, &ecc_pref));
+            EXPECT_NOT_NULL(ecc_pref);
+
+            const struct s2n_kem_preferences *kem_pref = NULL;
+            EXPECT_SUCCESS(s2n_connection_get_kem_preferences(server_conn, &kem_pref));
+            EXPECT_NOT_NULL(kem_pref);
+
+            /* Server would have initially chosen kem_group[0] when processing the supported_groups extension */
+            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+            struct s2n_kem_group_params *server_params = &server_conn->secure.server_kem_group_params;
+            const struct s2n_kem_group *kem_group0 = kem_pref->tls13_kem_groups[0];
+            server_params->kem_group = kem_group0;
+            server_params->kem_params.kem = kem_group0->kem;
+            server_params->ecc_params.negotiated_curve = kem_group0->curve;
+
+            /* Support all KEM groups and all curves */
+            for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
+                server_conn->secure.mutually_supported_kem_groups[i] = kem_pref->tls13_kem_groups[i];
+            }
+            for (size_t i = 0; i < ecc_pref->count; i++) {
+                server_conn->secure.mutually_supported_curves[i] = ecc_pref->ecc_curves[i];
+            }
+
+            /* No keyshares received */
+            for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
+                EXPECT_NULL(server_conn->secure.client_kem_group_params[i].kem_group);
+                EXPECT_NULL(server_conn->secure.client_kem_group_params[i].kem_params.kem);
+                EXPECT_NULL(server_conn->secure.client_kem_group_params[i].kem_params.public_key.data);
+                EXPECT_NULL(server_conn->secure.client_kem_group_params[i].ecc_params.negotiated_curve);
+                EXPECT_NULL(server_conn->secure.client_kem_group_params[i].ecc_params.evp_pkey);
+            }
+
+            EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
+
+            /* Server should still prefer kem_group[0], and send HRR */
+            EXPECT_EQUAL(server_params->kem_group, kem_group0);
+            EXPECT_EQUAL(server_params->kem_params.kem, kem_group0->kem);
+            EXPECT_EQUAL(server_params->ecc_params.negotiated_curve, kem_group0->curve);
+            EXPECT_NULL(server_conn->secure.chosen_client_kem_group_params);
+            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+            EXPECT_TRUE(s2n_is_hello_retry_handshake(server_conn));
+
+            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        }
+
+        /* When client and server mutually support all KEM groups and all curves, and client sent keyshares
+         * for everything, server should choose kem_group[0] and not send HRR. */
+        {
+            struct s2n_connection *server_conn = NULL;
+            EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+            server_conn->security_policy_override = &test_security_policy;
+            EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
+
+            const struct s2n_ecc_preferences *ecc_pref = NULL;
+            EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(server_conn, &ecc_pref));
+            EXPECT_NOT_NULL(ecc_pref);
+
+            const struct s2n_kem_preferences *kem_pref = NULL;
+            EXPECT_SUCCESS(s2n_connection_get_kem_preferences(server_conn, &kem_pref));
+            EXPECT_NOT_NULL(kem_pref);
+
+            /* Server would have initially chosen kem_group[0] when processing the supported_groups extension */
+            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+            struct s2n_kem_group_params *server_params = &server_conn->secure.server_kem_group_params;
+            const struct s2n_kem_group *kem_group0 = kem_pref->tls13_kem_groups[0];;
+            server_params->kem_group = kem_group0;
+            server_params->kem_params.kem = kem_group0->kem;
+            server_params->ecc_params.negotiated_curve = kem_group0->curve;
+
+            /* Support all KEM groups and curves; received keyshares for everything */
+            for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
+                struct s2n_kem_group_params *client_params = &server_conn->secure.client_kem_group_params[i];
+                const struct s2n_kem_group *kem_group = kem_pref->tls13_kem_groups[i];
+
+                server_conn->secure.mutually_supported_kem_groups[i] = kem_pref->tls13_kem_groups[i];
+
+                client_params->kem_group = kem_group;
+                client_params->kem_params.kem = kem_group->kem;
+                client_params->ecc_params.negotiated_curve = kem_group->curve;
+                EXPECT_SUCCESS(s2n_alloc(&client_params->kem_params.public_key, kem_group->kem->public_key_length));
+                EXPECT_SUCCESS(s2n_kem_generate_keypair(&client_params->kem_params));
+                EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_params->ecc_params));
+            }
+            for (size_t i = 0; i < ecc_pref->count; i++) {
+                struct s2n_ecc_evp_params *client_params = &server_conn->secure.client_ecc_evp_params[i];
+                const struct s2n_ecc_named_curve *curve = ecc_pref->ecc_curves[i];
+
+                server_conn->secure.mutually_supported_curves[i] = curve;
+
+                client_params->negotiated_curve = curve;
+                EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(client_params));
+            }
+
+            EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
+
+            /* Server should still prefer kem_group[0], no HRR */
+            EXPECT_EQUAL(server_params->kem_group, kem_group0);
+            EXPECT_EQUAL(server_params->kem_params.kem, kem_group0->kem);
+            EXPECT_EQUAL(server_params->ecc_params.negotiated_curve, kem_group0->curve);
+            EXPECT_EQUAL(server_conn->secure.chosen_client_kem_group_params, &server_conn->secure.client_kem_group_params[0]);
+            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+            EXPECT_FALSE(s2n_is_hello_retry_handshake(server_conn));
+
+            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        }
+
+        /* When client and server mutually support all KEM groups and all curves, but client sent keyshares
+         * only for ECC, server should choose curves[0] and not send HRR. */
+        {
+            struct s2n_connection *server_conn = NULL;
+            EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+            server_conn->security_policy_override = &test_security_policy;
+            EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
+
+            const struct s2n_ecc_preferences *ecc_pref = NULL;
+            EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(server_conn, &ecc_pref));
+            EXPECT_NOT_NULL(ecc_pref);
+
+            const struct s2n_kem_preferences *kem_pref = NULL;
+            EXPECT_SUCCESS(s2n_connection_get_kem_preferences(server_conn, &kem_pref));
+            EXPECT_NOT_NULL(kem_pref);
+
+            /* Server would have initially chosen kem_group[0] when processing the supported_groups extension */
+            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+            struct s2n_kem_group_params *server_params = &server_conn->secure.server_kem_group_params;
+            const struct s2n_kem_group *kem_group0 = kem_pref->tls13_kem_groups[0];;
+            server_params->kem_group = kem_group0;
+            server_params->kem_params.kem = kem_group0->kem;
+            server_params->ecc_params.negotiated_curve = kem_group0->curve;
+
+            /* Support all KEM groups, but no keyshares received */
+            for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
+                server_conn->secure.mutually_supported_kem_groups[i] = kem_pref->tls13_kem_groups[i];
+
+                EXPECT_NULL(server_conn->secure.client_kem_group_params[i].kem_group);
+                EXPECT_NULL(server_conn->secure.client_kem_group_params[i].kem_params.kem);
+                EXPECT_NULL(server_conn->secure.client_kem_group_params[i].kem_params.public_key.data);
+                EXPECT_NULL(server_conn->secure.client_kem_group_params[i].ecc_params.negotiated_curve);
+                EXPECT_NULL(server_conn->secure.client_kem_group_params[i].ecc_params.evp_pkey);
+            }
+            /* Support all curves, and all keyshares received */
+            for (size_t i = 0; i < ecc_pref->count; i++) {
+                struct s2n_ecc_evp_params *client_params = &server_conn->secure.client_ecc_evp_params[i];
+                const struct s2n_ecc_named_curve *curve = ecc_pref->ecc_curves[i];
+
+                server_conn->secure.mutually_supported_curves[i] = curve;
+
+                client_params->negotiated_curve = curve;
+                EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(client_params));
+            }
+
+            EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
+
+            /* Server should update it's choice to curve[0], no HRR */
+            EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[0]);
+            EXPECT_NULL(server_params->kem_group);
+            EXPECT_NULL(server_params->kem_params.kem);
+            EXPECT_NULL(server_params->ecc_params.negotiated_curve);
+            EXPECT_NULL(server_conn->secure.chosen_client_kem_group_params);
+            EXPECT_FALSE(s2n_is_hello_retry_handshake(server_conn));
+
+            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        }
+    }
+#endif
 
     END_TEST();
     return 0;

--- a/tests/unit/s2n_server_key_share_extension_test.c
+++ b/tests/unit/s2n_server_key_share_extension_test.c
@@ -862,8 +862,8 @@ int main(int argc, char **argv)
                 EXPECT_EQUAL(server_params->kem_group, kem_group);
                 EXPECT_EQUAL(server_params->kem_params.kem, kem_group->kem);
                 EXPECT_EQUAL(server_params->ecc_params.negotiated_curve, kem_group->curve);
-                EXPECT_EQUAL(server_params->kem_params.shared_secret.size, kem_group->kem->shared_secret_key_length);
-                EXPECT_NOT_NULL(server_params->kem_params.shared_secret.data);
+                EXPECT_EQUAL(client_params->kem_params.shared_secret.size, kem_group->kem->shared_secret_key_length);
+                EXPECT_NOT_NULL(client_params->kem_params.shared_secret.data);
 
                 EXPECT_SUCCESS(s2n_connection_free(conn));
             }

--- a/tests/unit/s2n_server_key_share_extension_test.c
+++ b/tests/unit/s2n_server_key_share_extension_test.c
@@ -31,12 +31,8 @@
 
 #define HELLO_RETRY_MSG_NO 1
 
-#define S2N_STUFFER_READ_SKIP_TILL_END( stuffer ) do { \
-    EXPECT_SUCCESS(s2n_stuffer_skip_read(stuffer,      \
-        s2n_stuffer_data_available(stuffer)));         \
-} while (0)
-
-int s2n_extensions_server_key_share_send_check(struct s2n_connection *conn);
+int s2n_server_key_share_send_check_pq_hybrid(struct s2n_connection *conn);
+int s2n_server_key_share_send_check_ecdhe(struct s2n_connection *conn);
 
 #if !defined(S2N_NO_PQ)
 static int s2n_read_server_key_share_hybrid_test_vectors(const struct s2n_kem_group *kem_group, struct s2n_blob *pq_private_key,
@@ -48,26 +44,41 @@ int main(int argc, char **argv)
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_enable_tls13());
 
-    /* Test s2n_extensions_server_key_share_send_check */
+    /* Test s2n_server_key_share_send_check_ecdhe */
     {
-        struct s2n_connection *conn;
+        struct s2n_security_policy test_security_policy_no_x25519 = {
+                .minimum_protocol_version = S2N_TLS10,
+                .cipher_preferences = &cipher_preferences_test_all_tls13,
+                .kem_preferences = &kem_preferences_null,
+                .signature_preferences = &s2n_signature_preferences_20200207,
+                .ecc_preferences = &s2n_ecc_preferences_20140601,
+        };
+
+        struct s2n_connection *conn = NULL;
+        EXPECT_FAILURE(s2n_server_key_share_send_check_ecdhe(conn));
 
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+        conn->security_policy_override = &test_security_policy_no_x25519;
+
+        EXPECT_FAILURE(s2n_server_key_share_send_check_ecdhe(conn));
+
+        if (s2n_is_evp_apis_supported()) {
+            conn->secure.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_x25519;
+            EXPECT_FAILURE(s2n_server_key_share_send_check_ecdhe(conn));
+        }
 
         const struct s2n_ecc_preferences *ecc_pref = NULL;
         EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
         EXPECT_NOT_NULL(ecc_pref);
 
-        EXPECT_FAILURE(s2n_extensions_server_key_share_send_check(conn));
-
         conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
-        EXPECT_FAILURE(s2n_extensions_server_key_share_send_check(conn));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_send_check_ecdhe(conn), S2N_ERR_BAD_KEY_SHARE);
 
         conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
-        EXPECT_FAILURE(s2n_extensions_server_key_share_send_check(conn));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_send_check_ecdhe(conn), S2N_ERR_BAD_KEY_SHARE);
 
         EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
-        EXPECT_SUCCESS(s2n_extensions_server_key_share_send_check(conn));
+        EXPECT_SUCCESS(s2n_server_key_share_send_check_ecdhe(conn));
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
@@ -101,35 +112,66 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
-    /* Test s2n_server_key_share_extension.send */
+    /* Test s2n_server_key_share_extension.send sends key share success (ECDHE) */
     {
-        struct s2n_connection *conn;
-
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
         const struct s2n_ecc_preferences *ecc_pref = NULL;
         EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
         EXPECT_NOT_NULL(ecc_pref);
 
-        struct s2n_stuffer* extension_stuffer = &conn->handshake.io;
+        EXPECT_NULL(conn->secure.server_kem_group_params.kem_group);
+        DEFER_CLEANUP(struct s2n_stuffer stuffer = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 1024));
 
-        /* Error if no curve have been selected */
-        EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.send(conn, extension_stuffer), S2N_ERR_NULL);
-
-        S2N_STUFFER_READ_SKIP_TILL_END(extension_stuffer);
-
-        for (int i = 0; i < ecc_pref->count; i++) {
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[i];
-            conn->secure.client_ecc_evp_params[i].negotiated_curve = ecc_pref->ecc_curves[i];
+        for (size_t i = 0; i < ecc_pref->count; i++) {
+            const struct s2n_ecc_named_curve *curve = ecc_pref->ecc_curves[i];
+            conn->secure.server_ecc_evp_params.negotiated_curve = curve;
+            conn->secure.client_ecc_evp_params[i].negotiated_curve = curve;
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[i]));
-            EXPECT_SUCCESS(s2n_server_key_share_extension.send(conn, extension_stuffer));
 
-            S2N_STUFFER_READ_EXPECT_EQUAL(extension_stuffer, ecc_pref->ecc_curves[i]->iana_id, uint16);
-            S2N_STUFFER_READ_EXPECT_EQUAL(extension_stuffer, ecc_pref->ecc_curves[i]->share_size, uint16);
-            S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(extension_stuffer, ecc_pref->ecc_curves[i]->share_size);
+            EXPECT_SUCCESS(s2n_server_key_share_extension.send(conn, &stuffer));
 
-            EXPECT_EQUAL(conn->secure.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[i]);
+            S2N_STUFFER_READ_EXPECT_EQUAL(&stuffer, curve->iana_id, uint16);
+            S2N_STUFFER_READ_EXPECT_EQUAL(&stuffer, curve->share_size, uint16);
+            S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(&stuffer, curve->share_size);
+            EXPECT_NULL(conn->secure.server_kem_group_params.kem_group);
+            EXPECT_EQUAL(conn->secure.server_ecc_evp_params.negotiated_curve, curve);
             EXPECT_SUCCESS(s2n_ecc_evp_params_free(&conn->secure.server_ecc_evp_params));
+            EXPECT_SUCCESS(s2n_ecc_evp_params_free(&conn->secure.client_ecc_evp_params[i]));
+        }
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test s2n_server_key_share_extension.send sends IANA ID for HRR (ECDHE) */
+    {
+        struct s2n_connection *conn = NULL;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+        conn->actual_protocol_version = S2N_TLS13;
+        conn->handshake.handshake_type = HELLO_RETRY_REQUEST;
+        conn->handshake.message_number = HELLO_RETRY_MSG_NO;
+
+        const struct s2n_ecc_preferences *ecc_pref = NULL;
+        EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+        EXPECT_NOT_NULL(ecc_pref);
+
+        EXPECT_NULL(conn->secure.server_kem_group_params.kem_group);
+        DEFER_CLEANUP(struct s2n_stuffer stuffer = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 1024));
+
+        for (size_t i = 0; i < ecc_pref->count; i++) {
+            const struct s2n_ecc_named_curve *curve = ecc_pref->ecc_curves[i];
+            conn->secure.server_ecc_evp_params.negotiated_curve = curve;
+            EXPECT_NULL(conn->secure.server_ecc_evp_params.evp_pkey);
+
+            EXPECT_SUCCESS(s2n_server_key_share_extension.send(conn, &stuffer));
+
+            S2N_STUFFER_READ_EXPECT_EQUAL(&stuffer, curve->iana_id, uint16);
+            EXPECT_EQUAL(0, s2n_stuffer_data_available(&stuffer));
+            EXPECT_EQUAL(conn->secure.server_ecc_evp_params.negotiated_curve, curve);
+            EXPECT_NULL(conn->secure.server_ecc_evp_params.evp_pkey);
         }
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -137,30 +179,20 @@ int main(int argc, char **argv)
 
     /* Test s2n_server_key_share_extension.send for failures */
     {
-        struct s2n_connection *conn;
+        EXPECT_FAILURE(s2n_server_key_share_extension.send(NULL, NULL));
 
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-        struct s2n_stuffer* extension_stuffer = &conn->handshake.io;
+        EXPECT_FAILURE(s2n_server_key_share_extension.send(conn, NULL));
 
-        const struct s2n_ecc_preferences *ecc_pref = NULL;
-        EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
-        EXPECT_NOT_NULL(ecc_pref);
+        DEFER_CLEANUP(struct s2n_stuffer stuffer = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
-        EXPECT_FAILURE(s2n_server_key_share_extension.send(conn, extension_stuffer));
+        /* Error if both curve and kem_group are NULL */
+        conn->secure.server_ecc_evp_params.negotiated_curve = NULL;
+        conn->secure.server_kem_group_params.kem_group = NULL;
+        EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.send(conn, &stuffer), S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
 
-        conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
-        EXPECT_FAILURE(s2n_server_key_share_extension.send(conn, extension_stuffer));
-
-        conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
-        EXPECT_FAILURE(s2n_server_key_share_extension.send(conn, extension_stuffer));
-
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
-        EXPECT_SUCCESS(s2n_server_key_share_extension.send(conn, extension_stuffer));
-
-        conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[1];
-        EXPECT_FAILURE(s2n_server_key_share_extension.send(conn, extension_stuffer));
-
-        EXPECT_SUCCESS(s2n_ecc_evp_params_free(&conn->secure.server_ecc_evp_params));
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
@@ -371,8 +403,7 @@ int main(int argc, char **argv)
 
         conn->secure.server_ecc_evp_params.negotiated_curve = test_curve;
         conn->secure.client_ecc_evp_params[0].negotiated_curve = test_curve;
-        EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.send(conn, &conn->handshake.io),
-                S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
+        EXPECT_FAILURE(s2n_server_key_share_extension.send(conn, &conn->handshake.io));
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
@@ -459,7 +490,6 @@ int main(int argc, char **argv)
 
 #if !defined(S2N_NO_PQ)
     {
-        /* Tests for s2n_server_key_share_extension.recv with hybrid PQ key shares */
         const struct s2n_kem_group *test_kem_groups[] = {
                 &s2n_secp256r1_sike_p434_r2,
                 &s2n_secp256r1_bike1_l1_r2,
@@ -488,221 +518,429 @@ int main(int argc, char **argv)
                 .ecc_preferences = &s2n_ecc_preferences_20200310,
         };
 
-        EXPECT_SUCCESS(s2n_enable_tls13());
+        const struct s2n_kem_group *kem_groups_sike_bike[] = {
+                &s2n_secp256r1_sike_p434_r2,
+                &s2n_secp256r1_bike1_l1_r2
+        };
 
-        if (s2n_is_in_fips_mode()) {
+        const struct s2n_kem_preferences kem_prefs_sike_bike = {
+                .kem_count = 0,
+                .kems = NULL,
+                .tls13_kem_group_count = s2n_array_len(kem_groups_sike_bike),
+                .tls13_kem_groups = kem_groups_sike_bike,
+        };
+
+        const struct s2n_security_policy security_policy_sike_bike = {
+                .minimum_protocol_version = S2N_SSLv3,
+                .cipher_preferences = &cipher_preferences_test_all_tls13,
+                .kem_preferences = &kem_prefs_sike_bike,
+                .signature_preferences = &s2n_signature_preferences_20200207,
+                .ecc_preferences = &s2n_ecc_preferences_20200310,
+        };
+
+        /* Tests for s2n_server_key_share_extension.recv with hybrid PQ key shares */
+        {
+            EXPECT_SUCCESS(s2n_enable_tls13());
+
             /* PQ KEMs are disabled in FIPs mode; test that we use the correct error */
-            struct s2n_connection *client_conn = NULL;
-            EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-            client_conn->security_policy_override = &test_security_policy;
+            if (s2n_is_in_fips_mode()) {
+                struct s2n_connection *client_conn = NULL;
+                EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+                client_conn->security_policy_override = &test_security_policy;
 
-            uint8_t iana_buffer[2];
-            struct s2n_blob iana_blob = { 0 };
-            struct s2n_stuffer iana_stuffer = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&iana_blob, iana_buffer, 2));
-            EXPECT_SUCCESS(s2n_stuffer_init(&iana_stuffer, &iana_blob));
-            EXPECT_SUCCESS(s2n_stuffer_write_uint16(&iana_stuffer,
-                    test_security_policy.kem_preferences->tls13_kem_groups[0]->iana_id));
+                uint8_t iana_buffer[2];
+                struct s2n_blob iana_blob = {0};
+                struct s2n_stuffer iana_stuffer = {0};
+                EXPECT_SUCCESS(s2n_blob_init(&iana_blob, iana_buffer, 2));
+                EXPECT_SUCCESS(s2n_stuffer_init(&iana_stuffer, &iana_blob));
+                EXPECT_SUCCESS(s2n_stuffer_write_uint16(&iana_stuffer,test_security_policy.kem_preferences->tls13_kem_groups[0]->iana_id));
 
-            EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.recv(client_conn, &iana_stuffer),
-                    S2N_ERR_PQ_KEMS_DISALLOWED_IN_FIPS);
+                EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.recv(client_conn, &iana_stuffer),
+                        S2N_ERR_PQ_KEMS_DISALLOWED_IN_FIPS);
 
-            EXPECT_SUCCESS(s2n_connection_free(client_conn));
-        } else {
-            {
-                for (size_t i = 0; i < s2n_array_len(test_kem_groups); i++) {
-                    const struct s2n_kem_group *kem_group = test_kem_groups[i];
+                EXPECT_SUCCESS(s2n_connection_free(client_conn));
+            }
+
+            /* Test s2n_server_key_share_extension.recv with KAT pq key shares */
+            if (!s2n_is_in_fips_mode()) {
+                {
+                    for (size_t i = 0; i < s2n_array_len(test_kem_groups); i++) {
+                        const struct s2n_kem_group *kem_group = test_kem_groups[i];
+                        struct s2n_connection *client_conn = NULL;
+                        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+                        client_conn->security_policy_override = &test_security_policy;
+
+                        /* Read the test vectors from the KAT file (the PQ key shares are too long to hardcode inline).
+                         * pq_private_key is intentionally missing DERFER_CLEANUP; it will get freed during s2n_connection_free. */
+                        struct s2n_blob *pq_private_key = &client_conn->secure.client_kem_group_params[i].kem_params.private_key;
+                        DEFER_CLEANUP(struct s2n_stuffer pq_shared_secret = {0}, s2n_stuffer_free);
+                        DEFER_CLEANUP(struct s2n_stuffer key_share_payload = {0}, s2n_stuffer_free);
+                        EXPECT_SUCCESS(s2n_read_server_key_share_hybrid_test_vectors(kem_group, pq_private_key,
+                                &pq_shared_secret, &key_share_payload));
+
+                        /* Assert correct initial state */
+                        EXPECT_NULL(client_conn->secure.server_kem_group_params.kem_group);
+                        EXPECT_NULL(client_conn->secure.chosen_client_kem_group_params);
+                        EXPECT_NULL(client_conn->secure.client_kem_group_params[i].kem_group);
+
+                        const struct s2n_kem_preferences *kem_prefs = NULL;
+                        EXPECT_SUCCESS(s2n_connection_get_kem_preferences(client_conn, &kem_prefs));
+                        EXPECT_NOT_NULL(kem_prefs);
+                        EXPECT_EQUAL(kem_group, kem_prefs->tls13_kem_groups[i]);
+
+                        /* This set up would have been done when the client sent its key share(s) */
+                        client_conn->secure.client_kem_group_params[i].kem_group = kem_group;
+                        client_conn->secure.client_kem_group_params[i].ecc_params.negotiated_curve = kem_group->curve;
+                        client_conn->secure.client_kem_group_params[i].kem_params.kem = kem_group->kem;
+                        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.client_kem_group_params[i].ecc_params));
+
+                        /* Call the function and assert correctness */
+                        EXPECT_SUCCESS(s2n_server_key_share_extension.recv(client_conn, &key_share_payload));
+
+                        EXPECT_NOT_NULL(client_conn->secure.server_kem_group_params.kem_group);
+                        EXPECT_EQUAL(client_conn->secure.server_kem_group_params.kem_group, kem_group);
+                        EXPECT_NOT_NULL(client_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
+                        EXPECT_EQUAL(client_conn->secure.server_kem_group_params.ecc_params.negotiated_curve,kem_group->curve);
+                        EXPECT_NOT_NULL(client_conn->secure.server_kem_group_params.kem_params.kem);
+                        EXPECT_EQUAL(client_conn->secure.server_kem_group_params.kem_params.kem, kem_group->kem);
+
+                        EXPECT_EQUAL(client_conn->secure.chosen_client_kem_group_params->kem_group, kem_group);
+                        EXPECT_EQUAL(client_conn->secure.chosen_client_kem_group_params->ecc_params.negotiated_curve,kem_group->curve);
+                        EXPECT_EQUAL(client_conn->secure.chosen_client_kem_group_params->kem_params.kem,kem_group->kem);
+                        EXPECT_NOT_NULL(client_conn->secure.chosen_client_kem_group_params->kem_params.shared_secret.data);
+                        EXPECT_EQUAL(client_conn->secure.chosen_client_kem_group_params->kem_params.shared_secret.size,
+                                kem_group->kem->shared_secret_key_length);
+                        EXPECT_BYTEARRAY_EQUAL(client_conn->secure.chosen_client_kem_group_params->kem_params.shared_secret.data,
+                                pq_shared_secret.blob.data, kem_group->kem->shared_secret_key_length);
+
+                        EXPECT_EQUAL(s2n_stuffer_data_available(&key_share_payload), 0);
+
+                        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+                    }
+                }
+
+                /* Test s2n_server_key_share_extension.recv with HRR for PQ */
+                {
                     struct s2n_connection *client_conn = NULL;
                     EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
                     client_conn->security_policy_override = &test_security_policy;
+                    client_conn->actual_protocol_version = S2N_TLS13;
+                    client_conn->handshake.handshake_type = HELLO_RETRY_REQUEST;
+                    client_conn->handshake.message_number = HELLO_RETRY_MSG_NO;
+                    client_conn->actual_protocol_version_established = 1;
 
-                    /* Read the test vectors from the KAT file (the PQ key shares are too long to hardcode inline).
-                     * pq_private_key is intentionally missing DERFER_CLEANUP; it will get freed during s2n_connection_free. */
-                    struct s2n_blob *pq_private_key = &client_conn->secure.client_kem_group_params[i].kem_params.private_key;
-                    DEFER_CLEANUP(struct s2n_stuffer pq_shared_secret = {0}, s2n_stuffer_free);
+                    /* In the HRR, the server indicated p256+BIKE as it's choice in the key share extension */
+                    const struct s2n_kem_group *kem_group = &s2n_secp256r1_bike1_l1_r2;
                     DEFER_CLEANUP(struct s2n_stuffer key_share_payload = {0}, s2n_stuffer_free);
-                    EXPECT_SUCCESS(s2n_read_server_key_share_hybrid_test_vectors(kem_group, pq_private_key,
-                            &pq_shared_secret,&key_share_payload));
+                    EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&key_share_payload, "2F23"));
 
-                    /* Assert correct initial state */
-                    EXPECT_NULL(client_conn->secure.server_kem_group_params.kem_group);
-                    EXPECT_NULL(client_conn->secure.chosen_client_kem_group_params);
-                    EXPECT_NULL(client_conn->secure.client_kem_group_params[i].kem_group);
-
-                    const struct s2n_kem_preferences *kem_prefs = NULL;
-                    EXPECT_SUCCESS(s2n_connection_get_kem_preferences(client_conn, &kem_prefs));
-                    EXPECT_NOT_NULL(kem_prefs);
-                    EXPECT_EQUAL(kem_group, kem_prefs->tls13_kem_groups[i]);
-
-                    /* This set up would have been done when the client sent its key share(s) */
-                    client_conn->secure.client_kem_group_params[i].kem_group = kem_group;
-                    client_conn->secure.client_kem_group_params[i].ecc_params.negotiated_curve = kem_group->curve;
-                    client_conn->secure.client_kem_group_params[i].kem_params.kem = kem_group->kem;
-                    EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(
-                            &client_conn->secure.client_kem_group_params[i].ecc_params));
-
-                    /* Call the function and assert correctness */
+                    /* Client should successfully parse the indicated group */
                     EXPECT_SUCCESS(s2n_server_key_share_extension.recv(client_conn, &key_share_payload));
 
                     EXPECT_NOT_NULL(client_conn->secure.server_kem_group_params.kem_group);
                     EXPECT_EQUAL(client_conn->secure.server_kem_group_params.kem_group, kem_group);
                     EXPECT_NOT_NULL(client_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-                    EXPECT_EQUAL(client_conn->secure.server_kem_group_params.ecc_params.negotiated_curve, kem_group->curve);
+                    EXPECT_EQUAL(client_conn->secure.server_kem_group_params.ecc_params.negotiated_curve,kem_group->curve);
                     EXPECT_NOT_NULL(client_conn->secure.server_kem_group_params.kem_params.kem);
                     EXPECT_EQUAL(client_conn->secure.server_kem_group_params.kem_params.kem, kem_group->kem);
 
-                    EXPECT_EQUAL(client_conn->secure.chosen_client_kem_group_params->kem_group, kem_group);
-                    EXPECT_EQUAL(client_conn->secure.chosen_client_kem_group_params->ecc_params.negotiated_curve,kem_group->curve);
-                    EXPECT_EQUAL(client_conn->secure.chosen_client_kem_group_params->kem_params.kem, kem_group->kem);
-                    EXPECT_NOT_NULL(client_conn->secure.chosen_client_kem_group_params->kem_params.shared_secret.data);
-                    EXPECT_EQUAL(client_conn->secure.chosen_client_kem_group_params->kem_params.shared_secret.size,
-                            kem_group->kem->shared_secret_key_length);
-                    EXPECT_BYTEARRAY_EQUAL(client_conn->secure.chosen_client_kem_group_params->kem_params.shared_secret.data,
-                            pq_shared_secret.blob.data, kem_group->kem->shared_secret_key_length);
+                    /* s2n_server_key_share_extension.recv should have exited early after parsing the indicated group,
+                     * so everything else should be NULL */
+                    EXPECT_NULL(client_conn->secure.chosen_client_kem_group_params);
 
-                    EXPECT_EQUAL(s2n_stuffer_data_available(&key_share_payload), 0);
+                    for (size_t i = 0; i < S2N_SUPPORTED_KEM_GROUPS_COUNT; i++) {
+                        EXPECT_NULL(client_conn->secure.client_kem_group_params[i].kem_group);
+                        EXPECT_NULL(client_conn->secure.client_kem_group_params[i].ecc_params.negotiated_curve);
+                        EXPECT_NULL(client_conn->secure.client_kem_group_params[i].ecc_params.evp_pkey);
+                        EXPECT_NULL(client_conn->secure.client_kem_group_params[i].kem_params.kem);
+                        EXPECT_NULL(client_conn->secure.client_kem_group_params[i].kem_params.private_key.data);
+                        EXPECT_NULL(client_conn->secure.client_kem_group_params[i].kem_params.public_key.data);
+                        EXPECT_NULL(client_conn->secure.client_kem_group_params[i].kem_params.shared_secret.data);
+                    }
 
-                    EXPECT_SUCCESS(s2n_connection_free(client_conn));
-                }
-            }
-            /* Test s2n_server_key_share_extension.recv with HRR for PQ */
-            {
-                struct s2n_connection *client_conn = NULL;
-                EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-                client_conn->security_policy_override = &test_security_policy;
-                client_conn->actual_protocol_version = S2N_TLS13;
-                client_conn->handshake.handshake_type = HELLO_RETRY_REQUEST;
-                client_conn->handshake.message_number = HELLO_RETRY_MSG_NO;
-                client_conn->actual_protocol_version_established = 1;
-
-                /* In the HRR, the server indicated p256+BIKE as it's choice in the key share extension */
-                const struct s2n_kem_group *kem_group = &s2n_secp256r1_bike1_l1_r2;
-                DEFER_CLEANUP(struct s2n_stuffer key_share_payload = { 0 }, s2n_stuffer_free);
-                EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&key_share_payload, "2F23"));
-
-                /* Client should successfully parse the indicated group */
-                EXPECT_SUCCESS(s2n_server_key_share_extension.recv(client_conn, &key_share_payload));
-
-                EXPECT_NOT_NULL(client_conn->secure.server_kem_group_params.kem_group);
-                EXPECT_EQUAL(client_conn->secure.server_kem_group_params.kem_group, kem_group);
-                EXPECT_NOT_NULL(client_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-                EXPECT_EQUAL(client_conn->secure.server_kem_group_params.ecc_params.negotiated_curve, kem_group->curve);
-                EXPECT_NOT_NULL(client_conn->secure.server_kem_group_params.kem_params.kem);
-                EXPECT_EQUAL(client_conn->secure.server_kem_group_params.kem_params.kem, kem_group->kem);
-
-                /* s2n_server_key_share_extension.recv should have exited early after parsing the indicated group,
-                 * so everything else should be NULL */
-                EXPECT_NULL(client_conn->secure.chosen_client_kem_group_params);
-
-                for (size_t i = 0; i < S2N_SUPPORTED_KEM_GROUPS_COUNT; i++) {
-                    EXPECT_NULL(client_conn->secure.client_kem_group_params[i].kem_group);
-                    EXPECT_NULL(client_conn->secure.client_kem_group_params[i].ecc_params.negotiated_curve);
-                    EXPECT_NULL(client_conn->secure.client_kem_group_params[i].ecc_params.evp_pkey);
-                    EXPECT_NULL(client_conn->secure.client_kem_group_params[i].kem_params.kem);
-                    EXPECT_NULL(client_conn->secure.client_kem_group_params[i].kem_params.private_key.data);
-                    EXPECT_NULL(client_conn->secure.client_kem_group_params[i].kem_params.public_key.data);
-                    EXPECT_NULL(client_conn->secure.client_kem_group_params[i].kem_params.shared_secret.data);
-                }
-
-                EXPECT_NULL(client_conn->secure.server_kem_group_params.ecc_params.evp_pkey);
-                EXPECT_NULL(client_conn->secure.server_kem_group_params.kem_params.shared_secret.data);
-
-                EXPECT_SUCCESS(s2n_connection_free(client_conn));
-            }
-            /* Various failure cases */
-            {
-                for (size_t i = 0; i < s2n_array_len(test_kem_groups); i++) {
-                    const struct s2n_kem_group *kem_group = test_kem_groups[i];
-                    struct s2n_connection *client_conn;
-                    EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-                    client_conn->security_policy_override = &test_security_policy;
-
-                    /* Server sends a named group identifier that isn't in the client's KEM preferences */
-                    const char *bad_group = "2F2C"; /* IANA ID for secp256r1_threebears-babybear-r2 (not imported into s2n) */
-                    DEFER_CLEANUP(struct s2n_stuffer bad_group_stuffer = {0}, s2n_stuffer_free);
-                    EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&bad_group_stuffer, bad_group));
-                    EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.recv(client_conn, &bad_group_stuffer),
-                            S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
-
-                    /* Server sends a key share that is in the client's KEM preferences, but client didn't send a key share */
-                    const char *wrong_share = "2F1F"; /* Full extension truncated - not necessary */
-                    DEFER_CLEANUP(struct s2n_stuffer wrong_share_stuffer = {0}, s2n_stuffer_free);
-                    EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&wrong_share_stuffer, wrong_share));
-                    EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.recv(client_conn, &wrong_share_stuffer),
-                            S2N_ERR_BAD_KEY_SHARE);
-
-                    /* To test the remaining failure cases, we need to read in the test vector from the KAT file, then
-                     * manipulate it as necessary. (We do this now, instead of earlier, because we needed
-                     * client_kem_group_params[i].kem_params.private_key to be empty to test the previous case.) */
-                    struct s2n_blob *pq_private_key = &client_conn->secure.client_kem_group_params[i].kem_params.private_key;
-                    DEFER_CLEANUP(struct s2n_stuffer pq_shared_secret = {0}, s2n_stuffer_free);
-                    DEFER_CLEANUP(struct s2n_stuffer key_share_payload = {0}, s2n_stuffer_free);
-                    EXPECT_SUCCESS(s2n_read_server_key_share_hybrid_test_vectors(kem_group, pq_private_key,
-                            &pq_shared_secret, &key_share_payload));
-
-                    /* Server sends the wrong (total) size: data[2] and data[3] are the bytes containing the total size
-                     * of the key share; bitflip data[2] to invalidate the sent size */
-                    key_share_payload.blob.data[2] = ~key_share_payload.blob.data[2];
-                    client_conn->secure.client_kem_group_params[i].kem_group = kem_group;
-                    client_conn->secure.client_kem_group_params[i].ecc_params.negotiated_curve = kem_group->curve;
-                    client_conn->secure.client_kem_group_params[i].kem_params.kem = kem_group->kem;
-                    EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(
-                            &client_conn->secure.client_kem_group_params[i].ecc_params));
-                    EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.recv(client_conn, &key_share_payload),
-                            S2N_ERR_BAD_KEY_SHARE);
-                    /* Revert key_share_payload back to correct state */
-                    key_share_payload.blob.data[2] = ~key_share_payload.blob.data[2];
-                    EXPECT_SUCCESS(s2n_stuffer_reread(&key_share_payload));
-
-                    /* Server sends the correct (total) size, but the extension doesn't contain all the data */
-                    uint8_t truncated_extension[10];
-                    EXPECT_MEMCPY_SUCCESS(truncated_extension, key_share_payload.blob.data, 10);
-                    struct s2n_blob trunc_ext_blob = {0};
-                    EXPECT_SUCCESS(s2n_blob_init(&trunc_ext_blob, truncated_extension, 10));
-                    struct s2n_stuffer trunc_ext_stuffer = {0};
-                    EXPECT_SUCCESS(s2n_stuffer_init(&trunc_ext_stuffer, &trunc_ext_blob));
-                    EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.recv(client_conn, &trunc_ext_stuffer),
-                            S2N_ERR_BAD_KEY_SHARE);
-
-                    /* Server sends the wrong ECC key share size: data[4] and data[5] are the two bytes containing
-                     * the size of the ECC key share; bitflip data[4] to invalidate the size */
-                    key_share_payload.blob.data[4] = ~key_share_payload.blob.data[4];
-                    EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.recv(client_conn, &key_share_payload),
-                            S2N_ERR_BAD_KEY_SHARE);
-                    /* Revert key_share_payload back to correct state */
-                    key_share_payload.blob.data[4] = ~key_share_payload.blob.data[4];
-                    EXPECT_SUCCESS(s2n_stuffer_reread(&key_share_payload));
-
-                    /* Server sends the wrong PQ share size size: index of the first byte of the size of the PQ key share
-                     * depends of how large the ECC key share is */
-                    size_t pq_share_size_index =
-                              S2N_SIZE_OF_NAMED_GROUP
-                            + S2N_SIZE_OF_KEY_SHARE_SIZE /* Not a typo; PQ shares have an overall (combined) size */
-                            + S2N_SIZE_OF_KEY_SHARE_SIZE /* and a size for each contribution of the hybrid share. */
-                            + kem_group->curve->share_size;
-                    key_share_payload.blob.data[pq_share_size_index] = ~key_share_payload.blob.data[pq_share_size_index];
-                    EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.recv(client_conn, &key_share_payload),
-                            S2N_ERR_BAD_KEY_SHARE);
-                    /* Revert key_share_payload back to correct state */
-                    key_share_payload.blob.data[pq_share_size_index] = ~key_share_payload.blob.data[pq_share_size_index];
-                    EXPECT_SUCCESS(s2n_stuffer_reread(&key_share_payload));
-
-                    /* Server sends a bad PQ key share (ciphertext): in order to guarantee certain crypto properties,
-                     * the PQ KEM decapsulation functions are written so that the decaps will succeed without error
-                     * in this case, but the returned PQ shared secret will be incorrect. In practice, this means
-                     * that the key_share.recv function will succeed, but the overall handshake will fail later when
-                     * client+server attempt to use the (different) shared secrets they each derived. */
-                    size_t pq_key_share_first_byte_index = pq_share_size_index + 2;
-                    key_share_payload.blob.data[pq_key_share_first_byte_index] = ~key_share_payload.blob.data[pq_key_share_first_byte_index];
-                    EXPECT_SUCCESS(s2n_server_key_share_extension.recv(client_conn, &key_share_payload));
-                    EXPECT_BYTEARRAY_NOT_EQUAL(client_conn->secure.chosen_client_kem_group_params->kem_params.shared_secret.data,
-                            pq_shared_secret.blob.data, kem_group->kem->shared_secret_key_length);
+                    EXPECT_NULL(client_conn->secure.server_kem_group_params.ecc_params.evp_pkey);
+                    EXPECT_NULL(client_conn->secure.server_kem_group_params.kem_params.shared_secret.data);
 
                     EXPECT_SUCCESS(s2n_connection_free(client_conn));
                 }
+
+                /* Various failure cases */
+                {
+                    for (size_t i = 0; i < s2n_array_len(test_kem_groups); i++) {
+                        const struct s2n_kem_group *kem_group = test_kem_groups[i];
+                        struct s2n_connection *client_conn;
+                        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+                        client_conn->security_policy_override = &test_security_policy;
+
+                        /* Server sends a named group identifier that isn't in the client's KEM preferences */
+                        const char *bad_group = "2F2C"; /* IANA ID for secp256r1_threebears-babybear-r2 (not imported into s2n) */
+                        DEFER_CLEANUP(struct s2n_stuffer bad_group_stuffer = {0}, s2n_stuffer_free);
+                        EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&bad_group_stuffer, bad_group));
+                        EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.recv(client_conn, &bad_group_stuffer),
+                                S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
+
+                        /* Server sends a key share that is in the client's KEM preferences, but client didn't send a key share */
+                        const char *wrong_share = "2F1F"; /* Full extension truncated - not necessary */
+                        DEFER_CLEANUP(struct s2n_stuffer wrong_share_stuffer = {0}, s2n_stuffer_free);
+                        EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&wrong_share_stuffer, wrong_share));
+                        EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.recv(client_conn, &wrong_share_stuffer),
+                                S2N_ERR_BAD_KEY_SHARE);
+
+                        /* To test the remaining failure cases, we need to read in the test vector from the KAT file, then
+                         * manipulate it as necessary. (We do this now, instead of earlier, because we needed
+                         * client_kem_group_params[i].kem_params.private_key to be empty to test the previous case.) */
+                        struct s2n_blob *pq_private_key = &client_conn->secure.client_kem_group_params[i].kem_params.private_key;
+                        DEFER_CLEANUP(struct s2n_stuffer pq_shared_secret = {0}, s2n_stuffer_free);
+                        DEFER_CLEANUP(struct s2n_stuffer key_share_payload = {0}, s2n_stuffer_free);
+                        EXPECT_SUCCESS(s2n_read_server_key_share_hybrid_test_vectors(kem_group, pq_private_key,
+                                &pq_shared_secret, &key_share_payload));
+
+                        /* Server sends the wrong (total) size: data[2] and data[3] are the bytes containing the total size
+                         * of the key share; bitflip data[2] to invalidate the sent size */
+                        key_share_payload.blob.data[2] = ~key_share_payload.blob.data[2];
+                        client_conn->secure.client_kem_group_params[i].kem_group = kem_group;
+                        client_conn->secure.client_kem_group_params[i].ecc_params.negotiated_curve = kem_group->curve;
+                        client_conn->secure.client_kem_group_params[i].kem_params.kem = kem_group->kem;
+                        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.client_kem_group_params[i].ecc_params));
+                        EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.recv(client_conn, &key_share_payload),
+                                S2N_ERR_BAD_KEY_SHARE);
+                        /* Revert key_share_payload back to correct state */
+                        key_share_payload.blob.data[2] = ~key_share_payload.blob.data[2];
+                        EXPECT_SUCCESS(s2n_stuffer_reread(&key_share_payload));
+
+                        /* Server sends the correct (total) size, but the extension doesn't contain all the data */
+                        uint8_t truncated_extension[10];
+                        EXPECT_MEMCPY_SUCCESS(truncated_extension, key_share_payload.blob.data, 10);
+                        struct s2n_blob trunc_ext_blob = {0};
+                        EXPECT_SUCCESS(s2n_blob_init(&trunc_ext_blob, truncated_extension, 10));
+                        struct s2n_stuffer trunc_ext_stuffer = {0};
+                        EXPECT_SUCCESS(s2n_stuffer_init(&trunc_ext_stuffer, &trunc_ext_blob));
+                        EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.recv(client_conn, &trunc_ext_stuffer),
+                                S2N_ERR_BAD_KEY_SHARE);
+
+                        /* Server sends the wrong ECC key share size: data[4] and data[5] are the two bytes containing
+                         * the size of the ECC key share; bitflip data[4] to invalidate the size */
+                        key_share_payload.blob.data[4] = ~key_share_payload.blob.data[4];
+                        EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.recv(client_conn, &key_share_payload),
+                                S2N_ERR_BAD_KEY_SHARE);
+                        /* Revert key_share_payload back to correct state */
+                        key_share_payload.blob.data[4] = ~key_share_payload.blob.data[4];
+                        EXPECT_SUCCESS(s2n_stuffer_reread(&key_share_payload));
+
+                        /* Server sends the wrong PQ share size size: index of the first byte of the size of the PQ key share
+                         * depends of how large the ECC key share is */
+                        size_t pq_share_size_index =
+                                S2N_SIZE_OF_NAMED_GROUP
+                                + S2N_SIZE_OF_KEY_SHARE_SIZE /* Not a typo; PQ shares have an overall (combined) size */
+                                + S2N_SIZE_OF_KEY_SHARE_SIZE /* and a size for each contribution of the hybrid share. */
+                                + kem_group->curve->share_size;
+                        key_share_payload.blob.data[pq_share_size_index] = ~key_share_payload.blob.data[pq_share_size_index];
+                        EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.recv(client_conn, &key_share_payload),
+                                S2N_ERR_BAD_KEY_SHARE);
+                        /* Revert key_share_payload back to correct state */
+                        key_share_payload.blob.data[pq_share_size_index] = ~key_share_payload.blob.data[pq_share_size_index];
+                        EXPECT_SUCCESS(s2n_stuffer_reread(&key_share_payload));
+
+                        /* Server sends a bad PQ key share (ciphertext): in order to guarantee certain crypto properties,
+                         * the PQ KEM decapsulation functions are written so that the decaps will succeed without error
+                         * in this case, but the returned PQ shared secret will be incorrect. In practice, this means
+                         * that the key_share.recv function will succeed, but the overall handshake will fail later when
+                         * client+server attempt to use the (different) shared secrets they each derived. */
+                        size_t pq_key_share_first_byte_index = pq_share_size_index + 2;
+                        key_share_payload.blob.data[pq_key_share_first_byte_index] = ~key_share_payload.blob.data[pq_key_share_first_byte_index];
+                        EXPECT_SUCCESS(s2n_server_key_share_extension.recv(client_conn, &key_share_payload));
+                        EXPECT_BYTEARRAY_NOT_EQUAL(client_conn->secure.chosen_client_kem_group_params->kem_params.shared_secret.data,
+                                pq_shared_secret.blob.data, kem_group->kem->shared_secret_key_length);
+
+                        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+                    }
+                }
+            }
+            EXPECT_SUCCESS(s2n_disable_tls13());
+        }
+
+        /* Test s2n_server_key_share_send_check_pq_hybrid */
+        {
+            struct s2n_connection *conn = NULL;
+            EXPECT_FAILURE(s2n_server_key_share_send_check_pq_hybrid(conn));
+
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+
+            if (s2n_is_in_fips_mode()) {
+                EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_send_check_pq_hybrid(conn),
+                        S2N_ERR_PQ_KEMS_DISALLOWED_IN_FIPS);
+            }
+
+            if (!s2n_is_in_fips_mode()) {
+                conn->security_policy_override = &security_policy_sike_bike;
+
+                EXPECT_FAILURE(s2n_server_key_share_send_check_pq_hybrid(conn));
+                conn->secure.server_kem_group_params.kem_params.kem = &s2n_kyber_512_r2;
+
+                EXPECT_FAILURE(s2n_server_key_share_send_check_pq_hybrid(conn));
+                conn->secure.server_kem_group_params.ecc_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
+
+                conn->secure.server_kem_group_params.kem_group = &s2n_secp256r1_kyber_512_r2;
+                EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_send_check_pq_hybrid(conn), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+
+                conn->secure.server_kem_group_params.kem_group = &s2n_secp256r1_bike1_l1_r2;
+                conn->secure.server_kem_group_params.kem_params.kem = &s2n_bike1_l1_r2;
+                EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_send_check_pq_hybrid(conn), S2N_ERR_NULL);
+
+                conn->secure.chosen_client_kem_group_params = &conn->secure.client_kem_group_params[1];
+                EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_send_check_pq_hybrid(conn), S2N_ERR_BAD_KEY_SHARE);
+
+                conn->secure.client_kem_group_params[1].kem_group = &s2n_secp256r1_bike1_l1_r2;
+                EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_send_check_pq_hybrid(conn), S2N_ERR_BAD_KEY_SHARE);
+
+                conn->secure.client_kem_group_params[1].ecc_params.negotiated_curve = s2n_secp256r1_bike1_l1_r2.curve;
+                EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_send_check_pq_hybrid(conn), S2N_ERR_BAD_KEY_SHARE);
+
+                EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_kem_group_params[1].ecc_params));
+                EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_send_check_pq_hybrid(conn), S2N_ERR_BAD_KEY_SHARE);
+
+                conn->secure.client_kem_group_params[1].kem_params.kem = s2n_secp256r1_bike1_l1_r2.kem;
+                EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_send_check_pq_hybrid(conn), S2N_ERR_BAD_KEY_SHARE);
+
+                EXPECT_SUCCESS(s2n_alloc(&conn->secure.client_kem_group_params[1].kem_params.public_key,
+                        s2n_secp256r1_bike1_l1_r2.kem->public_key_length));
+                EXPECT_SUCCESS(s2n_kem_generate_keypair(&conn->secure.client_kem_group_params[1].kem_params));
+                EXPECT_SUCCESS(s2n_server_key_share_send_check_pq_hybrid(conn));
+            }
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Test s2n_server_key_share_extension.send sends key share success (PQ) */
+        if (!s2n_is_in_fips_mode()) {
+            for (size_t i = 0; i < S2N_SUPPORTED_KEM_GROUPS_COUNT; i++) {
+                struct s2n_connection *conn = NULL;
+                EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+                conn->security_policy_override = &test_security_policy;
+
+                const struct s2n_kem_preferences *kem_pref = NULL;
+                EXPECT_SUCCESS(s2n_connection_get_kem_preferences(conn, &kem_pref));
+                EXPECT_NOT_NULL(kem_pref);
+
+                DEFER_CLEANUP(struct s2n_stuffer stuffer = { 0 }, s2n_stuffer_free);
+                EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 4096));
+
+                /* Set up the server so that it's chosen the correct KEM group and received
+                 * a correspond keyshare from client */
+                conn->secure.server_ecc_evp_params.negotiated_curve = NULL;
+
+                struct s2n_kem_group_params *server_params = &conn->secure.server_kem_group_params;
+                const struct s2n_kem_group *kem_group = kem_pref->tls13_kem_groups[i];
+                server_params->kem_group = kem_group;
+                server_params->kem_params.kem = kem_group->kem;
+                server_params->ecc_params.negotiated_curve = kem_group->curve;
+
+                struct s2n_kem_group_params *client_params = &conn->secure.client_kem_group_params[i];
+                conn->secure.chosen_client_kem_group_params = client_params;
+                client_params->kem_group = kem_group;
+                client_params->kem_params.kem = kem_group->kem;
+                client_params->ecc_params.negotiated_curve = kem_group->curve;
+
+                EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_params->ecc_params));
+                EXPECT_SUCCESS(s2n_alloc(&client_params->kem_params.public_key, kem_group->kem->public_key_length));
+                EXPECT_SUCCESS(s2n_kem_generate_keypair(&client_params->kem_params));
+
+                EXPECT_SUCCESS(s2n_server_key_share_extension.send(conn, &stuffer));
+
+                /* IANA ID (2 bytes) + total share size (2 bytes) + server hybrid share */
+                EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), (2 * sizeof(uint16_t)) + kem_group->server_share_size);
+
+                /* Assert we sent a hybrid key share */
+                S2N_STUFFER_READ_EXPECT_EQUAL(&stuffer, kem_group->iana_id, uint16);
+                S2N_STUFFER_READ_EXPECT_EQUAL(&stuffer, kem_group->server_share_size, uint16);
+                S2N_STUFFER_READ_EXPECT_EQUAL(&stuffer, kem_group->curve->share_size, uint16);
+                EXPECT_SUCCESS(s2n_stuffer_skip_read(&stuffer, kem_group->curve->share_size));
+                S2N_STUFFER_READ_EXPECT_EQUAL(&stuffer, kem_group->kem->ciphertext_length, uint16);
+                S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(&stuffer, kem_group->kem->ciphertext_length);
+
+                EXPECT_NULL(conn->secure.server_ecc_evp_params.negotiated_curve);
+                EXPECT_EQUAL(server_params->kem_group, kem_group);
+                EXPECT_EQUAL(server_params->kem_params.kem, kem_group->kem);
+                EXPECT_EQUAL(server_params->ecc_params.negotiated_curve, kem_group->curve);
+                EXPECT_EQUAL(server_params->kem_params.shared_secret.size, kem_group->kem->shared_secret_key_length);
+                EXPECT_NOT_NULL(server_params->kem_params.shared_secret.data);
+
+                EXPECT_SUCCESS(s2n_connection_free(conn));
             }
         }
-        EXPECT_SUCCESS(s2n_disable_tls13());
+
+        /* Test s2n_server_key_share_extension.send sends IANA ID for HRR (PQ) */
+        {
+            struct s2n_connection *conn = NULL;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            conn->security_policy_override = &test_security_policy;
+            conn->actual_protocol_version = S2N_TLS13;
+            conn->handshake.handshake_type = HELLO_RETRY_REQUEST;
+            conn->handshake.message_number = HELLO_RETRY_MSG_NO;
+
+            const struct s2n_kem_preferences *kem_pref = NULL;
+            EXPECT_SUCCESS(s2n_connection_get_kem_preferences(conn, &kem_pref));
+            EXPECT_NOT_NULL(kem_pref);
+
+            EXPECT_NULL(conn->secure.server_ecc_evp_params.negotiated_curve);
+            DEFER_CLEANUP(struct s2n_stuffer stuffer = { 0 }, s2n_stuffer_free);
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 1024));
+
+            for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
+                struct s2n_kem_group_params *server_params = &conn->secure.server_kem_group_params;
+                const struct s2n_kem_group *kem_group = kem_pref->tls13_kem_groups[i];
+
+                server_params->kem_group = kem_group;
+                server_params->kem_params.kem = kem_group->kem;
+                server_params->ecc_params.negotiated_curve = kem_group->curve;
+                EXPECT_NULL(conn->secure.chosen_client_kem_group_params);
+                EXPECT_NULL(conn->secure.server_ecc_evp_params.evp_pkey);
+                EXPECT_NULL(conn->secure.server_ecc_evp_params.negotiated_curve);
+
+                EXPECT_SUCCESS(s2n_server_key_share_extension.send(conn, &stuffer));
+
+                S2N_STUFFER_READ_EXPECT_EQUAL(&stuffer, kem_group->iana_id, uint16);
+                EXPECT_EQUAL(0, s2n_stuffer_data_available(&stuffer));
+
+                EXPECT_EQUAL(server_params->kem_group, kem_group);
+                EXPECT_EQUAL(server_params->kem_params.kem, kem_group->kem);
+                EXPECT_EQUAL(server_params->ecc_params.negotiated_curve, kem_group->curve);
+                EXPECT_NULL(server_params->kem_params.shared_secret.data);
+                EXPECT_EQUAL(0, server_params->kem_params.shared_secret.size);
+                EXPECT_NULL(server_params->ecc_params.evp_pkey);
+                EXPECT_NULL(conn->secure.chosen_client_kem_group_params);
+
+                EXPECT_NULL(conn->secure.server_ecc_evp_params.negotiated_curve);
+                EXPECT_NULL(conn->secure.server_ecc_evp_params.evp_pkey);
+            }
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Test s2n_server_key_share_extension.send fails when both server_kem_group and server_curve are non-NULL */
+        {
+            struct s2n_connection *conn = NULL;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            conn->security_policy_override = &test_security_policy;
+
+            const struct s2n_kem_preferences *kem_pref = NULL;
+            EXPECT_SUCCESS(s2n_connection_get_kem_preferences(conn, &kem_pref));
+            EXPECT_NOT_NULL(kem_pref);
+
+            const struct s2n_ecc_preferences *ecc_pref = NULL;
+            EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+            EXPECT_NOT_NULL(ecc_pref);
+
+            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+            conn->secure.server_kem_group_params.kem_group = kem_pref->tls13_kem_groups[0];
+
+            DEFER_CLEANUP(struct s2n_stuffer stuffer = { 0 }, s2n_stuffer_free);
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+            EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.send(conn, &stuffer), S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
     }
 #endif /* !defined(S2N_NO_PQ) */
 

--- a/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
@@ -473,11 +473,7 @@ int main(int argc, char **argv) {
 
             /* Failure because pq_shared_secret is NULL */
             EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &calculated_shared_secret), S2N_ERR_NULL);
-            if (conn->mode == S2N_CLIENT) {
-                EXPECT_SUCCESS(s2n_dup(test_vector->pq_secret, &conn->secure.chosen_client_kem_group_params->kem_params.shared_secret));
-            } else {
-                EXPECT_SUCCESS(s2n_dup(test_vector->pq_secret, &conn->secure.server_kem_group_params.kem_params.shared_secret));
-            }
+            EXPECT_SUCCESS(s2n_dup(test_vector->pq_secret, &conn->secure.chosen_client_kem_group_params->kem_params.shared_secret));
 
             /* Failure because the kem_group is NULL */
             EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &calculated_shared_secret), S2N_ERR_NULL);
@@ -547,9 +543,9 @@ static int set_up_conns(struct s2n_connection *client_conn, struct s2n_connectio
     client_conn->secure.server_kem_group_params.kem_params.kem = kem_group->kem;
     client_conn->secure.chosen_client_kem_group_params->kem_params.kem = kem_group->kem;
 
-    /* During an actual handshake, server will generate the shared secret and store it in server_kem_group_params,
+    /* During an actual handshake, server will generate the shared secret and store it in chosen_client_kem_group_params,
      * client will decapsulate the ciphertext and store the shared secret in chosen_client_kem_group_params. */
-    GUARD(s2n_dup(pq_shared_secret, &server_conn->secure.server_kem_group_params.kem_params.shared_secret));
+    GUARD(s2n_dup(pq_shared_secret, &server_conn->secure.chosen_client_kem_group_params->kem_params.shared_secret));
     GUARD(s2n_dup(pq_shared_secret, &client_conn->secure.chosen_client_kem_group_params->kem_params.shared_secret));
 
     /* Populate the client's PQ private key with something - it doesn't have to be a

--- a/tls/extensions/s2n_server_key_share.c
+++ b/tls/extensions/s2n_server_key_share.c
@@ -14,7 +14,6 @@
  */
 
 #include "tls/extensions/s2n_server_key_share.h"
-
 #include "tls/s2n_security_policies.h"
 #include "tls/s2n_tls.h"
 #include "tls/s2n_tls13.h"
@@ -35,26 +34,134 @@ const s2n_extension_type s2n_server_key_share_extension = {
     .if_missing = s2n_extension_noop_if_missing,
 };
 
-int s2n_extensions_server_key_share_send_check(struct s2n_connection *conn);
+static int s2n_server_key_share_generate_pq_hybrid(struct s2n_connection *conn, struct s2n_stuffer *out) {
+    notnull_check(out);
+    notnull_check(conn);
 
-static int s2n_server_key_share_send(struct s2n_connection *conn, struct s2n_stuffer *out)
-{
-    GUARD(s2n_extensions_server_key_share_send_check(conn));
+    ENSURE_POSIX(s2n_is_in_fips_mode() == false, S2N_ERR_PQ_KEMS_DISALLOWED_IN_FIPS);
+
+    struct s2n_kem_group_params *server_kem_group_params = &conn->secure.server_kem_group_params;
+
+    notnull_check(server_kem_group_params->kem_group);
+    GUARD(s2n_stuffer_write_uint16(out, server_kem_group_params->kem_group->iana_id));
+
+    struct s2n_stuffer_reservation total_share_size = { 0 };
+    GUARD(s2n_stuffer_reserve_uint16(out, &total_share_size));
+
+    struct s2n_ecc_evp_params *server_ecc_params = &server_kem_group_params->ecc_params;
+    notnull_check(server_ecc_params->negotiated_curve);
+    GUARD(s2n_stuffer_write_uint16(out, server_ecc_params->negotiated_curve->share_size));
+    GUARD(s2n_ecc_evp_generate_ephemeral_key(server_ecc_params));
+    GUARD(s2n_ecc_evp_write_params_point(server_ecc_params, out));
+
+    /* s2n_kem_send_ciphertext() expects to find the client's public key in the
+     * params passed to it. We temporarily point server_kem_params->public_key to
+     * the correct location. */
+    notnull_check(conn->secure.chosen_client_kem_group_params);
+    struct s2n_kem_params *client_kem_params = &conn->secure.chosen_client_kem_group_params->kem_params;
+    struct s2n_kem_params *server_kem_params = &server_kem_group_params->kem_params;
+    notnull_check(client_kem_params->public_key.data);
+    server_kem_params->public_key.data = client_kem_params->public_key.data;
+    server_kem_params->public_key.size = client_kem_params->public_key.size;
+    GUARD(s2n_kem_send_ciphertext(out, server_kem_params));
+    server_kem_params->public_key.data = NULL;
+    server_kem_params->public_key.size = 0;
+
+    GUARD(s2n_stuffer_write_vector_size(&total_share_size));
+    return S2N_SUCCESS;
+}
+
+/* Check that client has sent a corresponding key share for the server's KEM group */
+int s2n_server_key_share_send_check_pq_hybrid(struct s2n_connection *conn) {
+    notnull_check(conn);
+
+    ENSURE_POSIX(s2n_is_in_fips_mode() == false, S2N_ERR_PQ_KEMS_DISALLOWED_IN_FIPS);
+
+    notnull_check(conn->secure.server_kem_group_params.kem_group);
+    notnull_check(conn->secure.server_kem_group_params.kem_params.kem);
+    notnull_check(conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
+
+    const struct s2n_kem_group *server_kem_group = conn->secure.server_kem_group_params.kem_group;
+
+    const struct s2n_kem_preferences *kem_pref = NULL;
+    GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
+    notnull_check(kem_pref);
+
+    ENSURE_POSIX(s2n_kem_preferences_includes_tls13_kem_group(kem_pref, server_kem_group->iana_id),
+            S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+
+    struct s2n_kem_group_params *client_params = conn->secure.chosen_client_kem_group_params;
+    notnull_check(client_params);
+
+    ENSURE_POSIX(client_params->kem_group == server_kem_group, S2N_ERR_BAD_KEY_SHARE);
+
+    ENSURE_POSIX(client_params->ecc_params.negotiated_curve == server_kem_group->curve, S2N_ERR_BAD_KEY_SHARE);
+    ENSURE_POSIX(client_params->ecc_params.evp_pkey != NULL, S2N_ERR_BAD_KEY_SHARE);
+
+    ENSURE_POSIX(client_params->kem_params.kem == server_kem_group->kem, S2N_ERR_BAD_KEY_SHARE);
+    ENSURE_POSIX(client_params->kem_params.public_key.size == server_kem_group->kem->public_key_length, S2N_ERR_BAD_KEY_SHARE);
+    ENSURE_POSIX(client_params->kem_params.public_key.data != NULL, S2N_ERR_BAD_KEY_SHARE);
+
+    return S2N_SUCCESS;
+}
+
+/* Check that client has sent a corresponding key share for the server's EC curve */
+int s2n_server_key_share_send_check_ecdhe(struct s2n_connection *conn) {
+    notnull_check(conn);
+
+    const struct s2n_ecc_preferences *ecc_pref = NULL;
+    GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+    notnull_check(ecc_pref);
+
+    const struct s2n_ecc_named_curve *server_curve = conn->secure.server_ecc_evp_params.negotiated_curve;
+    notnull_check(server_curve);
+
+    struct s2n_ecc_evp_params *client_params = NULL;
+    for (size_t i = 0; i < ecc_pref->count; i++) {
+        if (server_curve == ecc_pref->ecc_curves[i]) {
+            client_params = &conn->secure.client_ecc_evp_params[i];
+            break;
+        }
+    }
+
+    notnull_check(client_params);
+    ENSURE_POSIX(client_params->negotiated_curve == server_curve, S2N_ERR_BAD_KEY_SHARE);
+    ENSURE_POSIX(client_params->evp_pkey != NULL, S2N_ERR_BAD_KEY_SHARE);
+
+    return S2N_SUCCESS;
+}
+
+static int s2n_server_key_share_send(struct s2n_connection *conn, struct s2n_stuffer *out) {
     notnull_check(conn);
     notnull_check(out);
+
+    const struct s2n_ecc_named_curve *curve = conn->secure.server_ecc_evp_params.negotiated_curve;
+    const struct s2n_kem_group *kem_group = conn->secure.server_kem_group_params.kem_group;
+
+    /* Boolean XOR: exactly one of {server_curve, server_kem_group} should be non-null. */
+    ENSURE_POSIX((curve == NULL) != (kem_group == NULL), S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
 
     /* Retry requests only require the selected named group, not an actual share.
      * https://tools.ietf.org/html/rfc8446#section-4.2.8 */
     if (s2n_is_hello_retry_message(conn)) {
-        notnull_check(conn->secure.server_ecc_evp_params.negotiated_curve);
+        uint16_t named_group_id;
+        if (curve != NULL) {
+            named_group_id = curve->iana_id;
+        } else {
+            named_group_id = kem_group->iana_id;
+        }
 
-        /* There was a mutually supported group, so that is the group we will select */
-        uint16_t curve = conn->secure.server_ecc_evp_params.negotiated_curve->iana_id;
-        GUARD(s2n_stuffer_write_uint16(out, curve));
-        return 0;
+        GUARD(s2n_stuffer_write_uint16(out, named_group_id));
+        return S2N_SUCCESS;
     }
 
-    GUARD(s2n_ecdhe_parameters_send(&conn->secure.server_ecc_evp_params, out));
+    if (curve != NULL) {
+        GUARD(s2n_server_key_share_send_check_ecdhe(conn));
+        GUARD(s2n_ecdhe_parameters_send(&conn->secure.server_ecc_evp_params, out));
+    } else {
+        GUARD(s2n_server_key_share_send_check_pq_hybrid(conn));
+        GUARD(s2n_server_key_share_generate_pq_hybrid(conn, out));
+    }
 
     return S2N_SUCCESS;
 }
@@ -213,75 +320,63 @@ static int s2n_server_key_share_recv(struct s2n_connection *conn, struct s2n_stu
     return S2N_SUCCESS;
 }
 
-/*
- * Check whether client has sent a corresponding curve and key_share
- */
-int s2n_extensions_server_key_share_send_check(struct s2n_connection *conn)
-{
+/* Selects highest priority mutually supported key share, or indicates need for HRR */
+int s2n_extensions_server_key_share_select(struct s2n_connection *conn) {
     notnull_check(conn);
-
-    /* If we are responding to a retry request then we don't have a valid
-     * curve from the client. Just return S2N_SUCCESS so a selected group will be
-     * chosen for the key share. */
-    if (s2n_is_hello_retry_message(conn)) {
-        return S2N_SUCCESS;
-    }
-
-    const struct s2n_ecc_named_curve *server_curve;
-    server_curve = conn->secure.server_ecc_evp_params.negotiated_curve;
-    notnull_check(server_curve);
 
     const struct s2n_ecc_preferences *ecc_pref = NULL;
     GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
     notnull_check(ecc_pref);
 
-    int curve_index = -1;
-    for (int i = 0; i < ecc_pref->count; i++) {
-        if (server_curve == ecc_pref->ecc_curves[i]) {
-            curve_index = i;
-            break;
+    const struct s2n_kem_preferences *kem_pref = NULL;
+    GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
+    notnull_check(kem_pref);
+
+    /* Boolean XOR check. When receiving the supported_groups extension, s2n server
+     * should (exclusively) set either server_curve or server_kem_group based on the
+     * set of mutually supported groups. If both server_curve and server_kem_group
+     * are NULL, it is because client and server do not share any mutually supported
+     * groups; key negotiation is not possible and the handshake should be aborted
+     * without sending HRR. (The case of both being non-NULL should never occur, and
+     * is an error.) */
+    const struct s2n_ecc_named_curve *server_curve = conn->secure.server_ecc_evp_params.negotiated_curve;
+    const struct s2n_kem_group *server_kem_group = conn->secure.server_kem_group_params.kem_group;
+    ENSURE_POSIX((server_curve == NULL) != (server_kem_group == NULL), S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
+
+    /* To avoid extra round trips, we prefer to negotiate a group for which we have already
+     * received a key share (even if it is different than the group previously chosen). In
+     * general, we prefer to negotiate PQ over ECDHE; however, if both client and server
+     * support PQ, but the client sent only EC key shares, then we will negotiate ECHDE. */
+    for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
+        if (conn->secure.mutually_supported_kem_groups[i] && conn->secure.client_kem_group_params[i].kem_group) {
+            notnull_check(conn->secure.client_kem_group_params[i].ecc_params.negotiated_curve);
+            notnull_check(conn->secure.client_kem_group_params[i].kem_params.kem);
+
+            conn->secure.server_kem_group_params.kem_group = conn->secure.client_kem_group_params[i].kem_group;
+            conn->secure.server_kem_group_params.ecc_params.negotiated_curve = conn->secure.client_kem_group_params[i].ecc_params.negotiated_curve;
+            conn->secure.server_kem_group_params.kem_params.kem = conn->secure.client_kem_group_params[i].kem_params.kem;
+            conn->secure.chosen_client_kem_group_params = &conn->secure.client_kem_group_params[i];
+
+            conn->secure.server_ecc_evp_params.negotiated_curve = NULL;
+            return S2N_SUCCESS;
         }
     }
-
-    S2N_ERROR_IF(curve_index < 0, S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
-
-    const struct s2n_ecc_evp_params client_ecc_evp = conn->secure.client_ecc_evp_params[curve_index];
-    const struct s2n_ecc_named_curve *client_curve = client_ecc_evp.negotiated_curve;
-
-    S2N_ERROR_IF(client_curve == NULL, S2N_ERR_BAD_KEY_SHARE);
-    S2N_ERROR_IF(client_curve != server_curve, S2N_ERR_BAD_KEY_SHARE);
-    S2N_ERROR_IF(client_ecc_evp.evp_pkey == NULL, S2N_ERR_BAD_KEY_SHARE);
-
-    return 0;
-}
-
-/*
- * Selects highest priority mutually supported keyshare
- */
-int s2n_extensions_server_key_share_select(struct s2n_connection *conn)
-{
-    notnull_check(conn);
-
-    const struct s2n_ecc_preferences *ecc_pref = NULL;
-    GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
-    notnull_check(ecc_pref);
-
-    for (uint32_t i = 0; i < ecc_pref->count; i++) {
-        /* Checks supported group and keyshare have both been sent */
-        if (conn->secure.client_ecc_evp_params[i].negotiated_curve &&
-                conn->secure.mutually_supported_curves[i]) {
+    for (size_t i = 0; i < ecc_pref->count; i++) {
+        if (conn->secure.mutually_supported_curves[i] && conn->secure.client_ecc_evp_params[i].negotiated_curve) {
             conn->secure.server_ecc_evp_params.negotiated_curve = conn->secure.client_ecc_evp_params[i].negotiated_curve;
-            return 0;
+
+            conn->secure.server_kem_group_params.kem_group = NULL;
+            conn->secure.server_kem_group_params.ecc_params.negotiated_curve = NULL;
+            conn->secure.server_kem_group_params.kem_params.kem = NULL;
+            conn->secure.chosen_client_kem_group_params = NULL;
+            return S2N_SUCCESS;
         }
     }
 
-    /* Client sent no keyshares, need to send Hello Retry Request with first negotiated curve */
-    if (conn->secure.server_ecc_evp_params.negotiated_curve) {
-        GUARD(s2n_set_hello_retry_required(conn));
-        return 0;
-    }
-
-    S2N_ERROR(S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
+    /* Server and client have mutually supported groups, but the client did not send key
+     * shares for any of them. Send HRR indicating the server's preference. */
+    GUARD(s2n_set_hello_retry_required(conn));
+    return S2N_SUCCESS;
 }
 
 /* Old-style extension functions -- remove after extensions refactor is complete */

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -105,17 +105,15 @@ int s2n_tls13_compute_pq_hybrid_shared_secret(struct s2n_connection *conn, struc
     notnull_check(client_ecc_params);
 
     DEFER_CLEANUP(struct s2n_blob ecdhe_shared_secret = { 0 }, s2n_blob_zeroize_free);
-    struct s2n_blob *pq_shared_secret = NULL;
 
     /* Compute the ECDHE shared secret, and retrieve the PQ shared secret. */
     if (conn->mode == S2N_CLIENT) {
         GUARD(s2n_ecc_evp_compute_shared_secret_from_params(client_ecc_params, server_ecc_params, &ecdhe_shared_secret));
-        pq_shared_secret = &client_kem_group_params->kem_params.shared_secret;
     } else {
         GUARD(s2n_ecc_evp_compute_shared_secret_from_params(server_ecc_params, client_ecc_params, &ecdhe_shared_secret));
-        pq_shared_secret = &server_kem_group_params->kem_params.shared_secret;
     }
 
+    struct s2n_blob *pq_shared_secret = &client_kem_group_params->kem_params.shared_secret;
     notnull_check(pq_shared_secret);
     notnull_check(pq_shared_secret->data);
 


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

Adds server-side functionality for sending a PQ key share (or HRR if no client key share is present).

### Call-outs:

* ~~**This is a draft PR.** This PR depends on https://github.com/awslabs/s2n/pull/2276. https://github.com/awslabs/s2n/pull/2276 must be merged first.~~
* Currently, all KEM preferences have `tls13_kem_groups == 0` and `tls13_kem_groups == NULL`. This should effectively feature-gate the new code.

### Testing:

* Unit tests added
* No integration tests yet - we are purposefully not adding any TLS 1.3 KEM preferences yet
* Built locally with `S2N_NO_PQ=1`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
