### PR TITLE
Modify CBMC proofs to make assumptions about malloc explicit

### DIFF
--- a/tests/cbmc/proofs/Makefile-project-defines
+++ b/tests/cbmc/proofs/Makefile-project-defines
@@ -32,6 +32,8 @@ INCLUDES += -I$(SRCDIR)/api
 AWS_DEEP_CHECKS ?= 0
 DEFINES += -DAWS_DEEP_CHECKS=$(AWS_DEEP_CHECKS)
 
+CBMC_FLAG_POINTER_PRIMITIVE_CHECK =
+
 ################################################################
 # Remove function bodies that are not used in the proofs.
 # Removing the function from the goto program helps CBMC's

--- a/tests/cbmc/proofs/s2n_alloc/Makefile
+++ b/tests/cbmc/proofs/s2n_alloc/Makefile
@@ -15,6 +15,8 @@
 
 CHECKFLAGS +=
 
+DEFINES += -DMADV_DONTDUMP=1
+
 HARNESS_ENTRY = s2n_alloc_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
 
@@ -25,6 +27,7 @@ PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
 PROOF_SOURCES += $(PROOF_STUB)/madvise.c
 PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 
@@ -33,6 +36,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
+# We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += s2n_ensure_memcpy_trace

--- a/tests/cbmc/proofs/s2n_array_insert/Makefile
+++ b/tests/cbmc/proofs/s2n_array_insert/Makefile
@@ -34,6 +34,7 @@ PROOF_SOURCES += $(PROOF_STUB)/madvise.c
 PROOF_SOURCES += $(PROOF_STUB)/memmove_havoc.c
 PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 

--- a/tests/cbmc/proofs/s2n_array_insert_and_copy/Makefile
+++ b/tests/cbmc/proofs/s2n_array_insert_and_copy/Makefile
@@ -34,6 +34,7 @@ PROOF_SOURCES += $(PROOF_STUB)/madvise.c
 PROOF_SOURCES += $(PROOF_STUB)/memmove_havoc.c
 PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 

--- a/tests/cbmc/proofs/s2n_array_new/Makefile
+++ b/tests/cbmc/proofs/s2n_array_new/Makefile
@@ -25,6 +25,7 @@ PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
 PROOF_SOURCES += $(PROOF_STUB)/memset_havoc.c
 PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 

--- a/tests/cbmc/proofs/s2n_array_pushback/Makefile
+++ b/tests/cbmc/proofs/s2n_array_pushback/Makefile
@@ -34,6 +34,7 @@ PROOF_SOURCES += $(PROOF_STUB)/madvise.c
 PROOF_SOURCES += $(PROOF_STUB)/memmove_havoc.c
 PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 

--- a/tests/cbmc/proofs/s2n_dup/Makefile
+++ b/tests/cbmc/proofs/s2n_dup/Makefile
@@ -24,6 +24,7 @@ PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
 PROOF_SOURCES += $(PROOF_STUB)/madvise.c
 PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 

--- a/tests/cbmc/proofs/s2n_realloc/Makefile
+++ b/tests/cbmc/proofs/s2n_realloc/Makefile
@@ -25,6 +25,7 @@ PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
 PROOF_SOURCES += $(PROOF_STUB)/madvise.c
 PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 

--- a/tests/cbmc/proofs/s2n_set_add/Makefile
+++ b/tests/cbmc/proofs/s2n_set_add/Makefile
@@ -36,6 +36,7 @@ PROOF_SOURCES += $(PROOF_STUB)/madvise.c
 PROOF_SOURCES += $(PROOF_STUB)/memmove_havoc.c
 PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 

--- a/tests/cbmc/proofs/s2n_set_new/Makefile
+++ b/tests/cbmc/proofs/s2n_set_new/Makefile
@@ -28,6 +28,7 @@ PROOF_SOURCES += $(PROOF_STUB)/madvise.c
 PROOF_SOURCES += $(PROOF_STUB)/memset_havoc.c
 PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 

--- a/tests/cbmc/proofs/s2n_strcpy/Makefile
+++ b/tests/cbmc/proofs/s2n_strcpy/Makefile
@@ -35,6 +35,9 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_str.c
 
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
 UNWINDSET += strlen.0:$(call addone,$(MAX_STRING_LEN))
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_strcpy/s2n_strcpy_harness.c
+++ b/tests/cbmc/proofs/s2n_strcpy/s2n_strcpy_harness.c
@@ -26,11 +26,9 @@
 void s2n_strcpy_harness()
 {
     char *         str  = ensure_c_str_is_allocated(MAX_STRING_LEN);
-    const uint32_t slen = strlen(str);
+    const uint32_t slen = (str == NULL) ? 0 : strlen(str);
     const uint32_t buflen;
-    const uint32_t index;
     __CPROVER_assume(buflen < MAX_STRING_LEN);
-    __CPROVER_assume(slen == 0 || index < slen);
     char buf[ buflen ];
 
     /* Last must point to a valid position in buf. */
@@ -41,8 +39,7 @@ void s2n_strcpy_harness()
     save_byte_from_array(str, slen, &str_byte);
     char *result;
 
-    /* Non-deterministically set initialized (in s2n_mem) to true. */
-    if (nondet_bool()) { s2n_mem_init(); }
+    nondet_s2n_mem_init();
 
     /* Non-deterministically set str to NULL. */
     bool nullstr = nondet_bool();

--- a/tests/cbmc/proofs/s2n_stuffer_alloc/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc/Makefile
@@ -15,6 +15,8 @@
 
 CHECKFLAGS +=
 
+DEFINES += -DMADV_DONTDUMP=1
+
 HARNESS_ENTRY = s2n_stuffer_alloc_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
 
@@ -24,6 +26,7 @@ PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
 PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 

--- a/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_string/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_string/Makefile
@@ -33,6 +33,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += s2n_free
 REMOVE_FUNCTION_BODY += s2n_stuffer_resize

--- a/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_string/s2n_stuffer_alloc_ro_from_string_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_string/s2n_stuffer_alloc_ro_from_string_harness.c
@@ -46,15 +46,6 @@ void s2n_stuffer_alloc_ro_from_string_harness()
         assert(stuffer->blob.size == length + 1);
         assert(stuffer->write_cursor == length);
         assert(stuffer->high_water_mark == length);
-    } else {
-        assert(stuffer->blob.data == NULL);
-        assert(stuffer->blob.size == 0);
-        assert(stuffer->read_cursor == 0);
-        assert(stuffer->write_cursor == 0);
-        assert(stuffer->high_water_mark == 0);
-        assert(stuffer->alloced == 0);
-        assert(stuffer->growable == 0);
-        assert(stuffer->tainted == 0);
     }
     assert(s2n_stuffer_is_valid(stuffer));
 }

