### PR TITLE
Remove incorrect check for tls1.3 support in tests

### DIFF
--- a/tests/unit/s2n_client_extensions_test.c
+++ b/tests/unit/s2n_client_extensions_test.c
@@ -898,7 +898,7 @@ int main(int argc, char **argv)
     }
 
     /* Server and client support the OCSP extension. Test Behavior for TLS 1.3 */
-    if(s2n_x509_ocsp_stapling_supported() && s2n_is_tls13_supported()) {
+    if(s2n_x509_ocsp_stapling_supported()) {
         struct s2n_connection *client_conn;
         struct s2n_connection *server_conn;
         struct s2n_config *server_config;
@@ -928,8 +928,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY, private_key, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key(server_config, cert_chain, private_key));
         EXPECT_SUCCESS(s2n_config_set_extension_data(server_config, S2N_EXTENSION_OCSP_STAPLING,
                     server_ocsp_status, sizeof(server_ocsp_status)));

--- a/tests/unit/s2n_self_talk_tls13_test.c
+++ b/tests/unit/s2n_self_talk_tls13_test.c
@@ -107,10 +107,6 @@ int main(int argc, char **argv)
 
     BEGIN_TEST();
 
-    if (!s2n_is_tls13_supported()) {
-        END_TEST();
-    }
-
     EXPECT_SUCCESS(s2n_enable_tls13());
 
     /* Create a pipe */
@@ -134,7 +130,7 @@ int main(int argc, char **argv)
 
     struct s2n_cert_chain_and_key *chain_and_key;
     EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
-                S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
+                S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
 
     EXPECT_NOT_NULL(config = s2n_config_new());
     EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));

--- a/tls/s2n_tls13.c
+++ b/tls/s2n_tls13.c
@@ -18,11 +18,6 @@
 #include "tls/s2n_tls13.h"
 #include "crypto/s2n_rsa_signing.h"
 
-int s2n_is_tls13_supported()
-{
-    return s2n_is_rsa_pss_signing_supported();
-}
-
 int s2n_is_tls13_enabled()
 {
     return s2n_highest_protocol_version == S2N_TLS13;

--- a/tls/s2n_tls13.h
+++ b/tls/s2n_tls13.h
@@ -33,7 +33,6 @@ extern int s2n_enable_tls13();
 /* from RFC: https://tools.ietf.org/html/rfc8446#section-4.1.3*/
 extern uint8_t hello_retry_req_random[S2N_TLS_RANDOM_DATA_LEN];
 
-int s2n_is_tls13_supported();
 int s2n_is_tls13_enabled();
 int s2n_disable_tls13();
 bool s2n_is_valid_tls13_cipher(const uint8_t version[2]);


### PR DESCRIPTION
### Description of changes: 

Some tests used a "is tls1.3 supported?" check which was just a
wrapper for "is rsa-pss supported?". However, TLS1.3 can be
negotiated without RSA-PSS support by using ECDSA certs instead
of RSA certs.

### Testing:

This is a change to existing tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
