### PR TITLE
Fix handling of user_canceled alert

### DIFF
--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -855,6 +855,8 @@ Sets whether or not a connection should terminate on receiving a WARNING alert f
 - `S2N_ALERT_FAIL_ON_WARNINGS` - default behavior: s2n will terminate the connection if its peer sends a WARNING alert.
 - `S2N_ALERT_IGNORE_WARNINGS` - with the exception of `close_notify` s2n will ignore all WARNING alerts and keep communicating with its peer.
 
+This setting is ignored in TLS1.3. TLS1.3 terminates a connection for all alerts except user_canceled.
+
 ## Certificate-related functions
 
 ### s2n\_cert\_chain\_and\_key\_new

--- a/tests/unit/s2n_alerts_test.c
+++ b/tests/unit/s2n_alerts_test.c
@@ -118,13 +118,12 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_disable_tls13());
             }
 
-            /* user_canceled ignored in TLS1.3 if alert_behavior == S2N_ALERT_IGNORE_WARNINGS */
+            /* user_canceled ignored in TLS1.3 by default */
             {
                 EXPECT_SUCCESS(s2n_enable_tls13());
 
                 struct s2n_config *config;
                 EXPECT_NOT_NULL(config = s2n_config_new());
-                EXPECT_SUCCESS(s2n_config_set_alert_behavior(config, S2N_ALERT_IGNORE_WARNINGS));
 
                 struct s2n_connection *conn;
                 EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));

--- a/tls/s2n_alerts.c
+++ b/tls/s2n_alerts.c
@@ -63,15 +63,18 @@ static bool s2n_alerts_supported(struct s2n_connection *conn)
     return conn && !conn->quic_enabled;
 }
 
-static bool s2n_is_warning(struct s2n_connection *conn, uint8_t level, uint8_t type)
+static bool s2n_handle_as_warning(struct s2n_connection *conn, uint8_t level, uint8_t type)
 {
-    /* Only TLS1.2 considers the warning level. The warning level field is
+    /* Only TLS1.2 considers the alert level. The alert level field is
      * considered deprecated in TLS1.3. */
     if (s2n_connection_get_protocol_version(conn) < S2N_TLS13) {
-        return level == S2N_TLS_ALERT_LEVEL_WARNING;
+        return level == S2N_TLS_ALERT_LEVEL_WARNING
+                && conn->config->alert_behavior == S2N_ALERT_IGNORE_WARNINGS;
     }
 
-    /* user_canceled is the only alert currently treated as a warning in TLS1.3 */
+    /* user_canceled is the only alert currently treated as a warning in TLS1.3.
+     * We need to treat it as a warning regardless of alert_behavior to avoid marking
+     * correctly-closed connections as failed. */
     return type == S2N_TLS_ALERT_USER_CANCELED;
 }
 
@@ -97,16 +100,13 @@ int s2n_process_alert_fragment(struct s2n_connection *conn)
         if (s2n_stuffer_data_available(&conn->alert_in) == 2) {
 
             /* Close notifications are handled as shutdowns */
-            if (conn->alert_in_data[1] == S2N_TLS_ALERT_CLOSE_NOTIFY ||
-                    (conn->alert_in_data[1] == S2N_TLS_ALERT_USER_CANCELED &&
-                     conn->actual_protocol_version >= S2N_TLS13)) {
+            if (conn->alert_in_data[1] == S2N_TLS_ALERT_CLOSE_NOTIFY) {
                 conn->closed = 1;
                 return 0;
             }
 
             /* Ignore warning-level alerts if we're in warning-tolerant mode */
-            if (conn->config->alert_behavior == S2N_ALERT_IGNORE_WARNINGS &&
-                    s2n_is_warning(conn, conn->alert_in_data[0], conn->alert_in_data[1])) {
+            if (s2n_handle_as_warning(conn, conn->alert_in_data[0], conn->alert_in_data[1])) {
                 GUARD(s2n_stuffer_wipe(&conn->alert_in));
                 return 0;
             }


### PR DESCRIPTION
### Description of changes: 

A [previous commit](https://github.com/awslabs/s2n/pull/2343/files) treated user_canceled alerts as close_notify alerts. Instead, they should always be treated as warnings.

Openssl backs up that this is the correct interpretation of the RFC: [code](https://github.com/openssl/openssl/blob/fcc3a5204c6daa0f0bbc1679ce1ce82fb767190d/ssl/record/rec_layer_s3.c#L1599-L1604)

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Unit tests. Also, existing integration tests with the Java client, which sends the user_canceled alert as part of its normal connection close.

 Is this a refactor change? No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
