### PR TITLE
dev: update docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,8 @@ pre_commit_check: all indent clean
 
 # TODO use awslabs instead
 DEV_IMAGE ?= camshaft/s2n-dev
-DEV_VERSION ?= ubuntu_18.04_openssl-1.1.1_gcc9
+DEV_OPENSSL_VERSION ?= openssl-1.1.1
+DEV_VERSION ?= ubuntu_18.04_$(DEV_OPENSSL_VERSION)_gcc9
 
 dev:
 	@docker run -it --rm --ulimit memlock=-1 -v `pwd`:/home/s2n-dev/s2n $(DEV_IMAGE):$(DEV_VERSION)

--- a/docker-images/docker-compose.yml
+++ b/docker-images/docker-compose.yml
@@ -12,8 +12,17 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-version: '3.8'
+version: '3.7'
 services:
+  ubuntu_18.04_openssl-1.0.2_gcc9:
+    build:
+      args:
+        UBUNTU_VERSION: 18.04
+        OPENSSL_VERSION: openssl-1.0.2
+        GCC_VERSION: 9
+      context: ./
+      dockerfile: ./ubuntu/Dockerfile
+    image: ${REPOSITORY_URI}:ubuntu_18.04_openssl-1.0.2_gcc9
   ubuntu_18.04_openssl-1.1.1_gcc9:
     build:
       args:

--- a/docker-images/docker-compose.yml
+++ b/docker-images/docker-compose.yml
@@ -32,3 +32,21 @@ services:
       context: ./
       dockerfile: ./ubuntu/Dockerfile
     image: ${REPOSITORY_URI}:ubuntu_18.04_openssl-1.1.1_gcc9
+  ubuntu_18.04_openssl-libressl_gcc9:
+    build:
+      args:
+        UBUNTU_VERSION: 18.04
+        OPENSSL_VERSION: libressl
+        GCC_VERSION: 9
+      context: ./
+      dockerfile: ./ubuntu/Dockerfile
+    image: ${REPOSITORY_URI}:ubuntu_18.04_libressl_gcc9
+  ubuntu_18.04_openssl-boringssl_gcc9:
+    build:
+      args:
+        UBUNTU_VERSION: 18.04
+        OPENSSL_VERSION: boringssl
+        GCC_VERSION: 9
+      context: ./
+      dockerfile: ./ubuntu/Dockerfile
+    image: ${REPOSITORY_URI}:ubuntu_18.04_boringssl_gcc9

--- a/docker-images/ubuntu/Dockerfile
+++ b/docker-images/ubuntu/Dockerfile
@@ -4,14 +4,14 @@ FROM ubuntu:${UBUNTU_VERSION}
 
 WORKDIR /opt/s2n
 
-ARG OPENSSL_VERSION=openssl-1.1.1
 ARG GCC_VERSION=9
 ARG ZSH_THEME=cypher
 
-ENV S2N_LIBCRYPTO=${OPENSSL_VERSION} \
-    GCC_VERSION=${GCC_VERSION} \
+ENV GCC_VERSION=${GCC_VERSION} \
     BUILD_S2N=true \
-    TESTS=integration
+    S2N_COVERAGE=false \
+    TESTS=integration \
+    LATEST_CLANG=true
 
 # The `s2n_setup_env` assumes bash, not sh
 SHELL ["/bin/bash", "-c"]
@@ -43,16 +43,17 @@ RUN set -eux; \
   source $ZSH/init.sh\n\
   \n\
   # s2n setup\n\
-  export S2N_LIBCRYPTO='"$S2N_LIBCRYPTO"$'\n\
   export BUILD_S2N=true\n\
   export GCC_VERSION='"$GCC_VERSION"$'\n\
   export TESTS=integration\n\
   export TEST_DEPS_DIR=/opt/s2n/test-deps\n\
+  export PATH=$TEST_DEPS_DIR/clang/bin:$PATH\n\
   cd /home/s2n-dev/s2n && source /opt/s2n/codebuild/bin/s2n_setup_env.sh\n\
   ' > /home/s2n-dev/.zshrc; \
   chown -R s2n-dev:s2n-dev /home/s2n-dev; \
   rm -rf /var/lib/apt/lists/*; \
   apt-get clean; \
+  rm -rf /tmp/*; \
   echo done
 
 ADD codebuild codebuild
@@ -61,10 +62,21 @@ ADD codebuild codebuild
 RUN set -eux; \
   export LD_LIBRARY_PATH=""; \
   . codebuild/bin/s2n_setup_env.sh; \
-  codebuild/bin/s2n_install_test_dependencies.sh; \
+  export PATH=$TEST_DEPS_DIR/clang/bin:$PATH; \
+  TESTS=integration codebuild/bin/s2n_install_test_dependencies.sh; \
+  TESTS=benchmark codebuild/bin/s2n_install_test_dependencies.sh; \
+  TESTS=fuzz codebuild/bin/s2n_install_test_dependencies.sh; \
+  TESTS=unit BUILD_S2N=false S2N_LIBCRYPTO=openssl-1.0.2 codebuild/bin/install_default_dependencies.sh; \
+  TESTS=unit BUILD_S2N=false S2N_LIBCRYPTO=openssl-1.0.2-fips codebuild/bin/install_default_dependencies.sh; \
+  TESTS=unit BUILD_S2N=false S2N_LIBCRYPTO=libressl codebuild/bin/install_default_dependencies.sh; \
+  TESTS=unit BUILD_S2N=false S2N_LIBCRYPTO=boringssl codebuild/bin/install_default_dependencies.sh; \
   rm -rf /var/lib/apt/lists/*; \
   apt-get clean; \
+  rm -rf /tmp/*; \
   echo done
+
+ARG OPENSSL_VERSION=openssl-1.1.1
+ENV S2N_LIBCRYPTO=${OPENSSL_VERSION}
 
 USER s2n-dev
 WORKDIR /home/s2n-dev/s2n


### PR DESCRIPTION
This change adds support for running fuzz tests in the dev docker environment as well as switching the linked openssl version.

```
𝄞 DEV_OPENSSL_VERSION=boringssl make dev
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=18.04
DISTRIB_CODENAME=bionic
DISTRIB_DESCRIPTION="Ubuntu 18.04.5 LTS"
UID=1000
OS_NAME=linux
S2N_LIBCRYPTO=boringssl
LIBCRYPTO_ROOT=/opt/s2n/test-deps/boringssl
BUILD_S2N=true
GCC_VERSION=9
LATEST_CLANG=true
TESTS=integration
PATH=/opt/s2n/test-deps/clang/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
LD_LIBRARY_PATH=
0c8fdab8c122 :: ~/s2n »
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
