### PR TITLE
Adds proof harnesses for s2n_hash functions

### DIFF
--- a/tests/cbmc/proofs/s2n_hash_const_time_get_currently_in_hash_block/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_const_time_get_currently_in_hash_block/Makefile
@@ -19,7 +19,7 @@ PROOF_UID = s2n_hash_const_time_get_currently_in_hash_block
 HARNESS_ENTRY = $(PROOF_UID)_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
 
-PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c

--- a/tests/cbmc/proofs/s2n_hash_const_time_get_currently_in_hash_block/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_const_time_get_currently_in_hash_block/Makefile
@@ -15,7 +15,8 @@
 
 CBMCFLAGS +=
 
-HARNESS_ENTRY = s2n_hash_const_time_get_currently_in_hash_block_harness
+PROOF_UID = s2n_hash_const_time_get_currently_in_hash_block
+HARNESS_ENTRY = $(PROOF_UID)_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
 
 PROOF_SOURCES += $(HARNESS_FILE)

--- a/tests/cbmc/proofs/s2n_hash_const_time_get_currently_in_hash_block/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_const_time_get_currently_in_hash_block/Makefile
@@ -1,0 +1,31 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 30 seconds.
+
+CBMCFLAGS +=
+
+HARNESS_ENTRY = s2n_hash_const_time_get_currently_in_hash_block_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hash_const_time_get_currently_in_hash_block/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_hash_const_time_get_currently_in_hash_block/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_hash_const_time_get_currently_in_hash_block/s2n_hash_const_time_get_currently_in_hash_block_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_const_time_get_currently_in_hash_block/s2n_hash_const_time_get_currently_in_hash_block_harness.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "crypto/s2n_hash.h"
+
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_hash_const_time_get_currently_in_hash_block_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_hash_state *state = cbmc_allocate_s2n_hash_state();
+    uint64_t size;
+    uint64_t* out = bounded_malloc(size);
+
+    /* Assumptions. */
+    __CPROVER_assume(s2n_hash_state_is_valid(state));
+    if (state != NULL)
+    {
+        __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(state);
+    }
+
+    /* Operation under verification. */
+    if (s2n_hash_const_time_get_currently_in_hash_block(state, out) == S2N_SUCCESS)
+    {
+        /* Post-conditions. */
+        assert(s2n_hash_state_is_valid(state));
+        assert(state->is_ready_for_input);
+    }
+}

--- a/tests/cbmc/proofs/s2n_hash_const_time_get_currently_in_hash_block/s2n_hash_const_time_get_currently_in_hash_block_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_const_time_get_currently_in_hash_block/s2n_hash_const_time_get_currently_in_hash_block_harness.c
@@ -39,5 +39,9 @@ void s2n_hash_const_time_get_currently_in_hash_block_harness()
         /* Post-conditions. */
         assert(s2n_hash_state_is_valid(state));
         assert(state->is_ready_for_input);
+        uint64_t hash_block_size = 0;
+        s2n_hash_block_size(state->alg, &hash_block_size);
+        /* Checks whether hash_block_size is power of two. */
+        assert(hash_block_size && (!(hash_block_size & (hash_block_size - 1))));
     }
 }

--- a/tests/cbmc/proofs/s2n_hash_get_currently_in_hash_total/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_get_currently_in_hash_total/Makefile
@@ -1,0 +1,31 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 20 seconds.
+
+CBMCFLAGS +=
+
+HARNESS_ENTRY = s2n_hash_get_currently_in_hash_total_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hash_get_currently_in_hash_total/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_get_currently_in_hash_total/Makefile
@@ -19,7 +19,7 @@ PROOF_UID = s2n_hash_get_currently_in_hash_total
 HARNESS_ENTRY = $(PROOF_UID)_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
 
-PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c

--- a/tests/cbmc/proofs/s2n_hash_get_currently_in_hash_total/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_get_currently_in_hash_total/Makefile
@@ -15,7 +15,8 @@
 
 CBMCFLAGS +=
 
-HARNESS_ENTRY = s2n_hash_get_currently_in_hash_total_harness
+PROOF_UID = s2n_hash_get_currently_in_hash_total
+HARNESS_ENTRY = $(PROOF_UID)_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
 
 PROOF_SOURCES += $(HARNESS_FILE)

--- a/tests/cbmc/proofs/s2n_hash_get_currently_in_hash_total/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_hash_get_currently_in_hash_total/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_hash_get_currently_in_hash_total/s2n_hash_get_currently_in_hash_total_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_get_currently_in_hash_total/s2n_hash_get_currently_in_hash_total_harness.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "crypto/s2n_hash.h"
+
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_hash_get_currently_in_hash_total_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_hash_state *state = cbmc_allocate_s2n_hash_state();
+    uint64_t size;
+    uint64_t* out = bounded_malloc(size);
+
+    /* Assumptions. */
+    __CPROVER_assume(s2n_hash_state_is_valid(state));
+    if (state != NULL)
+    {
+        __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(state);
+    }
+
+    /* Operation under verification. */
+    if (s2n_hash_get_currently_in_hash_total(state, out) == S2N_SUCCESS)
+    {
+        /* Post-conditions. */
+        assert(s2n_hash_state_is_valid(state));
+        assert(state->is_ready_for_input);
+        assert(*out == state->currently_in_hash);
+    }
+}

--- a/tests/cbmc/proofs/s2n_hash_is_ready_for_input/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_is_ready_for_input/Makefile
@@ -1,0 +1,28 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 20 seconds.
+
+CBMCFLAGS +=
+
+HARNESS_ENTRY = s2n_hash_is_ready_for_input_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hash_is_ready_for_input/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_is_ready_for_input/Makefile
@@ -19,7 +19,7 @@ PROOF_UID = s2n_hash_is_ready_for_input
 HARNESS_ENTRY = $(PROOF_UID)_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
 
-PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 
 PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c

--- a/tests/cbmc/proofs/s2n_hash_is_ready_for_input/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_is_ready_for_input/Makefile
@@ -15,7 +15,8 @@
 
 CBMCFLAGS +=
 
-HARNESS_ENTRY = s2n_hash_is_ready_for_input_harness
+PROOF_UID = s2n_hash_is_ready_for_input
+HARNESS_ENTRY = $(PROOF_UID)_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
 
 PROOF_SOURCES += $(HARNESS_FILE)

--- a/tests/cbmc/proofs/s2n_hash_is_ready_for_input/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_hash_is_ready_for_input/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_hash_is_ready_for_input/s2n_hash_is_ready_for_input_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_is_ready_for_input/s2n_hash_is_ready_for_input_harness.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "crypto/s2n_hash.h"
+
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_hash_is_ready_for_input_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_hash_state *state = cbmc_allocate_s2n_hash_state();
+    __CPROVER_assume(s2n_hash_state_is_valid(state));
+
+    /* Operation under verification. */
+    if(s2n_hash_is_ready_for_input(state))
+    {
+        /* Post-conditions. */
+        assert(s2n_hash_state_is_valid(state));
+    }
+}


### PR DESCRIPTION
### Resolved issues:

N/A.

### Description of changes: 

Adds proof harnesses for the following `s2n_hash` functions:
 - `s2n_hash_const_time_get_currently_in_hash_block`;
 - `s2n_hash_get_currently_in_hash_total`;
 - `s2n_hash_is_ready_for_input`;
 - `s2n_hash_init`;
 - `s2n_hash_free`;

It also upgrades the libcrypto verification model version.

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
