### PR TITLE
jdk integration test

### DIFF
--- a/codebuild/spec/buildspec_ubuntu_integrationv2.yml
+++ b/codebuild/spec/buildspec_ubuntu_integrationv2.yml
@@ -55,4 +55,6 @@ phases:
     commands:
       - printenv
       - . $CB_BIN_DIR/s2n_setup_env.sh
+      # For jdk integration test
+      - javac tests/integrationv2/bin/SSLSocketClient.java
       - make -C tests/integrationv2 $INTEGV2_TEST

--- a/tests/integrationv2/bin/SSLSocketClient.java
+++ b/tests/integrationv2/bin/SSLSocketClient.java
@@ -1,0 +1,96 @@
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.KeyStore;
+import java.io.FileInputStream;
+import java.io.OutputStream;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.SSLSocket;
+
+/*
+ * Simple JDK SSL client for integration testing purposes
+ */
+
+public class SSLSocketClient {
+    public static void main(String[] args) throws Exception {
+        int port = Integer.parseInt(args[0]);
+        String certificatePath = args[1];
+        String protocol = sslProtocols(args[2]);
+        String[] protocolList = new String[] {protocol};
+        String[] cipher = new String[] {args[3]};
+
+        String host = "localhost";
+        byte[] buffer = new byte[100];
+
+        SSLSocketFactory socketFactory = createSocketFactory(certificatePath, protocol);
+
+        try (
+            SSLSocket socket = (SSLSocket)socketFactory.createSocket(host, port);
+            OutputStream out = new BufferedOutputStream(socket.getOutputStream());
+            BufferedInputStream stdIn = new BufferedInputStream(System.in);
+        ) {
+            socket.setEnabledProtocols(protocolList);
+            socket.setEnabledCipherSuites(cipher);
+            socket.startHandshake();
+            System.out.println("Starting handshake");
+
+            while (stdIn.read(buffer) != -1) {
+                out.write(buffer);
+            }
+            out.flush();
+
+            out.close();
+            socket.close();
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static SSLSocketFactory createSocketFactory(String certificatePath, String protocol) {
+
+        try {
+            CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
+
+            FileInputStream is = new FileInputStream(certificatePath);
+
+            X509Certificate cert = (X509Certificate) certFactory.generateCertificate(is);
+            is.close();
+
+            KeyStore caKeyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            caKeyStore.load(null, null);
+            caKeyStore.setCertificateEntry("ca-certificate", cert);
+
+            TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(
+                    TrustManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory.init(caKeyStore);
+
+            SSLContext context = SSLContext.getInstance(protocol);
+            context.init(null, trustManagerFactory.getTrustManagers(), null);
+
+            return context.getSocketFactory();
+
+        } catch(Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    public static String sslProtocols(String s2nProtocol) {
+        switch (s2nProtocol) {
+            case "TLS1.3":
+                return "TLSv1.3";
+            case "TLS1.2":
+                return "TLSv1.2";
+            case "TLS1.1":
+                return "TLSv1.1";
+            case "TLS1.0":
+                return "TLSv1.0";
+        }
+
+        return null;
+    }
+}

--- a/tests/integrationv2/common.py
+++ b/tests/integrationv2/common.py
@@ -168,12 +168,13 @@ class Protocols(object):
 
 
 class Cipher(object):
-    def __init__(self, name, min_version, openssl1_1_1, fips, parameters=None):
+    def __init__(self, name, min_version, openssl1_1_1, fips, parameters=None, standard_name=None):
         self.name = name
         self.min_version = min_version
         self.openssl1_1_1 = openssl1_1_1
         self.fips = fips
         self.parameters = parameters
+        self.standard_name = standard_name
         self.algorithm = 'ANY'
 
         if 'ECDSA' in name:
@@ -195,40 +196,40 @@ class Ciphers(object):
     """
     When referencing ciphers, use these class values.
     """
-    DHE_RSA_DES_CBC3_SHA = Cipher("DHE-RSA-DES-CBC3-SHA", Protocols.SSLv3, False, False)
-    DHE_RSA_AES128_SHA = Cipher("DHE-RSA-AES128-SHA", Protocols.SSLv3, True, False, TEST_CERT_DIRECTORY + 'dhparams_2048.pem')
-    DHE_RSA_AES256_SHA = Cipher("DHE-RSA-AES256-SHA", Protocols.SSLv3, True, False, TEST_CERT_DIRECTORY + 'dhparams_2048.pem')
-    DHE_RSA_AES128_SHA256 = Cipher("DHE-RSA-AES128-SHA256", Protocols.TLS12, True, True, TEST_CERT_DIRECTORY + 'dhparams_2048.pem')
-    DHE_RSA_AES256_SHA256 = Cipher("DHE-RSA-AES256-SHA256", Protocols.TLS12, True, True, TEST_CERT_DIRECTORY + 'dhparams_2048.pem')
-    DHE_RSA_AES128_GCM_SHA256 = Cipher("DHE-RSA-AES128-GCM-SHA256", Protocols.TLS12, True, True, TEST_CERT_DIRECTORY + 'dhparams_2048.pem')
-    DHE_RSA_AES256_GCM_SHA384 = Cipher("DHE-RSA-AES256-GCM-SHA384", Protocols.TLS12, True, True, TEST_CERT_DIRECTORY + 'dhparams_2048.pem')
-    DHE_RSA_CHACHA20_POLY1305 = Cipher("DHE-RSA-CHACHA20-POLY1305", Protocols.TLS12, True, False, TEST_CERT_DIRECTORY + 'dhparams_2048.pem')
+    DHE_RSA_DES_CBC3_SHA = Cipher("DHE-RSA-DES-CBC3-SHA", Protocols.SSLv3, False, False, standard_name="SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA")
+    DHE_RSA_AES128_SHA = Cipher("DHE-RSA-AES128-SHA", Protocols.SSLv3, True, False, TEST_CERT_DIRECTORY + 'dhparams_2048.pem', standard_name="TLS_DHE_RSA_WITH_AES_128_CBC_SHA")
+    DHE_RSA_AES256_SHA = Cipher("DHE-RSA-AES256-SHA", Protocols.SSLv3, True, False, TEST_CERT_DIRECTORY + 'dhparams_2048.pem', standard_name="TLS_DHE_RSA_WITH_AES_256_CBC_SHA")
+    DHE_RSA_AES128_SHA256 = Cipher("DHE-RSA-AES128-SHA256", Protocols.TLS12, True, True, TEST_CERT_DIRECTORY + 'dhparams_2048.pem', standard_name="TLS_DHE_RSA_WITH_AES_128_CBC_SHA256")
+    DHE_RSA_AES256_SHA256 = Cipher("DHE-RSA-AES256-SHA256", Protocols.TLS12, True, True, TEST_CERT_DIRECTORY + 'dhparams_2048.pem', standard_name="TLS_DHE_RSA_WITH_AES_256_CBC_SHA256")
+    DHE_RSA_AES128_GCM_SHA256 = Cipher("DHE-RSA-AES128-GCM-SHA256", Protocols.TLS12, True, True, TEST_CERT_DIRECTORY + 'dhparams_2048.pem', standard_name="TLS_DHE_RSA_WITH_AES_128_GCM_SHA256")
+    DHE_RSA_AES256_GCM_SHA384 = Cipher("DHE-RSA-AES256-GCM-SHA384", Protocols.TLS12, True, True, TEST_CERT_DIRECTORY + 'dhparams_2048.pem', standard_name="TLS_DHE_RSA_WITH_AES_256_GCM_SHA384")
+    DHE_RSA_CHACHA20_POLY1305 = Cipher("DHE-RSA-CHACHA20-POLY1305", Protocols.TLS12, True, False, TEST_CERT_DIRECTORY + 'dhparams_2048.pem', standard_name="TLS_DHE_RSA_WITH_AES_256_GCM_SHA384")
 
-    AES128_SHA = Cipher("AES128-SHA", Protocols.SSLv3, True, True)
-    AES256_SHA = Cipher("AES256-SHA", Protocols.SSLv3, True, True)
-    AES128_SHA256 = Cipher("AES128-SHA256", Protocols.TLS12, True, True)
-    AES256_SHA256 = Cipher("AES256-SHA256", Protocols.TLS12, True, True)
-    AES128_GCM_SHA256 = Cipher("TLS_AES_128_GCM_SHA256", Protocols.TLS13, True, True)
-    AES256_GCM_SHA384 = Cipher("TLS_AES_256_GCM_SHA384", Protocols.TLS13, True, True)
+    AES128_SHA = Cipher("AES128-SHA", Protocols.SSLv3, True, True, standard_name="TLS_RSA_WITH_AES_128_CBC_SHA")
+    AES256_SHA = Cipher("AES256-SHA", Protocols.SSLv3, True, True, standard_name="TLS_RSA_WITH_AES_256_CBC_SHA")
+    AES128_SHA256 = Cipher("AES128-SHA256", Protocols.TLS12, True, True, standard_name="TLS_RSA_WITH_AES_128_CBC_SHA256")
+    AES256_SHA256 = Cipher("AES256-SHA256", Protocols.TLS12, True, True, standard_name="TLS_RSA_WITH_AES_256_CBC_SHA256")
+    AES128_GCM_SHA256 = Cipher("TLS_AES_128_GCM_SHA256", Protocols.TLS13, True, True, standard_name="TLS_AES_128_GCM_SHA256")
+    AES256_GCM_SHA384 = Cipher("TLS_AES_256_GCM_SHA384", Protocols.TLS13, True, True, standard_name="TLS_AES_256_GCM_SHA384")
 
-    ECDHE_ECDSA_AES128_SHA = Cipher("ECDHE-ECDSA-AES128-SHA", Protocols.SSLv3, True, False)
-    ECDHE_ECDSA_AES256_SHA = Cipher("ECDHE-ECDSA-AES256-SHA", Protocols.SSLv3, True, False)
-    ECDHE_ECDSA_AES128_SHA256 = Cipher("ECDHE-ECDSA-AES128-SHA256", Protocols.TLS12, True, True)
-    ECDHE_ECDSA_AES256_SHA384 = Cipher("ECDHE-ECDSA-AES256-SHA384", Protocols.TLS12, True, True)
-    ECDHE_ECDSA_AES128_GCM_SHA256 = Cipher("ECDHE-ECDSA-AES128-GCM-SHA256", Protocols.TLS12, True, True)
-    ECDHE_ECDSA_AES256_GCM_SHA384 = Cipher("ECDHE-ECDSA-AES256-GCM-SHA384", Protocols.TLS12, True, True)
-    ECDHE_ECDSA_CHACHA20_POLY1305 = Cipher("ECDHE-ECDSA-CHACHA20-POLY1305", Protocols.TLS12, True, False)
+    ECDHE_ECDSA_AES128_SHA = Cipher("ECDHE-ECDSA-AES128-SHA", Protocols.SSLv3, True, False, standard_name="TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA")
+    ECDHE_ECDSA_AES256_SHA = Cipher("ECDHE-ECDSA-AES256-SHA", Protocols.SSLv3, True, False, standard_name="TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA")
+    ECDHE_ECDSA_AES128_SHA256 = Cipher("ECDHE-ECDSA-AES128-SHA256", Protocols.TLS12, True, True, standard_name="TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256")
+    ECDHE_ECDSA_AES256_SHA384 = Cipher("ECDHE-ECDSA-AES256-SHA384", Protocols.TLS12, True, True, standard_name="TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384")
+    ECDHE_ECDSA_AES128_GCM_SHA256 = Cipher("ECDHE-ECDSA-AES128-GCM-SHA256", Protocols.TLS12, True, True, standard_name="TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256")
+    ECDHE_ECDSA_AES256_GCM_SHA384 = Cipher("ECDHE-ECDSA-AES256-GCM-SHA384", Protocols.TLS12, True, True, standard_name="TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384")
+    ECDHE_ECDSA_CHACHA20_POLY1305 = Cipher("ECDHE-ECDSA-CHACHA20-POLY1305", Protocols.TLS12, True, False, standard_name="TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256")
 
-    ECDHE_RSA_DES_CBC3_SHA = Cipher("ECDHE-RSA-DES-CBC3-SHA", Protocols.SSLv3, False, False)
-    ECDHE_RSA_AES128_SHA = Cipher("ECDHE-RSA-AES128-SHA", Protocols.SSLv3, True, False)
-    ECDHE_RSA_AES256_SHA = Cipher("ECDHE-RSA-AES256-SHA", Protocols.SSLv3, True, False)
-    ECDHE_RSA_RC4_SHA = Cipher("ECDHE-RSA-RC4-SHA", Protocols.SSLv3, False, False)
-    ECDHE_RSA_AES128_SHA256 = Cipher("ECDHE-RSA-AES128-SHA256", Protocols.TLS12, True, True)
-    ECDHE_RSA_AES256_SHA384 = Cipher("ECDHE-RSA-AES256-SHA384", Protocols.TLS12, True, True)
-    ECDHE_RSA_AES128_GCM_SHA256 = Cipher("ECDHE-RSA-AES128-GCM-SHA256", Protocols.TLS12, True, True)
-    ECDHE_RSA_AES256_GCM_SHA384 = Cipher("ECDHE-RSA-AES256-GCM-SHA384", Protocols.TLS12, True, True)
-    ECDHE_RSA_CHACHA20_POLY1305 = Cipher("ECDHE-RSA-CHACHA20-POLY1305", Protocols.TLS12, True, False)
-    CHACHA20_POLY1305_SHA256 = Cipher("TLS_CHACHA20_POLY1305_SHA256", Protocols.TLS13, True, False)
+    ECDHE_RSA_DES_CBC3_SHA = Cipher("ECDHE-RSA-DES-CBC3-SHA", Protocols.SSLv3, False, False, standard_name="TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA")
+    ECDHE_RSA_AES128_SHA = Cipher("ECDHE-RSA-AES128-SHA", Protocols.SSLv3, True, False, standard_name="TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA")
+    ECDHE_RSA_AES256_SHA = Cipher("ECDHE-RSA-AES256-SHA", Protocols.SSLv3, True, False, standard_name="TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA")
+    ECDHE_RSA_RC4_SHA = Cipher("ECDHE-RSA-RC4-SHA", Protocols.SSLv3, False, False, standard_name="TLS_ECDHE_RSA_WITH_RC4_128_SHA")
+    ECDHE_RSA_AES128_SHA256 = Cipher("ECDHE-RSA-AES128-SHA256", Protocols.TLS12, True, True, standard_name="TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256")
+    ECDHE_RSA_AES256_SHA384 = Cipher("ECDHE-RSA-AES256-SHA384", Protocols.TLS12, True, True, standard_name="TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384")
+    ECDHE_RSA_AES128_GCM_SHA256 = Cipher("ECDHE-RSA-AES128-GCM-SHA256", Protocols.TLS12, True, True, standard_name="TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+    ECDHE_RSA_AES256_GCM_SHA384 = Cipher("ECDHE-RSA-AES256-GCM-SHA384", Protocols.TLS12, True, True, standard_name="TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
+    ECDHE_RSA_CHACHA20_POLY1305 = Cipher("ECDHE-RSA-CHACHA20-POLY1305", Protocols.TLS12, True, False, standard_name="TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256")
+    CHACHA20_POLY1305_SHA256 = Cipher("TLS_CHACHA20_POLY1305_SHA256", Protocols.TLS13, True, False, standard_name="TLS_CHACHA20_POLY1305_SHA256")
 
     KMS_TLS_1_0_2018_10 = Cipher("KMS-TLS-1-0-2018-10", Protocols.TLS10, False, False)
     KMS_PQ_TLS_1_0_2019_06 = Cipher("KMS-PQ-TLS-1-0-2019-06", Protocols.TLS10, False, False)

--- a/tests/integrationv2/common.py
+++ b/tests/integrationv2/common.py
@@ -168,13 +168,13 @@ class Protocols(object):
 
 
 class Cipher(object):
-    def __init__(self, name, min_version, openssl1_1_1, fips, parameters=None, standard_name=None):
+    def __init__(self, name, min_version, openssl1_1_1, fips, parameters=None, iana_standard_name=None):
         self.name = name
         self.min_version = min_version
         self.openssl1_1_1 = openssl1_1_1
         self.fips = fips
         self.parameters = parameters
-        self.standard_name = standard_name
+        self.iana_standard_name = iana_standard_name
         self.algorithm = 'ANY'
 
         if 'ECDSA' in name:
@@ -196,40 +196,40 @@ class Ciphers(object):
     """
     When referencing ciphers, use these class values.
     """
-    DHE_RSA_DES_CBC3_SHA = Cipher("DHE-RSA-DES-CBC3-SHA", Protocols.SSLv3, False, False, standard_name="SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA")
-    DHE_RSA_AES128_SHA = Cipher("DHE-RSA-AES128-SHA", Protocols.SSLv3, True, False, TEST_CERT_DIRECTORY + 'dhparams_2048.pem', standard_name="TLS_DHE_RSA_WITH_AES_128_CBC_SHA")
-    DHE_RSA_AES256_SHA = Cipher("DHE-RSA-AES256-SHA", Protocols.SSLv3, True, False, TEST_CERT_DIRECTORY + 'dhparams_2048.pem', standard_name="TLS_DHE_RSA_WITH_AES_256_CBC_SHA")
-    DHE_RSA_AES128_SHA256 = Cipher("DHE-RSA-AES128-SHA256", Protocols.TLS12, True, True, TEST_CERT_DIRECTORY + 'dhparams_2048.pem', standard_name="TLS_DHE_RSA_WITH_AES_128_CBC_SHA256")
-    DHE_RSA_AES256_SHA256 = Cipher("DHE-RSA-AES256-SHA256", Protocols.TLS12, True, True, TEST_CERT_DIRECTORY + 'dhparams_2048.pem', standard_name="TLS_DHE_RSA_WITH_AES_256_CBC_SHA256")
-    DHE_RSA_AES128_GCM_SHA256 = Cipher("DHE-RSA-AES128-GCM-SHA256", Protocols.TLS12, True, True, TEST_CERT_DIRECTORY + 'dhparams_2048.pem', standard_name="TLS_DHE_RSA_WITH_AES_128_GCM_SHA256")
-    DHE_RSA_AES256_GCM_SHA384 = Cipher("DHE-RSA-AES256-GCM-SHA384", Protocols.TLS12, True, True, TEST_CERT_DIRECTORY + 'dhparams_2048.pem', standard_name="TLS_DHE_RSA_WITH_AES_256_GCM_SHA384")
-    DHE_RSA_CHACHA20_POLY1305 = Cipher("DHE-RSA-CHACHA20-POLY1305", Protocols.TLS12, True, False, TEST_CERT_DIRECTORY + 'dhparams_2048.pem', standard_name="TLS_DHE_RSA_WITH_AES_256_GCM_SHA384")
+    DHE_RSA_DES_CBC3_SHA = Cipher("DHE-RSA-DES-CBC3-SHA", Protocols.SSLv3, False, False, iana_standard_name="SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA")
+    DHE_RSA_AES128_SHA = Cipher("DHE-RSA-AES128-SHA", Protocols.SSLv3, True, False, TEST_CERT_DIRECTORY + 'dhparams_2048.pem', iana_standard_name="TLS_DHE_RSA_WITH_AES_128_CBC_SHA")
+    DHE_RSA_AES256_SHA = Cipher("DHE-RSA-AES256-SHA", Protocols.SSLv3, True, False, TEST_CERT_DIRECTORY + 'dhparams_2048.pem', iana_standard_name="TLS_DHE_RSA_WITH_AES_256_CBC_SHA")
+    DHE_RSA_AES128_SHA256 = Cipher("DHE-RSA-AES128-SHA256", Protocols.TLS12, True, True, TEST_CERT_DIRECTORY + 'dhparams_2048.pem', iana_standard_name="TLS_DHE_RSA_WITH_AES_128_CBC_SHA256")
+    DHE_RSA_AES256_SHA256 = Cipher("DHE-RSA-AES256-SHA256", Protocols.TLS12, True, True, TEST_CERT_DIRECTORY + 'dhparams_2048.pem', iana_standard_name="TLS_DHE_RSA_WITH_AES_256_CBC_SHA256")
+    DHE_RSA_AES128_GCM_SHA256 = Cipher("DHE-RSA-AES128-GCM-SHA256", Protocols.TLS12, True, True, TEST_CERT_DIRECTORY + 'dhparams_2048.pem', iana_standard_name="TLS_DHE_RSA_WITH_AES_128_GCM_SHA256")
+    DHE_RSA_AES256_GCM_SHA384 = Cipher("DHE-RSA-AES256-GCM-SHA384", Protocols.TLS12, True, True, TEST_CERT_DIRECTORY + 'dhparams_2048.pem', iana_standard_name="TLS_DHE_RSA_WITH_AES_256_GCM_SHA384")
+    DHE_RSA_CHACHA20_POLY1305 = Cipher("DHE-RSA-CHACHA20-POLY1305", Protocols.TLS12, True, False, TEST_CERT_DIRECTORY + 'dhparams_2048.pem', iana_standard_name="TLS_DHE_RSA_WITH_AES_256_GCM_SHA384")
 
-    AES128_SHA = Cipher("AES128-SHA", Protocols.SSLv3, True, True, standard_name="TLS_RSA_WITH_AES_128_CBC_SHA")
-    AES256_SHA = Cipher("AES256-SHA", Protocols.SSLv3, True, True, standard_name="TLS_RSA_WITH_AES_256_CBC_SHA")
-    AES128_SHA256 = Cipher("AES128-SHA256", Protocols.TLS12, True, True, standard_name="TLS_RSA_WITH_AES_128_CBC_SHA256")
-    AES256_SHA256 = Cipher("AES256-SHA256", Protocols.TLS12, True, True, standard_name="TLS_RSA_WITH_AES_256_CBC_SHA256")
-    AES128_GCM_SHA256 = Cipher("TLS_AES_128_GCM_SHA256", Protocols.TLS13, True, True, standard_name="TLS_AES_128_GCM_SHA256")
-    AES256_GCM_SHA384 = Cipher("TLS_AES_256_GCM_SHA384", Protocols.TLS13, True, True, standard_name="TLS_AES_256_GCM_SHA384")
+    AES128_SHA = Cipher("AES128-SHA", Protocols.SSLv3, True, True, iana_standard_name="TLS_RSA_WITH_AES_128_CBC_SHA")
+    AES256_SHA = Cipher("AES256-SHA", Protocols.SSLv3, True, True, iana_standard_name="TLS_RSA_WITH_AES_256_CBC_SHA")
+    AES128_SHA256 = Cipher("AES128-SHA256", Protocols.TLS12, True, True, iana_standard_name="TLS_RSA_WITH_AES_128_CBC_SHA256")
+    AES256_SHA256 = Cipher("AES256-SHA256", Protocols.TLS12, True, True, iana_standard_name="TLS_RSA_WITH_AES_256_CBC_SHA256")
+    AES128_GCM_SHA256 = Cipher("TLS_AES_128_GCM_SHA256", Protocols.TLS13, True, True, iana_standard_name="TLS_AES_128_GCM_SHA256")
+    AES256_GCM_SHA384 = Cipher("TLS_AES_256_GCM_SHA384", Protocols.TLS13, True, True, iana_standard_name="TLS_AES_256_GCM_SHA384")
 
-    ECDHE_ECDSA_AES128_SHA = Cipher("ECDHE-ECDSA-AES128-SHA", Protocols.SSLv3, True, False, standard_name="TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA")
-    ECDHE_ECDSA_AES256_SHA = Cipher("ECDHE-ECDSA-AES256-SHA", Protocols.SSLv3, True, False, standard_name="TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA")
-    ECDHE_ECDSA_AES128_SHA256 = Cipher("ECDHE-ECDSA-AES128-SHA256", Protocols.TLS12, True, True, standard_name="TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256")
-    ECDHE_ECDSA_AES256_SHA384 = Cipher("ECDHE-ECDSA-AES256-SHA384", Protocols.TLS12, True, True, standard_name="TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384")
-    ECDHE_ECDSA_AES128_GCM_SHA256 = Cipher("ECDHE-ECDSA-AES128-GCM-SHA256", Protocols.TLS12, True, True, standard_name="TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256")
-    ECDHE_ECDSA_AES256_GCM_SHA384 = Cipher("ECDHE-ECDSA-AES256-GCM-SHA384", Protocols.TLS12, True, True, standard_name="TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384")
-    ECDHE_ECDSA_CHACHA20_POLY1305 = Cipher("ECDHE-ECDSA-CHACHA20-POLY1305", Protocols.TLS12, True, False, standard_name="TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256")
+    ECDHE_ECDSA_AES128_SHA = Cipher("ECDHE-ECDSA-AES128-SHA", Protocols.SSLv3, True, False, iana_standard_name="TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA")
+    ECDHE_ECDSA_AES256_SHA = Cipher("ECDHE-ECDSA-AES256-SHA", Protocols.SSLv3, True, False, iana_standard_name="TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA")
+    ECDHE_ECDSA_AES128_SHA256 = Cipher("ECDHE-ECDSA-AES128-SHA256", Protocols.TLS12, True, True, iana_standard_name="TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256")
+    ECDHE_ECDSA_AES256_SHA384 = Cipher("ECDHE-ECDSA-AES256-SHA384", Protocols.TLS12, True, True, iana_standard_name="TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384")
+    ECDHE_ECDSA_AES128_GCM_SHA256 = Cipher("ECDHE-ECDSA-AES128-GCM-SHA256", Protocols.TLS12, True, True, iana_standard_name="TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256")
+    ECDHE_ECDSA_AES256_GCM_SHA384 = Cipher("ECDHE-ECDSA-AES256-GCM-SHA384", Protocols.TLS12, True, True, iana_standard_name="TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384")
+    ECDHE_ECDSA_CHACHA20_POLY1305 = Cipher("ECDHE-ECDSA-CHACHA20-POLY1305", Protocols.TLS12, True, False, iana_standard_name="TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256")
 
-    ECDHE_RSA_DES_CBC3_SHA = Cipher("ECDHE-RSA-DES-CBC3-SHA", Protocols.SSLv3, False, False, standard_name="TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA")
-    ECDHE_RSA_AES128_SHA = Cipher("ECDHE-RSA-AES128-SHA", Protocols.SSLv3, True, False, standard_name="TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA")
-    ECDHE_RSA_AES256_SHA = Cipher("ECDHE-RSA-AES256-SHA", Protocols.SSLv3, True, False, standard_name="TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA")
-    ECDHE_RSA_RC4_SHA = Cipher("ECDHE-RSA-RC4-SHA", Protocols.SSLv3, False, False, standard_name="TLS_ECDHE_RSA_WITH_RC4_128_SHA")
-    ECDHE_RSA_AES128_SHA256 = Cipher("ECDHE-RSA-AES128-SHA256", Protocols.TLS12, True, True, standard_name="TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256")
-    ECDHE_RSA_AES256_SHA384 = Cipher("ECDHE-RSA-AES256-SHA384", Protocols.TLS12, True, True, standard_name="TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384")
-    ECDHE_RSA_AES128_GCM_SHA256 = Cipher("ECDHE-RSA-AES128-GCM-SHA256", Protocols.TLS12, True, True, standard_name="TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
-    ECDHE_RSA_AES256_GCM_SHA384 = Cipher("ECDHE-RSA-AES256-GCM-SHA384", Protocols.TLS12, True, True, standard_name="TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
-    ECDHE_RSA_CHACHA20_POLY1305 = Cipher("ECDHE-RSA-CHACHA20-POLY1305", Protocols.TLS12, True, False, standard_name="TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256")
-    CHACHA20_POLY1305_SHA256 = Cipher("TLS_CHACHA20_POLY1305_SHA256", Protocols.TLS13, True, False, standard_name="TLS_CHACHA20_POLY1305_SHA256")
+    ECDHE_RSA_DES_CBC3_SHA = Cipher("ECDHE-RSA-DES-CBC3-SHA", Protocols.SSLv3, False, False, iana_standard_name="TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA")
+    ECDHE_RSA_AES128_SHA = Cipher("ECDHE-RSA-AES128-SHA", Protocols.SSLv3, True, False, iana_standard_name="TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA")
+    ECDHE_RSA_AES256_SHA = Cipher("ECDHE-RSA-AES256-SHA", Protocols.SSLv3, True, False, iana_standard_name="TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA")
+    ECDHE_RSA_RC4_SHA = Cipher("ECDHE-RSA-RC4-SHA", Protocols.SSLv3, False, False, iana_standard_name="TLS_ECDHE_RSA_WITH_RC4_128_SHA")
+    ECDHE_RSA_AES128_SHA256 = Cipher("ECDHE-RSA-AES128-SHA256", Protocols.TLS12, True, True, iana_standard_name="TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256")
+    ECDHE_RSA_AES256_SHA384 = Cipher("ECDHE-RSA-AES256-SHA384", Protocols.TLS12, True, True, iana_standard_name="TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384")
+    ECDHE_RSA_AES128_GCM_SHA256 = Cipher("ECDHE-RSA-AES128-GCM-SHA256", Protocols.TLS12, True, True, iana_standard_name="TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+    ECDHE_RSA_AES256_GCM_SHA384 = Cipher("ECDHE-RSA-AES256-GCM-SHA384", Protocols.TLS12, True, True, iana_standard_name="TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
+    ECDHE_RSA_CHACHA20_POLY1305 = Cipher("ECDHE-RSA-CHACHA20-POLY1305", Protocols.TLS12, True, False, iana_standard_name="TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256")
+    CHACHA20_POLY1305_SHA256 = Cipher("TLS_CHACHA20_POLY1305_SHA256", Protocols.TLS13, True, False, iana_standard_name="TLS_CHACHA20_POLY1305_SHA256")
 
     KMS_TLS_1_0_2018_10 = Cipher("KMS-TLS-1-0-2018-10", Protocols.TLS10, False, False)
     KMS_PQ_TLS_1_0_2019_06 = Cipher("KMS-PQ-TLS-1-0-2019-06", Protocols.TLS10, False, False)

--- a/tests/integrationv2/configuration.py
+++ b/tests/integrationv2/configuration.py
@@ -2,7 +2,7 @@ import collections
 
 from common import Certificates, Ciphers, Curves, Protocols, AvailablePorts
 from constants import TEST_SNI_CERT_DIRECTORY
-from providers import S2N, OpenSSL, BoringSSL
+from providers import S2N, OpenSSL, BoringSSL, JavaSSL
 
 
 # The boolean configuration will let a test run for True and False
@@ -20,7 +20,7 @@ PROTOCOLS = [
 
 
 # List of providers that will be tested.
-PROVIDERS = [S2N, OpenSSL]
+PROVIDERS = [S2N, OpenSSL, JavaSSL]
 
 
 # List of binary TLS13 settings
@@ -97,9 +97,6 @@ TLS13_CIPHERS = [
     Ciphers.AES128_GCM_SHA256,
     Ciphers.AES256_GCM_SHA384,
 ]
-
-# List of providers that will be tested.
-PROVIDERS = [S2N, OpenSSL]
 
 
 # List of ports available to tests.

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -453,8 +453,8 @@ class JavaSSL(Provider):
         if self.options.protocol is not None:
             cmd_line.extend([self.options.protocol.name])
         
-        if self.options.cipher.standard_name is not None:
-            cmd_line.extend([self.options.cipher.standard_name])
+        if self.options.cipher.iana_standard_name is not None:
+            cmd_line.extend([self.options.cipher.iana_standard_name])
 
         # Clients are always ready to connect
         self.set_provider_ready()

--- a/tests/integrationv2/test_happy_path.py
+++ b/tests/integrationv2/test_happy_path.py
@@ -4,7 +4,7 @@ import pytest
 from configuration import available_ports, ALL_TEST_CIPHERS, ALL_TEST_CURVES, ALL_TEST_CERTS, PROVIDERS, PROTOCOLS
 from common import ProviderOptions, Protocols, data_bytes
 from fixtures import managed_process
-from providers import Provider, S2N, OpenSSL
+from providers import Provider, S2N, OpenSSL, JavaSSL
 from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version
 
 
@@ -28,6 +28,7 @@ def test_s2n_server_happy_path(managed_process, cipher, provider, curve, protoco
         host="localhost",
         port=port,
         cipher=cipher,
+        cert=certificate,
         curve=curve,
         data_to_send=random_bytes,
         insecure=True,
@@ -57,7 +58,14 @@ def test_s2n_server_happy_path(managed_process, cipher, provider, curve, protoco
     # the stdout reliably.
     for results in server.get_results():
         assert results.exception is None
-        assert results.exit_code == 0
+        '''
+        In TLS1.3 the JDK sends a user_canceled alert as well as a close_notify alert
+        after a connection closes, so s2n will register the alert and complain.
+        '''
+        if protocol.name == "TLS1.3" and provider is JavaSSL:
+            assert results.exit_code == 1
+        else:
+            assert results.exit_code == 0
         assert bytes("Actual protocol version: {}".format(expected_version).encode('utf-8')) in results.stdout
         assert random_bytes in results.stdout
 

--- a/tests/integrationv2/test_happy_path.py
+++ b/tests/integrationv2/test_happy_path.py
@@ -58,14 +58,7 @@ def test_s2n_server_happy_path(managed_process, cipher, provider, curve, protoco
     # the stdout reliably.
     for results in server.get_results():
         assert results.exception is None
-        '''
-        In TLS1.3 the JDK sends a user_canceled alert as well as a close_notify alert
-        after a connection closes, so s2n will register the alert and complain.
-        '''
-        if protocol.name == "TLS1.3" and provider is JavaSSL:
-            assert results.exit_code == 1
-        else:
-            assert results.exit_code == 0
+        assert results.exit_code == 0
         assert bytes("Actual protocol version: {}".format(expected_version).encode('utf-8')) in results.stdout
         assert random_bytes in results.stdout
 

--- a/tests/integrationv2/test_happy_path.py
+++ b/tests/integrationv2/test_happy_path.py
@@ -75,7 +75,7 @@ def test_s2n_server_happy_path(managed_process, cipher, provider, curve, protoco
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
-@pytest.mark.parametrize("provider", PROVIDERS)
+@pytest.mark.parametrize("provider", [S2N, OpenSSL])
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)

--- a/tls/s2n_alerts.c
+++ b/tls/s2n_alerts.c
@@ -85,7 +85,9 @@ int s2n_process_alert_fragment(struct s2n_connection *conn)
         if (s2n_stuffer_data_available(&conn->alert_in) == 2) {
 
             /* Close notifications are handled as shutdowns */
-            if (conn->alert_in_data[1] == S2N_TLS_ALERT_CLOSE_NOTIFY) {
+            if (conn->alert_in_data[1] == S2N_TLS_ALERT_CLOSE_NOTIFY ||
+                    (conn->alert_in_data[1] == S2N_TLS_ALERT_USER_CANCELED &&
+                     conn->actual_protocol_version >= S2N_TLS13)) {
                 conn->closed = 1;
                 return 0;
             }


### PR DESCRIPTION
### Resolved issues:
resolves #2217 
### Description of changes: 
Adds jdk client provider to integration v2 test. Through testing s2n with the jdk, I found that s2n wasn't correctly handling the user_canceled alert in tls1.3. This pr also updates the way those alerts are handled.

### Call-outs:

s2n uses the Openssl name to reference cipher suites. However, the java client uses an iana standard name. In order to test that s2n and java can talk to each other using the agreed cipher suite, I added the iana standard name as a parameter to the cipher suite object in our testing framework. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
