### PR TITLE
Adds proof harnesses for s2n_hmac functions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,5 +7,3 @@
 [submodule "tests/litani"]
 	path = tests/litani
 	url = https://github.com/awslabs/aws-build-accumulator
-	update = rebase
-	branch = mainline

--- a/crypto/s2n_fips.h
+++ b/crypto/s2n_fips.h
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+#include <stdbool.h>
+
 #pragma once
 
 extern int s2n_fips_init(void);

--- a/crypto/s2n_fips.h
+++ b/crypto/s2n_fips.h
@@ -15,6 +15,8 @@
 
 #include <stdbool.h>
 
+#include "api/s2n.h"
+
 #pragma once
 
 extern int s2n_fips_init(void);

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -22,27 +22,9 @@
 
 #include "utils/s2n_safety.h"
 
-int s2n_hash_hmac_alg(s2n_hash_algorithm hash_alg, s2n_hmac_algorithm *out)
-{
-    ENSURE_POSIX(S2N_MEM_IS_READABLE(out, sizeof(*out)), S2N_ERR_PRECONDITION_VIOLATION);
-    switch(hash_alg) {
-    case S2N_HASH_NONE:       *out = S2N_HMAC_NONE;   break;
-    case S2N_HASH_MD5:        *out = S2N_HMAC_MD5;    break;
-    case S2N_HASH_SHA1:       *out = S2N_HMAC_SHA1;   break;
-    case S2N_HASH_SHA224:     *out = S2N_HMAC_SHA224; break;
-    case S2N_HASH_SHA256:     *out = S2N_HMAC_SHA256; break;
-    case S2N_HASH_SHA384:     *out = S2N_HMAC_SHA384; break;
-    case S2N_HASH_SHA512:     *out = S2N_HMAC_SHA512; break;
-    case S2N_HASH_MD5_SHA1:   /* Fall through ... */
-    default:
-        S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
-    }
-    return S2N_SUCCESS;
-}
-
 int s2n_hash_digest_size(s2n_hash_algorithm alg, uint8_t *out)
 {
-    notnull_check(out);
+    ENSURE_POSIX(S2N_MEM_IS_WRITABLE(out, sizeof(*out)), S2N_ERR_PRECONDITION_VIOLATION);
     switch (alg) {
     case S2N_HASH_NONE:     *out = 0;                    break;
     case S2N_HASH_MD5:      *out = MD5_DIGEST_LENGTH;    break;
@@ -63,7 +45,7 @@ int s2n_hash_digest_size(s2n_hash_algorithm alg, uint8_t *out)
  * If this ever becomes untrue, this would require fixing*/
 int s2n_hash_block_size(s2n_hash_algorithm alg, uint64_t *block_size)
 {
-    ENSURE_POSIX(S2N_MEM_IS_READABLE(block_size, sizeof(*block_size)), S2N_ERR_PRECONDITION_VIOLATION);
+    ENSURE_POSIX(S2N_MEM_IS_WRITABLE(block_size, sizeof(*block_size)), S2N_ERR_PRECONDITION_VIOLATION);
     switch(alg) {
     case S2N_HASH_NONE:       *block_size = 64;   break;
     case S2N_HASH_MD5:        *block_size = 64;   break;
@@ -623,7 +605,7 @@ int s2n_hash_free(struct s2n_hash_state *state)
 int s2n_hash_get_currently_in_hash_total(struct s2n_hash_state *state, uint64_t *out)
 {
     PRECONDITION_POSIX(s2n_hash_state_validate(state));
-    ENSURE_POSIX(S2N_MEM_IS_READABLE(out, sizeof(*out)), S2N_ERR_PRECONDITION_VIOLATION);
+    ENSURE_POSIX(S2N_MEM_IS_WRITABLE(out, sizeof(*out)), S2N_ERR_PRECONDITION_VIOLATION);
     ENSURE_POSIX(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
 
     *out = state->currently_in_hash;
@@ -635,7 +617,7 @@ int s2n_hash_get_currently_in_hash_total(struct s2n_hash_state *state, uint64_t 
 int s2n_hash_const_time_get_currently_in_hash_block(struct s2n_hash_state *state, uint64_t *out)
 {
     PRECONDITION_POSIX(s2n_hash_state_validate(state));
-    ENSURE_POSIX(S2N_MEM_IS_READABLE(out, sizeof(*out)), S2N_ERR_PRECONDITION_VIOLATION);
+    ENSURE_POSIX(S2N_MEM_IS_WRITABLE(out, sizeof(*out)), S2N_ERR_PRECONDITION_VIOLATION);
     ENSURE_POSIX(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
     uint64_t hash_block_size;
     GUARD(s2n_hash_block_size(state->alg, &hash_block_size));

--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -115,7 +115,7 @@ static int s2n_sslv3_mac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm a
     GUARD(s2n_hash_update(&state->outer_just_key, key, klen));
     GUARD(s2n_hash_update(&state->outer_just_key, state->xor_pad, state->xor_pad_size));
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 static int s2n_tls_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm alg, const void *key, uint32_t klen)
@@ -142,11 +142,12 @@ static int s2n_tls_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm al
     }
 
     GUARD(s2n_hash_update(&state->outer_just_key, state->xor_pad, state->xor_pad_size));
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_hmac_xor_pad_size(s2n_hmac_algorithm hmac_alg, uint16_t *xor_pad_size)
 {
+    PRECONDITION_POSIX(S2N_MEM_IS_WRITABLE(xor_pad_size, sizeof(*xor_pad_size)));
     switch(hmac_alg) {
     case S2N_HMAC_NONE:       *xor_pad_size = 64;   break;
     case S2N_HMAC_MD5:        *xor_pad_size = 64;   break;
@@ -160,11 +161,12 @@ int s2n_hmac_xor_pad_size(s2n_hmac_algorithm hmac_alg, uint16_t *xor_pad_size)
     default:
         S2N_ERROR(S2N_ERR_HMAC_INVALID_ALGORITHM);
     }
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_hmac_hash_block_size(s2n_hmac_algorithm hmac_alg, uint16_t *block_size)
 {
+    PRECONDITION_POSIX(S2N_MEM_IS_WRITABLE(block_size, sizeof(*block_size)));
     switch(hmac_alg) {
     case S2N_HMAC_NONE:       *block_size = 64;   break;
     case S2N_HMAC_MD5:        *block_size = 64;   break;
@@ -178,7 +180,7 @@ int s2n_hmac_hash_block_size(s2n_hmac_algorithm hmac_alg, uint16_t *block_size)
     default:
         S2N_ERROR(S2N_ERR_HMAC_INVALID_ALGORITHM);
     }
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_hmac_new(struct s2n_hmac_state *state)

--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -90,7 +90,7 @@ bool s2n_hmac_is_available(s2n_hmac_algorithm hmac_alg)
     case S2N_HMAC_SHA512:
         return true;
     default:
-        S2N_ERROR(S2N_ERR_HMAC_INVALID_ALGORITHM);
+        return false;
     }
     return false;
 }

--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -30,7 +30,7 @@
 
 int s2n_hash_hmac_alg(s2n_hash_algorithm hash_alg, s2n_hmac_algorithm *out)
 {
-    PRECONDITION_POSIX(S2N_MEM_IS_READABLE(out, sizeof(*out)));
+    ENSURE_POSIX(S2N_MEM_IS_WRITABLE(out, sizeof(*out)), S2N_ERR_PRECONDITION_VIOLATION);
     switch(hash_alg) {
     case S2N_HASH_NONE:       *out = S2N_HMAC_NONE;   break;
     case S2N_HASH_MD5:        *out = S2N_HMAC_MD5;    break;
@@ -48,7 +48,7 @@ int s2n_hash_hmac_alg(s2n_hash_algorithm hash_alg, s2n_hmac_algorithm *out)
 
 int s2n_hmac_hash_alg(s2n_hmac_algorithm hmac_alg, s2n_hash_algorithm *out)
 {
-    PRECONDITION_POSIX(S2N_MEM_IS_READABLE(out, sizeof(*out)));
+    ENSURE_POSIX(S2N_MEM_IS_WRITABLE(out, sizeof(*out)), S2N_ERR_PRECONDITION_VIOLATION);
     switch(hmac_alg) {
     case S2N_HMAC_NONE:       *out = S2N_HASH_NONE;   break;
     case S2N_HMAC_MD5:        *out = S2N_HASH_MD5;    break;
@@ -141,7 +141,7 @@ static int s2n_tls_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm al
 
 int s2n_hmac_xor_pad_size(s2n_hmac_algorithm hmac_alg, uint16_t *xor_pad_size)
 {
-    PRECONDITION_POSIX(S2N_MEM_IS_WRITABLE(xor_pad_size, sizeof(*xor_pad_size)));
+    ENSURE_POSIX(S2N_MEM_IS_WRITABLE(xor_pad_size, sizeof(*xor_pad_size)), S2N_ERR_PRECONDITION_VIOLATION);
     switch(hmac_alg) {
     case S2N_HMAC_NONE:       *xor_pad_size = 64;   break;
     case S2N_HMAC_MD5:        *xor_pad_size = 64;   break;
@@ -160,7 +160,7 @@ int s2n_hmac_xor_pad_size(s2n_hmac_algorithm hmac_alg, uint16_t *xor_pad_size)
 
 int s2n_hmac_hash_block_size(s2n_hmac_algorithm hmac_alg, uint16_t *block_size)
 {
-    PRECONDITION_POSIX(S2N_MEM_IS_WRITABLE(block_size, sizeof(*block_size)));
+    ENSURE_POSIX(S2N_MEM_IS_WRITABLE(block_size, sizeof(*block_size)), S2N_ERR_PRECONDITION_VIOLATION);
     switch(hmac_alg) {
     case S2N_HMAC_NONE:       *block_size = 64;   break;
     case S2N_HMAC_MD5:        *block_size = 64;   break;

--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -89,8 +89,6 @@ bool s2n_hmac_is_available(s2n_hmac_algorithm hmac_alg)
     case S2N_HMAC_SHA384:
     case S2N_HMAC_SHA512:
         return true;
-    default:
-        return false;
     }
     return false;
 }

--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -76,27 +76,23 @@ int s2n_hmac_digest_size(s2n_hmac_algorithm hmac_alg, uint8_t *out)
 /* Return 1 if hmac algorithm is available, 0 otherwise. */
 bool s2n_hmac_is_available(s2n_hmac_algorithm hmac_alg)
 {
-    bool is_available = false;
     switch(hmac_alg) {
     case S2N_HMAC_MD5:
     case S2N_HMAC_SSLv3_MD5:
     case S2N_HMAC_SSLv3_SHA1:
         /* Set is_available to 0 if in FIPS mode, as MD5/SSLv3 algs are not available in FIPS mode. */
-        is_available = !s2n_is_in_fips_mode();
-        break;
+        return !s2n_is_in_fips_mode();
     case S2N_HMAC_NONE:
     case S2N_HMAC_SHA1:
     case S2N_HMAC_SHA224:
     case S2N_HMAC_SHA256:
     case S2N_HMAC_SHA384:
     case S2N_HMAC_SHA512:
-        is_available = true;
-        break;
+        return true;
     default:
         S2N_ERROR(S2N_ERR_HMAC_INVALID_ALGORITHM);
     }
-
-    return is_available;
+    return false;
 }
 
 static int s2n_sslv3_mac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm alg, const void *key, uint32_t klen)

--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -28,9 +28,27 @@
 
 #include <stdint.h>
 
+int s2n_hash_hmac_alg(s2n_hash_algorithm hash_alg, s2n_hmac_algorithm *out)
+{
+    PRECONDITION_POSIX(S2N_MEM_IS_READABLE(out, sizeof(*out)));
+    switch(hash_alg) {
+    case S2N_HASH_NONE:       *out = S2N_HMAC_NONE;   break;
+    case S2N_HASH_MD5:        *out = S2N_HMAC_MD5;    break;
+    case S2N_HASH_SHA1:       *out = S2N_HMAC_SHA1;   break;
+    case S2N_HASH_SHA224:     *out = S2N_HMAC_SHA224; break;
+    case S2N_HASH_SHA256:     *out = S2N_HMAC_SHA256; break;
+    case S2N_HASH_SHA384:     *out = S2N_HMAC_SHA384; break;
+    case S2N_HASH_SHA512:     *out = S2N_HMAC_SHA512; break;
+    case S2N_HASH_MD5_SHA1:   /* Fall through ... */
+    default:
+        S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
+    }
+    return S2N_SUCCESS;
+}
 
 int s2n_hmac_hash_alg(s2n_hmac_algorithm hmac_alg, s2n_hash_algorithm *out)
 {
+    PRECONDITION_POSIX(S2N_MEM_IS_READABLE(out, sizeof(*out)));
     switch(hmac_alg) {
     case S2N_HMAC_NONE:       *out = S2N_HASH_NONE;   break;
     case S2N_HMAC_MD5:        *out = S2N_HASH_MD5;    break;
@@ -44,7 +62,7 @@ int s2n_hmac_hash_alg(s2n_hmac_algorithm hmac_alg, s2n_hash_algorithm *out)
     default:
         S2N_ERROR(S2N_ERR_HMAC_INVALID_ALGORITHM);
     }
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_hmac_digest_size(s2n_hmac_algorithm hmac_alg, uint8_t *out)
@@ -52,13 +70,13 @@ int s2n_hmac_digest_size(s2n_hmac_algorithm hmac_alg, uint8_t *out)
     s2n_hash_algorithm hash_alg;
     GUARD(s2n_hmac_hash_alg(hmac_alg, &hash_alg));
     GUARD(s2n_hash_digest_size(hash_alg, out));
-    return 0;
+    return S2N_SUCCESS;
 }
 
 /* Return 1 if hmac algorithm is available, 0 otherwise. */
-int s2n_hmac_is_available(s2n_hmac_algorithm hmac_alg)
+bool s2n_hmac_is_available(s2n_hmac_algorithm hmac_alg)
 {
-    int is_available = 0;
+    bool is_available = false;
     switch(hmac_alg) {
     case S2N_HMAC_MD5:
     case S2N_HMAC_SSLv3_MD5:
@@ -66,13 +84,13 @@ int s2n_hmac_is_available(s2n_hmac_algorithm hmac_alg)
         /* Set is_available to 0 if in FIPS mode, as MD5/SSLv3 algs are not available in FIPS mode. */
         is_available = !s2n_is_in_fips_mode();
         break;
-    case S2N_HMAC_NONE:    
+    case S2N_HMAC_NONE:
     case S2N_HMAC_SHA1:
     case S2N_HMAC_SHA224:
     case S2N_HMAC_SHA256:
     case S2N_HMAC_SHA384:
     case S2N_HMAC_SHA512:
-        is_available = 1;
+        is_available = true;
         break;
     default:
         S2N_ERROR(S2N_ERR_HMAC_INVALID_ALGORITHM);
@@ -103,7 +121,7 @@ static int s2n_sslv3_mac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm a
 static int s2n_tls_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm alg, const void *key, uint32_t klen)
 {
     memset(&state->xor_pad, 0, sizeof(state->xor_pad));
-    
+
     if (klen > state->xor_pad_size) {
         GUARD(s2n_hash_update(&state->outer, key, klen));
         GUARD(s2n_hash_digest(&state->outer, state->digest_pad, state->digest_size));
@@ -223,9 +241,9 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
      * value that is congruent to 0 modulo all of our HMAC block sizes, that is also
      * at least 16k smaller than 2^32. It therefore has no effect on the mathematical
      * result, and no valid record size can cause it to overflow.
-     * 
+     *
      * The value was found with the following python code;
-     * 
+     *
      * x = (2 ** 32) - (2 ** 14)
      * while True:
      *   if x % 40 | x % 48 | x % 64 | x % 128 == 0:
@@ -291,7 +309,7 @@ int s2n_hmac_free(struct s2n_hmac_state *state)
 int s2n_hmac_reset(struct s2n_hmac_state *state)
 {
     GUARD(s2n_hash_copy(&state->inner, &state->inner_just_key));
-    
+
     uint64_t bytes_in_hash;
     GUARD(s2n_hash_get_currently_in_hash_total(&state->inner, &bytes_in_hash));
     /* The length of the key is not private, so don't need to do tricky math here */
@@ -328,7 +346,7 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
 }
 
 
-/* Preserve the handlers for hmac state pointers to avoid re-allocation 
+/* Preserve the handlers for hmac state pointers to avoid re-allocation
  * Only valid if the HMAC is in EVP mode
  */
 int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac)

--- a/crypto/s2n_hmac.h
+++ b/crypto/s2n_hmac.h
@@ -60,7 +60,7 @@ struct s2n_hmac_evp_backup {
 };
 
 extern int s2n_hmac_digest_size(s2n_hmac_algorithm alg, uint8_t *out);
-extern int s2n_hmac_is_available(s2n_hmac_algorithm alg);
+extern bool s2n_hmac_is_available(s2n_hmac_algorithm alg);
 extern int s2n_hmac_hash_alg(s2n_hmac_algorithm hmac_alg, s2n_hash_algorithm *out);
 extern int s2n_hash_hmac_alg(s2n_hash_algorithm hash_alg, s2n_hmac_algorithm *out);
 
@@ -75,5 +75,3 @@ extern int s2n_hmac_reset(struct s2n_hmac_state *state);
 extern int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from);
 extern int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac);
 extern int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac);
-
-

--- a/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips/s2n_digest_allow_md5_for_fips_harness.c
+++ b/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips/s2n_digest_allow_md5_for_fips_harness.c
@@ -15,7 +15,7 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
-#include "api/s2n.h"
+#include "crypto/s2n_fips.h"
 #include "crypto/s2n_evp.h"
 
 void s2n_digest_allow_md5_for_fips_harness()

--- a/tests/cbmc/proofs/s2n_digest_is_md5_allowed_for_fips/s2n_digest_is_md5_allowed_for_fips_harness.c
+++ b/tests/cbmc/proofs/s2n_digest_is_md5_allowed_for_fips/s2n_digest_is_md5_allowed_for_fips_harness.c
@@ -15,7 +15,7 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
-#include "api/s2n.h"
+#include "crypto/s2n_fips.h"
 #include "crypto/s2n_evp.h"
 #include "utils/s2n_result.h"
 

--- a/tests/cbmc/proofs/s2n_hash_allow_md5_for_fips/s2n_hash_allow_md5_for_fips_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_allow_md5_for_fips/s2n_hash_allow_md5_for_fips_harness.c
@@ -15,7 +15,7 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
-#include "api/s2n.h"
+#include "crypto/s2n_fips.h"
 #include "crypto/s2n_hash.h"
 
 void s2n_hash_allow_md5_for_fips_harness()

--- a/tests/cbmc/proofs/s2n_hash_block_size/s2n_hash_block_size_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_block_size/s2n_hash_block_size_harness.c
@@ -16,7 +16,6 @@
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/proof_allocators.h>
 
-#include "api/s2n.h"
 #include "crypto/s2n_hash.h"
 
 void s2n_hash_block_size_harness()
@@ -29,13 +28,19 @@ void s2n_hash_block_size_harness()
     /* Operation under verification. */
     if (s2n_hash_block_size(alg, block_size) == S2N_SUCCESS) {
         /* Post-conditions. */
-        assert(IMPLIES(alg == S2N_HASH_NONE, *block_size == 64));
-        assert(IMPLIES(alg == S2N_HASH_MD5, *block_size == 64));
-        assert(IMPLIES(alg == S2N_HASH_SHA1, *block_size == 64));
-        assert(IMPLIES(alg == S2N_HASH_SHA224, *block_size == 64));
-        assert(IMPLIES(alg == S2N_HASH_SHA256, *block_size == 64));
-        assert(IMPLIES(alg == S2N_HASH_SHA384, *block_size == 128));
-        assert(IMPLIES(alg == S2N_HASH_SHA512, *block_size == 128));
-        assert(IMPLIES(alg == S2N_HASH_MD5_SHA1, *block_size == 64));
+        switch(alg) {
+            case S2N_HASH_NONE:
+            case S2N_HASH_MD5:
+            case S2N_HASH_SHA1:
+            case S2N_HASH_SHA224:
+            case S2N_HASH_SHA256:
+            case S2N_HASH_MD5_SHA1:
+                assert(*block_size == 64); break;
+            case S2N_HASH_SHA384:
+            case S2N_HASH_SHA512:
+                assert(*block_size == 128); break;
+            default:
+                __CPROVER_assert(0, "Unssuported algorithm.");
+        }
     }
 }

--- a/tests/cbmc/proofs/s2n_hash_const_time_get_currently_in_hash_block/s2n_hash_const_time_get_currently_in_hash_block_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_const_time_get_currently_in_hash_block/s2n_hash_const_time_get_currently_in_hash_block_harness.c
@@ -13,7 +13,6 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
 #include "crypto/s2n_hash.h"
 
 #include <cbmc_proof/make_common_datastructures.h>

--- a/tests/cbmc/proofs/s2n_hash_copy/s2n_hash_copy_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_copy/s2n_hash_copy_harness.c
@@ -13,7 +13,6 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
 #include "crypto/s2n_hash.h"
 
 #include <cbmc_proof/make_common_datastructures.h>

--- a/tests/cbmc/proofs/s2n_hash_digest/s2n_hash_digest_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_digest/s2n_hash_digest_harness.c
@@ -13,7 +13,6 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
 #include "crypto/s2n_hash.h"
 
 #include <cbmc_proof/make_common_datastructures.h>

--- a/tests/cbmc/proofs/s2n_hash_digest_size/s2n_hash_digest_size_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_digest_size/s2n_hash_digest_size_harness.c
@@ -16,7 +16,6 @@
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/proof_allocators.h>
 
-#include "api/s2n.h"
 #include "crypto/s2n_hash.h"
 
 void s2n_hash_digest_size_harness()
@@ -29,13 +28,17 @@ void s2n_hash_digest_size_harness()
     /* Operation under verification. */
     if (s2n_hash_digest_size(alg, out) == S2N_SUCCESS) {
         /* Post-conditions. */
-        assert(IMPLIES(alg == S2N_HASH_NONE, *out == 0));
-        assert(IMPLIES(alg == S2N_HASH_MD5, *out == MD5_DIGEST_LENGTH));
-        assert(IMPLIES(alg == S2N_HASH_SHA1, *out == SHA_DIGEST_LENGTH));
-        assert(IMPLIES(alg == S2N_HASH_SHA224, *out == SHA224_DIGEST_LENGTH));
-        assert(IMPLIES(alg == S2N_HASH_SHA256, *out == SHA256_DIGEST_LENGTH));
-        assert(IMPLIES(alg == S2N_HASH_SHA384, *out == SHA384_DIGEST_LENGTH));
-        assert(IMPLIES(alg == S2N_HASH_SHA512, *out == SHA512_DIGEST_LENGTH));
-        assert(IMPLIES(alg == S2N_HASH_MD5_SHA1, *out == MD5_DIGEST_LENGTH + SHA_DIGEST_LENGTH));
+        switch (alg) {
+        case S2N_HASH_NONE:     assert(*out == 0);                    break;
+        case S2N_HASH_MD5:      assert(*out == MD5_DIGEST_LENGTH);    break;
+        case S2N_HASH_SHA1:     assert(*out == SHA_DIGEST_LENGTH);    break;
+        case S2N_HASH_SHA224:   assert(*out == SHA224_DIGEST_LENGTH); break;
+        case S2N_HASH_SHA256:   assert(*out == SHA256_DIGEST_LENGTH); break;
+        case S2N_HASH_SHA384:   assert(*out == SHA384_DIGEST_LENGTH); break;
+        case S2N_HASH_SHA512:   assert(*out == SHA512_DIGEST_LENGTH); break;
+        case S2N_HASH_MD5_SHA1: assert(*out == MD5_DIGEST_LENGTH + SHA_DIGEST_LENGTH); break;
+        default:
+            __CPROVER_assert(0, "Unssuported algorithm.");
+        }
     }
 }

--- a/tests/cbmc/proofs/s2n_hash_get_currently_in_hash_total/s2n_hash_get_currently_in_hash_total_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_get_currently_in_hash_total/s2n_hash_get_currently_in_hash_total_harness.c
@@ -13,7 +13,6 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
 #include "crypto/s2n_hash.h"
 
 #include <cbmc_proof/make_common_datastructures.h>

--- a/tests/cbmc/proofs/s2n_hash_hmac_alg/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_hmac_alg/Makefile
@@ -23,7 +23,7 @@ PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 
-PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c
 
 UNWINDSET +=
 

--- a/tests/cbmc/proofs/s2n_hash_hmac_alg/s2n_hash_hmac_alg_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_hmac_alg/s2n_hash_hmac_alg_harness.c
@@ -16,26 +16,32 @@
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/proof_allocators.h>
 
-#include "api/s2n.h"
-#include "crypto/s2n_hash.h"
 #include "crypto/s2n_hmac.h"
 
 void s2n_hash_hmac_alg_harness()
 {
     /* Non-deterministic inputs. */
     s2n_hash_algorithm hash_alg;
-    size_t             alg_size;
-    uint8_t *          out = bounded_malloc(alg_size);
+    s2n_hmac_algorithm *out = malloc(sizeof(*out));
+
+    /* Save previous state. */
+    s2n_hmac_algorithm old_out = (out) ? *out : -1;
 
     /* Operation under verification. */
     if (s2n_hash_hmac_alg(hash_alg, out) == S2N_SUCCESS) {
         /* Post-conditions. */
-        assert(IMPLIES(hash_alg == S2N_HASH_NONE, *out == S2N_HMAC_NONE));
-        assert(IMPLIES(hash_alg == S2N_HASH_MD5, *out == S2N_HMAC_MD5));
-        assert(IMPLIES(hash_alg == S2N_HASH_SHA1, *out == S2N_HMAC_SHA1));
-        assert(IMPLIES(hash_alg == S2N_HASH_SHA224, *out == S2N_HMAC_SHA224));
-        assert(IMPLIES(hash_alg == S2N_HASH_SHA256, *out == S2N_HMAC_SHA256));
-        assert(IMPLIES(hash_alg == S2N_HASH_SHA384, *out == S2N_HMAC_SHA384));
-        assert(IMPLIES(hash_alg == S2N_HASH_SHA512, *out == S2N_HMAC_SHA512));
+        switch(hash_alg) {
+        case S2N_HASH_NONE:       assert(*out == S2N_HMAC_NONE);   break;
+        case S2N_HASH_MD5:        assert(*out == S2N_HMAC_MD5);    break;
+        case S2N_HASH_SHA1:       assert(*out == S2N_HMAC_SHA1);   break;
+        case S2N_HASH_SHA224:     assert(*out == S2N_HMAC_SHA224); break;
+        case S2N_HASH_SHA256:     assert(*out == S2N_HMAC_SHA256); break;
+        case S2N_HASH_SHA384:     assert(*out == S2N_HMAC_SHA384); break;
+        case S2N_HASH_SHA512:     assert(*out == S2N_HMAC_SHA512); break;
+        default:
+            __CPROVER_assert(0, "Unssuported algorithm.");
+        }
+    } else {
+        assert(IMPLIES(out != NULL && hash_alg == S2N_HASH_MD5_SHA1, *out == old_out));
     }
 }

--- a/tests/cbmc/proofs/s2n_hash_is_available/s2n_hash_is_available_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_is_available/s2n_hash_is_available_harness.c
@@ -15,7 +15,7 @@
 
 #include <cbmc_proof/cbmc_utils.h>
 
-#include "api/s2n.h"
+#include "crypto/s2n_fips.h"
 #include "crypto/s2n_hash.h"
 
 void s2n_hash_is_available_harness()
@@ -25,13 +25,22 @@ void s2n_hash_is_available_harness()
 
     /* Operation under verification. */
     bool is_available = s2n_hash_is_available(alg);
-    assert(IMPLIES(alg == S2N_HASH_MD5, is_available == !s2n_is_in_fips_mode()));
-    assert(IMPLIES(alg == S2N_HASH_MD5_SHA1, is_available == !s2n_is_in_fips_mode()));
-    assert(IMPLIES(alg == S2N_HASH_NONE, is_available));
-    assert(IMPLIES(alg == S2N_HASH_SHA1, is_available));
-    assert(IMPLIES(alg == S2N_HASH_SHA224, is_available));
-    assert(IMPLIES(alg == S2N_HASH_SHA256, is_available));
-    assert(IMPLIES(alg == S2N_HASH_SHA384, is_available));
-    assert(IMPLIES(alg == S2N_HASH_SHA512, is_available));
-    assert(IMPLIES(alg == S2N_HASH_SENTINEL, !is_available));
+
+    /* Postconditions. */
+    switch (alg) {
+        case S2N_HASH_MD5:
+        case S2N_HASH_MD5_SHA1:
+            assert(is_available == !s2n_is_in_fips_mode()); break;
+        case S2N_HASH_NONE:
+        case S2N_HASH_SHA1:
+        case S2N_HASH_SHA224:
+        case S2N_HASH_SHA256:
+        case S2N_HASH_SHA384:
+        case S2N_HASH_SHA512:
+            assert(is_available); break;
+        case S2N_HASH_SENTINEL:
+            assert(!is_available); break;
+        default:
+            __CPROVER_assert(!is_available, "Unssuported algorithm.");
+    }
 }

--- a/tests/cbmc/proofs/s2n_hash_is_ready_for_input/s2n_hash_is_ready_for_input_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_is_ready_for_input/s2n_hash_is_ready_for_input_harness.c
@@ -13,7 +13,6 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
 #include "crypto/s2n_hash.h"
 
 #include <cbmc_proof/make_common_datastructures.h>

--- a/tests/cbmc/proofs/s2n_hash_new/s2n_hash_new_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_new/s2n_hash_new_harness.c
@@ -15,7 +15,6 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
-#include "api/s2n.h"
 #include "crypto/s2n_hash.h"
 
 void s2n_hash_new_harness()

--- a/tests/cbmc/proofs/s2n_hash_reset/s2n_hash_reset_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_reset/s2n_hash_reset_harness.c
@@ -13,7 +13,6 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
 #include "crypto/s2n_hash.h"
 
 #include <cbmc_proof/make_common_datastructures.h>

--- a/tests/cbmc/proofs/s2n_hash_update/s2n_hash_update_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_update/s2n_hash_update_harness.c
@@ -13,7 +13,6 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
 #include "crypto/s2n_hash.h"
 
 #include <cbmc_proof/make_common_datastructures.h>

--- a/tests/cbmc/proofs/s2n_hex_string_to_bytes/s2n_hex_string_to_bytes_harness.c
+++ b/tests/cbmc/proofs/s2n_hex_string_to_bytes/s2n_hex_string_to_bytes_harness.c
@@ -18,7 +18,6 @@
 #include <cbmc_proof/proof_allocators.h>
 #include <string.h>
 
-#include "api/s2n.h"
 #include "error/s2n_errno.h"
 #include "utils/s2n_blob.h"
 

--- a/tests/cbmc/proofs/s2n_hmac_digest_size/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_digest_size/Makefile
@@ -1,0 +1,31 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 5 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hmac_digest_size
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hmac_digest_size/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_hmac_digest_size/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_hmac_digest_size/s2n_hmac_digest_size_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_digest_size/s2n_hmac_digest_size_harness.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/proof_allocators.h>
+
+#include "crypto/s2n_hmac.h"
+
+void s2n_hmac_digest_size_harness()
+{
+    /* Non-deterministic inputs. */
+    s2n_hmac_algorithm alg;
+    size_t             alg_size;
+    uint8_t *          out = bounded_malloc(alg_size);
+
+    /* Operation under verification. */
+    if (s2n_hmac_digest_size(alg, out) == S2N_SUCCESS) {
+        /* Post-conditions. */
+        assert(IMPLIES(alg == S2N_HMAC_NONE, *out == 0));
+        assert(IMPLIES(alg == S2N_HMAC_MD5, *out == MD5_DIGEST_LENGTH));
+        assert(IMPLIES(alg == S2N_HMAC_SHA1, *out == SHA_DIGEST_LENGTH));
+        assert(IMPLIES(alg == S2N_HMAC_SHA224, *out == SHA224_DIGEST_LENGTH));
+        assert(IMPLIES(alg == S2N_HMAC_SHA256, *out == SHA256_DIGEST_LENGTH));
+        assert(IMPLIES(alg == S2N_HMAC_SHA384, *out == SHA384_DIGEST_LENGTH));
+        assert(IMPLIES(alg == S2N_HMAC_SHA512, *out == SHA512_DIGEST_LENGTH));
+        assert(IMPLIES(alg == S2N_HMAC_SSLv3_MD5, *out == MD5_DIGEST_LENGTH));
+        assert(IMPLIES(alg == S2N_HMAC_SSLv3_SHA1, *out == SHA_DIGEST_LENGTH));
+    }
+}

--- a/tests/cbmc/proofs/s2n_hmac_digest_size/s2n_hmac_digest_size_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_digest_size/s2n_hmac_digest_size_harness.c
@@ -21,21 +21,25 @@
 void s2n_hmac_digest_size_harness()
 {
     /* Non-deterministic inputs. */
-    s2n_hmac_algorithm alg;
+    s2n_hmac_algorithm hmac_alg;
     size_t             alg_size;
     uint8_t *          out = bounded_malloc(alg_size);
 
     /* Operation under verification. */
-    if (s2n_hmac_digest_size(alg, out) == S2N_SUCCESS) {
+    if (s2n_hmac_digest_size(hmac_alg, out) == S2N_SUCCESS) {
         /* Post-conditions. */
-        assert(IMPLIES(alg == S2N_HMAC_NONE, *out == 0));
-        assert(IMPLIES(alg == S2N_HMAC_MD5, *out == MD5_DIGEST_LENGTH));
-        assert(IMPLIES(alg == S2N_HMAC_SHA1, *out == SHA_DIGEST_LENGTH));
-        assert(IMPLIES(alg == S2N_HMAC_SHA224, *out == SHA224_DIGEST_LENGTH));
-        assert(IMPLIES(alg == S2N_HMAC_SHA256, *out == SHA256_DIGEST_LENGTH));
-        assert(IMPLIES(alg == S2N_HMAC_SHA384, *out == SHA384_DIGEST_LENGTH));
-        assert(IMPLIES(alg == S2N_HMAC_SHA512, *out == SHA512_DIGEST_LENGTH));
-        assert(IMPLIES(alg == S2N_HMAC_SSLv3_MD5, *out == MD5_DIGEST_LENGTH));
-        assert(IMPLIES(alg == S2N_HMAC_SSLv3_SHA1, *out == SHA_DIGEST_LENGTH));
+        switch (hmac_alg) {
+        case S2N_HMAC_NONE:       assert(*out == 0);                    break;
+        case S2N_HMAC_MD5:        assert(*out == MD5_DIGEST_LENGTH);    break;
+        case S2N_HMAC_SHA1:       assert(*out == SHA_DIGEST_LENGTH);    break;
+        case S2N_HMAC_SHA224:     assert(*out == SHA224_DIGEST_LENGTH); break;
+        case S2N_HMAC_SHA256:     assert(*out == SHA256_DIGEST_LENGTH); break;
+        case S2N_HMAC_SHA384:     assert(*out == SHA384_DIGEST_LENGTH); break;
+        case S2N_HMAC_SHA512:     assert(*out == SHA512_DIGEST_LENGTH); break;
+        case S2N_HMAC_SSLv3_MD5:  assert(*out == MD5_DIGEST_LENGTH);    break;
+        case S2N_HMAC_SSLv3_SHA1: assert(*out == SHA_DIGEST_LENGTH);    break;
+        default:
+            __CPROVER_assert(0, "Unssuported algorithm.");
+        }
     }
 }

--- a/tests/cbmc/proofs/s2n_hmac_hash_alg/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_hash_alg/Makefile
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 5 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hmac_hash_alg
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hmac_hash_alg/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_hmac_hash_alg/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_hmac_hash_alg/s2n_hmac_hash_alg_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_hash_alg/s2n_hmac_hash_alg_harness.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/proof_allocators.h>
+
+#include "crypto/s2n_hmac.h"
+
+void s2n_hmac_hash_alg_harness()
+{
+    /* Non-deterministic inputs. */
+    s2n_hmac_algorithm alg;
+    s2n_hash_algorithm *out = malloc(sizeof(*out));
+
+    /* Operation under verification. */
+    if (s2n_hmac_hash_alg(alg, out) == S2N_SUCCESS) {
+        /* Post-conditions. */
+        assert(IMPLIES(alg == S2N_HMAC_NONE, *out == S2N_HASH_NONE));
+        assert(IMPLIES(alg == S2N_HMAC_MD5, *out == S2N_HASH_MD5));
+        assert(IMPLIES(alg == S2N_HMAC_SHA1, *out == S2N_HASH_SHA1));
+        assert(IMPLIES(alg == S2N_HMAC_SHA224, *out == S2N_HASH_SHA224));
+        assert(IMPLIES(alg == S2N_HMAC_SHA256, *out == S2N_HASH_SHA256));
+        assert(IMPLIES(alg == S2N_HMAC_SHA384, *out == S2N_HASH_SHA384));
+        assert(IMPLIES(alg == S2N_HMAC_SHA512, *out == S2N_HASH_SHA512));
+        assert(IMPLIES(alg == S2N_HMAC_SSLv3_MD5, *out == S2N_HASH_MD5));
+        assert(IMPLIES(alg == S2N_HMAC_SSLv3_SHA1, *out == S2N_HASH_SHA1));
+    }
+}

--- a/tests/cbmc/proofs/s2n_hmac_hash_alg/s2n_hmac_hash_alg_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_hash_alg/s2n_hmac_hash_alg_harness.c
@@ -21,20 +21,24 @@
 void s2n_hmac_hash_alg_harness()
 {
     /* Non-deterministic inputs. */
-    s2n_hmac_algorithm alg;
+    s2n_hmac_algorithm hmac_alg;
     s2n_hash_algorithm *out = malloc(sizeof(*out));
 
     /* Operation under verification. */
-    if (s2n_hmac_hash_alg(alg, out) == S2N_SUCCESS) {
+    if (s2n_hmac_hash_alg(hmac_alg, out) == S2N_SUCCESS) {
         /* Post-conditions. */
-        assert(IMPLIES(alg == S2N_HMAC_NONE, *out == S2N_HASH_NONE));
-        assert(IMPLIES(alg == S2N_HMAC_MD5, *out == S2N_HASH_MD5));
-        assert(IMPLIES(alg == S2N_HMAC_SHA1, *out == S2N_HASH_SHA1));
-        assert(IMPLIES(alg == S2N_HMAC_SHA224, *out == S2N_HASH_SHA224));
-        assert(IMPLIES(alg == S2N_HMAC_SHA256, *out == S2N_HASH_SHA256));
-        assert(IMPLIES(alg == S2N_HMAC_SHA384, *out == S2N_HASH_SHA384));
-        assert(IMPLIES(alg == S2N_HMAC_SHA512, *out == S2N_HASH_SHA512));
-        assert(IMPLIES(alg == S2N_HMAC_SSLv3_MD5, *out == S2N_HASH_MD5));
-        assert(IMPLIES(alg == S2N_HMAC_SSLv3_SHA1, *out == S2N_HASH_SHA1));
+        switch(hmac_alg) {
+        case S2N_HMAC_NONE:       assert(*out == S2N_HASH_NONE);   break;
+        case S2N_HMAC_MD5:        assert(*out == S2N_HASH_MD5);    break;
+        case S2N_HMAC_SHA1:       assert(*out == S2N_HASH_SHA1);   break;
+        case S2N_HMAC_SHA224:     assert(*out == S2N_HASH_SHA224); break;
+        case S2N_HMAC_SHA256:     assert(*out == S2N_HASH_SHA256); break;
+        case S2N_HMAC_SHA384:     assert(*out == S2N_HASH_SHA384); break;
+        case S2N_HMAC_SHA512:     assert(*out == S2N_HASH_SHA512); break;
+        case S2N_HMAC_SSLv3_MD5:  assert(*out == S2N_HASH_MD5);    break;
+        case S2N_HMAC_SSLv3_SHA1: assert(*out == S2N_HASH_SHA1);   break;
+        default:
+            __CPROVER_assert(0, "Unssuported algorithm.");
+        }
     }
 }

--- a/tests/cbmc/proofs/s2n_hmac_hash_block_size/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_hash_block_size/Makefile
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 5 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hmac_hash_block_size
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hmac_hash_block_size/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_hmac_hash_block_size/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_hmac_hash_block_size/s2n_hmac_hash_block_size_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_hash_block_size/s2n_hmac_hash_block_size_harness.c
@@ -28,14 +28,20 @@ void s2n_hmac_hash_block_size_harness()
     /* Operation under verification. */
     if (s2n_hmac_hash_block_size(hmac_alg, block_size) == S2N_SUCCESS) {
         /* Post-conditions. */
-        assert(IMPLIES(hmac_alg == S2N_HMAC_NONE, *block_size == 64));
-        assert(IMPLIES(hmac_alg == S2N_HMAC_MD5, *block_size == 64));
-        assert(IMPLIES(hmac_alg == S2N_HMAC_SHA1, *block_size == 64));
-        assert(IMPLIES(hmac_alg == S2N_HMAC_SHA224, *block_size == 64));
-        assert(IMPLIES(hmac_alg == S2N_HMAC_SHA256, *block_size == 64));
-        assert(IMPLIES(hmac_alg == S2N_HMAC_SHA384, *block_size == 128));
-        assert(IMPLIES(hmac_alg == S2N_HMAC_SHA512, *block_size == 128));
-        assert(IMPLIES(hmac_alg == S2N_HMAC_SSLv3_MD5, *block_size == 64));
-        assert(IMPLIES(hmac_alg == S2N_HMAC_SSLv3_SHA1, *block_size == 64));
+        switch(hmac_alg) {
+            case S2N_HMAC_NONE:
+            case S2N_HMAC_MD5:
+            case S2N_HMAC_SHA1:
+            case S2N_HMAC_SHA224:
+            case S2N_HMAC_SSLv3_MD5:
+            case S2N_HMAC_SSLv3_SHA1:
+            case S2N_HMAC_SHA256:
+                assert(*block_size == 64); break;
+            case S2N_HMAC_SHA384:
+            case S2N_HMAC_SHA512:
+                assert(*block_size == 128); break;
+            default:
+                __CPROVER_assert(0, "Unssuported algorithm.");
+        }
     }
 }

--- a/tests/cbmc/proofs/s2n_hmac_hash_block_size/s2n_hmac_hash_block_size_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_hash_block_size/s2n_hmac_hash_block_size_harness.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/proof_allocators.h>
+
+#include "crypto/s2n_hmac.h"
+
+void s2n_hmac_hash_block_size_harness()
+{
+    /* Non-deterministic inputs. */
+    s2n_hmac_algorithm hmac_alg;
+    size_t             size;
+    uint16_t *         block_size = bounded_malloc(size);
+
+    /* Operation under verification. */
+    if (s2n_hmac_hash_block_size(hmac_alg, block_size) == S2N_SUCCESS) {
+        /* Post-conditions. */
+        assert(IMPLIES(hmac_alg == S2N_HMAC_NONE, *block_size == 64));
+        assert(IMPLIES(hmac_alg == S2N_HMAC_MD5, *block_size == 64));
+        assert(IMPLIES(hmac_alg == S2N_HMAC_SHA1, *block_size == 64));
+        assert(IMPLIES(hmac_alg == S2N_HMAC_SHA224, *block_size == 64));
+        assert(IMPLIES(hmac_alg == S2N_HMAC_SHA256, *block_size == 64));
+        assert(IMPLIES(hmac_alg == S2N_HMAC_SHA384, *block_size == 128));
+        assert(IMPLIES(hmac_alg == S2N_HMAC_SHA512, *block_size == 128));
+        assert(IMPLIES(hmac_alg == S2N_HMAC_SSLv3_MD5, *block_size == 64));
+        assert(IMPLIES(hmac_alg == S2N_HMAC_SSLv3_SHA1, *block_size == 64));
+    }
+}

--- a/tests/cbmc/proofs/s2n_hmac_is_available/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_is_available/Makefile
@@ -1,0 +1,31 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 5 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hmac_is_available
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hmac_is_available/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_hmac_is_available/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_hmac_is_available/s2n_hmac_is_available_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_is_available/s2n_hmac_is_available_harness.c
@@ -16,22 +16,31 @@
 #include <cbmc_proof/cbmc_utils.h>
 #include <cbmc_proof/proof_allocators.h>
 
+#include "crypto/s2n_fips.h"
 #include "crypto/s2n_hmac.h"
 
 void s2n_hmac_is_available_harness()
 {
     /* Non-deterministic inputs. */
-    s2n_hmac_algorithm alg;
+    s2n_hmac_algorithm hmac_alg;
 
     /* Operation under verification. */
-    bool is_available = s2n_hmac_is_available(alg);
-    assert(IMPLIES(alg == S2N_HMAC_MD5, is_available == !s2n_is_in_fips_mode()));
-    assert(IMPLIES(alg == S2N_HMAC_SSLv3_MD5, is_available == !s2n_is_in_fips_mode()));
-    assert(IMPLIES(alg == S2N_HMAC_SSLv3_SHA1, is_available == !s2n_is_in_fips_mode()));
-    assert(IMPLIES(alg == S2N_HMAC_NONE, is_available));
-    assert(IMPLIES(alg == S2N_HMAC_SHA1, is_available));
-    assert(IMPLIES(alg == S2N_HASH_SHA224, is_available));
-    assert(IMPLIES(alg == S2N_HASH_SHA256, is_available));
-    assert(IMPLIES(alg == S2N_HASH_SHA384, is_available));
-    assert(IMPLIES(alg == S2N_HASH_SHA512, is_available));
+    bool is_available = s2n_hmac_is_available(hmac_alg);
+
+    /* Postconditions. */
+    switch (hmac_alg) {
+        case S2N_HASH_MD5:
+        case S2N_HMAC_SSLv3_MD5:
+        case S2N_HMAC_SSLv3_SHA1:
+            assert(is_available == !s2n_is_in_fips_mode()); break;
+        case S2N_HASH_NONE:
+        case S2N_HASH_SHA1:
+        case S2N_HASH_SHA224:
+        case S2N_HASH_SHA256:
+        case S2N_HASH_SHA384:
+        case S2N_HASH_SHA512:
+            assert(is_available); break;
+        default:
+            __CPROVER_assert(!is_available, "Unssuported algorithm.");
+    }
 }

--- a/tests/cbmc/proofs/s2n_hmac_is_available/s2n_hmac_is_available_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_is_available/s2n_hmac_is_available_harness.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/proof_allocators.h>
+
+#include "crypto/s2n_hmac.h"
+
+void s2n_hmac_is_available_harness()
+{
+    /* Non-deterministic inputs. */
+    s2n_hmac_algorithm alg;
+
+    /* Operation under verification. */
+    bool is_available = s2n_hmac_is_available(alg);
+    assert(IMPLIES(alg == S2N_HMAC_MD5, is_available == !s2n_is_in_fips_mode()));
+    assert(IMPLIES(alg == S2N_HMAC_SSLv3_MD5, is_available == !s2n_is_in_fips_mode()));
+    assert(IMPLIES(alg == S2N_HMAC_SSLv3_SHA1, is_available == !s2n_is_in_fips_mode()));
+    assert(IMPLIES(alg == S2N_HMAC_NONE, is_available));
+    assert(IMPLIES(alg == S2N_HMAC_SHA1, is_available));
+    assert(IMPLIES(alg == S2N_HASH_SHA224, is_available));
+    assert(IMPLIES(alg == S2N_HASH_SHA256, is_available));
+    assert(IMPLIES(alg == S2N_HASH_SHA384, is_available));
+    assert(IMPLIES(alg == S2N_HASH_SHA512, is_available));
+}

--- a/tests/cbmc/proofs/s2n_hmac_xor_pad_size/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_xor_pad_size/Makefile
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 5 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hmac_xor_pad_size
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hmac_xor_pad_size/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_hmac_xor_pad_size/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_hmac_xor_pad_size/s2n_hmac_xor_pad_size_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_xor_pad_size/s2n_hmac_xor_pad_size_harness.c
@@ -27,15 +27,19 @@ void s2n_hmac_xor_pad_size_harness()
 
     /* Operation under verification. */
     if (s2n_hmac_xor_pad_size(hmac_alg, xor_pad_size) == S2N_SUCCESS) {
-        /* Post-conditions. */
-        assert(IMPLIES(hmac_alg == S2N_HMAC_NONE, *xor_pad_size == 64));
-        assert(IMPLIES(hmac_alg == S2N_HMAC_MD5, *xor_pad_size == 64));
-        assert(IMPLIES(hmac_alg == S2N_HMAC_SHA1, *xor_pad_size == 64));
-        assert(IMPLIES(hmac_alg == S2N_HMAC_SHA224, *xor_pad_size == 64));
-        assert(IMPLIES(hmac_alg == S2N_HMAC_SHA256, *xor_pad_size == 64));
-        assert(IMPLIES(hmac_alg == S2N_HMAC_SHA384, *xor_pad_size == 128));
-        assert(IMPLIES(hmac_alg == S2N_HMAC_SHA512, *xor_pad_size == 128));
-        assert(IMPLIES(hmac_alg == S2N_HMAC_SSLv3_MD5, *xor_pad_size == 48));
-        assert(IMPLIES(hmac_alg == S2N_HMAC_SSLv3_SHA1, *xor_pad_size == 40));
+        /* Postconditions. */
+        switch (hmac_alg) {
+            case S2N_HASH_NONE:       assert(*xor_pad_size == 64);  break;
+            case S2N_HASH_MD5:        assert(*xor_pad_size == 64);  break;
+            case S2N_HASH_SHA1:       assert(*xor_pad_size == 64);  break;
+            case S2N_HASH_SHA224:     assert(*xor_pad_size == 64);  break;
+            case S2N_HASH_SHA256:     assert(*xor_pad_size == 64);  break;
+            case S2N_HASH_SHA384:     assert(*xor_pad_size == 128); break;
+            case S2N_HASH_SHA512:     assert(*xor_pad_size == 128); break;
+            case S2N_HMAC_SSLv3_MD5:  assert(*xor_pad_size == 48);  break;
+            case S2N_HMAC_SSLv3_SHA1: assert(*xor_pad_size == 40);  break;
+            default:
+                __CPROVER_assert(0, "Unssuported algorithm.");
+        }
     }
 }

--- a/tests/cbmc/proofs/s2n_hmac_xor_pad_size/s2n_hmac_xor_pad_size_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_xor_pad_size/s2n_hmac_xor_pad_size_harness.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/proof_allocators.h>
+
+#include "crypto/s2n_hmac.h"
+
+void s2n_hmac_xor_pad_size_harness()
+{
+    /* Non-deterministic inputs. */
+    s2n_hmac_algorithm hmac_alg;
+    size_t             size;
+    uint16_t *         xor_pad_size = bounded_malloc(size);
+
+    /* Operation under verification. */
+    if (s2n_hmac_xor_pad_size(hmac_alg, xor_pad_size) == S2N_SUCCESS) {
+        /* Post-conditions. */
+        assert(IMPLIES(hmac_alg == S2N_HMAC_NONE, *xor_pad_size == 64));
+        assert(IMPLIES(hmac_alg == S2N_HMAC_MD5, *xor_pad_size == 64));
+        assert(IMPLIES(hmac_alg == S2N_HMAC_SHA1, *xor_pad_size == 64));
+        assert(IMPLIES(hmac_alg == S2N_HMAC_SHA224, *xor_pad_size == 64));
+        assert(IMPLIES(hmac_alg == S2N_HMAC_SHA256, *xor_pad_size == 64));
+        assert(IMPLIES(hmac_alg == S2N_HMAC_SHA384, *xor_pad_size == 128));
+        assert(IMPLIES(hmac_alg == S2N_HMAC_SHA512, *xor_pad_size == 128));
+        assert(IMPLIES(hmac_alg == S2N_HMAC_SSLv3_MD5, *xor_pad_size == 48));
+        assert(IMPLIES(hmac_alg == S2N_HMAC_SSLv3_SHA1, *xor_pad_size == 40));
+    }
+}

--- a/tests/sidetrail/working/patches/hmac.patch
+++ b/tests/sidetrail/working/patches/hmac.patch
@@ -97,7 +97,7 @@ index 7af7e61..e6382ce 100644
 
  extern int s2n_hmac_digest_size(s2n_hmac_algorithm alg, uint8_t *out);
  extern bool s2n_hmac_is_available(s2n_hmac_algorithm alg);
-@@ -72,7 +72,7 @@ extern int s2n_hmac_digest_verify(const void *a, const void *b, uint32_t len);
+@@ -72,5 +72,5 @@ extern int s2n_hmac_digest_verify(const void *a, const void *b, uint32_t len);
  extern int s2n_hmac_free(struct s2n_hmac_state *state);
  extern int s2n_hmac_reset(struct s2n_hmac_state *state);
  extern int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from);

--- a/tests/sidetrail/working/patches/hmac.patch
+++ b/tests/sidetrail/working/patches/hmac.patch
@@ -5,7 +5,7 @@ index 3405781..3beeacf 100644
 @@ -26,6 +26,9 @@
  #include "utils/s2n_blob.h"
  #include "utils/s2n_mem.h"
- 
+
 +#include "smack.h"
 +#include "sidetrail.h"
 +
@@ -19,22 +19,22 @@ index 3405781..3beeacf 100644
 -    state->currently_in_hash_block += (4294949760 + size) % state->hash_block_size;
 +    state->currently_in_hash_block += (size) % state->hash_block_size;
      state->currently_in_hash_block %= state->hash_block_size;
- 
+
      return s2n_hash_update(&state->inner, in, size);
 @@ -311,30 +314,30 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
      GUARD(s2n_hash_copy(&to->outer_just_key, &from->outer_just_key));
- 
- 
+
+
 -    memcpy_check(to->xor_pad, from->xor_pad, sizeof(to->xor_pad));
 -    memcpy_check(to->digest_pad, from->digest_pad, sizeof(to->digest_pad));
 +    //memcpy_check(to->xor_pad, from->xor_pad, sizeof(to->xor_pad));
 +    //memcpy_check(to->digest_pad, from->digest_pad, sizeof(to->digest_pad));
- 
+
      return 0;
  }
- 
- 
--/* Preserve the handlers for hmac state pointers to avoid re-allocation 
+
+
+-/* Preserve the handlers for hmac state pointers to avoid re-allocation
 - * Only valid if the HMAC is in EVP mode
 - */
 -int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac)
@@ -81,7 +81,7 @@ index 7af7e61..e6382ce 100644
 @@ -52,12 +52,12 @@ struct s2n_hmac_state {
      uint8_t digest_pad[SHA512_DIGEST_LENGTH];
  };
- 
+
 -struct s2n_hmac_evp_backup {
 -    struct s2n_hash_evp_digest inner;
 -    struct s2n_hash_evp_digest inner_just_key;
@@ -94,9 +94,9 @@ index 7af7e61..e6382ce 100644
 +/*     struct s2n_hash_evp_digest outer; */
 +/*     struct s2n_hash_evp_digest outer_just_key; */
 +/* }; */
- 
+
  extern int s2n_hmac_digest_size(s2n_hmac_algorithm alg, uint8_t *out);
- extern int s2n_hmac_is_available(s2n_hmac_algorithm alg);
+ extern bool s2n_hmac_is_available(s2n_hmac_algorithm alg);
 @@ -72,7 +72,7 @@ extern int s2n_hmac_digest_verify(const void *a, const void *b, uint32_t len);
  extern int s2n_hmac_free(struct s2n_hmac_state *state);
  extern int s2n_hmac_reset(struct s2n_hmac_state *state);
@@ -105,5 +105,3 @@ index 7af7e61..e6382ce 100644
 -extern int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac);
 +//extern int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac);
 +//extern int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac);
- 
- 


### PR DESCRIPTION
### Resolved issues:

N/A.

### Description of changes: 

Upgrades our OpenSSL verification model version, moves `s2n_hash_hmac_alg` to the correct location along with its function declaration, and adds proof harnesses for `s2n_hmac_is_available`, `s2n_hmac_hash_alg`, and `s2n_hmac_digest_size`.
### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