--- a/tests/cbmc/proofs/s2n_stuffer_copy/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_copy/Makefile
@@ -24,6 +24,7 @@ PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
 PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 

--- a/tests/cbmc/proofs/s2n_stuffer_growable_alloc/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_growable_alloc/Makefile
@@ -24,6 +24,7 @@ PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
 PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 

--- a/tests/cbmc/proofs/s2n_stuffer_read_base64/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_base64/Makefile
@@ -26,6 +26,7 @@ PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
 PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 
@@ -38,6 +39,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 

--- a/tests/cbmc/proofs/s2n_stuffer_read_line/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_line/Makefile
@@ -26,6 +26,7 @@ PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
 PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 
@@ -37,6 +38,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 

--- a/tests/cbmc/proofs/s2n_stuffer_recv_from_fd/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_recv_from_fd/Makefile
@@ -24,6 +24,7 @@ PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
 PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
 PROOF_SOURCES += $(PROOF_STUB)/read.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
@@ -37,6 +38,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 

--- a/tests/cbmc/proofs/s2n_stuffer_reserve/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve/Makefile
@@ -24,6 +24,7 @@ PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
 PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 
@@ -35,6 +36,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 

--- a/tests/cbmc/proofs/s2n_stuffer_resize/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_resize/Makefile
@@ -24,6 +24,7 @@ PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
 PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 
@@ -35,6 +36,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 
 UNWINDSET +=

--- a/tests/cbmc/proofs/s2n_stuffer_skip_read_until/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_read_until/Makefile
@@ -27,6 +27,7 @@ PROOF_SOURCES += $(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 
 PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c

--- a/tests/cbmc/proofs/s2n_stuffer_skip_write/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_write/Makefile
@@ -24,6 +24,7 @@ PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
 PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 
@@ -34,8 +35,8 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
-REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 
 UNWINDSET +=

--- a/tests/cbmc/proofs/s2n_stuffer_write_base64/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_base64/Makefile
@@ -11,7 +11,7 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Enough to get full coverage with 9 minutes of runtime.
+# Enough to get full coverage with 11 minutes of runtime.
 MAX_BLOB_SIZE = 4
 DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
 
@@ -26,6 +26,7 @@ PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
 PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 
@@ -38,6 +39,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 

--- a/tests/cbmc/proofs/s2n_stuffer_write_reservation/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_reservation/Makefile
@@ -30,6 +30,7 @@ PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
 PROOF_SOURCES += $(PROOF_STUB)/madvise.c
 PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 

--- a/tests/cbmc/proofs/s2n_stuffer_writev_bytes/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_writev_bytes/Makefile
@@ -29,6 +29,7 @@ PROOF_SOURCES += $(PROOF_STUB)/madvise.c
 PROOF_SOURCES += $(PROOF_STUB)/memcpy_havoc.c
 PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 

--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -58,7 +58,7 @@ const char *ensure_c_str_is_allocated(size_t max_size)
     /* Ensure that its a valid c string. Since all bytes are nondeterminstic, the actual
      * string length is 0..str_cap
      */
-    __CPROVER_assume(str[ cap - 1 ] == 0);
+    __CPROVER_assume(IMPLIES(str != NULL, str[ cap - 1 ] == '\0'));
     return str;
 }
 

--- a/tests/cbmc/stubs/posix_memalign_override.c
+++ b/tests/cbmc/stubs/posix_memalign_override.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#undef posix_memalign
+
+#include <cbmc_proof/nondet.h>
+#include <errno.h>
+#include <stdint.h>
+
+/**
+ * Overrides the version of posix_memalign used by CBMC.
+ * The current CBMC model doesn't consider malloc may fail.
+ */
+int posix_memalign(void **ptr, __CPROVER_size_t alignment, __CPROVER_size_t size)
+{
+    __CPROVER_HIDE:;
+
+    __CPROVER_size_t multiplier = alignment / sizeof(void *);
+    /* Modeling the posix_memalign checks on alignment. */
+    if (alignment % sizeof(void *) != 0 ||
+        ((multiplier) & (multiplier - 1)) != 0 || alignment == 0) {
+      return EINVAL;
+    }
+    void *tmp = malloc(size);
+    if(tmp != NULL) {
+        *ptr = tmp;
+        return 0;
+    }
+    return ENOMEM;
+}


### PR DESCRIPTION
### Resolved issues:

N/A.

### Description of changes: 

Modify CBMC proofs to make assumptions about malloc explicit. It also updates the version of the CBMC templates used across all proof harnesses and it adds a stub for `posix_memalign`.

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
