### PR TITLE
Clean up deprecated "--tls13" argument

### DIFF
--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -35,7 +35,6 @@
 #include <error/s2n_errno.h>
 
 #include "tls/s2n_connection.h"
-#include "tls/s2n_tls13.h"
 #include "utils/s2n_safety.h"
 
 #define S2N_MAX_ECC_CURVE_NAME_LENGTH 10
@@ -85,8 +84,6 @@ void usage()
     fprintf(stderr, "    Set dynamic record timeout threshold\n");
     fprintf(stderr, "  -C,--corked-io\n");
     fprintf(stderr, "    Turn on corked io\n");
-    fprintf(stderr, "  --tls13\n");
-    fprintf(stderr, "    Turn on experimental TLS1.3 support.\n");
     fprintf(stderr, "  --non-blocking\n");
     fprintf(stderr, "    Set the non-blocking flag on the connection's socket.\n");
     fprintf(stderr, "  -K ,--keyshares\n");
@@ -250,7 +247,6 @@ int main(int argc, char *const *argv)
     const char *port = "443";
     int echo_input = 0;
     int use_corked_io = 0;
-    int use_tls13 = 0;
     uint8_t non_blocking = 0;
     int keyshares_count = 0;
     char keyshares[S2N_ECC_EVP_SUPPORTED_CURVES_COUNT][S2N_MAX_ECC_CURVE_NAME_LENGTH];
@@ -356,7 +352,7 @@ int main(int argc, char *const *argv)
             }
             break;
         case '3':
-            use_tls13 = 1;
+            /* Do nothing -- this argument is deprecated. */
             break;
         case 'B':
             non_blocking = 1;
@@ -393,10 +389,6 @@ int main(int argc, char *const *argv)
     if (signal(SIGPIPE, SIG_IGN) == SIG_ERR) {
         fprintf(stderr, "Error disabling SIGPIPE\n");
         exit(1);
-    }
-
-    if (use_tls13) {
-        GUARD_EXIT(s2n_enable_tls13(), "Error enabling TLS1.3");
     }
 
     GUARD_EXIT(s2n_init(), "Error running s2n_init()");

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -41,7 +41,6 @@
 #include <s2n.h>
 #include "common.h"
 
-#include "tls/s2n_tls13.h"
 #include "utils/s2n_safety.h"
 
 #define MAX_CERTIFICATES 50
@@ -281,8 +280,6 @@ void usage()
     fprintf(stderr, "    Disable session ticket for resumption.\n");
     fprintf(stderr, "  -C,--corked-io\n");
     fprintf(stderr, "    Turn on corked io\n");
-    fprintf(stderr, "  --tls13\n");
-    fprintf(stderr, "    Turn on experimental TLS1.3 support.\n");
     fprintf(stderr, "  --non-blocking\n");
     fprintf(stderr, "    Set the non-blocking flag on the connection's socket.\n");
     fprintf(stderr, "  -w --https-server\n");
@@ -407,7 +404,6 @@ int main(int argc, char *const *argv)
     struct conn_settings conn_settings = { 0 };
     int fips_mode = 0;
     int parallelize = 0;
-    int use_tls13 = 0;
     int non_blocking = 0;
     long int bytes = 0;
     conn_settings.session_ticket = 1;
@@ -519,7 +515,7 @@ int main(int argc, char *const *argv)
             conn_settings.session_ticket = 0;
             break;
         case '3':
-            use_tls13 = 1;
+            /* Do nothing -- this argument is deprecated */
             break;
         case 'X':
             if (optarg == NULL) {
@@ -628,10 +624,6 @@ int main(int argc, char *const *argv)
         fprintf(stderr, "Error entering FIPS mode. s2nd is not linked with a FIPS-capable libcrypto.\n");
         exit(1);
 #endif
-    }
-
-    if (use_tls13) {
-        GUARD_EXIT(s2n_enable_tls13(), "Error enabling TLS1.3");
     }
 
     GUARD_EXIT(s2n_init(), "Error running s2n_init()");

--- a/tests/integration/common/s2n_test_common.py
+++ b/tests/integration/common/s2n_test_common.py
@@ -147,7 +147,6 @@ def get_s2n_cmd(scenario):
         s2n_cmd.append("--echo")
 
     if scenario.version is Version.TLS13:
-        s2n_cmd.append("--tls13")
         s2n_cmd.extend(["-c", "test_all"])
     else:
         s2n_cmd.extend(["-c", "test_all_tls12"])

--- a/tests/integration/s2n_client_endpoint_handshake_test.py
+++ b/tests/integration/s2n_client_endpoint_handshake_test.py
@@ -99,7 +99,7 @@ def well_known_endpoints_test(use_corked_io, tls13_enabled):
     opt_list = []
 
     if tls13_enabled:
-        arguments += ["--tls13", "--ciphers", "default_tls13"]
+        arguments += ["--ciphers", "default_tls13"]
         opt_list += ["TLS 1.3"]
     if use_corked_io:
         arguments += ["-C"]

