### PR TITLE
Disable middlebox compat mode for QUIC

### DIFF
--- a/tests/saw/spec/handshake/s2n_handshake_io.cry
+++ b/tests/saw/spec/handshake/s2n_handshake_io.cry
@@ -170,7 +170,7 @@ IS_TLS13_HANDSHAKE conn = conn.actual_protocol_version == S2N_TLS13
 ACTIVE_STATE_MACHINE : connection -> [19]handshake_action
 ACTIVE_STATE_MACHINE conn = if IS_TLS13_HANDSHAKE conn then tls13_state_machine else state_machine # zero
 
-ACTIVE_HANDSHAKES : connection -> [256][32][32]
+ACTIVE_HANDSHAKES : connection -> [512][32][32]
 ACTIVE_HANDSHAKES conn = if IS_TLS13_HANDSHAKE conn then tls13_handshakes else handshakes
 
 ACTIVE_MESSAGE : connection -> [32]
@@ -257,8 +257,8 @@ state_machine_fn m =
   else zero
 
 // A model of the tls1.3 handshake state machine (array handshakes in C)
-tls13_handshakes : [256][32][32]
-tls13_handshakes = [tls13_handshakes_fn h | h <- [0..255]]
+tls13_handshakes : [512][32][32]
+tls13_handshakes = [tls13_handshakes_fn h | h <- [0..511]]
 
 // A function that gives the tls1.3 handshake sequence for each valid handshake_type.
 tls13_handshakes_fn: [32] -> [32][32]
@@ -285,8 +285,8 @@ tls13_handshakes_fn handshk =
   else zero
 
 // A model of the handshake state machine (array handshakes in C)
-handshakes : [256][32][32]
-handshakes = [handshakes_fn h | h <- [0..255]]
+handshakes : [512][32][32]
+handshakes = [handshakes_fn h | h <- [0..511]]
 
 // A function that gives the handshake sequence for each valid handshake_type.
 // This is a sparse encoding of the handshakes array (which is sparse too).

--- a/tests/unit/s2n_client_auth_handshake_test.c
+++ b/tests/unit/s2n_client_auth_handshake_test.c
@@ -172,7 +172,7 @@ int s2n_test_client_auth_message_by_message(bool no_cert)
     EXPECT_SUCCESS(s2n_handshake_read_io(server_conn));
 
     EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS13); /* Server is now on TLS13 */
-    EXPECT_EQUAL(server_conn->handshake.handshake_type, NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH);
+    EXPECT_EQUAL(server_conn->handshake.handshake_type, NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH | MIDDLEBOX_COMPAT);
 
     EXPECT_SUCCESS(s2n_conn_set_handshake_type(server_conn));
 
@@ -225,7 +225,7 @@ int s2n_test_client_auth_message_by_message(bool no_cert)
     }
     EXPECT_SUCCESS(s2n_handshake_read_io(client_conn));
 
-    EXPECT_EQUAL(client_conn->handshake.handshake_type, NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH);
+    EXPECT_EQUAL(client_conn->handshake.handshake_type, NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH | MIDDLEBOX_COMPAT);
 
     /* Client reads ServerCert */
     EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), SERVER_CERT);
@@ -248,9 +248,9 @@ int s2n_test_client_auth_message_by_message(bool no_cert)
     EXPECT_SUCCESS(s2n_handshake_write_io(client_conn));
 
     if (no_cert) {
-        EXPECT_EQUAL(client_conn->handshake.handshake_type, NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH | NO_CLIENT_CERT);
+        EXPECT_EQUAL(client_conn->handshake.handshake_type, NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH | NO_CLIENT_CERT | MIDDLEBOX_COMPAT);
     } else {
-        EXPECT_EQUAL(client_conn->handshake.handshake_type, NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH);
+        EXPECT_EQUAL(client_conn->handshake.handshake_type, NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH | MIDDLEBOX_COMPAT);
 
         /*Client sends CertVerify */
         EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), CLIENT_CERT_VERIFY);
@@ -271,9 +271,9 @@ int s2n_test_client_auth_message_by_message(bool no_cert)
     EXPECT_SUCCESS(s2n_handshake_read_io(server_conn));
 
     if (no_cert) {
-        EXPECT_EQUAL(server_conn->handshake.handshake_type, NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH | NO_CLIENT_CERT);
+        EXPECT_EQUAL(server_conn->handshake.handshake_type, NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH | NO_CLIENT_CERT | MIDDLEBOX_COMPAT);
     } else {
-        EXPECT_EQUAL(server_conn->handshake.handshake_type, NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH);
+        EXPECT_EQUAL(server_conn->handshake.handshake_type, NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH | MIDDLEBOX_COMPAT);
 
         /* Server reads CertVerify */
         EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), CLIENT_CERT_VERIFY);

