### PR TITLE
Eliminate EC_KEY_check_key validation in s2n_ecc_evp_write_params_point

### DIFF
--- a/crypto/s2n_ecc_evp.c
+++ b/crypto/s2n_ecc_evp.c
@@ -375,7 +375,6 @@ int s2n_ecc_evp_write_params_point(struct s2n_ecc_evp_params *ecc_evp_params, st
 
     DEFER_CLEANUP(EC_KEY *ec_key = EVP_PKEY_get1_EC_KEY(ecc_evp_params->evp_pkey), EC_KEY_free_pointer);
     S2N_ERROR_IF(ec_key == NULL, S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
-    GUARD_OSSL(EC_KEY_check_key(ec_key), S2N_ERR_ECDHE_SERIALIZING);
     const EC_POINT *point = EC_KEY_get0_public_key(ec_key);
     const EC_GROUP *group = EC_KEY_get0_group(ec_key);
     S2N_ERROR_IF(point == NULL || group == NULL, S2N_ERR_ECDHE_UNSUPPORTED_CURVE);

--- a/tests/unit/s2n_ecc_evp_test.c
+++ b/tests/unit/s2n_ecc_evp_test.c
@@ -34,6 +34,7 @@ int main(int argc, char **argv) {
             /* Server generates a key */
             evp_params.negotiated_curve = s2n_all_supported_curves_list[i];
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&evp_params));
+            EXPECT_NOT_NULL(evp_params.evp_pkey);
             EXPECT_SUCCESS(s2n_ecc_evp_params_free(&evp_params));
         }
     }
@@ -44,6 +45,7 @@ int main(int argc, char **argv) {
             /* Server generates a key */
             evp_params.negotiated_curve = NULL;
             EXPECT_FAILURE(s2n_ecc_evp_generate_ephemeral_key(&evp_params));
+            EXPECT_NULL(evp_params.evp_pkey);
             EXPECT_SUCCESS(s2n_ecc_evp_params_free(&evp_params));
         }
     }
@@ -58,10 +60,12 @@ int main(int argc, char **argv) {
             /* Server generates a key */
             server_params.negotiated_curve = s2n_all_supported_curves_list[i];
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_params));
+            EXPECT_NOT_NULL(server_params.evp_pkey);
 
             /* Client generates a key */
             client_params.negotiated_curve = s2n_all_supported_curves_list[i];
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_params));
+            EXPECT_NOT_NULL(client_params.evp_pkey);
 
             /* Compute shared secret for server */
             EXPECT_SUCCESS(
@@ -100,10 +104,12 @@ int main(int argc, char **argv) {
                 server_params.negotiated_curve = s2n_all_supported_curves_list[j];
 
                 EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_params));
+                EXPECT_NOT_NULL(server_params.evp_pkey);
 
                 /* Client generates a key */
                 client_params.negotiated_curve = s2n_all_supported_curves_list[i];
                 EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_params));
+                EXPECT_NOT_NULL(client_params.evp_pkey);
 
                 /* Compute shared secret for server */
                 EXPECT_FAILURE(
@@ -131,6 +137,7 @@ int main(int argc, char **argv) {
             /* Server generates a key for a given curve */
             test_params.negotiated_curve = s2n_all_supported_curves_list[i];
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&test_params));
+            EXPECT_NOT_NULL(test_params.evp_pkey);
             EXPECT_SUCCESS(s2n_ecc_evp_write_params_point(&test_params, &wire));
 
             /* Verify output is of the right length */
@@ -162,6 +169,7 @@ int main(int argc, char **argv) {
             /* Server generates a key for a given curve */
             write_params.negotiated_curve = s2n_all_supported_curves_list[i];
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&write_params));
+            EXPECT_NOT_NULL(write_params.evp_pkey);
             EXPECT_SUCCESS(s2n_ecc_evp_write_params_point(&write_params, &wire));
 
             /* Read point back in */
@@ -191,6 +199,7 @@ int main(int argc, char **argv) {
 
             /* Server generates a key for a given curve */
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&write_params));
+            EXPECT_NOT_NULL(write_params.evp_pkey);
             EXPECT_SUCCESS(s2n_ecc_evp_write_params_point(&write_params, &wire));
 
             /* Read point back in */
@@ -221,6 +230,7 @@ int main(int argc, char **argv) {
 
             /* Server generates a key for a given curve */
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&write_params));
+            EXPECT_NOT_NULL(write_params.evp_pkey);
 
              /* Write params points to wire */
             EXPECT_SUCCESS(s2n_ecc_evp_write_params(&write_params, &wire, &ecdh_params_sent));
@@ -256,6 +266,7 @@ int main(int argc, char **argv) {
 
             /* Server generates a key for a given curve */
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_params));
+            EXPECT_NOT_NULL(server_params.evp_pkey);
 
             /* Server sends the public */
             EXPECT_SUCCESS(s2n_ecc_evp_write_params(&server_params, &wire, &ecdh_params_sent));
@@ -271,6 +282,7 @@ int main(int argc, char **argv) {
              /* Client generates its key for the given curve */
             client_params.negotiated_curve =s2n_all_supported_curves_list[i];
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_params));
+            EXPECT_NOT_NULL(client_params.evp_pkey);
         
             /* Compute shared secret for the server */
             EXPECT_SUCCESS(
@@ -305,6 +317,7 @@ int main(int argc, char **argv) {
             /* Server generates a key for a given curve */
             server_params.negotiated_curve = s2n_all_supported_curves_list[i];
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_params));
+            EXPECT_NOT_NULL(server_params.evp_pkey);
             /* Server sends the public */
             EXPECT_SUCCESS(s2n_ecc_evp_write_params(&server_params, &wire, &ecdh_params_sent));
             /* Client reads the public */


### PR DESCRIPTION

### Description of changes: 

We use the `EC_KEY_check_key` function to validate/sanity check the ec_key object prior to obtaining the point and group in the `s2n_ecc_evp_write_params_point` function. Ref: https://github.com/awslabs/s2n/blob/71cfa3f1c316810404a0cc0ca4533dacb5b41491/crypto/s2n_ecc_evp.c#L378. 

The EC_KEY_check_key performs the following validations: Ref: ec_key.c#L294

   - Tests if EC_POINT is at infinity
   - Tests whether pub_key is on the elliptic curve
   - Tests whether pub_key * order is the point at infinity
   - Tests whether public key is in the intended subgroup

This check is expensive and performs additional validations that is unnecessary at this step. We can eliminate this check altogether as the sanity check is not required in this step.

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer? Unit Tests are updated to assert `evp_pkey` object generated is not_null value. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
