### PR TITLE
[PSK] Update s2n_hash_algorithm to s2n_hmac_algorithm

### DIFF
--- a/tests/unit/s2n_cipher_suite_match_test.c
+++ b/tests/unit/s2n_cipher_suite_match_test.c
@@ -695,11 +695,9 @@ int main(int argc, char **argv)
 
                 EXPECT_OK(s2n_conn_set_chosen_psk(conn));
 
-                s2n_hmac_algorithm chosen_psk_hmac_alg = { 0 };
-                EXPECT_SUCCESS(s2n_hash_hmac_alg(conn->psk_params.chosen_psk->hash_alg, &chosen_psk_hmac_alg));
                 EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_tls13, cipher_count_tls13));
                 EXPECT_EQUAL(conn->secure.cipher_suite, &s2n_tls13_aes_128_gcm_sha256);
-                EXPECT_EQUAL(conn->secure.cipher_suite->prf_alg, chosen_psk_hmac_alg);
+                EXPECT_EQUAL(conn->secure.cipher_suite->prf_alg, conn->psk_params.chosen_psk->hmac_alg);
 
                 EXPECT_SUCCESS(s2n_psk_parameters_free(&conn->psk_params));
                 EXPECT_SUCCESS(s2n_connection_wipe(conn));
@@ -715,7 +713,7 @@ int main(int argc, char **argv)
                 EXPECT_OK(s2n_conn_set_chosen_psk(conn));
 
                 /* S2N_HASH_SHA1 is not a matching hash algorithm for the cipher suites present in wire_ciphers_with_tls13 */ 
-                conn->psk_params.chosen_psk->hash_alg = S2N_HASH_SHA1;
+                conn->psk_params.chosen_psk->hmac_alg = S2N_HASH_SHA1;
                 EXPECT_FAILURE_WITH_ERRNO(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_tls13, cipher_count_tls13), S2N_ERR_CIPHER_NOT_SUPPORTED);
                 EXPECT_EQUAL(conn->secure.cipher_suite, &s2n_null_cipher_suite);
 
@@ -747,15 +745,12 @@ int main(int argc, char **argv)
                 conn->actual_protocol_version = S2N_TLS12;
 
                 EXPECT_OK(s2n_conn_set_chosen_psk(conn));
-                conn->psk_params.chosen_psk->hash_alg = S2N_HASH_SHA512;
-
-                s2n_hmac_algorithm chosen_psk_hmac_alg = { 0 };
-                EXPECT_SUCCESS(s2n_hash_hmac_alg(conn->psk_params.chosen_psk->hash_alg, &chosen_psk_hmac_alg));
+                conn->psk_params.chosen_psk->hmac_alg = S2N_HASH_SHA512;
 
                 EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_tls13, cipher_count_tls13));
                 EXPECT_EQUAL(conn->secure.cipher_suite, &s2n_rsa_with_aes_128_cbc_sha);
                 EXPECT_EQUAL(conn->secure.cipher_suite->prf_alg, S2N_HMAC_SHA256);
-                EXPECT_NOT_EQUAL(conn->secure.cipher_suite->prf_alg, chosen_psk_hmac_alg);
+                EXPECT_NOT_EQUAL(conn->secure.cipher_suite->prf_alg, conn->psk_params.chosen_psk->hmac_alg);
 
 
                 EXPECT_SUCCESS(s2n_psk_parameters_free(&conn->psk_params));
@@ -775,15 +770,13 @@ int main(int argc, char **argv)
                 };
 
                 EXPECT_OK(s2n_conn_set_chosen_psk(conn));
-                conn->psk_params.chosen_psk->hash_alg = S2N_HASH_SHA384;
-                s2n_hmac_algorithm chosen_psk_hmac_alg = { 0 };
-                EXPECT_SUCCESS(s2n_hash_hmac_alg(conn->psk_params.chosen_psk->hash_alg, &chosen_psk_hmac_alg));
+                conn->psk_params.chosen_psk->hmac_alg = S2N_HASH_SHA384;
 
                 /* Skip check for PSK hash match for TLS versions less than or equal to tls 1.2 */
                 EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, test_wire_ciphers, 3));
                 EXPECT_EQUAL(conn->secure.cipher_suite, &s2n_ecdhe_rsa_with_aes_128_cbc_sha);
                 EXPECT_EQUAL(conn->secure.cipher_suite->prf_alg, S2N_HMAC_SHA256);