--- a/tests/unit/s2n_self_talk_quic_support_test.c
+++ b/tests/unit/s2n_self_talk_quic_support_test.c
@@ -19,7 +19,7 @@
 #include "tls/s2n_quic_support.h"
 
 static const uint8_t CLIENT_TRANSPORT_PARAMS[] = "client transport params";
-static const uint8_t SERVER_TRANSPORT_PARAMS[] = "client transport params";
+static const uint8_t SERVER_TRANSPORT_PARAMS[] = "server transport params";
 
 int main(int argc, char **argv)
 {
@@ -79,6 +79,14 @@ int main(int argc, char **argv)
             &transport_params, &transport_params_len));
     EXPECT_EQUAL(transport_params_len, sizeof(CLIENT_TRANSPORT_PARAMS));
     EXPECT_BYTEARRAY_EQUAL(transport_params, CLIENT_TRANSPORT_PARAMS, transport_params_len);
+
+    /* Verify legacy_session_id not set (QUIC does not use middlebox compat mode) */
+    EXPECT_EQUAL(client_conn->session_id_len, 0);
+    EXPECT_EQUAL(server_conn->session_id_len, 0);
+
+    /* Verify handshake not MIDDLEBOX_COMPAT (QUIC does not use middlebox compat mode) */
+    EXPECT_FALSE(IS_MIDDLEBOX_COMPAT_MODE(client_conn->handshake.handshake_type));
+    EXPECT_FALSE(IS_MIDDLEBOX_COMPAT_MODE(server_conn->handshake.handshake_type));
 
     EXPECT_SUCCESS(s2n_connection_free(server_conn));
     EXPECT_SUCCESS(s2n_connection_free(client_conn));

--- a/tests/unit/s2n_self_talk_quic_support_test.c
+++ b/tests/unit/s2n_self_talk_quic_support_test.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+
+#include "tls/s2n_quic_support.h"
+
+static const uint8_t CLIENT_TRANSPORT_PARAMS[] = "client transport params";
+static const uint8_t SERVER_TRANSPORT_PARAMS[] = "client transport params";
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+    EXPECT_SUCCESS(s2n_enable_tls13());
+
+    const uint8_t *transport_params = NULL;
+    uint16_t transport_params_len = 0;
+
+    /* Setup connections */
+    struct s2n_connection *client_conn, *server_conn;
+    EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+    EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+
+    /* Setup config */
+    struct s2n_cert_chain_and_key *chain_and_key;
+    EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
+            S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
+    struct s2n_config *config;
+    EXPECT_NOT_NULL(config = s2n_config_new());
+    EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
+    EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+    EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+    EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+    /* Create nonblocking pipes */
+    struct s2n_test_io_pair io_pair;
+    EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+    EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
+    EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
+
+    /* Enable quic */
+    EXPECT_SUCCESS(s2n_connection_enable_quic(client_conn));
+    EXPECT_SUCCESS(s2n_connection_enable_quic(server_conn));
+
+    /* Setup quic transport parameters */
+    EXPECT_SUCCESS(s2n_connection_set_quic_transport_parameters(client_conn,
+            CLIENT_TRANSPORT_PARAMS, sizeof(CLIENT_TRANSPORT_PARAMS)));
+    EXPECT_SUCCESS(s2n_connection_set_quic_transport_parameters(server_conn,
+            SERVER_TRANSPORT_PARAMS, sizeof(SERVER_TRANSPORT_PARAMS)));
+
+    /* Do handshake */
+    EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+
+    /* Verify TLS1.3 */
+    EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS13);
+    EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS13);
+
+    /* Verify server quic_transport_parameters on client */
+    EXPECT_SUCCESS(s2n_connection_get_quic_transport_parameters(client_conn,
+            &transport_params, &transport_params_len));
+    EXPECT_EQUAL(transport_params_len, sizeof(SERVER_TRANSPORT_PARAMS));
+    EXPECT_BYTEARRAY_EQUAL(transport_params, SERVER_TRANSPORT_PARAMS, transport_params_len);
+
+    /* Verify client quic_transport_parameters on server */
+    EXPECT_SUCCESS(s2n_connection_get_quic_transport_parameters(server_conn,
+            &transport_params, &transport_params_len));
+    EXPECT_EQUAL(transport_params_len, sizeof(CLIENT_TRANSPORT_PARAMS));
+    EXPECT_BYTEARRAY_EQUAL(transport_params, CLIENT_TRANSPORT_PARAMS, transport_params_len);
+
+    EXPECT_SUCCESS(s2n_connection_free(server_conn));
+    EXPECT_SUCCESS(s2n_connection_free(client_conn));
+    EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
+    EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+    EXPECT_SUCCESS(s2n_config_free(config));
+
+    END_TEST();
+}

--- a/tests/unit/s2n_tls13_handshake_state_machine_test.c
+++ b/tests/unit/s2n_tls13_handshake_state_machine_test.c
@@ -27,6 +27,7 @@
 #include "tls/s2n_cipher_suites.h"
 #include "tls/s2n_connection.h"
 #include "tls/s2n_handshake.h"
