### PR TITLE
Add psk binder functions

### DIFF
--- a/crypto/s2n_tls13_keys.c
+++ b/crypto/s2n_tls13_keys.c
@@ -140,7 +140,7 @@ int s2n_tls13_keys_free(struct s2n_tls13_keys *keys) {
 /*
  * Derives binder_key from PSK.
  */
-int s2n_tls13_derive_binder_key_secret(struct s2n_tls13_keys *keys, struct s2n_psk *psk)
+int s2n_tls13_derive_binder_key(struct s2n_tls13_keys *keys, struct s2n_psk *psk)
 {
     notnull_check(keys);
     notnull_check(psk);

--- a/crypto/s2n_tls13_keys.h
+++ b/crypto/s2n_tls13_keys.h
@@ -19,9 +19,9 @@
 
 #include "crypto/s2n_hmac.h"
 #include "crypto/s2n_hkdf.h"
-#include "crypto/s2n_tls13_keys.h"
 #include "stuffer/s2n_stuffer.h"
 #include "tls/s2n_tls_parameters.h"
+#include "tls/s2n_psk.h"
 #include "utils/s2n_blob.h"
 #include "utils/s2n_safety.h"
 #include "utils/s2n_mem.h"
@@ -73,6 +73,7 @@ extern const struct s2n_blob s2n_tls13_label_traffic_secret_iv;
 
 int s2n_tls13_keys_init(struct s2n_tls13_keys *handshake, s2n_hmac_algorithm alg);
 int s2n_tls13_keys_free(struct s2n_tls13_keys *keys);
+int s2n_tls13_derive_binder_key_secret(struct s2n_tls13_keys *keys, struct s2n_psk *psk);
 int s2n_tls13_derive_early_secrets(struct s2n_tls13_keys *handshake);
 int s2n_tls13_derive_handshake_secrets(struct s2n_tls13_keys *handshake,
                                         const struct s2n_blob *ecdhe,

--- a/crypto/s2n_tls13_keys.h
+++ b/crypto/s2n_tls13_keys.h
@@ -73,7 +73,7 @@ extern const struct s2n_blob s2n_tls13_label_traffic_secret_iv;
 
 int s2n_tls13_keys_init(struct s2n_tls13_keys *handshake, s2n_hmac_algorithm alg);
 int s2n_tls13_keys_free(struct s2n_tls13_keys *keys);
-int s2n_tls13_derive_binder_key_secret(struct s2n_tls13_keys *keys, struct s2n_psk *psk);
+int s2n_tls13_derive_binder_key(struct s2n_tls13_keys *keys, struct s2n_psk *psk);
 int s2n_tls13_derive_early_secrets(struct s2n_tls13_keys *handshake);
 int s2n_tls13_derive_handshake_secrets(struct s2n_tls13_keys *handshake,
                                         const struct s2n_blob *ecdhe,

--- a/tests/unit/s2n_psk_test.c
+++ b/tests/unit/s2n_psk_test.c
@@ -1,0 +1,203 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+
+#include "tls/s2n_psk.h"
+
+#define TEST_VALUE_1 "test value"
+#define TEST_VALUE_2 "another"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Test s2n_psk_init */
+    {
+        DEFER_CLEANUP(struct s2n_psk psk, s2n_psk_free);
+
+        EXPECT_SUCCESS(s2n_psk_init(&psk, S2N_PSK_TYPE_EXTERNAL));
+        EXPECT_EQUAL(psk.type, S2N_PSK_TYPE_EXTERNAL);
+        EXPECT_EQUAL(psk.hash_alg, S2N_HASH_SHA256);
+        EXPECT_EQUAL(psk.obfuscated_ticket_age, 0);
+
+        EXPECT_SUCCESS(s2n_psk_init(&psk, S2N_PSK_TYPE_RESUMPTION));
+        EXPECT_EQUAL(psk.type, S2N_PSK_TYPE_RESUMPTION);
+        EXPECT_EQUAL(psk.hash_alg, S2N_HASH_SHA256);
+        EXPECT_EQUAL(psk.obfuscated_ticket_age, 0);
+    }
+
+    /* Test s2n_psk_new_identity */
+    {
+        DEFER_CLEANUP(struct s2n_psk psk, s2n_psk_free);
+        EXPECT_SUCCESS(s2n_psk_init(&psk, S2N_PSK_TYPE_EXTERNAL));
+
+        uint8_t test_value_1[] = TEST_VALUE_1;
+
+        EXPECT_SUCCESS(s2n_psk_new_identity(&psk, test_value_1, sizeof(test_value_1)));
+        EXPECT_EQUAL(psk.identity.size, sizeof(TEST_VALUE_1));
+        EXPECT_BYTEARRAY_EQUAL(psk.identity.data, TEST_VALUE_1, sizeof(TEST_VALUE_1));
+
+        /* source can be modified without affecting psk */
+        test_value_1[0] = 'A';
+        EXPECT_BYTEARRAY_EQUAL(psk.identity.data, TEST_VALUE_1, sizeof(TEST_VALUE_1));
+
+        /* method can be called again to replace identity */
+        uint8_t test_value_2[] = TEST_VALUE_2;
+        EXPECT_SUCCESS(s2n_psk_new_identity(&psk, test_value_2, sizeof(test_value_2)));
+        EXPECT_EQUAL(psk.identity.size, sizeof(TEST_VALUE_2));
+        EXPECT_BYTEARRAY_EQUAL(psk.identity.data, TEST_VALUE_2, sizeof(TEST_VALUE_2));
+    }
+
+    /* Test s2n_psk_new_secret */
+    {
+        DEFER_CLEANUP(struct s2n_psk psk, s2n_psk_free);
+        EXPECT_SUCCESS(s2n_psk_init(&psk, S2N_PSK_TYPE_EXTERNAL));
+
+        uint8_t test_value_1[] = TEST_VALUE_1;
+
+        EXPECT_SUCCESS(s2n_psk_new_secret(&psk, test_value_1, sizeof(test_value_1)));
+        EXPECT_EQUAL(psk.secret.size, sizeof(TEST_VALUE_1));
+        EXPECT_BYTEARRAY_EQUAL(psk.secret.data, TEST_VALUE_1, sizeof(TEST_VALUE_1));
+
+        /* source identity can be modified without affecting psk */
+        test_value_1[0] = 'A';
+        EXPECT_BYTEARRAY_EQUAL(psk.secret.data, TEST_VALUE_1, sizeof(TEST_VALUE_1));
+
+        /* method can be called again to replace secret */
+        uint8_t test_value_2[] = TEST_VALUE_2;
+        EXPECT_SUCCESS(s2n_psk_new_secret(&psk, test_value_2, sizeof(test_value_2)));
+        EXPECT_EQUAL(psk.secret.size, sizeof(TEST_VALUE_2));
+        EXPECT_BYTEARRAY_EQUAL(psk.secret.data, TEST_VALUE_2, sizeof(TEST_VALUE_2));
+    }
+
+    /* Test s2n_psk_free */
+    {
+        const uint8_t test_value[] = TEST_VALUE_1;
+        struct s2n_psk psk;
+        EXPECT_SUCCESS(s2n_psk_init(&psk, S2N_PSK_TYPE_EXTERNAL));
+
+        /* No-op if blobs not allocated yet */
+        EXPECT_SUCCESS(s2n_psk_free(&psk));
+
+        EXPECT_SUCCESS(s2n_psk_new_identity(&psk, test_value, sizeof(test_value)));
+        EXPECT_NOT_EQUAL(psk.identity.size, 0);
+        EXPECT_SUCCESS(s2n_psk_new_secret(&psk, test_value, sizeof(test_value)));
+        EXPECT_NOT_EQUAL(psk.secret.size, 0);
+        EXPECT_SUCCESS(s2n_alloc(&psk.early_secret, sizeof(test_value)));
+        EXPECT_NOT_EQUAL(psk.early_secret.size, 0);
+
+        /* Frees all blobs */
+        EXPECT_SUCCESS(s2n_psk_free(&psk));
+        EXPECT_EQUAL(psk.identity.size, 0);
+        EXPECT_EQUAL(psk.secret.size, 0);
+        EXPECT_EQUAL(psk.early_secret.size, 0);
+
+        /* No-op if already freed */
+        EXPECT_SUCCESS(s2n_psk_free(&psk));
+    }
+
+    /* Test binder calculations with known values */
+    {
+        /* Test Vectors from https://tools.ietf.org/html/rfc8448#section-4 */
+        S2N_BLOB_FROM_HEX(client_hello_prefix,
+            "010001fc03031bc3ceb6bbe39cff938355b5a50adb6db21b7a6af649d7b4bc419d"
+            "7876487d95000006130113031302010001cd0000000b0009000006736572766572"
+            "ff01000100000a00140012001d0017001800190100010101020103010400330026"
+            "0024001d0020e4ffb68ac05f8d96c99da26698346c6be16482badddafe051a66b4"
+            "f18d668f0b002a0000002b0003020304000d0020001e0403050306030203080408"
+            "05080604010501060102010402050206020202002d00020101001c000240010015"
+            "005700000000000000000000000000000000000000000000000000000000000000"
+            "000000000000000000000000000000000000000000000000000000000000000000"
+            "0000000000000000000000000000000000000000000000002900dd00b800b22c03"
+            "5d829359ee5ff7af4ec900000000262a6494dc486d2c8a34cb33fa90bf1b0070ad"
+            "3c498883c9367c09a2be785abc55cd226097a3a982117283f82a03a143efd3ff5d"
+            "d36d64e861be7fd61d2827db279cce145077d454a3664d4e6da4d29ee03725a6a4"
+            "dafcd0fc67d2aea70529513e3da2677fa5906c5b3f7d8f92f228bda40dda721470"
+            "f9fbf297b5aea617646fac5c03272e970727c621a79141ef5f7de6505e5bfbc388"
+            "e93343694093934ae4d357fad6aacb");
+        S2N_BLOB_FROM_HEX(resumption_secret,
+            "4ecd0eb6ec3b4d87f5d6028f922ca4c5851a277fd41311c9e62d2c9492e1c4f3");
+        S2N_BLOB_FROM_HEX(binder_hash,
+            "63224b2e4573f2d3454ca84b9d009a04f6be9e05711a8396473aefa01e924a14");
+        S2N_BLOB_FROM_HEX(early_secret,
+            "9b2188e9b2fc6d64d71dc329900e20bb41915000f678aa839cbb797cb7d8332c");
+        S2N_BLOB_FROM_HEX(finished_binder,
+            "3add4fb2d8fdf822a0ca3cf7678ef5e88dae990141c5924d57bb6fa31b9e5f9d");
+
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+        /* Test s2n_psk_calculate_binder_hash with known values */
+        {
+            struct s2n_blob hash_value;
+            uint8_t hash_value_data[SHA256_DIGEST_LENGTH];
+            EXPECT_SUCCESS(s2n_blob_init(&hash_value, hash_value_data, sizeof(hash_value_data)));
+
+            EXPECT_SUCCESS(s2n_psk_calculate_binder_hash(conn, S2N_HASH_SHA256, &client_hello_prefix, &hash_value));
+            S2N_BLOB_EXPECT_EQUAL(hash_value, binder_hash);
+        }
+
+        /* Test s2n_psk_calculate_binder with known values */
+        {
+            DEFER_CLEANUP(struct s2n_psk test_psk, s2n_psk_free);
+            EXPECT_SUCCESS(s2n_psk_init(&test_psk, S2N_PSK_TYPE_RESUMPTION));
+            EXPECT_SUCCESS(s2n_psk_new_secret(&test_psk, resumption_secret.data, resumption_secret.size));
+
+            struct s2n_blob binder_value;
+            uint8_t binder_value_data[SHA256_DIGEST_LENGTH];
+            EXPECT_SUCCESS(s2n_blob_init(&binder_value, binder_value_data, sizeof(binder_value_data)));
+
+            EXPECT_SUCCESS(s2n_psk_calculate_binder(&test_psk, &binder_hash, &binder_value));
+            S2N_BLOB_EXPECT_EQUAL(test_psk.early_secret, early_secret);
+            S2N_BLOB_EXPECT_EQUAL(binder_value, finished_binder);
+        }
+
+        /* Test s2n_psk_verify_binder with known values */
+        {
+            DEFER_CLEANUP(struct s2n_psk test_psk, s2n_psk_free);
+            EXPECT_SUCCESS(s2n_psk_init(&test_psk, S2N_PSK_TYPE_RESUMPTION));
+            EXPECT_SUCCESS(s2n_psk_new_secret(&test_psk, resumption_secret.data, resumption_secret.size));
+
+            struct s2n_blob binder_value;
+            uint8_t binder_value_data[SHA256_DIGEST_LENGTH];
+            EXPECT_SUCCESS(s2n_blob_init(&binder_value, binder_value_data, sizeof(binder_value_data)));
+
+            EXPECT_SUCCESS(s2n_psk_verify_binder(conn, &test_psk, &client_hello_prefix, &finished_binder));
+            S2N_BLOB_EXPECT_EQUAL(test_psk.early_secret, early_secret);
+        }
+
+        /* Test s2n_psk_verify_binder with incorrect binder */
+        {
+            DEFER_CLEANUP(struct s2n_psk test_psk, s2n_psk_free);
+            EXPECT_SUCCESS(s2n_psk_init(&test_psk, S2N_PSK_TYPE_RESUMPTION));
+            EXPECT_SUCCESS(s2n_psk_new_secret(&test_psk, resumption_secret.data, resumption_secret.size));
+
+            struct s2n_blob *incorrect_binder_value = &resumption_secret;
+
+            struct s2n_blob binder_value;
+            uint8_t binder_value_data[SHA256_DIGEST_LENGTH];
+            EXPECT_SUCCESS(s2n_blob_init(&binder_value, binder_value_data, sizeof(binder_value_data)));
+
+            EXPECT_FAILURE(s2n_psk_verify_binder(conn, &test_psk, &client_hello_prefix, incorrect_binder_value));
+            S2N_BLOB_EXPECT_EQUAL(test_psk.early_secret, early_secret);
+        }
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    END_TEST();
+}

--- a/tests/unit/s2n_tls13_keys_test.c
+++ b/tests/unit/s2n_tls13_keys_test.c
@@ -298,7 +298,7 @@ int main(int argc, char **argv)
         DEFER_CLEANUP(struct s2n_tls13_keys test_keys, s2n_tls13_keys_free);
         GUARD(s2n_tls13_keys_init(&test_keys, test_psk.hash_alg));
 
-        EXPECT_SUCCESS(s2n_tls13_derive_binder_key_secret(&test_keys, &test_psk));
+        EXPECT_SUCCESS(s2n_tls13_derive_binder_key(&test_keys, &test_psk));
 
         S2N_BLOB_EXPECT_EQUAL(test_keys.extract_secret, expected_resumption_early_secret);
         S2N_BLOB_EXPECT_EQUAL(test_keys.derive_secret, expected_binder_key);

--- a/tls/s2n_handshake.c
+++ b/tls/s2n_handshake.c
@@ -70,6 +70,8 @@ int s2n_handshake_parse_header(struct s2n_connection *conn, uint8_t * message_ty
 
 static int s2n_handshake_get_hash_state_ptr(struct s2n_connection *conn, s2n_hash_algorithm hash_alg, struct s2n_hash_state **hash_state)
 {
+    notnull_check(conn);
+
     switch (hash_alg) {
     case S2N_HASH_MD5:
         *hash_state = &conn->handshake.md5;

--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -126,7 +126,7 @@ int s2n_psk_calculate_binder(struct s2n_psk *psk, const struct s2n_blob *binder_
     GUARD(s2n_blob_init(&psk_keys.extract_secret, psk->early_secret.data, psk_keys.size));
 
     /* Derive the binder key */
-    GUARD(s2n_tls13_derive_binder_key_secret(&psk_keys, psk));
+    GUARD(s2n_tls13_derive_binder_key(&psk_keys, psk));
     struct s2n_blob *binder_key = &psk_keys.derive_secret;
 
     /* Expand the binder key into the finished key */

--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -62,6 +62,9 @@ int s2n_psk_free(struct s2n_psk *psk)
     return S2N_SUCCESS;
 }
 
+/* The binder hash is computed by hashing the concatenation of the current transcript
+ * and a partial ClientHello that does not include the binders themselves.
+ */
 int s2n_psk_calculate_binder_hash(struct s2n_connection *conn, s2n_hash_algorithm hash_alg,
         const struct s2n_blob *partial_client_hello, struct s2n_blob *output_binder_hash)
 {
@@ -101,6 +104,11 @@ static int s2n_tls13_keys_init_with_psk(struct s2n_tls13_keys *keys, struct s2n_
     return S2N_SUCCESS;
 }
 
+/* The binder is computed in the same way as the Finished message
+ * (https://tools.ietf.org/html/rfc8446#section-4.4.4) but with the BaseKey being the binder_key
+ * derived via the key schedule from the corresponding PSK which is being offered
+ * (https://tools.ietf.org/html/rfc8446#section-7.1)
+ */
 int s2n_psk_calculate_binder(struct s2n_psk *psk, const struct s2n_blob *binder_hash,
         struct s2n_blob *output_binder)
 {

--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -1,0 +1,157 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "crypto/s2n_tls13_keys.h"
+#include "tls/s2n_handshake.h"
+#include "tls/s2n_tls13_handshake.h"
+#include "tls/s2n_psk.h"
+#include "utils/s2n_safety.h"
+#include "utils/s2n_mem.h"
+
+int s2n_psk_init(struct s2n_psk *psk, s2n_psk_type type)
+{
+    notnull_check(psk);
+
+    memset_check(psk, 0, sizeof(struct s2n_psk));
+    psk->hash_alg = S2N_HASH_SHA256;
+    psk->type = type;
+
+    return S2N_SUCCESS;
+}
+
+int s2n_psk_new_identity(struct s2n_psk *psk, const uint8_t *identity, size_t identity_size)
+{
+    notnull_check(psk);
+
+    GUARD(s2n_realloc(&psk->identity, identity_size));
+    memcpy_check(psk->identity.data, identity, identity_size);
+
+    return S2N_SUCCESS;
+}
+
+int s2n_psk_new_secret(struct s2n_psk *psk, const uint8_t *secret, size_t secret_size)
+{
+    notnull_check(psk);
+
+    GUARD(s2n_realloc(&psk->secret, secret_size));
+    memcpy_check(psk->secret.data, secret, secret_size);
+
+    return S2N_SUCCESS;
+}
+
+int s2n_psk_free(struct s2n_psk *psk)
+{
+    notnull_check(psk);
+
+    GUARD(s2n_free(&psk->early_secret));
+    GUARD(s2n_free(&psk->identity));
+    GUARD(s2n_free(&psk->secret));
+
+    return S2N_SUCCESS;
+}
+
+int s2n_psk_calculate_binder_hash(struct s2n_connection *conn, s2n_hash_algorithm hash_alg,
+        const struct s2n_blob *partial_client_hello, struct s2n_blob *output_binder_hash)
+{
+    notnull_check(partial_client_hello);
+    notnull_check(output_binder_hash);
+
+    /* Retrieve the current transcript.
+     * The current transcript will be empty unless this handshake included a HelloRetryRequest. */
+    struct s2n_hash_state current_hash_state = {0};
+    GUARD(s2n_handshake_get_hash_state(conn, hash_alg, &current_hash_state));
+
+    /* Copy the current transcript to avoid modifying the original. */
+    DEFER_CLEANUP(struct s2n_hash_state hash_copy, s2n_hash_free);
+    GUARD(s2n_hash_new(&hash_copy));
+    GUARD(s2n_hash_copy(&hash_copy, &current_hash_state));
+
+    /* Add the partial client hello to the transcript. */
+    GUARD(s2n_hash_update(&hash_copy, partial_client_hello->data, partial_client_hello->size));
+
+    /* Get the transcript digest */
+    GUARD(s2n_hash_digest(&hash_copy, output_binder_hash->data, output_binder_hash->size));
+
+    return S2N_SUCCESS;
+}
+
+static int s2n_tls13_keys_init_with_psk(struct s2n_tls13_keys *keys, struct s2n_psk *psk)
+{
+    notnull_check(keys);
+
+    keys->hash_algorithm = psk->hash_alg;
+    GUARD(s2n_hash_hmac_alg(keys->hash_algorithm, &keys->hmac_algorithm));
+    GUARD(s2n_hash_digest_size(keys->hash_algorithm, &keys->size));
+    GUARD(s2n_blob_init(&keys->extract_secret, keys->extract_secret_bytes, keys->size));
+    GUARD(s2n_blob_init(&keys->derive_secret, keys->derive_secret_bytes, keys->size));
+    GUARD(s2n_hmac_new(&keys->hmac));
+
+    return S2N_SUCCESS;
+}
+
+int s2n_psk_calculate_binder(struct s2n_psk *psk, const struct s2n_blob *binder_hash,
+        struct s2n_blob *output_binder)
+{
+    notnull_check(psk);
+    notnull_check(binder_hash);
+    notnull_check(output_binder);
+
+    DEFER_CLEANUP(struct s2n_tls13_keys psk_keys, s2n_tls13_keys_free);
+    GUARD(s2n_tls13_keys_init_with_psk(&psk_keys, psk));
+    eq_check(binder_hash->size, psk_keys.size);
+    eq_check(output_binder->size, psk_keys.size);
+
+    /* Make sure the early secret is saved on the psk structure for later use */
+    GUARD(s2n_alloc(&psk->early_secret, psk_keys.size));
+    GUARD(s2n_blob_init(&psk_keys.extract_secret, psk->early_secret.data, psk_keys.size));
+
+    /* Derive the binder key */
+    GUARD(s2n_tls13_derive_binder_key_secret(&psk_keys, psk));
+    struct s2n_blob *binder_key = &psk_keys.derive_secret;
+
+    /* Expand the binder key into the finished key */
+    s2n_tls13_key_blob(finished_key, psk_keys.size);
+    GUARD(s2n_tls13_derive_finished_key(&psk_keys, binder_key, &finished_key));
+
+    /* HMAC the binder hash with the binder finished key */
+    GUARD(s2n_hkdf_extract(&psk_keys.hmac, psk_keys.hmac_algorithm, &finished_key, binder_hash, output_binder));
+
+    return S2N_SUCCESS;
+}
+
+int s2n_psk_verify_binder(struct s2n_connection *conn, struct s2n_psk *psk,
+        const struct s2n_blob *partial_client_hello, struct s2n_blob *binder_to_verify)
+{
+    notnull_check(psk);
+    notnull_check(binder_to_verify);
+
+    DEFER_CLEANUP(struct s2n_tls13_keys psk_keys, s2n_tls13_keys_free);
+    GUARD(s2n_tls13_keys_init_with_psk(&psk_keys, psk));
+    eq_check(binder_to_verify->size, psk_keys.size);
+
+    /* Calculate the binder hash from the transcript */
+    s2n_tls13_key_blob(binder_hash, psk_keys.size);
+    GUARD(s2n_psk_calculate_binder_hash(conn, psk->hash_alg, partial_client_hello, &binder_hash));
+
+    /* Calculate the expected binder from the binder hash */
+    s2n_tls13_key_blob(expected_binder, psk_keys.size);
+    GUARD(s2n_psk_calculate_binder(psk, &binder_hash, &expected_binder));
+
+    /* Verify the expected binder matches the given binder.
+     * This operation must be constant time. */
+    GUARD(s2n_tls13_mac_verify(&psk_keys, &expected_binder, binder_to_verify));
+
+    return S2N_SUCCESS;
+}

--- a/tls/s2n_psk.h
+++ b/tls/s2n_psk.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include <s2n.h>
+
+#include "crypto/s2n_hash.h"
+#include "utils/s2n_blob.h"
+#include "utils/s2n_result.h"
+
+typedef enum {
+    S2N_PSK_TYPE_UNKNOWN_TYPE = 0,
+    S2N_PSK_TYPE_EXTERNAL,
+    S2N_PSK_TYPE_RESUMPTION
+} s2n_psk_type;
+
+struct s2n_psk {
+    s2n_psk_type type;
+    struct s2n_blob identity;
+    struct s2n_blob secret;
+    s2n_hash_algorithm hash_alg;
+    uint32_t obfuscated_ticket_age;
+    struct s2n_blob early_secret;
+};
+
+int s2n_psk_init(struct s2n_psk *psk, s2n_psk_type type);
+int s2n_psk_new_identity(struct s2n_psk *psk, const uint8_t *identity, size_t identity_size);
+int s2n_psk_new_secret(struct s2n_psk *psk, const uint8_t *secret, size_t secret_size);
+int s2n_psk_free(struct s2n_psk *psk);
+
+int s2n_psk_calculate_binder_hash(struct s2n_connection *conn, s2n_hash_algorithm hash_alg,
+        const struct s2n_blob *partial_client_hello, struct s2n_blob *output_binder_hash);
+int s2n_psk_calculate_binder(struct s2n_psk *psk, const struct s2n_blob *binder_hash,
+        struct s2n_blob *output_binder);
+int s2n_psk_verify_binder(struct s2n_connection *conn, struct s2n_psk *psk,
+        const struct s2n_blob *partial_client_hello, struct s2n_blob *binder_to_verify);

--- a/tls/s2n_psk.h
+++ b/tls/s2n_psk.h
@@ -22,9 +22,8 @@
 #include "utils/s2n_result.h"
 
 typedef enum {
-    S2N_PSK_TYPE_UNKNOWN_TYPE = 0,
+    S2N_PSK_TYPE_RESUMPTION,
     S2N_PSK_TYPE_EXTERNAL,
-    S2N_PSK_TYPE_RESUMPTION
 } s2n_psk_type;
 
 struct s2n_psk {


### PR DESCRIPTION
### Resolved issues:

 resolves https://github.com/awslabs/s2n/issues/2389

### Description of changes: 

Add methods to calculate and verify the binders needed by the client pre_shared_key extension.

### Call-outs:

**Why not S2N_RESULT?** Three of my new methods couldn't use S2N_RESULT:
* s2n_psk_free needs to work with DEFER_CLEANUP, which uses an attribute which requires a posix return.
* s2n_psk_calculate_binder and s2n_psk_verify_binder need to work with s2n_tls13_key_blob. It seemed like an unnecessary complication to make S2N_RESULT versions of that macro and the other macros it depends on.

Mixing S2N_RESULT and posix methods into the same module made dealing with the module much trickier, so I decided to just make them all posix.

### Testing:

Unit tests, including known-value tests using test vectors from https://tools.ietf.org/html/rfc8448#section-4.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
