### PR TITLE
Remove s2n_is_tls13_enabled()

### DIFF
--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -488,7 +488,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
             EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS12);
             EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS12);
-            EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS13);
+            EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS12);
             EXPECT_EQUAL(server_conn->client_hello_version, S2N_TLS12);
 
             EXPECT_SUCCESS(s2n_connection_free(server_conn));

--- a/tests/unit/s2n_client_key_share_extension_test.c
+++ b/tests/unit/s2n_client_key_share_extension_test.c
@@ -531,7 +531,7 @@ int main(int argc, char **argv)
     /* Test s2n_client_key_share_extension.recv */
     {
         /* Test that s2n_client_key_share_extension.recv is a no-op
-         * if tls1.3 not enabled AND in use  */
+         * if not using TLS1.3 */
         {
             struct s2n_connection *client_conn, *server_conn;
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
@@ -542,16 +542,6 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_client_key_share_extension.send(client_conn, &key_share_extension));
             uint16_t key_share_extension_size = s2n_stuffer_data_available(&key_share_extension);
-
-            EXPECT_SUCCESS(s2n_disable_tls13());
-            server_conn->actual_protocol_version = S2N_TLS12;
-            EXPECT_SUCCESS(s2n_client_key_share_extension.recv(server_conn, &key_share_extension));
-            EXPECT_EQUAL(s2n_stuffer_data_available(&key_share_extension), key_share_extension_size);
-
-            EXPECT_SUCCESS(s2n_disable_tls13());
-            server_conn->actual_protocol_version = S2N_TLS13;
-            EXPECT_SUCCESS(s2n_client_key_share_extension.recv(server_conn, &key_share_extension));
-            EXPECT_EQUAL(s2n_stuffer_data_available(&key_share_extension), key_share_extension_size);
 
             EXPECT_SUCCESS(s2n_enable_tls13());
             server_conn->actual_protocol_version = S2N_TLS12;

--- a/tests/unit/s2n_client_supported_groups_extension_test.c
+++ b/tests/unit/s2n_client_supported_groups_extension_test.c
@@ -223,9 +223,9 @@ int main()
         }
         /* Test that send does not send KEM group IDs for versions != TLS 1.3 */
         {
-            EXPECT_FALSE(s2n_is_tls13_enabled());
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_EQUAL(s2n_connection_get_protocol_version(conn), S2N_TLS12);
 
             DEFER_CLEANUP(struct s2n_stuffer stuffer = {0}, s2n_stuffer_free);
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
@@ -420,9 +420,9 @@ int main()
         /* Test recv - server doesn't recognize PQ group IDs when TLS 1.3 is disabled */
         {
             EXPECT_SUCCESS(s2n_disable_tls13());
-            EXPECT_FALSE(s2n_is_tls13_enabled());
             struct s2n_connection *client_conn;
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_EQUAL(s2n_connection_get_protocol_version(client_conn), S2N_TLS12);
             client_conn->security_policy_override = &test_pq_security_policy_sike_bike;
 
             const struct s2n_ecc_preferences *client_ecc_pref = NULL;

--- a/tests/unit/s2n_client_supported_versions_extension_test.c
+++ b/tests/unit/s2n_client_supported_versions_extension_test.c
@@ -117,8 +117,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_free(&extension));
     }
 
-    /* Server selects highest supported version shared by client (when server uses TLS1.2)
-     * but retains the client's requested version. */
+    /* Server does not process the extension if using TLS1.2. */
     {
         EXPECT_SUCCESS(s2n_disable_tls13());
         struct s2n_connection *server_conn;
@@ -137,9 +136,9 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_enable_tls13());
         EXPECT_SUCCESS(s2n_client_supported_versions_extension.recv(server_conn, &extension));
-        EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS13);
+        EXPECT_EQUAL(server_conn->client_protocol_version, S2N_UNKNOWN_PROTOCOL_VERSION);
         EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS12);
-        EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS12);
+        EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_UNKNOWN_PROTOCOL_VERSION);
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_stuffer_free(&extension));

