### PR TITLE
Clean up integ test protocol version / cipher preferences

### DIFF
--- a/tests/integration/Makefile
+++ b/tests/integration/Makefile
@@ -28,6 +28,10 @@ ifeq ($(S2N_CORKED_IO),true)
 	HANDSHAKE_TEST_PARAMS:=--use_corked_io $(HANDSHAKE_TEST_PARAMS)
 endif
 
+ifeq ($(OPENSSL_0_9_8_INSTALL_DIR),)
+	OPENSSL_0_9_8_INSTALL_DIR:=${CURDIR}/../../test-deps/openssl-0.9.8
+endif
+
 .PHONY : all
 ifdef S2N_NO_PQ
 all: tls13 client_endpoints dynamic_record old_s_client s_client s_server gnutls_cli gnutls_serv sslyze

--- a/tests/integration/common/s2n_test_common.py
+++ b/tests/integration/common/s2n_test_common.py
@@ -22,7 +22,7 @@ import uuid
 
 from common.s2n_test_scenario import Mode, Version, run_scenarios
 from common.s2n_test_reporting import Result
-from s2n_test_constants import NUM_EXPECTED_LINES_OUTPUT
+from s2n_test_constants import NUM_EXPECTED_LINES_OUTPUT, ACTUAL_VERSION_STR
 
 
 def get_error(process, line_limit=10):
@@ -137,8 +137,7 @@ def run_connection_test(get_peer, scenarios, test_func=basic_write_test):
 def get_s2n_cmd(scenario):
     mode_char = 'c' if scenario.s2n_mode.is_client() else 'd'
 
-    s2n_cmd = [ "../../bin/s2n%c" % mode_char,
-                "-c", "test_all" ]
+    s2n_cmd = [ "../../bin/s2n%c" % mode_char ]
 
     if scenario.s2n_mode.is_server():
         s2n_cmd.extend(["--key", scenario.cert.key])
@@ -149,6 +148,9 @@ def get_s2n_cmd(scenario):
 
     if scenario.version is Version.TLS13:
         s2n_cmd.append("--tls13")
+        s2n_cmd.extend(["-c", "test_all"])
+    else:
+        s2n_cmd.extend(["-c", "test_all_tls12"])
 
     s2n_cmd.extend(scenario.s2n_flags)
     s2n_cmd.extend([str(scenario.host), str(scenario.port)])
