### PR TITLE
Support for curve secp521r1

### DIFF
--- a/crypto/s2n_ecc_evp.h
+++ b/crypto/s2n_ecc_evp.h
@@ -27,6 +27,7 @@
  * and include the extra "legacy_form" byte */
 #define SECP256R1_SHARE_SIZE ((32 * 2 ) + 1)
 #define SECP384R1_SHARE_SIZE ((48 * 2 ) + 1)
+#define SECP521R1_SHARE_SIZE ((66 * 2 ) + 1)
 #define X25519_SHARE_SIZE (32)
 
 struct s2n_ecc_named_curve {
@@ -36,10 +37,12 @@ struct s2n_ecc_named_curve {
     int libcrypto_nid;
     const char *name;
     const uint8_t share_size;
+    int (*generate_key) (const struct s2n_ecc_named_curve *named_curve, EVP_PKEY **evp_pkey);
 };
 
 extern const struct s2n_ecc_named_curve s2n_ecc_curve_secp256r1;
 extern const struct s2n_ecc_named_curve s2n_ecc_curve_secp384r1;
+extern const struct s2n_ecc_named_curve s2n_ecc_curve_secp521r1;
 extern const struct s2n_ecc_named_curve s2n_ecc_curve_x25519;
 
 /* BoringSSL only supports using EVP_PKEY_X25519 with "modern" EC EVP APIs. BoringSSL has a note to possibly add this in
@@ -47,10 +50,10 @@ extern const struct s2n_ecc_named_curve s2n_ecc_curve_x25519;
  */
 #if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0) && !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_IS_BORINGSSL)
     #define EVP_APIS_SUPPORTED 1
-    #define S2N_ECC_EVP_SUPPORTED_CURVES_COUNT 3
+    #define S2N_ECC_EVP_SUPPORTED_CURVES_COUNT 4
 #else
     #define EVP_APIS_SUPPORTED 0
-    #define S2N_ECC_EVP_SUPPORTED_CURVES_COUNT 2
+    #define S2N_ECC_EVP_SUPPORTED_CURVES_COUNT 3
 #endif
 
 extern const struct s2n_ecc_named_curve *const s2n_all_supported_curves_list[];

--- a/tests/integration/common/s2n_test_scenario.py
+++ b/tests/integration/common/s2n_test_scenario.py
@@ -151,7 +151,8 @@ class Curve():
 ALL_CURVES = [
     Curve("X25519", Version.TLS13),
     Curve("P-256", Version.SSLv3),
-    Curve("P-384", Version.SSLv3)
+    Curve("P-384", Version.SSLv3),
+    Curve("P-521", Version.SSLv3)
 ]
 
 # Older versions of Openssl, do not support X25519. Current versions of LibreSSL and BoringSSL use a different API

--- a/tests/integration/s2n_handshake_test_gnutls-cli.py
+++ b/tests/integration/s2n_handshake_test_gnutls-cli.py
@@ -33,6 +33,8 @@ from s2n_test_constants import *
 # A container to make passing the return values from an attempted handshake more convenient
 HANDSHAKE_RC = collections.namedtuple('HANDSHAKE_RC', 'handshake_success gnutls_stdout')
 
+LIBCRYPTO_SUPPORT_X25519 = ['openssl-1.1.1']
+
 # Helper to print just the SHA256 portion of SIGN-RSA-SHA256
 def sigalg_str_from_list(sigalgs):
     # strip the first nine bytes from each name for "SIGN-RSA", 11 for "SIGN-ECDSA"
@@ -113,18 +115,22 @@ def try_gnutls_handshake(endpoint, port, priority_str, mfl_extension_test, enter
     s2nd.wait()
     return HANDSHAKE_RC(True, gnutls_initial_stdout_str)
 
-def handshake(endpoint, port, cipher_name, ssl_version, priority_str, digests, mfl_extension_test, fips_mode,
+def handshake(endpoint, port, cipher_name, ssl_version, priority_str, digests, curves, mfl_extension_test, fips_mode,
         other_prefix=None):
     ret = try_gnutls_handshake(endpoint, port, priority_str, mfl_extension_test, fips_mode)
 
     prefix = other_prefix or ""
     if mfl_extension_test:
         prefix += "MFL: %-10s Cipher: %-10s Vers: %-10s ... " % (mfl_extension_test, cipher_name, S2N_PROTO_VERS_TO_STR[ssl_version])
-    elif len(digests) == 0:
-        prefix += "Cipher: %-30s Vers: %-10s ... " % (cipher_name, S2N_PROTO_VERS_TO_STR[ssl_version])
-    else:
+    elif digests:
         # strip the first nine bytes from each name for "SIGN-RSA", 11 for "SIGN-ECDSA"
         prefix += "Digests: %-40s Vers: %-10s ... " % (sigalg_str_from_list(digests), S2N_PROTO_VERS_TO_STR[ssl_version])
+    elif curves:
+         # strip the first 6 bytes of each curve name ("CURVE-")
+         curve_string = ":".join([x[6:] for x in curves])
+         prefix += "Curves: %-40s Vers: %-10s ... " % (curve_string, S2N_PROTO_VERS_TO_STR[ssl_version])
+    else:
+        prefix += "Cipher: %-30s Vers: %-10s ... " % (cipher_name, S2N_PROTO_VERS_TO_STR[ssl_version])
 
     suffix = ""
     if ret.handshake_success == True:
@@ -191,9 +197,9 @@ def main():
                 cipher_priority_str = cipher_priority_str + ":%NO_EXTENSIONS"
 
             # Add the SSL version to make the cipher priority string fully qualified
-            complete_priority_str = cipher_priority_str + ":+" + S2N_PROTO_VERS_TO_GNUTLS[ssl_version] + ":+SIGN-ALL"
+            complete_priority_str = cipher_priority_str + ":+" + S2N_PROTO_VERS_TO_GNUTLS[ssl_version] + ":+SIGN-ALL" + ":+CURVE-ALL"
 
-            async_result = threadpool.apply_async(handshake, (host, port + port_offset, cipher_name, ssl_version, complete_priority_str, [], 0, fips_mode))
+            async_result = threadpool.apply_async(handshake, (host, port + port_offset, cipher_name, ssl_version, complete_priority_str, [], [], 0, fips_mode))
             port_offset += 1
             results.append(async_result)
 
@@ -214,8 +220,8 @@ def main():
             for cipher in filter(lambda x: x.openssl_name == "ECDHE-RSA-AES128-GCM-SHA256" or x.openssl_name == "DHE-RSA-AES128-GCM-SHA256", ALL_TEST_CIPHERS):
                 if fips_mode and cipher.openssl_fips_compatible == False:
                     continue
-                complete_priority_str = cipher.gnutls_priority_str + ":+VERS-TLS1.2:+" + ":+".join(permutation)
-                async_result = threadpool.apply_async(handshake,(host, port + port_offset, cipher.openssl_name, S2N_TLS12, complete_priority_str, permutation, 0, fips_mode))
+                complete_priority_str = cipher.gnutls_priority_str + ":+CURVE-ALL" + ":+VERS-TLS1.2:+" + ":+".join(permutation)
+                async_result = threadpool.apply_async(handshake,(host, port + port_offset, cipher.openssl_name, S2N_TLS12, complete_priority_str, permutation, [], 0, fips_mode))
                 port_offset += 1
                 results.append(async_result)
 
@@ -235,8 +241,8 @@ def main():
             for cipher in filter(lambda x: x.openssl_name == "ECDHE-ECDSA-AES128-SHA", ALL_TEST_CIPHERS):
                 if fips_mode and cipher.openssl_fips_compatible == False:
                     continue
-                complete_priority_str = cipher.gnutls_priority_str + ":+VERS-TLS1.2:+" + ":+".join(permutation)
-                async_result = threadpool.apply_async(handshake,(host, port + port_offset, cipher.openssl_name, S2N_TLS12, complete_priority_str, permutation, 0, fips_mode))
+                complete_priority_str = cipher.gnutls_priority_str + ":+CURVE-ALL" + ":+VERS-TLS1.2:+" + ":+".join(permutation)
+                async_result = threadpool.apply_async(handshake,(host, port + port_offset, cipher.openssl_name, S2N_TLS12, complete_priority_str, permutation, [], 0, fips_mode))
                 port_offset += 1
                 results.append(async_result)
 
@@ -264,8 +270,8 @@ def main():
             sig_algs = "SIGN-ALL"
             if len(sig_algs_to_remove) > 0:
                 sig_algs += ":!" + sig_algs_to_remove
-            priority_str = cipher.gnutls_priority_str + ":+VERS-TLS1.2:+" + sig_algs
-            rc = handshake(host, port, cipher.openssl_name, S2N_TLS12, priority_str, [], 0, fips_mode, "Preferences found: %-40s "
+            priority_str = cipher.gnutls_priority_str + ":+CURVE-ALL" + ":+VERS-TLS1.2:+" + sig_algs
+            rc = handshake(host, port, cipher.openssl_name, S2N_TLS12, priority_str, [], [], 0, fips_mode, "Preferences found: %-40s "
                     % (sigalg_str_from_list(current_preferences_found)))
             if rc.handshake_success == False:
                 print("Failed to negotiate " + expected_sigalg + " as expected! Priority string: "
@@ -301,8 +307,8 @@ def main():
             sig_algs = "SIGN-ALL"
             if len(sig_algs_to_remove) > 0:
                 sig_algs += ":!" + sig_algs_to_remove
-            priority_str = cipher.gnutls_priority_str + ":+VERS-TLS1.2:+" + sig_algs
-            rc = handshake(host, port, cipher.openssl_name, S2N_TLS12, priority_str, [], 0, fips_mode, "Preferences found: %-40s "
+            priority_str = cipher.gnutls_priority_str + ":+CURVE-ALL" + ":+VERS-TLS1.2:+" + sig_algs
+            rc = handshake(host, port, cipher.openssl_name, S2N_TLS12, priority_str, [], [], 0, fips_mode, "Preferences found: %-40s "
                     % (sigalg_str_from_list(current_preferences_found)))
             if rc.handshake_success == False:
                 print("Failed to negotiate " + expected_sigalg + " as expected! Priority string: " +
@@ -323,6 +329,27 @@ def main():
                         " Priority string: " + priority_str)
                 return -1
 
+    # Produce permutations of every curve s2n supports in every possible order
+    curves = ["CURVE-SECP256R1", "CURVE-SECP384R1"]
+    if not fips_mode:
+        curves.append("CURVE-SECP521R1")
+    for size in range(1, len(curves) + 1):
+        print("\n\tTesting named curve preferences of size: " + str(size))
+        threadpool = create_thread_pool()
+        port_offset = 0
+        results = []
+        for permutation in itertools.permutations(curves,size):
+            # Use an arbitrary ECDHE kx cipher
+            cipher = [x for x in ALL_TEST_CIPHERS if x.openssl_name == "ECDHE-RSA-AES128-GCM-SHA256"][0]
+            complete_priority_str = cipher.gnutls_priority_str + ":+SIGN-ALL" + ":+VERS-TLS1.2:+" + ":+".join(permutation)
+            async_result = threadpool.apply_async(handshake, (host, port + port_offset, cipher.openssl_name, S2N_TLS12, complete_priority_str, [], permutation, 0, fips_mode))
+            port_offset += 1
+            results.append(async_result)
+        threadpool.close()
+        threadpool.join()
+        for async_result in results:
+            if async_result.get().handshake_success == False:
+                return -1
 
     print("\n\tTesting handshakes with Max Fragment Length Extension")
     for ssl_version in [S2N_TLS10, S2N_TLS11, S2N_TLS12]:
@@ -332,8 +359,8 @@ def main():
         results = []
         for mfl_extension_test in [512, 1024, 2048, 4096]:
             cipher = test_ciphers[0]
-            complete_priority_str = cipher.gnutls_priority_str + ":+" + S2N_PROTO_VERS_TO_GNUTLS[ssl_version] + ":+SIGN-ALL"
-            async_result = threadpool.apply_async(handshake,(host, port + port_offset, cipher.openssl_name, ssl_version, complete_priority_str, [], mfl_extension_test, fips_mode))
+            complete_priority_str = cipher.gnutls_priority_str + ":+CURVE-ALL" + ":+" + S2N_PROTO_VERS_TO_GNUTLS[ssl_version] + ":+SIGN-ALL"
+            async_result = threadpool.apply_async(handshake,(host, port + port_offset, cipher.openssl_name, ssl_version, complete_priority_str, [], [], mfl_extension_test, fips_mode))
             port_offset += 1
             results.append(async_result)
 

--- a/tests/integration/s2n_handshake_test_gnutls-serv.py
+++ b/tests/integration/s2n_handshake_test_gnutls-serv.py
@@ -94,7 +94,7 @@ def try_gnutls_handshake(endpoint, port, priority_str, session_tickets, ocsp):
     return found == 1
 
 def handshake(endpoint, port, cipher, session_tickets, ocsp):
-    success = try_gnutls_handshake(endpoint, port, cipher.gnutls_priority_str + ":+VERS-TLS1.2:+SIGN-ALL:+SHA1", session_tickets, ocsp)
+    success = try_gnutls_handshake(endpoint, port, cipher.gnutls_priority_str + ":+CURVE-ALL:+VERS-TLS1.2:+SIGN-ALL:+SHA1", session_tickets, ocsp)
 
     prefix = "Cipher: %-30s Session Tickets: %-5s OCSP: %-5s ... " % (cipher.openssl_name, session_tickets, ocsp)
 

--- a/tests/integration/s2n_handshake_test_s_client.py
+++ b/tests/integration/s2n_handshake_test_s_client.py
@@ -632,6 +632,8 @@ def elliptic_curve_test(host, port, libcrypto_version, fips_mode, **kwargs):
     for noise.
     """
     supported_curves = ["P-256", "P-384"]
+    if not fips_mode:
+        supported_curves.append("P-521")
     unsupported_curves = ["B-163", "K-409"]
     print("\n\tRunning elliptic curve tests:")
     print("\tExpected supported:   " + str(supported_curves))

--- a/tests/integration/s2n_handshake_test_s_server.py
+++ b/tests/integration/s2n_handshake_test_s_server.py
@@ -296,7 +296,7 @@ def elliptic_curve_test(host, port, libcrypto_version):
     Acceptance test for supported elliptic curves. Tests all possible supported curves with unsupported curves mixed in
     for noise.
     """
-    supported_curves = ["P-256", "P-384"]
+    supported_curves = ["P-256", "P-384", "P-521"]
     unsupported_curves = ["B-163", "K-409"]
     print("\n\tRunning s2n Client elliptic curve tests:")
     print("\tExpected supported:   " + str(supported_curves))

--- a/tests/integration/s2n_test_constants.py
+++ b/tests/integration/s2n_test_constants.py
@@ -37,7 +37,7 @@ S2N_CIPHER = collections.namedtuple('S2N_CIPHER', 'openssl_name gnutls_priority_
 
 # Specifying a single cipher suite in GnuTLS requires specifying a "priority string" that removes all cipher suites,
 # and then adds each algorithm(kx,auth,enc,mac) for a given suite. See https://www.gnutls.org/manual/html_node/Priority-Strings.html
-S2N_GNUTLS_PRIORITY_PREFIX="NONE:+COMP-NULL:+CTYPE-ALL:+CURVE-ALL"
+S2N_GNUTLS_PRIORITY_PREFIX="NONE:+COMP-NULL:+CTYPE-ALL"
 
 ALL_TEST_CIPHERS = [
     S2N_CIPHER("RC4-MD5", S2N_GNUTLS_PRIORITY_PREFIX + ":+RSA:+ARCFOUR-128:+MD5", S2N_SSLv3, False, False),

--- a/tests/integrationv2/common.py
+++ b/tests/integrationv2/common.py
@@ -255,6 +255,7 @@ class Curves(object):
     X25519 = Curve("X25519", Protocols.TLS13)
     P256 = Curve("P-256")
     P384 = Curve("P-384")
+    P521 = Curve("P-521")
 
 
 class Signature(object):

--- a/tests/integrationv2/configuration.py
+++ b/tests/integrationv2/configuration.py
@@ -32,6 +32,7 @@ ALL_TEST_CURVES = [
     Curves.X25519,
     Curves.P256,
     Curves.P384,
+    Curves.P521
 ]
 
 

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -449,6 +449,8 @@ class BoringSSL(Provider):
                 cmd_line.extend(['-curves', 'P-256'])
             elif self.options.curve == Curves.P384:
                 cmd_line.extend(['-curves', 'P-384'])
+            elif self.options.curve == Curves.P521:
+                cmd_line.extend(['-curves', 'P-521'])
             elif self.options.curve == Curves.X25519:
                 pytest.skip('BoringSSL does not support curve {}'.format(self.options.curve))
 

--- a/tests/integrationv2/test_hello_retry_requests.py
+++ b/tests/integrationv2/test_hello_retry_requests.py
@@ -15,6 +15,7 @@ HRR_CLIENT_KEYSHARES = [
     ["-K", "none"],
     ["-K", "secp256r1"],
     ["-K", "secp256r1:secp384r1"],
+    ["-K", "secp256r1:secp384r1:secp521r1"]
 ]
 
 
@@ -22,7 +23,8 @@ HRR_CLIENT_KEYSHARES = [
 CURVE_NAMES = {
     "X25519": "x25519",
     "P-256": "secp256r1",
-    "P-384": "secp384r1"
+    "P-384": "secp384r1",
+    "P-521": "secp521r1"
 }
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)

--- a/tests/unit/s2n_client_key_share_extension_test.c
+++ b/tests/unit/s2n_client_key_share_extension_test.c
@@ -956,7 +956,8 @@ static int s2n_write_key_share(struct s2n_stuffer *out,
             .iana_id = iana_value,
             .libcrypto_nid = existing_curve->libcrypto_nid,
             .name = existing_curve->name,
-            .share_size = share_size
+            .share_size = share_size,
+            .generate_key = existing_curve->generate_key
     };
 
     ecc_evp_params.negotiated_curve = &test_curve;

--- a/tests/unit/s2n_ecc_preferences_test.c
+++ b/tests/unit/s2n_ecc_preferences_test.c
@@ -35,6 +35,11 @@ int main(int argc, char **argv) {
 #else
         EXPECT_FALSE(s2n_ecc_preferences_includes_curve(&s2n_ecc_preferences_20200310, TLS_EC_CURVE_ECDH_X25519));
 #endif
+
+        EXPECT_TRUE(s2n_ecc_preferences_includes_curve(&s2n_ecc_preferences_20201021, TLS_EC_CURVE_SECP_256_R1));
+        EXPECT_TRUE(s2n_ecc_preferences_includes_curve(&s2n_ecc_preferences_20201021, TLS_EC_CURVE_SECP_384_R1));
+        EXPECT_TRUE(s2n_ecc_preferences_includes_curve(&s2n_ecc_preferences_20201021, TLS_EC_CURVE_SECP_521_R1));
+        EXPECT_FALSE(s2n_ecc_preferences_includes_curve(&s2n_ecc_preferences_20201021, TLS_EC_CURVE_ECDH_X25519));
     }
 
     END_TEST();

--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -138,6 +138,15 @@ int main(int argc, char **argv)
         EXPECT_NULL(security_policy->kem_preferences->kems);
         EXPECT_NULL(security_policy->kem_preferences->tls13_kem_groups);
         EXPECT_EQUAL(0, security_policy->kem_preferences->tls13_kem_group_count);
+
+        security_policy = NULL;
+        EXPECT_SUCCESS(s2n_find_security_policy_from_version("20201021", &security_policy));
+        EXPECT_TRUE(s2n_ecc_is_extension_required(security_policy));
+        EXPECT_FALSE(s2n_pq_kem_is_extension_required(security_policy));
+        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_count);
+        EXPECT_NULL(security_policy->kem_preferences->kems);
+        EXPECT_NULL(security_policy->kem_preferences->tls13_kem_groups);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->tls13_kem_group_count);
     }
 
     {
@@ -190,6 +199,7 @@ int main(int argc, char **argv)
             "20190120",
             "20190121",
             "20190122",
+            "20201021",
             "test_all_fips",
             "test_all_ecdsa",
             "test_ecdsa_priority",

--- a/tls/s2n_ecc_preferences.c
+++ b/tls/s2n_ecc_preferences.c
@@ -33,6 +33,21 @@ const struct s2n_ecc_named_curve *const s2n_ecc_pref_list_20200310[] = {
     &s2n_ecc_curve_secp384r1,
 };
 
+const struct s2n_ecc_named_curve *const s2n_ecc_pref_list_20201021[] = {
+    &s2n_ecc_curve_secp256r1,
+    &s2n_ecc_curve_secp384r1,
+    &s2n_ecc_curve_secp521r1,
+};
+
+const struct s2n_ecc_named_curve *const s2n_ecc_pref_list_test_all[] = {
+#if EVP_APIS_SUPPORTED
+    &s2n_ecc_curve_x25519,
+#endif
+    &s2n_ecc_curve_secp256r1,
+    &s2n_ecc_curve_secp384r1,
+    &s2n_ecc_curve_secp521r1,
+};
+
 const struct s2n_ecc_preferences s2n_ecc_preferences_20140601 = {
         .count = s2n_array_len(s2n_ecc_pref_list_20140601),
         .ecc_curves = s2n_ecc_pref_list_20140601,
@@ -41,6 +56,16 @@ const struct s2n_ecc_preferences s2n_ecc_preferences_20140601 = {
 const struct s2n_ecc_preferences s2n_ecc_preferences_20200310 = {
         .count = s2n_array_len(s2n_ecc_pref_list_20200310),
         .ecc_curves = s2n_ecc_pref_list_20200310,
+};
+
+const struct s2n_ecc_preferences s2n_ecc_preferences_20201021 = {
+        .count = s2n_array_len(s2n_ecc_pref_list_20201021),
+        .ecc_curves = s2n_ecc_pref_list_20201021,
+};
+
+const struct s2n_ecc_preferences s2n_ecc_preferences_test_all = {
+        .count = s2n_array_len(s2n_ecc_pref_list_test_all),
+        .ecc_curves = s2n_ecc_pref_list_test_all,
 };
 
 const struct s2n_ecc_preferences s2n_ecc_preferences_null = {

--- a/tls/s2n_ecc_preferences.h
+++ b/tls/s2n_ecc_preferences.h
@@ -27,6 +27,8 @@ struct s2n_ecc_preferences {
 };
 extern const struct s2n_ecc_preferences s2n_ecc_preferences_20140601;
 extern const struct s2n_ecc_preferences s2n_ecc_preferences_20200310;
+extern const struct s2n_ecc_preferences s2n_ecc_preferences_20201021;
+extern const struct s2n_ecc_preferences s2n_ecc_preferences_test_all;
 extern const struct s2n_ecc_preferences s2n_ecc_preferences_null;
 
 int s2n_check_ecc_preferences_curves_list(const struct s2n_ecc_preferences *ecc_preferences);

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -443,6 +443,14 @@ const struct s2n_security_policy security_policy_20170718 = {
     .ecc_preferences = &s2n_ecc_preferences_20140601,
 };
 
+const struct s2n_security_policy security_policy_20201021 = {
+    .minimum_protocol_version = S2N_TLS10,
+    .cipher_preferences = &cipher_preferences_20190122,
+    .kem_preferences = &kem_preferences_null,
+    .signature_preferences = &s2n_signature_preferences_20201021,
+    .ecc_preferences = &s2n_ecc_preferences_20201021,
+};
+
 const struct s2n_security_policy security_policy_test_all = {
     .minimum_protocol_version = S2N_SSLv3,
     .cipher_preferences = &cipher_preferences_test_all,
@@ -451,8 +459,8 @@ const struct s2n_security_policy security_policy_test_all = {
 #else
     .kem_preferences = &kem_preferences_null,
 #endif
-    .signature_preferences = &s2n_signature_preferences_20200207,
-    .ecc_preferences = &s2n_ecc_preferences_20200310,
+    .signature_preferences = &s2n_signature_preferences_20201021,
+    .ecc_preferences = &s2n_ecc_preferences_test_all,
 };
 
 const struct s2n_security_policy security_policy_test_all_tls12 = {
@@ -463,8 +471,8 @@ const struct s2n_security_policy security_policy_test_all_tls12 = {
 #else
     .kem_preferences = &kem_preferences_null,
 #endif
-    .signature_preferences = &s2n_signature_preferences_20140601,
-    .ecc_preferences = &s2n_ecc_preferences_20140601,
+    .signature_preferences = &s2n_signature_preferences_20201021,
+    .ecc_preferences = &s2n_ecc_preferences_20201021,
 };
 
 const struct s2n_security_policy security_policy_test_all_fips = {
@@ -479,8 +487,8 @@ const struct s2n_security_policy security_policy_test_all_ecdsa = {
     .minimum_protocol_version = S2N_TLS10,
     .cipher_preferences = &cipher_preferences_test_all_ecdsa,
     .kem_preferences = &kem_preferences_null,
-    .signature_preferences = &s2n_signature_preferences_20140601,
-    .ecc_preferences = &s2n_ecc_preferences_20140601,
+    .signature_preferences = &s2n_signature_preferences_20201021,
+    .ecc_preferences = &s2n_ecc_preferences_test_all,
 };
 
 const struct s2n_security_policy security_policy_test_all_rsa_kex = {
@@ -495,16 +503,16 @@ const struct s2n_security_policy security_policy_test_all_tls13 = {
     .minimum_protocol_version = S2N_SSLv3,
     .cipher_preferences = &cipher_preferences_test_all_tls13,
     .kem_preferences = &kem_preferences_null,
-    .signature_preferences = &s2n_signature_preferences_20200207,
-    .ecc_preferences = &s2n_ecc_preferences_20200310,
+    .signature_preferences = &s2n_signature_preferences_20201021,
+    .ecc_preferences = &s2n_ecc_preferences_test_all,
 };
 
 const struct s2n_security_policy security_policy_test_ecdsa_priority = {
     .minimum_protocol_version = S2N_SSLv3,
     .cipher_preferences = &cipher_preferences_test_ecdsa_priority,
-    .kem_preferences = &kem_preferences_null,    
-    .signature_preferences = &s2n_signature_preferences_20140601,
-    .ecc_preferences = &s2n_ecc_preferences_20140601,    
+    .kem_preferences = &kem_preferences_null,
+    .signature_preferences = &s2n_signature_preferences_20201021,
+    .ecc_preferences = &s2n_ecc_preferences_test_all,
 };
 
 const struct s2n_security_policy security_policy_null = {
@@ -578,6 +586,7 @@ struct s2n_security_policy_selection security_policy_selection[] = {
     { .version="20190801", .security_policy=&security_policy_20190801, .ecc_extension_required=0, .pq_kem_extension_required=0 },
     { .version="20190802", .security_policy=&security_policy_20190802, .ecc_extension_required=0, .pq_kem_extension_required=0 },
     { .version="20200207", .security_policy=&security_policy_test_all_tls13, .ecc_extension_required=0, .pq_kem_extension_required=0 },
+    { .version="20201021", .security_policy=&security_policy_20201021, .ecc_extension_required=0, .pq_kem_extension_required=0 },
     { .version="test_all", .security_policy=&security_policy_test_all, .ecc_extension_required=0, .pq_kem_extension_required=0 },
     { .version="test_all_fips", .security_policy=&security_policy_test_all_fips, .ecc_extension_required=0, .pq_kem_extension_required=0 },
     { .version="test_all_ecdsa", .security_policy=&security_policy_test_all_ecdsa, .ecc_extension_required=0, .pq_kem_extension_required=0 },

--- a/tls/s2n_signature_scheme.c
+++ b/tls/s2n_signature_scheme.c
@@ -131,6 +131,14 @@ const struct s2n_signature_scheme s2n_ecdsa_secp384r1_sha384 = {
         .minimum_protocol_version = S2N_TLS13,
 };
 
+const struct s2n_signature_scheme s2n_ecdsa_secp521r1_sha512 = {
+        .iana_value = TLS_SIGNATURE_SCHEME_ECDSA_SECP521R1_SHA512,
+        .hash_alg = S2N_HASH_SHA512,
+        .sig_alg = S2N_SIGNATURE_ECDSA,
+        .signature_curve = &s2n_ecc_curve_secp521r1, /* Hardcoded as of TLS 1.3 */
+        .minimum_protocol_version = S2N_TLS13,
+};
+
 /**
  * RSA-PSS-RSAE
  */
@@ -233,6 +241,36 @@ const struct s2n_signature_scheme* const s2n_sig_scheme_pref_list_20200207[] = {
         &s2n_ecdsa_sha1,
 };
 
+/* Add s2n_ecdsa_secp521r1_sha512 */
+const struct s2n_signature_scheme* const s2n_sig_scheme_pref_list_20201021[] = {
+        /* RSA PSS */
+        &s2n_rsa_pss_pss_sha256,
+        &s2n_rsa_pss_pss_sha384,
+        &s2n_rsa_pss_pss_sha512,
+        &s2n_rsa_pss_rsae_sha256,
+        &s2n_rsa_pss_rsae_sha384,
+        &s2n_rsa_pss_rsae_sha512,
+
+        /* RSA PKCS1 */
+        &s2n_rsa_pkcs1_sha256,
+        &s2n_rsa_pkcs1_sha384,
+        &s2n_rsa_pkcs1_sha512,
+        &s2n_rsa_pkcs1_sha224,
+
+        /* ECDSA - TLS 1.2 */
+        &s2n_ecdsa_sha256, /* same iana value as TLS 1.3 s2n_ecdsa_secp256r1_sha256 */
+        &s2n_ecdsa_secp256r1_sha256,
+        &s2n_ecdsa_sha384, /* same iana value as TLS 1.3 s2n_ecdsa_secp384r1_sha384 */
+        &s2n_ecdsa_secp384r1_sha384,
+        &s2n_ecdsa_sha512, /* same iana value as TLS 1.3 s2n_ecdsa_secp521r1_sha512 */
+        &s2n_ecdsa_secp521r1_sha512,
+        &s2n_ecdsa_sha224,
+
+        /* SHA-1 Legacy */
+        &s2n_rsa_pkcs1_sha1,
+        &s2n_ecdsa_sha1,
+};
+
 const struct s2n_signature_preferences s2n_signature_preferences_20140601 = {
         .count = s2n_array_len(s2n_sig_scheme_pref_list_20140601),
         .signature_schemes = s2n_sig_scheme_pref_list_20140601,
@@ -241,6 +279,11 @@ const struct s2n_signature_preferences s2n_signature_preferences_20140601 = {
 const struct s2n_signature_preferences s2n_signature_preferences_20200207 = {
         .count = s2n_array_len(s2n_sig_scheme_pref_list_20200207),
         .signature_schemes = s2n_sig_scheme_pref_list_20200207,
+};
+
+const struct s2n_signature_preferences s2n_signature_preferences_20201021 = {
+        .count = s2n_array_len(s2n_sig_scheme_pref_list_20201021),
+        .signature_schemes = s2n_sig_scheme_pref_list_20201021,
 };
 
 const struct s2n_signature_preferences s2n_signature_preferences_null = {

--- a/tls/s2n_signature_scheme.h
+++ b/tls/s2n_signature_scheme.h
@@ -58,6 +58,7 @@ extern const struct s2n_signature_scheme s2n_ecdsa_sha512;
 /* TLS 1.3 Compatible ECDSA Schemes */
 extern const struct s2n_signature_scheme s2n_ecdsa_secp256r1_sha256;
 extern const struct s2n_signature_scheme s2n_ecdsa_secp384r1_sha384;
+extern const struct s2n_signature_scheme s2n_ecdsa_secp521r1_sha512;
 
 /* RSA PSS */
 /*
@@ -73,4 +74,5 @@ extern const struct s2n_signature_scheme s2n_rsa_pss_rsae_sha512;
 
 extern const struct s2n_signature_preferences s2n_signature_preferences_20140601;
 extern const struct s2n_signature_preferences s2n_signature_preferences_20200207;
+extern const struct s2n_signature_preferences s2n_signature_preferences_20201021;
 extern const struct s2n_signature_preferences s2n_signature_preferences_null;

--- a/tls/s2n_tls_parameters.h
+++ b/tls/s2n_tls_parameters.h
@@ -188,6 +188,7 @@
 /* Elliptic curves from https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8 */
 #define TLS_EC_CURVE_SECP_256_R1           23
 #define TLS_EC_CURVE_SECP_384_R1           24
+#define TLS_EC_CURVE_SECP_521_R1           25
 #define TLS_EC_CURVE_ECDH_X25519           29
 
 /* Ethernet maximum transmission unit (MTU)


### PR DESCRIPTION
### Resolved issues:

 We use s2n in server mode and need the elliptic curve secp521r1 for specific usage.

### Description of changes: 

s2n only support secp256r1 and secp384r1, with this change, s2n will support a new curve secp521r1.
And add a new security policies and ecc preference to contains these 3 curves.

### Testing:

Add new unit test and integration test. All of test case passed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
