### PR TITLE
Shorten paths to CBMC submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "tests/cbmc/aws-templates-for-cbmc-proofs"]
-	path = tests/cbmc/aws-templates-for-cbmc-proofs
+[submodule "cbmc-templates"]
+	path = tests/cbmc/templates
 	url = https://github.com/awslabs/aws-templates-for-cbmc-proofs

--- a/tests/cbmc/include/README.md
+++ b/tests/cbmc/include/README.md
@@ -1,1 +1,1 @@
-../aws-templates-for-cbmc-proofs/template-for-repository/include/README.md
+../templates/template-for-repository/include/README.md

--- a/tests/cbmc/proofs/Makefile.common
+++ b/tests/cbmc/proofs/Makefile.common
@@ -1,1 +1,1 @@
-../aws-templates-for-cbmc-proofs/template-for-repository/proofs/Makefile.common
+../templates/template-for-repository/proofs/Makefile.common

--- a/tests/cbmc/proofs/README.md
+++ b/tests/cbmc/proofs/README.md
@@ -1,1 +1,1 @@
-../aws-templates-for-cbmc-proofs/template-for-repository/proofs/README.md
+../templates/template-for-repository/proofs/README.md

--- a/tests/cbmc/sources/README.md
+++ b/tests/cbmc/sources/README.md
@@ -1,1 +1,1 @@
-../aws-templates-for-cbmc-proofs/template-for-repository/sources/README.md
+../templates/template-for-repository/sources/README.md

--- a/tests/cbmc/stubs/README.md
+++ b/tests/cbmc/stubs/README.md
@@ -1,1 +1,1 @@
-../aws-templates-for-cbmc-proofs/template-for-repository/stubs/README.md
+../templates/template-for-repository/stubs/README.md


### PR DESCRIPTION
### Resolved issues:

Part of addressing an issue with long filepaths in a repo contains s2n as one of its recursive submodules:
https://github.com/aws/aws-iot-device-sdk-cpp-v2/issues/165

### Description of changes: 

Shorten "logical path" of submodule, as well as actual file path.

### Testing:

If CI passes, this worked.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
