### PR TITLE
Remove hash state from s2n_map

### DIFF
--- a/utils/s2n_map.c
+++ b/utils/s2n_map.c
@@ -38,13 +38,11 @@ static S2N_RESULT s2n_map_slot(const struct s2n_map *map, struct s2n_blob *key, 
         uint32_t u32[8];
     } digest;
 
-    struct s2n_hash_state sha256;
-
+    DEFER_CLEANUP(struct s2n_hash_state sha256 = {0}, s2n_hash_free);
     GUARD_AS_RESULT(s2n_hash_new(&sha256));
     GUARD_AS_RESULT(s2n_hash_init(&sha256, S2N_HASH_SHA256));
     GUARD_AS_RESULT(s2n_hash_update(&sha256, key->data, key->size));
     GUARD_AS_RESULT(s2n_hash_digest(&sha256, digest.u8, sizeof(digest)));
-    GUARD_AS_RESULT(s2n_hash_free(&sha256));
 
     *slot = digest.u32[0] % map->capacity;
     return S2N_RESULT_OK;

--- a/utils/s2n_map.c
+++ b/utils/s2n_map.c
@@ -31,17 +31,20 @@
 
 #define S2N_INITIAL_TABLE_SIZE 1024
 
-static S2N_RESULT s2n_map_slot(struct s2n_map *map, struct s2n_blob *key, uint32_t *slot)
+static S2N_RESULT s2n_map_slot(const struct s2n_map *map, struct s2n_blob *key, uint32_t *slot)
 {
     union {
         uint8_t u8[32];
         uint32_t u32[8];
     } digest;
 
-    GUARD_AS_RESULT(s2n_hash_update(&map->sha256, key->data, key->size));
-    GUARD_AS_RESULT(s2n_hash_digest(&map->sha256, digest.u8, sizeof(digest)));
+    struct s2n_hash_state sha256;
 
-    GUARD_AS_RESULT(s2n_hash_reset(&map->sha256));
+    GUARD_AS_RESULT(s2n_hash_new(&sha256));
+    GUARD_AS_RESULT(s2n_hash_init(&sha256, S2N_HASH_SHA256));
+    GUARD_AS_RESULT(s2n_hash_update(&sha256, key->data, key->size));
+    GUARD_AS_RESULT(s2n_hash_digest(&sha256, digest.u8, sizeof(digest)));
+    GUARD_AS_RESULT(s2n_hash_free(&sha256));
 
     *slot = digest.u32[0] % map->capacity;
     return S2N_RESULT_OK;
@@ -61,7 +64,6 @@ static S2N_RESULT s2n_map_embiggen(struct s2n_map *map, uint32_t capacity)
     tmp.size = 0;
     tmp.table = (void *) mem.data;
     tmp.immutable = 0;
-    tmp.sha256 = map->sha256;
 
     for (int i = 0; i < map->capacity; i++) {
         if (map->table[i].key.size) {
@@ -77,7 +79,6 @@ static S2N_RESULT s2n_map_embiggen(struct s2n_map *map, uint32_t capacity)
     map->size = tmp.size;
     map->table = tmp.table;
     map->immutable = 0;
-    map->sha256 = tmp.sha256;
 
     return S2N_RESULT_OK;
 }
@@ -100,9 +101,6 @@ struct s2n_map *s2n_map_new_with_initial_capacity(uint32_t capacity)
     map->size = 0;
     map->immutable = 0;
     map->table = NULL;
-
-    GUARD_POSIX_PTR(s2n_hash_new(&map->sha256));
-    GUARD_POSIX_PTR(s2n_hash_init(&map->sha256, S2N_HASH_SHA256));
 
     GUARD_RESULT_PTR(s2n_map_embiggen(map, capacity));
 
@@ -190,7 +188,7 @@ S2N_RESULT s2n_map_unlock(struct s2n_map *map)
     return S2N_RESULT_OK;
 }
 
-S2N_RESULT s2n_map_lookup(struct s2n_map *map, struct s2n_blob *key, struct s2n_blob *value, bool *key_found)
+S2N_RESULT s2n_map_lookup(const struct s2n_map *map, struct s2n_blob *key, struct s2n_blob *value, bool *key_found)
 {
     ENSURE(map->immutable, S2N_ERR_MAP_MUTABLE);
 
@@ -233,8 +231,6 @@ S2N_RESULT s2n_map_free(struct s2n_map *map)
             GUARD_AS_RESULT(s2n_free(&map->table[i].value));
         }
     }
-
-    GUARD_AS_RESULT(s2n_hash_free(&map->sha256));
 
     /* Free the table */
     GUARD_AS_RESULT(s2n_free_object((uint8_t **)&map->table, map->capacity * sizeof(struct s2n_map_entry)));

--- a/utils/s2n_map.h
+++ b/utils/s2n_map.h
@@ -29,5 +29,5 @@ extern S2N_RESULT s2n_map_add(struct s2n_map *map, struct s2n_blob *key, struct 
 extern S2N_RESULT s2n_map_put(struct s2n_map *map, struct s2n_blob *key, struct s2n_blob *value);
 extern S2N_RESULT s2n_map_complete(struct s2n_map *map);
 extern S2N_RESULT s2n_map_unlock(struct s2n_map *map);
-extern S2N_RESULT s2n_map_lookup(struct s2n_map *map, struct s2n_blob *key, struct s2n_blob *value, bool *key_found);
+extern S2N_RESULT s2n_map_lookup(const struct s2n_map *map, struct s2n_blob *key, struct s2n_blob *value, bool *key_found);
 extern S2N_RESULT s2n_map_free(struct s2n_map *map);

--- a/utils/s2n_map_internal.h
+++ b/utils/s2n_map_internal.h
@@ -33,6 +33,4 @@ struct s2n_map {
 
     /* Pointer to the hash-table, should be capacity * sizeof(struct s2n_map_entry) */
     struct s2n_map_entry *table;
-
-    struct s2n_hash_state sha256;
 };


### PR DESCRIPTION
### Description of changes: 

This change removes the map local sha256 state in s2n_map

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
