### PR TITLE
Add support for AES-GCM through the AWS-LC/BoringSSL AEAD API

### DIFF
--- a/crypto/s2n_aead_cipher_aes_gcm.c
+++ b/crypto/s2n_aead_cipher_aes_gcm.c
@@ -23,18 +23,118 @@
 #include "utils/s2n_safety.h"
 #include "utils/s2n_blob.h"
 
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
+#define S2N_AEAD_AES_GCM_AVAILABLE_BSSL_AWSLC
+#endif
+
 static uint8_t s2n_aead_cipher_aes128_gcm_available()
 {
+#if defined(S2N_AEAD_AES_GCM_AVAILABLE_BSSL_AWSLC)
+    return (EVP_aead_aes_128_gcm() ? 1 : 0);
+#else
     return (EVP_aes_128_gcm() ? 1 : 0);
+#endif
 }
 
 static uint8_t s2n_aead_cipher_aes256_gcm_available()
 {
+#if defined(S2N_AEAD_AES_GCM_AVAILABLE_BSSL_AWSLC)
+    return (EVP_aead_aes_256_gcm() ? 1 : 0);
+#else
     return (EVP_aes_256_gcm() ? 1 : 0);
+#endif
 }
+
+#if defined(S2N_AEAD_AES_GCM_AVAILABLE_BSSL_AWSLC) /* BoringSSL and AWS-LC AEAD interface implementation */
 
 static int s2n_aead_cipher_aes_gcm_encrypt(struct s2n_session_key *key, struct s2n_blob *iv, struct s2n_blob *aad, struct s2n_blob *in, struct s2n_blob *out)
 {
+    /* The size of the |in| blob includes the size of the data and the size of the AES-GCM tag */
+    gte_check(in->size, S2N_TLS_GCM_TAG_LEN);
+    gte_check(out->size, in->size);
+    eq_check(iv->size, S2N_TLS_GCM_IV_LEN);
+
+    /* Adjust input length to account for the Tag length */
+    size_t in_len = in->size - S2N_TLS_GCM_TAG_LEN;
+    size_t out_len = 0;
+
+    GUARD_OSSL(EVP_AEAD_CTX_seal(key->evp_aead_ctx, out->data, &out_len, out->size, iv->data, iv->size, in->data, in_len, aad->data, aad->size), S2N_ERR_ENCRYPT);
+
+    S2N_ERROR_IF((in_len + S2N_TLS_GCM_TAG_LEN) != out_len, S2N_ERR_ENCRYPT);
+
+    return 0;
+}
+
+static int s2n_aead_cipher_aes_gcm_decrypt(struct s2n_session_key *key, struct s2n_blob *iv, struct s2n_blob *aad, struct s2n_blob *in, struct s2n_blob *out)
+{
+    gte_check(in->size, S2N_TLS_GCM_TAG_LEN);
+    gte_check(out->size, in->size - S2N_TLS_GCM_TAG_LEN);
+    eq_check(iv->size, S2N_TLS_GCM_IV_LEN);
+
+    size_t out_len = 0;
+
+    GUARD_OSSL(EVP_AEAD_CTX_open(key->evp_aead_ctx, out->data, &out_len, out->size, iv->data, iv->size, in->data, in->size, aad->data, aad->size), S2N_ERR_DECRYPT);
+
+    S2N_ERROR_IF((in->size - S2N_TLS_GCM_TAG_LEN) != out_len, S2N_ERR_ENCRYPT);
+
+    return 0;
+}
+
+static int s2n_aead_cipher_aes128_gcm_set_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
+{
+    eq_check(in->size, S2N_TLS_AES_128_GCM_KEY_LEN);
+
+    GUARD_OSSL(EVP_AEAD_CTX_init(key->evp_aead_ctx, EVP_aead_aes_128_gcm(), in->data, in->size, S2N_TLS_GCM_TAG_LEN, NULL), S2N_ERR_KEY_INIT);
+
+    return 0;
+}
+
+static int s2n_aead_cipher_aes256_gcm_set_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
+{
+    eq_check(in->size, S2N_TLS_AES_256_GCM_KEY_LEN);
+
+    GUARD_OSSL(EVP_AEAD_CTX_init(key->evp_aead_ctx, EVP_aead_aes_256_gcm(), in->data, in->size, S2N_TLS_GCM_TAG_LEN, NULL), S2N_ERR_KEY_INIT);
+
+    return 0;
+}
+
+static int s2n_aead_cipher_aes128_gcm_set_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
+{
+    eq_check(in->size, S2N_TLS_AES_128_GCM_KEY_LEN);
+
+    GUARD_OSSL(EVP_AEAD_CTX_init(key->evp_aead_ctx, EVP_aead_aes_128_gcm(), in->data, in->size, S2N_TLS_GCM_TAG_LEN, NULL), S2N_ERR_KEY_INIT);
+
+    return 0;
+}
+
+static int s2n_aead_cipher_aes256_gcm_set_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
+{
+    eq_check(in->size, S2N_TLS_AES_256_GCM_KEY_LEN);
+
+    GUARD_OSSL(EVP_AEAD_CTX_init(key->evp_aead_ctx, EVP_aead_aes_256_gcm(), in->data, in->size, S2N_TLS_GCM_TAG_LEN, NULL), S2N_ERR_KEY_INIT);
+
+    return 0;
+}
+
+static int s2n_aead_cipher_aes_gcm_init(struct s2n_session_key *key)
+{
+    EVP_AEAD_CTX_zero(key->evp_aead_ctx);
+
+    return 0;
+}
+
+static int s2n_aead_cipher_aes_gcm_destroy_key(struct s2n_session_key *key)
+{
+    EVP_AEAD_CTX_cleanup(key->evp_aead_ctx);
+
+    return 0;
+}
+
+#else /* Standard AES-GCM implementation */
+
+static int s2n_aead_cipher_aes_gcm_encrypt(struct s2n_session_key *key, struct s2n_blob *iv, struct s2n_blob *aad, struct s2n_blob *in, struct s2n_blob *out)
+{
+    /* The size of the |in| blob includes the size of the data and the size of the ChaCha20-Poly1305 tag */
     gte_check(in->size, S2N_TLS_GCM_TAG_LEN);
     gte_check(out->size, in->size);
     eq_check(iv->size, S2N_TLS_GCM_IV_LEN);
@@ -42,7 +142,7 @@ static int s2n_aead_cipher_aes_gcm_encrypt(struct s2n_session_key *key, struct s
     /* Initialize the IV */
     GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
 
-    /* Adjust our buffer pointers to account for the explicit IV and TAG lengths */
+    /* Adjust input length and buffer pointer to account for the Tag length */
     int in_len = in->size - S2N_TLS_GCM_TAG_LEN;
     uint8_t *tag_data = out->data + out->size - S2N_TLS_GCM_TAG_LEN;
 
@@ -53,11 +153,17 @@ static int s2n_aead_cipher_aes_gcm_encrypt(struct s2n_session_key *key, struct s
     /* Encrypt the data */
     GUARD_OSSL(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &out_len, in->data, in_len), S2N_ERR_ENCRYPT);
 
+    /* When using AES-GCM, *out_len is the number of bytes written by EVP_EncryptUpdate. Since the tag is not written during this call, we do not take S2N_TLS_GCM_TAG_LEN into account */
+    S2N_ERROR_IF(in_len != out_len, S2N_ERR_ENCRYPT);
+
     /* Finalize */
     GUARD_OSSL(EVP_EncryptFinal_ex(key->evp_cipher_ctx, out->data, &out_len), S2N_ERR_ENCRYPT);
 
     /* write the tag */
     GUARD_OSSL(EVP_CIPHER_CTX_ctrl(key->evp_cipher_ctx, EVP_CTRL_GCM_GET_TAG, S2N_TLS_GCM_TAG_LEN, tag_data), S2N_ERR_ENCRYPT);
+
+    /* When using AES-GCM, EVP_EncryptFinal_ex does not write any bytes. So, we should expect *out_len = 0. */
+    S2N_ERROR_IF(0 != out_len, S2N_ERR_ENCRYPT);
 
     return 0;
 }
@@ -71,7 +177,7 @@ static int s2n_aead_cipher_aes_gcm_decrypt(struct s2n_session_key *key, struct s
     /* Initialize the IV */
     GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
 
-    /* Adjust our buffer pointers to account for the explicit IV and TAG lengths */
+    /* Adjust input length and buffer pointer to account for the Tag length */
     int in_len = in->size - S2N_TLS_GCM_TAG_LEN;
     uint8_t *tag_data = in->data + in->size - S2N_TLS_GCM_TAG_LEN;
 
@@ -91,12 +197,14 @@ static int s2n_aead_cipher_aes_gcm_decrypt(struct s2n_session_key *key, struct s
 
     S2N_ERROR_IF(evp_decrypt_rc != 1, S2N_ERR_DECRYPT);
 
+    /* While we verify the content of out_len in s2n_aead_cipher_aes_gcm_encrypt, we refrain from this here. This is to avoid doing any branching before the ciphertext is verified. */
+
     return 0;
 }
 
 static int s2n_aead_cipher_aes128_gcm_set_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
-    eq_check(in->size, 16);
+    eq_check(in->size, S2N_TLS_AES_128_GCM_KEY_LEN);
 
     GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_aes_128_gcm(), NULL, NULL, NULL), S2N_ERR_KEY_INIT);
 
