### PR TITLE
ci: CodeBuild scripts to support AL2

### DIFF
--- a/codebuild/bin/install_al2_dependencies.sh
+++ b/codebuild/bin/install_al2_dependencies.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+set -eu
+source ./codebuild/bin/s2n_setup_env.sh
+
+base_packages() {
+    yum update -y
+    yum erase -y openssl-devel || true
+    yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm || true
+    yum install amazon-linux-extras
+
+    # Who owns this package? It needs updating to not install modules under python2.7
+    PYTHON=$(which python2) amazon-linux-extras install -y ruby2.6 rust1 python3.8
+    PYTHON=$(which python2) amazon-linux-extras enable epel
+    PYTHON=$(which python2) amazon-linux-extras enable corretto8
+    yum install -y openssh-clients
+}
+
+mono() {
+    rpm --import https://download.mono-project.com/repo/xamarin.gpg
+    curl https://download.mono-project.com/repo/centos7-stable.repo | tee /etc/yum.repos.d/mono-centos7-stable.repo
+}
+
+symlink_all_the_things() {
+    # Package owners should be doing this.
+    # Note the version number at the end allows for upgrades to superceeded these.
+    update-alternatives --install /usr/bin/pip pip3 /usr/bin/pip3 300
+    update-alternatives --install /usr/bin/ninja ninja /usr/bin/ninja-build 170
+    update-alternatives --install /usr/bin/cmake cmake /usr/bin/cmake3 313
+    update-alternatives --install /usr/bin/gcc-7 gcc /usr/bin/gcc 700
+    update-alternatives --install /usr/bin/g++-7 g++ /usr/bin/g++ 700
+    update-alternatives --install /usr/bin/g++-7 g++ /usr/bin/g++ 700
+}
+
+
+base_packages
+mono
+yum groupinstall -y "Development tools"
+yum install -y which nettle-devel openssl11-devel which sudo python3-pip cmake3 tcpdump unzip zlib-devel libtool ninja-build wget
+symlink_all_the_things

--- a/codebuild/bin/install_al2_dependencies.sh
+++ b/codebuild/bin/install_al2_dependencies.sh
@@ -36,7 +36,7 @@ mono() {
 
 symlink_all_the_things() {
     # Package owners should be doing this.
-    # Note the version number at the end allows for upgrades to superceeded these.
+    # Note the version number at the end allows for upgrades to supersede these.
     update-alternatives --install /usr/bin/pip pip3 /usr/bin/pip3 300
     update-alternatives --install /usr/bin/ninja ninja /usr/bin/ninja-build 170
     update-alternatives --install /usr/bin/cmake cmake /usr/bin/cmake3 313

--- a/codebuild/bin/install_default_dependencies.sh
+++ b/codebuild/bin/install_default_dependencies.sh
@@ -70,7 +70,7 @@ if [[ "$TESTS" == "integration" || "$TESTS" == "integrationv2" || "$TESTS" == "A
         "ubuntu")
           apt-get -y install tox
           ;;
-        "redhat"|"fedora"|"centos"|"amazon linux")
+        "amazon linux")
           yum install -y python3-pip
           python3 -m pip install --user tox          ;;
         "apple")
@@ -122,7 +122,7 @@ if [[ ! -x `which cmake` ]]; then
     "ubuntu")
         apt-get -y install cmake
         ;;
-    "redhat"|"fedora"|"centos"|"amazon linux")
+    "amazon linux")
         yum install -y cmake3
         update-alternatives --install /usr/bin/cmake cmake /usr/bin/cmake3 30
         ;;

--- a/codebuild/bin/install_gnutls.sh
+++ b/codebuild/bin/install_gnutls.sh
@@ -15,32 +15,39 @@
 #
 
 set -e
+source codebuild/bin/s2n_setup_env.sh
 
 usage() {
     echo "install_gnutls.sh build_dir install_dir os_name"
     exit 1
 }
 
-if [ "$#" -ne "3" ]; then
+if [ "$#" -ne "2" ]; then
     usage
 fi
 
 GNUTLS_BUILD_DIR=$1
 GNUTLS_INSTALL_DIR=$2
-OS_NAME=$3
 
 source codebuild/bin/jobs.sh
 
 # libgmp is needed for libnettle
