### PR TITLE
Calculate TLS1.3 server application secret earlier

### DIFF
--- a/crypto/s2n_tls13_keys.h
+++ b/crypto/s2n_tls13_keys.h
@@ -79,7 +79,8 @@ int s2n_tls13_derive_handshake_secrets(struct s2n_tls13_keys *handshake,
                                         struct s2n_hash_state *client_server_hello_hash,
                                         struct s2n_blob *client_secret,
                                         struct s2n_blob *server_secret);
-int s2n_tls13_derive_application_secrets(struct s2n_tls13_keys *handshake, struct s2n_hash_state *hashes, struct s2n_blob *client_secret, struct s2n_blob *server_secret);
+int s2n_tls13_extract_master_secret(struct s2n_tls13_keys *handshake);
+int s2n_tls13_derive_application_secret(struct s2n_tls13_keys *handshake, struct s2n_hash_state *hashes, struct s2n_blob *secret_blob, s2n_mode mode);
 
 int s2n_tls13_derive_traffic_keys(struct s2n_tls13_keys *handshake, struct s2n_blob *secret, struct s2n_blob *key, struct s2n_blob *iv);
 int s2n_tls13_derive_finished_key(struct s2n_tls13_keys *keys, struct s2n_blob *secret_key, struct s2n_blob *output_finish_key);

--- a/tests/unit/s2n_tls13_keys_test.c
+++ b/tests/unit/s2n_tls13_keys_test.c
@@ -229,10 +229,13 @@ int main(int argc, char **argv)
     /* Test Client Finished MAC hash */
     S2N_BLOB_EXPECT_EQUAL(expect_client_finished_verify, client_finished_verify);
 
-    EXPECT_SUCCESS(s2n_tls13_derive_application_secrets(&secrets, &hash_state, &client_application_secret, &server_application_secret));
+    EXPECT_SUCCESS(s2n_tls13_extract_master_secret(&secrets));
     S2N_BLOB_EXPECT_EQUAL(expect_extract_master_secret, secrets.extract_secret);
 
+    EXPECT_SUCCESS(s2n_tls13_derive_application_secret(&secrets, &hash_state, &client_application_secret, S2N_CLIENT));
     S2N_BLOB_EXPECT_EQUAL(expect_derived_client_application_traffic_secret, client_application_secret);
+
+    EXPECT_SUCCESS(s2n_tls13_derive_application_secret(&secrets, &hash_state, &server_application_secret, S2N_SERVER));
     S2N_BLOB_EXPECT_EQUAL(expect_derived_server_application_traffic_secret, server_application_secret);
 
     /* Test Traffic Keys */

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -236,43 +236,56 @@ int s2n_tls13_handle_handshake_secrets(struct s2n_connection *conn)
     return 0;
 }
 
