### PR TITLE
Fix declaration order in cbmc_utils.c

### DIFF
--- a/tests/cbmc/sources/cbmc_utils.c
+++ b/tests/cbmc/sources/cbmc_utils.c
@@ -119,6 +119,9 @@ int nondet_compare(const void *const a, const void *const b)
 }
 
 int __CPROVER_uninterpreted_compare(const void *const a, const void *const b);
+bool __CPROVER_uninterpreted_equals(const void *const a, const void *const b);
+uint64_t __CPROVER_uninterpreted_hasher(const void *const a);
+
 int uninterpreted_compare(const void *const a, const void *const b)
 {
     assert(a != NULL);
@@ -140,8 +143,6 @@ bool nondet_equals(const void *const a, const void *const b)
     return nondet_bool();
 }
 
-bool     __CPROVER_uninterpreted_equals(const void *const a, const void *const b);
-uint64_t __CPROVER_uninterpreted_hasher(const void *const a);
 /**
  * Add assumptions that equality is reflexive and symmetric. Don't bother with
  * transitivity because it doesn't cause any spurious proof failures on hash-table


### PR DESCRIPTION
### Resolved issues:

N/A.

### Description of changes: 

This PR fixes the declaration order in `cbmc_utils.c`, which might cause proof failure in newer CBMC versions.

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
