### PR TITLE
Gate non-fips curves in fips mode

### DIFF
--- a/crypto/s2n_ecc_evp.c
+++ b/crypto/s2n_ecc_evp.c
@@ -48,7 +48,7 @@ static EC_POINT *s2n_ecc_evp_blob_to_point(struct s2n_blob *blob, const EC_KEY *
 static int s2n_ecc_evp_generate_key_nist_curves(const struct s2n_ecc_named_curve *named_curve, EVP_PKEY **evp_pkey);
 static int s2n_ecc_evp_generate_own_key(const struct s2n_ecc_named_curve *named_curve, EVP_PKEY **evp_pkey);
 static int s2n_ecc_evp_compute_shared_secret(EVP_PKEY *own_key, EVP_PKEY *peer_public, uint16_t iana_id, struct s2n_blob *shared_secret);
-static bool s2n_ecc_evp_is_available(uint16_t query_iana_id);
+static bool s2n_ecc_evp_curve_is_available(uint16_t query_iana_id);
 
 /* IANA values can be found here: https://tools.ietf.org/html/rfc8446#appendix-B.3.1.4 */
 
@@ -191,7 +191,7 @@ static int s2n_ecc_evp_compute_shared_secret(EVP_PKEY *own_key, EVP_PKEY *peer_p
     return 0;
 }
 
-static bool s2n_ecc_evp_is_available(uint16_t query_iana_id) {
+static bool s2n_ecc_evp_curve_is_available(uint16_t query_iana_id) {
     switch (query_iana_id) {
     case TLS_EC_CURVE_SECP_521_R1:
         return !s2n_is_in_fips_mode();
@@ -204,11 +204,11 @@ static bool s2n_ecc_evp_is_available(uint16_t query_iana_id) {
     return false;
 }
 
-int s2n_ecc_evp_init(void) {
+int s2n_ecc_evp_curves_init(void) {
     for (size_t i = 0; i < s2n_all_supported_curves_list_len; i++) {
         struct s2n_ecc_named_curve *named_curve = s2n_all_supported_curves_list[i];
         named_curve->available = 0;
-        if (s2n_ecc_evp_is_available(named_curve->iana_id)) {
+        if (s2n_ecc_evp_curve_is_available(named_curve->iana_id)) {
             named_curve->available = 1;
         }
     }

--- a/crypto/s2n_ecc_evp.h
+++ b/crypto/s2n_ecc_evp.h
@@ -31,6 +31,7 @@
 #define X25519_SHARE_SIZE (32)
 
 struct s2n_ecc_named_curve {
+    unsigned int available:1;
     /* See https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8 */
     uint16_t iana_id;
     /* See nid_list in openssl/ssl/t1_lib.c */
@@ -40,10 +41,10 @@ struct s2n_ecc_named_curve {
     int (*generate_key) (const struct s2n_ecc_named_curve *named_curve, EVP_PKEY **evp_pkey);
 };
 
-extern const struct s2n_ecc_named_curve s2n_ecc_curve_secp256r1;
-extern const struct s2n_ecc_named_curve s2n_ecc_curve_secp384r1;
-extern const struct s2n_ecc_named_curve s2n_ecc_curve_secp521r1;
-extern const struct s2n_ecc_named_curve s2n_ecc_curve_x25519;
+extern struct s2n_ecc_named_curve s2n_ecc_curve_secp256r1;
+extern struct s2n_ecc_named_curve s2n_ecc_curve_secp384r1;
+extern struct s2n_ecc_named_curve s2n_ecc_curve_secp521r1;
+extern struct s2n_ecc_named_curve s2n_ecc_curve_x25519;
 
 /* BoringSSL only supports using EVP_PKEY_X25519 with "modern" EC EVP APIs. BoringSSL has a note to possibly add this in
  * the future. See https://github.com/google/boringssl/blob/master/crypto/evp/p_x25519_asn1.c#L233
@@ -56,7 +57,7 @@ extern const struct s2n_ecc_named_curve s2n_ecc_curve_x25519;
     #define S2N_ECC_EVP_SUPPORTED_CURVES_COUNT 3
 #endif
 
-extern const struct s2n_ecc_named_curve *const s2n_all_supported_curves_list[];
+extern struct s2n_ecc_named_curve *s2n_all_supported_curves_list[];
 extern const size_t s2n_all_supported_curves_list_len;
 
 struct s2n_ecc_evp_params {
@@ -64,6 +65,7 @@ struct s2n_ecc_evp_params {
     EVP_PKEY *evp_pkey;
 };
 
+int s2n_ecc_evp_init(void);
 int s2n_ecc_evp_generate_ephemeral_key(struct s2n_ecc_evp_params *ecc_evp_params);
 int s2n_ecc_evp_compute_shared_secret_from_params(struct s2n_ecc_evp_params *private_ecc_evp_params,
                                                   struct s2n_ecc_evp_params *public_ecc_evp_params,

--- a/crypto/s2n_ecc_evp.h
+++ b/crypto/s2n_ecc_evp.h
@@ -65,7 +65,7 @@ struct s2n_ecc_evp_params {
     EVP_PKEY *evp_pkey;
 };
 
-int s2n_ecc_evp_init(void);
+int s2n_ecc_evp_curves_init(void);
 int s2n_ecc_evp_generate_ephemeral_key(struct s2n_ecc_evp_params *ecc_evp_params);
 int s2n_ecc_evp_compute_shared_secret_from_params(struct s2n_ecc_evp_params *private_ecc_evp_params,
                                                   struct s2n_ecc_evp_params *public_ecc_evp_params,

--- a/tests/fuzz/s2n_client_key_recv_fuzz_test.c
+++ b/tests/fuzz/s2n_client_key_recv_fuzz_test.c
@@ -120,7 +120,9 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     notnull_check(ecc_preferences);
 
     if (server_conn->secure.cipher_suite->key_exchange_alg->client_key_recv == s2n_ecdhe_client_key_recv || server_conn->secure.cipher_suite->key_exchange_alg->client_key_recv == s2n_hybrid_client_key_recv) {
-        server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
+        int selected_curve_index = -1;
+        EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_preferences, &selected_curve_index));
+        server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[selected_curve_index];
         s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.server_ecc_evp_params);
     }
 

--- a/tests/fuzz/s2n_extensions_server_key_share_recv_test.c
+++ b/tests/fuzz/s2n_extensions_server_key_share_recv_test.c
@@ -66,8 +66,10 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
 
     /* Generate ephemeral keys for all supported curves */
     for (int i = 0; i < ecc_preferences->count; i++) {
-        client_conn->secure.client_ecc_evp_params[i].negotiated_curve = ecc_preferences->ecc_curves[i];
-        GUARD(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.client_ecc_evp_params[i]));
+        if (ecc_preferences->ecc_curves[i]->available) {
+            client_conn->secure.client_ecc_evp_params[i].negotiated_curve = ecc_preferences->ecc_curves[i];
+            GUARD(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.client_ecc_evp_params[i]));
+        }
     }
 
     /* Run Test

--- a/tests/fuzz/s2n_hybrid_ecdhe_bike_r1_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_bike_r1_fuzz_test.c
@@ -50,7 +50,10 @@ static int setup_connection(struct s2n_connection *server_conn)
     GUARD(s2n_connection_get_ecc_preferences(server_conn, &ecc_preferences));
     notnull_check(ecc_preferences);
 
-    server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
+    int selected_curve_index = -1;
+    EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_preferences, &selected_curve_index));
+
+    server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[selected_curve_index];
     server_conn->secure.server_ecc_evp_params.evp_pkey = NULL;
     server_conn->secure.kem_params.kem = &s2n_bike1_l1_r1;
     server_conn->secure.cipher_suite = &s2n_ecdhe_bike_rsa_with_aes_256_gcm_sha384;

--- a/tests/fuzz/s2n_hybrid_ecdhe_bike_r2_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_bike_r2_fuzz_test.c
@@ -50,7 +50,9 @@ static int setup_connection(struct s2n_connection *server_conn)
     GUARD(s2n_connection_get_ecc_preferences(server_conn, &ecc_preferences));
     notnull_check(ecc_preferences);
 
-    server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
+    int selected_curve_index = -1;
+    EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_preferences, &selected_curve_index));
+    server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[selected_curve_index];
     server_conn->secure.server_ecc_evp_params.evp_pkey = NULL;
     server_conn->secure.kem_params.kem = &s2n_bike1_l1_r2;
     server_conn->secure.cipher_suite = &s2n_ecdhe_bike_rsa_with_aes_256_gcm_sha384;

--- a/tests/fuzz/s2n_hybrid_ecdhe_kyber_r2_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_kyber_r2_fuzz_test.c
@@ -50,7 +50,9 @@ static int setup_connection(struct s2n_connection *server_conn)
     GUARD(s2n_connection_get_ecc_preferences(server_conn, &ecc_preferences));
     notnull_check(ecc_preferences);
 
-    server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
+    int selected_curve_index = -1;
+    EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_preferences, &selected_curve_index));
+    server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[selected_curve_index];
     server_conn->secure.server_ecc_evp_params.evp_pkey = NULL;
     server_conn->secure.kem_params.kem = &s2n_kyber_512_r2;
     server_conn->secure.cipher_suite = &s2n_ecdhe_kyber_rsa_with_aes_256_gcm_sha384;

--- a/tests/fuzz/s2n_hybrid_ecdhe_sike_r1_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_sike_r1_fuzz_test.c
@@ -50,7 +50,9 @@ static int setup_connection(struct s2n_connection *server_conn)
     GUARD(s2n_connection_get_ecc_preferences(server_conn, &ecc_preferences));
     notnull_check(ecc_preferences);
 
-    server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
+    int selected_curve_index = -1;
+    EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_preferences, &selected_curve_index));
+    server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[selected_curve_index];
     server_conn->secure.server_ecc_evp_params.evp_pkey = NULL;
     server_conn->secure.kem_params.kem = &s2n_sike_p503_r1;
     server_conn->secure.cipher_suite = &s2n_ecdhe_sike_rsa_with_aes_256_gcm_sha384;

--- a/tests/fuzz/s2n_hybrid_ecdhe_sike_r2_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_sike_r2_fuzz_test.c
@@ -50,7 +50,9 @@ static int setup_connection(struct s2n_connection *server_conn)
     GUARD(s2n_connection_get_ecc_preferences(server_conn, &ecc_preferences));
     notnull_check(ecc_preferences);
 
-    server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
+    int selected_curve_index = -1;
+    EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_preferences, &selected_curve_index));
+    server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[selected_curve_index];
     server_conn->secure.server_ecc_evp_params.evp_pkey = NULL;
     server_conn->secure.kem_params.kem = &s2n_sike_p434_r2;
     server_conn->secure.cipher_suite = &s2n_ecdhe_sike_rsa_with_aes_256_gcm_sha384;

--- a/tests/integration/s2n_handshake_test_s_client.py
+++ b/tests/integration/s2n_handshake_test_s_client.py
@@ -634,9 +634,11 @@ def elliptic_curve_test(host, port, libcrypto_version, fips_mode, **kwargs):
     for noise.
     """
     supported_curves = ["P-256", "P-384"]
+    unsupported_curves = ["B-163", "K-409"]
     if not fips_mode:
         supported_curves.append("P-521")
-    unsupported_curves = ["B-163", "K-409"]
+    else:
+        unsupported_curves.append("P-521")
     print("\n\tRunning elliptic curve tests:")
     print("\tExpected supported:   " + str(supported_curves))
     print("\tExpected unsupported: " + str(unsupported_curves))

--- a/tests/testlib/s2n_pq_hybrid_test_utils.c
+++ b/tests/testlib/s2n_pq_hybrid_test_utils.c
@@ -63,7 +63,7 @@ static int setup_connection(struct s2n_connection *conn, const struct s2n_kem *k
     GUARD_NONNULL(ecc_preferences);
 
     int selected_curve_index = -1;
-    GUARD(s2n_ecc_preference_first_available_curve_index(ecc_pref, &selected_curve_index));
+    GUARD(s2n_ecc_preference_first_available_curve_index(ecc_preferences, &selected_curve_index));
 
     conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[selected_curve_index];
     conn->secure.kem_params.kem = kem;

--- a/tests/testlib/s2n_pq_hybrid_test_utils.c
+++ b/tests/testlib/s2n_pq_hybrid_test_utils.c
@@ -62,7 +62,10 @@ static int setup_connection(struct s2n_connection *conn, const struct s2n_kem *k
     GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_preferences));
     GUARD_NONNULL(ecc_preferences);
 
-    conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
+    int selected_curve_index = -1;
+    GUARD(s2n_ecc_preference_first_available_curve_index(ecc_pref, &selected_curve_index));
+
+    conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[selected_curve_index];
     conn->secure.kem_params.kem = kem;
     conn->secure.cipher_suite = cipher_suite;
     conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;

--- a/tests/unit/s2n_choose_supported_group_test.c
+++ b/tests/unit/s2n_choose_supported_group_test.c
@@ -95,13 +95,16 @@ int main() {
                 EXPECT_NULL(server_conn->secure.mutually_supported_kem_groups[i]);
             }
 
-            server_conn->secure.mutually_supported_curves[1] = ecc_pref->ecc_curves[1];
+            int selected_curve_index = -1;
+            EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_pref, &selected_curve_index));
+
+            server_conn->secure.mutually_supported_curves[selected_curve_index] = ecc_pref->ecc_curves[selected_curve_index];
             EXPECT_SUCCESS(s2n_choose_supported_group(server_conn));
 
             EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
             EXPECT_NULL(server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
             EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_params.kem);
-            EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[1]);
+            EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[selected_curve_index]);
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
         }
 
@@ -121,19 +124,24 @@ int main() {
             EXPECT_EQUAL(kem_pref, &kem_preferences_null);
 
             for (size_t i = 0; i < ecc_pref->count; i++) {
-                server_conn->secure.mutually_supported_curves[i] = ecc_pref->ecc_curves[i];
+                if (ecc_pref->ecc_curves[i]->available) {
+                    server_conn->secure.mutually_supported_curves[i] = ecc_pref->ecc_curves[i];
+                }
             }
 
             for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
                 EXPECT_NULL(server_conn->secure.mutually_supported_kem_groups[i]);
             }
 
+            int selected_curve_index = -1;
+            EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_pref, &selected_curve_index));
+
             EXPECT_SUCCESS(s2n_choose_supported_group(server_conn));
 
             EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
             EXPECT_NULL(server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
             EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_params.kem);
-            EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[0]);
+            EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[selected_curve_index]);
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
         }
     }
@@ -183,19 +191,24 @@ int main() {
             EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
 
             for (size_t i = 0; i < ecc_pref->count; i++) {
-                server_conn->secure.mutually_supported_curves[i] = ecc_pref->ecc_curves[i];
+                if (ecc_pref->ecc_curves[i]->available) {
+                    server_conn->secure.mutually_supported_curves[i] = ecc_pref->ecc_curves[i];
+                }
             }
 
             for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
                 EXPECT_NULL(server_conn->secure.mutually_supported_kem_groups[i]);
             }
 
+            int selected_curve_index = -1;
+            EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_pref, &selected_curve_index));
+
             EXPECT_SUCCESS(s2n_choose_supported_group(server_conn));
 
             EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
             EXPECT_NULL(server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
             EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_params.kem);
-            EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[0]);
+            EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[selected_curve_index]);
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
         }
 
@@ -221,7 +234,9 @@ int main() {
             EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
 
             for (size_t i = 0; i < ecc_pref->count; i++) {
-                server_conn->secure.mutually_supported_curves[i] = ecc_pref->ecc_curves[i];
+                if (ecc_pref->ecc_curves[i]->available) {
+                    server_conn->secure.mutually_supported_curves[i] = ecc_pref->ecc_curves[i];
+                }
             }
 
             for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
@@ -259,7 +274,9 @@ int main() {
             EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
 
             for (size_t i = 0; i < ecc_pref->count; i++) {
-                server_conn->secure.mutually_supported_curves[i] = ecc_pref->ecc_curves[i];
+                if (ecc_pref->ecc_curves[i]->available) {
+                    server_conn->secure.mutually_supported_curves[i] = ecc_pref->ecc_curves[i];
+                }
             }
 
             for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {

--- a/tests/unit/s2n_cipher_suite_match_test.c
+++ b/tests/unit/s2n_cipher_suite_match_test.c
@@ -237,9 +237,12 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
         EXPECT_NOT_NULL(ecc_pref);
 
+        int selected_curve_index = -1;
+        EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_pref, &selected_curve_index));
+        conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
+
         /* Assume default for negotiated curve. */
         /* Shouldn't be necessary unless the test fails, but we want the failure to be obvious. */
-        conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
         conn->actual_protocol_version = conn->server_protocol_version;
         const uint8_t expected_rsa_wire_choice[] = { TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA };
         EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
@@ -261,7 +264,9 @@ int main(int argc, char **argv)
             int client_extensions_len = sizeof(client_extensions_data);
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "KMS-PQ-TLS-1-0-2019-06"));
             conn->actual_protocol_version = S2N_TLS12;
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+
+            EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_pref, &selected_curve_index));
+            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
             conn->secure.client_pq_kem_extension.data = client_extensions_data;
             conn->secure.client_pq_kem_extension.size = client_extensions_len;
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers, cipher_count));
@@ -275,7 +280,8 @@ int main(int argc, char **argv)
                 const uint8_t expected_classic_wire_choice[] = {TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA};
                 EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "KMS-PQ-TLS-1-0-2019-06"));
                 conn->actual_protocol_version = i;
