### PR TITLE
Move API to enable QUIC to config

### DIFF
--- a/tests/saw/spec/handshake/handshake_io_lowlevel.saw
+++ b/tests/saw/spec/handshake/handshake_io_lowlevel.saw
@@ -158,11 +158,11 @@ let setup_connection = do {
    crucible_points_to (ocsp_status_size cak) (crucible_term status_size);
    crucible_equal (crucible_term status_size) (crucible_term {{zero : [32]}});
 
-   config_bitfield_value <- crucible_fresh_var "config_bitfield" (llvm_int 8);
+   config_bitfield_value <- crucible_fresh_var "config_bitfield" (llvm_int 16);
    crucible_points_to (config_bitfield config) (crucible_term config_bitfield_value);
    // The following line could be made more precise, we only care that the use_tickets
    // bit is zero 
-   crucible_equal (crucible_term config_bitfield_value) (crucible_term {{zero : [8]}});
+   crucible_equal (crucible_term config_bitfield_value) (crucible_term {{zero : [16]}});
 
    session_ticket_status <- crucible_fresh_var "session_ticket_status" (llvm_int 32);
    crucible_points_to (conn_session_ticket_status pconn) (crucible_term session_ticket_status);

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -206,6 +206,7 @@ int main(int argc, char **argv)
                 EXPECT_EQUAL(session_id_length, 0);
 
                 EXPECT_SUCCESS(s2n_connection_free(conn));
+                EXPECT_SUCCESS(s2n_config_free(config));
             }
 
             EXPECT_SUCCESS(s2n_disable_tls13());

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -189,9 +189,13 @@ int main(int argc, char **argv)
              * For now, middlebox compatibility mode is only disabled by QUIC.
              */
             {
+                struct s2n_config *config;
+                EXPECT_NOT_NULL(config = s2n_config_new());
+                EXPECT_SUCCESS(s2n_config_enable_quic(config));
+
                 struct s2n_connection *conn;
                 EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
-                EXPECT_SUCCESS(s2n_connection_enable_quic(conn));
+                EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
                 struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
 
                 EXPECT_SUCCESS(s2n_client_hello_send(conn));
@@ -351,29 +355,28 @@ int main(int argc, char **argv)
 
     /* Test that negotiating TLS1.2 with QUIC-enabled server fails */
     {
+        EXPECT_SUCCESS(s2n_reset_tls13());
+
         struct s2n_config *config = s2n_config_new();
+        EXPECT_SUCCESS(s2n_config_enable_quic(config));
         EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "test_all"));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, ecdsa_chain_and_key));
 
         /* Succeeds when negotiating TLS1.3 */
         {
-            EXPECT_SUCCESS(s2n_enable_tls13());
-
             struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
             EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
-            EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS13);
 
             struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
-            EXPECT_EQUAL(client_conn->client_protocol_version, S2N_TLS13);
-
-            EXPECT_SUCCESS(s2n_connection_enable_quic(client_conn));
-            EXPECT_SUCCESS(s2n_connection_enable_quic(server_conn));
 
             EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
             EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io,
                     &server_conn->handshake.io, s2n_stuffer_data_available(&client_conn->handshake.io)));
             EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
+
+            EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS13);
+            EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS13);
 
             EXPECT_SUCCESS(s2n_connection_free(client_conn));
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
@@ -381,23 +384,19 @@ int main(int argc, char **argv)
 
         /* Fails when negotiating TLS1.2 */
         {
-            EXPECT_SUCCESS(s2n_disable_tls13());
             struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
-            EXPECT_EQUAL(client_conn->client_protocol_version, S2N_TLS12);
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "test_all_tls12"));
 
-            EXPECT_SUCCESS(s2n_enable_tls13());
             struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
             EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
-            EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS13);
-
-            client_conn->quic_enabled = true; /* Actual api requires tls1.3, so set flag directly */
-            EXPECT_SUCCESS(s2n_connection_enable_quic(server_conn));
 
             EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
             EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io,
                     &server_conn->handshake.io, s2n_stuffer_data_available(&client_conn->handshake.io)));
             EXPECT_FAILURE_WITH_ERRNO(s2n_client_hello_recv(server_conn), S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
+
+            EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS12);
 
             EXPECT_SUCCESS(s2n_connection_free(client_conn));
             EXPECT_SUCCESS(s2n_connection_free(server_conn));

--- a/tests/unit/s2n_quic_support_test.c
+++ b/tests/unit/s2n_quic_support_test.c
@@ -23,33 +23,30 @@ static const uint8_t TEST_DATA[] = "test";
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
-    EXPECT_SUCCESS(s2n_disable_tls13());
 
