### PR TITLE
Add S2N_RESULT to a couple functions.

### DIFF
--- a/tests/sidetrail/working/s2n-record-read-aead/Makefile
+++ b/tests/sidetrail/working/s2n-record-read-aead/Makefile
@@ -20,6 +20,7 @@ extras += utils/s2n_blob.c
 extras += utils/s2n_ensure.c
 extras += utils/s2n_mem.c
 extras += utils/s2n_safety.c
+extras += utils/s2n_result.c
 goals  += s2n_record_parse_wrapper@s2n_record_read_wrapper.c
 #goals += test_leakage@s2n_record_read_wrapper.c
 full_self_comp += true

--- a/tests/sidetrail/working/s2n-record-read-aead/copy_as_needed.sh
+++ b/tests/sidetrail/working/s2n-record-read-aead/copy_as_needed.sh
@@ -50,6 +50,8 @@ cp s2n_annotations.h utils/
 cp $S2N_BASE/utils/s2n_blob.c utils/
 cp $S2N_BASE/utils/s2n_safety.c utils/
 cp $S2N_BASE/utils/s2n_safety.h utils/
+cp $S2N_BASE/utils/s2n_result.c utils/
+cp $S2N_BASE/utils/s2n_result.h utils/
 cp ../stubs/s2n_mem.c utils/
 patch -p1 < ../patches/safety.patch
 

--- a/tests/unit/s2n_tls13_record_aead_test.c
+++ b/tests/unit/s2n_tls13_record_aead_test.c
@@ -104,28 +104,28 @@ int main(int argc, char **argv)
         s2n_stack_blob(aad, S2N_TLS13_AAD_LEN, S2N_TLS13_AAD_LEN);
         struct s2n_stuffer associated_data_stuffer;
         EXPECT_SUCCESS(s2n_stuffer_init(&associated_data_stuffer, &aad));
-        EXPECT_SUCCESS(s2n_tls13_aead_aad_init(662, 12, &associated_data_stuffer));
+        EXPECT_OK(s2n_tls13_aead_aad_init(662, 12, &associated_data_stuffer));
         S2N_BLOB_FROM_HEX(expected_aad, "17030302a2");
         S2N_BLOB_EXPECT_EQUAL(expected_aad, aad);
 
         /* record length 16640 should be valid */
         EXPECT_SUCCESS(s2n_stuffer_rewrite(&associated_data_stuffer));
-        EXPECT_SUCCESS(s2n_tls13_aead_aad_init(16628, 12, &associated_data_stuffer));
+        EXPECT_OK(s2n_tls13_aead_aad_init(16628, 12, &associated_data_stuffer));
 
         /* record length 16641 should be invalid */
         EXPECT_SUCCESS(s2n_stuffer_rewrite(&associated_data_stuffer));
-        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_aead_aad_init(16629, 12, &associated_data_stuffer), S2N_ERR_RECORD_LIMIT);
+        EXPECT_ERROR_WITH_ERRNO(s2n_tls13_aead_aad_init(16629, 12, &associated_data_stuffer), S2N_ERR_RECORD_LIMIT);
 
         /* Test failure case: No AAD should be invalid */
         EXPECT_SUCCESS(s2n_stuffer_rewrite(&associated_data_stuffer));
-        EXPECT_FAILURE(s2n_tls13_aead_aad_init(16629, 12, NULL));
+        EXPECT_ERROR(s2n_tls13_aead_aad_init(16629, 12, NULL));
 
         /* Test failure case: 0-length tag should be invalid */
         EXPECT_SUCCESS(s2n_stuffer_rewrite(&associated_data_stuffer));
-        EXPECT_FAILURE(s2n_tls13_aead_aad_init(16628, 0, &associated_data_stuffer));
+        EXPECT_ERROR(s2n_tls13_aead_aad_init(16628, 0, &associated_data_stuffer));
 
         /* Test failure case: invalid record length (-1) should be invalid */
