### PR TITLE
Updated PSS support definition to account for new BoringSSL version

### DIFF
--- a/crypto/s2n_rsa_signing.h
+++ b/crypto/s2n_rsa_signing.h
@@ -22,7 +22,7 @@
 #include "crypto/s2n_rsa.h"
 
 /* Check for libcrypto 1.1 for RSA PSS Signing and EV_Key usage */
-#if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 1) && !defined(LIBRESSL_VERSION_NUMBER)
+#if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 1) && !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_IS_BORINGSSL)
 #define RSA_PSS_SIGNING_SUPPORTED 1
 #else
 #define RSA_PSS_SIGNING_SUPPORTED 0


### PR DESCRIPTION
### Description of changes: 

BoringSSL updated their version number, but does not support PSS signing. This required an update in our code to exclude BoringSSL when checking for PSS support..

### Testing:

CI and local.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