-if [ "$OS_NAME" == "linux" ]; then
+case "$DISTRO" in
+  "ubuntu")
     sudo apt-get -qq install libgmp3-dev -y
-elif [ "$OS_NAME" == "osx" ]; then
+    ;;
+  "redhat"|"fedora"|"centos"|"amazon linux")
+    sudo yum install -y gmp-devel
+    ;;
+"darwin" )
     # Installing an existing package is a "failure" in brew
-    brew install gmp || true ;
-else
+    brew install gmp || true 
+    ;;
+*)
     echo "Invalid platform! $OS_NAME"
     usage
-fi
+    ;;
+esac
 
 cd "$GNUTLS_BUILD_DIR"
 

--- a/codebuild/bin/install_gnutls.sh
+++ b/codebuild/bin/install_gnutls.sh
@@ -36,7 +36,7 @@ case "$DISTRO" in
   "ubuntu")
     sudo apt-get -qq install libgmp3-dev -y
     ;;
-  "redhat"|"fedora"|"centos"|"amazon linux")
+  "amazon linux")
     sudo yum install -y gmp-devel
     ;;
 "darwin" )

--- a/codebuild/bin/install_shellcheck.sh
+++ b/codebuild/bin/install_shellcheck.sh
@@ -34,7 +34,7 @@ if [ "$#" -ne "0" ]; then
 fi
 
 case "$OS_NAME" in
-  "ubuntu"|"fedora"|"redhat"|"centos"|"amazon linux")
+  "amazon linux")
     which shellcheck || install_shellcheck
     ;;
   "darwin" )

--- a/codebuild/bin/install_shellcheck.sh
+++ b/codebuild/bin/install_shellcheck.sh
@@ -17,25 +17,31 @@
 set -e
 source codebuild/bin/s2n_setup_env.sh
 
-if [ -f "/etc/lsb-release" ]; then
-    source /etc/lsb-release
-fi
-
 usage() {
     echo "install_shellcheck.sh"
     exit 1
+}
+
+install_shellcheck() {
+   wget "https://github.com/koalaman/shellcheck/releases/download/v0.7.1/shellcheck-v0.7.1.linux.$ARCH.tar.xz" -O /tmp/shellcheck.tar.xz
+   tar -Jxf /tmp/shellcheck.tar.xz -C /tmp
+   mv /tmp/shellcheck-v*/shellcheck /usr/local/bin/
+   chmod 755 /usr/local/bin/shellcheck
 }
 
 if [ "$#" -ne "0" ]; then
     usage
 fi
 
-if [ "$OS_NAME" == "linux" ]; then
-    which shellcheck || (sudo apt-get -qq update && sudo apt-get -qq install shellcheck -y)
-elif [ "$OS_NAME" == "darwin" ]; then
-    # Installing an existing package is a "failure" in brew
+case "$OS_NAME" in
+  "ubuntu"|"fedora"|"redhat"|"centos"|"amazon linux")
+    which shellcheck || install_shellcheck
+    ;;
+  "darwin" )
     brew install shellcheck || true ;
-else
-    echo "Invalid platform! $OS_NAME"
-    usage
-fi
+    ;;
+  *)
+    echo "Unknown platfom"
+    exit 255
+    ;;
+esac

--- a/codebuild/bin/install_sslyze.sh
+++ b/codebuild/bin/install_sslyze.sh
@@ -28,7 +28,7 @@ case "$ARCH" in
   *)
         python3 -m pip install --user --upgrade pip setuptools
         # Version 3.0.0 introduces backwards incompatible changes in the JSON we parse.
-        # If we upgrade, the json format changes, breaking either Codebuild.
+        # TODO: unpin the version and update the json parsing sslyze output.
         python3 -m pip install --user "sslyze<3.0.0"
         sudo ln -s /root/.local/bin/sslyze /usr/bin/sslyze || true
         which sslyze

--- a/codebuild/bin/install_sslyze.sh
+++ b/codebuild/bin/install_sslyze.sh
@@ -13,15 +13,25 @@
 # permissions and limitations under the License.
 #
 
-set -ex
+set -e
+. codebuild/bin/s2n_setup_env.sh
 
-python3 -m pip install --user --upgrade pip setuptools
+aarch64_install() {
+        echo "sslyze has a dependency on nassl, which will not build on ARM."
+}
 