@@ -109,7 +217,7 @@ static int s2n_aead_cipher_aes128_gcm_set_encryption_key(struct s2n_session_key 
 
 static int s2n_aead_cipher_aes256_gcm_set_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
-    eq_check(in->size, 32);
+    eq_check(in->size, S2N_TLS_AES_256_GCM_KEY_LEN);
 
     GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_aes_256_gcm(), NULL, NULL, NULL), S2N_ERR_KEY_INIT);
 
@@ -122,7 +230,7 @@ static int s2n_aead_cipher_aes256_gcm_set_encryption_key(struct s2n_session_key 
 
 static int s2n_aead_cipher_aes128_gcm_set_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
-    eq_check(in->size, 16);
+    eq_check(in->size, S2N_TLS_AES_128_GCM_KEY_LEN);
 
     GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_aes_128_gcm(), NULL, NULL, NULL), S2N_ERR_KEY_INIT);
 
@@ -135,7 +243,7 @@ static int s2n_aead_cipher_aes128_gcm_set_decryption_key(struct s2n_session_key 
 
 static int s2n_aead_cipher_aes256_gcm_set_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
-    eq_check(in->size, 32);
+    eq_check(in->size, S2N_TLS_AES_256_GCM_KEY_LEN);
 
     GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_aes_256_gcm(), NULL, NULL, NULL), S2N_ERR_KEY_INIT);
 