-        EXPECT_FAILURE(s2n_tls13_aead_aad_init(-1, 0, &associated_data_stuffer));
+        EXPECT_ERROR(s2n_tls13_aead_aad_init(-1, 0, &associated_data_stuffer));
     }
 
     /* Test s2n_tls13_aes_128_gcm_sha256 cipher suite with TLS 1.3 test vectors */

--- a/tls/s2n_record.h
+++ b/tls/s2n_record.h
@@ -30,5 +30,5 @@ extern int s2n_record_header_parse(struct s2n_connection *conn, uint8_t * conten
 extern int s2n_tls13_parse_record_type(struct s2n_stuffer *stuffer, uint8_t * record_type);
 extern int s2n_sslv2_record_header_parse(struct s2n_connection *conn, uint8_t * record_type, uint8_t * client_protocol_version, uint16_t * fragment_length);
 extern int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, struct s2n_blob *decrypted);
-extern int s2n_aead_aad_init(const struct s2n_connection *conn, uint8_t * sequence_number, uint8_t content_type, uint16_t record_length, struct s2n_stuffer *ad);
-extern int s2n_tls13_aead_aad_init(uint16_t record_length, uint8_t tag_length, struct s2n_stuffer *ad);
+extern S2N_RESULT s2n_aead_aad_init(const struct s2n_connection *conn, uint8_t * sequence_number, uint8_t content_type, uint16_t record_length, struct s2n_stuffer *ad);
+extern S2N_RESULT s2n_tls13_aead_aad_init(uint16_t record_length, uint8_t tag_length, struct s2n_stuffer *ad);

--- a/tls/s2n_record_read_aead.c
+++ b/tls/s2n_record_read_aead.c
@@ -91,9 +91,9 @@ int s2n_record_parse_aead(
     GUARD(s2n_stuffer_init(&ad_stuffer, &aad));
 
     if (is_tls13_record) {
-        GUARD(s2n_tls13_aead_aad_init(payload_length, cipher_suite->record_alg->cipher->io.aead.tag_size, &ad_stuffer));
+        GUARD_AS_POSIX(s2n_tls13_aead_aad_init(payload_length, cipher_suite->record_alg->cipher->io.aead.tag_size, &ad_stuffer));
     } else {
-        GUARD(s2n_aead_aad_init(conn, sequence_number, content_type, payload_length, &ad_stuffer));
+        GUARD_AS_POSIX(s2n_aead_aad_init(conn, sequence_number, content_type, payload_length, &ad_stuffer));
     }
 
     /* Decrypt stuff! */

--- a/tls/s2n_record_write.c
+++ b/tls/s2n_record_write.c
@@ -327,9 +327,9 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
         struct s2n_stuffer ad_stuffer = {0};
         GUARD(s2n_stuffer_init(&ad_stuffer, &aad));
         if (is_tls13_record) {
-            GUARD(s2n_tls13_aead_aad_init(data_bytes_to_take + TLS13_CONTENT_TYPE_LENGTH, cipher_suite->record_alg->cipher->io.aead.tag_size, &ad_stuffer));
+            GUARD_AS_POSIX(s2n_tls13_aead_aad_init(data_bytes_to_take + TLS13_CONTENT_TYPE_LENGTH, cipher_suite->record_alg->cipher->io.aead.tag_size, &ad_stuffer));
         } else {
-            GUARD(s2n_aead_aad_init(conn, sequence_number, content_type, data_bytes_to_take, &ad_stuffer));
+            GUARD_AS_POSIX(s2n_aead_aad_init(conn, sequence_number, content_type, data_bytes_to_take, &ad_stuffer));
         }
     } else if (cipher_suite->record_alg->cipher->type == S2N_CBC || cipher_suite->record_alg->cipher->type == S2N_COMPOSITE) {
         s2n_blob_init(&iv, implicit_iv, block_size);


### PR DESCRIPTION
### Description of changes: 

On going ops work to move to the `S2N_RESULT` pattern.


### Testing:

This is a refactor change. Testing includes local test runs and the standard CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
