### PR TITLE
Allow a larger inner plaintext to handle broken clients

### DIFF
--- a/tests/unit/s2n_tls13_parse_record_type_test.c
+++ b/tests/unit/s2n_tls13_parse_record_type_test.c
@@ -142,6 +142,13 @@ int main(int argc, char **argv)
         }
         EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH + 1);
 
+        EXPECT_SUCCESS(s2n_tls13_parse_record_type(&stuffer, &record_type));
+
+        /* fill up stuffer still after the limit */
+        while (s2n_stuffer_data_available(&stuffer) < S2N_ACCEPTED_MAXIUMUM_INNER_PLAINTEXT_LENGTH + 1) {
+            EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, 0x00));
+        }
+        EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), S2N_ACCEPTED_MAXIUMUM_INNER_PLAINTEXT_LENGTH + 1);
         EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_parse_record_type(&stuffer, &record_type), S2N_ERR_MAX_INNER_PLAINTEXT_SIZE);
 
         EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));

--- a/tls/s2n_record_read.c
+++ b/tls/s2n_record_read.c
@@ -171,9 +171,11 @@ int s2n_tls13_parse_record_type(struct s2n_stuffer *stuffer, uint8_t *record_typ
     /* From rfc8446 Section 5.4
      * The presence of padding does not change the overall record size
      * limitations: the full encoded TLSInnerPlaintext MUST NOT exceed 2^14
-     * + 1 octets
+     * + 1 octets.
+     * S2N accepts a larger plaintext size to handle some broken clients that have
+     * been seen in the field.
      */
-    S2N_ERROR_IF(bytes_left > S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH, S2N_ERR_MAX_INNER_PLAINTEXT_SIZE);
+    S2N_ERROR_IF(bytes_left > S2N_ACCEPTED_MAXIUMUM_INNER_PLAINTEXT_LENGTH, S2N_ERR_MAX_INNER_PLAINTEXT_SIZE);
 
     /* set cursor to the end of the stuffer */
     GUARD(s2n_stuffer_skip_read(stuffer, bytes_left));

--- a/tls/s2n_tls_parameters.h
+++ b/tls/s2n_tls_parameters.h
@@ -257,6 +257,9 @@
 /* Maximum size for full encoded TLSInnerPlaintext (https://tools.ietf.org/html/rfc8446#section-5.4) */
 #define S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH ((1 << 14) + 1)
 
+/* Maximum size S2N accepts for full encoded TLSInnerPlaintext */
+#define S2N_ACCEPTED_MAXIUMUM_INNER_PLAINTEXT_LENGTH 65280
+
 /* Alert messages are always 2 bytes long */
 #define S2N_ALERT_LENGTH 2
 


### PR DESCRIPTION
### Description of changes: 

Add a larger inner plaintext value that can be accepted while reading records.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