-                EXPECT_NOT_EQUAL(conn->secure.cipher_suite->prf_alg, chosen_psk_hmac_alg);
+                EXPECT_NOT_EQUAL(conn->secure.cipher_suite->prf_alg, conn->psk_params.chosen_psk->hmac_alg);
 
                 EXPECT_SUCCESS(s2n_psk_parameters_free(&conn->psk_params));
                 EXPECT_SUCCESS(s2n_connection_wipe(conn));
@@ -802,14 +795,12 @@ int main(int argc, char **argv)
                 };
 
                 EXPECT_OK(s2n_conn_set_chosen_psk(conn));
-                conn->psk_params.chosen_psk->hash_alg = S2N_HASH_SHA384;
-                s2n_hmac_algorithm chosen_psk_hmac_alg = { 0 };
-                EXPECT_SUCCESS(s2n_hash_hmac_alg(conn->psk_params.chosen_psk->hash_alg, &chosen_psk_hmac_alg));
+                conn->psk_params.chosen_psk->hmac_alg = S2N_HASH_SHA384;
 
                 EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, test_wire_ciphers, 2));
                 EXPECT_EQUAL(conn->secure.cipher_suite, &s2n_ecdhe_rsa_with_aes_128_gcm_sha256);
                 EXPECT_EQUAL(conn->secure.cipher_suite->prf_alg, S2N_HMAC_SHA256);
-                EXPECT_NOT_EQUAL(conn->secure.cipher_suite->prf_alg, chosen_psk_hmac_alg);
+                EXPECT_NOT_EQUAL(conn->secure.cipher_suite->prf_alg,  conn->psk_params.chosen_psk->hmac_alg);
 
                 EXPECT_SUCCESS(s2n_psk_parameters_free(&conn->psk_params));
                 EXPECT_SUCCESS(s2n_connection_wipe(conn));

--- a/tests/unit/s2n_cipher_suite_match_test.c
+++ b/tests/unit/s2n_cipher_suite_match_test.c
@@ -800,7 +800,7 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, test_wire_ciphers, 2));
                 EXPECT_EQUAL(conn->secure.cipher_suite, &s2n_ecdhe_rsa_with_aes_128_gcm_sha256);
                 EXPECT_EQUAL(conn->secure.cipher_suite->prf_alg, S2N_HMAC_SHA256);
-                EXPECT_NOT_EQUAL(conn->secure.cipher_suite->prf_alg,  conn->psk_params.chosen_psk->hmac_alg);
+                EXPECT_NOT_EQUAL(conn->secure.cipher_suite->prf_alg, conn->psk_params.chosen_psk->hmac_alg);
 
                 EXPECT_SUCCESS(s2n_psk_parameters_free(&conn->psk_params));
                 EXPECT_SUCCESS(s2n_connection_wipe(conn));

--- a/tests/unit/s2n_client_psk_extension_test.c
+++ b/tests/unit/s2n_client_psk_extension_test.c
@@ -16,7 +16,7 @@
 #include "s2n_test.h"
 #include "testlib/s2n_testlib.h"
 
-#include "crypto/s2n_hash.h"
+#include "crypto/s2n_hmac.h"
 #include "tls/extensions/s2n_client_psk.h"
 
 /* Include source to test static methods. */
