### PR TITLE
Remove obsolete integv2 makefile target

### DIFF
--- a/tests/integrationv2/Makefile
+++ b/tests/integrationv2/Makefile
@@ -51,8 +51,6 @@ test_sni_match:
 	$(call run_tox,$@.py)
 test_well_known_endpoints:
 	$(call run_tox,$@.py)
-# TODO Remove this target from CI, then from Makefile
-test_compatibility_with_oqs_openssl: ;
 test_fragmentation:
 	$(call run_tox,$@.py)
 test_hello_retry_requests:


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

Removes the obsolete OQS compatibility target from the integv2 Makefile. The OQS compatibility test was combined with PQ handshake test in https://github.com/awslabs/s2n/pull/2444/. The target has been removed from CI.

### Call-outs:

N/A

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