-# Version 3.0.0 introduces backwards incompatible changes in the JSON we parse.
-# If we upgrade, the json format changes, breaking either Travis OR Codebuild.
-python3 -m pip install --user "sslyze<3.0.0"
-
-sudo ln -s /root/.local/bin/sslyze /usr/bin/sslyze || true
-
-which sslyze
-sslyze --version
+case "$ARCH" in
+  "aarch64")
+        aarch64_install
+        exit 1
+        ;;
+  *)
+        python3 -m pip install --user --upgrade pip setuptools
+        # Version 3.0.0 introduces backwards incompatible changes in the JSON we parse.
+        # If we upgrade, the json format changes, breaking either Codebuild.
+        python3 -m pip install --user "sslyze<3.0.0"
+        sudo ln -s /root/.local/bin/sslyze /usr/bin/sslyze || true
+        which sslyze
+        sslyze --version
+        ;;
+esac

--- a/codebuild/bin/s2n_setup_env.sh
+++ b/codebuild/bin/s2n_setup_env.sh
@@ -59,7 +59,7 @@
   #  VERSION_CODENAME = "bionic"
   if [[ -f "/etc/os-release" ]]; then
     # AL2 doesn't provide a codename.
-     . /etc/os-release
+    . /etc/os-release
     export DISTRO=$(echo "$NAME"|tr "[:upper:]" "[:lower:]")
     export VERSION_ID=${VERSION_ID:-"unknown"}
     export VERSION_CODENAME=${VERSION_CODENAME:-"unknown"}

--- a/codebuild/bin/s2n_setup_env.sh
+++ b/codebuild/bin/s2n_setup_env.sh
@@ -21,6 +21,8 @@
 : "${GCC_VERSION:=NONE}"
 : "${LATEST_CLANG:=false}"
 : "${TESTS:=integration}"
+: "${S2N_COVERAGE:=false}"
+: "${LD_LIBRARY_PATH:=NONE}"
 
 # Setup the cache directory paths.
 # Set Env Variables with defaults if they aren't already set
@@ -48,8 +50,30 @@
 : "${GB_INSTALL_DIR:=$TEST_DEPS_DIR/gb}"
 : "${FUZZ_TIMEOUT_SEC:=10}"
 
-# OS_NAME
+  # Set some environment vars for OS, Distro and architecture.
+  # Standardized as part of systemd http://0pointer.de/blog/projects/os-release
+  # Samples:
+  #  OS_NAME = "linux"
+  #  DISTRO="ubuntu"
+  #  VERSION_ID = "18.04"
+  #  VERSION_CODENAME = "bionic"
+  if [[ -f "/etc/os-release" ]]; then
+    # AL2 doesn't provide a codename.
+     . /etc/os-release
+    export DISTRO=$(echo "$NAME"|tr "[:upper:]" "[:lower:]")
+    export VERSION_ID=${VERSION_ID:-"unknown"}
+    export VERSION_CODENAME=${VERSION_CODENAME:-"unknown"}
+  elif [[ -x "/usr/bin/sw_vers" ]]; then
+    export DISTRO="apple"
+    export VERSION_ID=$(sw_vers -productVersion|sed 's/:[[:space:]]*/=/g')
+    export VERSION_CODENAME="unknown"  # not queriable via CLI
+  else
+    export DISTRO="unknown"
+    export VERSION_ID="unknown"
+    export VERSION_CODENAME="unknown"
+  fi
 export OS_NAME=$(uname -s|tr "[:upper:]" "[:lower:]")
+export ARCH=$(uname -m)
 
 # Export all Env Variables
 export S2N_LIBCRYPTO
@@ -85,8 +109,8 @@ export S2N_CORKED_IO
 
 # S2N_COVERAGE should not be used with fuzz tests, use FUZZ_COVERAGE instead
 if [[ "$S2N_COVERAGE" == "true" && "$TESTS" == "fuzz" ]]; then
-    unset S2N_COVERAGE
-    export FUZZ_COVERAGE=true
+    export S2N_COVERAGE="false"
+    export FUZZ_COVERAGE="true"
 fi
 
 # Select the libcrypto to build s2n against. If this is unset, default to the latest stable version(Openssl 1.1.1)

