### PR TITLE
Add secret callbacks for QUIC

### DIFF
--- a/tests/unit/s2n_tls13_handshake_test.c
+++ b/tests/unit/s2n_tls13_handshake_test.c
@@ -372,10 +372,10 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_config_enable_quic(config));
 
                 const uint8_t expected_secrets_handled[S2N_SECRET_TYPE_COUNT] = {
-                        [S2N_CLIENT_HANDSHAKE_TRAFFIC_SECRET] = 1,
-                        [S2N_SERVER_HANDSHAKE_TRAFFIC_SECRET] = 1,
-                        [S2N_CLIENT_APPLICATION_TRAFFIC_SECRET] = 1,
-                        [S2N_SERVER_APPLICATION_TRAFFIC_SECRET] = 1,
+                    [S2N_CLIENT_HANDSHAKE_TRAFFIC_SECRET] = 1,
+                    [S2N_SERVER_HANDSHAKE_TRAFFIC_SECRET] = 1,
+                    [S2N_CLIENT_APPLICATION_TRAFFIC_SECRET] = 1,
+                    [S2N_SERVER_APPLICATION_TRAFFIC_SECRET] = 1,
                 };
 
                 for (s2n_mode mode = 0; mode <= 1; mode++) {

--- a/tests/unit/s2n_tls13_handshake_test.c
+++ b/tests/unit/s2n_tls13_handshake_test.c
@@ -27,6 +27,7 @@
 #include "tls/s2n_cipher_suites.h"
 #include "tls/s2n_connection.h"
 #include "tls/s2n_handshake.h"
+#include "tls/s2n_quic_support.h"
 #include "tls/s2n_tls13.h"
 #include "tls/s2n_tls13_handshake.h"
 #include "tls/extensions/s2n_server_key_share.h"
@@ -39,20 +40,35 @@
 #include "tls/s2n_tls13_handshake.c"
 #include "tls/s2n_handshake_transcript.c"
 
+#define S2N_SECRET_TYPE_COUNT 5
+
 static int s2n_tls13_conn_copy_server_finished_hash(struct s2n_connection *conn);
+
+static int s2n_setup_tls13_secrets_prereqs(struct s2n_connection *conn)
+{
+    conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
+    GUARD(s2n_tls13_conn_copy_server_finished_hash(conn));
+
+    const struct s2n_ecc_preferences *ecc_pref = NULL;
+    GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+    notnull_check(ecc_pref);
+
+    conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+    conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
+    GUARD(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.server_ecc_evp_params));
+    GUARD(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
+
+    return S2N_SUCCESS;
+}
 
 static int s2n_test_tls13_handle_secrets(s2n_mode mode, uint8_t version, message_type_t *update_points, size_t update_points_len)
 {
     for (size_t i = 0; i < S2N_MAX_HANDSHAKE_LENGTH; i++) {
         struct s2n_connection *conn;
         notnull_check(conn = s2n_connection_new(mode));
-
-        const struct s2n_ecc_preferences *ecc_pref = NULL;
-        GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
-        notnull_check(ecc_pref);
+        GUARD(s2n_setup_tls13_secrets_prereqs(conn));
 
         conn->actual_protocol_version = version;
-        conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
 
         s2n_tls13_connection_keys(client_secrets, conn);
 
@@ -64,13 +80,6 @@ static int s2n_test_tls13_handle_secrets(s2n_mode mode, uint8_t version, message
         /* verify that that is the initial secret state */
         conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
         conn->handshake.message_number = i;
-
-        GUARD(s2n_tls13_conn_copy_server_finished_hash(conn));
-
-        conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
-        conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
-        GUARD(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.server_ecc_evp_params));
-        GUARD(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
 
         GUARD(s2n_tls13_handle_secrets(conn));
 
@@ -89,6 +98,39 @@ static int s2n_test_tls13_handle_secrets(s2n_mode mode, uint8_t version, message
         }
 
         GUARD(s2n_connection_free(conn));
+    }
+
+    return S2N_SUCCESS;
+}
+
+
+static int s2n_test_secret_handler(void* context, struct s2n_connection *conn,
+                                          s2n_secret_type_t secret_type,
+                                          uint8_t *secret, uint8_t secret_size)
+{
+    uint8_t *secrets_handled = (uint8_t *) context;
+    secrets_handled[secret_type] += 1;
+
+    switch(secret_type) {
+        case S2N_CLIENT_HANDSHAKE_TRAFFIC_SECRET:
+            eq_check(s2n_conn_get_current_message_type(conn), SERVER_HELLO);
+            break;
+        case S2N_SERVER_HANDSHAKE_TRAFFIC_SECRET:
+            eq_check(s2n_conn_get_current_message_type(conn), SERVER_HELLO);
+            break;
+        case S2N_SERVER_APPLICATION_TRAFFIC_SECRET:
+            if (conn->mode == S2N_SERVER) {
+                eq_check(s2n_conn_get_current_message_type(conn), SERVER_FINISHED);
+            } else {
+                eq_check(s2n_conn_get_current_message_type(conn), CLIENT_FINISHED);
+            }
+            break;
+        case S2N_CLIENT_APPLICATION_TRAFFIC_SECRET:
+            eq_check(s2n_conn_get_current_message_type(conn), CLIENT_FINISHED);
+            break;
+        case S2N_CLIENT_EARLY_TRAFFIC_SECRET:
+            S2N_ERROR(S2N_ERR_UNIMPLEMENTED);
+            break;
     }
 
     return S2N_SUCCESS;
@@ -292,6 +334,74 @@ int main(int argc, char **argv)
             message_type_t server_secret_update_points[] = { SERVER_HELLO, SERVER_FINISHED };
             EXPECT_SUCCESS(s2n_test_tls13_handle_secrets(S2N_SERVER, S2N_TLS13,
                     server_secret_update_points, s2n_array_len(server_secret_update_points)));
+        }
+
+        /* Test: secret handlers called when QUIC enabled */
+        {
+            /* Test: secret handlers NOT called when QUIC NOT enabled */
+            {
+                const uint8_t expected_secrets_handled[S2N_SECRET_TYPE_COUNT] = { 0 };
+                for (uint8_t version = S2N_TLS12; version <= S2N_TLS13; version++) {
+                    for (s2n_mode mode = 0; mode <= 1; mode++) {
+                        uint8_t secrets_handled[S2N_SECRET_TYPE_COUNT] = { 0 };
+
+                        for (size_t i = 0; i < S2N_MAX_HANDSHAKE_LENGTH; i++) {
+                            struct s2n_connection *conn;
+                            EXPECT_NOT_NULL(conn = s2n_connection_new(mode));
+                            EXPECT_SUCCESS(s2n_setup_tls13_secrets_prereqs(conn));
+
+                            conn->actual_protocol_version = version;
+                            conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
+                            conn->handshake.message_number = i;
+
+                            EXPECT_SUCCESS(s2n_connection_set_secret_callback(conn, s2n_test_secret_handler, secrets_handled));
+                            GUARD(s2n_tls13_handle_secrets(conn));
+
+                            EXPECT_SUCCESS(s2n_connection_free(conn));
+                        }
+
+                        EXPECT_BYTEARRAY_EQUAL(secrets_handled, expected_secrets_handled, sizeof(expected_secrets_handled));
+                    }
+                }
+            }
+
+            /* Test: secret handlers called when QUIC enabled */
+            {
+                struct s2n_config *config;
+                EXPECT_NOT_NULL(config = s2n_config_new());
+                EXPECT_SUCCESS(s2n_config_enable_quic(config));
+
+                const uint8_t expected_secrets_handled[S2N_SECRET_TYPE_COUNT] = {
+                        [S2N_CLIENT_HANDSHAKE_TRAFFIC_SECRET] = 1,
+                        [S2N_SERVER_HANDSHAKE_TRAFFIC_SECRET] = 1,
+                        [S2N_CLIENT_APPLICATION_TRAFFIC_SECRET] = 1,
+                        [S2N_SERVER_APPLICATION_TRAFFIC_SECRET] = 1,
+                };
+
+                for (s2n_mode mode = 0; mode <= 1; mode++) {
+                    uint8_t secrets_handled[S2N_SECRET_TYPE_COUNT] = { 0 };
+
+                    for (size_t i = 0; i < S2N_MAX_HANDSHAKE_LENGTH; i++) {
+                        struct s2n_connection *conn;
+                        EXPECT_NOT_NULL(conn = s2n_connection_new(mode));
+                        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+                        EXPECT_SUCCESS(s2n_setup_tls13_secrets_prereqs(conn));
+
+                        conn->actual_protocol_version = S2N_TLS13;
+                        conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
+                        conn->handshake.message_number = i;
+
+                        EXPECT_SUCCESS(s2n_connection_set_secret_callback(conn, s2n_test_secret_handler, secrets_handled));
+                        GUARD(s2n_tls13_handle_secrets(conn));
+
+                        EXPECT_SUCCESS(s2n_connection_free(conn));
+                    }
+
+                    EXPECT_BYTEARRAY_EQUAL(secrets_handled, expected_secrets_handled, sizeof(expected_secrets_handled));
+                }
+
+                EXPECT_SUCCESS(s2n_config_free(config));
+            }
         }
     }
 

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -27,13 +27,13 @@
 #include "tls/s2n_crypto.h"
 #include "tls/s2n_handshake.h"
 #include "tls/s2n_prf.h"
+#include "tls/s2n_quic_support.h"
 #include "tls/s2n_tls_parameters.h"
 #include "tls/s2n_x509_validator.h"
 #include "tls/s2n_key_update.h"
 #include "tls/s2n_kem_preferences.h"
 #include "tls/s2n_ecc_preferences.h"
 #include "tls/s2n_security_policies.h"
-
 
 #include "crypto/s2n_hash.h"
 #include "crypto/s2n_hmac.h"
@@ -60,6 +60,10 @@ struct s2n_connection {
 
     /* The user defined context associated with connection */
     void *context;
+
+    /* The user defined secret callback and context */
+    s2n_secret_cb secret_cb;
+    void *secret_cb_context;
 
     /* The send and receive callbacks don't have to be the same (e.g. two pipes) */
     s2n_send_fn *send;

--- a/tls/s2n_quic_support.c
+++ b/tls/s2n_quic_support.c
@@ -67,6 +67,17 @@ int s2n_connection_get_quic_transport_parameters(struct s2n_connection *conn,
     return S2N_SUCCESS;
 }
 
+int s2n_connection_set_secret_callback(struct s2n_connection *conn, s2n_secret_cb cb_func, void *ctx)
+{
+    notnull_check(conn);
+    notnull_check(cb_func);
+
+    conn->secret_cb = cb_func;
+    conn->secret_cb_context = ctx;
+
+    return S2N_SUCCESS;
+}
+
 /* When using QUIC, S2N reads unencrypted handshake messages instead of encrypted records.
  * This method sets up the S2N input buffers to match the results of using s2n_read_full_record.
  */

--- a/tls/s2n_quic_support.h
+++ b/tls/s2n_quic_support.h
@@ -47,3 +47,30 @@ S2N_API int s2n_connection_set_quic_transport_parameters(struct s2n_connection *
  */
 S2N_API int s2n_connection_get_quic_transport_parameters(struct s2n_connection *conn,
         const uint8_t **data_buffer, uint16_t *data_len);
+
+typedef enum {
+    S2N_CLIENT_EARLY_TRAFFIC_SECRET = 0,
+    S2N_CLIENT_HANDSHAKE_TRAFFIC_SECRET,
+    S2N_SERVER_HANDSHAKE_TRAFFIC_SECRET,
+    S2N_CLIENT_APPLICATION_TRAFFIC_SECRET,
+    S2N_SERVER_APPLICATION_TRAFFIC_SECRET,
+} s2n_secret_type_t;
+
+/*
+ * Called when S2N begins using a new key.
+ *
+ * The memory pointed to by "secret" will be wiped after this method returns and should be copied by
+ * the application if necessary. The application should also be very careful managing the memory and
+ * lifespan of the secret: if the secret is compromised, TLS is compromised.
+ */
+typedef int (*s2n_secret_cb) (void* context, struct s2n_connection *conn,
+                              s2n_secret_type_t secret_type,
+                              uint8_t *secret, uint8_t secret_size);
+
+/*
+ * Set the function to be called when S2N begins using a new key.
+ *
+ * The callback function will ONLY be triggered if QUIC is enabled. This API is not intended to be
+ * used outside of a QUIC implementation.
+ */
+int s2n_connection_set_secret_callback(struct s2n_connection *conn, s2n_secret_cb cb_func, void *ctx);


### PR DESCRIPTION
### Resolved issues:

https://github.com/awslabs/s2n/issues/2277

### Description of changes: 

Adds the secret callbacks required by QUIC to extract S2N's secrets.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Unit tests

 Is this a refactor change?  No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