-    /* Test s2n_connection_enable_quic */
+    /* Test s2n_config_enable_quic */
     {
-        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
-        EXPECT_NOT_NULL(conn);
-        EXPECT_FALSE(conn->quic_enabled);
+        struct s2n_config *config = s2n_config_new();
+        EXPECT_NOT_NULL(config);
+        EXPECT_FALSE(config->quic_enabled);
 
         /* Check error handling */
         {
-            EXPECT_SUCCESS(s2n_enable_tls13());
-            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_enable_quic(NULL), S2N_ERR_NULL);
-            EXPECT_FALSE(conn->quic_enabled);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_config_enable_quic(NULL), S2N_ERR_NULL);
+            EXPECT_FALSE(config->quic_enabled);
         }
 
         /* Check success */
         {
-            EXPECT_SUCCESS(s2n_enable_tls13());
-            EXPECT_SUCCESS(s2n_connection_enable_quic(conn));
-            EXPECT_TRUE(conn->quic_enabled);
+            EXPECT_SUCCESS(s2n_config_enable_quic(config));
+            EXPECT_TRUE(config->quic_enabled);
 
             /* Enabling QUIC again still succeeds */
-            EXPECT_SUCCESS(s2n_connection_enable_quic(conn));
-            EXPECT_TRUE(conn->quic_enabled);
+            EXPECT_SUCCESS(s2n_config_enable_quic(config));
+            EXPECT_TRUE(config->quic_enabled);
         }
 
-        EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
     }
 
     /* Test s2n_connection_set_quic_transport_parameters */

--- a/tests/unit/s2n_self_talk_quic_support_test.c
+++ b/tests/unit/s2n_self_talk_quic_support_test.c
@@ -42,6 +42,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
     EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+    EXPECT_SUCCESS(s2n_config_enable_quic(config));
     EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
     EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
@@ -50,10 +51,6 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
     EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
     EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