+#include "tls/s2n_quic_support.h"
 #include "tls/s2n_tls13.h"
 
 /* Just to get access to the static functions / variables we need to test */
@@ -98,6 +99,8 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
+    EXPECT_SUCCESS(s2n_enable_tls13());
+
     /* Construct an array of all valid tls1.3 handshake_types */
     uint16_t valid_tls13_handshakes[S2N_HANDSHAKES_COUNT];
     int valid_tls13_handshakes_size = 0;
@@ -114,6 +117,43 @@ int main(int argc, char **argv)
     for (int i = 0; i < s2n_array_len(tls13_state_machine); i++) {
         tls13_state_machine[i].handler[0] = s2n_test_handler;
         tls13_state_machine[i].handler[1] = s2n_test_handler;
+    }
+
+    /* Test: A MIDDLEBOX_COMPAT form of every valid, negotiated handshake exists
+     *       and matches the non-MIDDLEBOX_COMPAT form EXCEPT for CCS messages */
+    {
+        uint32_t handshake_type_original, handshake_type_mc;
+        message_type_t *messages_original, *messages_mc;
+
+        for (size_t i = 0; i < valid_tls13_handshakes_size; i++) {
+
+            handshake_type_original = valid_tls13_handshakes[i];
+            messages_original = tls13_handshakes[handshake_type_original];
+
+            /* Ignore INITIAL and MIDDLEBOX_COMPAT handshakes */
+            if (!IS_NEGOTIATED(handshake_type_original) || IS_MIDDLEBOX_COMPAT_MODE(handshake_type_original)) {
+                continue;
+            }
+
+            /* MIDDLEBOX_COMPAT form of the handshake */
+            handshake_type_mc = handshake_type_original | MIDDLEBOX_COMPAT;
+            messages_mc = tls13_handshakes[handshake_type_mc];
+
+            for (size_t j = 0, j_mc = 0; j < S2N_MAX_HANDSHAKE_LENGTH && j_mc < S2N_MAX_HANDSHAKE_LENGTH; j++, j_mc++) {
+                /* The original handshake cannot contain CCS messages */
+                EXPECT_NOT_EQUAL(messages_original[j], SERVER_CHANGE_CIPHER_SPEC);
+                EXPECT_NOT_EQUAL(messages_original[j], CLIENT_CHANGE_CIPHER_SPEC);
+
+                /* Skip CCS messages in the MIDDLEBOX_COMPAT handshake */
+                while (messages_mc[j_mc] == SERVER_CHANGE_CIPHER_SPEC ||
+                        messages_mc[j_mc] == CLIENT_CHANGE_CIPHER_SPEC) {
+                    j_mc++;
+                }
+
+                /* The handshakes must be otherwise equivalent */
+                EXPECT_EQUAL(messages_original[j], messages_mc[j_mc]);
+            }
+        }
     }
 
     /* Test: When using TLS 1.3, use the new state machine and handshakes */
@@ -274,6 +314,42 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
+    /* Test: TLS1.3 client fails on a server cipher change spec when using QUIC */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_SUCCESS(s2n_connection_enable_quic(conn));
+        conn->actual_protocol_version = S2N_TLS13;
+
+        struct s2n_stuffer input;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, NULL, conn));
+
+        EXPECT_SUCCESS(s2n_setup_handler_to_expect(SERVER_CHANGE_CIPHER_SPEC, S2N_CLIENT));
+
+        for (int i = 0; i < valid_tls13_handshakes_size; i++) {
+            int handshake = valid_tls13_handshakes[i];
+
+            conn->handshake.handshake_type = handshake;
+            conn->in_status = ENCRYPTED;
+
+            for (int j = 1; j < S2N_MAX_HANDSHAKE_LENGTH; j++) {
+                conn->handshake.message_number = j;
+
+                EXPECT_SUCCESS(s2n_test_write_header(&input, TLS_CHANGE_CIPHER_SPEC, 0));
+                EXPECT_FAILURE_WITH_ERRNO(s2n_handshake_read_io(conn), S2N_ERR_BAD_MESSAGE);
+
+                EXPECT_EQUAL(conn->handshake.message_number, j);
+                EXPECT_FALSE(unexpected_handler_called);
+                EXPECT_FALSE(expected_handler_called);
+
+                EXPECT_SUCCESS(s2n_stuffer_wipe(&input));
+            }
+        }
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&input));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
     /* Test: TLS1.3 server can receive a client cipher change request at any time. */
     {
         struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
@@ -306,6 +382,42 @@ int main(int argc, char **argv)
 
                 EXPECT_FALSE(unexpected_handler_called);
                 EXPECT_TRUE(expected_handler_called);
+
+                EXPECT_SUCCESS(s2n_stuffer_wipe(&input));
+            }
+        }
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&input));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test: TLS1.3 server fails on a client cipher change spec when using QUIC */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_SUCCESS(s2n_connection_enable_quic(conn));
+        conn->actual_protocol_version = S2N_TLS13;
+
+        struct s2n_stuffer input;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, NULL, conn));
+
+        EXPECT_SUCCESS(s2n_setup_handler_to_expect(CLIENT_CHANGE_CIPHER_SPEC, S2N_SERVER));
+
+        for (int i = 0; i < valid_tls13_handshakes_size; i++) {
+            int handshake = valid_tls13_handshakes[i];
+
+            conn->handshake.handshake_type = handshake;
+            conn->in_status = ENCRYPTED;
+
+            for (int j = 1; j < S2N_MAX_HANDSHAKE_LENGTH; j++) {
+                conn->handshake.message_number = j;
+
+                EXPECT_SUCCESS(s2n_test_write_header(&input, TLS_CHANGE_CIPHER_SPEC, 0));
+                EXPECT_FAILURE_WITH_ERRNO(s2n_handshake_read_io(conn), S2N_ERR_BAD_MESSAGE);
+
+                EXPECT_EQUAL(conn->handshake.message_number, j);
+                EXPECT_FALSE(unexpected_handler_called);
+                EXPECT_FALSE(expected_handler_called);
 
                 EXPECT_SUCCESS(s2n_stuffer_wipe(&input));
             }
@@ -402,7 +514,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, NULL, conn));
 
             uint8_t server_css_message_number = 2;
