### PR TITLE
Fix S2N_NO_PQ build

### DIFF
--- a/tests/testlib/s2n_kem_fuzz_testlib.c
+++ b/tests/testlib/s2n_kem_fuzz_testlib.c
@@ -18,7 +18,6 @@
 #include "tls/s2n_kem.h"
 #include "tests/testlib/s2n_nist_kats.h"
 
-#define UNUSED_VAR(x) do { (void) (x); } while (0)
 
 int s2n_kem_recv_ciphertext_fuzz_test_init(const char *kat_file_path, struct s2n_kem_params *kem_params) {
     notnull_check(kat_file_path);
@@ -45,7 +44,6 @@ int s2n_kem_recv_ciphertext_fuzz_test(const uint8_t *buf, size_t len, struct s2n
     notnull_check(kem_params);
 
 #if defined(S2N_NO_PQ)
-    UNUSED_VAR(len);
     return S2N_FAILURE;
 #else
     notnull_check(kem_params->kem);
@@ -81,7 +79,6 @@ int s2n_kem_recv_public_key_fuzz_test(const uint8_t *buf, size_t len, struct s2n
     notnull_check(kem_params);
 
 #if defined(S2N_NO_PQ)
-    UNUSED_VAR(len);
     return S2N_FAILURE;
 #else
     notnull_check(kem_params->kem);

--- a/tests/testlib/s2n_kem_fuzz_testlib.c
+++ b/tests/testlib/s2n_kem_fuzz_testlib.c
@@ -18,8 +18,15 @@
 #include "tls/s2n_kem.h"
 #include "tests/testlib/s2n_nist_kats.h"
 
+#define UNUSED_VAR(x) do { (void) (x); } while (0)
+
 int s2n_kem_recv_ciphertext_fuzz_test_init(const char *kat_file_path, struct s2n_kem_params *kem_params) {
+    notnull_check(kat_file_path);
     notnull_check(kem_params);
+
+#if defined(S2N_NO_PQ)
+    return S2N_FAILURE;
+#else
     notnull_check(kem_params->kem);
 
     GUARD(s2n_alloc(&kem_params->private_key, kem_params->kem->private_key_length));
@@ -30,12 +37,19 @@ int s2n_kem_recv_ciphertext_fuzz_test_init(const char *kat_file_path, struct s2n
     fclose(kat_file);
 
     return S2N_SUCCESS;
+#endif
 }
 
 int s2n_kem_recv_ciphertext_fuzz_test(const uint8_t *buf, size_t len, struct s2n_kem_params *kem_params) {
     notnull_check(buf);
     notnull_check(kem_params);
+
+#if defined(S2N_NO_PQ)
+    UNUSED_VAR(len);
+    return S2N_FAILURE;
+#else
     notnull_check(kem_params->kem);
+
     /* Because of the way BIKE1_L1_R1's decapsulation function is written, this test will not work for that KEM. */
     ENSURE_POSIX(kem_params->kem != &s2n_bike1_l1_r1, S2N_ERR_KEM_UNSUPPORTED_PARAMS);
 
@@ -59,11 +73,17 @@ int s2n_kem_recv_ciphertext_fuzz_test(const uint8_t *buf, size_t len, struct s2n
     GUARD(s2n_free(&kem_params->shared_secret));
 
     return S2N_SUCCESS;
+#endif
 }
 
 int s2n_kem_recv_public_key_fuzz_test(const uint8_t *buf, size_t len, struct s2n_kem_params *kem_params) {
     notnull_check(buf);
     notnull_check(kem_params);
+
+#if defined(S2N_NO_PQ)
+    UNUSED_VAR(len);
+    return S2N_FAILURE;
+#else
     notnull_check(kem_params->kem);
 
     struct s2n_stuffer public_key = { 0 };
@@ -90,4 +110,6 @@ int s2n_kem_recv_public_key_fuzz_test(const uint8_t *buf, size_t len, struct s2n
     GUARD(s2n_kem_free(kem_params));
 
     return S2N_SUCCESS;
+#endif
 }
+


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

* A previous PR broke build where `S2N_NO_PQ` is defined. This fixes it.

### Call-outs:

N/A

### Testing:

* Built locally with `S2N_NO_PQ=1`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
