### PR TITLE
Adds proof harnesses for s2n_dhe functions

### DIFF
--- a/tests/cbmc/proofs/s2n_dh_params_check/Makefile
+++ b/tests/cbmc/proofs/s2n_dh_params_check/Makefile
@@ -1,0 +1,37 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+
+CHECKFLAGS +=
+
+PROOF_UID = s2n_dh_params_check
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(OPENSSL_SOURCE)/dh_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_dhe.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+
+UNWINDSET +=
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_dh_params_check/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_dh_params_check/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_dh_params_check/s2n_dh_params_check_harness.c
+++ b/tests/cbmc/proofs/s2n_dh_params_check/s2n_dh_params_check_harness.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+#include "api/s2n.h"
+#include "crypto/s2n_dhe.h"
+#include "stuffer/s2n_stuffer.h"
+
+void s2n_dh_params_check_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_dh_params *dh_params = cbmc_allocate_dh_params();
+
+    /* Assumptions. */
+    nondet_s2n_mem_init();
+
+    /* Operation under verification. */
+    if (s2n_dh_params_check(dh_params) == S2N_SUCCESS) {
+        /* Postconditions. */
+        assert(dh_params->dh != NULL);
+    }
+}

--- a/tests/cbmc/proofs/s2n_dh_params_copy/Makefile
+++ b/tests/cbmc/proofs/s2n_dh_params_copy/Makefile
@@ -1,0 +1,38 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 12 seconds.
+
+CHECKFLAGS +=
+
+PROOF_UID = s2n_dh_params_copy
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(OPENSSL_SOURCE)/bn_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/dh_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_dhe.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+
+UNWINDSET +=
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_dh_params_copy/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_dh_params_copy/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_dh_params_copy/s2n_dh_params_copy_harness.c
+++ b/tests/cbmc/proofs/s2n_dh_params_copy/s2n_dh_params_copy_harness.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+#include "api/s2n.h"
+#include "crypto/s2n_dhe.h"
+#include "stuffer/s2n_stuffer.h"
+
+void s2n_dh_params_copy_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_dh_params *from = cbmc_allocate_dh_params();
+    struct s2n_dh_params *to = cbmc_allocate_dh_params();
+
+    /* Assumptions. */
+    nondet_s2n_mem_init();
+
+    /* Operation under verification. */
+    if (s2n_dh_params_copy(from, to) == S2N_SUCCESS) {
+        /* Postconditions. */
+        assert(from->dh->pad == to->dh->pad);
+        assert(from->dh->version == to->dh->version);
+        assert(from->dh->params == to->dh->params);
+        assert(from->dh->length == to->dh->length);
+        assert(from->dh->flags == to->dh->flags);
+        assert(IMPLIES(from->dh->pub_key != NULL, *(from->dh->pub_key) == *(to->dh->pub_key)));
+        assert(IMPLIES(from->dh->priv_key != NULL, *(from->dh->priv_key) == *(to->dh->priv_key)));
+        assert(IMPLIES(from->dh->p != NULL, *(from->dh->p) == *(to->dh->p)));
+        assert(IMPLIES(from->dh->g != NULL, *(from->dh->g) == *(to->dh->g)));
+    }
+}

--- a/tests/cbmc/proofs/s2n_dh_params_free/Makefile
+++ b/tests/cbmc/proofs/s2n_dh_params_free/Makefile
@@ -1,0 +1,38 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+
+CHECKFLAGS +=
+
+PROOF_UID = s2n_dh_params_free
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(OPENSSL_SOURCE)/dh_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_dhe.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+
+UNWINDSET +=
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_dh_params_free/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_dh_params_free/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_dh_params_free/s2n_dh_params_free_harness.c
+++ b/tests/cbmc/proofs/s2n_dh_params_free/s2n_dh_params_free_harness.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+#include "api/s2n.h"
+#include "crypto/s2n_dhe.h"
+#include "stuffer/s2n_stuffer.h"
+
+void s2n_dh_params_free_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_dh_params *dh_params = cbmc_allocate_dh_params();
+
+    /* Assumptions. */
+    nondet_s2n_mem_init();
+
+    /* Operation under verification. */
+    if (s2n_dh_params_free(dh_params) == S2N_SUCCESS) {
+        /* Postconditions. */
+        assert(dh_params->dh == NULL);
+    }
+}

--- a/tests/cbmc/proofs/s2n_dh_params_to_p_g_Ys/Makefile
+++ b/tests/cbmc/proofs/s2n_dh_params_to_p_g_Ys/Makefile
@@ -1,0 +1,48 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 5 minutes.
+
+CHECKFLAGS +=
+
+PROOF_UID = s2n_dh_params_to_p_g_Ys
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(OPENSSL_SOURCE)/dh_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/bn_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_dhe.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+UNWINDSET +=
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+#REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+#REMOVE_FUNCTION_BODY +=  	s2n_stuffer_wipe
+
+UNWINDSET += s2n_stuffer_write_network_order.4:9
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_dh_params_to_p_g_Ys/Makefile
+++ b/tests/cbmc/proofs/s2n_dh_params_to_p_g_Ys/Makefile
@@ -39,10 +39,6 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
 UNWINDSET +=
 
-# We abstract this function because manual inspection demonstrates it is unreachable.
-#REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
-#REMOVE_FUNCTION_BODY +=  	s2n_stuffer_wipe
-
 UNWINDSET += s2n_stuffer_write_network_order.4:9
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_dh_params_to_p_g_Ys/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_dh_params_to_p_g_Ys/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_dh_params_to_p_g_Ys/s2n_dh_params_to_p_g_Ys_harness.c
+++ b/tests/cbmc/proofs/s2n_dh_params_to_p_g_Ys/s2n_dh_params_to_p_g_Ys_harness.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/nondet.h>
+#include <cbmc_proof/proof_allocators.h>
+
+#include "api/s2n.h"
+#include "crypto/s2n_dhe.h"
+#include "stuffer/s2n_stuffer.h"
+
+void s2n_dh_params_to_p_g_Ys_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_dh_params *server_dh_params = cbmc_allocate_dh_params();
+    struct s2n_stuffer *     out     = cbmc_allocate_s2n_stuffer();
+    struct s2n_blob *     output     = cbmc_allocate_s2n_blob();
+
+    /* Assumptions. */
+    __CPROVER_assume(s2n_stuffer_is_valid(out));
+    __CPROVER_assume(s2n_blob_is_valid(output));
+    nondet_s2n_mem_init();
+
+    /* Operation under verification. */
+    if (s2n_dh_params_to_p_g_Ys(server_dh_params, out, output) == S2N_SUCCESS) {
+        /* Postconditions. */
+        assert(s2n_stuffer_is_valid(out));
+    }
+}


### PR DESCRIPTION
### Resolved issues:

N/A.

### Description of changes: 

Adds proof harnesses for the following `s2n_dhe` functions:
 - `s2n_dh_params_check`;
 - `s2n_dh_params_copy`;
 - `s2n_dh_params_free`;
 - `s2n_dh_params_to_p_g_Ys`;

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
