### PR TITLE
docs: fix simple typo, requried -> required

### DIFF
--- a/pq-crypto/bike_r1/sampling.h
+++ b/pq-crypto/bike_r1/sampling.h
@@ -34,7 +34,7 @@ get_seeds(OUT seeds_t *seeds)
 
 // Return's an array of r pseudorandom bits
 // No restrictions exist for the top or bottom bits -
-// in case an odd number is requried then set must_be_odd=1
+// in case an odd number is required then set must_be_odd=1
 // Uses the provided prf context
 ret_t
 sample_uniform_r_bits_with_fixed_prf_context(OUT r_t *r,
@@ -44,7 +44,7 @@ sample_uniform_r_bits_with_fixed_prf_context(OUT r_t *r,
 
 // Return's an array of r pseudorandom bits
 // No restrictions exist for the top or bottom bits -
-// in case an odd number is  requried then set must_be_odd=1
+// in case an odd number is  required then set must_be_odd=1
 _INLINE_ ret_t
 sample_uniform_r_bits(OUT r_t *r,
                       IN const seed_t *      seed,

--- a/pq-crypto/bike_r1/utilities.c
+++ b/pq-crypto/bike_r1/utilities.c
@@ -42,7 +42,7 @@ r_bits_vector_weight(IN const r_t *in)
 _INLINE_ void
 print_uint64(IN const uint64_t val)
 {
-// If printing in BE is requried swap the order of bytes
+// If printing in BE is required swap the order of bytes
 #ifdef PRINT_IN_BE
   uint64_t tmp = bswap_64(val);
 #else

--- a/pq-crypto/bike_r2/sampling.h
+++ b/pq-crypto/bike_r2/sampling.h
@@ -34,7 +34,7 @@ get_seeds(OUT seeds_t *seeds)
 
 // Return's an array of r pseudorandom bits
 // No restrictions exist for the top or bottom bits -
-// in case an odd number is requried then set must_be_odd=1
+// in case an odd number is required then set must_be_odd=1
 // Uses the provided prf context
 ret_t
 sample_uniform_r_bits_with_fixed_prf_context(OUT r_t *r,
@@ -44,7 +44,7 @@ sample_uniform_r_bits_with_fixed_prf_context(OUT r_t *r,
 
 // Return's an array of r pseudorandom bits
 // No restrictions exist for the top or bottom bits -
-// in case an odd number is  requried then set must_be_odd=1
+// in case an odd number is  required then set must_be_odd=1
 _INLINE_ ret_t
 sample_uniform_r_bits(OUT r_t *r,
                       IN const seed_t *      seed,

--- a/pq-crypto/bike_r2/utilities.c
+++ b/pq-crypto/bike_r2/utilities.c
@@ -42,7 +42,7 @@ r_bits_vector_weight(IN const r_t *in)
 _INLINE_ void
 print_uint64(IN const uint64_t val)
 {
-// If printing in BE is requried swap the order of bytes
+// If printing in BE is required swap the order of bytes
 #ifdef PRINT_IN_BE
   uint64_t tmp = bswap_64(val);
 #else


### PR DESCRIPTION
There is a small typo in pq-crypto/bike_r1/sampling.h, pq-crypto/bike_r1/utilities.c, pq-crypto/bike_r2/sampling.h, pq-crypto/bike_r2/utilities.c.

Should read `required` rather than `requried`.

