### PR TITLE
Adds CBMC proofs for s2n_evp functions

### DIFF
--- a/tests/cbmc/.gitignore
+++ b/tests/cbmc/.gitignore
@@ -7,3 +7,4 @@ logs
 property.xml
 
 .litani_cache_dir
+.ninja_log

--- a/tests/cbmc/include/cbmc_proof/make_common_datastructures.h
+++ b/tests/cbmc/include/cbmc_proof/make_common_datastructures.h
@@ -20,6 +20,7 @@
 
 #include "api/s2n.h"
 #include "crypto/s2n_dhe.h"
+#include "crypto/s2n_evp.h"
 #include "crypto/s2n_hash.h"
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_array.h"
@@ -107,3 +108,8 @@ EVP_MD_CTX* cbmc_allocate_EVP_MD_CTX();
  * Properly allocates s2n_hash_state for CBMC proofs.
  */
 struct s2n_hash_state *cbmc_allocate_s2n_hash_state();
+
+/*
+ * Properly allocates s2n_evp_digest for CBMC proofs.
+ */
+struct s2n_evp_digest* cbmc_allocate_s2n_evp_digest();

--- a/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips/Makefile
+++ b/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips/Makefile
@@ -19,7 +19,7 @@ PROOF_UID = s2n_digest_allow_md5_for_fips
 HARNESS_ENTRY = $(PROOF_UID)_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
 
-PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c

--- a/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips/Makefile
+++ b/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips/Makefile
@@ -1,0 +1,31 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 5 seconds.
+
+CBMCFLAGS +=
+
+HARNESS_ENTRY = s2n_digest_allow_md5_for_fips_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_evp.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips/s2n_digest_allow_md5_for_fips_harness.c
+++ b/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips/s2n_digest_allow_md5_for_fips_harness.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <cbmc_proof/make_common_datastructures.h>
+
+#include "api/s2n.h"
+#include "crypto/s2n_evp.h"
+
+void s2n_digest_allow_md5_for_fips_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_evp_digest *evp_digest = cbmc_allocate_s2n_evp_digest();
+
+    /* Save previous state. */
+    unsigned long old_flags;
+    if (evp_digest != NULL && evp_digest->ctx != NULL) old_flags = evp_digest->ctx->flags;
+
+    /* Operation under verification. */
+    if (s2n_digest_allow_md5_for_fips(evp_digest) == S2N_SUCCESS) {
+        /* Post-conditions. */
+        assert(evp_digest != NULL);
+        assert(evp_digest->ctx != NULL);
+        assert(s2n_is_in_fips_mode());
+        assert(evp_digest->ctx->flags == (old_flags | EVP_MD_CTX_FLAG_NON_FIPS_ALLOW));
+    }
+}

--- a/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips_boringssl_awslc/Makefile
+++ b/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips_boringssl_awslc/Makefile
@@ -1,0 +1,35 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 5 seconds.
+
+DEFINES += -DOPENSSL_IS_BORINGSSL=1
+DEFINES += -DOPENSSL_IS_AWSLC=1
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_digest_allow_md5_for_fips
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_evp.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips_boringssl_awslc/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips_boringssl_awslc/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips_boringssl_awslc/s2n_digest_allow_md5_for_fips_harness.c
+++ b/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips_boringssl_awslc/s2n_digest_allow_md5_for_fips_harness.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <cbmc_proof/make_common_datastructures.h>
+
+#include "api/s2n.h"
+#include "crypto/s2n_evp.h"
+
+void s2n_digest_allow_md5_for_fips_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_evp_digest *evp_digest = cbmc_allocate_s2n_evp_digest();
+
+    /* Save previous state. */
+    unsigned long old_flags;
+    if (evp_digest != NULL && evp_digest->ctx != NULL) old_flags = evp_digest->ctx->flags;
+
+    /* Operation under verification. */
+    if (s2n_digest_allow_md5_for_fips(evp_digest) == S2N_SUCCESS) {
+        /* Post-conditions. */
+        assert(evp_digest != NULL);
+        assert(evp_digest->ctx != NULL);
+        assert(s2n_is_in_fips_mode());
+    }
+}

--- a/tests/cbmc/proofs/s2n_digest_is_md5_allowed_for_fips/Makefile
+++ b/tests/cbmc/proofs/s2n_digest_is_md5_allowed_for_fips/Makefile
@@ -19,7 +19,7 @@ PROOF_UID = s2n_digest_is_md5_allowed_for_fips
 HARNESS_ENTRY = $(PROOF_UID)_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
 
-PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c

--- a/tests/cbmc/proofs/s2n_digest_is_md5_allowed_for_fips/Makefile
+++ b/tests/cbmc/proofs/s2n_digest_is_md5_allowed_for_fips/Makefile
@@ -15,7 +15,7 @@
 
 CBMCFLAGS +=
 
-PROOF_UID = s2n_digest_allow_md5_for_fips
+PROOF_UID = s2n_digest_is_md5_allowed_for_fips
 HARNESS_ENTRY = $(PROOF_UID)_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
 
@@ -26,6 +26,7 @@ PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
 
 PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_evp.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
 
 UNWINDSET +=
 

--- a/tests/cbmc/proofs/s2n_digest_is_md5_allowed_for_fips/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_digest_is_md5_allowed_for_fips/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_digest_is_md5_allowed_for_fips/s2n_digest_is_md5_allowed_for_fips_harness.c
+++ b/tests/cbmc/proofs/s2n_digest_is_md5_allowed_for_fips/s2n_digest_is_md5_allowed_for_fips_harness.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <cbmc_proof/make_common_datastructures.h>
+
+#include "api/s2n.h"
+#include "crypto/s2n_evp.h"
+#include "utils/s2n_result.h"
+
+void s2n_digest_is_md5_allowed_for_fips_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_evp_digest *evp_digest = cbmc_allocate_s2n_evp_digest();
+    bool *out = malloc(sizeof(*out));
+
+    /* Operation under verification. */
+    if (s2n_result_is_ok(s2n_digest_is_md5_allowed_for_fips(evp_digest, out)) && *out) {
+        /* Post-conditions. */
+        assert(evp_digest != NULL);
+        assert(evp_digest->ctx != NULL);
+        assert(s2n_is_in_fips_mode());
+        assert((evp_digest->ctx->flags & EVP_MD_CTX_FLAG_NON_FIPS_ALLOW));
+    }
+}

--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -172,3 +172,14 @@ struct s2n_hash_state* cbmc_allocate_s2n_hash_state()
     }
     return state;
 }
+
+struct s2n_evp_digest* cbmc_allocate_s2n_evp_digest()
+{
+    struct s2n_evp_digest *evp_digest = malloc(sizeof(*evp_digest));
+    if (evp_digest != NULL)
+    {
+        evp_digest->md = malloc(sizeof(*(evp_digest->md)));
+        evp_digest->ctx = malloc(sizeof(*(evp_digest->ctx)));
+    }
+    return evp_digest;
+}


### PR DESCRIPTION
### Resolved issues:

N/A.

### Description of changes: 

Adds CBMC proof harnesses for the following `s2n_evp` functions:
 - `s2n_digest_allow_md5_for_fips`;
 - `s2n_digest_is_md5_allowed_for_fips`;

It also adds an allocator for `s2n_evp_digest`, updates `.gitignore` for CBMC folder, and upgrades OpenSSL verification model version.

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
