### PR TITLE
Adds CBMC proof harness for s2n_array_init

### DIFF
--- a/tests/cbmc/proofs/s2n_array_init/Makefile
+++ b/tests/cbmc/proofs/s2n_array_init/Makefile
@@ -21,18 +21,16 @@ HARNESS_FILE = $(HARNESS_ENTRY).c
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
-PROOF_SOURCES += $(PROOF_STUB)/memset_havoc.c
 PROOF_SOURCES += $(PROOF_STUB)/mlock.c
 PROOF_SOURCES += $(PROOF_STUB)/munlock.c
-PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
 
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
-PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 

--- a/tests/cbmc/proofs/s2n_array_init/Makefile
+++ b/tests/cbmc/proofs/s2n_array_init/Makefile
@@ -1,0 +1,46 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 20 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_array_init
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/memset_havoc.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_ensure_memcpy_trace
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_array_init/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_array_init/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_array_init/s2n_array_init_harness.c
+++ b/tests/cbmc/proofs/s2n_array_init/s2n_array_init_harness.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "utils/s2n_array.h"
+
+#include <assert.h>
+#include <cbmc_proof/proof_allocators.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/cbmc_utils.h>
+
+void s2n_array_init_harness()
+{
+    /* Non-deterministic inputs. */
+    uint32_t element_size;
+    struct s2n_array *array = can_fail_malloc(sizeof(struct s2n_array));
+
+    nondet_s2n_mem_init();
+
+    /* Operation under verification. */
+    if (s2n_result_is_ok(s2n_array_init(array, element_size))) {
+
+        /* Post-conditions. */
+        assert(s2n_result_is_ok(s2n_array_validate(array)));
+        assert_all_zeroes(array, element_size);
+        assert(array->element_size == element_size);
+        assert(array->len == 0);
+    }
+}

--- a/tests/cbmc/proofs/s2n_array_init/s2n_array_init_harness.c
+++ b/tests/cbmc/proofs/s2n_array_init/s2n_array_init_harness.c
@@ -25,7 +25,7 @@ void s2n_array_init_harness()
 {
     /* Non-deterministic inputs. */
     uint32_t element_size;
-    struct s2n_array *array = can_fail_malloc(sizeof(struct s2n_array));
+    struct s2n_array *array = cbmc_allocate_s2n_array();
 
     nondet_s2n_mem_init();
 
@@ -34,7 +34,7 @@ void s2n_array_init_harness()
 
         /* Post-conditions. */
         assert(s2n_result_is_ok(s2n_array_validate(array)));
-        assert_all_zeroes(array, element_size);
+        assert_all_zeroes((uint8_t*) &array->mem, sizeof(array->mem));
         assert(array->element_size == element_size);
         assert(array->len == 0);
     }

--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -83,7 +83,7 @@ struct s2n_stuffer_reservation *cbmc_allocate_s2n_stuffer_reservation()
 
 struct s2n_array *cbmc_allocate_s2n_array()
 {
-    struct s2n_array *array = can_fail_malloc(sizeof(*array));
+    struct s2n_array *array = malloc(sizeof(*array));
     if (array != NULL) { ensure_s2n_blob_has_allocated_fields(&array->mem); }
     return array;
 }

--- a/utils/s2n_array.c
+++ b/utils/s2n_array.c
@@ -69,9 +69,9 @@ S2N_RESULT s2n_array_init(struct s2n_array *array, uint32_t element_size)
 {
     ENSURE_REF(array);
 
-    CHECKED_MEMSET(array, 0, sizeof(struct s2n_array));
-    array->element_size = element_size;
+    *array = (struct s2n_array){.element_size = element_size};
 
+    GUARD_RESULT(s2n_array_validate(array));
     return S2N_RESULT_OK;
 }
 


### PR DESCRIPTION
### Resolved issues:

 resolves https://github.com/awslabs/s2n/issues/2415

### Description of changes: 

Adds the CBMC proof harness for the new s2n_array method, `s2n_array_init` which initializes a zero-capacity s2n_array.

### Testing:

CBMC verification. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