-/*
- * This must be called after ServerFinished
- */
-int s2n_tls13_handle_application_secrets(struct s2n_connection *conn)
+static int s2n_tls13_handle_application_secret(struct s2n_connection *conn, s2n_mode mode)
 {
     /* get tls13 key context */
     s2n_tls13_connection_keys(keys, conn);
 
-    /* produce application secrets */
-    struct s2n_blob client_app_secret = { .data = conn->secure.client_app_secret, .size = keys.size };
-    struct s2n_blob server_app_secret = { .data = conn->secure.server_app_secret, .size = keys.size };
+    uint8_t *app_secret_data, *implicit_iv_data;
+    struct s2n_session_key *session_key;
+    if (mode == S2N_CLIENT) {
+        app_secret_data = conn->secure.client_app_secret;
+        implicit_iv_data = conn->secure.client_implicit_iv;
+        session_key = &conn->secure.client_key;
+    } else {
+        app_secret_data = conn->secure.server_app_secret;
+        implicit_iv_data = conn->secure.server_implicit_iv;
+        session_key = &conn->secure.server_key;
+    }
 
     /* use frozen hashes during the server finished state */
     struct s2n_hash_state *hash_state;
     GUARD_NONNULL(hash_state = &conn->handshake.server_finished_copy);
-    GUARD(s2n_tls13_derive_application_secrets(&keys, hash_state, &client_app_secret, &server_app_secret));
 
-    s2n_tls13_key_blob(s_app_key, conn->secure.cipher_suite->record_alg->cipher->key_material_size);
-    struct s2n_blob s_app_iv = { .data = conn->secure.server_implicit_iv, .size = S2N_TLS13_FIXED_IV_LEN };
-    GUARD(s2n_tls13_derive_traffic_keys(&keys, &server_app_secret, &s_app_key, &s_app_iv));
+    /* calculate secret */
+    struct s2n_blob app_secret = { .data = app_secret_data, .size = keys.size };
+    GUARD(s2n_tls13_derive_application_secret(&keys, hash_state, &app_secret, mode));
 
-    s2n_tls13_key_blob(c_app_key, conn->secure.cipher_suite->record_alg->cipher->key_material_size);
-    struct s2n_blob c_app_iv = { .data = conn->secure.client_implicit_iv, .size = S2N_TLS13_FIXED_IV_LEN };
-    GUARD(s2n_tls13_derive_traffic_keys(&keys, &client_app_secret, &c_app_key, &c_app_iv));
+    /* derive key from secret */
+    s2n_tls13_key_blob(app_key, conn->secure.cipher_suite->record_alg->cipher->key_material_size);
+    struct s2n_blob app_iv = { .data = implicit_iv_data, .size = S2N_TLS13_FIXED_IV_LEN };
+    GUARD(s2n_tls13_derive_traffic_keys(&keys, &app_secret, &app_key, &app_iv));
 
     /* update record algorithm secrets */
-    GUARD(conn->secure.cipher_suite->record_alg->cipher->set_decryption_key(&conn->secure.server_key, &s_app_key));
-    GUARD(conn->secure.cipher_suite->record_alg->cipher->set_encryption_key(&conn->secure.client_key, &c_app_key));
+    GUARD(conn->secure.cipher_suite->record_alg->cipher->set_decryption_key(session_key, &app_key));
 
     /* According to https://tools.ietf.org/html/rfc8446#section-5.3:
      * Each sequence number is set to zero at the beginning of a connection and
      * whenever the key is changed
      */
-    GUARD(s2n_zero_sequence_number(conn, S2N_CLIENT));
-    GUARD(s2n_zero_sequence_number(conn, S2N_SERVER));
+    GUARD(s2n_zero_sequence_number(conn, mode));
 
-    return 0;
+    return S2N_SUCCESS;
+}
+
+/* The application secrets are derived from the master secret, so the
+ * master secret must be handled BEFORE the application secrets.
+ */
+static int s2n_tls13_handle_master_secret(struct s2n_connection *conn)
+{
+    s2n_tls13_connection_keys(keys, conn);
+    GUARD(s2n_tls13_extract_master_secret(&keys));
+    return S2N_SUCCESS;
 }
 
 int s2n_tls13_handle_secrets(struct s2n_connection *conn)
@@ -289,8 +302,18 @@ int s2n_tls13_handle_secrets(struct s2n_connection *conn)
             conn->server = &conn->secure;
             conn->client = &conn->secure;
             break;
+        case SERVER_FINISHED:
+            if (conn->mode == S2N_SERVER) {
+                GUARD(s2n_tls13_handle_master_secret(conn));
+                GUARD(s2n_tls13_handle_application_secret(conn, S2N_SERVER));
+            }
+            break;
         case CLIENT_FINISHED:
-            GUARD(s2n_tls13_handle_application_secrets(conn));
+            if (conn->mode == S2N_CLIENT) {
+                GUARD(s2n_tls13_handle_master_secret(conn));
+                GUARD(s2n_tls13_handle_application_secret(conn, S2N_SERVER));
+            }
+            GUARD(s2n_tls13_handle_application_secret(conn, S2N_CLIENT));
             break;
         default:
             break;


### PR DESCRIPTION
### Resolved issues:

https://github.com/awslabs/s2n/issues/2277

### Description of changes: 

The RFC says that the server should calculate its application traffic sending key after the ServerFinished message is sent-- see [this server state machine diagram](https://tools.ietf.org/html/rfc8446#appendix-A.2) and look for "K_send =". However, instead S2N currently calculates that secret at the same time the client does, after the ClientFinished message is sent/received.

This has no practical impact on TLS over TCP, but does matter for TLS over QUIC. In standard TLS, the server doesn't send any messages with the application secret until after the ClientFinished message, so calculating the sending key late arguably doesn't matter. However, QUIC begins sending application data immediately after the ServerFinished message, so requires that the secret be available at that time.

### Callouts:
**Why split the master secret calculation out into a separate method?** The master secret only needs to be calculated once, before either of the application secrets. While we could just tie calculating the master secret to calculating the server application secret and then make sure we always calculate the server application secret before the client application secret, that seemed too "hidden". It would not be obvious that the server application secret needs to be calculated before the client application secret. I prefer explicitly and independently calculating the master secret first.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Updated existing unit tests

 Is this a refactor change? Specific unit tests still pass, and (since this is core to the handshake) integ tests still pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