--- a/tests/integration/s2n_handshake_test_s_client.py
+++ b/tests/integration/s2n_handshake_test_s_client.py
@@ -220,7 +220,7 @@ def try_handshake(endpoint, port, cipher, ssl_version, server_name=None, strict_
         server_cert_key_list=None, expected_server_cert=None, server_cipher_pref=None, ocsp=None, sig_algs=None, curves=None, resume=False, no_ticket=False,
         prefer_low_latency=False, enter_fips_mode=False, client_auth=None, client_cert=DEFAULT_CLIENT_CERT_PATH,
         client_key=DEFAULT_CLIENT_KEY_PATH, expected_cipher=None, expected_extensions=None,
-        simulate_tests=False, debug_cmds=False, tls13_flag=False, results=dict
+        simulate_tests=False, debug_cmds=False, results=dict
         ):
     """
     Attempt to handshake against s2nd listening on `endpoint` and `port` using Openssl s_client
@@ -249,7 +249,6 @@ def try_handshake(endpoint, port, cipher, ssl_version, server_name=None, strict_
     :param list expected_extensions: list of expected extensions that s_client should receive.
     :param bool simulate_tests: simulate tests passing but do not actually run them
     :param bool debug_cmds: print commands that are invoked for the handshake tests
-    :param bool tls13_flag: determine whether to add tls13_flag to s2nd
     :param dict results: object that can be used to update tests results like run count back to caller
     :return: 0 on successfully negotiation(s), -1 on failure
     """
@@ -291,9 +290,6 @@ def try_handshake(endpoint, port, cipher, ssl_version, server_name=None, strict_
     if enter_fips_mode == True:
         s2nd_ciphers = "test_all_fips"
         s2nd_cmd.append("--enter-fips-mode")
-
-    if tls13_flag:
-        s2nd_cmd.append("--tls13")
 
     s2nd_cmd.append("-c")
     s2nd_cmd.append(s2nd_ciphers)
@@ -873,30 +869,26 @@ def main():
     results = {'tests_ran': 0}
 
     try:
-        for tls13_flag in [False, True]:
-            # options are additional arguments that eventually gets passed to try_handshake()
-            options = dict(
-                results=results,
-                tls13_flag=tls13_flag,
-                debug_cmds=args.debug,
-                simulate_tests=args.dryrun,
-            )
-            if tls13_flag:
-                print("\n\n------------- Testing with TLS1.3 Flag -------------\n\n")
+        # options are additional arguments that eventually gets passed to try_handshake()
+        options = dict(
+            results=results,
+            debug_cmds=args.debug,
+            simulate_tests=args.dryrun,
+        )
 
-            resume_test(host, port, test_ciphers, fips_mode, no_ticket=True, **options)
-            resume_test(host, port, test_ciphers, fips_mode, **options)
-            handshake_test(host, port, test_ciphers, fips_mode, **options)
-            client_auth_test(host, port, test_ciphers, fips_mode, **options)
-            sigalg_test(host, port, fips_mode, no_ticket=False, **options)
-            sigalg_test(host, port, fips_mode, use_client_auth=True, no_ticket=True, **options)
-            elliptic_curve_test(host, port, libcrypto_version, fips_mode, **options)
-            elliptic_curve_fallback_test(host, port, fips_mode, **options)
-            handshake_fragmentation_test(host, port, fips_mode, **options)
-            ocsp_stapling_test(host, port, fips_mode, **options)
-            cert_type_cipher_match_test(host, port, libcrypto_version, **options)
-            multiple_cert_type_test(host, port, libcrypto_version, **options)
-            multiple_cert_domain_name_test(host, port, **options)
+        resume_test(host, port, test_ciphers, fips_mode, no_ticket=True, **options)
+        resume_test(host, port, test_ciphers, fips_mode, **options)
+        handshake_test(host, port, test_ciphers, fips_mode, **options)
+        client_auth_test(host, port, test_ciphers, fips_mode, **options)
+        sigalg_test(host, port, fips_mode, no_ticket=False, **options)
+        sigalg_test(host, port, fips_mode, use_client_auth=True, no_ticket=True, **options)
+        elliptic_curve_test(host, port, libcrypto_version, fips_mode, **options)
+        elliptic_curve_fallback_test(host, port, fips_mode, **options)
+        handshake_fragmentation_test(host, port, fips_mode, **options)
+        ocsp_stapling_test(host, port, fips_mode, **options)
+        cert_type_cipher_match_test(host, port, libcrypto_version, **options)
+        multiple_cert_type_test(host, port, libcrypto_version, **options)
+        multiple_cert_domain_name_test(host, port, **options)
     except IntegrationTestFailure as ex:
         return 1
 

--- a/tests/integration/s2n_tls13_handshake_tests.py
+++ b/tests/integration/s2n_tls13_handshake_tests.py
@@ -15,7 +15,6 @@
 
 """
 Handshake tests against openssl using TLS13.
-At the moment these tests are expected fail, as TLS13 is incomplete.
 """
 
 import argparse

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -156,9 +156,6 @@ class S2N(Provider):
         if self.options.reconnect is True:
             cmd_line.append('-r')
 
-        if self.options.protocol == Protocols.TLS13:
-            cmd_line.append('--tls13')
-
         cipher_prefs = 'test_all_tls12'
         if self.options.cipher is Ciphers.KMS_PQ_TLS_1_0_2019_06:
             cipher_prefs = 'KMS-PQ-TLS-1-0-2019-06'
@@ -199,7 +196,6 @@ class S2N(Provider):
             cmd_line.append('--insecure')
 
         if self.options.protocol == Protocols.TLS13:
-            cmd_line.append('--tls13')
             cmd_line.extend(['-c', 'test_all'])
         else:
             cmd_line.extend(['-c', 'test_all_tls12'])


### PR DESCRIPTION
### Description of changes: 

We already deprecated s2n_enable_tls13() in favor of using security policies to configure TLS1.3, so the "--tls13" argument for s2nc and s2nd is no longer needed.

### Testing:

Existing integration tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