-                conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+                EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_pref, &selected_curve_index));
+                conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
                 conn->secure.client_pq_kem_extension.data = client_extensions_data;
                 conn->secure.client_pq_kem_extension.size = client_extensions_len;
                 EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers, cipher_count));
@@ -300,7 +306,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_all_ecdsa"));
         const uint8_t expected_ecdsa_wire_choice[] = { TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 };
         /* Assume default for negotiated curve. */
-        conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+        EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_pref, &selected_curve_index));
+        conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
         conn->actual_protocol_version = conn->server_protocol_version;
         EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
         EXPECT_EQUAL(conn->secure_renegotiation, 0);
@@ -310,7 +317,8 @@ int main(int argc, char **argv)
         /* TEST ECDSA cipher chosen when RSA cipher is at top */
         EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_all"));
         /* Assume default for negotiated curve. */
-        conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+        EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_pref, &selected_curve_index));
+        conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
         conn->actual_protocol_version = conn->server_protocol_version;
         EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
         EXPECT_EQUAL(conn->secure_renegotiation, 0);
@@ -329,7 +337,8 @@ int main(int argc, char **argv)
         {
             const uint8_t expected_wire_choice[] = { TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 };
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_ecdsa_priority"));
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+            EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_pref, &selected_curve_index));
+            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
             conn->actual_protocol_version = conn->server_protocol_version;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
