### PR TITLE
Ensure TLS1.3 never ignores warnings

### DIFF
--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -851,9 +851,11 @@ terminate handshake early with fatal handshake failure alert.
 ```c
 int s2n_config_set_alert_behavior(struct s2n_config *config, s2n_alert_behavior alert_behavior);
 ```
-Sets whether or not a should terminate connection on WARNING alert from peer. `alert_behavior` can take the following values:
-- `S2N_ALERT_FAIL_ON_WARNINGS` - default behavior: s2n will terminate conneciton if peer sends WARNING alert.
+Sets whether or not a connection should terminate on receiving a WARNING alert from its peer. `alert_behavior` can take the following values:
+- `S2N_ALERT_FAIL_ON_WARNINGS` - default behavior: s2n will terminate the connection if its peer sends a WARNING alert.
 - `S2N_ALERT_IGNORE_WARNINGS` - with the exception of `close_notify` s2n will ignore all WARNING alerts and keep communicating with its peer.
+
+This setting is ignored in TLS1.3, which requires that all alerts cause the connection to terminate.
 
 ## Certificate-related functions
 

--- a/tls/s2n_alerts.c
+++ b/tls/s2n_alerts.c
@@ -92,6 +92,7 @@ int s2n_process_alert_fragment(struct s2n_connection *conn)
 
             /* Ignore warning-level alerts if we're in warning-tolerant mode */
             if (conn->config->alert_behavior == S2N_ALERT_IGNORE_WARNINGS &&
+                    s2n_connection_get_protocol_version(conn) < S2N_TLS13 &&
                     conn->alert_in_data[0] == S2N_TLS_ALERT_LEVEL_WARNING) {
                 GUARD(s2n_stuffer_wipe(&conn->alert_in));
                 return 0;


### PR DESCRIPTION
### Description of changes: 

By default, S2N treats warnings as fatal. However, it also provides a configuration value customers can use to ignore warnings instead. TLS1.3 should not respect that configuration value, because the RFC specifies that it must ignore the alert level.

https://tools.ietf.org/html/rfc8446#section-6
> Alert messages convey a description of the alert and a legacy field
   that conveyed the severity level of the message in previous versions
   of TLS.  Alerts are divided into two classes: closure alerts and
   error alerts.  In TLS 1.3, the severity is implicit in the type of
   alert being sent, and the "level" field can safely be ignored.

> All the alerts listed in Section 6.2 MUST be sent with
   AlertLevel=fatal and MUST be treated as error alerts when received
   regardless of the AlertLevel in the message.  Unknown Alert types
   MUST be treated as error alerts.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)?  Unit tests

 Is this a refactor change? No, new behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