-            conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
+            conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE | MIDDLEBOX_COMPAT;
             conn->handshake.message_number = server_css_message_number;
             EXPECT_EQUAL(ACTIVE_MESSAGE(conn), SERVER_CHANGE_CIPHER_SPEC);
             EXPECT_SUCCESS(s2n_setup_handler_to_expect(SERVER_CHANGE_CIPHER_SPEC, S2N_CLIENT));
@@ -419,7 +531,7 @@ int main(int argc, char **argv)
         }
     }
 
-    /* Test: TLS 1.3 handshakes all follow CCS middlebox compatibility rules.
+    /* Test: TLS 1.3 MIDDLEBOX_COMPAT handshakes all follow CCS middlebox compatibility rules.
      * RFC: https://tools.ietf.org/html/rfc8446#appendix-D.4 */
     {
         bool change_cipher_spec_found;
@@ -433,12 +545,12 @@ int main(int argc, char **argv)
             handshake_type = valid_tls13_handshakes[i];
             messages = tls13_handshakes[handshake_type];
 
-            for (size_t j = 1; j < S2N_MAX_HANDSHAKE_LENGTH; j++) {
+            /* Ignore INITIAL and non-MIDDLEBOX_COMPAT handshakes */
+            if (!IS_NEGOTIATED(handshake_type) || !IS_MIDDLEBOX_COMPAT_MODE(handshake_type)) {
+                continue;
+            }
 
-                /* Ignore initial handshakes */
-                if (!IS_NEGOTIATED(handshake_type)) {
-                    continue;
-                }
+            for (size_t j = 1; j < S2N_MAX_HANDSHAKE_LENGTH; j++) {
 
                 /* Is it the second client flight?
                  * Have we switched from the server sending to the client sending? */
@@ -455,9 +567,7 @@ int main(int argc, char **argv)
                 break;
             }
 
-            if (IS_NEGOTIATED(handshake_type)) {
-                EXPECT_TRUE(change_cipher_spec_found);
-            }
+            EXPECT_TRUE(change_cipher_spec_found);
         }
 
         /* Test: "If offering early data, the [change_cipher_spce] record is placed immediately after the first ClientHello."
@@ -471,12 +581,12 @@ int main(int argc, char **argv)
             handshake_type = valid_tls13_handshakes[i];
             messages = tls13_handshakes[handshake_type];
 
-            for (size_t j = 1; j < S2N_MAX_HANDSHAKE_LENGTH; j++) {
+            /* Ignore INITIAL and non-MIDDLEBOX_COMPAT handshakes */
+            if (!IS_NEGOTIATED(handshake_type) || !IS_MIDDLEBOX_COMPAT_MODE(handshake_type)) {
+                continue;
+            }
 
-                /* Ignore initial handshakes */
-                if (!IS_NEGOTIATED(handshake_type)) {
-                    continue;
-                }
+            for (size_t j = 1; j < S2N_MAX_HANDSHAKE_LENGTH; j++) {
 
                 /* Is it the first server flight?
                  * Have we switched from the client sending to the server sending? */
@@ -493,13 +603,11 @@ int main(int argc, char **argv)
                 break;
             }
 
-            if (IS_NEGOTIATED(handshake_type)) {
-                EXPECT_TRUE(change_cipher_spec_found);
-            }
+            EXPECT_TRUE(change_cipher_spec_found);
         }
     }
 