@@ -26,7 +26,7 @@
 #define TEST_BYTES_SIZE 0x00, 0x03
 
 struct s2n_psk_test_case {
-    s2n_hash_algorithm hash_alg;
+    s2n_hmac_algorithm hmac_alg;
     uint8_t hash_size;
     const uint8_t* identity;
     size_t identity_size;
@@ -79,7 +79,7 @@ int main(int argc, char **argv)
             EXPECT_OK(s2n_array_pushback(&conn->psk_params.psk_list, (void**) &psk));
             EXPECT_SUCCESS(s2n_psk_init(psk, S2N_PSK_TYPE_EXTERNAL));
             EXPECT_SUCCESS(s2n_psk_new_identity(psk, test_identity, sizeof(test_identity)));
-            psk->hash_alg = S2N_HASH_SHA384;
+            psk->hmac_alg = S2N_HMAC_SHA384;
 
             EXPECT_SUCCESS(s2n_client_psk_extension.send(conn, &out));
 
@@ -116,9 +116,9 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             struct s2n_psk_test_case test_cases[] = {
-                    { .hash_alg = S2N_HASH_SHA224, .hash_size = SHA224_DIGEST_LENGTH,
+                    { .hmac_alg = S2N_HMAC_SHA224, .hash_size = SHA224_DIGEST_LENGTH,
                             .identity = test_identity, .identity_size = sizeof(test_identity) },
-                    { .hash_alg = S2N_HASH_SHA384, .hash_size = SHA384_DIGEST_LENGTH,
+                    { .hmac_alg = S2N_HMAC_SHA384, .hash_size = SHA384_DIGEST_LENGTH,
                             .identity = test_identity_2, .identity_size =  sizeof(test_identity_2)},
             };
 
@@ -128,7 +128,7 @@ int main(int argc, char **argv)
                 EXPECT_OK(s2n_array_pushback(&conn->psk_params.psk_list, (void**) &psk));
                 EXPECT_SUCCESS(s2n_psk_init(psk, S2N_PSK_TYPE_EXTERNAL));
                 EXPECT_SUCCESS(s2n_psk_new_identity(psk, test_cases[i].identity, test_cases[i].identity_size));
-                psk->hash_alg = test_cases[i].hash_alg;
+                psk->hmac_alg = test_cases[i].hmac_alg;
 
                 binder_list_size += test_cases[i].hash_size
                         + sizeof(uint8_t) /* size of binder size */;
@@ -353,7 +353,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_psk_init(&psk, S2N_PSK_TYPE_EXTERNAL));
         EXPECT_SUCCESS(s2n_psk_new_secret(&psk, secret_data, sizeof(secret_data)));
 
-        EXPECT_SUCCESS(s2n_psk_calculate_binder_hash(conn, psk.hash_alg, &partial_client_hello, &binder_hash));
+        EXPECT_SUCCESS(s2n_psk_calculate_binder_hash(conn, psk.hmac_alg, &partial_client_hello, &binder_hash));
         EXPECT_SUCCESS(s2n_psk_calculate_binder(&psk, &binder_hash, &valid_binder));
 
         struct s2n_stuffer wire_binders_in = { 0 };

--- a/tests/unit/s2n_tls13_keys_test.c
+++ b/tests/unit/s2n_tls13_keys_test.c
@@ -296,7 +296,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_psk_new_secret(&test_psk, resumption_secret.data, resumption_secret.size));
 
         DEFER_CLEANUP(struct s2n_tls13_keys test_keys, s2n_tls13_keys_free);
-        GUARD(s2n_tls13_keys_init(&test_keys, test_psk.hash_alg));
+        GUARD(s2n_tls13_keys_init(&test_keys, test_psk.hmac_alg));
 
         EXPECT_SUCCESS(s2n_tls13_derive_binder_key(&test_keys, &test_psk));
 

--- a/tls/extensions/s2n_client_psk.c
+++ b/tls/extensions/s2n_client_psk.c
@@ -68,7 +68,7 @@ static int s2n_client_psk_send(struct s2n_connection *conn, struct s2n_stuffer *
 
         /* Calculate binder size */
         uint8_t hash_size = 0;
-        GUARD(s2n_hash_digest_size(psk->hash_alg, &hash_size));
+        GUARD(s2n_hmac_digest_size(psk->hmac_alg, &hash_size));
         binder_list_size += hash_size + SIZE_OF_BINDER_SIZE;
     }
 

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -1225,9 +1225,7 @@ static int s2n_set_cipher_as_server(struct s2n_connection *conn, uint8_t *wire, 
              * continue to the next candidate. 
              * */     
             if (conn->actual_protocol_version >= S2N_TLS13 && conn->psk_params.chosen_psk != NULL) {
-                s2n_hmac_algorithm chosen_psk_hmac_alg = { 0 };
-                GUARD(s2n_hash_hmac_alg(conn->psk_params.chosen_psk->hash_alg, &chosen_psk_hmac_alg));
-                if (match->prf_alg != chosen_psk_hmac_alg) {
+                if (match->prf_alg != conn->psk_params.chosen_psk->hmac_alg) {
                     continue;
                 }
             }

--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -31,7 +31,7 @@ int s2n_psk_init(struct s2n_psk *psk, s2n_psk_type type)
     notnull_check(psk);
 
     memset_check(psk, 0, sizeof(struct s2n_psk));
-    psk->hash_alg = S2N_HASH_SHA256;
+    psk->hmac_alg = S2N_HMAC_SHA256;
     psk->type = type;
 
     return S2N_SUCCESS;
@@ -119,7 +119,7 @@ int s2n_psk_parameters_free(struct s2n_psk_parameters *params)
 /* The binder hash is computed by hashing the concatenation of the current transcript
  * and a partial ClientHello that does not include the binders themselves.
  */
-int s2n_psk_calculate_binder_hash(struct s2n_connection *conn, s2n_hash_algorithm hash_alg,
+int s2n_psk_calculate_binder_hash(struct s2n_connection *conn, s2n_hmac_algorithm hmac_alg,
         const struct s2n_blob *partial_client_hello, struct s2n_blob *output_binder_hash)
 {
     notnull_check(partial_client_hello);
@@ -128,6 +128,9 @@ int s2n_psk_calculate_binder_hash(struct s2n_connection *conn, s2n_hash_algorith
     /* Retrieve the current transcript.
      * The current transcript will be empty unless this handshake included a HelloRetryRequest. */
     struct s2n_hash_state current_hash_state = {0};
+
+    s2n_hash_algorithm hash_alg;
+    GUARD(s2n_hmac_hash_alg(hmac_alg, &hash_alg));
     GUARD(s2n_handshake_get_hash_state(conn, hash_alg, &current_hash_state));
 
     /* Copy the current transcript to avoid modifying the original. */
@@ -148,9 +151,9 @@ static int s2n_tls13_keys_init_with_psk(struct s2n_tls13_keys *keys, struct s2n_
 {
     notnull_check(keys);
 
-    keys->hash_algorithm = psk->hash_alg;
-    GUARD(s2n_hash_hmac_alg(keys->hash_algorithm, &keys->hmac_algorithm));
-    GUARD(s2n_hash_digest_size(keys->hash_algorithm, &keys->size));
+    keys->hmac_algorithm = psk->hmac_alg;
+    GUARD(s2n_hmac_hash_alg(psk->hmac_alg, &keys->hash_algorithm));
+    GUARD(s2n_hmac_digest_size(keys->hmac_algorithm, &keys->size));
     GUARD(s2n_blob_init(&keys->extract_secret, keys->extract_secret_bytes, keys->size));
     GUARD(s2n_blob_init(&keys->derive_secret, keys->derive_secret_bytes, keys->size));
     GUARD(s2n_hmac_new(&keys->hmac));
@@ -205,7 +208,7 @@ int s2n_psk_verify_binder(struct s2n_connection *conn, struct s2n_psk *psk,
 
     /* Calculate the binder hash from the transcript */
     s2n_tls13_key_blob(binder_hash, psk_keys.size);
-    GUARD(s2n_psk_calculate_binder_hash(conn, psk->hash_alg, partial_client_hello, &binder_hash));
+    GUARD(s2n_psk_calculate_binder_hash(conn, psk->hmac_alg, partial_client_hello, &binder_hash));
 
     /* Calculate the expected binder from the binder hash */
     s2n_tls13_key_blob(expected_binder, psk_keys.size);
@@ -258,12 +261,12 @@ static S2N_RESULT s2n_psk_write_binder_list(struct s2n_connection *conn, const s
         ENSURE_REF(psk);
 
         /* Retrieve or calculate the binder hash. */
-        struct s2n_blob *binder_hash = &binder_hashes[psk->hash_alg];
+        struct s2n_blob *binder_hash = &binder_hashes[psk->hmac_alg];
         if (binder_hash->size == 0) {
             uint8_t hash_size = 0;
-            GUARD_AS_RESULT(s2n_hash_digest_size(psk->hash_alg, &hash_size));
-            GUARD_AS_RESULT(s2n_blob_init(binder_hash, binder_hashes_data[psk->hash_alg], hash_size));
-            GUARD_AS_RESULT(s2n_psk_calculate_binder_hash(conn, psk->hash_alg, partial_client_hello, binder_hash));
+            GUARD_AS_RESULT(s2n_hmac_digest_size(psk->hmac_alg, &hash_size));
+            GUARD_AS_RESULT(s2n_blob_init(binder_hash, binder_hashes_data[psk->hmac_alg], hash_size));
+            GUARD_AS_RESULT(s2n_psk_calculate_binder_hash(conn, psk->hmac_alg, partial_client_hello, binder_hash));
         }
 
         GUARD_RESULT(s2n_psk_write_binder(conn, psk, binder_hash, out));

--- a/tls/s2n_psk.h
+++ b/tls/s2n_psk.h
@@ -31,7 +31,7 @@ struct s2n_psk {
     s2n_psk_type type;
     struct s2n_blob identity;
     struct s2n_blob secret;
-    s2n_hash_algorithm hash_alg;
+    s2n_hmac_algorithm hmac_alg;
     uint32_t obfuscated_ticket_age;
     struct s2n_blob early_secret;
 };
@@ -55,7 +55,7 @@ int s2n_psk_parameters_free(struct s2n_psk_parameters *params);
 
 S2N_RESULT s2n_finish_psk_extension(struct s2n_connection *conn);
 
-int s2n_psk_calculate_binder_hash(struct s2n_connection *conn, s2n_hash_algorithm hash_alg,
+int s2n_psk_calculate_binder_hash(struct s2n_connection *conn, s2n_hmac_algorithm hmac_alg,
         const struct s2n_blob *partial_client_hello, struct s2n_blob *output_binder_hash);
 int s2n_psk_calculate_binder(struct s2n_psk *psk, const struct s2n_blob *binder_hash,
         struct s2n_blob *output_binder);


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Resolved issues:

 resolves https://github.com/awslabs/s2n/issues/2458

### Description of changes: 

For PSKs, We convert the s2n_hash_algorithm to s2n_hmac_algorithm every time we use it. Instead, we can update the s2n_psk object to contain s2n_hmac_algorithm in place of s2n_hash_algorithm.

- Updates the s2n_psk struct to include `s2n_hmac_algorithm hmac_alg` as shown below:

```
struct s2n_psk {
    s2n_psk_type type;
    struct s2n_blob identity;
    struct s2n_blob secret;
    s2n_hmac_algorithm hmac_alg;
    uint32_t obfuscated_ticket_age;
    struct s2n_blob early_secret;
};

```
-  Update s2n_psk_calculate_binder_hash to input s2n_hmac_algorithm inplace of s2n_hash_algorithm as follows:

```
int s2n_psk_calculate_binder_hash(struct s2n_connection *conn, s2n_hmac_algorithm hmac_alg,
        const struct s2n_blob *partial_client_hello, struct s2n_blob *output_binder_hash);

```

### Testing:

Updates existing psk unit tests to reflect the refactor change. 

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? Yes, The successful passing of the unit tests for the PSK APIs and `s2n_psk_calculate_binder_hash` function, verifies that the refactor is of the intended behavior. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