@@ -342,7 +351,8 @@ int main(int argc, char **argv)
         {
             const uint8_t expected_wire_choice[] = { TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA };
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_all"));
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+            EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_pref, &selected_curve_index));
+            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
             conn->actual_protocol_version = conn->server_protocol_version;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
@@ -358,7 +368,8 @@ int main(int argc, char **argv)
             const uint8_t expected_wire_choice[] = { TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA };
             /* 20170328 only supports RSA ciphers */
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "20170328"));
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+            EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_pref, &selected_curve_index));
+            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
             conn->actual_protocol_version = conn->server_protocol_version;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
@@ -373,7 +384,8 @@ int main(int argc, char **argv)
         {
             const uint8_t expected_wire_choice[] = { TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 };
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_all_ecdsa"));
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+            EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_pref, &selected_curve_index));
+            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
             conn->actual_protocol_version = conn->server_protocol_version;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
@@ -388,7 +400,8 @@ int main(int argc, char **argv)
         {
             const uint8_t expected_wire_choice[] = { TLS_RSA_WITH_RC4_128_MD5 };
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_ecdsa_priority"));
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+            EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_pref, &selected_curve_index));
+            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
             conn->actual_protocol_version = conn->server_protocol_version;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers, cipher_count));
@@ -403,7 +416,8 @@ int main(int argc, char **argv)
         {
             const uint8_t expected_wire_choice[] = { TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA };
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_ecdsa_priority"));
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+            EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_pref, &selected_curve_index));
+            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
             conn->actual_protocol_version = conn->server_protocol_version;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_only_ecdsa, cipher_count_only_ecdsa));
