### PR TITLE
Record layer changes for QUIC

### DIFF
--- a/tests/unit/s2n_quic_support_io_test.c
+++ b/tests/unit/s2n_quic_support_io_test.c
@@ -243,7 +243,7 @@ int main(int argc, char **argv)
         s2n_blocked_status blocked_status;
 
         /* Use handler stubs to avoid executing complicated handler implementations */
-        for (int i = 0; i < s2n_array_len(tls13_state_machine); i++) {
+        for (size_t i = 0; i < s2n_array_len(tls13_state_machine); i++) {
             tls13_state_machine[i].handler[S2N_SERVER] = s2n_test_read_handler;
             tls13_state_machine[i].handler[S2N_CLIENT] = s2n_test_write_handler;
         }

--- a/tests/unit/s2n_quic_support_io_test.c
+++ b/tests/unit/s2n_quic_support_io_test.c
@@ -1,0 +1,412 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+#include "tls/s2n_quic_support.h"
+
+#include "tls/s2n_connection.h"
+#include "tls/s2n_handshake.h"
+#include "tls/s2n_tls.h"
+#include "utils/s2n_mem.h"
+
+/* We need access to some io logic */
+#include "tls/s2n_handshake_io.c"
+
+static const uint8_t TEST_DATA[] = "test";
+static const size_t TEST_DATA_SIZE = sizeof(TEST_DATA);
+
+struct s2n_stuffer input_stuffer, output_stuffer;
+static int s2n_setup_conn(struct s2n_connection *conn)
+{
+    GUARD(s2n_connection_enable_quic(conn));
+    conn->actual_protocol_version = S2N_TLS13;
+
+    GUARD(s2n_stuffer_wipe(&input_stuffer));
+    GUARD(s2n_stuffer_wipe(&output_stuffer));
+    GUARD(s2n_connection_set_io_stuffers(&input_stuffer, &output_stuffer, conn));
+
+    return S2N_SUCCESS;
+}
+
+static int s2n_setup_conn_for_client_hello(struct s2n_connection *conn)
+{
+    GUARD(s2n_setup_conn(conn));
+    conn->handshake.handshake_type = INITIAL;
+    conn->handshake.message_number = 0;
+    eq_check(s2n_conn_get_current_message_type(conn), CLIENT_HELLO);
+    return S2N_SUCCESS;
+}
+
+static int s2n_setup_conn_for_server_hello(struct s2n_connection *conn)
+{
+    GUARD(s2n_setup_conn(conn));
+
+    /* Use arbitrary cipher suite */
+    conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
+
+    /* Setup secrets */
+    const struct s2n_ecc_preferences *ecc_preferences = NULL;
+    GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_preferences));
+    conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
+    conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_preferences->ecc_curves[0];
+    if(conn->secure.server_ecc_evp_params.evp_pkey == NULL) {
+        GUARD(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.server_ecc_evp_params));
+    }
+    if(conn->secure.client_ecc_evp_params[0].evp_pkey == NULL) {
+        GUARD(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
+    }
+
+    /* Set handshake to write message */
+    conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
+    conn->handshake.message_number = 1;
+    eq_check(s2n_conn_get_current_message_type(conn), SERVER_HELLO);
+
+    return S2N_SUCCESS;
+}
+
+static int s2n_write_test_message(struct s2n_blob *out, message_type_t message_type)
+{
+    GUARD(s2n_alloc(out, TEST_DATA_SIZE + TLS_HANDSHAKE_HEADER_LENGTH));
+
+    struct s2n_stuffer stuffer;
+    GUARD(s2n_stuffer_init(&stuffer, out));
+
+    GUARD(s2n_stuffer_write_uint8(&stuffer, message_type));
+    GUARD(s2n_stuffer_write_uint24(&stuffer, TEST_DATA_SIZE));
+    GUARD(s2n_stuffer_write_bytes(&stuffer, TEST_DATA, TEST_DATA_SIZE));
+
+    return S2N_SUCCESS;
+}
+
+static int s2n_test_write_handler(struct s2n_connection* conn)
+{
+    EXPECT_SUCCESS(s2n_stuffer_write_bytes(&conn->handshake.io, TEST_DATA, TEST_DATA_SIZE));
+    return S2N_SUCCESS;
+}
+
+static int s2n_test_read_handler(struct s2n_connection* conn)
+{
+    EXPECT_EQUAL(s2n_stuffer_data_available(&conn->handshake.io), TEST_DATA_SIZE);
+    EXPECT_BYTEARRAY_EQUAL(s2n_stuffer_raw_read(&conn->handshake.io, TEST_DATA_SIZE),
+            TEST_DATA, TEST_DATA_SIZE);
+    return S2N_SUCCESS;
+}
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+    EXPECT_SUCCESS(s2n_enable_tls13());
+
+    /* Test: s2n_quic_write_handshake_message */
+    {
+        /* Safety checks */
+        {
+            struct s2n_connection conn = { 0 };
+            struct s2n_blob blob = { 0 };
+
+            EXPECT_FAILURE(s2n_quic_write_handshake_message(NULL, &blob));
+            EXPECT_FAILURE(s2n_quic_write_handshake_message(&conn, NULL));
+        }
+
+        /* Writes handshake message */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+            uint8_t message_data[] = "The client says hello";
+            struct s2n_blob in;
+            EXPECT_SUCCESS(s2n_blob_init(&in, message_data, sizeof(message_data)));
+
+            EXPECT_SUCCESS(s2n_quic_write_handshake_message(conn, &in));
+            EXPECT_EQUAL(s2n_stuffer_data_available(&conn->out), sizeof(message_data));
+            EXPECT_BYTEARRAY_EQUAL(s2n_stuffer_raw_read(&conn->out, sizeof(message_data)),
+                    message_data, sizeof(message_data));
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+    }
+
+    /* Test: s2n_quic_read_handshake_message */
+    {
+        /* Safety checks */
+        {
+            struct s2n_connection conn = { 0 };
+            uint8_t message_type = 0;
+
+            EXPECT_FAILURE(s2n_quic_read_handshake_message(NULL, &message_type));
+            EXPECT_FAILURE(s2n_quic_read_handshake_message(&conn, NULL));
+        }
+
+        /* Reads basic handshake message */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+            struct s2n_stuffer stuffer;
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+            EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&stuffer, &stuffer, conn));
+
+            uint8_t expected_message_type = 7;
+            EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, expected_message_type));
+            EXPECT_SUCCESS(s2n_stuffer_write_uint24(&stuffer, TEST_DATA_SIZE));
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&stuffer, TEST_DATA, TEST_DATA_SIZE));
+
+            uint8_t actual_message_type = 0;
+            EXPECT_SUCCESS(s2n_quic_read_handshake_message(conn, &actual_message_type));
+
+            EXPECT_EQUAL(actual_message_type, expected_message_type);
+            EXPECT_EQUAL(s2n_stuffer_data_available(&conn->handshake.io), TLS_HANDSHAKE_HEADER_LENGTH);
+            EXPECT_EQUAL(s2n_stuffer_data_available(&conn->in), TEST_DATA_SIZE);
+            EXPECT_BYTEARRAY_EQUAL(s2n_stuffer_raw_read(&conn->in, TEST_DATA_SIZE),
+                    TEST_DATA, sizeof(TEST_DATA));
+
+            EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Blocks on insufficient data for handshake message header */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+            struct s2n_stuffer stuffer;
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+            EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&stuffer, &stuffer, conn));
+
+            EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, 7));
+
+            uint8_t actual_message_type = 0;
+            EXPECT_FAILURE_WITH_ERRNO(s2n_quic_read_handshake_message(conn, &actual_message_type),
+                    S2N_ERR_IO_BLOCKED);
+
+            EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Blocks on insufficient data for handshake message data */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+            struct s2n_stuffer stuffer;
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+            EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&stuffer, &stuffer, conn));
+
+            EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, 7));
+            EXPECT_SUCCESS(s2n_stuffer_write_uint24(&stuffer, TEST_DATA_SIZE));
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&stuffer, TEST_DATA, TEST_DATA_SIZE - 1));
+
+            uint8_t actual_message_type = 0;
+            EXPECT_FAILURE_WITH_ERRNO(s2n_quic_read_handshake_message(conn, &actual_message_type),
+                    S2N_ERR_IO_BLOCKED);
+
+            EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Fails for an impossibly large handshake message */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+            struct s2n_stuffer stuffer;
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+            EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&stuffer, &stuffer, conn));
+
+            EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, 7));
+            EXPECT_SUCCESS(s2n_stuffer_write_uint24(&stuffer, S2N_MAXIMUM_HANDSHAKE_MESSAGE_LENGTH + 1));
+
+            uint8_t actual_message_type = 0;
+            EXPECT_FAILURE_WITH_ERRNO(s2n_quic_read_handshake_message(conn, &actual_message_type),
+                    S2N_ERR_BAD_MESSAGE);
+
+            EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+    }
+
+    /* Functional Tests */
+    {
+        s2n_blocked_status blocked_status;
+
+        /* Use handler stubs to avoid executing complicated handler implementations */
+        for (int i = 0; i < s2n_array_len(tls13_state_machine); i++) {
+            tls13_state_machine[i].handler[S2N_SERVER] = s2n_test_read_handler;
+            tls13_state_machine[i].handler[S2N_CLIENT] = s2n_test_write_handler;
+        }
+
+        /* Write test message */
+        DEFER_CLEANUP(struct s2n_blob server_hello, s2n_free);
+        EXPECT_SUCCESS(s2n_write_test_message(&server_hello, TLS_SERVER_HELLO));
+
+        /* Setup IO buffers */
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input_stuffer, 0));
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output_stuffer, 0));
+
+        /* Functional: successfully reads full handshake message */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_SUCCESS(s2n_setup_conn_for_server_hello(conn));
+
+            EXPECT_SUCCESS(s2n_stuffer_write(&input_stuffer, &server_hello));
+            EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate(conn, &blocked_status), S2N_ERR_IO_BLOCKED);
+
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), ENCRYPTED_EXTENSIONS);
+            EXPECT_EQUAL(s2n_stuffer_data_available(&input_stuffer), 0);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Functional: successfully reads fragmented handshake message */
+        for(size_t i = 1; i < server_hello.size - 1; i++) {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_SUCCESS(s2n_setup_conn_for_server_hello(conn));
+
+            /* Write initial fragment */
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&input_stuffer, server_hello.data, i));
+            EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate(conn, &blocked_status), S2N_ERR_IO_BLOCKED);
+
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_HELLO);
+            EXPECT_EQUAL(s2n_stuffer_data_available(&input_stuffer), 0);
+
+            /* Write rest of message */
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&input_stuffer,
+                    server_hello.data + i, server_hello.size - i));
+            EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate(conn, &blocked_status), S2N_ERR_IO_BLOCKED);
+
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), ENCRYPTED_EXTENSIONS);
+            EXPECT_EQUAL(s2n_stuffer_data_available(&input_stuffer), 0);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Functional: successfully reads multiple handshake messages */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_SUCCESS(s2n_setup_conn_for_server_hello(conn));
+
+            DEFER_CLEANUP(struct s2n_blob encrypted_extensions, s2n_free);
+            EXPECT_SUCCESS(s2n_write_test_message(&encrypted_extensions, TLS_ENCRYPTED_EXTENSIONS));
+
+            EXPECT_SUCCESS(s2n_stuffer_write(&input_stuffer, &server_hello));
+            EXPECT_SUCCESS(s2n_stuffer_write(&input_stuffer, &encrypted_extensions));
+            EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate(conn, &blocked_status), S2N_ERR_IO_BLOCKED);
+
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_CERT);
+            EXPECT_EQUAL(s2n_stuffer_data_available(&input_stuffer), 0);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Function: fails to read record instead of handshake message */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_SUCCESS(s2n_setup_conn_for_server_hello(conn));
+
+            /* Write the record: record type, protocol version,
+             *                   handshake message size, handshake message */
+            GUARD(s2n_stuffer_write_uint8(&input_stuffer, TLS_HANDSHAKE));
+            GUARD(s2n_stuffer_write_uint8(&input_stuffer, 3));
+            GUARD(s2n_stuffer_write_uint8(&input_stuffer, 3));
+            GUARD(s2n_stuffer_write_uint16(&input_stuffer, server_hello.size));
+            EXPECT_SUCCESS(s2n_stuffer_write(&input_stuffer, &server_hello));
+
+            EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate(conn, &blocked_status), S2N_ERR_BAD_MESSAGE);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Function: fails to read Change Cipher Spec record */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_SUCCESS(s2n_setup_conn_for_server_hello(conn));
+
+            /* Write the record: record type, protocol version,
+             *                   record data size, standard "0x01" record data */
+            GUARD(s2n_stuffer_write_uint8(&input_stuffer, TLS_CHANGE_CIPHER_SPEC));
+            GUARD(s2n_stuffer_write_uint8(&input_stuffer, 3));
+            GUARD(s2n_stuffer_write_uint8(&input_stuffer, 3));
+            GUARD(s2n_stuffer_write_uint16(&input_stuffer, 1));
+            GUARD(s2n_stuffer_write_uint8(&input_stuffer, 1));
+
+            EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate(conn, &blocked_status), S2N_ERR_BAD_MESSAGE);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        uint32_t client_hello_length = 0;
+
+        /* Functional: successfully writes full handshake message */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_SUCCESS(s2n_setup_conn_for_client_hello(conn));
+
+            EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate(conn, &blocked_status), S2N_ERR_IO_BLOCKED);
+            client_hello_length = s2n_stuffer_data_available(&output_stuffer);
+
+            uint8_t actual_message_type;
+            EXPECT_SUCCESS(s2n_stuffer_read_uint8(&output_stuffer, &actual_message_type));
+            EXPECT_EQUAL(actual_message_type, TLS_CLIENT_HELLO);
+
+            uint32_t actual_message_size;
+            EXPECT_SUCCESS(s2n_stuffer_read_uint24(&output_stuffer, &actual_message_size));
+            EXPECT_EQUAL(actual_message_size, TEST_DATA_SIZE);
+
+            EXPECT_EQUAL(s2n_stuffer_data_available(&output_stuffer), TEST_DATA_SIZE);
+            EXPECT_BYTEARRAY_EQUAL(s2n_stuffer_raw_read(&output_stuffer, TEST_DATA_SIZE),
+                    TEST_DATA, TEST_DATA_SIZE);
+
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_HELLO);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Functional: successfully retries after blocked write */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_SUCCESS(s2n_setup_conn_for_client_hello(conn));
+
+            /* Sabotage the output stuffer to block writing */
+            struct s2n_stuffer bad_stuffer;
+            EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input_stuffer, &bad_stuffer, conn));
+
+            EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate(conn, &blocked_status), S2N_ERR_IO_BLOCKED);
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), CLIENT_HELLO);
+            EXPECT_EQUAL(s2n_stuffer_data_available(&output_stuffer), 0);
+
+            /* Fix the output stuffer */
+            EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input_stuffer, &output_stuffer, conn));
+
+            EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate(conn, &blocked_status), S2N_ERR_IO_BLOCKED);
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_HELLO);
+            EXPECT_EQUAL(s2n_stuffer_data_available(&output_stuffer), client_hello_length);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&input_stuffer));
+        EXPECT_SUCCESS(s2n_stuffer_free(&output_stuffer));
+    }
+
+    END_TEST();
+}

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -218,3 +218,5 @@ struct s2n_cert_chain_and_key *s2n_get_compatible_cert_chain_and_key(struct s2n_
 int s2n_conn_post_handshake_hashes_update(struct s2n_connection *conn);
 int s2n_conn_pre_handshake_hashes_update(struct s2n_connection *conn);
 int s2n_conn_update_handshake_hashes(struct s2n_connection *conn, struct s2n_blob *data);
+int s2n_quic_read_handshake_message(struct s2n_connection *conn, uint8_t *message_type);
+int s2n_quic_write_handshake_message(struct s2n_connection *conn, struct s2n_blob *in);

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -218,5 +218,5 @@ struct s2n_cert_chain_and_key *s2n_get_compatible_cert_chain_and_key(struct s2n_
 int s2n_conn_post_handshake_hashes_update(struct s2n_connection *conn);
 int s2n_conn_pre_handshake_hashes_update(struct s2n_connection *conn);
 int s2n_conn_update_handshake_hashes(struct s2n_connection *conn, struct s2n_blob *data);
-int s2n_quic_read_handshake_message(struct s2n_connection *conn, uint8_t *message_type);
-int s2n_quic_write_handshake_message(struct s2n_connection *conn, struct s2n_blob *in);
+S2N_RESULT s2n_quic_read_handshake_message(struct s2n_connection *conn, uint8_t *message_type);
+S2N_RESULT s2n_quic_write_handshake_message(struct s2n_connection *conn, struct s2n_blob *in);

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -932,7 +932,7 @@ static int s2n_handshake_read_io(struct s2n_connection *conn)
 {
     uint8_t record_type;
     uint8_t message_type;
-    int isSSLv2 = false;
+    int isSSLv2 = 0;
 
     /* Fill conn->in stuffer necessary for the handshake.
      * If using TCP, read a record. If using QUIC, read a message. */

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -768,7 +768,7 @@ static int s2n_handshake_write_io(struct s2n_connection *conn)
         notnull_check(out.data);
 
         if (conn->quic_enabled) {
-            GUARD(s2n_quic_write_handshake_message(conn, &out));
+            GUARD_AS_POSIX(s2n_quic_write_handshake_message(conn, &out));
         } else {
             GUARD(s2n_record_write(conn, record_type, &out));
         }
@@ -938,7 +938,7 @@ static int s2n_handshake_read_io(struct s2n_connection *conn)
      * If using TCP, read a record. If using QUIC, read a message. */
     if (conn->quic_enabled) {
         record_type = TLS_HANDSHAKE;
-        GUARD(s2n_quic_read_handshake_message(conn, &message_type));
+        GUARD_AS_POSIX(s2n_quic_read_handshake_message(conn, &message_type));
     } else {
         GUARD(s2n_read_full_record(conn, &record_type, &isSSLv2));
     }

--- a/tls/s2n_quic_support.c
+++ b/tls/s2n_quic_support.c
@@ -66,6 +66,9 @@ int s2n_quic_read_handshake_message(struct s2n_connection *conn, uint8_t *messag
 {
     notnull_check(conn);
 
+    /* Allocate the maximum stuffer size now so that we don't have to realloc later in the handshake. */
+    GUARD(s2n_stuffer_resize_if_empty(&conn->in, S2N_MAXIMUM_HANDSHAKE_MESSAGE_LENGTH));
+
     GUARD(s2n_read_in_bytes(conn, &conn->handshake.io, TLS_HANDSHAKE_HEADER_LENGTH));
 
     uint32_t message_len;
@@ -84,6 +87,9 @@ int s2n_quic_read_handshake_message(struct s2n_connection *conn, uint8_t *messag
 int s2n_quic_write_handshake_message(struct s2n_connection *conn, struct s2n_blob *in)
 {
     notnull_check(conn);
+
+    /* Allocate the maximum stuffer size now so that we don't have to realloc later in the handshake. */
+    GUARD(s2n_stuffer_resize_if_empty(&conn->out, S2N_MAXIMUM_HANDSHAKE_MESSAGE_LENGTH));
 
     GUARD(s2n_stuffer_write(&conn->out, in));
     return S2N_SUCCESS;

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -38,30 +38,13 @@
 #include "utils/s2n_safety.h"
 #include "utils/s2n_blob.h"
 
-int s2n_read_full_record(struct s2n_connection *conn, uint8_t * record_type, int *isSSLv2)
+int s2n_read_in_bytes(struct s2n_connection *conn, struct s2n_stuffer *output, uint32_t length)
 {
-    int r;
-
-    *isSSLv2 = 0;
-
-    /* If the record has already been decrypted, then leave it alone */
-    if (conn->in_status == PLAINTEXT) {
-        /* Only application data packets count as plaintext */
-        *record_type = TLS_APPLICATION_DATA;
-        return 0;
-    }
-    GUARD(s2n_stuffer_resize_if_empty(&conn->in, S2N_LARGE_FRAGMENT_LENGTH));
-
-    /* Read the record until we at least have a header */
-    while (s2n_stuffer_data_available(&conn->header_in) < S2N_TLS_RECORD_HEADER_LENGTH) {
-        int remaining = S2N_TLS_RECORD_HEADER_LENGTH - s2n_stuffer_data_available(&conn->header_in);
-
-        if (s2n_connection_is_managed_corked(conn)) {
-            GUARD(s2n_socket_set_read_size(conn, remaining));
-        }
+    while (s2n_stuffer_data_available(output) < length) {
+        uint32_t remaining = length - s2n_stuffer_data_available(output);
 
         errno = 0;
-        r = s2n_connection_recv_stuffer(&conn->header_in, conn, remaining);
+        int r = s2n_connection_recv_stuffer(output, conn, remaining);
         if (r == 0) {
             conn->closed = 1;
             S2N_ERROR(S2N_ERR_CLOSED);
@@ -73,6 +56,25 @@ int s2n_read_full_record(struct s2n_connection *conn, uint8_t * record_type, int
         }
         conn->wire_bytes_in += r;
     }
+
+    return S2N_SUCCESS;
+}
+
+int s2n_read_full_record(struct s2n_connection *conn, uint8_t * record_type, int *isSSLv2)
+{
+    *isSSLv2 = 0;
+
+    /* If the record has already been decrypted, then leave it alone */
+    if (conn->in_status == PLAINTEXT) {
+        /* Only application data packets count as plaintext */
+        *record_type = TLS_APPLICATION_DATA;
+        return 0;
+    }
+    GUARD(s2n_stuffer_resize_if_empty(&conn->in, S2N_LARGE_FRAGMENT_LENGTH));
+
+    /* Read the record until we at least have a header */
+    GUARD(s2n_read_in_bytes(conn, &conn->header_in, S2N_TLS_RECORD_HEADER_LENGTH));
+
     uint16_t fragment_length;
 
     /* If the first bit is set then this is an SSLv2 record */
@@ -92,26 +94,7 @@ int s2n_read_full_record(struct s2n_connection *conn, uint8_t * record_type, int
     }
 
     /* Read enough to have the whole record */
-    while (s2n_stuffer_data_available(&conn->in) < fragment_length) {
-        int remaining = fragment_length - s2n_stuffer_data_available(&conn->in);
-
-        if (s2n_connection_is_managed_corked(conn)) {
-            GUARD(s2n_socket_set_read_size(conn, remaining));
-        }
-
-        errno = 0;
-        r = s2n_connection_recv_stuffer(&conn->in, conn, remaining);
-        if (r == 0) {
-            conn->closed = 1;
-            S2N_ERROR(S2N_ERR_CLOSED);
-        } else if (r < 0) {
-            if (errno == EWOULDBLOCK || errno == EAGAIN) {
-                S2N_ERROR(S2N_ERR_IO_BLOCKED);
-            }
-            S2N_ERROR(S2N_ERR_IO);
-        }
-        conn->wire_bytes_in += r;
-    }
+    GUARD(s2n_read_in_bytes(conn, &conn->in, fragment_length));
 
     if (*isSSLv2) {
         return 0;

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -68,7 +68,7 @@ int s2n_read_full_record(struct s2n_connection *conn, uint8_t * record_type, int
     if (conn->in_status == PLAINTEXT) {
         /* Only application data packets count as plaintext */
         *record_type = TLS_APPLICATION_DATA;
-        return 0;
+        return S2N_SUCCESS;
     }
     GUARD(s2n_stuffer_resize_if_empty(&conn->in, S2N_LARGE_FRAGMENT_LENGTH));
 


### PR DESCRIPTION
### Resolved issues:

https://github.com/awslabs/s2n/issues/2277

### Description of changes: 

When using QUIC instead of TCP, S2N doesn't use records. Instead, it sends and receives unencrypted handshake messages directly. We therefore need to skip S2N's record handling logic.

### Call-outs:
* This solution requires us to read the 4-byte message header twice for every message. This reread can be avoided, but doing so makes the s2n_handshake_io logic more complicated. Getting to reuse more of the standard io logic seems worth reading an extra 4 bytes.
* I removed the QUIC CCS state machine tests because they are no longer possible. QUIC can't receive CCS messages, because CCS messages aren't handshake messages (they are actually a different record content type). There is a new test in s2n_quic_support_io_test to verify S2N can't actually read a CCS message.
* s2n_recv.c is logically unchanged. I just moved some of the code into a separate method to reduce duplication and let me reuse it in the QUIC methods.

### Testing:

Unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
