### PR TITLE
Allow slightly overlarge TLS 1.3 inner plaintext

### DIFF
--- a/tests/unit/s2n_tls13_parse_record_type_test.c
+++ b/tests/unit/s2n_tls13_parse_record_type_test.c
@@ -115,42 +115,46 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
     }
 
-    /* Test maximum record length size (with padding) */
+    /* Defining these here as variables as they aren't used in prior tests. */
+    const uint8_t padding_value = 0x00;
+    const uint8_t not_padding_value = 0x16;
+
+    /* Test maximum record length size (empty data) */
     {
         EXPECT_EQUAL(S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH, 16385);
 
         struct s2n_stuffer stuffer;
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 1024));
 
-        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, 0x16));
+        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, not_padding_value));
 
         /* fill up stuffer to before the limit */
         while (s2n_stuffer_data_available(&stuffer) < S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH) {
-            EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, 0x00));
+            EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, padding_value));
         }
         EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH);
 
         EXPECT_SUCCESS(s2n_tls13_parse_record_type(&stuffer, &record_type));
-        EXPECT_EQUAL(record_type, 0x16);
+        EXPECT_EQUAL(record_type, not_padding_value);
         /* There was no data before the record type */
         EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
 
         EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
     }
 
-    /* Test maximum record length size (without padding) */
+    /* Test maximum record length size (maximum data) */
     {
         struct s2n_stuffer stuffer;
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 1024));
 
         /* fill up stuffer to before the limit */
         while (s2n_stuffer_data_available(&stuffer) < S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH) {
-            EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, 0x16));
+            EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, not_padding_value));
         }
         EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH);
 
         EXPECT_SUCCESS(s2n_tls13_parse_record_type(&stuffer, &record_type));
-        EXPECT_EQUAL(record_type, 0x16);
+        EXPECT_EQUAL(record_type, not_padding_value);
         /* The last byte is stripped as the content type */
         EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH - 1);
 
@@ -162,86 +166,86 @@ int main(int argc, char **argv)
      * However, after the padding is stripped, the result will always be no more than
      * S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH - 1
      */
-
-    /* Test slightly overlarge record for compatibility (with padding) */
     {
+        const size_t extra_length_tolerated = 16;
+        /* Test slightly overlarge record for compatibility (empty data) */
+        {
+            struct s2n_stuffer stuffer;
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 1024));
 
-        struct s2n_stuffer stuffer;
-        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 1024));
+            EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, not_padding_value));
+            /* fill up stuffer the limit  + 16 */
+            while (s2n_stuffer_data_available(&stuffer) < S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH + extra_length_tolerated) {
+                EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, padding_value));
+            }
+            EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH + extra_length_tolerated);
+            EXPECT_SUCCESS(s2n_tls13_parse_record_type(&stuffer, &record_type));
+            EXPECT_EQUAL(record_type, not_padding_value);
+            /* There was no data before the record type */
+            EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
 
-        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, 0x16));
-        /* fill up stuffer the limit  + 16 */
-        while (s2n_stuffer_data_available(&stuffer) < S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH + 16) {
-            EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, 0x00));
+            EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
         }
-        EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH + 16);
-        EXPECT_SUCCESS(s2n_tls13_parse_record_type(&stuffer, &record_type));
-        EXPECT_EQUAL(record_type, 0x16);
-        /* There was no data before the record type */
-        EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
 
