### PR TITLE
Remove static qualifier from pq unit test helper function

### DIFF
--- a/tests/unit/s2n_tls13_pq_handshake_test.c
+++ b/tests/unit/s2n_tls13_pq_handshake_test.c
@@ -25,7 +25,7 @@
 /* Include C file directly to access static functions */
 #include "tls/s2n_handshake_io.c"
 
-static int s2n_test_tls13_pq_handshake(const struct s2n_security_policy *client_sec_policy,
+int s2n_test_tls13_pq_handshake(const struct s2n_security_policy *client_sec_policy,
         const struct s2n_security_policy *server_sec_policy, const struct s2n_kem_group *expected_kem_group,
         const struct s2n_ecc_named_curve *expected_curve, bool should_send_ec_shares, bool hrr_expected) {
     /* XOR check: can expect to negotiate either a KEM group, or a classic EC curve, but not both/neither */


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

Removes the `static` qualifier from a helper function in a PQ unit test so that the compiler won't warn when `S2N_NO_PQ` is defined.

### Call-outs:

N/A

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