@@ -164,6 +166,10 @@ S2N_SIGNALS = {
 def get_s2n(scenario):
     s2n_cmd = get_s2n_cmd(scenario)
     s2n = get_process(s2n_cmd)
+
+    if (scenario.s2n_mode is Mode.client):
+        if not wait_for_output(s2n.stdout, ACTUAL_VERSION_STR.format(scenario.version.value)):
+            raise AssertionError("s2n %s: %s" % (scenario.s2n_mode, "Wrong negotiated version: {}".format(get_error(s2n))))
 
     if not wait_for_output(s2n.stdout, S2N_SIGNALS[scenario.s2n_mode]):
         raise AssertionError("s2n %s: %s" % (scenario.s2n_mode, get_error(s2n)))

--- a/tests/integration/s2n_dynamic_record_size_test.py
+++ b/tests/integration/s2n_dynamic_record_size_test.py
@@ -138,13 +138,15 @@ def try_dynamic_record(endpoint, port, cipher, ssl_version, threshold, server_ce
 
     # Read from s2nc until we get successful connection message
     found = 0
-    seperators = 0
+    right_version = 0
     for line in range(0, NUM_EXPECTED_LINES_OUTPUT):
         output = s2nc.stdout.readline().decode("utf-8")
         if output.strip() == "Connected to {}:{}".format(endpoint, port):
             found = 1
+        if ACTUAL_VERSION_STR.format(ssl_version or S2N_TLS12) in output:
+            right_version = 1
 
-    if not found:
+    if not found or not right_version:
         sys.stderr.write("= TEST FAILED =\ns_server cmd: {}\n s_server STDERR: {}\n\ns2nc cmd: {}\nSTDERR {}\n".format(" ".join(s_server_cmd), s_server.stderr.read().decode("utf-8"), " ".join(s2nc_cmd), s2nc.stderr.read().decode("utf-8")))
         return -1
 

--- a/tests/integration/s2n_handshake_test_gnutls-serv.py
+++ b/tests/integration/s2n_handshake_test_gnutls-serv.py
@@ -77,11 +77,13 @@ def try_gnutls_handshake(endpoint, port, priority_str, session_tickets, ocsp):
 
     # Read it
     found = 0
+    right_version = 0
     for line in range(0, 50):
         output = s2nc.stdout.readline().decode("utf-8")
         if output.strip().startswith("Connected to"):
             found = 1
-            break
+        if ACTUAL_VERSION_STR.format(S2N_TLS12) in output:
+            right_version = 1
 
     gnutls_serv.kill()
     gnutls_serv.communicate()
@@ -91,7 +93,7 @@ def try_gnutls_handshake(endpoint, port, priority_str, session_tickets, ocsp):
     s2nc.communicate()
     s2nc.wait()
 
-    return found == 1
+    return found == 1 and right_version == 1
 
 def handshake(endpoint, port, cipher, session_tickets, ocsp):
     success = try_gnutls_handshake(endpoint, port, cipher.gnutls_priority_str + ":+VERS-TLS1.2:+SIGN-ALL:+SHA1", session_tickets, ocsp)

--- a/tests/integration/s2n_handshake_test_s_client.py
+++ b/tests/integration/s2n_handshake_test_s_client.py
@@ -85,6 +85,12 @@ def cleanup_processes(*processes):
         p.kill()
         p.wait()
 
+def validate_version(expected_version, output):
+    for line in output.splitlines():
+        if ACTUAL_VERSION_STR.format(expected_version or S2N_TLS12) in line:
+            return 0
+    return -1
+
 def validate_data_transfer(expected_data, s_client_out, s2nd_out):
     """
     Verify that the application data written between s_client and s2nd is encrypted and decrypted successfuly.
@@ -279,7 +285,7 @@ def try_handshake(endpoint, port, cipher, ssl_version, server_name=None, strict_
 
     s2nd_cmd.extend([str(endpoint), str(port)])
 
-    s2nd_ciphers = "test_all"
+    s2nd_ciphers = "test_all_tls12"
     if server_cipher_pref is not None:
         s2nd_ciphers = server_cipher_pref
     if enter_fips_mode == True:
@@ -288,9 +294,6 @@ def try_handshake(endpoint, port, cipher, ssl_version, server_name=None, strict_
 
     if tls13_flag:
         s2nd_cmd.append("--tls13")
-        # we use tls12 only cipher preferences to keep s2nd negotiating maximum versions of TLS 1.2
-        if s2nd_ciphers == "test_all":
-            s2nd_ciphers = "test_all_tls12"
 
     s2nd_cmd.append("-c")
     s2nd_cmd.append(s2nd_ciphers)
@@ -394,6 +397,9 @@ def try_handshake(endpoint, port, cipher, ssl_version, server_name=None, strict_
     cleanup_processes(s2nd, s_client)
 
     if validate_data_transfer(data_to_validate, s_client_out, s2nd_out) != 0:
+        return -1
+
+    if validate_version(ssl_version, s2nd_out) != 0:
         return -1
 
     if resume is True:
@@ -738,7 +744,7 @@ def cert_type_cipher_match_test(host, port, libcrypto_version, **kwargs):
 
     # Handshake with ECDSA cert + RSA priority server cipher prefs (must skip rsa ciphers)
     ecdsa_ret = try_handshake(host, port, cipher, None, curves=supported_curves,
-            server_cert=TEST_ECDSA_CERT, server_key=TEST_ECDSA_KEY, server_cipher_pref="test_all",
+            server_cert=TEST_ECDSA_CERT, server_key=TEST_ECDSA_KEY, server_cipher_pref="test_all_tls12",
             **kwargs)
     result_prefix = "Cert Type: ecdsa  Server Pref: rsa priority.  Vers: %-10s ... " % S2N_PROTO_VERS_TO_STR[None]
     print_result(result_prefix, ecdsa_ret)
@@ -759,7 +765,7 @@ def multiple_cert_type_test(host, port, libcrypto_version, **kwargs):
     # Basic handshake with ECDSA cert + RSA cert
     for cipher in ["ECDHE-ECDSA-AES128-SHA", "ECDHE-RSA-AES128-GCM-SHA256"]:
         supported_curves = "P-256:P-384"
-        server_prefs = "test_all"
+        server_prefs = "test_all_tls12"
         ret = try_handshake(host, port, cipher, None, curves=supported_curves,
                 server_cert_key_list=[(TEST_RSA_CERT, TEST_RSA_KEY),(TEST_ECDSA_CERT, TEST_ECDSA_KEY)],
                 server_cipher_pref=server_prefs,
@@ -800,7 +806,7 @@ def multiple_cert_type_test(host, port, libcrypto_version, **kwargs):
     for cipher in ["ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-GCM-SHA256:AES128-SHA", "ECDHE-ECDSA-AES256-SHA:AES128-SHA"]:
         # Assume this is a curve s2n does not support
         supported_curves = "P-521"
-        server_prefs = "test_all"
+        server_prefs = "test_all_tls12"
         ret = try_handshake(host, port, cipher, None, curves=supported_curves,
                 server_cert_key_list=[(TEST_RSA_CERT, TEST_RSA_KEY),(TEST_ECDSA_CERT, TEST_ECDSA_KEY)],
                 server_cipher_pref=server_prefs,

--- a/tests/integration/s2n_pq_handshake_test.py
+++ b/tests/integration/s2n_pq_handshake_test.py
@@ -13,7 +13,7 @@
 # permissions and limitations under the License.
 #
 
-from s2n_test_constants import NUM_EXPECTED_LINES_OUTPUT
+from s2n_test_constants import NUM_EXPECTED_LINES_OUTPUT, ACTUAL_VERSION_STR, S2N_TLS12
 
 """
 PQ Handshake tests: s2nd and s2nc negotiate a handshake using BIKE or SIKE KEMs
@@ -57,6 +57,9 @@ pq_handshake_test_vectors = [
     {"client_ciphers": "KMS-TLS-1-0-2018-10", "server_ciphers": "KMS-PQ-TLS-1-0-2020-07", "expected_cipher": "ECDHE-RSA-AES256-GCM-SHA384", "expected_kem": "NONE"},
 ]
 
+def validate_version(expected_version, line):
+    return ACTUAL_VERSION_STR.format(expected_version or S2N_TLS12) in line
+
 def print_result(result_prefix, return_code):
     print(result_prefix, end="")
     if return_code == 0:
@@ -83,8 +86,10 @@ def do_pq_handshake(client_ciphers, server_ciphers, expected_cipher, expected_ke
 
     client_kem_found = False
     client_cipher_found = False
+    client_version_correct = False
     server_kem_found = False
     server_cipher_found = False
+    server_version_correct = False
 
     for i in range(0, NUM_EXPECTED_LINES_OUTPUT):
         client_line = str(s2nc.stdout.readline().decode("utf-8"))
@@ -92,12 +97,16 @@ def do_pq_handshake(client_ciphers, server_ciphers, expected_cipher, expected_ke
             client_kem_found = True
         if expected_cipher_output in client_line:
             client_cipher_found = True
+        if validate_version(S2N_TLS12, client_line):
+            client_version_correct = True
 
         server_line = str(s2nd.stdout.readline().decode("utf-8"))
         if expected_kem_output in server_line:
             server_kem_found = True
         if expected_cipher_output in server_line:
             server_cipher_found = True
+        if validate_version(S2N_TLS12, server_line):
+            server_version_correct = True
 
     s2nc.kill()
     s2nc.wait()
@@ -106,6 +115,9 @@ def do_pq_handshake(client_ciphers, server_ciphers, expected_cipher, expected_ke
     s2nd.wait()
 
     if not (client_kem_found and server_kem_found and client_cipher_found and server_cipher_found):
+        return 1
+
+    if not (client_version_correct and server_version_correct):
         return 1
 
     return 0

--- a/tests/integration/s2n_sslyze_test.py
+++ b/tests/integration/s2n_sslyze_test.py
@@ -45,7 +45,7 @@ def run_sslyze_scan(endpoint, port, scan_output_location, enter_fips_mode=False)
     s2nd_cmd = ["../../bin/s2nd"]
     s2nd_cmd.extend([str(endpoint), str(port), "-n", "-s", "--parallelize"])
     
-    s2nd_ciphers = "test_all"
+    s2nd_ciphers = "test_all_tls12"
     if enter_fips_mode == True:
         s2nd_ciphers = "test_all_fips"
         s2nd_cmd.append("--enter-fips-mode")

--- a/tests/integration/s2n_test_constants.py
+++ b/tests/integration/s2n_test_constants.py
@@ -31,6 +31,8 @@ S2N_TLS11 = 32
 S2N_TLS12 = 33
 S2N_TLS13 = 34
 
+ACTUAL_VERSION_STR = "Actual protocol version: {}"
+
 # namedtuple makes iterating through ciphers across client libraries easier. The openssl_1_1_1_compatible flag is for
 # s_client tests. s_client won't be able to use those ciphers.
 S2N_CIPHER = collections.namedtuple('S2N_CIPHER', 'openssl_name gnutls_priority_str min_tls_vers openssl_1_1_1_compatible openssl_fips_compatible')

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -159,15 +159,15 @@ class S2N(Provider):
         if self.options.protocol == Protocols.TLS13:
             cmd_line.append('--tls13')
 
-        if self.options.cipher is not None:
-            if self.options.cipher is Ciphers.KMS_PQ_TLS_1_0_2019_06:
-                cmd_line.extend(['-c', 'KMS-PQ-TLS-1-0-2019-06'])
-            elif self.options.cipher is Ciphers.PQ_SIKE_TEST_TLS_1_0_2019_11:
-                cmd_line.extend(['-c', 'PQ-SIKE-TEST-TLS-1-0-2019-11'])
-            else:
-                cmd_line.extend(['-c', 'test_all'])
-        else:
-            cmd_line.extend(['-c', 'test_all'])
+        cipher_prefs = 'test_all_tls12'
+        if self.options.cipher is Ciphers.KMS_PQ_TLS_1_0_2019_06:
+            cipher_prefs = 'KMS-PQ-TLS-1-0-2019-06'
+        elif self.options.cipher is Ciphers.PQ_SIKE_TEST_TLS_1_0_2019_11:
+            cipher_prefs = 'PQ-SIKE-TEST-TLS-1-0-2019-11'
+        elif self.options.protocol is Protocols.TLS13:
+            cipher_prefs = 'test_all'
+
+        cmd_line.extend(['-c', cipher_prefs])
 
         if self.options.client_key_file:
             cmd_line.extend(['--key', self.options.client_key_file])
@@ -200,8 +200,9 @@ class S2N(Provider):
 
         if self.options.protocol == Protocols.TLS13:
             cmd_line.append('--tls13')
-
-        cmd_line.extend(['-c', 'test_all'])
+            cmd_line.extend(['-c', 'test_all'])
+        else:
+            cmd_line.extend(['-c', 'test_all_tls12'])
 
         if self.options.use_client_auth is True:
             cmd_line.append('-m')


### PR DESCRIPTION
### Resolved issues:

Part of #2336 

### Description of changes: 

* Add checks to verify all legacy integ tests use the right version
* Configure TLS1.3 via setting the correct security policy, without relying on --tls13

### Call-outs:

* Makefile change: I like to run the S2N tests with just make, which does not set OPENSSL_0_9_8_INSTALL_DIR. if OPENSSL_0_9_8_INSTALL_DIR is not set, old_s_client falls back to the installed Openssl. That is not what the test is intended to do, and will negotiate a protocol version higher than the test expects.

### Testing:

I have also run the integ tests with TLS1.3 allowed by default (s2n_highest_protocol_version = S2N_TLS13) to verify that they still pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