-        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        /* Test slightly overlarge record for compatibility (maximum data) */
+        {
+            struct s2n_stuffer stuffer;
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 1024));
+
+            /* fill up stuffer to before the limit */
+            while (s2n_stuffer_data_available(&stuffer) < S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH) {
+                EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, not_padding_value));
+            }
+            /* pad up stuffer the limit  + 16 */
+            while (s2n_stuffer_data_available(&stuffer) < S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH + extra_length_tolerated) {
+                EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, padding_value));
+            }
+            EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH + extra_length_tolerated);
+
+            EXPECT_SUCCESS(s2n_tls13_parse_record_type(&stuffer, &record_type));
+            EXPECT_EQUAL(record_type, not_padding_value);
+            /* The last byte is stripped as the content type */
+            EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH - 1);
+
+            EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        }
+
+        /* Test slightly overlarge record for compatibility (with too much data) */
+        {
+            struct s2n_stuffer stuffer;
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 1024));
+
+            /* Finally, do this with an overall length which should pass, but too much data before the padding */
+            /* fill up stuffer to the maximum amount of data */
+            while (s2n_stuffer_data_available(&stuffer) < S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH) {
+                EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, padding_value));
+            }
+            EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, not_padding_value)); /* Record type */
+            /* 16 bytes of padding*/
+            while (s2n_stuffer_data_available(&stuffer) < S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH + extra_length_tolerated) {
+                EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, padding_value));
+            }
+            EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH + extra_length_tolerated);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_parse_record_type(&stuffer, &record_type), S2N_ERR_MAX_INNER_PLAINTEXT_SIZE);
+
+            EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        }
+
+        /* Test slightly overlarge + 1 record for compatibility (empty data) */
+        {
+            struct s2n_stuffer stuffer;
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 1024));
+
+            EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, not_padding_value));
+            while (s2n_stuffer_data_available(&stuffer) < S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH + extra_length_tolerated + 1) {
+                EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, padding_value));
+            }
+            EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH + extra_length_tolerated + 1);
+
+            EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_parse_record_type(&stuffer, &record_type), S2N_ERR_MAX_INNER_PLAINTEXT_SIZE);
+            EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        }
     }
-
-    /* Test slightly overlarge record for compatibility (without padding) */
-    {
-        struct s2n_stuffer stuffer;
-        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 1024));
-
-        /* fill up stuffer to before the limit */
-        while (s2n_stuffer_data_available(&stuffer) < S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH) {
-            EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, 0x16));
-        }
-        /* pad up stuffer the limit  + 16 */
-        while (s2n_stuffer_data_available(&stuffer) < S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH + 16) {
-            EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, 0x00));
-        }
-        EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH + 16);
-
-        EXPECT_SUCCESS(s2n_tls13_parse_record_type(&stuffer, &record_type));
-        EXPECT_EQUAL(record_type, 0x16);
-        /* The last byte is stripped as the content type */
-        EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH - 1);
-
-        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
-    }
-
-    /* Test slightly overlarge record for compatibility (with too much inner data) */
-    {
-        struct s2n_stuffer stuffer;
-        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 1024));
-
-        /* Finally, do this with an overall length which should pass, but too much data before the padding */
-        /* fill up stuffer to the maximum amount of data */
-        while (s2n_stuffer_data_available(&stuffer) < S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH) {
-            EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, 0x00));
-        }
-        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, 0x16)); /* Record type */
-        /* 16 bytes of padding*/
-        while (s2n_stuffer_data_available(&stuffer) < S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH + 16) {
-            EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, 0x00));
-        }
-        EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH + 16);
-        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_parse_record_type(&stuffer, &record_type), S2N_ERR_MAX_INNER_PLAINTEXT_SIZE);
-
-        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
-    }
-
-    /* Test slightly overlarge + 1 record for compatibility (with padding) */
-    {
-        struct s2n_stuffer stuffer;
-        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 1024));
-
-        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, 0x16));
-        while (s2n_stuffer_data_available(&stuffer) < S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH + 17) {
-            EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, 0x00));
-        }
-        EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH + 17);
-
-        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_parse_record_type(&stuffer, &record_type), S2N_ERR_MAX_INNER_PLAINTEXT_SIZE);
-        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
-    }
-
     END_TEST();
 }
 


### PR DESCRIPTION
### Description of changes: 

[Some clients](https://bugs.openjdk.java.net/browse/JDK-8221253) will incorrectly send TLS 1.3 records containing inner plaintexts up to 16 bytes too large after padding. (After the padding is stripped, the data is in an acceptable range.) This is behavior is in violation of rfc8446 Section 5.4.

This change relaxes s2n's checks on received inner plaintexts so as to not break these clients.

### Call-outs:

This is my first non-trivial contribution to s2n, so reviewers should ensure I meet the coding standards.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
* Unit test has been modified to cover the new cases. (True test-driven development here.)

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?
* Not a refactor change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