@@ -444,7 +458,8 @@ int main(int argc, char **argv)
         {
             const uint8_t expected_wire_choice[] = { TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA };
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_ecdsa_priority"));
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+            EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_pref, &selected_curve_index));
+            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
             conn->actual_protocol_version = conn->server_protocol_version;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
@@ -461,7 +476,8 @@ int main(int argc, char **argv)
         {
             const uint8_t expected_wire_choice[] = { TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 };
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_all"));
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+            EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_pref, &selected_curve_index));
+            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
             conn->actual_protocol_version = conn->server_protocol_version;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
@@ -478,7 +494,8 @@ int main(int argc, char **argv)
         {
             const uint8_t expected_wire_choice[] = { TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 };
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_ecdsa_priority"));
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+            EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_pref, &selected_curve_index));
+            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
             conn->actual_protocol_version = conn->server_protocol_version;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
@@ -503,7 +520,8 @@ int main(int argc, char **argv)
         {
             const uint8_t expected_wire_choice[] = { TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA };
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_all"));
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+            EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_pref, &selected_curve_index));
+            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
             conn->actual_protocol_version = conn->server_protocol_version;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));

--- a/tests/unit/s2n_client_hello_retry_test.c
+++ b/tests/unit/s2n_client_hello_retry_test.c
@@ -57,11 +57,13 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(ecc_pref);
 
             conn->actual_protocol_version = S2N_TLS13;
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
-            conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
+            int selected_curve_index = -1;
+            EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_pref, &selected_curve_index));
+            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
+            conn->secure.client_ecc_evp_params[selected_curve_index].negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
 
             EXPECT_NULL(conn->secure.client_ecc_evp_params->evp_pkey);
