### PR TITLE
Only check the auth method for signatures server side

### DIFF
--- a/tls/s2n_auth_selection.c
+++ b/tls/s2n_auth_selection.c
@@ -179,10 +179,10 @@ int s2n_is_sig_scheme_valid_for_auth(struct s2n_connection *conn, const struct s
 
     GUARD(s2n_certs_exist_for_sig_scheme(conn, sig_scheme));
 
+    /* For the client side, signature algorithm does not need to match the cipher suite. */
     if (conn->mode == S2N_SERVER) {
         GUARD(s2n_is_sig_alg_valid_for_cipher_suite(sig_scheme->sig_alg, cipher_suite));
     }
-
     return S2N_SUCCESS;
 }
 

--- a/tls/s2n_auth_selection.c
+++ b/tls/s2n_auth_selection.c
@@ -164,7 +164,8 @@ int s2n_is_cipher_suite_valid_for_auth(struct s2n_connection *conn, struct s2n_c
 
 /* A signature algorithm is valid if:
  * - At least one compatible cert is configured.
- * - The signature algorithm is allowed by the cipher suite's auth method (if present).
+ * - The signature algorithm is allowed by the cipher suite's auth method
+ *   (if running as a pre-TLS1.3 server).
  *
  * This method is called by the both server and client when choosing a signature algorithm.
  */
@@ -177,7 +178,10 @@ int s2n_is_sig_scheme_valid_for_auth(struct s2n_connection *conn, const struct s
     notnull_check(cipher_suite);
 
     GUARD(s2n_certs_exist_for_sig_scheme(conn, sig_scheme));
-    GUARD(s2n_is_sig_alg_valid_for_cipher_suite(sig_scheme->sig_alg, cipher_suite));
+
+    if (conn->mode == S2N_SERVER) {
+        GUARD(s2n_is_sig_alg_valid_for_cipher_suite(sig_scheme->sig_alg, cipher_suite));
+    }
 
     return S2N_SUCCESS;
 }


### PR DESCRIPTION
### Resolved issues:

 resolves [IoT#200](https://github.com/aws/aws-iot-device-sdk-cpp-v2/issues/200)

### Description of changes: 

For client side connections, don't check for a match between signature algorithm and auth type.

(see linked issue for details)

### Call-outs:

Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? Yes, better tests are needed.
### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

```
./bin/s2nc -i --cert ./tests/pems/ecdsa_p384_pkcs1_cert.pem --key ./tests/pems/ecdsa_p384_pkcs1_key.pem aouj3c4the4zq-ats.iot.eu-central-1.amazonaws.com 8443
```

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed ? no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
