### PR TITLE
Update well known endpoint test with new PQ KMS ciphers

### DIFF
--- a/tests/integrationv2/common.py
+++ b/tests/integrationv2/common.py
@@ -239,6 +239,11 @@ class Ciphers(object):
     PQ_SIKE_TEST_TLS_1_0_2020_02 = Cipher("PQ-SIKE-TEST-TLS-1-0-2020-02", Protocols.TLS10, False, False)
 
 
+TLS12_PQ_CIPHER_PREFS = [Ciphers.KMS_PQ_TLS_1_0_2019_06, Ciphers.PQ_SIKE_TEST_TLS_1_0_2019_11,
+                         Ciphers.KMS_PQ_TLS_1_0_2020_07, Ciphers.KMS_PQ_TLS_1_0_2020_02,
+                         Ciphers.PQ_SIKE_TEST_TLS_1_0_2020_02]
+
+
 class Curve(object):
     def __init__(self, name, min_protocol=Protocols.SSLv3):
         self.name = name

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -1,7 +1,7 @@
 import pytest
 import threading
 
-from common import ProviderOptions, Ciphers, Curves, Protocols, Certificates
+from common import ProviderOptions, Ciphers, Curves, Protocols, Certificates, TLS12_PQ_CIPHER_PREFS
 from global_flags import get_flag, S2N_PROVIDER_VERSION
 
 
@@ -113,9 +113,6 @@ class S2N(Provider):
     """
     def __init__(self, options: ProviderOptions):
         self.ready_to_send_input_marker = None
-        self.tls12_pq_cipher_prefs = [Ciphers.KMS_PQ_TLS_1_0_2019_06, Ciphers.PQ_SIKE_TEST_TLS_1_0_2019_11,
-                                      Ciphers.KMS_PQ_TLS_1_0_2020_07, Ciphers.KMS_PQ_TLS_1_0_2020_02,
-                                      Ciphers.PQ_SIKE_TEST_TLS_1_0_2020_02]
         Provider.__init__(self, options)
 
     @classmethod
@@ -162,7 +159,7 @@ class S2N(Provider):
         cipher_prefs = 'test_all_tls12'
         if self.options.protocol is Protocols.TLS13:
             cipher_prefs = 'test_all'
-        if self.options.cipher in self.tls12_pq_cipher_prefs:
+        if self.options.cipher in TLS12_PQ_CIPHER_PREFS:
             cipher_prefs = self.options.cipher.name
 
         cmd_line.extend(['-c', cipher_prefs])

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -157,12 +157,15 @@ class S2N(Provider):
             cmd_line.append('-r')
 
         cipher_prefs = 'test_all_tls12'
-        if self.options.cipher is Ciphers.KMS_PQ_TLS_1_0_2019_06:
-            cipher_prefs = 'KMS-PQ-TLS-1-0-2019-06'
-        elif self.options.cipher is Ciphers.PQ_SIKE_TEST_TLS_1_0_2019_11:
-            cipher_prefs = 'PQ-SIKE-TEST-TLS-1-0-2019-11'
-        elif self.options.protocol is Protocols.TLS13:
+        if self.options.protocol is Protocols.TLS13:
             cipher_prefs = 'test_all'
+
+        if self.options.cipher is Ciphers.KMS_PQ_TLS_1_0_2019_06 or \
+                self.options.cipher is Ciphers.PQ_SIKE_TEST_TLS_1_0_2019_11 or \
+                self.options.cipher is Ciphers.KMS_PQ_TLS_1_0_2020_07 or \
+                self.options.cipher is Ciphers.KMS_PQ_TLS_1_0_2020_02 or \
+                self.options.cipher is Ciphers.PQ_SIKE_TEST_TLS_1_0_2020_02:
+            cipher_prefs = self.options.cipher.name
 
         cmd_line.extend(['-c', cipher_prefs])
 

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -113,6 +113,9 @@ class S2N(Provider):
     """
     def __init__(self, options: ProviderOptions):
         self.ready_to_send_input_marker = None