-
-    /* Enable quic */
-    EXPECT_SUCCESS(s2n_connection_enable_quic(client_conn));
-    EXPECT_SUCCESS(s2n_connection_enable_quic(server_conn));
 
     /* Setup quic transport parameters */
     EXPECT_SUCCESS(s2n_connection_set_quic_transport_parameters(client_conn,

--- a/tls/extensions/s2n_quic_transport_params.c
+++ b/tls/extensions/s2n_quic_transport_params.c
@@ -31,13 +31,14 @@
 
 static bool s2n_quic_transport_params_should_send(struct s2n_connection *conn)
 {
-    return conn && conn->quic_enabled;
+    return conn && conn->config && conn->config->quic_enabled;
 }
 
 static int s2n_quic_transport_params_if_missing(struct s2n_connection *conn)
 {
     notnull_check(conn);
-    ENSURE_POSIX(!conn->quic_enabled, S2N_ERR_MISSING_EXTENSION);
+    notnull_check(conn->config);
+    ENSURE_POSIX(!conn->config->quic_enabled, S2N_ERR_MISSING_EXTENSION);
     return S2N_SUCCESS;
 }
 
@@ -56,7 +57,8 @@ static int s2n_quic_transport_params_recv(struct s2n_connection *conn, struct s2
 {
     notnull_check(conn);
     notnull_check(extension);
-    ENSURE_POSIX(conn->quic_enabled, S2N_ERR_UNSUPPORTED_EXTENSION);
+    notnull_check(conn->config);
+    ENSURE_POSIX(conn->config->quic_enabled, S2N_ERR_UNSUPPORTED_EXTENSION);
 
     if (s2n_stuffer_data_available(extension)) {
         GUARD(s2n_alloc(&conn->peer_quic_transport_parameters, s2n_stuffer_data_available(extension)));

--- a/tls/s2n_alerts.c
+++ b/tls/s2n_alerts.c
@@ -60,7 +60,7 @@ static bool s2n_alerts_supported(struct s2n_connection *conn)
 {
     /* If running in QUIC mode, QUIC handles alerting.
      * S2N should not send or receive alerts. */
-    return conn && !conn->quic_enabled;
+    return conn && conn->config && !conn->config->quic_enabled;
 }
 
 static bool s2n_handle_as_warning(struct s2n_connection *conn, uint8_t level, uint8_t type)

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -59,6 +59,7 @@ static uint32_t min_size(struct s2n_blob *blob, uint32_t max_length) {
 static S2N_RESULT s2n_generate_client_session_id(struct s2n_connection *conn)
 {
     ENSURE_REF(conn);
+    ENSURE_REF(conn->config);
 
     /* Session id already generated - no-op */
     if (conn->session_id_len) {
@@ -72,7 +73,7 @@ static S2N_RESULT s2n_generate_client_session_id(struct s2n_connection *conn)
 
     /* Generate the session id for TLS1.3 if in middlebox compatibility mode.
      * For now, we default to middlebox compatibility mode unless using QUIC. */
-    if (conn->quic_enabled) {
+    if (conn->config->quic_enabled) {
         return S2N_RESULT_OK;
     }
 
@@ -260,7 +261,7 @@ int s2n_process_client_hello(struct s2n_connection *conn)
 
     /* for pre TLS 1.3 connections, protocol selection is not done in supported_versions extensions, so do it here */
     if (conn->actual_protocol_version < S2N_TLS13) {
-        ENSURE_POSIX(!conn->quic_enabled, S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
+        ENSURE_POSIX(!conn->config->quic_enabled, S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
         conn->actual_protocol_version = MIN(conn->server_protocol_version, conn->client_protocol_version);
     }
 

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -112,6 +112,7 @@ static int s2n_config_init(struct s2n_config *config)
     config->ticket_key_hashes = NULL;
     config->encrypt_decrypt_key_lifetime_in_nanos = S2N_TICKET_ENCRYPT_DECRYPT_KEY_LIFETIME_IN_NANOS;
     config->decrypt_key_lifetime_in_nanos = S2N_TICKET_DECRYPT_KEY_LIFETIME_IN_NANOS;
+    config->quic_enabled = 0;
 
     /* By default, only the client will authenticate the Server's Certificate. The Server does not request or
      * authenticate any client certificates. */

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -38,6 +38,9 @@ struct s2n_config {
     unsigned check_ocsp:1;
     unsigned disable_x509_validation:1;
     unsigned max_verify_cert_chain_depth_set:1;
+    /* Whether a connection can be used by a QUIC implementation.
+     * See s2n_quic_support.h */
+    unsigned quic_enabled:1;
 
     struct s2n_dh_params *dhparams;
     /* Needed until we can deprecate s2n_config_add_cert_chain_and_key. This is

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -309,10 +309,6 @@ struct s2n_connection {
     /* Key update data */
     unsigned key_update_pending:1;
 
-    /* Whether this connection can be used by a QUIC implementation.
-     * See s2n_quic_support.h */
-    unsigned quic_enabled:1;
-
     /* Bitmap to represent preferred list of keyshare for client to generate and send keyshares in the ClientHello message.
      * The least significant bit (lsb), if set, indicates that the client must send an empty keyshare list.
      * Each bit value in the bitmap indiciates the corresponding curve in the ecc_preferences list for which a key share needs to be generated.

--- a/tls/s2n_quic_support.c
+++ b/tls/s2n_quic_support.c
@@ -35,10 +35,10 @@
 
 S2N_RESULT s2n_read_in_bytes(struct s2n_connection *conn, struct s2n_stuffer *output, uint32_t length);
 
-int s2n_connection_enable_quic(struct s2n_connection *conn)
+int s2n_config_enable_quic(struct s2n_config *config)
 {
-    notnull_check(conn);
-    conn->quic_enabled = true;
+    notnull_check(config);
+    config->quic_enabled = true;
     return S2N_SUCCESS;
 }
 

--- a/tls/s2n_quic_support.h
+++ b/tls/s2n_quic_support.h
@@ -29,7 +29,7 @@
  * and are subject to change without notice. They should only be used for testing purposes.
  */
 
-S2N_API int s2n_connection_enable_quic(struct s2n_connection *conn);
+S2N_API int s2n_config_enable_quic(struct s2n_config *config);
 
 /*
  * Set the data to be sent in the quic_transport_parameters extension.

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -132,7 +132,7 @@ static int s2n_server_hello_parse(struct s2n_connection *conn)
         conn->server_protocol_version = (uint8_t)(protocol_version[0] * 10) + protocol_version[1];
 
         S2N_ERROR_IF(s2n_client_detect_downgrade_mechanism(conn), S2N_ERR_PROTOCOL_DOWNGRADE_DETECTED);
-        ENSURE_POSIX(!conn->quic_enabled, S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
+        ENSURE_POSIX(!conn->config->quic_enabled, S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
 
         const struct s2n_security_policy *security_policy;
         GUARD(s2n_connection_get_security_policy(conn, &security_policy));


### PR DESCRIPTION
### Description of changes: 

Currently, QUIC support is configured per-connection. This is because the original plan involved configuring the transport parameters in the same API that configures QUIC. However, I ended up implementing the two APIs separately, so QUIC can now be enabled at the config level instead.

While switching the tests over to configure QUIC via config, I also removed s2n_enable/disable_tls13() where the change was straightforward.

### Callouts

**Saw change:** The bitfield I added was the 9th, so the bitfield size needed to increase to 2 bytes.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