@@ -160,8 +268,10 @@ static int s2n_aead_cipher_aes_gcm_destroy_key(struct s2n_session_key *key)
     return 0;
 }
 
+#endif
+
 struct s2n_cipher s2n_aes128_gcm = {
-    .key_material_size = 16,
+    .key_material_size = S2N_TLS_AES_128_GCM_KEY_LEN,
     .type = S2N_AEAD,
     .io.aead = {
                 .record_iv_size = S2N_TLS_GCM_EXPLICIT_IV_LEN,
@@ -177,7 +287,7 @@ struct s2n_cipher s2n_aes128_gcm = {
 };
 
 struct s2n_cipher s2n_aes256_gcm = {
-    .key_material_size = 32,
+    .key_material_size = S2N_TLS_AES_256_GCM_KEY_LEN,
     .type = S2N_AEAD,
     .io.aead = {
                 .record_iv_size = S2N_TLS_GCM_EXPLICIT_IV_LEN,
@@ -194,7 +304,7 @@ struct s2n_cipher s2n_aes256_gcm = {
 
 /* TLS 1.3 GCM ciphers */
 struct s2n_cipher s2n_tls13_aes128_gcm = {
-    .key_material_size = 16,
+    .key_material_size = S2N_TLS_AES_128_GCM_KEY_LEN,
     .type = S2N_AEAD,
     .io.aead = {
                 .record_iv_size = S2N_TLS13_RECORD_IV_LEN,
@@ -210,7 +320,7 @@ struct s2n_cipher s2n_tls13_aes128_gcm = {
 };
 
 struct s2n_cipher s2n_tls13_aes256_gcm = {
-    .key_material_size = 32,
+    .key_material_size = S2N_TLS_AES_256_GCM_KEY_LEN,
     .type = S2N_AEAD,
     .io.aead = {
                 .record_iv_size = S2N_TLS13_RECORD_IV_LEN,

--- a/crypto/s2n_aead_cipher_aes_gcm.c
+++ b/crypto/s2n_aead_cipher_aes_gcm.c
@@ -24,12 +24,12 @@
 #include "utils/s2n_blob.h"
 
 #if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
-#define S2N_AEAD_AES_GCM_AVAILABLE_BSSL_AWSLC
+#define S2N_AEAD_AES_GCM_AVAILABLE
 #endif
 
 static uint8_t s2n_aead_cipher_aes128_gcm_available()
 {
-#if defined(S2N_AEAD_AES_GCM_AVAILABLE_BSSL_AWSLC)
+#if defined(S2N_AEAD_AES_GCM_AVAILABLE)
     return (EVP_aead_aes_128_gcm() ? 1 : 0);
 #else
     return (EVP_aes_128_gcm() ? 1 : 0);
@@ -38,17 +38,23 @@ static uint8_t s2n_aead_cipher_aes128_gcm_available()
 
 static uint8_t s2n_aead_cipher_aes256_gcm_available()
 {
-#if defined(S2N_AEAD_AES_GCM_AVAILABLE_BSSL_AWSLC)
+#if defined(S2N_AEAD_AES_GCM_AVAILABLE)
     return (EVP_aead_aes_256_gcm() ? 1 : 0);
 #else
     return (EVP_aes_256_gcm() ? 1 : 0);
 #endif
 }
 
-#if defined(S2N_AEAD_AES_GCM_AVAILABLE_BSSL_AWSLC) /* BoringSSL and AWS-LC AEAD API implementation */
+#if defined(S2N_AEAD_AES_GCM_AVAILABLE) /* BoringSSL and AWS-LC AEAD API implementation */
 
 static int s2n_aead_cipher_aes_gcm_encrypt(struct s2n_session_key *key, struct s2n_blob *iv, struct s2n_blob *aad, struct s2n_blob *in, struct s2n_blob *out)
 {
+    notnull_check(in);
+    notnull_check(out);
+    notnull_check(iv);
+    notnull_check(key);
+    notnull_check(aad);
+
     /* The size of the |in| blob includes the size of the data and the size of the AES-GCM tag */
     gte_check(in->size, S2N_TLS_GCM_TAG_LEN);
     gte_check(out->size, in->size);
@@ -67,6 +73,12 @@ static int s2n_aead_cipher_aes_gcm_encrypt(struct s2n_session_key *key, struct s
 
 static int s2n_aead_cipher_aes_gcm_decrypt(struct s2n_session_key *key, struct s2n_blob *iv, struct s2n_blob *aad, struct s2n_blob *in, struct s2n_blob *out)
 {
+    notnull_check(in);
+    notnull_check(out);
+    notnull_check(iv);
+    notnull_check(key);
+    notnull_check(aad);
+
     gte_check(in->size, S2N_TLS_GCM_TAG_LEN);
     gte_check(out->size, in->size - S2N_TLS_GCM_TAG_LEN);
     eq_check(iv->size, S2N_TLS_GCM_IV_LEN);
@@ -82,6 +94,9 @@ static int s2n_aead_cipher_aes_gcm_decrypt(struct s2n_session_key *key, struct s
 
 static int s2n_aead_cipher_aes128_gcm_set_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
+    notnull_check(key);
+    notnull_check(in);
+
     eq_check(in->size, S2N_TLS_AES_128_GCM_KEY_LEN);
 
     GUARD_OSSL(EVP_AEAD_CTX_init(key->evp_aead_ctx, EVP_aead_aes_128_gcm(), in->data, in->size, S2N_TLS_GCM_TAG_LEN, NULL), S2N_ERR_KEY_INIT);
@@ -91,6 +106,9 @@ static int s2n_aead_cipher_aes128_gcm_set_encryption_key(struct s2n_session_key 
 
 static int s2n_aead_cipher_aes256_gcm_set_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
+    notnull_check(key);
+    notnull_check(in);
+
     eq_check(in->size, S2N_TLS_AES_256_GCM_KEY_LEN);
 
     GUARD_OSSL(EVP_AEAD_CTX_init(key->evp_aead_ctx, EVP_aead_aes_256_gcm(), in->data, in->size, S2N_TLS_GCM_TAG_LEN, NULL), S2N_ERR_KEY_INIT);
@@ -100,6 +118,9 @@ static int s2n_aead_cipher_aes256_gcm_set_encryption_key(struct s2n_session_key 
 
 static int s2n_aead_cipher_aes128_gcm_set_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
+    notnull_check(key);
+    notnull_check(in);
+
     eq_check(in->size, S2N_TLS_AES_128_GCM_KEY_LEN);
 
     GUARD_OSSL(EVP_AEAD_CTX_init(key->evp_aead_ctx, EVP_aead_aes_128_gcm(), in->data, in->size, S2N_TLS_GCM_TAG_LEN, NULL), S2N_ERR_KEY_INIT);
@@ -109,6 +130,9 @@ static int s2n_aead_cipher_aes128_gcm_set_decryption_key(struct s2n_session_key 
 
 static int s2n_aead_cipher_aes256_gcm_set_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
+    notnull_check(key);
+    notnull_check(in);
+
     eq_check(in->size, S2N_TLS_AES_256_GCM_KEY_LEN);
 
     GUARD_OSSL(EVP_AEAD_CTX_init(key->evp_aead_ctx, EVP_aead_aes_256_gcm(), in->data, in->size, S2N_TLS_GCM_TAG_LEN, NULL), S2N_ERR_KEY_INIT);
@@ -118,6 +142,8 @@ static int s2n_aead_cipher_aes256_gcm_set_decryption_key(struct s2n_session_key 
 
 static int s2n_aead_cipher_aes_gcm_init(struct s2n_session_key *key)
 {
+    notnull_check(key);
+
     EVP_AEAD_CTX_zero(key->evp_aead_ctx);
 
     return 0;
@@ -125,6 +151,8 @@ static int s2n_aead_cipher_aes_gcm_init(struct s2n_session_key *key)
 
 static int s2n_aead_cipher_aes_gcm_destroy_key(struct s2n_session_key *key)
 {
+    notnull_check(key);
+
     EVP_AEAD_CTX_cleanup(key->evp_aead_ctx);
 
     return 0;

--- a/crypto/s2n_aead_cipher_aes_gcm.c
+++ b/crypto/s2n_aead_cipher_aes_gcm.c
@@ -45,7 +45,7 @@ static uint8_t s2n_aead_cipher_aes256_gcm_available()
 #endif
 }
 
-#if defined(S2N_AEAD_AES_GCM_AVAILABLE_BSSL_AWSLC) /* BoringSSL and AWS-LC AEAD interface implementation */
+#if defined(S2N_AEAD_AES_GCM_AVAILABLE_BSSL_AWSLC) /* BoringSSL and AWS-LC AEAD API implementation */
 
 static int s2n_aead_cipher_aes_gcm_encrypt(struct s2n_session_key *key, struct s2n_blob *iv, struct s2n_blob *aad, struct s2n_blob *in, struct s2n_blob *out)
 {

--- a/crypto/s2n_aead_cipher_aes_gcm.c
+++ b/crypto/s2n_aead_cipher_aes_gcm.c
@@ -68,7 +68,7 @@ static int s2n_aead_cipher_aes_gcm_encrypt(struct s2n_session_key *key, struct s
 
     S2N_ERROR_IF((in_len + S2N_TLS_GCM_TAG_LEN) != out_len, S2N_ERR_ENCRYPT);
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 static int s2n_aead_cipher_aes_gcm_decrypt(struct s2n_session_key *key, struct s2n_blob *iv, struct s2n_blob *aad, struct s2n_blob *in, struct s2n_blob *out)
@@ -89,7 +89,7 @@ static int s2n_aead_cipher_aes_gcm_decrypt(struct s2n_session_key *key, struct s
 
     S2N_ERROR_IF((in->size - S2N_TLS_GCM_TAG_LEN) != out_len, S2N_ERR_ENCRYPT);
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 static int s2n_aead_cipher_aes128_gcm_set_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
@@ -101,7 +101,7 @@ static int s2n_aead_cipher_aes128_gcm_set_encryption_key(struct s2n_session_key 
 
     GUARD_OSSL(EVP_AEAD_CTX_init(key->evp_aead_ctx, EVP_aead_aes_128_gcm(), in->data, in->size, S2N_TLS_GCM_TAG_LEN, NULL), S2N_ERR_KEY_INIT);
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 static int s2n_aead_cipher_aes256_gcm_set_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
@@ -113,7 +113,7 @@ static int s2n_aead_cipher_aes256_gcm_set_encryption_key(struct s2n_session_key 
 
     GUARD_OSSL(EVP_AEAD_CTX_init(key->evp_aead_ctx, EVP_aead_aes_256_gcm(), in->data, in->size, S2N_TLS_GCM_TAG_LEN, NULL), S2N_ERR_KEY_INIT);
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 static int s2n_aead_cipher_aes128_gcm_set_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
@@ -125,7 +125,7 @@ static int s2n_aead_cipher_aes128_gcm_set_decryption_key(struct s2n_session_key 
 
     GUARD_OSSL(EVP_AEAD_CTX_init(key->evp_aead_ctx, EVP_aead_aes_128_gcm(), in->data, in->size, S2N_TLS_GCM_TAG_LEN, NULL), S2N_ERR_KEY_INIT);
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 static int s2n_aead_cipher_aes256_gcm_set_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
@@ -137,7 +137,7 @@ static int s2n_aead_cipher_aes256_gcm_set_decryption_key(struct s2n_session_key 
 
     GUARD_OSSL(EVP_AEAD_CTX_init(key->evp_aead_ctx, EVP_aead_aes_256_gcm(), in->data, in->size, S2N_TLS_GCM_TAG_LEN, NULL), S2N_ERR_KEY_INIT);
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 static int s2n_aead_cipher_aes_gcm_init(struct s2n_session_key *key)
@@ -146,7 +146,7 @@ static int s2n_aead_cipher_aes_gcm_init(struct s2n_session_key *key)
 
     EVP_AEAD_CTX_zero(key->evp_aead_ctx);
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 static int s2n_aead_cipher_aes_gcm_destroy_key(struct s2n_session_key *key)
@@ -155,7 +155,7 @@ static int s2n_aead_cipher_aes_gcm_destroy_key(struct s2n_session_key *key)
 
     EVP_AEAD_CTX_cleanup(key->evp_aead_ctx);
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 #else /* Standard AES-GCM implementation */
@@ -193,7 +193,7 @@ static int s2n_aead_cipher_aes_gcm_encrypt(struct s2n_session_key *key, struct s
     /* When using AES-GCM, EVP_EncryptFinal_ex does not write any bytes. So, we should expect *out_len = 0. */
     S2N_ERROR_IF(0 != out_len, S2N_ERR_ENCRYPT);
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 static int s2n_aead_cipher_aes_gcm_decrypt(struct s2n_session_key *key, struct s2n_blob *iv, struct s2n_blob *aad, struct s2n_blob *in, struct s2n_blob *out)
@@ -227,7 +227,7 @@ static int s2n_aead_cipher_aes_gcm_decrypt(struct s2n_session_key *key, struct s
 
     /* While we verify the content of out_len in s2n_aead_cipher_aes_gcm_encrypt, we refrain from this here. This is to avoid doing any branching before the ciphertext is verified. */
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 static int s2n_aead_cipher_aes128_gcm_set_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
@@ -240,7 +240,7 @@ static int s2n_aead_cipher_aes128_gcm_set_encryption_key(struct s2n_session_key 
 
     GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 static int s2n_aead_cipher_aes256_gcm_set_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
@@ -253,7 +253,7 @@ static int s2n_aead_cipher_aes256_gcm_set_encryption_key(struct s2n_session_key 
 
     GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 static int s2n_aead_cipher_aes128_gcm_set_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
@@ -266,7 +266,7 @@ static int s2n_aead_cipher_aes128_gcm_set_decryption_key(struct s2n_session_key 
 
     GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 static int s2n_aead_cipher_aes256_gcm_set_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
@@ -279,21 +279,21 @@ static int s2n_aead_cipher_aes256_gcm_set_decryption_key(struct s2n_session_key 
 
     GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 static int s2n_aead_cipher_aes_gcm_init(struct s2n_session_key *key)
 {
     s2n_evp_ctx_init(key->evp_cipher_ctx);
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 static int s2n_aead_cipher_aes_gcm_destroy_key(struct s2n_session_key *key)
 {
     EVP_CIPHER_CTX_cleanup(key->evp_cipher_ctx);
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 #endif

--- a/tls/s2n_crypto_constants.h
+++ b/tls/s2n_crypto_constants.h
@@ -31,6 +31,8 @@
 #define S2N_TLS_GCM_EXPLICIT_IV_LEN     8
 #define S2N_TLS_GCM_IV_LEN            (S2N_TLS_GCM_FIXED_IV_LEN + S2N_TLS_GCM_EXPLICIT_IV_LEN)
 #define S2N_TLS_GCM_TAG_LEN            16
+#define S2N_TLS_AES_128_GCM_KEY_LEN     16
+#define S2N_TLS_AES_256_GCM_KEY_LEN     32
 
 /* TLS 1.3 uses only implicit IVs - RFC 8446 5.3 */
 #define S2N_TLS13_AAD_LEN               5


### PR DESCRIPTION
### Resolved issues:

CryptoAlg-412 

### Description of changes: 

s2n supports one backing implementation of AWS-GCM-based cipher suites through the EVP API. AWS-LC/BoringSSL supports consuming AES-GCM through the EVP API, but also through the native AEAD API. This API provides better mis-use resistance and is the preferred API for consuming AEAD ciphers.

This PR adds another backing implementation for AES-GCM-based cipher suites that works with BoringSSL and AWS-LC consuming AES-GCM through the AEAD API.

The overall structure implemented is the similar to that of PR #2284

Additionally, I made the wording more precise various places and stopped assuming that the length of the `out` blob for decrypt functions includes the length of the MAC tag.

### Call-outs:

BoringSSL and AWS-LC AEAD API documentation: https://github.com/google/boringssl/blob/master/include/openssl/aead.h

### Testing:

Current unit tests should cover code-paths since BoringSSL and AWS-LC are already dimensions in the CI.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

