### PR TITLE
Add API to display KEM group name for hybrid 1.3

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -404,6 +404,8 @@ extern const char *s2n_connection_get_curve(struct s2n_connection *conn);
 S2N_API
 extern const char *s2n_connection_get_kem_name(struct s2n_connection *conn);
 S2N_API
+extern const char *s2n_connection_get_kem_group_name(struct s2n_connection *conn);
+S2N_API
 extern int s2n_connection_get_alert(struct s2n_connection *conn);
 S2N_API
 extern const char *s2n_connection_get_handshake_type_name(struct s2n_connection *conn);

--- a/bin/echo.c
+++ b/bin/echo.c
@@ -124,6 +124,7 @@ int negotiate(struct s2n_connection *conn, int fd)
 
     printf("Curve: %s\n", s2n_connection_get_curve(conn));
     printf("KEM: %s\n", s2n_connection_get_kem_name(conn));
+    printf("KEM Group: %s\n", s2n_connection_get_kem_group_name(conn));
 
     uint32_t length;
     const uint8_t *status = s2n_connection_get_ocsp_response(conn, &length);

--- a/bin/https.c
+++ b/bin/https.c
@@ -108,6 +108,7 @@ int https(struct s2n_connection *conn, uint32_t bench)
 
     BUFFER("Curve: %s\n", s2n_connection_get_curve(conn));
     BUFFER("KEM: %s\n", s2n_connection_get_kem_name(conn));
+    BUFFER("KEM Group: %s\n", s2n_connection_get_kem_group_name(conn));
     BUFFER("Cipher negotiated: %s\n", s2n_connection_get_cipher(conn));
     BUFFER("Session resumption: %s\n", s2n_connection_is_session_resumed(conn) ? "true" : "false");
 

--- a/tests/integration/common/s2n_test_common.py
+++ b/tests/integration/common/s2n_test_common.py
@@ -35,7 +35,7 @@ def get_error(process, line_limit=10):
     return error
 
 
-def wait_for_output(output, marker, line_limit=10):
+def wait_for_output(output, marker, line_limit=20):
     for count in range(line_limit):
         line = output.readline().decode("utf-8")
         if marker in line:

--- a/tests/integration/common/s2n_test_common.py
+++ b/tests/integration/common/s2n_test_common.py
@@ -24,7 +24,7 @@ from common.s2n_test_scenario import Mode, Version, run_scenarios
 from common.s2n_test_reporting import Result
 
 
-def get_error(process, line_limit=10):
+def get_error(process, line_limit=11):
     error = ""
     for count in range(line_limit):
         line = process.stderr.readline().decode("utf-8")
@@ -35,7 +35,7 @@ def get_error(process, line_limit=10):
     return error
 
 
-def wait_for_output(output, marker, line_limit=20):
+def wait_for_output(output, marker, line_limit=11):
     for count in range(line_limit):
         line = output.readline().decode("utf-8")
         if marker in line:

--- a/tests/integration/common/s2n_test_common.py
+++ b/tests/integration/common/s2n_test_common.py
@@ -22,9 +22,10 @@ import uuid
 
 from common.s2n_test_scenario import Mode, Version, run_scenarios
 from common.s2n_test_reporting import Result
+from s2n_test_constants import NUM_EXPECTED_LINES_OUTPUT
 
 
-def get_error(process, line_limit=11):
+def get_error(process, line_limit=10):
     error = ""
     for count in range(line_limit):
         line = process.stderr.readline().decode("utf-8")
@@ -35,7 +36,7 @@ def get_error(process, line_limit=11):
     return error
 
 
-def wait_for_output(output, marker, line_limit=11):
+def wait_for_output(output, marker, line_limit=NUM_EXPECTED_LINES_OUTPUT):
     for count in range(line_limit):
         line = output.readline().decode("utf-8")
         if marker in line:

--- a/tests/integration/data/test_buf
+++ b/tests/integration/data/test_buf
@@ -160,7 +160,7 @@ def try_handshake(endpoint, port, cipher, ssl_version, server_cert=None, server_
 
     # Read it
     found = 0
-    for line in range(0, 10):
+    for line in range(0, 11):
         output = s2nd.stdout.readline().decode("utf-8")
         if output.strip() == cipher:
             found = 1
@@ -642,7 +642,7 @@ def try_handshake(endpoint, port, cipher, ssl_version, server_cert=None, server_
 
     # Read it
     found = 0
-    for line in range(0, 10):
+    for line in range(0, 11):
         output = s2nd.stdout.readline().decode("utf-8")
         if output.strip() == cipher:
             found = 1

--- a/tests/integration/data/test_buf
+++ b/tests/integration/data/test_buf
@@ -160,7 +160,7 @@ def try_handshake(endpoint, port, cipher, ssl_version, server_cert=None, server_
 
     # Read it
     found = 0
-    for line in range(0, 11):
+    for line in range(0, 10):
         output = s2nd.stdout.readline().decode("utf-8")
         if output.strip() == cipher:
             found = 1
@@ -642,7 +642,7 @@ def try_handshake(endpoint, port, cipher, ssl_version, server_cert=None, server_
 
     # Read it
     found = 0
-    for line in range(0, 11):
+    for line in range(0, 10):
         output = s2nd.stdout.readline().decode("utf-8")
         if output.strip() == cipher:
             found = 1

--- a/tests/integration/s2n_client_endpoint_handshake_test.py
+++ b/tests/integration/s2n_client_endpoint_handshake_test.py
@@ -78,7 +78,7 @@ def try_client_handshake(endpoint, arguments, expected_cipher):
     if expected_cipher:
         expected_output += expected_cipher
 
-    for line in range(0, 20):
+    for line in range(0, NUM_EXPECTED_LINES_OUTPUT):
         output = str(s2nc.stdout.readline().decode("utf-8"))
         if expected_output in output:
             found = 1

--- a/tests/integration/s2n_client_endpoint_handshake_test.py
+++ b/tests/integration/s2n_client_endpoint_handshake_test.py
@@ -78,7 +78,7 @@ def try_client_handshake(endpoint, arguments, expected_cipher):
     if expected_cipher:
         expected_output += expected_cipher
 
-    for line in range(0, 10):
+    for line in range(0, 20):
         output = str(s2nc.stdout.readline().decode("utf-8"))
         if expected_output in output:
             found = 1

--- a/tests/integration/s2n_dynamic_record_size_test.py
+++ b/tests/integration/s2n_dynamic_record_size_test.py
@@ -125,7 +125,7 @@ def try_dynamic_record(endpoint, port, cipher, ssl_version, threshold, server_ce
     # Read from s2nc until we get successful connection message
     found = 0
     seperators = 0
-    for line in range(0, 10):
+    for line in range(0, NUM_EXPECTED_LINES_OUTPUT):
         output = s2nc.stdout.readline().decode("utf-8")
         if output.strip() == "Connected to {}:{}".format(endpoint, port):
             found = 1

--- a/tests/integration/s2n_handshake_test_s_server.py
+++ b/tests/integration/s2n_handshake_test_s_server.py
@@ -133,7 +133,7 @@ def try_handshake(endpoint, port, cipher, ssl_version, server_cert=None, server_
                 found = 1
                 break
     else:
-        for line in range(0, 10):
+        for line in range(0, NUM_EXPECTED_LINES_OUTPUT):
             output = s2nc.stdout.readline().decode("utf-8")
             if output.strip() == "Connected to {}:{}".format(endpoint, port):
                 found = 1

--- a/tests/integration/s2n_pq_handshake_test.py
+++ b/tests/integration/s2n_pq_handshake_test.py
@@ -84,7 +84,7 @@ def do_pq_handshake(client_ciphers, server_ciphers, expected_cipher, expected_ke
     server_kem_found = False
     server_cipher_found = False
 
-    for i in range(0, 20):
+    for i in range(0, NUM_EXPECTED_LINES_OUTPUT):
         client_line = str(s2nc.stdout.readline().decode("utf-8"))
         if expected_kem_output in client_line:
             client_kem_found = True

--- a/tests/integration/s2n_pq_handshake_test.py
+++ b/tests/integration/s2n_pq_handshake_test.py
@@ -13,6 +13,8 @@
 # permissions and limitations under the License.
 #
 
+from s2n_test_constants import NUM_EXPECTED_LINES_OUTPUT
+
 """
 PQ Handshake tests: s2nd and s2nc negotiate a handshake using BIKE or SIKE KEMs
 """

--- a/tests/integration/s2n_pq_handshake_test.py
+++ b/tests/integration/s2n_pq_handshake_test.py
@@ -84,7 +84,7 @@ def do_pq_handshake(client_ciphers, server_ciphers, expected_cipher, expected_ke
     server_kem_found = False
     server_cipher_found = False
 
-    for i in range(0, 10):
+    for i in range(0, 20):
         client_line = str(s2nc.stdout.readline().decode("utf-8"))
         if expected_kem_output in client_line:
             client_kem_found = True

--- a/tests/integration/s2n_test_constants.py
+++ b/tests/integration/s2n_test_constants.py
@@ -16,6 +16,10 @@
 import collections
 from enum import Enum
 
+# Number of lines of output to stdout s2nc or s2nd are expected
+# to produce after a successful handshake
+NUM_EXPECTED_LINES_OUTPUT = 11
+
 class OCSP(Enum):
     ENABLED = 1
     DISABLED = 2

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -997,6 +997,17 @@ const char *s2n_connection_get_kem_name(struct s2n_connection *conn)
     return conn->secure.kem_params.kem->name;
 }
 
+const char *s2n_connection_get_kem_group_name(struct s2n_connection *conn)
+{
+    notnull_check_ptr(conn);
+
+    if (!conn->secure.chosen_client_kem_group_params || !conn->secure.chosen_client_kem_group_params->kem_group) {
+        return "NONE";
+    }
+
+    return conn->secure.chosen_client_kem_group_params->kem_group->name;
+}
+
 int s2n_connection_get_client_protocol_version(struct s2n_connection *conn)
 {
     notnull_check(conn);


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

Adds `s2n_connection_get_kem_group_name` API to display the negotiated KEM group for PQ TLS 1.3.

### Call-outs:

N/A

### Testing:

It works! (Not that PQ 1.3 security policies haven't been merged yet; `PQ-KYBER-TEST-TLS-1-0-2020-09` is only in my local repo.)

```
./s2nd --tls13 --negotiate --ciphers PQ-KYBER-TEST-TLS-1-0-2020-09 127.0.0.1 8888
Listening on 127.0.0.1:8888
CONNECTED:
Client hello version: 33
Client protocol version: 34
Server protocol version: 34
Actual protocol version: 34
Server name: 127.0.0.1
Curve: NONE
KEM: NONE
KEM Group: x25519_kyber-512-r2
Cipher negotiated: TLS_AES_256_GCM_SHA384
```

```
./s2nc -i --tls13 --ciphers PQ-KYBER-TEST-TLS-1-0-2020-09 127.0.0.1 8888
CONNECTED:
Client hello version: 33
Client protocol version: 34
Server protocol version: 34
Actual protocol version: 34
Server name: 127.0.0.1
Curve: NONE
KEM: NONE
KEM Group: x25519_kyber-512-r2
Cipher negotiated: TLS_AES_256_GCM_SHA384
Connected to 127.0.0.1:8888
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