-            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[selected_curve_index]));
             EXPECT_NOT_NULL(conn->secure.client_ecc_evp_params->evp_pkey);
 
             EXPECT_FAILURE_WITH_ERRNO(s2n_server_hello_retry_recv(conn), S2N_ERR_INVALID_HELLO_RETRY);

--- a/tests/unit/s2n_ecc_preferences_test.c
+++ b/tests/unit/s2n_ecc_preferences_test.c
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
 
         EXPECT_TRUE(s2n_ecc_preferences_includes_curve(&s2n_ecc_preferences_20201021, TLS_EC_CURVE_SECP_256_R1));
         EXPECT_TRUE(s2n_ecc_preferences_includes_curve(&s2n_ecc_preferences_20201021, TLS_EC_CURVE_SECP_384_R1));
-        EXPECT_TRUE(s2n_ecc_preferences_includes_curve(&s2n_ecc_preferences_20201021, TLS_EC_CURVE_SECP_521_R1));
+        EXPECT_EQUAL(s2n_ecc_preferences_includes_curve(&s2n_ecc_preferences_20201021, TLS_EC_CURVE_SECP_521_R1), !s2n_is_in_fips_mode());
         EXPECT_FALSE(s2n_ecc_preferences_includes_curve(&s2n_ecc_preferences_20201021, TLS_EC_CURVE_ECDH_X25519));
     }
 

--- a/tests/unit/s2n_ecc_preferences_test.c
+++ b/tests/unit/s2n_ecc_preferences_test.c
@@ -16,6 +16,7 @@
 #include "s2n_test.h"
 #include "tls/s2n_ecc_preferences.h"
 #include "tls/s2n_tls_parameters.h"
