### PR TITLE
Ensure memory safety in s2n_hash functions

### DIFF
--- a/crypto/s2n_evp.c
+++ b/crypto/s2n_evp.c
@@ -20,6 +20,7 @@
 
 int s2n_digest_allow_md5_for_fips(struct s2n_evp_digest *evp_digest)
 {
+    notnull_check(evp_digest);
     /* This is only to be used for EVP digests that will require MD5 to be used
      * to comply with the TLS 1.0 and 1.1 RFC's for the PRF. MD5 cannot be used
      * outside of the TLS 1.0 and 1.1 PRF when in FIPS mode.
@@ -35,12 +36,10 @@ int s2n_digest_allow_md5_for_fips(struct s2n_evp_digest *evp_digest)
 int s2n_digest_is_md5_allowed_for_fips(struct s2n_evp_digest *evp_digest)
 {
 #if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
-    PRECONDITION_POSIX(evp_digest != NULL);
-    PRECONDITION_POSIX(evp_digest->ctx != NULL);
-    if (s2n_is_in_fips_mode() && EVP_MD_CTX_test_flags(evp_digest->ctx, EVP_MD_CTX_FLAG_NON_FIPS_ALLOW)) {
+    if (evp_digest && evp_digest->ctx && s2n_is_in_fips_mode() && EVP_MD_CTX_test_flags(evp_digest->ctx, EVP_MD_CTX_FLAG_NON_FIPS_ALLOW)) {
         /* s2n is in FIPS mode and the EVP digest allows MD5. */
         return 1;
     }
 #endif
-    return S2N_SUCCESS;
+    return 0;
 }

--- a/crypto/s2n_evp.c
+++ b/crypto/s2n_evp.c
@@ -25,7 +25,7 @@ int s2n_digest_allow_md5_for_fips(struct s2n_evp_digest *evp_digest)
      * to comply with the TLS 1.0 and 1.1 RFC's for the PRF. MD5 cannot be used
      * outside of the TLS 1.0 and 1.1 PRF when in FIPS mode.
      */
-    ENSURE_POSIX(s2n_is_in_fips_mode() && (evp_digest->ctx != NULL), S2N_ERR_ALLOW_MD5_FOR_FIPS_FAILED);
+    S2N_ERROR_IF(!s2n_is_in_fips_mode() || (evp_digest->ctx == NULL), S2N_ERR_ALLOW_MD5_FOR_FIPS_FAILED);
 
 #if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
     EVP_MD_CTX_set_flags(evp_digest->ctx, EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
@@ -33,13 +33,15 @@ int s2n_digest_allow_md5_for_fips(struct s2n_evp_digest *evp_digest)
     return S2N_SUCCESS;
 }
 
-bool s2n_digest_is_md5_allowed_for_fips(struct s2n_evp_digest *evp_digest)
+S2N_RESULT s2n_digest_is_md5_allowed_for_fips(struct s2n_evp_digest *evp_digest, bool *out)
 {
+    ENSURE_REF(out);
+    *out = false;
 #if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
     if (evp_digest && evp_digest->ctx && s2n_is_in_fips_mode() && EVP_MD_CTX_test_flags(evp_digest->ctx, EVP_MD_CTX_FLAG_NON_FIPS_ALLOW)) {
         /* s2n is in FIPS mode and the EVP digest allows MD5. */
-        return true;
+        *out = true;
     }
 #endif
-    return false;
+    return S2N_RESULT_OK;
 }

--- a/crypto/s2n_evp.c
+++ b/crypto/s2n_evp.c
@@ -15,8 +15,8 @@
 
 #include "crypto/s2n_evp.h"
 #include "crypto/s2n_fips.h"
-
 #include "error/s2n_errno.h"