--- a/tests/unit/s2n_quic_support_test.c
+++ b/tests/unit/s2n_quic_support_test.c
@@ -32,10 +32,6 @@ int main(int argc, char **argv)
 
         /* Check error handling */
         {
-            EXPECT_SUCCESS(s2n_disable_tls13());
-            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_enable_quic(conn), S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
-            EXPECT_FALSE(conn->quic_enabled);
-
             EXPECT_SUCCESS(s2n_enable_tls13());
             EXPECT_FAILURE_WITH_ERRNO(s2n_connection_enable_quic(NULL), S2N_ERR_NULL);
             EXPECT_FALSE(conn->quic_enabled);

--- a/tests/unit/s2n_tls13_cookie_test.c
+++ b/tests/unit/s2n_tls13_cookie_test.c
@@ -136,7 +136,7 @@ int main(int argc, char *argv[])
 
             EXPECT_SUCCESS(s2n_server_cookie_extension.send(server_conn, &stuffer));
 
-            EXPECT_SUCCESS(s2n_disable_tls13());
+            client_conn->actual_protocol_version = S2N_TLS12;
             EXPECT_SUCCESS(s2n_server_cookie_extension.recv(client_conn, &stuffer));
             EXPECT_EQUAL(s2n_stuffer_data_available(&client_conn->cookie_stuffer), 0);
 

--- a/tls/extensions/s2n_client_key_share.c
+++ b/tls/extensions/s2n_client_key_share.c
@@ -439,7 +439,7 @@ static int s2n_client_key_share_recv(struct s2n_connection *conn, struct s2n_stu
     notnull_check(conn);
     notnull_check(extension);
 
-    if (!s2n_is_tls13_enabled() || conn->actual_protocol_version < S2N_TLS13) {
+    if (s2n_connection_get_protocol_version(conn) < S2N_TLS13) {
         return S2N_SUCCESS;
     }
 

--- a/tls/extensions/s2n_client_supported_groups.c
+++ b/tls/extensions/s2n_client_supported_groups.c
@@ -63,7 +63,7 @@ static int s2n_client_supported_groups_send(struct s2n_connection *conn, struct 
     GUARD(s2n_stuffer_reserve_uint16(out, &group_list_len));
 
     /* Send KEM groups list first */
-    if (s2n_is_tls13_enabled() && !s2n_is_in_fips_mode()) {
+    if (s2n_connection_get_protocol_version(conn) >= S2N_TLS13 && !s2n_is_in_fips_mode()) {
         for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
             GUARD(s2n_stuffer_write_uint16(out, kem_pref->tls13_kem_groups[i]->iana_id));
         }
@@ -98,7 +98,7 @@ static int s2n_client_supported_groups_recv_iana_id(struct s2n_connection *conn,
     }
 
     /* Return early if in FIPS mode, or if TLS 1.3 is disabled, so as to ignore PQ IDs */
-    if (s2n_is_in_fips_mode() || !s2n_is_tls13_enabled()) {
+    if (s2n_is_in_fips_mode() || s2n_connection_get_protocol_version(conn) < S2N_TLS13) {
         return S2N_SUCCESS;
     }
 

--- a/tls/extensions/s2n_client_supported_versions.c
+++ b/tls/extensions/s2n_client_supported_versions.c
@@ -121,7 +121,7 @@ static int s2n_extensions_client_supported_versions_process(struct s2n_connectio
 
 static int s2n_client_supported_versions_recv(struct s2n_connection *conn, struct s2n_stuffer *in)
 {
-    if (!s2n_is_tls13_enabled()) {
+    if (s2n_connection_get_protocol_version(conn) < S2N_TLS13) {
         return S2N_SUCCESS;
     }
 

--- a/tls/extensions/s2n_cookie.c
+++ b/tls/extensions/s2n_cookie.c
@@ -60,7 +60,7 @@ static int s2n_cookie_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 static int s2n_cookie_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
     notnull_check(conn);
-    if (!s2n_is_tls13_enabled()) {
+    if (s2n_connection_get_protocol_version(conn) < S2N_TLS13) {
         return S2N_SUCCESS;
     }
 

--- a/tls/extensions/s2n_server_key_share.c
+++ b/tls/extensions/s2n_server_key_share.c
@@ -286,7 +286,7 @@ static int s2n_server_key_share_recv_ecc(struct s2n_connection *conn, uint16_t n
  */
 static int s2n_server_key_share_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
-    if (!s2n_is_tls13_enabled()) {
+    if (s2n_connection_get_protocol_version(conn) < S2N_TLS13) {
         return S2N_SUCCESS;
     }
 

--- a/tls/extensions/s2n_server_supported_versions.c
+++ b/tls/extensions/s2n_server_supported_versions.c
@@ -80,7 +80,7 @@ static int s2n_extensions_server_supported_versions_process(struct s2n_connectio
 
 static int s2n_server_supported_versions_recv(struct s2n_connection *conn, struct s2n_stuffer *in)
 {
-    if (!s2n_is_tls13_enabled()) {
+    if (s2n_connection_get_protocol_version(conn) < S2N_TLS13) {
         return S2N_SUCCESS;
     }
 

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -124,7 +124,7 @@ static int s2n_config_init(struct s2n_config *config)
     config->async_pkey_cb = NULL;
 
     GUARD(s2n_config_setup_default(config));
-    if (s2n_is_tls13_enabled()) {
+    if (s2n_use_default_tls13_config()) {
        GUARD(s2n_config_setup_tls13(config));
     } else if (s2n_is_in_fips_mode()) {
         GUARD(s2n_config_setup_fips(config));
@@ -228,7 +228,7 @@ static int s2n_config_build_domain_name_to_cert_map(struct s2n_config *config, s
 
 struct s2n_config *s2n_fetch_default_config(void)
 {
-    if (s2n_is_tls13_enabled()) {
+    if (s2n_use_default_tls13_config()) {
         return &s2n_default_tls13_config;
     }
     if (s2n_is_in_fips_mode()) {

--- a/tls/s2n_quic_support.c
+++ b/tls/s2n_quic_support.c
@@ -37,9 +37,6 @@ S2N_RESULT s2n_read_in_bytes(struct s2n_connection *conn, struct s2n_stuffer *ou
 
 int s2n_connection_enable_quic(struct s2n_connection *conn)
 {
-    /* The QUIC protocol doesn't use pre-1.3 TLS */
-    ENSURE_POSIX(s2n_is_tls13_enabled(), S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
-
     notnull_check(conn);
     conn->quic_enabled = true;
     return S2N_SUCCESS;

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -60,10 +60,6 @@ static int s2n_hello_retry_validate(struct s2n_connection *conn) {
 }
 
 static int s2n_client_detect_downgrade_mechanism(struct s2n_connection *conn) {
-    if (!s2n_is_tls13_enabled()) {
-        return 0;
-    }
-
     notnull_check(conn);
     uint8_t *downgrade_bytes = &conn->secure.server_random[S2N_TLS_RANDOM_DATA_LEN - S2N_DOWNGRADE_PROTECTION_SIZE];
 
@@ -82,10 +78,6 @@ static int s2n_client_detect_downgrade_mechanism(struct s2n_connection *conn) {
 }
 
 static int s2n_server_add_downgrade_mechanism(struct s2n_connection *conn) {
-    if (!s2n_is_tls13_enabled()) {
-        return 0;
-    }
-
     notnull_check(conn);
     uint8_t *downgrade_bytes = &conn->secure.server_random[S2N_TLS_RANDOM_DATA_LEN - S2N_DOWNGRADE_PROTECTION_SIZE];
 

--- a/tls/s2n_tls13.c
+++ b/tls/s2n_tls13.c
@@ -18,9 +18,11 @@
 #include "tls/s2n_tls13.h"
 #include "crypto/s2n_rsa_signing.h"
 
-int s2n_is_tls13_enabled()
+bool s2n_use_default_tls13_config_flag = false;
+
+bool s2n_use_default_tls13_config()
 {
-    return s2n_highest_protocol_version == S2N_TLS13;
+    return s2n_use_default_tls13_config_flag;
 }
 
 /* ** WARNING **
@@ -31,12 +33,14 @@ int s2n_is_tls13_enabled()
 int s2n_enable_tls13()
 {
     s2n_highest_protocol_version = S2N_TLS13;
+    s2n_use_default_tls13_config_flag = true;
     return 0;
 }
 
 int s2n_disable_tls13()
 {
     s2n_highest_protocol_version = S2N_TLS12;
+    s2n_use_default_tls13_config_flag = false;
     return 0;
 }
 

--- a/tls/s2n_tls13.h
+++ b/tls/s2n_tls13.h
@@ -33,7 +33,7 @@ extern int s2n_enable_tls13();
 /* from RFC: https://tools.ietf.org/html/rfc8446#section-4.1.3*/
 extern uint8_t hello_retry_req_random[S2N_TLS_RANDOM_DATA_LEN];
 
-int s2n_is_tls13_enabled();
+bool s2n_use_default_tls13_config();
 int s2n_disable_tls13();
 bool s2n_is_valid_tls13_cipher(const uint8_t version[2]);
 


### PR DESCRIPTION
Part of https://github.com/awslabs/s2n/issues/2336

### Description of changes: 

Remove the "s2n_is_tls13_enabled()" method that is used to check if "s2n_enable_tls13()" has been called. Instead, we should check the protocol version of the connection. 

The only "s2n_is_tls13_enabled()" calls that can't be replaced by checking a connection's protocol version are the ones in s2n_config.c that determine whether a the default config is "default" or "default_tls13". We do NOT want to change the default config to "default_tls13" (Yet!), so I added a new, separate boolean to control the default config.

### Callouts

We no longer parse TLS1.3 extensions in TLS1.2, even if you call s2n_enable_tls13(). This is important because it avoids changing the behavior for TLS1.2-only customers once we deprecate s2n_enable_tls13().

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? New and existing unit tests.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? Old tests still pass, and new tests verify the slight changes in behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