+#include "crypto/s2n_fips.h"
 
 int main(int argc, char **argv) {
     BEGIN_TEST();

--- a/tests/unit/s2n_server_extensions_test.c
+++ b/tests/unit/s2n_server_extensions_test.c
@@ -49,9 +49,11 @@ static int configure_tls13_connection(struct s2n_connection *conn)
     EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
     EXPECT_NOT_NULL(ecc_pref);
 
-    conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
-    conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
-    GUARD(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
+    int selected_curve_index = -1;
+    EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_pref, &selected_curve_index));
+    conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
+    conn->secure.client_ecc_evp_params[selected_curve_index].negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
+    GUARD(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[selected_curve_index]));
     GUARD(s2n_stuffer_wipe(&conn->handshake.io));
     GUARD(s2n_connection_allow_all_response_extensions(conn));
 
@@ -280,13 +282,16 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(ecc_pref);
 
             struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+
+            int selected_curve_index = -1;
+            EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_pref, &selected_curve_index));
+            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
 
             /* Test that s2n_server_extensions_send() only works when protocol version is TLS13 */
             conn->actual_protocol_version = S2N_TLS13;
 
             /* key_share_send() requires a negotiated_curve */
-            conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
+            conn->secure.client_ecc_evp_params[selected_curve_index].negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
 
             const uint8_t size = P256_KEYSHARE_SIZE + SUPPORTED_VERSION_SIZE;
 
@@ -296,7 +301,7 @@ int main(int argc, char **argv)
             EXPECT_FAILURE(s2n_server_extensions_send(conn, hello_stuffer));
 
             EXPECT_SUCCESS(s2n_stuffer_wipe(hello_stuffer));
-            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[selected_curve_index]));
 
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
             S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, size + EXTENSION_LEN);
@@ -324,21 +329,24 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(ecc_pref);
 
             struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+
+            int selected_curve_index = -1;
+            EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_pref, &selected_curve_index));
+            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
             /* secure renegotiation is requested */
             conn->secure_renegotiation = 1;
             /* Test that s2n_server_extensions_send() only works when protocol version is TLS13 */
             conn->actual_protocol_version = S2N_TLS13;
 
             /* key_share_send() requires a negotiated_curve */
-            conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
+            conn->secure.client_ecc_evp_params[selected_curve_index].negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
             /* secure_renegotiation extension not send >=TLS13*/
             uint8_t size = s2n_extensions_server_key_share_send_size(conn)
                 + s2n_extensions_server_supported_versions_size(conn);
 
             EXPECT_FAILURE(s2n_server_extensions_send(conn, hello_stuffer));
 
-            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[selected_curve_index]));
 
             EXPECT_SUCCESS(s2n_stuffer_skip_read(hello_stuffer, s2n_stuffer_data_available(hello_stuffer)));
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
@@ -367,7 +375,10 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(ecc_pref);
 
             struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+
+            int selected_curve_index = -1;
+            EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_pref, &selected_curve_index));
+            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
 
             /* New Session Ticket Requested*/
             conn->config->use_tickets = 1;
@@ -377,7 +388,7 @@ int main(int argc, char **argv)
             conn->actual_protocol_version = S2N_TLS13;
 
             /* key_share_send() requires a negotiated_curve */
-            conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
+            conn->secure.client_ecc_evp_params[selected_curve_index].negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
 
             /* nst extension not send >=TLS13*/
             uint8_t size = s2n_extensions_server_key_share_send_size(conn)
@@ -385,7 +396,7 @@ int main(int argc, char **argv)
 
             EXPECT_FAILURE(s2n_server_extensions_send(conn, hello_stuffer));
 
-            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[selected_curve_index]));
 
             EXPECT_SUCCESS(s2n_stuffer_skip_read(hello_stuffer, s2n_stuffer_data_available(hello_stuffer)));
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
@@ -425,7 +436,10 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
             EXPECT_NOT_NULL(ecc_pref);
             struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+
+            int selected_curve_index = -1;
+            EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_pref, &selected_curve_index));
+            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
 
             /* Test that s2n_server_extensions_send() only works when protocol version is TLS13 */
             conn->client_protocol_version = S2N_TLS13;
@@ -433,14 +447,14 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_tls13, cipher_count_tls13));
 
             /* key_share_send() requires a negotiated_curve */
-            conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
+            conn->secure.client_ecc_evp_params[selected_curve_index].negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
 
             uint8_t size = s2n_extensions_server_key_share_send_size(conn)
                 + s2n_extensions_server_supported_versions_size(conn);
 
             EXPECT_FAILURE(s2n_server_extensions_send(conn, hello_stuffer));
 
-            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[selected_curve_index]));
 
             EXPECT_SUCCESS(s2n_stuffer_skip_read(hello_stuffer, s2n_stuffer_data_available(hello_stuffer)));
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));

