### PR TITLE
add FALL_THROUGH macro to support clang

### DIFF
--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -394,7 +394,7 @@ static int s2n_evp_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *f
         if (s2n_digest_is_md5_allowed_for_fips(&from->digest.high_level.evp)) {
             GUARD(s2n_hash_allow_md5_for_fips(to));
         }
-    /* fall through */
+        FALL_THROUGH;
     case S2N_HASH_SHA1:
     case S2N_HASH_SHA224:
     case S2N_HASH_SHA256:

--- a/utils/s2n_asn1_time.c
+++ b/utils/s2n_asn1_time.c
@@ -176,7 +176,7 @@ static S2N_RESULT process_state(parser_state *state, char current_char, struct p
                 *state = ON_SUBSECOND;
                 return S2N_RESULT_OK;
             }
-        /* fall through */
+            FALL_THROUGH;
         case ON_TIMEZONE:
             if (current_char == 'Z' || current_char == 'z') {
                 args->local_time_assumed = 0;

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -292,7 +292,7 @@
 /**
  * Marks a case of a switch statement as able to fall through to the next case
  */
-#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 7)
+#if (defined(__clang__) && __clang__ >= 4) || (defined(__GNUC__) && __GNUC__ >= 7)
 #    define FALL_THROUGH __attribute__((fallthrough))
 #else
 #    define FALL_THROUGH ((void)0)

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -289,6 +289,15 @@
  */
 #define CHECKED_MEMSET( d , c , n )                 __S2N_ENSURE_SAFE_MEMSET((d), (c), (n), ENSURE_REF)
 
+/**
+ * Marks a case of a switch statement as able to fall through to the next case
+ */
+#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 7)
+#    define FALL_THROUGH __attribute__((fallthrough))
+#else
+#    define FALL_THROUGH ((void)0)
+#endif
+
 /* Returns `true` if s2n is in unit test mode, `false` otherwise */
 bool s2n_in_unit_test();
 

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -292,7 +292,7 @@
 /**
  * Marks a case of a switch statement as able to fall through to the next case
  */
-#if (defined(__clang__) && __clang__ >= 4) || (defined(__GNUC__) && __GNUC__ >= 7)
+#if (defined(__clang__) && __clang_major__ >= 4) || (defined(__GNUC__) && __GNUC__ >= 7)
 #    define FALL_THROUGH __attribute__((fallthrough))
 #else
 #    define FALL_THROUGH ((void)0)


### PR DESCRIPTION
I ran into an issue with `-Wimplicit-fallthrough` when building s2n with the latest clang:

```
s2n_asn1_time.c:180:9: error: unannotated fall-through between switch labels [-Werror,-Wimplicit-fallthrough]
        case ON_TIMEZONE:
        ^
s2n_asn1_time.c:180:9: note: insert '__attribute__((fallthrough));' to silence this warning
        case ON_TIMEZONE:
        ^
        __attribute__((fallthrough));
s2n_asn1_time.c:180:9: note: insert 'break;' to avoid fall-through
        case ON_TIMEZONE:
        ^
        break;
```

It doesn't recognize the comment markers so I've added a `FALL_THROUGH` macro which uses the `__attribute((fallthrough))` instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