+#include "utils/s2n_safety.h"
 
 int s2n_digest_allow_md5_for_fips(struct s2n_evp_digest *evp_digest)
 {
@@ -35,6 +35,8 @@ int s2n_digest_allow_md5_for_fips(struct s2n_evp_digest *evp_digest)
 int s2n_digest_is_md5_allowed_for_fips(struct s2n_evp_digest *evp_digest)
 {
 #if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
+    PRECONDITION_POSIX(evp_digest != NULL);
+    PRECONDITION_POSIX(evp_digest->ctx != NULL);
     if (s2n_is_in_fips_mode() && EVP_MD_CTX_test_flags(evp_digest->ctx, EVP_MD_CTX_FLAG_NON_FIPS_ALLOW)) {
         /* s2n is in FIPS mode and the EVP digest allows MD5. */
         return 1;

--- a/crypto/s2n_evp.c
+++ b/crypto/s2n_evp.c
@@ -33,13 +33,13 @@ int s2n_digest_allow_md5_for_fips(struct s2n_evp_digest *evp_digest)
     return S2N_SUCCESS;
 }
 
-int s2n_digest_is_md5_allowed_for_fips(struct s2n_evp_digest *evp_digest)
+bool s2n_digest_is_md5_allowed_for_fips(struct s2n_evp_digest *evp_digest)
 {
 #if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
     if (evp_digest && evp_digest->ctx && s2n_is_in_fips_mode() && EVP_MD_CTX_test_flags(evp_digest->ctx, EVP_MD_CTX_FLAG_NON_FIPS_ALLOW)) {
         /* s2n is in FIPS mode and the EVP digest allows MD5. */
-        return 1;
+        return true;
     }
 #endif
-    return 0;
+    return false;
 }

--- a/crypto/s2n_evp.c
+++ b/crypto/s2n_evp.c
@@ -25,7 +25,7 @@ int s2n_digest_allow_md5_for_fips(struct s2n_evp_digest *evp_digest)
      * to comply with the TLS 1.0 and 1.1 RFC's for the PRF. MD5 cannot be used
      * outside of the TLS 1.0 and 1.1 PRF when in FIPS mode.
      */
-    S2N_ERROR_IF(!s2n_is_in_fips_mode() || (evp_digest->ctx == NULL), S2N_ERR_ALLOW_MD5_FOR_FIPS_FAILED);
+    ENSURE_POSIX(s2n_is_in_fips_mode() && (evp_digest->ctx != NULL), S2N_ERR_ALLOW_MD5_FOR_FIPS_FAILED);
 
 #if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
     EVP_MD_CTX_set_flags(evp_digest->ctx, EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);

--- a/crypto/s2n_evp.h
+++ b/crypto/s2n_evp.h
@@ -18,6 +18,7 @@
 #include <openssl/evp.h>
 
 #include "crypto/s2n_openssl.h"
+#include "utils/s2n_result.h"
 
 struct s2n_evp_digest {
     const EVP_MD *md;
@@ -41,4 +42,4 @@ struct s2n_evp_hmac_state {
 #endif
 
 extern int s2n_digest_allow_md5_for_fips(struct s2n_evp_digest *evp_digest);
-extern bool s2n_digest_is_md5_allowed_for_fips(struct s2n_evp_digest *evp_digest);
+extern S2N_RESULT s2n_digest_is_md5_allowed_for_fips(struct s2n_evp_digest *evp_digest, bool *out);

--- a/crypto/s2n_evp.h
+++ b/crypto/s2n_evp.h
@@ -41,4 +41,4 @@ struct s2n_evp_hmac_state {
 #endif
 
 extern int s2n_digest_allow_md5_for_fips(struct s2n_evp_digest *evp_digest);
-extern int s2n_digest_is_md5_allowed_for_fips(struct s2n_evp_digest *evp_digest);
+extern bool s2n_digest_is_md5_allowed_for_fips(struct s2n_evp_digest *evp_digest);

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -326,9 +326,7 @@ static int s2n_evp_hash_update(struct s2n_hash_state *state, const void *data, u
 {
     ENSURE_POSIX(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
     notnull_check(state->digest.high_level.evp.ctx);
-    notnull_check(EVP_MD_CTX_md(state->digest.high_level.evp.ctx));
     notnull_check(state->digest.high_level.evp_md5_secondary.ctx);
-    notnull_check(EVP_MD_CTX_md(state->digest.high_level.evp_md5_secondary.ctx));
 
     switch (state->alg) {
     case S2N_HASH_NONE:
@@ -339,9 +337,12 @@ static int s2n_evp_hash_update(struct s2n_hash_state *state, const void *data, u
     case S2N_HASH_SHA256:
     case S2N_HASH_SHA384:
     case S2N_HASH_SHA512:
+        notnull_check(EVP_MD_CTX_md(state->digest.high_level.evp.ctx));
         GUARD_OSSL(EVP_DigestUpdate(state->digest.high_level.evp.ctx, data, size), S2N_ERR_HASH_UPDATE_FAILED);
         break;
     case S2N_HASH_MD5_SHA1:
+        notnull_check(EVP_MD_CTX_md(state->digest.high_level.evp.ctx));
+        notnull_check(EVP_MD_CTX_md(state->digest.high_level.evp_md5_secondary.ctx));
         GUARD_OSSL(EVP_DigestUpdate(state->digest.high_level.evp.ctx, data, size), S2N_ERR_HASH_UPDATE_FAILED);
         GUARD_OSSL(EVP_DigestUpdate(state->digest.high_level.evp_md5_secondary.ctx, data, size), S2N_ERR_HASH_UPDATE_FAILED);
         break;

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -102,7 +102,8 @@ bool s2n_hash_is_available(s2n_hash_algorithm alg)
 
 int s2n_hash_is_ready_for_input(struct s2n_hash_state *state)
 {
-  return state->is_ready_for_input;
+    PRECONDITION_POSIX(s2n_hash_state_is_valid(state));
+    return state->is_ready_for_input;
 }
 
 static int s2n_low_level_hash_new(struct s2n_hash_state *state)
@@ -188,9 +189,10 @@ static int s2n_low_level_hash_update(struct s2n_hash_state *state, const void *d
         S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
     }
 
+    S2N_ERROR_IF(size > (UINT64_MAX - state->currently_in_hash), S2N_ERR_INTEGER_OVERFLOW);
     state->currently_in_hash += size;
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 static int s2n_low_level_hash_digest(struct s2n_hash_state *state, void *out, uint32_t size)
@@ -246,7 +248,7 @@ static int s2n_low_level_hash_copy(struct s2n_hash_state *to, struct s2n_hash_st
 
 static int s2n_low_level_hash_reset(struct s2n_hash_state *state)
 {
-    /* hash_init resets the ready_for_input and currently_in_hash fields */
+    /* hash_init resets the ready_for_input and currently_in_hash fields. */
     return s2n_low_level_hash_init(state, state->alg);
 }
 
@@ -256,7 +258,7 @@ static int s2n_low_level_hash_free(struct s2n_hash_state *state)
      * being used. For the s2n_low_level_hash implementation, free is a no-op.
      */
     state->is_ready_for_input = 0;
-    return 0;
+    return S2N_SUCCESS;
 }
 
 static int s2n_evp_hash_new(struct s2n_hash_state *state)
@@ -282,6 +284,8 @@ static int s2n_evp_hash_allow_md5_for_fips(struct s2n_hash_state *state)
 
 static int s2n_evp_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm alg)
 {
+    notnull_check(state->digest.high_level.evp.ctx);
+    notnull_check(state->digest.high_level.evp_md5_secondary.ctx);
     switch (alg) {
     case S2N_HASH_NONE:
         break;
@@ -304,6 +308,7 @@ static int s2n_evp_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm al
         GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha512(), NULL), S2N_ERR_HASH_INIT_FAILED);
         break;
     case S2N_HASH_MD5_SHA1:
+        notnull_check(state->digest.high_level.evp_md5_secondary.ctx);
         GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha1(), NULL), S2N_ERR_HASH_INIT_FAILED);
         GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp_md5_secondary.ctx, EVP_md5(), NULL), S2N_ERR_HASH_INIT_FAILED);
         break;
@@ -315,12 +320,16 @@ static int s2n_evp_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm al
     state->is_ready_for_input = 1;
     state->currently_in_hash = 0;
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 static int s2n_evp_hash_update(struct s2n_hash_state *state, const void *data, uint32_t size)
 {
     S2N_ERROR_IF(!state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
+    notnull_check(state->digest.high_level.evp.ctx);
+    notnull_check(state->digest.high_level.evp.ctx->digest);
+    notnull_check(state->digest.high_level.evp_md5_secondary.ctx);
+    notnull_check(state->digest.high_level.evp_md5_secondary.ctx->digest);
 
     switch (state->alg) {
     case S2N_HASH_NONE:
@@ -341,14 +350,19 @@ static int s2n_evp_hash_update(struct s2n_hash_state *state, const void *data, u
         S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
     }
 
+    S2N_ERROR_IF(size > (UINT64_MAX - state->currently_in_hash), S2N_ERR_INTEGER_OVERFLOW);
     state->currently_in_hash += size;
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 static int s2n_evp_hash_digest(struct s2n_hash_state *state, void *out, uint32_t size)
 {
     S2N_ERROR_IF(!state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
+    notnull_check(state->digest.high_level.evp.ctx);
+    notnull_check(state->digest.high_level.evp.ctx->digest);
+    notnull_check(state->digest.high_level.evp_md5_secondary.ctx);
+    notnull_check(state->digest.high_level.evp_md5_secondary.ctx->digest);
 
     unsigned int digest_size = size;
     uint8_t expected_digest_size;
@@ -369,12 +383,15 @@ static int s2n_evp_hash_digest(struct s2n_hash_state *state, void *out, uint32_t
     case S2N_HASH_SHA256:
     case S2N_HASH_SHA384:
     case S2N_HASH_SHA512:
+        S2N_ERROR_IF(EVP_MD_CTX_size(state->digest.high_level.evp.ctx) > digest_size, S2N_ERR_HASH_DIGEST_FAILED);
         GUARD_OSSL(EVP_DigestFinal_ex(state->digest.high_level.evp.ctx, out, &digest_size), S2N_ERR_HASH_DIGEST_FAILED);
         break;
     case S2N_HASH_MD5_SHA1:
         GUARD(s2n_hash_digest_size(S2N_HASH_SHA1, &sha1_digest_size));
         sha1_primary_digest_size = sha1_digest_size;
         md5_secondary_digest_size = digest_size - sha1_primary_digest_size;
+        S2N_ERROR_IF(EVP_MD_CTX_size(state->digest.high_level.evp.ctx) > sha1_digest_size, S2N_ERR_HASH_DIGEST_FAILED);
+        S2N_ERROR_IF(EVP_MD_CTX_size(state->digest.high_level.evp_md5_secondary.ctx) > md5_secondary_digest_size, S2N_ERR_HASH_DIGEST_FAILED);
 
         GUARD_OSSL(EVP_DigestFinal_ex(state->digest.high_level.evp.ctx, ((uint8_t *) out) + MD5_DIGEST_LENGTH, &sha1_primary_digest_size), S2N_ERR_HASH_DIGEST_FAILED);
         GUARD_OSSL(EVP_DigestFinal_ex(state->digest.high_level.evp_md5_secondary.ctx, out, &md5_secondary_digest_size), S2N_ERR_HASH_DIGEST_FAILED);
@@ -385,11 +402,15 @@ static int s2n_evp_hash_digest(struct s2n_hash_state *state, void *out, uint32_t
 
     state->currently_in_hash = 0;
     state->is_ready_for_input = 0;
-    return 0;
+    return S2N_SUCCESS;
 }
 
 static int s2n_evp_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *from)
 {
+    notnull_check(to->digest.high_level.evp.ctx);
+    notnull_check(to->digest.high_level.evp.ctx->digest);
+    notnull_check(to->digest.high_level.evp_md5_secondary.ctx);
+    notnull_check(to->digest.high_level.evp_md5_secondary.ctx->digest);
     switch (from->alg) {
     case S2N_HASH_NONE:
         break;
@@ -421,7 +442,7 @@ static int s2n_evp_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *f
     to->is_ready_for_input = from->is_ready_for_input;
     to->currently_in_hash = from->currently_in_hash;
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 static int s2n_evp_hash_reset(struct s2n_hash_state *state)
@@ -437,10 +458,16 @@ static int s2n_evp_hash_reset(struct s2n_hash_state *state)
         GUARD_OSSL(S2N_EVP_MD_CTX_RESET(state->digest.high_level.evp_md5_secondary.ctx), S2N_ERR_HASH_WIPE_FAILED);
     }
 
+    /* ctx must be initialized before calling EVP_DigestInit_ex function in s2n_evp_hash_init.
+     * Per https://www.openssl.org/docs/man1.0.2/man3/EVP_DigestInit_ex.html.
+     */
+    GUARD(s2n_evp_hash_new(state));
+
     if (reset_md5_for_fips) {
         GUARD(s2n_hash_allow_md5_for_fips(state));
     }
-    /* hash_init resets the ready_for_input and currently_in_hash fields */
+
+    /* hash_init resets the ready_for_input and currently_in_hash fields. */
     return s2n_evp_hash_init(state, state->alg);
 }
 
@@ -448,10 +475,10 @@ static int s2n_evp_hash_free(struct s2n_hash_state *state)
 {
     S2N_EVP_MD_CTX_FREE(state->digest.high_level.evp.ctx);
     S2N_EVP_MD_CTX_FREE(state->digest.high_level.evp_md5_secondary.ctx);
-    state->digest.high_level.evp.ctx = NULL;
     state->digest.high_level.evp_md5_secondary.ctx = NULL;
+    state->digest.high_level.evp.ctx = NULL;
     state->is_ready_for_input = 0;
-    return 0;
+    return S2N_SUCCESS;
 }
 
 static const struct s2n_hash s2n_low_level_hash = {
@@ -515,6 +542,7 @@ int s2n_hash_allow_md5_for_fips(struct s2n_hash_state *state)
 
 int s2n_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm alg)
 {
+    notnull_check(state);
     /* Ensure that hash_impl is set, as it may have been reset for s2n_hash_state on s2n_connection_wipe.
      * When in FIPS mode, the EVP API's must be used for hashes.
      */
@@ -525,7 +553,7 @@ int s2n_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm alg)
         /* s2n will continue to initialize an "unavailable" hash when s2n is in FIPS mode and
          * FIPS is forcing the hash to be made available.
          */
-        notnull_check(state->hash_impl->init);
+        notnull_check_ptr(state->hash_impl->init);
 
         return state->hash_impl->init(state, alg);
     } else {
@@ -535,6 +563,9 @@ int s2n_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm alg)
 
 int s2n_hash_update(struct s2n_hash_state *state, const void *data, uint32_t size)
 {
+    PRECONDITION_POSIX(s2n_hash_state_is_valid(state));
+    PRECONDITION_POSIX(size != 0);
+    PRECONDITION_POSIX(S2N_MEM_IS_READABLE(data, size));
     notnull_check(state->hash_impl->update);
 
     return state->hash_impl->update(state, data, size);
@@ -542,6 +573,8 @@ int s2n_hash_update(struct s2n_hash_state *state, const void *data, uint32_t siz
 
 int s2n_hash_digest(struct s2n_hash_state *state, void *out, uint32_t size)
 {
+    PRECONDITION_POSIX(s2n_hash_state_is_valid(state));
+    PRECONDITION_POSIX(S2N_MEM_IS_READABLE(out, size));
     notnull_check(state->hash_impl->digest);
 
     return state->hash_impl->digest(state, out, size);
@@ -549,6 +582,8 @@ int s2n_hash_digest(struct s2n_hash_state *state, void *out, uint32_t size)
 
 int s2n_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *from)
 {
+    PRECONDITION_POSIX(s2n_hash_state_is_valid(to));
+    PRECONDITION_POSIX(s2n_hash_state_is_valid(from));
     notnull_check(from->hash_impl->copy);
 
     return from->hash_impl->copy(to, from);
@@ -556,18 +591,24 @@ int s2n_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *from)
 
 int s2n_hash_reset(struct s2n_hash_state *state)
 {
+    notnull_check(state);
     /* Ensure that hash_impl is set, as it may have been reset for s2n_hash_state on s2n_connection_wipe.
      * When in FIPS mode, the EVP API's must be used for hashes.
      */
     GUARD(s2n_hash_set_impl(state));
 
-    notnull_check(state->hash_impl->reset);
+    notnull_check_ptr(state->hash_impl->reset);
 
     return state->hash_impl->reset(state);
 }
 
 int s2n_hash_free(struct s2n_hash_state *state)
 {
+    if (state == NULL)
+    {
+        return S2N_SUCCESS;
+    }
+    PRECONDITION_POSIX(s2n_hash_state_is_valid(state));
     /* Ensure that hash_impl is set, as it may have been reset for s2n_hash_state on s2n_connection_wipe.
      * When in FIPS mode, the EVP API's must be used for hashes.
      */
@@ -580,16 +621,20 @@ int s2n_hash_free(struct s2n_hash_state *state)
 
 int s2n_hash_get_currently_in_hash_total(struct s2n_hash_state *state, uint64_t *out)
 {
+    PRECONDITION_POSIX(s2n_hash_state_is_valid(state));
+    PRECONDITION_POSIX(S2N_MEM_IS_READABLE(out, sizeof(*out)));
     S2N_ERROR_IF(!state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
 
     *out = state->currently_in_hash;
-    return 0;
+    return S2N_SUCCESS;
 }
 
 
 /* Calculate, in constant time, the number of bytes currently in the hash_block */
 int s2n_hash_const_time_get_currently_in_hash_block(struct s2n_hash_state *state, uint64_t *out)
 {
+    PRECONDITION_POSIX(s2n_hash_state_is_valid(state));
+    PRECONDITION_POSIX(S2N_MEM_IS_READABLE(out, sizeof(*out)));
     S2N_ERROR_IF(!state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
     uint64_t hash_block_size;
     GUARD(s2n_hash_block_size(state->alg, &hash_block_size));
@@ -597,5 +642,5 @@ int s2n_hash_const_time_get_currently_in_hash_block(struct s2n_hash_state *state
     /* Requires that hash_block_size is a power of 2. This is true for all hashes we currently support
      * If this ever becomes untrue, this would require fixing this*/
     *out = state->currently_in_hash & (hash_block_size - 1);
-    return 0;
+    return S2N_SUCCESS;
 }

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -308,7 +308,6 @@ static int s2n_evp_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm al
         GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha512(), NULL), S2N_ERR_HASH_INIT_FAILED);
         break;
     case S2N_HASH_MD5_SHA1:
-        notnull_check(state->digest.high_level.evp_md5_secondary.ctx);
         GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha1(), NULL), S2N_ERR_HASH_INIT_FAILED);
         GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp_md5_secondary.ctx, EVP_md5(), NULL), S2N_ERR_HASH_INIT_FAILED);
         break;
@@ -327,9 +326,9 @@ static int s2n_evp_hash_update(struct s2n_hash_state *state, const void *data, u
 {
     ENSURE_POSIX(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
     notnull_check(state->digest.high_level.evp.ctx);
-    notnull_check(state->digest.high_level.evp.ctx->digest);
+    notnull_check(EVP_MD_CTX_md(state->digest.high_level.evp.ctx));
     notnull_check(state->digest.high_level.evp_md5_secondary.ctx);
-    notnull_check(state->digest.high_level.evp_md5_secondary.ctx->digest);
+    notnull_check(EVP_MD_CTX_md(state->digest.high_level.evp_md5_secondary.ctx));
 
     switch (state->alg) {
     case S2N_HASH_NONE:
@@ -360,9 +359,9 @@ static int s2n_evp_hash_digest(struct s2n_hash_state *state, void *out, uint32_t
 {
     ENSURE_POSIX(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
     notnull_check(state->digest.high_level.evp.ctx);
-    notnull_check(state->digest.high_level.evp.ctx->digest);
+    notnull_check(EVP_MD_CTX_md(state->digest.high_level.evp.ctx));
     notnull_check(state->digest.high_level.evp_md5_secondary.ctx);
-    notnull_check(state->digest.high_level.evp_md5_secondary.ctx->digest);
+    notnull_check(EVP_MD_CTX_md(state->digest.high_level.evp_md5_secondary.ctx));
 
     unsigned int digest_size = size;
     uint8_t expected_digest_size;
@@ -408,9 +407,9 @@ static int s2n_evp_hash_digest(struct s2n_hash_state *state, void *out, uint32_t
 static int s2n_evp_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *from)
 {
     notnull_check(to->digest.high_level.evp.ctx);
-    notnull_check(to->digest.high_level.evp.ctx->digest);
+    notnull_check(EVP_MD_CTX_md(to->digest.high_level.evp.ctx));
     notnull_check(to->digest.high_level.evp_md5_secondary.ctx);
-    notnull_check(to->digest.high_level.evp_md5_secondary.ctx->digest);
+    notnull_check(EVP_MD_CTX_md(to->digest.high_level.evp_md5_secondary.ctx));
     bool is_md5_allowed_for_fips = false;
     switch (from->alg) {
     case S2N_HASH_NONE:

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -360,9 +360,7 @@ static int s2n_evp_hash_digest(struct s2n_hash_state *state, void *out, uint32_t
 {
     ENSURE_POSIX(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
     notnull_check(state->digest.high_level.evp.ctx);
-    notnull_check(EVP_MD_CTX_md(state->digest.high_level.evp.ctx));
     notnull_check(state->digest.high_level.evp_md5_secondary.ctx);
-    notnull_check(EVP_MD_CTX_md(state->digest.high_level.evp_md5_secondary.ctx));
 
     unsigned int digest_size = size;
     uint8_t expected_digest_size;
@@ -383,10 +381,13 @@ static int s2n_evp_hash_digest(struct s2n_hash_state *state, void *out, uint32_t
     case S2N_HASH_SHA256:
     case S2N_HASH_SHA384:
     case S2N_HASH_SHA512:
+        notnull_check(EVP_MD_CTX_md(state->digest.high_level.evp.ctx));
         ENSURE_POSIX(EVP_MD_CTX_size(state->digest.high_level.evp.ctx) <= digest_size, S2N_ERR_HASH_DIGEST_FAILED);
         GUARD_OSSL(EVP_DigestFinal_ex(state->digest.high_level.evp.ctx, out, &digest_size), S2N_ERR_HASH_DIGEST_FAILED);
         break;
     case S2N_HASH_MD5_SHA1:
+        notnull_check(EVP_MD_CTX_md(state->digest.high_level.evp.ctx));
+        notnull_check(EVP_MD_CTX_md(state->digest.high_level.evp_md5_secondary.ctx));
         GUARD(s2n_hash_digest_size(S2N_HASH_SHA1, &sha1_digest_size));
         sha1_primary_digest_size = sha1_digest_size;
         md5_secondary_digest_size = digest_size - sha1_primary_digest_size;
@@ -424,7 +425,6 @@ static int s2n_evp_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *f
     case S2N_HASH_SHA256:
     case S2N_HASH_SHA384:
     case S2N_HASH_SHA512:
-        notnull_check(EVP_MD_CTX_md(to->digest.high_level.evp.ctx));
         GUARD_OSSL(EVP_MD_CTX_copy_ex(to->digest.high_level.evp.ctx, from->digest.high_level.evp.ctx), S2N_ERR_HASH_COPY_FAILED);
         break;
     case S2N_HASH_MD5_SHA1:

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -615,7 +615,6 @@ int s2n_hash_free(struct s2n_hash_state *state)
     {
         return S2N_SUCCESS;
     }
-    PRECONDITION_POSIX(s2n_hash_state_is_valid(state));
     /* Ensure that hash_impl is set, as it may have been reset for s2n_hash_state on s2n_connection_wipe.
      * When in FIPS mode, the EVP API's must be used for hashes.
      */

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -464,11 +464,6 @@ static int s2n_evp_hash_reset(struct s2n_hash_state *state)
         GUARD_OSSL(S2N_EVP_MD_CTX_RESET(state->digest.high_level.evp_md5_secondary.ctx), S2N_ERR_HASH_WIPE_FAILED);
     }
 
-    /* ctx must be initialized before calling EVP_DigestInit_ex function in s2n_evp_hash_init.
-     * Per https://www.openssl.org/docs/man1.0.2/man3/EVP_DigestInit_ex.html.
-     */
-    GUARD(s2n_evp_hash_new(state));
-
     if (reset_md5_for_fips) {
         GUARD(s2n_hash_allow_md5_for_fips(state));
     }
@@ -481,8 +476,8 @@ static int s2n_evp_hash_free(struct s2n_hash_state *state)
 {
     S2N_EVP_MD_CTX_FREE(state->digest.high_level.evp.ctx);
     S2N_EVP_MD_CTX_FREE(state->digest.high_level.evp_md5_secondary.ctx);
-    state->digest.high_level.evp_md5_secondary.ctx = NULL;
     state->digest.high_level.evp.ctx = NULL;
+    state->digest.high_level.evp_md5_secondary.ctx = NULL;
     state->is_ready_for_input = 0;
     return S2N_SUCCESS;
 }

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -571,7 +571,6 @@ int s2n_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm alg)
 int s2n_hash_update(struct s2n_hash_state *state, const void *data, uint32_t size)
 {
     PRECONDITION_POSIX(s2n_hash_state_is_valid(state));
-    PRECONDITION_POSIX(size != 0);
     PRECONDITION_POSIX(S2N_MEM_IS_READABLE(data, size));
     notnull_check(state->hash_impl->update);
 

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -408,9 +408,7 @@ static int s2n_evp_hash_digest(struct s2n_hash_state *state, void *out, uint32_t
 static int s2n_evp_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *from)
 {
     notnull_check(to->digest.high_level.evp.ctx);
-    notnull_check(EVP_MD_CTX_md(to->digest.high_level.evp.ctx));
     notnull_check(to->digest.high_level.evp_md5_secondary.ctx);
-    notnull_check(EVP_MD_CTX_md(to->digest.high_level.evp_md5_secondary.ctx));
     bool is_md5_allowed_for_fips = false;
     switch (from->alg) {
     case S2N_HASH_NONE:
@@ -426,9 +424,12 @@ static int s2n_evp_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *f
     case S2N_HASH_SHA256:
     case S2N_HASH_SHA384:
     case S2N_HASH_SHA512:
+        notnull_check(EVP_MD_CTX_md(to->digest.high_level.evp.ctx));
         GUARD_OSSL(EVP_MD_CTX_copy_ex(to->digest.high_level.evp.ctx, from->digest.high_level.evp.ctx), S2N_ERR_HASH_COPY_FAILED);
         break;
     case S2N_HASH_MD5_SHA1:
+        notnull_check(EVP_MD_CTX_md(to->digest.high_level.evp.ctx));
+        notnull_check(EVP_MD_CTX_md(to->digest.high_level.evp_md5_secondary.ctx));
         GUARD_AS_POSIX(s2n_digest_is_md5_allowed_for_fips(&from->digest.high_level.evp, &is_md5_allowed_for_fips));
         if (is_md5_allowed_for_fips) {
             GUARD(s2n_hash_allow_md5_for_fips(to));

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -553,7 +553,7 @@ int s2n_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm alg)
         /* s2n will continue to initialize an "unavailable" hash when s2n is in FIPS mode and
          * FIPS is forcing the hash to be made available.
          */
-        notnull_check_ptr(state->hash_impl->init);
+        notnull_check(state->hash_impl->init);
 
         return state->hash_impl->init(state, alg);
     } else {
@@ -597,7 +597,7 @@ int s2n_hash_reset(struct s2n_hash_state *state)
      */
     GUARD(s2n_hash_set_impl(state));
 
-    notnull_check_ptr(state->hash_impl->reset);
+    notnull_check(state->hash_impl->reset);
 
     return state->hash_impl->reset(state);
 }

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -325,8 +325,6 @@ static int s2n_evp_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm al
 static int s2n_evp_hash_update(struct s2n_hash_state *state, const void *data, uint32_t size)
 {
     ENSURE_POSIX(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
-    notnull_check(state->digest.high_level.evp.ctx);
-    notnull_check(state->digest.high_level.evp_md5_secondary.ctx);
 
     switch (state->alg) {
     case S2N_HASH_NONE:
@@ -359,8 +357,6 @@ static int s2n_evp_hash_update(struct s2n_hash_state *state, const void *data, u
 static int s2n_evp_hash_digest(struct s2n_hash_state *state, void *out, uint32_t size)
 {
     ENSURE_POSIX(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
-    notnull_check(state->digest.high_level.evp.ctx);
-    notnull_check(state->digest.high_level.evp_md5_secondary.ctx);
 
     unsigned int digest_size = size;
     uint8_t expected_digest_size;
@@ -408,8 +404,6 @@ static int s2n_evp_hash_digest(struct s2n_hash_state *state, void *out, uint32_t
 
 static int s2n_evp_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *from)
 {
-    notnull_check(to->digest.high_level.evp.ctx);
-    notnull_check(to->digest.high_level.evp_md5_secondary.ctx);
     bool is_md5_allowed_for_fips = false;
     switch (from->alg) {
     case S2N_HASH_NONE:
@@ -428,8 +422,6 @@ static int s2n_evp_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *f
         GUARD_OSSL(EVP_MD_CTX_copy_ex(to->digest.high_level.evp.ctx, from->digest.high_level.evp.ctx), S2N_ERR_HASH_COPY_FAILED);
         break;
     case S2N_HASH_MD5_SHA1:
-        notnull_check(EVP_MD_CTX_md(to->digest.high_level.evp.ctx));
-        notnull_check(EVP_MD_CTX_md(to->digest.high_level.evp_md5_secondary.ctx));
         GUARD_AS_POSIX(s2n_digest_is_md5_allowed_for_fips(&from->digest.high_level.evp, &is_md5_allowed_for_fips));
         if (is_md5_allowed_for_fips) {
             GUARD(s2n_hash_allow_md5_for_fips(to));

--- a/tests/cbmc/include/cbmc_proof/make_common_datastructures.h
+++ b/tests/cbmc/include/cbmc_proof/make_common_datastructures.h
@@ -101,4 +101,9 @@ struct s2n_dh_params *cbmc_allocate_dh_params();
 /*
  * Properly allocates s2n_hash_state for CBMC proofs.
  */
+EVP_MD_CTX* cbmc_allocate_EVP_MD_CTX();
+
+/*
+ * Properly allocates s2n_hash_state for CBMC proofs.
+ */
 struct s2n_hash_state *cbmc_allocate_s2n_hash_state();

--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -130,6 +130,35 @@ struct s2n_dh_params *cbmc_allocate_dh_params()
     return dh_params;
 }
 
+EVP_MD_CTX* cbmc_allocate_EVP_MD_CTX() {
+    EVP_MD_CTX *ctx = malloc(sizeof(*ctx));
+    if (ctx != NULL) {
+        ctx->digest = malloc(sizeof(*(ctx->digest)));
+        ctx->md_data = malloc(EVP_MAX_MD_SIZE);
+        ctx->pctx = malloc(sizeof(*(ctx->pctx)));
+        if (ctx->pctx != NULL) {
+            ctx->pctx->pkey = malloc(sizeof(*(ctx->pctx->pkey)));
+            if (ctx->pctx->pkey != NULL) {
+                ctx->pctx->pkey->ec_key = malloc(sizeof(*(ctx->pctx->pkey->ec_key)));
+                if (ctx->pctx->pkey->ec_key != NULL) {
+                    ctx->pctx->pkey->ec_key->group = malloc(sizeof(*(ctx->pctx->pkey->ec_key->group)));
+                    if (ctx->pctx->pkey->ec_key->group != NULL) {
+                        ctx->pctx->pkey->ec_key->group->order = malloc(sizeof(*(ctx->pctx->pkey->ec_key->group->order)));
+                        if (ctx->pctx->pkey->ec_key->group->order != NULL) {
+                            ctx->pctx->pkey->ec_key->group->order->d = malloc(sizeof(*(ctx->pctx->pkey->ec_key->group->order->d)));
+                        }
+                    }
+                    ctx->pctx->pkey->ec_key->priv_key = malloc(sizeof(*(ctx->pctx->pkey->ec_key->priv_key)));
+                    if (ctx->pctx->pkey->ec_key->priv_key != NULL) {
+                        ctx->pctx->pkey->ec_key->priv_key->d = malloc(sizeof(*(ctx->pctx->pkey->ec_key->priv_key->d)));
+                    }
+                }
+            }
+        }
+    }
+    return ctx;
+}
+
 struct s2n_hash_state* cbmc_allocate_s2n_hash_state()
 {
     struct s2n_hash_state *state = malloc(sizeof(*state));
@@ -137,9 +166,9 @@ struct s2n_hash_state* cbmc_allocate_s2n_hash_state()
     {
         state->hash_impl = malloc(sizeof(*(state->hash_impl)));
         state->digest.high_level.evp.md = malloc(sizeof(*(state->digest.high_level.evp.md)));
-        state->digest.high_level.evp.ctx = malloc(sizeof(*(state->digest.high_level.evp.ctx)));
+        state->digest.high_level.evp.ctx = cbmc_allocate_EVP_MD_CTX();
         state->digest.high_level.evp_md5_secondary.md = malloc(sizeof(*(state->digest.high_level.evp_md5_secondary.md)));
-        state->digest.high_level.evp_md5_secondary.ctx = malloc(sizeof(*(state->digest.high_level.evp_md5_secondary.ctx)));
+        state->digest.high_level.evp_md5_secondary.ctx = cbmc_allocate_EVP_MD_CTX();
     }
     return state;
 }


### PR DESCRIPTION
### Resolved issues:

N/A.

### Description of changes: 

- Adds a new allocator for `s2n_hash` proofs;
- Adds preconditions to `s2n_evp` and `s2n_hash`to ensure memory safety.

### Call-outs:

N/A.

### Testing:
I'll add proofs for each function on a separate PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
