### PR TITLE
Update PSS support definition to account for new AWS-LC version

### DIFF
--- a/crypto/s2n_rsa_signing.h
+++ b/crypto/s2n_rsa_signing.h
@@ -22,7 +22,7 @@
 #include "crypto/s2n_rsa.h"
 
 /* Check for libcrypto 1.1 for RSA PSS Signing and EV_Key usage */
-#if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 1) && !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_IS_BORINGSSL)
+#if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 1) && !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
 #define RSA_PSS_SIGNING_SUPPORTED 1
 #else
 #define RSA_PSS_SIGNING_SUPPORTED 0


### PR DESCRIPTION
### Description of changes: 

The version number for AWS-LC was updated after performing an [upstream merge from BoringSSL](https://github.com/awslabs/aws-lc/pull/59). This change excludes AWS-LC when checking for PSS support. 

### Testing:

Tested locally and through CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