--- a/tests/unit/s2n_server_hello_test.c
+++ b/tests/unit/s2n_server_hello_test.c
@@ -110,9 +110,11 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(ecc_preferences);
         /* configure these parameters so server hello can be sent */
         conn->actual_protocol_version = S2N_TLS13;
-        conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
-        conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_preferences->ecc_curves[0];
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
+        int selected_curve_index = -1;
+        EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_preferences, &selected_curve_index));
+        conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[selected_curve_index];
+        conn->secure.client_ecc_evp_params[selected_curve_index].negotiated_curve = ecc_preferences->ecc_curves[selected_curve_index];
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[selected_curve_index]));
 
         struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
         EXPECT_SUCCESS(s2n_server_hello_send(conn));

--- a/tests/unit/s2n_tls13_compute_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_compute_shared_secret_test.c
@@ -44,8 +44,10 @@ int main(int argc, char **argv) {
         EXPECT_NOT_NULL(ecc_pref);
 
         /* Select curve and generate key for client */
-        client_conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.client_ecc_evp_params[0]));
+        int selected_curve_index = -1;
+        EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_pref, &selected_curve_index));
+        client_conn->secure.client_ecc_evp_params[selected_curve_index].negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.client_ecc_evp_params[selected_curve_index]));
         /* Recreating conditions where negotiated curve was not set */
         struct s2n_ecc_evp_params missing_params = {NULL,NULL};
         client_conn->secure.server_ecc_evp_params = missing_params;
@@ -68,12 +70,15 @@ int main(int argc, char **argv) {
         EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(client_conn, &ecc_pref));
         EXPECT_NOT_NULL(ecc_pref);
 
+        int selected_curve_index = -1;
+        EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_pref, &selected_curve_index));
+
         /* Select curve and generate key for client */
-        client_conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.client_ecc_evp_params[0]));
+        client_conn->secure.client_ecc_evp_params[selected_curve_index].negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.client_ecc_evp_params[selected_curve_index]));
 
         /* Set curve server sent in server hello */
-        client_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+        client_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
 
         DEFER_CLEANUP(struct s2n_blob client_shared_secret = {0}, s2n_free);
         /* Compute fails because server's public key is missing */
@@ -94,12 +99,15 @@ int main(int argc, char **argv) {
 
         client_conn->actual_protocol_version = S2N_TLS13;
 
+        int selected_curve_index = -1;
+        EXPECT_SUCCESS(s2n_ecc_preference_first_available_curve_index(ecc_pref, &selected_curve_index));
+
         /* Select curve and generate key for client */
-        client_conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.client_ecc_evp_params[0]));
+        client_conn->secure.client_ecc_evp_params[selected_curve_index].negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.client_ecc_evp_params[selected_curve_index]));
 
         /* Set curve server sent in server hello */
-        client_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+        client_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[selected_curve_index];
 
         /* Generate public key server sent in server hello */
         EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.server_ecc_evp_params));

