### PR TITLE
Fix FALL_THROUGH macro for older clang versions

### DIFF
--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -292,7 +292,7 @@
 /**
  * Marks a case of a switch statement as able to fall through to the next case
  */
-#if (defined(__clang__) && __clang_major__ >= 4) || (defined(__GNUC__) && __GNUC__ >= 7)
+#if (defined(__clang__) && __clang_major__ >= 10) || (defined(__GNUC__) && __GNUC__ >= 7)
 #    define FALL_THROUGH __attribute__((fallthrough))
 #else
 #    define FALL_THROUGH ((void)0)


### PR DESCRIPTION
### Description of changes: 

[This](https://github.com/awslabs/s2n/commit/4cf944b68d1d039654e27c6ab988d2208f045514) commit introduced a new macro using the fallthrough attribute, which apparently only exists in clang 10 and higher.

### Testing:

Case statement fallthrough fails in clang 10 without macro: https://godbolt.org/z/rs8Gar
Succeeds with macro: https://godbolt.org/z/o4Y3Pe

Case statement fallthrough succeeds in clang 9 without macro: https://godbolt.org/z/dafMea
Succeeds with macro too: https://godbolt.org/z/bx647o

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