--- a/codebuild/spec/buildspec_amazonlinux2.yml
+++ b/codebuild/spec/buildspec_amazonlinux2.yml
@@ -1,0 +1,26 @@
+version: 0.2
+
+env:
+  variables:
+    # CODEBUILD_ is a reserved namespace.
+    CB_BIN_DIR: "./codebuild/bin"
+
+phases:
+  install:
+    runtime-versions:
+      python: 3.7
+  pre_build:
+    commands:
+      - |
+        if [ -d "third-party-src" ]; then
+          cd third-party-src;
+        fi
+      - ./codebuild/bin/install_al2_dependencies.sh
+      - ./codebuild/bin/install_default_dependencies.sh
+  build:
+    commands:
+      - printenv
+      - $CB_BIN_DIR/s2n_codebuild.sh
+  post_build:
+    commands:
+      - echo Build completed on `date`

--- a/tests/integration/Makefile
+++ b/tests/integration/Makefile
@@ -32,11 +32,11 @@ ifeq ($(OPENSSL_0_9_8_INSTALL_DIR),)
 	OPENSSL_0_9_8_INSTALL_DIR:=${CURDIR}/../../test-deps/openssl-0.9.8
 endif
 
-.PHONY : all
-ifdef S2N_NO_PQ
 TESTS = tls13 client_endpoints dynamic_record old_s_client s_client s_server gnutls_cli gnutls_serv
-else
-TESTS = tls13 client_endpoints dynamic_record old_s_client s_client s_server gnutls_cli gnutls_serv pq_handshake
+
+.PHONY : all
+ifndef S2N_NO_PQ
+TESTS += pq_handshake
 endif
 
 ifneq (S2N_NO_SSLYZE, "true")

--- a/tests/integration/Makefile
+++ b/tests/integration/Makefile
@@ -34,10 +34,16 @@ endif
 
 .PHONY : all
 ifdef S2N_NO_PQ
-all: tls13 client_endpoints dynamic_record old_s_client s_client s_server gnutls_cli gnutls_serv sslyze
+TESTS = tls13 client_endpoints dynamic_record old_s_client s_client s_server gnutls_cli gnutls_serv
 else
-all: tls13 client_endpoints dynamic_record old_s_client s_client s_server gnutls_cli gnutls_serv sslyze pq_handshake
+TESTS = tls13 client_endpoints dynamic_record old_s_client s_client s_server gnutls_cli gnutls_serv pq_handshake
 endif
+
+ifneq (S2N_NO_SSLYZE, "true")
+TESTS += sslyze
+endif
+
+all: $(TESTS)
 
 tls13:
 	( \


### PR DESCRIPTION
### Resolved issues:

Ci portion of #387 

### Description of changes: 

Scripts to support running Ci on AmazonLinux2, both aarch64 and x86_64.
This is splitting up a previous PR that created a pre-build docker image.

### Call-outs:

- Unit tests passing
- Added a S2N_NO_SSLYZE flag to prevent it running on AL2
- Integration v1 tests currently hang when s2nd exits (crashes?)
- Must run tests as root
- Changed how shellcheck is installed  (this should really be a github action)
- Added 4 new env vars to s2n_setup_env.sh: DISTRO, ARCH, VERSION_ID, VERSION_CODENAME so we can be more granular with what gets installed where
- Only packages for gcc-7 ready to go.  Ask AL2 maintainers for newer builds
- Tweaked tox and gnuTLS installs for AL2/mac

### Testing:

> How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?


AL2 docker images and Graviton2 EC2 instances.  Sample ASAN test in [codebuild](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nOmnibus/build/s2nOmnibus%3A27031db1-2c8c-4590-b786-59291e876e2c?region=us-west-2)
Please help double check with the following steps:

(as root)
```
./codebuild/bin/install_al2_dependencies.sh
TESTS=integrationv2 S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true GCC_VERSION=7 NO_PQ=1 S2N_NO_SSLYZE=true  ./codebuild/bin/install_default_dependencies.sh
PATH=$PATH:/root/.local/bin TESTS=integrationv2 S2N_LIBCRYPTO=openssl11 make
PATH=$PATH:/root/.local/bin TESTS=integrationv2 S2N_NO_SSLYZE=true make -C tests/integrationv2 all
```


> Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

Script changes, yes. CodeBuild runs against Ubuntu need to pass before merging. AL2 CodeBuild automatio will come in future PRs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
