### PR TITLE
Pin the version of the BoringSSL test dependency

### DIFF
--- a/codebuild/bin/install_boringssl.sh
+++ b/codebuild/bin/install_boringssl.sh
@@ -27,15 +27,19 @@ fi
 BUILD_DIR=$1
 INSTALL_DIR=$2
 source codebuild/bin/jobs.sh
-
 cd "$BUILD_DIR"
-git clone https://github.com/google/boringssl.git
-cd boringssl
 
 # BoringSSL doesn't have tags or versions in the Github repo.
 # This commit represents the latest version that S2N is compatible
 # with. It prevents our build system from breaking when BoringSSL
 # is updated.
+mkdir boringssl
+cd boringssl
+git init
+git remote add origin https://github.com/google/boringssl.git
+git fetch origin --depth=1 3743aafdacff2f7b083615a043a37101f740fa53
+git reset --hard FETCH_HEAD
+
 git checkout 3743aafdacff2f7b083615a043a37101f740fa53
 mkdir ../build
 cd ../build

--- a/codebuild/bin/install_boringssl.sh
+++ b/codebuild/bin/install_boringssl.sh
@@ -30,8 +30,15 @@ source codebuild/bin/jobs.sh
 
 cd "$BUILD_DIR"
 git clone https://github.com/google/boringssl.git
-mkdir build
-cd build
+cd boringssl
+
+# BoringSSL doesn't have tags or versions in the Github repo.
+# This commit represents the latest version that S2N is compatible
+# with. It prevents our build system from breaking when BoringSSL
+# is updated.
+git checkout 3743aafdacff2f7b083615a043a37101f740fa53
+mkdir ../build
+cd ../build
 
 cmake ../boringssl -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release
 make -j $JOBS


### PR DESCRIPTION
### Resolved issues:

BoringSSL can break our build system when new commits are pushed.

### Description of changes: 

This change pins the BoringSSL version through a commit id (tags are not available in the BoringSSL repo).

### Call-outs:

This commit should be updated periodically, this is an internal team process at the moment.

### Testing:

Integration tests



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
