### PR TITLE
Fix edge cases with buffer write in both s2nc and the java client.

### DIFF
--- a/bin/echo.c
+++ b/bin/echo.c
@@ -165,9 +165,7 @@ int echo(struct s2n_connection *conn, int sockfd)
                 s2n_errno = S2N_ERR_T_OK;
                 bytes_read = s2n_recv(conn, buffer, STDIO_BUFSIZE, &blocked);
                 if (bytes_read == 0) {
-                    if (blocked == S2N_NOT_BLOCKED) {
-                        return 0;
-                    }
+                    return 0;
                 }
                 if (bytes_read < 0) {
                     if (s2n_error_get_type(s2n_errno) == S2N_ERR_T_BLOCKED) {
@@ -235,7 +233,7 @@ int echo(struct s2n_connection *conn, int sockfd)
                                 S2N_ERROR_PRESERVE_ERRNO();
                             }
                         } else {
-                            // Don't modify the counts if we were blocked from sending
+                            // Only modify the counts if we successfully wrote the data
                             bytes_read -= bytes_written;
                             buf_ptr += bytes_written;
                         }

--- a/tests/integrationv2/bin/SSLSocketClient.java
+++ b/tests/integrationv2/bin/SSLSocketClient.java
@@ -37,8 +37,11 @@ public class SSLSocketClient {
             socket.startHandshake();
             System.out.println("Starting handshake");
 
-            while (stdIn.read(buffer) != -1) {
-                out.write(buffer);
+            while (true) {
+                int read = stdIn.read(buffer);
+                if (read == -1)
+                    break;
+                out.write(buffer, 0, read);
             }
             out.flush();
 


### PR DESCRIPTION
This fixes a few intermittent errors with larger tests.

### Resolved issues:

 resolves #2366

### Description of changes: 

Java integv2 tests were failing when an edge case occurred where 0 bytes were read successfully from stdin, and the previous contents of the buffer were written to the socket.

While finding that issue, an off-by-one error was found in s2nc. If the socket write blocked, s2c added -1 to the buffer position, causing a single byte to be written twice.

### Testing:

Just running all the tests sooo many times with very large buffer sizes to increase the frequency of the error.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
