### PR TITLE
Fix a build error with older versions of GCC.

### DIFF
--- a/tls/s2n_tls13.h
+++ b/tls/s2n_tls13.h
@@ -17,14 +17,21 @@
 
 #include "api/s2n.h"
 #include "tls/s2n_crypto.h"
+#include "utils/s2n_compiler.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-S2N_API
-__attribute__((deprecated("The use of TLS1.3 is configured through security policies")))
-extern int s2n_enable_tls13();
+#if S2N_GCC_VERSION_AT_LEAST(4, 5, 0)
+    S2N_API
+    __attribute__((deprecated("The use of TLS1.3 is configured through security policies")))
+    extern int s2n_enable_tls13();
+#else
+    S2N_API
+    __attribute__((deprecated))
+    extern int s2n_enable_tls13();
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Description of changes: 

Build error on GCC < 4.5.0. Arguments to the `deprecated` attribute weren't introduced until 4.5.0. https://gcc.gnu.org/gcc-4.5/changes.html.

### Testing:

This only affects one deprecated function. It was tested on in the Github CI and other CI systems.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