+        self.tls12_pq_cipher_prefs = [Ciphers.KMS_PQ_TLS_1_0_2019_06, Ciphers.PQ_SIKE_TEST_TLS_1_0_2019_11,
+                                      Ciphers.KMS_PQ_TLS_1_0_2020_07, Ciphers.KMS_PQ_TLS_1_0_2020_02,
+                                      Ciphers.PQ_SIKE_TEST_TLS_1_0_2020_02]
         Provider.__init__(self, options)
 
     @classmethod
@@ -159,12 +162,7 @@ class S2N(Provider):
         cipher_prefs = 'test_all_tls12'
         if self.options.protocol is Protocols.TLS13:
             cipher_prefs = 'test_all'
-
-        if self.options.cipher is Ciphers.KMS_PQ_TLS_1_0_2019_06 or \
-                self.options.cipher is Ciphers.PQ_SIKE_TEST_TLS_1_0_2019_11 or \
-                self.options.cipher is Ciphers.KMS_PQ_TLS_1_0_2020_07 or \
-                self.options.cipher is Ciphers.KMS_PQ_TLS_1_0_2020_02 or \
-                self.options.cipher is Ciphers.PQ_SIKE_TEST_TLS_1_0_2020_02:
+        if self.options.cipher in self.tls12_pq_cipher_prefs:
             cipher_prefs = self.options.cipher.name
 
         cmd_line.extend(['-c', cipher_prefs])

--- a/tests/integrationv2/test_well_known_endpoints.py
+++ b/tests/integrationv2/test_well_known_endpoints.py
@@ -29,13 +29,33 @@ if get_flag(S2N_NO_PQ, False) is False:
         {
             "endpoint": "kms.us-east-1.amazonaws.com",
             "cipher_preference_version": Ciphers.KMS_PQ_TLS_1_0_2019_06,
-            "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384"
+            "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384",
+            "expected_kem": "BIKE1r1-Level1",
         },
         {
             "endpoint": "kms.us-east-1.amazonaws.com",
             "cipher_preference_version": Ciphers.PQ_SIKE_TEST_TLS_1_0_2019_11,
-            "expected_cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384"
-        }
+            "expected_cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384",
+            "expected_kem": "SIKEp503r1-KEM",
+        },
+        {
+            "endpoint": "kms.us-east-1.amazonaws.com",
+            "cipher_preference_version": Ciphers.KMS_PQ_TLS_1_0_2020_07,
+            "expected_cipher": "ECDHE-KYBER-RSA-AES256-GCM-SHA384",
+            "expected_kem": "kyber512r2",
+        },
+        {
+            "endpoint": "kms.us-east-1.amazonaws.com",
+            "cipher_preference_version": Ciphers.KMS_PQ_TLS_1_0_2020_02,
+            "expected_cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384",
+            "expected_kem": "BIKE1r2-Level1",
+        },
+        {
+            "endpoint": "kms.us-east-1.amazonaws.com",
+            "cipher_preference_version": Ciphers.PQ_SIKE_TEST_TLS_1_0_2020_02,
+            "expected_cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384",
+            "expected_kem": "SIKEp434r2-KEM",
+        },
     ]
 
     ENDPOINTS.extend(pq_endpoints)
@@ -71,3 +91,6 @@ def test_well_known_endpoints(managed_process, protocol, endpoint):
 
         if 'expected_cipher' in endpoint:
             assert bytes(endpoint['expected_cipher'].encode('utf-8')) in results.stdout
+
+        if 'expected_kem' in endpoint:
+            assert bytes(endpoint['expected_kem'].encode('utf-8')) in results.stdout


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

Now that [round 2 PQ ciphers are available in KMS](https://aws.amazon.com/blogs/security/round-2-post-quantum-tls-is-now-supported-in-aws-kms/), this updates the well known endpoint test to test for them.

### Call-outs:

N/A

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

* This is a test!

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

* Not a refactor.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
