### PR TITLE
FindLibCrypto.cmake is easier to consume.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,6 +331,6 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
         COMPONENT Development)
 
 install(FILES "cmake/modules/FindLibCrypto.cmake"
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/cmake/modules/"
         COMPONENT Development)
 

--- a/cmake/s2n-config.cmake
+++ b/cmake/s2n-config.cmake
@@ -5,6 +5,7 @@ if (NOT MSVC)
     find_package(Threads REQUIRED)
 endif()
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/modules")
 find_dependency(LibCrypto)
 
 if (BUILD_SHARED_LIBS)


### PR DESCRIPTION
### Description of changes: 

Currently, s2n installs `lib/cmake/FindLibCrypto.cmake`. Downstream projects need to modify their `CMAKE_MODULE_PATH` so that this file can be found. We have the following copy/pasted in the `CMakeLists.txt` of every aws-c-* library:
```
# This is required in order to append /lib/cmake to each element in CMAKE_PREFIX_PATH
set(AWS_MODULE_DIR "/${CMAKE_INSTALL_LIBDIR}/cmake")
string(REPLACE ";" "${AWS_MODULE_DIR};" AWS_MODULE_PATH "${CMAKE_PREFIX_PATH}${AWS_MODULE_DIR}")
# Append that generated list to the module search path
list(APPEND CMAKE_MODULE_PATH ${AWS_MODULE_PATH})
```

I'm trying to write a simple CMakeLists.txt file for a standalone app using the aws-c-*** libraries, and it was ending up with a lot of copy/paste voodoo like this and I thought there must be a better way.

This change makes it so that any consumer of `s2n-config.cmake` gets their CMAKE_MODULE_PATH automatically modified so that FindLibCrypto.cmake will be found. Also moved the file to `/lib/s2n/cmake/modules/` instead of the "shared" `lib/cmake/`. I got the idea from this [stackoverflow post](https://stackoverflow.com/questions/44920389/installing-a-cmake-library-also-ship-find-modules-for-the-dependencies). It feels a little hacky, but overall a better solution than what we had before.

### Testing:

Tested by building downstream projects with the copy/paste code above removed from their CMakeLists.txt.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