-    /* Test: TLS1.3 s2n_conn_set_handshake_type sets FULL_HANDSHAKE, HELLO_RETRY_REQUEST, and CLIENT_AUTH*/
+    /* Test: TLS1.3 s2n_conn_set_handshake_type sets only handshake flags allowed by TLS1.3 */
     {
         struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
 
@@ -516,7 +624,7 @@ int main(int argc, char **argv)
         /* Ensure OCSP_STATUS is set by setting the connection status_type */
         conn->status_type = S2N_STATUS_REQUEST_OCSP;
 
-        /* Verify setup: tls1.2 DOES set the flags */
+        /* Verify that tls1.2 DOES set the flags allowed by tls1.2 */
         conn->actual_protocol_version = S2N_TLS12;
         EXPECT_SUCCESS(s2n_conn_set_handshake_type(conn));
         EXPECT_TRUE(conn->handshake.handshake_type & TLS12_PERFECT_FORWARD_SECRECY );
@@ -524,16 +632,31 @@ int main(int argc, char **argv)
         EXPECT_TRUE(conn->handshake.handshake_type & WITH_SESSION_TICKET );
         EXPECT_TRUE(conn->handshake.handshake_type & CLIENT_AUTH );
 
-        /* Verify that tls1.3 ONLY sets the CLIENT_AUTH flag */
+        /* Verify that tls1.2 DOES NOT set the flags only allowed by tls1.3 */
+        EXPECT_FALSE(conn->handshake.handshake_type & MIDDLEBOX_COMPAT);
+
+        /* Verify that tls1.3 ONLY sets the flags allowed by tls1.3 */
         conn->actual_protocol_version = S2N_TLS13;
         EXPECT_SUCCESS(s2n_conn_set_handshake_type(conn));
-        EXPECT_EQUAL(conn->handshake.handshake_type, NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH);
+        EXPECT_EQUAL(conn->handshake.handshake_type, NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH | MIDDLEBOX_COMPAT);
 
-        /* Verify that tls1.3 DOES NOT set the flags even when a HelloRetryRequest is in the mix */
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test: TLS1.3 s2n_conn_set_handshake_type only allows HELLO_RETRY_REQUEST with tls1.3 */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+
+        /* HELLO_RETRY_REQUEST allowed with tls1.3 */
         conn->actual_protocol_version = S2N_TLS13;
         conn->handshake.handshake_type = INITIAL | HELLO_RETRY_REQUEST;
         EXPECT_SUCCESS(s2n_conn_set_handshake_type(conn));
-        EXPECT_EQUAL(conn->handshake.handshake_type, NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH | HELLO_RETRY_REQUEST);
+        EXPECT_TRUE(conn->handshake.handshake_type & HELLO_RETRY_REQUEST);
+
+        /* HELLO_RETRY_REQUEST not allowed with tls1.2 */
+        conn->actual_protocol_version = S2N_TLS12;
+        conn->handshake.handshake_type = INITIAL | HELLO_RETRY_REQUEST;
+        EXPECT_FAILURE_WITH_ERRNO(s2n_conn_set_handshake_type(conn), S2N_ERR_INVALID_HELLO_RETRY);
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
@@ -552,8 +675,10 @@ int main(int argc, char **argv)
         conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE | HELLO_RETRY_REQUEST;
         EXPECT_STRING_EQUAL("NEGOTIATED|FULL_HANDSHAKE|HELLO_RETRY_REQUEST", s2n_connection_get_handshake_type_name(conn));
 
-        const char* all_flags_handshake_type_name = "NEGOTIATED|FULL_HANDSHAKE|CLIENT_AUTH|WITH_SESSION_TICKET|NO_CLIENT_CERT";
-        conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH | WITH_SESSION_TICKET | NO_CLIENT_CERT;
+        const char* all_flags_handshake_type_name = "NEGOTIATED|FULL_HANDSHAKE|CLIENT_AUTH|WITH_SESSION_TICKET|"
+                "NO_CLIENT_CERT|MIDDLEBOX_COMPAT";
+        conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH | WITH_SESSION_TICKET |
+                NO_CLIENT_CERT | MIDDLEBOX_COMPAT;
         EXPECT_STRING_EQUAL(all_flags_handshake_type_name, s2n_connection_get_handshake_type_name(conn));
 
         const char *handshake_type_name;
@@ -578,7 +703,7 @@ int main(int argc, char **argv)
 
     /* Test: TLS 1.3 message types are all properly printed */
     {
-        uint32_t test_handshake_type = NEGOTIATED | FULL_HANDSHAKE;
+        uint32_t test_handshake_type = NEGOTIATED | FULL_HANDSHAKE | MIDDLEBOX_COMPAT;
         const char* expected[] = { "CLIENT_HELLO", "SERVER_HELLO", "SERVER_CHANGE_CIPHER_SPEC",
                 "ENCRYPTED_EXTENSIONS", "SERVER_CERT", "SERVER_CERT_VERIFY", "SERVER_FINISHED",
                 "CLIENT_CHANGE_CIPHER_SPEC", "CLIENT_FINISHED", "APPLICATION_DATA" };
@@ -600,8 +725,8 @@ int main(int argc, char **argv)
     {
         uint32_t test_handshake_type = NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH;
         const char* expected[] = { "CLIENT_HELLO",
-            "SERVER_HELLO", "SERVER_CHANGE_CIPHER_SPEC", "ENCRYPTED_EXTENSIONS", "SERVER_CERT_REQ", "SERVER_CERT", "SERVER_CERT_VERIFY", "SERVER_FINISHED",
-            "CLIENT_CHANGE_CIPHER_SPEC", "CLIENT_CERT", "CLIENT_CERT_VERIFY", "CLIENT_FINISHED",
+            "SERVER_HELLO", "ENCRYPTED_EXTENSIONS", "SERVER_CERT_REQ", "SERVER_CERT", "SERVER_CERT_VERIFY", "SERVER_FINISHED",
+            "CLIENT_CERT", "CLIENT_CERT_VERIFY", "CLIENT_FINISHED",
             "APPLICATION_DATA" };
 
         struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);

--- a/tests/unit/s2n_tls13_handshake_state_machine_test.c
+++ b/tests/unit/s2n_tls13_handshake_state_machine_test.c
@@ -326,13 +326,13 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_setup_handler_to_expect(SERVER_CHANGE_CIPHER_SPEC, S2N_CLIENT));
 
-        for (int i = 0; i < valid_tls13_handshakes_size; i++) {
+        for (size_t i = 0; i < valid_tls13_handshakes_size; i++) {
             int handshake = valid_tls13_handshakes[i];
 
             conn->handshake.handshake_type = handshake;
             conn->in_status = ENCRYPTED;
 
-            for (int j = 1; j < S2N_MAX_HANDSHAKE_LENGTH; j++) {
+            for (size_t j = 1; j < S2N_MAX_HANDSHAKE_LENGTH; j++) {
                 conn->handshake.message_number = j;
 
                 EXPECT_SUCCESS(s2n_test_write_header(&input, TLS_CHANGE_CIPHER_SPEC, 0));
@@ -403,13 +403,13 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_setup_handler_to_expect(CLIENT_CHANGE_CIPHER_SPEC, S2N_SERVER));
 
-        for (int i = 0; i < valid_tls13_handshakes_size; i++) {
+        for (size_t i = 0; i < valid_tls13_handshakes_size; i++) {
             int handshake = valid_tls13_handshakes[i];
 
             conn->handshake.handshake_type = handshake;
             conn->in_status = ENCRYPTED;
 
-            for (int j = 1; j < S2N_MAX_HANDSHAKE_LENGTH; j++) {
+            for (size_t j = 1; j < S2N_MAX_HANDSHAKE_LENGTH; j++) {
                 conn->handshake.message_number = j;
 
                 EXPECT_SUCCESS(s2n_test_write_header(&input, TLS_CHANGE_CIPHER_SPEC, 0));

--- a/tests/unit/s2n_tls13_handshake_test.c
+++ b/tests/unit/s2n_tls13_handshake_test.c
@@ -452,7 +452,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_handshake_read_io(server_conn));
 
         EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS13); /* Server is now on TLS13 */
-        EXPECT_EQUAL(server_conn->handshake.handshake_type, NEGOTIATED | FULL_HANDSHAKE);
+        EXPECT_EQUAL(server_conn->handshake.handshake_type, NEGOTIATED | FULL_HANDSHAKE | MIDDLEBOX_COMPAT);
 
         s2n_tls13_connection_keys(server_secrets, server_conn);
         EXPECT_EQUAL(server_secrets.size, 48);

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -170,16 +170,21 @@ struct s2n_handshake {
 #define CLIENT_AUTH                 0x10
 #define IS_CLIENT_AUTH_HANDSHAKE( type )   ( (type) & CLIENT_AUTH )
 
-/* Handshake requested a Client Certificate but did not get one */
-#define NO_CLIENT_CERT              0x40
-#define IS_CLIENT_AUTH_NO_CERT( type )   ( IS_CLIENT_AUTH_HANDSHAKE( (type) ) && ( (type) & NO_CLIENT_CERT) )
-
 /* Session Resumption via session-tickets */
 #define WITH_SESSION_TICKET         0x20
 #define IS_ISSUING_NEW_SESSION_TICKET( type )   ( (type) & WITH_SESSION_TICKET )
 
+/* Handshake requested a Client Certificate but did not get one */
+#define NO_CLIENT_CERT              0x40
+#define IS_CLIENT_AUTH_NO_CERT( type )   ( IS_CLIENT_AUTH_HANDSHAKE( (type) ) && ( (type) & NO_CLIENT_CERT) )
+
 /* A HelloRetryRequest was needed to proceed with the handshake */
 #define HELLO_RETRY_REQUEST         0x80
+
+/* Disguise a TLS1.3 handshake as a TLS1.2 handshake for backwards compatibility
+ * with some middleboxes: https://tools.ietf.org/html/rfc8446#appendix-D.4 */
+#define MIDDLEBOX_COMPAT            0x100
+#define IS_MIDDLEBOX_COMPAT_MODE( type ) ( (type) & MIDDLEBOX_COMPAT )
 
     /* Which handshake message number are we processing */
     int message_number;

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -121,7 +121,7 @@ static const char *message_names[] = {
 };
 
 /* Maximum number of valid handshakes */
-#define S2N_HANDSHAKES_COUNT        256
+#define S2N_HANDSHAKES_COUNT        512
 
 /* Maximum number of messages in a handshake */
 #define S2N_MAX_HANDSHAKE_LENGTH    32
@@ -363,12 +363,28 @@ static message_type_t tls13_handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_L
 
     [NEGOTIATED | FULL_HANDSHAKE] = {
             CLIENT_HELLO,
+            SERVER_HELLO, ENCRYPTED_EXTENSIONS, SERVER_CERT, SERVER_CERT_VERIFY, SERVER_FINISHED,
+            CLIENT_FINISHED,
+            APPLICATION_DATA
+    },
+
+    [NEGOTIATED | FULL_HANDSHAKE | MIDDLEBOX_COMPAT] = {
+            CLIENT_HELLO,
             SERVER_HELLO, SERVER_CHANGE_CIPHER_SPEC, ENCRYPTED_EXTENSIONS, SERVER_CERT, SERVER_CERT_VERIFY, SERVER_FINISHED,
             CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
             APPLICATION_DATA
     },
 
     [NEGOTIATED | FULL_HANDSHAKE | HELLO_RETRY_REQUEST] = {
+            CLIENT_HELLO,
+            HELLO_RETRY_MSG,
+            CLIENT_HELLO,
+            SERVER_HELLO, ENCRYPTED_EXTENSIONS, SERVER_CERT, SERVER_CERT_VERIFY, SERVER_FINISHED,
+            CLIENT_FINISHED,
+            APPLICATION_DATA
+    },
+
+    [NEGOTIATED | FULL_HANDSHAKE | HELLO_RETRY_REQUEST | MIDDLEBOX_COMPAT] = {
             CLIENT_HELLO,
             HELLO_RETRY_MSG, SERVER_CHANGE_CIPHER_SPEC,
             CLIENT_CHANGE_CIPHER_SPEC, CLIENT_HELLO,
@@ -379,6 +395,15 @@ static message_type_t tls13_handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_L
 
     [NEGOTIATED | FULL_HANDSHAKE | HELLO_RETRY_REQUEST | CLIENT_AUTH] = {
             CLIENT_HELLO,
+            HELLO_RETRY_MSG,
+            CLIENT_HELLO,
+            SERVER_HELLO, ENCRYPTED_EXTENSIONS, SERVER_CERT_REQ, SERVER_CERT, SERVER_CERT_VERIFY, SERVER_FINISHED,
+            CLIENT_CERT, CLIENT_CERT_VERIFY, CLIENT_FINISHED,
+            APPLICATION_DATA
+    },
+
+    [NEGOTIATED | FULL_HANDSHAKE | HELLO_RETRY_REQUEST | CLIENT_AUTH | MIDDLEBOX_COMPAT] = {
+            CLIENT_HELLO,
             HELLO_RETRY_MSG, SERVER_CHANGE_CIPHER_SPEC,
             CLIENT_CHANGE_CIPHER_SPEC, CLIENT_HELLO,
             SERVER_HELLO, ENCRYPTED_EXTENSIONS, SERVER_CERT_REQ, SERVER_CERT, SERVER_CERT_VERIFY, SERVER_FINISHED,
@@ -386,7 +411,16 @@ static message_type_t tls13_handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_L
             APPLICATION_DATA
     },
 
-    [NEGOTIATED | FULL_HANDSHAKE | HELLO_RETRY_REQUEST | CLIENT_AUTH | NO_CLIENT_CERT ] = {
+    [NEGOTIATED | FULL_HANDSHAKE | HELLO_RETRY_REQUEST | CLIENT_AUTH | NO_CLIENT_CERT] = {
+            CLIENT_HELLO,
+            HELLO_RETRY_MSG,
+            CLIENT_HELLO,
+            SERVER_HELLO, ENCRYPTED_EXTENSIONS, SERVER_CERT_REQ, SERVER_CERT, SERVER_CERT_VERIFY, SERVER_FINISHED,
+            CLIENT_CERT, CLIENT_FINISHED,
+            APPLICATION_DATA
+    },
+
+    [NEGOTIATED | FULL_HANDSHAKE | HELLO_RETRY_REQUEST | CLIENT_AUTH | NO_CLIENT_CERT | MIDDLEBOX_COMPAT] = {
             CLIENT_HELLO,
             HELLO_RETRY_MSG, SERVER_CHANGE_CIPHER_SPEC,
             CLIENT_CHANGE_CIPHER_SPEC, CLIENT_HELLO,
@@ -397,22 +431,35 @@ static message_type_t tls13_handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_L
 
     [NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH] = {
             CLIENT_HELLO,
+            SERVER_HELLO, ENCRYPTED_EXTENSIONS, SERVER_CERT_REQ, SERVER_CERT, SERVER_CERT_VERIFY, SERVER_FINISHED,
+            CLIENT_CERT, CLIENT_CERT_VERIFY, CLIENT_FINISHED,
+            APPLICATION_DATA
+    },
+
+    [NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH | MIDDLEBOX_COMPAT] = {
+            CLIENT_HELLO,
             SERVER_HELLO, SERVER_CHANGE_CIPHER_SPEC, ENCRYPTED_EXTENSIONS, SERVER_CERT_REQ, SERVER_CERT, SERVER_CERT_VERIFY, SERVER_FINISHED,
             CLIENT_CHANGE_CIPHER_SPEC, CLIENT_CERT, CLIENT_CERT_VERIFY, CLIENT_FINISHED,
             APPLICATION_DATA
     },
 
-    [NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH | NO_CLIENT_CERT ] = {
+    [NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH | NO_CLIENT_CERT] = {
+            CLIENT_HELLO,
+            SERVER_HELLO, ENCRYPTED_EXTENSIONS, SERVER_CERT_REQ, SERVER_CERT, SERVER_CERT_VERIFY, SERVER_FINISHED,
+            CLIENT_CERT, CLIENT_FINISHED,
+            APPLICATION_DATA
+    },
+
+    [NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH | NO_CLIENT_CERT | MIDDLEBOX_COMPAT] = {
             CLIENT_HELLO,
             SERVER_HELLO, SERVER_CHANGE_CIPHER_SPEC, ENCRYPTED_EXTENSIONS, SERVER_CERT_REQ, SERVER_CERT, SERVER_CERT_VERIFY, SERVER_FINISHED,
             CLIENT_CHANGE_CIPHER_SPEC, CLIENT_CERT, CLIENT_FINISHED,
             APPLICATION_DATA
     },
-
 };
 /* clang-format on */
 
-#define MAX_HANDSHAKE_TYPE_LEN 128
+#define MAX_HANDSHAKE_TYPE_LEN 155
 static char handshake_type_str[S2N_HANDSHAKES_COUNT][MAX_HANDSHAKE_TYPE_LEN] = {0};
 
 static const char* handshake_type_names[] = {
@@ -423,7 +470,8 @@ static const char* handshake_type_names[] = {
     "CLIENT_AUTH|",
     "WITH_SESSION_TICKET|",
     "NO_CLIENT_CERT|",
-    "HELLO_RETRY_REQUEST|"
+    "HELLO_RETRY_REQUEST|",
+    "MIDDLEBOX_COMPAT|",
 };
 
 #define IS_TLS13_HANDSHAKE( conn )    ((conn)->actual_protocol_version == S2N_TLS13)
@@ -557,6 +605,10 @@ int s2n_conn_set_handshake_type(struct s2n_connection *conn)
     }
 
     if (IS_TLS13_HANDSHAKE(conn)) {
+        if (!conn->quic_enabled) {
+            /* Use middlebox compatibility mode for TLS1.3 by default */
+            conn->handshake.handshake_type |= MIDDLEBOX_COMPAT;
+        }
         conn->handshake.handshake_type |= FULL_HANDSHAKE;
 
         return 0;
@@ -890,8 +942,9 @@ static int s2n_handshake_read_io(struct s2n_connection *conn)
      */
     S2N_ERROR_IF(record_type == TLS_APPLICATION_DATA, S2N_ERR_BAD_MESSAGE);
     if (record_type == TLS_CHANGE_CIPHER_SPEC) {
-        /* TLS1.2 should not receive unexpected change cipher spec messages, but TLS1.3 might. */
-        if (!IS_TLS13_HANDSHAKE(conn)) {
+        /* TLS1.2 should not receive unexpected change cipher spec messages.
+         * TLS1.3 using QUIC should never receive change cipher spec messages. */
+        if (!IS_TLS13_HANDSHAKE(conn) || conn->quic_enabled) {
             ENSURE_POSIX(EXPECTED_RECORD_TYPE(conn) == TLS_CHANGE_CIPHER_SPEC, S2N_ERR_BAD_MESSAGE);
             ENSURE_POSIX(!CONNECTION_IS_WRITER(conn), S2N_ERR_BAD_MESSAGE);
         }


### PR DESCRIPTION
### Resolved issues:

 resolves https://github.com/awslabs/s2n/issues/2289

### Description of changes: 

Add a "MIDDLEBOX_COMPAT" handshake flag to all existing TLS1.3 handshakes, then add new handshakes without the change cipher spec messages.

### Testing:

* New QUIC self-talk test
* New unit test to prove that existing MIDDLEBOX_COMPAT and new non-MIDDLEBOX_COMPAT handshakes are identical except for the change cipher spec messages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
