### PR TITLE
Fix typo edx->ebx in SIKE asm check

### DIFF
--- a/pq-crypto/sike_r2/P434.c
+++ b/pq-crypto/sike_r2/P434.c
@@ -145,13 +145,13 @@ int s2n_check_sike434_r2_asm_compatibility() {
     s2n_cpuid(&eax, &ebx, &ecx, &edx, leaf);
 
     /* Check for bmi2 support */
-    if (!(edx & (1U << 8))) {
+    if (!(ebx & (1U << 8))) {
         return 0;
     }
 
 #if defined(_ADX_)
     /* Check for adx support */
-    if (!(edx & (1U << 19))) {
+    if (!(ebx & (1U << 19))) {
         return 0;
     }
 #endif /* _ADX_ */


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

* Fixes a typo in the SIKE r2 assembly compatibility check. the BMI2 and ADX instructions are indicated in `ebx`, not `edx` (https://en.wikipedia.org/wiki/CPUID#EAX=7,_ECX=0:_Extended_Features). 

### Call-outs:

* Because of this typo, the SIKE r2 optimized assembly was basically always disabled. This should enabled it (when appropriate). 
* Our current method of calling `cpuid` is pretty suboptimal, e.g. it doesn't make use of `<cpuid.h>`, and we call this compatibility check way more than necessary. I am in the process of refactoring and optimizing all of this, but I wanted to get this bug fix out in the meantime.

### Testing:

* Existing tests should cover it 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
