### PR TITLE
Fix cert verify signature size calculation

### DIFF
--- a/tests/unit/s2n_client_cert_verify_test.c
+++ b/tests/unit/s2n_client_cert_verify_test.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <stdint.h>
+#include <s2n.h>
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+
+#include "tls/s2n_tls.h"
+#include "tls/s2n_connection.h"
+#include "utils/s2n_safety.h"
+
+const uint8_t test_signature_data[] = "I signed this";
+const uint32_t test_signature_size = sizeof(test_signature_data);
+const uint32_t test_max_signature_size = 2 * sizeof(test_signature_data);
+
+static int test_size(const struct s2n_pkey *pkey)
+{
+    return test_max_signature_size;
+}
+
+static int test_sign(const struct s2n_pkey *priv_key, s2n_signature_algorithm sig_alg,
+        struct s2n_hash_state *digest, struct s2n_blob *signature)
+{
+    memcpy_check(signature->data, test_signature_data, test_signature_size);
+    signature->size = test_signature_size;
+    return S2N_SUCCESS;
+}
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Test that the signature size is written correctly when not equal to the maximum */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(conn);
+
+        /* Set any signature scheme. Our test pkey methods ignore it. */
+        conn->secure.client_cert_sig_scheme = s2n_rsa_pkcs1_md5_sha1;
+
+        struct s2n_cert_chain_and_key *chain_and_key;
+        EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
+                S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
+        chain_and_key->private_key->size = test_size;
+        chain_and_key->private_key->sign = test_sign;
+        conn->handshake_params.our_chain_and_key = chain_and_key;
+
+        EXPECT_SUCCESS(s2n_client_cert_verify_send(conn));
+
+        uint16_t signature_scheme_iana;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint16(&conn->handshake.io, &signature_scheme_iana));
+        EXPECT_EQUAL(signature_scheme_iana, s2n_rsa_pkcs1_md5_sha1.iana_value);
+
+        uint16_t signature_size;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint16(&conn->handshake.io, &signature_size));
+        EXPECT_NOT_EQUAL(signature_size, test_max_signature_size);
+        EXPECT_EQUAL(signature_size, test_signature_size);
+        EXPECT_EQUAL(signature_size, s2n_stuffer_data_available(&conn->handshake.io));
+
+        uint8_t *signature_data = s2n_stuffer_raw_read(&conn->handshake.io, test_signature_size);
+        EXPECT_NOT_NULL(signature_data);
+        EXPECT_BYTEARRAY_EQUAL(signature_data, test_signature_data, test_signature_size);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+    }
+
+    END_TEST();
+}

--- a/tls/s2n_client_cert_verify.c
+++ b/tls/s2n_client_cert_verify.c
@@ -63,7 +63,7 @@ int s2n_client_cert_verify_send(struct s2n_connection *conn)
 
     struct s2n_signature_scheme chosen_sig_scheme = s2n_rsa_pkcs1_md5_sha1;
 
-    if(conn->actual_protocol_version >= S2N_TLS12){
+    if (conn->actual_protocol_version >= S2N_TLS12) {
         chosen_sig_scheme =  conn->secure.client_cert_sig_scheme;
         GUARD(s2n_stuffer_write_uint16(out, conn->secure.client_cert_sig_scheme.iana_value));
     }
@@ -74,13 +74,15 @@ int s2n_client_cert_verify_send(struct s2n_connection *conn)
     GUARD(s2n_hash_copy(&conn->handshake.ccv_hash_copy, &hash_state));
 
     struct s2n_cert_chain_and_key *cert_chain_and_key = conn->handshake_params.our_chain_and_key;
-    struct s2n_blob signature = {0};
-    signature.size = s2n_pkey_size(cert_chain_and_key->private_key);
-    GUARD(s2n_stuffer_write_uint16(out, signature.size));
-    signature.data = s2n_stuffer_raw_write(out, signature.size);
-    notnull_check(signature.data);
+
+    DEFER_CLEANUP(struct s2n_blob signature = {0}, s2n_free);
+    uint32_t max_signature_size = s2n_pkey_size(cert_chain_and_key->private_key);
+    GUARD(s2n_alloc(&signature, max_signature_size));
 
     GUARD(s2n_pkey_sign(cert_chain_and_key->private_key, chosen_sig_scheme.sig_alg, &conn->handshake.ccv_hash_copy, &signature));
+
+    GUARD(s2n_stuffer_write_uint16(out, signature.size));
+    GUARD(s2n_stuffer_write(out, &signature));
 
     /* Client certificate has been verified. Minimize required handshake hash algs */
     GUARD(s2n_conn_update_required_handshake_hashes(conn));


### PR DESCRIPTION
### Description of changes: 

Calling `s2n_pkey_sign` may produce a signature smaller than the maximum signature size returned by `s2n_pkey_size`. Therefore, we must not write the signature size or the signature data until after the call to `s2n_pkey_sign`.

### Call-outs:

The new version of the code now allocates heap memory. If we're worried about the cost of the memory allocation, it can be avoided by using `s2n_stuffer_reserve_uint16` to postpone writing the signature size and then wiping any excess bytes written but not used for the signature from the stuffer with `s2n_stuffer_wipe_n` after the call to `s2n_pkey_sign`. However, that solution is exactly as messy and hard to follow as it sounds.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? New unit test, and tested that the repro'd customer setup now passes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
