### PR TITLE
Add checks for underflow in record parsing

### DIFF
--- a/tls/s2n_record_read_cbc.c
+++ b/tls/s2n_record_read_cbc.c
@@ -86,7 +86,9 @@ int s2n_record_parse_cbc(
 
     /* Subtract the padding length */
     gt_check(en.size, 0);
-    payload_length -= (en.data[en.size - 1] + 1);
+    uint16_t padding_length = en.data[en.size - 1] + 1;
+    gte_check(payload_length, padding_length);
+    payload_length -= padding_length;
 
     /* Update the MAC */
     header[3] = (payload_length >> 8);

--- a/tls/s2n_record_read_composite.c
+++ b/tls/s2n_record_read_composite.c
@@ -69,6 +69,7 @@ int s2n_record_parse_composite(
     payload_length -= mac_size;
     /* Adjust payload_length for explicit IV */
     if (conn->actual_protocol_version > S2N_TLS10) {
+        gte_check(payload_length, cipher_suite->record_alg->cipher->io.comp.record_iv_size);
         payload_length -= cipher_suite->record_alg->cipher->io.comp.record_iv_size;
     }
 
@@ -86,7 +87,9 @@ int s2n_record_parse_composite(
 
     /* Subtract the padding length */
     gt_check(en.size, 0);
-    payload_length -= (en.data[en.size - 1] + 1);
+    uint16_t padding_length = en.data[en.size - 1] + 1;
+    gte_check(payload_length, padding_length);
+    payload_length -= padding_length;
 
     struct s2n_blob seq = {.data = sequence_number,.size = S2N_TLS_SEQUENCE_NUM_LEN };
     GUARD(s2n_increment_sequence_number(&seq));


### PR DESCRIPTION
### Description of changes: 

Add some underflow checks to read methods.

### Testing:

Existing tests pass. I am open to suggestions for how to write a unit test for this case, but I could not produce a correctly malformed record in a reasonable time period.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
