### PR TITLE
Added psk to key schedule

### DIFF
--- a/crypto/s2n_tls13_keys.c
+++ b/crypto/s2n_tls13_keys.c
@@ -184,7 +184,7 @@ int s2n_tls13_derive_early_secrets(struct s2n_tls13_keys *keys, struct s2n_psk *
         GUARD(s2n_hkdf_extract(&keys->hmac, keys->hmac_algorithm, &zero_length_blob, &psk_ikm, &keys->extract_secret));
     } else {
         /* Sanity check that an early secret exists */
-        S2N_ERROR_IF(psk->early_secret.size == 0, S2N_ERR_SAFETY);
+        ne_check(psk->early_secret.size, 0);
         keys->extract_secret = psk->early_secret;
     }
 

--- a/crypto/s2n_tls13_keys.c
+++ b/crypto/s2n_tls13_keys.c
@@ -176,11 +176,11 @@ int s2n_tls13_derive_early_secrets(struct s2n_tls13_keys *keys, struct s2n_psk *
 {
     notnull_check(keys);
 
+    /* Early Secret */
     if (psk == NULL) {
         /* in 1-RTT, PSK is 0-filled of key length */
         s2n_tls13_key_blob(psk_ikm, keys->size);
 
-        /* Early Secret */
         GUARD(s2n_hkdf_extract(&keys->hmac, keys->hmac_algorithm, &zero_length_blob, &psk_ikm, &keys->extract_secret));
     } else {
         keys->extract_secret = psk->early_secret;

--- a/crypto/s2n_tls13_keys.c
+++ b/crypto/s2n_tls13_keys.c
@@ -183,6 +183,8 @@ int s2n_tls13_derive_early_secrets(struct s2n_tls13_keys *keys, struct s2n_psk *
 
         GUARD(s2n_hkdf_extract(&keys->hmac, keys->hmac_algorithm, &zero_length_blob, &psk_ikm, &keys->extract_secret));
     } else {
+        /* Sanity check that an early secret exists */
+        S2N_ERROR_IF(psk->early_secret.size == 0, S2N_ERR_SAFETY);
         keys->extract_secret = psk->early_secret;
     }
 

--- a/crypto/s2n_tls13_keys.h
+++ b/crypto/s2n_tls13_keys.h
@@ -74,7 +74,7 @@ extern const struct s2n_blob s2n_tls13_label_traffic_secret_iv;
 int s2n_tls13_keys_init(struct s2n_tls13_keys *handshake, s2n_hmac_algorithm alg);
 int s2n_tls13_keys_free(struct s2n_tls13_keys *keys);
 int s2n_tls13_derive_binder_key(struct s2n_tls13_keys *keys, struct s2n_psk *psk);
-int s2n_tls13_derive_early_secrets(struct s2n_tls13_keys *handshake);
+int s2n_tls13_derive_early_secrets(struct s2n_tls13_keys *handshake, struct s2n_psk *psk);
 int s2n_tls13_derive_handshake_secrets(struct s2n_tls13_keys *handshake,
                                         const struct s2n_blob *ecdhe,
                                         struct s2n_hash_state *client_server_hello_hash,

--- a/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
@@ -408,7 +408,8 @@ int main(int argc, char **argv) {
              * the client & server traffic secrets */
             DEFER_CLEANUP(struct s2n_tls13_keys secrets = {0}, s2n_tls13_keys_free);
             EXPECT_SUCCESS(s2n_tls13_keys_init(&secrets, test_vector->cipher_suite->prf_alg));
-            EXPECT_SUCCESS(s2n_tls13_derive_early_secrets(&secrets));
+            struct s2n_psk *psk = NULL;
+            EXPECT_SUCCESS(s2n_tls13_derive_early_secrets(&secrets, psk));
 
             DEFER_CLEANUP(struct s2n_hash_state hash_state, s2n_hash_free);
             EXPECT_SUCCESS(s2n_hash_new(&hash_state));

--- a/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
@@ -408,8 +408,7 @@ int main(int argc, char **argv) {
              * the client & server traffic secrets */
             DEFER_CLEANUP(struct s2n_tls13_keys secrets = {0}, s2n_tls13_keys_free);
             EXPECT_SUCCESS(s2n_tls13_keys_init(&secrets, test_vector->cipher_suite->prf_alg));
-            struct s2n_psk *psk = NULL;
-            EXPECT_SUCCESS(s2n_tls13_derive_early_secrets(&secrets, psk));
+            EXPECT_SUCCESS(s2n_tls13_derive_early_secrets(&secrets, NULL));
 
             DEFER_CLEANUP(struct s2n_hash_state hash_state, s2n_hash_free);
             EXPECT_SUCCESS(s2n_hash_new(&hash_state));

--- a/tests/unit/s2n_tls13_keys_test.c
+++ b/tests/unit/s2n_tls13_keys_test.c
@@ -312,11 +312,11 @@ int main(int argc, char **argv)
         S2N_BLOB_FROM_HEX(expected_derived_secret,
             "5f1790bbd82c5e7d376ed2e1e52f8e6038c9346db61b43be9a52f77ef3998e80");
 
-        DEFER_CLEANUP(struct s2n_psk test_psk = {0}, s2n_psk_free);
+        DEFER_CLEANUP(struct s2n_psk test_psk = { 0 }, s2n_psk_free);
         EXPECT_SUCCESS(s2n_psk_init(&test_psk, S2N_PSK_TYPE_RESUMPTION));
         test_psk.early_secret = resumption_early_secret;
 
-        DEFER_CLEANUP(struct s2n_tls13_keys test_keys = {0}, s2n_tls13_keys_free);
+        DEFER_CLEANUP(struct s2n_tls13_keys test_keys = { 0 }, s2n_tls13_keys_free);
         EXPECT_SUCCESS(s2n_tls13_keys_init(&test_keys, test_psk.hmac_alg));
 
         EXPECT_SUCCESS(s2n_tls13_derive_early_secrets(&test_keys, &test_psk));
@@ -328,11 +328,11 @@ int main(int argc, char **argv)
     {
         struct s2n_blob empty_blob = { .data = NULL, .size = 0 };
 
-        DEFER_CLEANUP(struct s2n_psk test_psk = {0}, s2n_psk_free);
+        DEFER_CLEANUP(struct s2n_psk test_psk = { 0 }, s2n_psk_free);
         EXPECT_SUCCESS(s2n_psk_init(&test_psk, S2N_PSK_TYPE_RESUMPTION));
         test_psk.early_secret = empty_blob;
 
-        DEFER_CLEANUP(struct s2n_tls13_keys test_keys = {0}, s2n_tls13_keys_free);
+        DEFER_CLEANUP(struct s2n_tls13_keys test_keys = { 0 }, s2n_tls13_keys_free);
         EXPECT_SUCCESS(s2n_tls13_keys_init(&test_keys, test_psk.hmac_alg));
 
         EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_derive_early_secrets(&test_keys, &test_psk), S2N_ERR_SAFETY);

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -189,7 +189,7 @@ int s2n_tls13_handle_handshake_secrets(struct s2n_connection *conn)
     GUARD(s2n_tls13_compute_shared_secret(conn, &shared_secret));
 
     /* derive early secrets */
-    GUARD(s2n_tls13_derive_early_secrets(&secrets));
+    GUARD(s2n_tls13_derive_early_secrets(&secrets, conn->psk_params.chosen_psk));
 
     /* produce handshake secrets */
     s2n_stack_blob(client_hs_secret, secrets.size, S2N_TLS13_SECRET_MAX_LEN);


### PR DESCRIPTION
### Resolved issues:

 resolves #2396 

### Description of changes: 
Now s2n_tls13_derive_early_secrets uses a psk as the extract secret if it is set.
### Call-outs:
In order to test that this function correctly generates the right secret, I used test vectors from: https://tools.ietf.org/html/rfc8448#section-4. You can double-check that I'm using the right test vectors there.
### Testing:

 Unit test added plus previous s2n_tls13_derive_early_secrets unit test still passes. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