--- a/tls/extensions/s2n_server_key_share.c
+++ b/tls/extensions/s2n_server_key_share.c
@@ -114,7 +114,7 @@ int s2n_server_key_share_send_check_ecdhe(struct s2n_connection *conn) {
 
     struct s2n_ecc_evp_params *client_params = NULL;
     for (size_t i = 0; i < ecc_pref->count; i++) {
-        if (server_curve == ecc_pref->ecc_curves[i]) {
+        if (ecc_pref->ecc_curves[i]->available && server_curve == ecc_pref->ecc_curves[i]) {
             client_params = &conn->secure.client_ecc_evp_params[i];
             break;
         }
@@ -244,7 +244,7 @@ static int s2n_server_key_share_recv_ecc(struct s2n_connection *conn, uint16_t n
     size_t supported_curve_index = 0;
 
     for (size_t i = 0; i < ecc_pref->count; i++) {
-        if (named_group_iana == ecc_pref->ecc_curves[i]->iana_id) {
+        if (ecc_pref->ecc_curves[i]->available && named_group_iana == ecc_pref->ecc_curves[i]->iana_id) {
             supported_curve_index = i;
             break;
         }

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1344,7 +1344,7 @@ int s2n_connection_set_keyshare_by_name_for_testing(struct s2n_connection *conn,
     notnull_check(ecc_pref);
 
     for (size_t i = 0; i < ecc_pref->count; i++) {
-        if (!strcmp(ecc_pref->ecc_curves[i]->name, curve_name)) {
+        if (ecc_pref->ecc_curves[i]->available && !strcmp(ecc_pref->ecc_curves[i]->name, curve_name)) {
             S2N_SET_KEY_SHARE_REQUEST(conn->preferred_key_shares, i);
             return S2N_SUCCESS;
         }

--- a/tls/s2n_ecc_preferences.c
+++ b/tls/s2n_ecc_preferences.c
@@ -101,7 +101,7 @@ bool s2n_ecc_preferences_includes_curve(const struct s2n_ecc_preferences *ecc_pr
     }
 
     for (size_t i = 0; i < ecc_preferences->count; i++) {
-        if (query_iana_id == ecc_preferences->ecc_curves[i]->iana_id) {
+        if (ecc_preferences->ecc_curves[i]->available && query_iana_id == ecc_preferences->ecc_curves[i]->iana_id) {
             return true;
         }
     }

--- a/tls/s2n_ecc_preferences.c
+++ b/tls/s2n_ecc_preferences.c
@@ -109,3 +109,16 @@ bool s2n_ecc_preferences_includes_curve(const struct s2n_ecc_preferences *ecc_pr
     return false;
 }
 
+int s2n_ecc_preference_first_available_curve_index(const struct s2n_ecc_preferences *ecc_preferences, int *index) {
+    notnull_check(ecc_preferences);
+    notnull_check(index);
+
+    for (size_t i = 0; i < ecc_preferences->count; i++) {
+        if (ecc_preferences->ecc_curves[i]->available) {
+            *index = i;
+            return S2N_SUCCESS;
+        }
+    }
+
+    S2N_ERROR(S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
+}

--- a/tls/s2n_ecc_preferences.h
+++ b/tls/s2n_ecc_preferences.h
@@ -33,3 +33,4 @@ extern const struct s2n_ecc_preferences s2n_ecc_preferences_null;
 
 int s2n_check_ecc_preferences_curves_list(const struct s2n_ecc_preferences *ecc_preferences);
 bool s2n_ecc_preferences_includes_curve(const struct s2n_ecc_preferences *ecc_preferences, uint16_t query_iana_id);
+int s2n_ecc_preference_first_available_curve_index(const struct s2n_ecc_preferences *ecc_preferences, int *index);

--- a/tls/s2n_server_hello_retry.c
+++ b/tls/s2n_server_hello_retry.c
@@ -98,7 +98,7 @@ int s2n_server_hello_retry_recv(struct s2n_connection *conn)
 
     if (named_curve != NULL) {
         for (size_t i = 0; i < ecc_pref->count; i++) {
-            if (ecc_pref->ecc_curves[i] == named_curve) {
+            if (ecc_pref->ecc_curves[i]->available && ecc_pref->ecc_curves[i] == named_curve) {
                 match_found = true;
                 ENSURE_POSIX(conn->secure.client_ecc_evp_params[i].evp_pkey == NULL, S2N_ERR_INVALID_HELLO_RETRY);
                 break;

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -78,7 +78,7 @@ int s2n_tls13_compute_ecc_shared_secret(struct s2n_connection *conn, struct s2n_
      * this can be simplified if we get an index or a pointer to a specific key */
     int selection = -1;
     for (int i = 0; i < ecc_preferences->count; i++) {
-        if (server_key->negotiated_curve->iana_id == ecc_preferences->ecc_curves[i]->iana_id) {
+        if (server_key->negotiated_curve->available && server_key->negotiated_curve->iana_id == ecc_preferences->ecc_curves[i]->iana_id) {
             selection = i;
             break;
         }

--- a/utils/s2n_init.c
+++ b/utils/s2n_init.c
@@ -42,6 +42,7 @@ int s2n_init(void)
     GUARD_POSIX(s2n_mem_init());
     GUARD_AS_POSIX(s2n_rand_init());
     GUARD_POSIX(s2n_cipher_suites_init());
+    GUARD_POSIX(s2n_ecc_evp_init());
     GUARD_POSIX(s2n_security_policies_init());
     GUARD_POSIX(s2n_config_defaults_init());
     GUARD_POSIX(s2n_extension_type_init());

--- a/utils/s2n_init.c
+++ b/utils/s2n_init.c
@@ -39,10 +39,11 @@ unsigned long s2n_get_openssl_version(void)
 int s2n_init(void)
 {
     GUARD_POSIX(s2n_fips_init());
+
     GUARD_POSIX(s2n_mem_init());
     GUARD_AS_POSIX(s2n_rand_init());
     GUARD_POSIX(s2n_cipher_suites_init());
-    GUARD_POSIX(s2n_ecc_evp_init());
+    GUARD_POSIX(s2n_ecc_evp_curves_init());         /* s2n_ecc_evp_curves_init is dependency of s2n_fips_init function */
     GUARD_POSIX(s2n_security_policies_init());
     GUARD_POSIX(s2n_config_defaults_init());
     GUARD_POSIX(s2n_extension_type_init());


### PR DESCRIPTION
### Resolved issues:

 resolves [#ISSUE-2416](https://github.com/awslabs/s2n/issues/2416)

### Description of changes: 

Current s2n have a non-fips curve(secp521r1) that shouldn't be used in fips mode but there's no existing way to prevent those non-fips curve used in fips mode.

Add a `available` flag in each curve and check this available before using curves.

### Call-outs:

Test code for these non-fips curves in fips mode might need to add.

### Testing:

Unit tests and integ tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
