### PR TITLE
Verify HMAC with unbounded key/data.

### DIFF
--- a/codebuild/bin/install_saw.sh
+++ b/codebuild/bin/install_saw.sh
@@ -37,7 +37,7 @@ mkdir -p "$DOWNLOAD_DIR"
 cd "$DOWNLOAD_DIR"
 
 #download saw binaries
-curl --retry 3 https://s2n-public-test-dependencies.s3-us-west-2.amazonaws.com/saw-0.4.0.99-2020-03-31-Ubuntu14.04-64.tar.gz --output saw.tar.gz
+curl --retry 3 https://s2n-public-test-dependencies.s3-us-west-2.amazonaws.com/saw-0.6.0.99-2020-10-12-Ubuntu14.04-64.tar.gz --output saw.tar.gz
 
 mkdir -p saw && tar -xzf saw.tar.gz --strip-components=1 -C saw
 mkdir -p "$INSTALL_DIR" && mv saw/* "$INSTALL_DIR"

--- a/codebuild/bin/install_z3_yices.sh
+++ b/codebuild/bin/install_z3_yices.sh
@@ -34,10 +34,11 @@ cd "$DOWNLOAD_DIR"
 curl --retry 3 https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/yices-2.6.1-x86_64-pc-linux-gnu-static-gmp.tar.gz --output yices.tar.gz
 tar -xf yices.tar.gz
 
-curl --retry 3 https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/z3-2017-04-04-Ubuntu14.04-64 --output z3
+curl --retry 3 https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/z3-4.8.8-x64-ubuntu-16.04.zip --output z3.zip
+unzip z3.zip
 
 mkdir -p "$INSTALL_DIR"/bin
-mv z3 "$INSTALL_DIR"/bin
+mv z3-4.8.8-x64-ubuntu-16.04/bin/* "$INSTALL_DIR"/bin
 mv yices-2.6.1/bin/* "$INSTALL_DIR"/bin
 chmod +x  "$INSTALL_DIR"/bin/*
 

--- a/tests/saw/HMAC/spec/HMAC.saw
+++ b/tests/saw/HMAC/spec/HMAC.saw
@@ -50,9 +50,10 @@ let ptr_to_fresh_readonly n ty = do {
     return (x, p);
 };
 
-let yices_hash_unint =
-    unint_yices [ "hash_init_c_state"
+let z3_hash_unint =
+    w4_unint_z3 [ "hash_init_c_state"
                 , "hash_update_c_state"
+                , "hash_update_c_state_unbounded"
                 , "hash_digest_c_state"
                 ];
 
@@ -172,6 +173,23 @@ let hash_update_spec msg_size = do {
     crucible_return (crucible_term {{ 0 : [32] }});
 };
 
+let hash_update_unbounded_spec = do {
+    pstate <- crucible_alloc (llvm_struct "struct.s2n_hash_state");
+    (st0, _) <- setup_hash_state pstate;
+
+    size <- crucible_fresh_var "size" (llvm_int 32);
+    pmsg <- crucible_symbolic_alloc true 1 {{ (0 # size) : [64] }};
+    msg <- crucible_fresh_cryptol_var "msg" {| ByteArray |};
+    crucible_points_to_array_prefix pmsg msg {{ (0 # size) : [64] }};
+
+    crucible_execute_func [pstate, pmsg, (crucible_term size)];
+
+    let st1 = {{ hash_update_c_state_unbounded st0 msg size }};
+    update_hash_state pstate st1;
+
+    crucible_return (crucible_term {{ 0 : [32] }});
+};
+
 let hash_digest_spec digest_size = do {
     pstate <- crucible_alloc (llvm_struct "struct.s2n_hash_state");
     (dgst, pdgst) <- ptr_to_fresh "out" (llvm_array digest_size (llvm_int 8));
@@ -281,22 +299,24 @@ let hmac_invariants
 ////////////////////////////////////////////////////////////////
 
 let hmac_init_spec
-      key_size
       (cfg : { name            : String
              , hmac_alg        : Term
              , digest_size     : Int
              , block_size      : Int
              , hash_block_size : Int
              }) = do {
-    (key0, pkey) <- ptr_to_fresh_readonly "key" (llvm_array key_size (llvm_int 8));
-
     alg0 <- crucible_fresh_var "alg" (llvm_int 32);
     hash_block_size0 <- crucible_fresh_var "hash_block_size" (llvm_int 16);
     block_size0 <- crucible_fresh_var "block_size" (llvm_int 16);
     digest_size0 <- crucible_fresh_var "digest_size" (llvm_int 8);
     (pstate, st0) <- setup_hmac_state alg0 hash_block_size0 block_size0 digest_size0;
 
-    crucible_execute_func [pstate, crucible_term (cfg.hmac_alg), pkey, crucible_term {{ `key_size : [32] }}];
+    klen <- crucible_fresh_var "klen" (llvm_int 32);
+    pkey <- crucible_symbolic_alloc true 1 {{ (0 # klen) : [64] }};
+    key <- crucible_fresh_cryptol_var "key" {| ByteArray |};
+    crucible_points_to_array_prefix pkey key {{ (0 # klen) : [64] }};
+
+    crucible_execute_func [pstate, crucible_term (cfg.hmac_alg), pkey, (crucible_term klen)];
 
     let block_size      = cfg.block_size;
     let hash_block_size = cfg.hash_block_size;
@@ -304,12 +324,11 @@ let hmac_init_spec
     let alg0            = cfg.hmac_alg;
 
     let st1 = {{
-      hmac_init_c_state
-        `{key_size=key_size
-         ,block_size=block_size
+      hmac_init_c_state_unbounded
+        `{block_size=block_size
          ,hash_block_size=hash_block_size
          ,digest_size=digest_size}
-        st0 alg0 key0
+        st0 alg0 key klen
     }};
     check_hmac_state pstate st1;
     hmac_invariants st1 cfg;
@@ -317,15 +336,12 @@ let hmac_init_spec
 };
 
 let hmac_update_spec
-      msg_size
       (cfg : { name            : String
              , hmac_alg        : Term
              , digest_size     : Int
              , block_size      : Int
              , hash_block_size : Int
              }) = do {
-    (msg, pmsg) <- ptr_to_fresh_readonly "msg" (llvm_array msg_size (llvm_int 8));
-
     let digest_size = cfg.digest_size;
     let block_size = cfg.block_size;
     let hash_block_size = cfg.hash_block_size;
@@ -337,10 +353,14 @@ let hmac_update_spec
 
     hmac_invariants st0 cfg;
 
-    let size = {{ `msg_size : [32] }};
-    crucible_execute_func [pstate, pmsg, crucible_term size];
+    size <- crucible_fresh_var "size" (llvm_int 32);
+    pmsg <- crucible_symbolic_alloc true 1 {{ (0 # size) : [64] }};
+    msg <- crucible_fresh_cryptol_var "msg" {| ByteArray |};
+    crucible_points_to_array_prefix pmsg msg {{ (0 # size) : [64] }};
 
-    let st1 = {{ hmac_update_c_state st0 msg }};
+    crucible_execute_func [pstate, pmsg, (crucible_term size)];
+
+    let st1 = {{ hmac_update_c_state_unbounded st0 msg size }};
     check_hmac_state pstate st1;
     hmac_invariants st1 cfg;
 

--- a/tests/saw/HMAC/spec/HMAC.saw
+++ b/tests/saw/HMAC/spec/HMAC.saw
@@ -70,7 +70,7 @@ let setup_hash_state pstate = do {
     is_ready_for_input0 <- crucible_fresh_var "is_ready_for_input" (llvm_int 8);
     currently_in_hash0 <- crucible_fresh_var "currently_in_hash" (llvm_int 64);
     md_len0 <- crucible_fresh_var "md_len" (llvm_int 32);
-    (_, pimpl) <- ptr_to_fresh "impl" (llvm_struct "struct.s2n_hash");
+    (_, pimpl) <- ptr_to_fresh_readonly "impl" (llvm_struct "struct.s2n_hash");
     crucible_points_to pstate
       (crucible_struct
         [ pimpl
@@ -106,7 +106,7 @@ let update_hash_state pstate st = do {
     alg <- crucible_fresh_var "alg" (llvm_int 32);
     is_ready_for_input <- crucible_fresh_var "is_ready_for_input" (llvm_int 8);
     currently_in_hash <- crucible_fresh_var "currently_in_hash" (llvm_int 64);
-    (_, pimpl) <- ptr_to_fresh "impl" (llvm_struct "struct.s2n_hash");
+    (_, pimpl) <- ptr_to_fresh_readonly "impl" (llvm_struct "struct.s2n_hash");
 
     crucible_points_to pstate
       (crucible_struct

--- a/tests/saw/HMAC/spec/HMAC_iterative.cry
+++ b/tests/saw/HMAC/spec/HMAC_iterative.cry
@@ -21,6 +21,7 @@
 
 module HMAC_iterative where
 
+import Array
 import SHA256
 import Hashing
 
@@ -93,6 +94,8 @@ type HMAC_c_state =
 // corresponding hash functions on the raw C hash states, instead of
 // converting them to Cryptol SHA256 hash states.
 
+type ByteArray = Array[64][8]
+
 type hash_init_ty =
   SHA512_c_state -> SHA512_c_state
 type hash_update_ty msg_size =
@@ -114,6 +117,9 @@ hash_update_c_state :
   {msg_size} (fin msg_size) => hash_update_ty msg_size
 hash_update_c_state = sha256_update_sha512_c_state
 //hash_update_c_state = undefined
+hash_update_c_state_unbounded :
+  SHA512_c_state -> ByteArray -> [32] -> SHA512_c_state
+hash_update_c_state_unbounded = undefined
 
 
 hash_digest_c_state :
@@ -171,6 +177,32 @@ key_init_c_state outer0 digest_pad0 key =
   // Short key.
   key' = take `{block_size} (key # (zero : [block_size][8]))
 
+key_init_c_state_unbounded : { block_size, digest_size }
+        ( 16 >= width block_size, SHA512_DIGEST_LENGTH >= digest_size )
+     => SHA512_c_state
+     -> [SHA512_DIGEST_LENGTH][8]
+     -> ByteArray
+     -> [32]
+     -> (SHA512_c_state, [SHA512_DIGEST_LENGTH][8], [block_size][8])
+key_init_c_state_unbounded outer0 digest_pad0 key klen =
+  if klen > (`block_size : [32])
+  then (outer2, digest_pad1, hash')
+  else (outer1, digest_pad0, key')
+  where
+  outer1 = hash_init_c_state outer0
+
+  // Long key.
+  outer2 = hash_update_c_state_unbounded outer1 key klen
+  hash : [digest_size][8]
+  hash = hash_digest_c_state outer2
+  digest_pad1 = hash # drop `{digest_size} digest_pad0
+  hash' = take `{block_size} (hash # (zero : [block_size][8]))
+
+  // Short key.
+  key' = map
+    (\i -> if (i <$ (0 # klen)) then (arrayLookup key i) else 0)
+    (take`{block_size} [0 .. block_size])
+
 hmac_init_c_state :
      { key_size, block_size, hash_block_size, digest_size }
      ( fin key_size
@@ -214,6 +246,49 @@ hmac_init_c_state st0 alg key =
       (hash_init_c_state st0.outer_just_key) okey
     xor_pad = zero //okey # drop st0.xor_pad
 
+hmac_init_c_state_unbounded :
+     { block_size, hash_block_size, digest_size }
+     ( 16 >= width hash_block_size
+     , 16 >= width block_size
+     , 8 >= width digest_size
+     , 128 >= block_size
+     , 64 >= digest_size )
+  => HMAC_c_state
+  -> [32]
+  -> ByteArray
+  -> [32]
+  -> HMAC_c_state
+hmac_init_c_state_unbounded st0 alg key klen =
+  { alg                     = alg
+  , hash_block_size         = `hash_block_size
+  , currently_in_hash_block = currently_in_hash_block
+  , block_size              = `block_size
+  , digest_size             = `digest_size
+
+  , inner                   = inner
+  , inner_just_key          = inner_just_key
+  , outer                   = outer
+  , outer_just_key          = outer_just_key
+  , xor_pad                 = xor_pad
+  , digest_pad              = digest_pad
+  }
+  where
+    currently_in_hash_block = 0
+
+    k0 : [block_size][8]
+    (outer, digest_pad, k0) =
+      key_init_c_state_unbounded `{digest_size=digest_size}
+        st0.outer st0.digest_pad key klen
+    ikey = [ k ^ 0x36 | k <- k0 ]
+    okey = [ k ^ 0x6a | k <- ikey ]
+
+    inner_just_key = hash_update_c_state
+      (hash_init_c_state st0.inner_just_key) ikey
+    inner          = inner_just_key
+    outer_just_key = hash_update_c_state
+      (hash_init_c_state st0.outer_just_key) okey
+    xor_pad = zero //okey # drop st0.xor_pad
+
 
 hmac_update_c_state : {msg_size} (32 >= width msg_size) =>
   HMAC_c_state -> [msg_size][8] -> HMAC_c_state
@@ -234,6 +309,27 @@ hmac_update_c_state s m =
   , xor_pad         = s.xor_pad
   , digest_pad      = s.digest_pad
   }
+
+hmac_update_c_state_unbounded :
+  HMAC_c_state -> ByteArray -> [32] -> HMAC_c_state
+hmac_update_c_state_unbounded s m sz =
+  { inner = hash_update_c_state_unbounded s.inner m sz
+  , currently_in_hash_block =
+      (s.currently_in_hash_block + (sz % (zero # s.hash_block_size))) %
+      (zero # s.block_size)
+
+  // Rest unchanged.
+  , alg             = s.alg
+  , hash_block_size = s.hash_block_size
+  , block_size      = s.block_size
+  , digest_size     = s.digest_size
+  , inner_just_key  = s.inner_just_key
+  , outer           = s.outer
+  , outer_just_key  = s.outer_just_key
+  , xor_pad         = s.xor_pad
+  , digest_pad      = s.digest_pad
+  }
+
 
 // TODO: What about `size` argument to `s2n_hmac_digest`? The `size`
 // argument is supposed to be the "digest length" of the underlying

--- a/tests/saw/bike_r1/proof/base.saw
+++ b/tests/saw/bike_r1/proof/base.saw
@@ -26,7 +26,7 @@ let verify func overrides spec = verify_unint func overrides [] spec;
 enable_experimental;
 let verify_asm func spec =
     if do_prove then
-        crucible_llvm_verify_x86 m "../../s2n/lib/libs2n.so" func [] false spec
+        crucible_llvm_verify_x86 m "../../s2n/lib/libs2n.so" func [] false spec w4
     else
         crucible_llvm_unsafe_assume_spec m func spec;
 

--- a/tests/saw/bike_r2/proof/base.saw
+++ b/tests/saw/bike_r2/proof/base.saw
@@ -26,7 +26,7 @@ let verify func overrides spec = verify_unint func overrides [] spec;
 enable_experimental;
 let verify_asm func spec =
     if do_prove then
-        crucible_llvm_verify_x86 m "../../s2n/lib/libs2n.so" func [] false spec
+        crucible_llvm_verify_x86 m "../../s2n/lib/libs2n.so" func [] false spec w4
     else
         crucible_llvm_unsafe_assume_spec m func spec;
 

--- a/tests/saw/sike_r2/proof/sike_r2_x64_defs.saw
+++ b/tests/saw/sike_r2/proof/sike_r2_x64_defs.saw
@@ -15,7 +15,7 @@ let asm_globals =
 
 let verify_asm func spec =
     if do_prove then
-        crucible_llvm_verify_x86 m "../../s2n/lib/libs2n.so" func asm_globals false spec
+        crucible_llvm_verify_x86 m "../../s2n/lib/libs2n.so" func asm_globals false spec w4
     else
         crucible_llvm_unsafe_assume_spec m func spec;
 

--- a/tests/saw/spec/DRBG/DRBG_properties.cry
+++ b/tests/saw/spec/DRBG/DRBG_properties.cry
@@ -106,17 +106,17 @@ drbg = drbg_instantiate (nist_aes128_reference_entropy_hex @ 0) (nist_aes128_ref
 
 test_drbg : [8] -> Bit
 test_drbg n =
-  bits_out == nist_aes128_reference_returned_bits_hex @ n &&
-  drbg1.v == nist_aes128_reference_values_hex @ (3 * n) &&
-  drbg2.v == nist_aes128_reference_values_hex @ (3 * n + 1) &&
+  bits_out == nist_aes128_reference_returned_bits_hex @ n /\
+  drbg1.v == nist_aes128_reference_values_hex @ (3 * n) /\
+  drbg2.v == nist_aes128_reference_values_hex @ (3 * n + 1) /\
   drbg3.v == nist_aes128_reference_values_hex @ (3 * n + 2)
   where
     drbg1 = drbg_instantiate (nist_aes128_reference_entropy_hex @ (3*n))
                              (nist_aes128_reference_personalization_strings_hex @ n)
     ((bits1, drbg2) : ([512], s2n_drbg)) =
-      drbg_generate drbg1 (nist_aes128_reference_entropy_hex @ (3 * n + 1)) True
+      drbg_generate`{blocks=4} drbg1 (nist_aes128_reference_entropy_hex @ (3 * n + 1)) True
     ((bits_out, drbg3) : ([512], s2n_drbg)) =
-      drbg_generate drbg2 (nist_aes128_reference_entropy_hex @ (3 * n + 2)) True
+      drbg_generate`{blocks=4} drbg2 (nist_aes128_reference_entropy_hex @ (3 * n + 2)) True
 
 property drbg_tests_pass =
   ~zero == [ test_drbg n | n <- [0 .. 14] ]

--- a/tests/saw/spec/handshake/rfc_handshake_tls13.cry
+++ b/tests/saw/spec/handshake/rfc_handshake_tls13.cry
@@ -121,12 +121,12 @@ doHandshake params = (foldl doState initialHandshake (take`{n} (stateMachine par
                              then updateHandshake hs action.message
                              else hs
         updateHandshake hs value = {
-            messages = update`{ix=(width n)} hs.messages hs.index value,
+            messages = update hs.messages hs.index value,
             index = hs.index + 1
         }
         initialHandshake = {
             messages = repeat { messageType = applicationData, sender = both },
-            index = zero
+            index = 0:[width n]
         }
 
 /*

--- a/tests/saw/verify_HMAC.saw
+++ b/tests/saw/verify_HMAC.saw
@@ -19,6 +19,8 @@
 //
 ////////////////////////////////////////////////////////////////
 
+enable_experimental;
+
 include "HMAC/spec/HMAC.saw";
 
 m <- llvm_load_module "bitcode/all_llvm.bc";
@@ -43,6 +45,7 @@ let verify_s2n_hmac_init
   (t, hash_reset_ov) <- with_time (crucible_llvm_unsafe_assume_spec m "s2n_hash_reset" hash_reset_spec);
   (t, hash_get_currently_in_hash_total_ov) <- with_time (crucible_llvm_unsafe_assume_spec m "s2n_hash_get_currently_in_hash_total" (hash_get_currently_in_hash_total_spec));
   (t, hash_update_block_size_ov)  <- with_time (crucible_llvm_unsafe_assume_spec m "s2n_hash_update" (hash_update_spec cfg.block_size));
+  (t, hash_update_key_size_ov) <- with_time (crucible_llvm_unsafe_assume_spec m "s2n_hash_update" hash_update_unbounded_spec);
   (t, hash_digest_ov) <- with_time (crucible_llvm_unsafe_assume_spec m "s2n_hash_digest" (hash_digest_spec (cfg.digest_size)));
   print "Done";
   
@@ -53,23 +56,12 @@ let verify_s2n_hmac_init
     , hash_reset_ov
     , hash_get_currently_in_hash_total_ov
     , hash_update_block_size_ov
+    , hash_update_key_size_ov
     , hash_digest_ov
     ];
   let block_size = cfg.block_size;
   
-  // We do verification at the block size, less than the blocksize and greater
-  // than the blocksize, because these cover distinct code paths
-  for [ eval_size {| block_size - 1 |},
-        block_size
-      , eval_size {| block_size + 1 |}] 
-        (\key_size -> do{
-          print "";
-          print (str_concat "Proving s2n_hmac_init: key_size=" (show key_size));
-          // We do this override here because it is key-size specific, the
-          // ones above are agnostic
-          (t, hash_update_key_size_ov) <- with_time (crucible_llvm_unsafe_assume_spec m "s2n_hash_update" (hash_update_spec key_size));
-          with_time (crucible_llvm_verify m "s2n_hmac_init" (concat ovs [hash_update_key_size_ov]) false (hmac_init_spec key_size cfg) yices_hash_unint);
-        });
+  with_time (crucible_llvm_verify m "s2n_hmac_init" ovs false (hmac_init_spec cfg) z3_hash_unint);
         
   print "Finished proving s2n_hmac_init";
 };
@@ -81,20 +73,14 @@ let verify_s2n_hmac_update
              , digest_size     : Int
              , block_size      : Int
              , hash_block_size : Int
-             })
-  message_sizes = do {
+             }) = do {
   set_base 16;
   
   print "";
   print (str_concat "Verifying HMAC update: alg = " cfg.name);
   
-  for message_sizes 
-        (\message_size -> do{
-          print "";
-          print (str_concat "Proving s2n_hmac_update: message_size=" (show message_size));
-          (t, hash_update_msg_size_ov) <- with_time (crucible_llvm_unsafe_assume_spec m "s2n_hash_update" (hash_update_spec message_size));
-          with_time (crucible_llvm_verify m "s2n_hmac_update" [hash_update_msg_size_ov] false (hmac_update_spec message_size cfg) yices_hash_unint);
-        });
+  (t, hash_update_msg_size_ov) <- with_time (crucible_llvm_unsafe_assume_spec m "s2n_hash_update" hash_update_unbounded_spec);
+  with_time (crucible_llvm_verify m "s2n_hmac_update" [hash_update_msg_size_ov] false (hmac_update_spec cfg) z3_hash_unint);
         
   print "Finished proving s2n_hmac_update";
 };
@@ -125,7 +111,7 @@ let verify_s2n_hmac_digest
     ];
   
   (t, hmac_digest_ov) <-
-    with_time (crucible_llvm_verify m "s2n_hmac_digest" ovs false (hmac_digest_spec cfg) yices_hash_unint);
+    with_time (crucible_llvm_verify m "s2n_hmac_digest" ovs false (hmac_digest_spec cfg) z3_hash_unint);
         
   print "Finished proving s2n_hmac_digest";
 };
@@ -190,24 +176,22 @@ let sha512_cfg =
   , hash_block_size = 128
   };
 
-let verify_s2n_hmac_at_several_key_and_msg_sizes
+let verify_s2n_hmac_at_config
       (cfg : { name            : String
              , hmac_alg        : Term
              , digest_size     : Int
              , block_size      : Int
              , hash_block_size : Int
-             }) msg_sizes = do {
-  let block_size = cfg.block_size;
+             }) = do {
   verify_s2n_hmac_init cfg;
-  verify_s2n_hmac_update cfg msg_sizes;
+  verify_s2n_hmac_update cfg;
   verify_s2n_hmac_digest cfg;
 };
 
 let verify_s2n_hmac = do {
   let configs = [md5_cfg, sha1_cfg, sha224_cfg, sha256_cfg, sha384_cfg, sha512_cfg];
-  let sizes = [1,10,100,200,300,400];
   
-  for configs (\config -> verify_s2n_hmac_at_several_key_and_msg_sizes config sizes);
+  for configs (\config -> verify_s2n_hmac_at_config config);
 };
 
 verify_s2n_hmac;


### PR DESCRIPTION
### Description of changes: 

* Verify HMAC with unbounded key/data. This uses the new Cryptol type `Array`, which represents the SMT type `Array`, and the new SAW commands `crucible_symbolic_alloc` (which declares a memory region with symbolic size), `crucible_fresh_cryptol_var` (which creates a fresh symbolic variable with a Cryptol type), and `crucible_points_to_array_prefix` (which declares that a memory region contains an array prefix). The specs for `hmac_init` and `hmac_update` use the new type and the new commands.
* Bump SAW to 0.6.0.99-2020-10-12
* Update the existing proofs to work with the latest SAW version

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Existing codebuild jobs.

 Is this a refactor change? No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
