### PR TITLE
Cleanup TLS1.3 key schedule

### DIFF
--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -215,8 +215,6 @@ extern int s2n_handshake_reset_hash_state(struct s2n_connection *conn, s2n_hash_
 extern int s2n_conn_find_name_matching_certs(struct s2n_connection *conn);
 extern int s2n_create_wildcard_hostname(struct s2n_stuffer *hostname, struct s2n_stuffer *output);
 struct s2n_cert_chain_and_key *s2n_get_compatible_cert_chain_and_key(struct s2n_connection *conn, const s2n_pkey_type cert_type);
-int s2n_conn_post_handshake_hashes_update(struct s2n_connection *conn);
-int s2n_conn_pre_handshake_hashes_update(struct s2n_connection *conn);
 int s2n_conn_update_handshake_hashes(struct s2n_connection *conn, struct s2n_blob *data);
 S2N_RESULT s2n_quic_read_handshake_message(struct s2n_connection *conn, uint8_t *message_type);
 S2N_RESULT s2n_quic_write_handshake_message(struct s2n_connection *conn, struct s2n_blob *in);

--- a/tls/s2n_handshake_transcript.c
+++ b/tls/s2n_handshake_transcript.c
@@ -83,8 +83,9 @@ int s2n_conn_update_handshake_hashes(struct s2n_connection *conn, struct s2n_blo
     }
 
     /* Copy the CLIENT_HELLO -> SERVER_FINISHED hash.
-     * We'll need it later to calculate the application secrets. */
-    if (s2n_conn_get_current_message_type(conn) == SERVER_FINISHED) {
+     * TLS1.3 will need it later to calculate the application secrets. */
+    if (s2n_connection_get_protocol_version(conn) >= S2N_TLS13 &&
+            s2n_conn_get_current_message_type(conn) == SERVER_FINISHED) {
         GUARD(s2n_tls13_conn_copy_server_finished_hash(conn));
     }
 

--- a/tls/s2n_tls13_handshake.h
+++ b/tls/s2n_tls13_handshake.h
@@ -34,8 +34,7 @@ int s2n_tls13_mac_verify(struct s2n_tls13_keys *keys, struct s2n_blob *finished_
 
 int s2n_tls13_keys_from_conn(struct s2n_tls13_keys *keys, struct s2n_connection *conn);
 
-int s2n_tls13_handle_handshake_secrets(struct s2n_connection *conn);
-int s2n_tls13_handle_application_secrets(struct s2n_connection *conn);
+int s2n_tls13_handle_secrets(struct s2n_connection *conn);
 int s2n_update_application_traffic_keys(struct s2n_connection *conn, s2n_mode mode, keyupdate_status status);
 
 int s2n_server_hello_retry_recreate_transcript(struct s2n_connection *conn);


### PR DESCRIPTION
### Resolved issues:

https://github.com/awslabs/s2n/issues/2277

### Description of changes: 
* **Finish decoupling secrets from hash calculation:** Because we already save a copy of the ClientHello...ServerFinished hash, we can calculate the application secrets after the hashes are updated just like the handshake secrets. This removes the need for pre- and post- hash update "hooks."
* **Sequence number updates:** We should just wipe the sequence number whenever we update a key. This is already how KeyUpdate handles sequence numbers.
* **Reorder secret calculation:** Previously, we calculated new secrets after creating a record but before that record was actually sent. This is fine, but complicates the QUIC integration by making it a unclear what secret S2N is actually using at any particular moment. I've removed the ambiguity by moving secret calculation to just before the state transition.

### Callouts

The only new code is `s2n_tls13_handle_secrets`, but it's really just a combination of the old pre- and post- hash update hooks.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Updated existing unit tests to test the new method.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? Existing functional and integration tests cover the logic I changed. Any mistake in this code would also likely completely break the handshake.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
