### PR TITLE
Ensures memory safety in s2n_hmac functions

### DIFF
--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -18,7 +18,7 @@ OBJS=$(SRCS:.c=.o)
 
 BITCODE_DIR?=../tests/saw/bitcode/
 
-BCS_1=s2n_hmac.bc s2n_drbg.bc s2n_fips.bc s2n_sequence.bc
+BCS_1= s2n_hash.bc s2n_hmac.bc s2n_drbg.bc s2n_fips.bc s2n_sequence.bc
 BCS=$(addprefix $(BITCODE_DIR), $(BCS_1))
 
 .PHONY : all

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -505,7 +505,6 @@ int s2n_hash_new(struct s2n_hash_state *state)
 S2N_RESULT s2n_hash_state_validate(struct s2n_hash_state *state)
 {
     ENSURE_REF(state);
-    ENSURE_REF(state->hash_impl);
     return S2N_RESULT_OK;
 }
 

--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -268,7 +268,6 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
     const uint32_t HIGHEST_32_BIT = 4294949760;
     ENSURE_POSIX(size <= (UINT32_MAX - HIGHEST_32_BIT), S2N_ERR_INTEGER_OVERFLOW);
     uint32_t value = (HIGHEST_32_BIT + size) % state->hash_block_size;
-    ENSURE_POSIX(value <= (UINT32_MAX - state->currently_in_hash_block), S2N_ERR_INTEGER_OVERFLOW);
     state->currently_in_hash_block += value;
     state->currently_in_hash_block %= state->hash_block_size;
 

--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -179,12 +179,24 @@ int s2n_hmac_hash_block_size(s2n_hmac_algorithm hmac_alg, uint16_t *block_size)
 
 int s2n_hmac_new(struct s2n_hmac_state *state)
 {
+    notnull_check(state);
     GUARD(s2n_hash_new(&state->inner));
     GUARD(s2n_hash_new(&state->inner_just_key));
     GUARD(s2n_hash_new(&state->outer));
     GUARD(s2n_hash_new(&state->outer_just_key));
 
     return S2N_SUCCESS;
+}
+
+
+S2N_RESULT s2n_hmac_state_validate(struct s2n_hmac_state *state)
+{
+    ENSURE_REF(state);
+    GUARD_RESULT(s2n_hash_state_validate(&state->inner));
+    GUARD_RESULT(s2n_hash_state_validate(&state->inner_just_key));
+    GUARD_RESULT(s2n_hash_state_validate(&state->outer));
+    GUARD_RESULT(s2n_hash_state_validate(&state->outer_just_key));
+    return S2N_RESULT_OK;
 }
 
 int s2n_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm alg, const void *key, uint32_t klen)

--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -266,9 +266,9 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
      * smaller number of cycles if the input is "small".
      */
     const uint32_t HIGHEST_32_BIT = 4294949760;
-    ENSURE_POSIX(size <= UINT32_MAX - HIGHEST_32_BIT, S2N_ERR_INTEGER_OVERFLOW);
+    ENSURE_POSIX(size <= (UINT32_MAX - HIGHEST_32_BIT), S2N_ERR_INTEGER_OVERFLOW);
     uint32_t value = (HIGHEST_32_BIT + size) % state->hash_block_size;
-    ENSURE_POSIX(state->currently_in_hash_block <= UINT32_MAX - value, S2N_ERR_INTEGER_OVERFLOW);
+    ENSURE_POSIX(value <= (UINT32_MAX - state->currently_in_hash_block), S2N_ERR_INTEGER_OVERFLOW);
     state->currently_in_hash_block += value;
     state->currently_in_hash_block %= state->hash_block_size;
 

--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -333,7 +333,7 @@ int s2n_hmac_reset(struct s2n_hmac_state *state)
     bytes_in_hash %= state->hash_block_size;
     ENSURE_POSIX(bytes_in_hash <= UINT32_MAX, S2N_ERR_INTEGER_OVERFLOW);
     /* The length of the key is not private, so don't need to do tricky math here */
-    state->currently_in_hash_block = bytes_in_hash % state->hash_block_size;
+    state->currently_in_hash_block = bytes_in_hash;
     return S2N_SUCCESS;
 }
 

--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -243,6 +243,7 @@ int s2n_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm alg, const vo
 int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
 {
     PRECONDITION_POSIX(s2n_hmac_state_validate(state));
+    ENSURE_POSIX(state->hash_block_size != 0, S2N_ERR_PRECONDITION_VIOLATION);
     /* Keep track of how much of the current hash block is full
      *
      * Why the 4294949760 constant in this code? 4294949760 is the highest 32-bit
@@ -264,7 +265,6 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
      * input. On some platforms, including Intel, the operation can take a
      * smaller number of cycles if the input is "small".
      */
-    ENSURE_POSIX(state->hash_block_size != 0, S2N_ERR_INTEGER_OVERFLOW);
     ENSURE_POSIX(size <= UINT32_MAX - 4294949760, S2N_ERR_INTEGER_OVERFLOW);
     uint32_t value = (4294949760 + size) % state->hash_block_size;
     ENSURE_POSIX(state->currently_in_hash_block <= UINT32_MAX - value, S2N_ERR_INTEGER_OVERFLOW);

--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -184,7 +184,7 @@ int s2n_hmac_new(struct s2n_hmac_state *state)
     GUARD(s2n_hash_new(&state->outer));
     GUARD(s2n_hash_new(&state->outer_just_key));
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm alg, const void *key, uint32_t klen)
@@ -226,7 +226,7 @@ int s2n_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm alg, const vo
     memset(&state->xor_pad, 0, sizeof(state->xor_pad));
     GUARD(s2n_hmac_reset(state));
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
@@ -282,7 +282,7 @@ int s2n_hmac_digest_two_compression_rounds(struct s2n_hmac_state *state, void *o
      */
     const uint8_t space_left = (state->hash_block_size == 128) ? 17 : 9;
     if (state->currently_in_hash_block > (state->hash_block_size - space_left)) {
-        return 0;
+        return S2N_SUCCESS;
     }
 
     /* Can't reuse a hash after it has been finalized, so reset and push another block in */
@@ -299,7 +299,7 @@ int s2n_hmac_free(struct s2n_hmac_state *state)
     GUARD(s2n_hash_free(&state->outer));
     GUARD(s2n_hash_free(&state->outer_just_key));
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_hmac_reset(struct s2n_hmac_state *state)
@@ -310,12 +310,12 @@ int s2n_hmac_reset(struct s2n_hmac_state *state)
     GUARD(s2n_hash_get_currently_in_hash_total(&state->inner, &bytes_in_hash));
     /* The length of the key is not private, so don't need to do tricky math here */
     state->currently_in_hash_block = bytes_in_hash % state->hash_block_size;
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_hmac_digest_verify(const void *a, const void *b, uint32_t len)
 {
-    return 0 - !s2n_constant_time_equals(a, b, len);
+    return S2N_SUCCESS - !s2n_constant_time_equals(a, b, len);
 }
 
 int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
@@ -338,7 +338,7 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
     memcpy_check(to->xor_pad, from->xor_pad, sizeof(to->xor_pad));
     memcpy_check(to->digest_pad, from->digest_pad, sizeof(to->digest_pad));
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 
@@ -351,7 +351,7 @@ int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_
     backup->inner_just_key = hmac->inner_just_key.digest.high_level;
     backup->outer = hmac->outer.digest.high_level;
     backup->outer_just_key = hmac->outer_just_key.digest.high_level;
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac)
@@ -360,5 +360,5 @@ int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s
     hmac->inner_just_key.digest.high_level = backup->inner_just_key;
     hmac->outer.digest.high_level = backup->outer;
     hmac->outer_just_key.digest.high_level = backup->outer_just_key;
-    return 0;
+    return S2N_SUCCESS;
 }

--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -323,11 +323,11 @@ int s2n_hmac_free(struct s2n_hmac_state *state)
 int s2n_hmac_reset(struct s2n_hmac_state *state)
 {
     PRECONDITION_POSIX(s2n_hmac_state_validate(state));
+    ENSURE_POSIX(state->hash_block_size != 0, S2N_ERR_PRECONDITION_VIOLATION);
     GUARD(s2n_hash_copy(&state->inner, &state->inner_just_key));
 
     uint64_t bytes_in_hash;
     GUARD(s2n_hash_get_currently_in_hash_total(&state->inner, &bytes_in_hash));
-    ENSURE_POSIX(state->hash_block_size != 0, S2N_ERR_INTEGER_OVERFLOW);
     bytes_in_hash %= state->hash_block_size;
     ENSURE_POSIX(bytes_in_hash <= UINT32_MAX, S2N_ERR_INTEGER_OVERFLOW);
     /* The length of the key is not private, so don't need to do tricky math here */

--- a/crypto/s2n_hmac.h
+++ b/crypto/s2n_hmac.h
@@ -65,6 +65,7 @@ extern int s2n_hmac_hash_alg(s2n_hmac_algorithm hmac_alg, s2n_hash_algorithm *ou
 extern int s2n_hash_hmac_alg(s2n_hash_algorithm hash_alg, s2n_hmac_algorithm *out);
 
 extern int s2n_hmac_new(struct s2n_hmac_state *state);
+S2N_RESULT s2n_hmac_state_validate(struct s2n_hmac_state *state);
 extern int s2n_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm alg, const void *key, uint32_t klen);
 extern int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size);
 extern int s2n_hmac_digest(struct s2n_hmac_state *state, void *out, uint32_t size);

--- a/tests/cbmc/include/cbmc_proof/make_common_datastructures.h
+++ b/tests/cbmc/include/cbmc_proof/make_common_datastructures.h
@@ -119,3 +119,8 @@ struct s2n_evp_digest* cbmc_allocate_s2n_evp_digest();
  * Properly allocates s2n_hmac_state for CBMC proofs.
  */
 struct s2n_hmac_state* cbmc_allocate_s2n_hmac_state();
+
+/*
+ * Properly allocates s2n_hmac_state for CBMC proofs.
+ */
+struct s2n_hmac_evp_backup* cbmc_allocate_s2n_hmac_evp_backup();

--- a/tests/cbmc/include/cbmc_proof/make_common_datastructures.h
+++ b/tests/cbmc/include/cbmc_proof/make_common_datastructures.h
@@ -22,6 +22,7 @@
 #include "crypto/s2n_dhe.h"
 #include "crypto/s2n_evp.h"
 #include "crypto/s2n_hash.h"
+#include "crypto/s2n_hmac.h"
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_array.h"
 #include "utils/s2n_blob.h"
@@ -113,3 +114,8 @@ struct s2n_hash_state *cbmc_allocate_s2n_hash_state();
  * Properly allocates s2n_evp_digest for CBMC proofs.
  */
 struct s2n_evp_digest* cbmc_allocate_s2n_evp_digest();
+
+/*
+ * Properly allocates s2n_hmac_state for CBMC proofs.
+ */
+struct s2n_hmac_state* cbmc_allocate_s2n_hmac_state();

--- a/tests/cbmc/proofs/s2n_constant_time_equals/Makefile
+++ b/tests/cbmc/proofs/s2n_constant_time_equals/Makefile
@@ -27,6 +27,6 @@ PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
 
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 
-UNWINDSET += s2n_constant_time_equals.0:$(call addone,$(MAX_ARR_LEN))
+UNWINDSET += s2n_constant_time_equals.6:$(call addone,$(MAX_ARR_LEN))
 
 include ../Makefile.common

--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -204,3 +204,39 @@ struct s2n_hmac_state* cbmc_allocate_s2n_hmac_state()
     }
     return state;
 }
+
+struct s2n_hmac_evp_backup* cbmc_allocate_s2n_hmac_evp_backup()
+{
+    struct s2n_hmac_evp_backup *backup = malloc(sizeof(*backup));
+    if(backup != NULL) {
+        /* inner */
+        struct s2n_evp_digest *inner_evp = cbmc_allocate_s2n_evp_digest();
+        __CPROVER_assume(inner_evp != NULL);
+        backup->inner.evp = *inner_evp;
+        struct s2n_evp_digest *inner_evp_md5_secondary = cbmc_allocate_s2n_evp_digest();
+        __CPROVER_assume(inner_evp_md5_secondary != NULL);
+        backup->inner.evp_md5_secondary = *inner_evp_md5_secondary;
+        /* inner_just_key */
+        struct s2n_evp_digest *inner_just_key_evp = cbmc_allocate_s2n_evp_digest();
+        __CPROVER_assume(inner_just_key_evp != NULL);
+        backup->inner_just_key.evp = *inner_just_key_evp;
+        struct s2n_evp_digest *inner_just_key_evp_md5_secondary = cbmc_allocate_s2n_evp_digest();
+        __CPROVER_assume(inner_just_key_evp_md5_secondary != NULL);
+        backup->inner_just_key.evp_md5_secondary = *inner_just_key_evp_md5_secondary;
+        /* outer */
+        struct s2n_evp_digest *outer_evp = cbmc_allocate_s2n_evp_digest();
+        __CPROVER_assume(outer_evp != NULL);
+        backup->outer.evp = *outer_evp;
+        struct s2n_evp_digest *outer_evp_md5_secondary = cbmc_allocate_s2n_evp_digest();
+        __CPROVER_assume(outer_evp_md5_secondary != NULL);
+        backup->outer.evp_md5_secondary = *outer_evp_md5_secondary;
+        /* outer_just_key */
+        struct s2n_evp_digest *outer_just_key_evp = cbmc_allocate_s2n_evp_digest();
+        __CPROVER_assume(outer_just_key_evp != NULL);
+        backup->outer_just_key.evp = *outer_just_key_evp;
+        struct s2n_evp_digest *outer_just_key_evp_md5_secondary = cbmc_allocate_s2n_evp_digest();
+        __CPROVER_assume(outer_just_key_evp_md5_secondary != NULL);
+        backup->outer_just_key.evp_md5_secondary = *outer_just_key_evp_md5_secondary;
+    }
+    return backup;
+}

--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -183,3 +183,24 @@ struct s2n_evp_digest* cbmc_allocate_s2n_evp_digest()
     }
     return evp_digest;
 }
+
+
+struct s2n_hmac_state* cbmc_allocate_s2n_hmac_state()
+{
+    struct s2n_hmac_state *state = malloc(sizeof(*state));
+    if (state != NULL) {
+        struct s2n_hash_state *inner = cbmc_allocate_s2n_hash_state();
+        __CPROVER_assume(inner != NULL); /* Declared on stack. */
+        state->inner = *inner;
+        struct s2n_hash_state *inner_just_key = cbmc_allocate_s2n_hash_state();
+        __CPROVER_assume(inner_just_key != NULL); /* Declared on stack. */
+        state->inner_just_key = *inner_just_key;
+        struct s2n_hash_state *outer = cbmc_allocate_s2n_hash_state();
+        __CPROVER_assume(outer != NULL); /* Declared on stack. */
+        state->outer = *outer;
+        struct s2n_hash_state *outer_just_key = cbmc_allocate_s2n_hash_state();
+        __CPROVER_assume(outer_just_key != NULL); /* Declared on stack. */
+        state->outer_just_key = *outer_just_key;
+    }
+    return state;
+}

--- a/tests/saw/HMAC/spec/HMAC.saw
+++ b/tests/saw/HMAC/spec/HMAC.saw
@@ -355,7 +355,7 @@ let hmac_update_spec
 
     size <- crucible_fresh_var "size" (llvm_int 32);
     crucible_precond {{ size <= 17535 }};
-    crucible_precond {{ st0.currently_in_hash_block <= 4294967295 - ((4294949760 + size) % st0.hash_block_size) }};
+    crucible_precond {{ (`st0.currently_in_hash_block) <= 4294967295 - ((4294949760 + (`size)) % (`st0.hash_block_size)) }};
 
     pmsg <- crucible_symbolic_alloc true 1 {{ (0 # size) : [64] }};
     msg <- crucible_fresh_cryptol_var "msg" {| ByteArray |};

--- a/tests/saw/HMAC/spec/HMAC.saw
+++ b/tests/saw/HMAC/spec/HMAC.saw
@@ -355,7 +355,7 @@ let hmac_update_spec
 
     size <- crucible_fresh_var "size" (llvm_int 32);
     crucible_precond {{ size <= 17535 }};
-    crucible_precond {{ currently_in_hash_block <= 4294967295 - ((4294949760 + size) % state->hash_block_size) }};
+    crucible_precond {{ currently_in_hash_block <= 4294967295 - ((4294949760 + size) % hash_block_size) }};
 
     pmsg <- crucible_symbolic_alloc true 1 {{ (0 # size) : [64] }};
     msg <- crucible_fresh_cryptol_var "msg" {| ByteArray |};

--- a/tests/saw/HMAC/spec/HMAC.saw
+++ b/tests/saw/HMAC/spec/HMAC.saw
@@ -354,8 +354,10 @@ let hmac_update_spec
     hmac_invariants st0 cfg;
 
     size <- crucible_fresh_var "size" (llvm_int 32);
-    crucible_precond {{ size <= 17535 }};
-    crucible_precond {{ st0.currently_in_hash_block <= 4294967295 - ((4294949760 + size) % (0 # st0.hash_block_size)) }};
+    let uint32_max = {{~0 : [32]}};
+    let highest_32_bit = {{4294949760 : [32]}};
+    crucible_precond {{ size <= uint32_max - highest_32_bit }};
+    crucible_precond {{ st0.currently_in_hash_block <= uint32_max - ((highest_32_bit + size) % (0 # st0.hash_block_size)) }};
 
     pmsg <- crucible_symbolic_alloc true 1 {{ (0 # size) : [64] }};
     msg <- crucible_fresh_cryptol_var "msg" {| ByteArray |};

--- a/tests/saw/HMAC/spec/HMAC.saw
+++ b/tests/saw/HMAC/spec/HMAC.saw
@@ -354,6 +354,9 @@ let hmac_update_spec
     hmac_invariants st0 cfg;
 
     size <- crucible_fresh_var "size" (llvm_int 32);
+    crucible_precond {{ size <= 17535 }};
+    crucible_precond {{ currently_in_hash_block <= 4294967295 - ((4294949760 + size) % state->hash_block_size) }};
+
     pmsg <- crucible_symbolic_alloc true 1 {{ (0 # size) : [64] }};
     msg <- crucible_fresh_cryptol_var "msg" {| ByteArray |};
     crucible_points_to_array_prefix pmsg msg {{ (0 # size) : [64] }};

--- a/tests/saw/HMAC/spec/HMAC.saw
+++ b/tests/saw/HMAC/spec/HMAC.saw
@@ -355,7 +355,7 @@ let hmac_update_spec
 
     size <- crucible_fresh_var "size" (llvm_int 32);
     crucible_precond {{ size <= 17535 }};
-    crucible_precond {{ (`st0.currently_in_hash_block) <= 4294967295 - ((4294949760 + (`size)) % (`st0.hash_block_size)) }};
+    crucible_precond {{ `(st0.currently_in_hash_block) <= 4294967295 - ((4294949760 + `(size)) % `(st0.hash_block_size)) }};
 
     pmsg <- crucible_symbolic_alloc true 1 {{ (0 # size) : [64] }};
     msg <- crucible_fresh_cryptol_var "msg" {| ByteArray |};

--- a/tests/saw/HMAC/spec/HMAC.saw
+++ b/tests/saw/HMAC/spec/HMAC.saw
@@ -355,7 +355,7 @@ let hmac_update_spec
 
     size <- crucible_fresh_var "size" (llvm_int 32);
     crucible_precond {{ size <= 17535 }};
-    crucible_precond {{ `(st0.currently_in_hash_block) <= 4294967295 - ((4294949760 + `(size)) % `(st0.hash_block_size)) }};
+    crucible_precond {{ st0.currently_in_hash_block <= 4294967295 - ((4294949760 + size) % (0 # st0.hash_block_size)) }};
 
     pmsg <- crucible_symbolic_alloc true 1 {{ (0 # size) : [64] }};
     msg <- crucible_fresh_cryptol_var "msg" {| ByteArray |};

--- a/tests/saw/HMAC/spec/HMAC.saw
+++ b/tests/saw/HMAC/spec/HMAC.saw
@@ -357,7 +357,6 @@ let hmac_update_spec
     let uint32_max = {{~0 : [32]}};
     let highest_32_bit = {{4294949760 : [32]}};
     crucible_precond {{ size <= uint32_max - highest_32_bit }};
-    crucible_precond {{ st0.currently_in_hash_block <= uint32_max - ((highest_32_bit + size) % (0 # st0.hash_block_size)) }};
 
     pmsg <- crucible_symbolic_alloc true 1 {{ (0 # size) : [64] }};
     msg <- crucible_fresh_cryptol_var "msg" {| ByteArray |};

--- a/tests/saw/HMAC/spec/HMAC.saw
+++ b/tests/saw/HMAC/spec/HMAC.saw
@@ -355,7 +355,7 @@ let hmac_update_spec
 
     size <- crucible_fresh_var "size" (llvm_int 32);
     crucible_precond {{ size <= 17535 }};
-    crucible_precond {{ currently_in_hash_block <= 4294967295 - ((4294949760 + size) % hash_block_size) }};
+    crucible_precond {{ st0.currently_in_hash_block <= 4294967295 - ((4294949760 + size) % st0.hash_block_size) }};
 
     pmsg <- crucible_symbolic_alloc true 1 {{ (0 # size) : [64] }};
     msg <- crucible_fresh_cryptol_var "msg" {| ByteArray |};

--- a/tests/saw/failure_tests/sha_bad_magic_mod.patch
+++ b/tests/saw/failure_tests/sha_bad_magic_mod.patch
@@ -1,14 +1,14 @@
 diff -r -u s2n/crypto/s2n_hmac.c s2n_break/crypto/s2n_hmac.c
 --- s2n/crypto/s2n_hmac.c	2016-05-23 09:59:56.600873694 -0700
 +++ s2n_break/crypto/s2n_hmac.c	2016-05-27 16:12:24.278698053 -0700
-@@ -193,7 +193,7 @@
+@@ -265,7 +265,7 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
       * input. On some platforms, including Intel, the operation can take a
       * smaller number of cycles if the input is "small".
       */
--    state->currently_in_hash_block += (4294949760 + size) % state->hash_block_size;
-+    state->currently_in_hash_block += (4294949761 + size) % state->hash_block_size;
-     state->currently_in_hash_block %= state->hash_block_size;
-
-     return s2n_hash_update(&state->inner, in, size);
+-    const uint32_t HIGHEST_32_BIT = 4294949760;
++    const uint32_t HIGHEST_32_BIT = 4294949761;
+     ENSURE_POSIX(size <= UINT32_MAX - HIGHEST_32_BIT, S2N_ERR_INTEGER_OVERFLOW);
+     uint32_t value = (HIGHEST_32_BIT + size) % state->hash_block_size;
+     ENSURE_POSIX(state->currently_in_hash_block <= UINT32_MAX - value, S2N_ERR_INTEGER_OVERFLOW);
 Binary files s2n/.git/index and s2n_break/.git/index differ
 Only in s2n/tests/saw: bad_magic_mod.patch

--- a/tests/saw/failure_tests/sha_bad_magic_mod.patch
+++ b/tests/saw/failure_tests/sha_bad_magic_mod.patch
@@ -1,14 +1,13 @@
 diff -r -u s2n/crypto/s2n_hmac.c s2n_break/crypto/s2n_hmac.c
 --- s2n/crypto/s2n_hmac.c	2016-05-23 09:59:56.600873694 -0700
 +++ s2n_break/crypto/s2n_hmac.c	2016-05-27 16:12:24.278698053 -0700
-@@ -265,7 +265,7 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
+@@ -265,6 +265,6 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
       * input. On some platforms, including Intel, the operation can take a
       * smaller number of cycles if the input is "small".
       */
 -    const uint32_t HIGHEST_32_BIT = 4294949760;
 +    const uint32_t HIGHEST_32_BIT = 4294949761;
-     ENSURE_POSIX(size <= UINT32_MAX - HIGHEST_32_BIT, S2N_ERR_INTEGER_OVERFLOW);
+     ENSURE_POSIX(size <= (UINT32_MAX - HIGHEST_32_BIT), S2N_ERR_INTEGER_OVERFLOW);
      uint32_t value = (HIGHEST_32_BIT + size) % state->hash_block_size;
-     ENSURE_POSIX(state->currently_in_hash_block <= UINT32_MAX - value, S2N_ERR_INTEGER_OVERFLOW);
 Binary files s2n/.git/index and s2n_break/.git/index differ
 Only in s2n/tests/saw: bad_magic_mod.patch

--- a/tests/sidetrail/working/patches/hmac.patch
+++ b/tests/sidetrail/working/patches/hmac.patch
@@ -12,35 +12,16 @@ index 3405781..3beeacf 100644
  #include <stdint.h>
 
  int s2n_hash_hmac_alg(s2n_hash_algorithm hash_alg, s2n_hmac_algorithm *out)
-@@ -191,10 +194,10 @@ int s2n_hmac_new(struct s2n_hmac_state *state)
- S2N_RESULT s2n_hmac_state_validate(struct s2n_hmac_state *state)
- {
-     ENSURE_REF(state);
--    GUARD_RESULT(s2n_hash_state_validate(&state->inner));
--    GUARD_RESULT(s2n_hash_state_validate(&state->inner_just_key));
--    GUARD_RESULT(s2n_hash_state_validate(&state->outer));
--    GUARD_RESULT(s2n_hash_state_validate(&state->outer_just_key));
-+    //GUARD_RESULT(s2n_hash_state_validate(&state->inner));
-+    //GUARD_RESULT(s2n_hash_state_valiLdate(&state->inner_just_key));
-+    //GUARD_RESULT(s2n_hash_state_validate(&state->outer));
-+    //GUARD_RESULT(s2n_hash_state_validate(&state->outer_just_key));
-     return S2N_RESULT_OK;
- }
-
-@@ -265,11 +265,7 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
-      * input. On some platforms, including Intel, the operation can take a
-      * smaller number of cycles if the input is "small".
-      */
--    const uint32_t HIGHEST_32_BIT = 4294949760;
--    ENSURE_POSIX(size <= UINT32_MAX - HIGHEST_32_BIT, S2N_ERR_INTEGER_OVERFLOW);
--    uint32_t value = (HIGHEST_32_BIT + size) % state->hash_block_size;
--    ENSURE_POSIX(state->currently_in_hash_block <= UINT32_MAX - value, S2N_ERR_INTEGER_OVERFLOW);
+@@ -269,7 +272,7 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
+     ENSURE_POSIX(size <= (UINT32_MAX - HIGHEST_32_BIT), S2N_ERR_INTEGER_OVERFLOW);
+     uint32_t value = (HIGHEST_32_BIT + size) % state->hash_block_size;
+     ENSURE_POSIX(value <= (UINT32_MAX - state->currently_in_hash_block), S2N_ERR_INTEGER_OVERFLOW);
 -    state->currently_in_hash_block += value;
 +    state->currently_in_hash_block += (size) % state->hash_block_size;
      state->currently_in_hash_block %= state->hash_block_size;
 
      return s2n_hash_update(&state->inner, in, size);
-@@ -361,8 +361,8 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
+@@ -361,8 +364,8 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
      GUARD(s2n_hash_copy(&to->outer_just_key, &from->outer_just_key));
 
 
@@ -51,7 +32,7 @@ index 3405781..3beeacf 100644
      POSTCONDITION_POSIX(s2n_hmac_state_validate(to));
      POSTCONDITION_POSIX(s2n_hmac_state_validate(from));
      return S2N_SUCCESS;
-@@ -372,25 +372,25 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
+@@ -372,25 +375,25 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
  /* Preserve the handlers for hmac state pointers to avoid re-allocation
   * Only valid if the HMAC is in EVP mode
   */

--- a/tests/sidetrail/working/patches/hmac.patch
+++ b/tests/sidetrail/working/patches/hmac.patch
@@ -12,16 +12,16 @@ index 3405781..3beeacf 100644
  #include <stdint.h>
 
  int s2n_hash_hmac_alg(s2n_hash_algorithm hash_alg, s2n_hmac_algorithm *out)
-@@ -269,7 +272,7 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
+@@ -268,7 +271,7 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
+     const uint32_t HIGHEST_32_BIT = 4294949760;
      ENSURE_POSIX(size <= (UINT32_MAX - HIGHEST_32_BIT), S2N_ERR_INTEGER_OVERFLOW);
      uint32_t value = (HIGHEST_32_BIT + size) % state->hash_block_size;
-     ENSURE_POSIX(value <= (UINT32_MAX - state->currently_in_hash_block), S2N_ERR_INTEGER_OVERFLOW);
 -    state->currently_in_hash_block += value;
 +    state->currently_in_hash_block += (size) % state->hash_block_size;
      state->currently_in_hash_block %= state->hash_block_size;
 
      return s2n_hash_update(&state->inner, in, size);
-@@ -361,8 +364,8 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
+@@ -360,8 +363,8 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
      GUARD(s2n_hash_copy(&to->outer_just_key, &from->outer_just_key));
 
 
@@ -32,7 +32,7 @@ index 3405781..3beeacf 100644
      POSTCONDITION_POSIX(s2n_hmac_state_validate(to));
      POSTCONDITION_POSIX(s2n_hmac_state_validate(from));
      return S2N_SUCCESS;
-@@ -372,25 +375,25 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
+@@ -371,25 +374,25 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
  /* Preserve the handlers for hmac state pointers to avoid re-allocation
   * Only valid if the HMAC is in EVP mode
   */

--- a/tests/sidetrail/working/patches/hmac.patch
+++ b/tests/sidetrail/working/patches/hmac.patch
@@ -12,7 +12,22 @@ index 3405781..3beeacf 100644
  #include <stdint.h>
 
  int s2n_hash_hmac_alg(s2n_hash_algorithm hash_alg, s2n_hmac_algorithm *out)
-@@ -265,10 +267,7 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
+@@ -191,10 +194,10 @@ int s2n_hmac_new(struct s2n_hmac_state *state)
+ S2N_RESULT s2n_hmac_state_validate(struct s2n_hmac_state *state)
+ {
+     ENSURE_REF(state);
+-    GUARD_RESULT(s2n_hash_state_validate(&state->inner));
+-    GUARD_RESULT(s2n_hash_state_validate(&state->inner_just_key));
+-    GUARD_RESULT(s2n_hash_state_validate(&state->outer));
+-    GUARD_RESULT(s2n_hash_state_validate(&state->outer_just_key));
++    //GUARD_RESULT(s2n_hash_state_validate(&state->inner));
++    //GUARD_RESULT(s2n_hash_state_validate(&state->inner_just_key));
++    //GUARD_RESULT(s2n_hash_state_validate(&state->outer));
++    //GUARD_RESULT(s2n_hash_state_validate(&state->outer_just_key));
+     return S2N_RESULT_OK;
+ }
+
+@@ -265,10 +268,7 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
       * input. On some platforms, including Intel, the operation can take a
       * smaller number of cycles if the input is "small".
       */
@@ -24,7 +39,7 @@ index 3405781..3beeacf 100644
      state->currently_in_hash_block %= state->hash_block_size;
 
      return s2n_hash_update(&state->inner, in, size);
-@@ -361,8 +360,8 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
+@@ -361,8 +361,8 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
      GUARD(s2n_hash_copy(&to->outer_just_key, &from->outer_just_key));
 
 
@@ -35,7 +50,7 @@ index 3405781..3beeacf 100644
      POSTCONDITION_POSIX(s2n_hmac_state_validate(to));
      POSTCONDITION_POSIX(s2n_hmac_state_validate(from));
      return S2N_SUCCESS;
-@@ -372,25 +371,25 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
+@@ -372,25 +372,25 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
  /* Preserve the handlers for hmac state pointers to avoid re-allocation
   * Only valid if the HMAC is in EVP mode
   */

--- a/tests/sidetrail/working/patches/hmac.patch
+++ b/tests/sidetrail/working/patches/hmac.patch
@@ -12,11 +12,10 @@ index 3405781..3beeacf 100644
  #include <stdint.h>
 
  int s2n_hash_hmac_alg(s2n_hash_algorithm hash_alg, s2n_hmac_algorithm *out)
-@@ -264,11 +267,7 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
+@@ -265,10 +267,7 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
       * input. On some platforms, including Intel, the operation can take a
       * smaller number of cycles if the input is "small".
       */
--    ENSURE_POSIX(state->hash_block_size != 0, S2N_ERR_INTEGER_OVERFLOW);
 -    ENSURE_POSIX(size <= UINT32_MAX - 4294949760, S2N_ERR_INTEGER_OVERFLOW);
 -    uint32_t value = (4294949760 + size) % state->hash_block_size;
 -    ENSURE_POSIX(state->currently_in_hash_block <= UINT32_MAX - value, S2N_ERR_INTEGER_OVERFLOW);

--- a/tests/sidetrail/working/patches/hmac.patch
+++ b/tests/sidetrail/working/patches/hmac.patch
@@ -21,18 +21,19 @@ index 3405781..3beeacf 100644
 -    GUARD_RESULT(s2n_hash_state_validate(&state->outer));
 -    GUARD_RESULT(s2n_hash_state_validate(&state->outer_just_key));
 +    //GUARD_RESULT(s2n_hash_state_validate(&state->inner));
-+    //GUARD_RESULT(s2n_hash_state_validate(&state->inner_just_key));
++    //GUARD_RESULT(s2n_hash_state_valiLdate(&state->inner_just_key));
 +    //GUARD_RESULT(s2n_hash_state_validate(&state->outer));
 +    //GUARD_RESULT(s2n_hash_state_validate(&state->outer_just_key));
      return S2N_RESULT_OK;
  }
 
-@@ -265,10 +268,7 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
+@@ -265,11 +265,7 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
       * input. On some platforms, including Intel, the operation can take a
       * smaller number of cycles if the input is "small".
       */
--    ENSURE_POSIX(size <= UINT32_MAX - 4294949760, S2N_ERR_INTEGER_OVERFLOW);
--    uint32_t value = (4294949760 + size) % state->hash_block_size;
+-    const uint32_t HIGHEST_32_BIT = 4294949760;
+-    ENSURE_POSIX(size <= UINT32_MAX - HIGHEST_32_BIT, S2N_ERR_INTEGER_OVERFLOW);
+-    uint32_t value = (HIGHEST_32_BIT + size) % state->hash_block_size;
 -    ENSURE_POSIX(state->currently_in_hash_block <= UINT32_MAX - value, S2N_ERR_INTEGER_OVERFLOW);
 -    state->currently_in_hash_block += value;
 +    state->currently_in_hash_block += (size) % state->hash_block_size;

--- a/tests/sidetrail/working/patches/hmac.patch
+++ b/tests/sidetrail/working/patches/hmac.patch
@@ -9,19 +9,23 @@ index 3405781..3beeacf 100644
 +#include "smack.h"
 +#include "sidetrail.h"
 +
- int s2n_hmac_hash_alg(s2n_hmac_algorithm hmac_alg, s2n_hash_algorithm *out)
- {
-     switch(hmac_alg) {
-@@ -235,7 +238,7 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
+ #include <stdint.h>
+
+ int s2n_hash_hmac_alg(s2n_hash_algorithm hash_alg, s2n_hmac_algorithm *out)
+@@ -264,11 +267,7 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
       * input. On some platforms, including Intel, the operation can take a
       * smaller number of cycles if the input is "small".
       */
--    state->currently_in_hash_block += (4294949760 + size) % state->hash_block_size;
+-    ENSURE_POSIX(state->hash_block_size != 0, S2N_ERR_INTEGER_OVERFLOW);
+-    ENSURE_POSIX(size <= UINT32_MAX - 4294949760, S2N_ERR_INTEGER_OVERFLOW);
+-    uint32_t value = (4294949760 + size) % state->hash_block_size;
+-    ENSURE_POSIX(state->currently_in_hash_block <= UINT32_MAX - value, S2N_ERR_INTEGER_OVERFLOW);
+-    state->currently_in_hash_block += value;
 +    state->currently_in_hash_block += (size) % state->hash_block_size;
      state->currently_in_hash_block %= state->hash_block_size;
 
      return s2n_hash_update(&state->inner, in, size);
-@@ -311,30 +314,30 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
+@@ -361,8 +360,8 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
      GUARD(s2n_hash_copy(&to->outer_just_key, &from->outer_just_key));
 
 
@@ -29,51 +33,57 @@ index 3405781..3beeacf 100644
 -    memcpy_check(to->digest_pad, from->digest_pad, sizeof(to->digest_pad));
 +    //memcpy_check(to->xor_pad, from->xor_pad, sizeof(to->xor_pad));
 +    //memcpy_check(to->digest_pad, from->digest_pad, sizeof(to->digest_pad));
-
-     return 0;
- }
-
-
--/* Preserve the handlers for hmac state pointers to avoid re-allocation
-- * Only valid if the HMAC is in EVP mode
-- */
+     POSTCONDITION_POSIX(s2n_hmac_state_validate(to));
+     POSTCONDITION_POSIX(s2n_hmac_state_validate(from));
+     return S2N_SUCCESS;
+@@ -372,25 +371,25 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
+ /* Preserve the handlers for hmac state pointers to avoid re-allocation
+  * Only valid if the HMAC is in EVP mode
+  */
 -int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac)
 -{
+-    ENSURE_POSIX_REF(backup);
+-    PRECONDITION_POSIX(s2n_hmac_state_validate(hmac));
 -    backup->inner = hmac->inner.digest.high_level;
 -    backup->inner_just_key = hmac->inner_just_key.digest.high_level;
 -    backup->outer = hmac->outer.digest.high_level;
 -    backup->outer_just_key = hmac->outer_just_key.digest.high_level;
--    return 0;
+-    return S2N_SUCCESS;
 -}
 -
 -int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac)
 -{
+-    ENSURE_POSIX_REF(backup);
+-    PRECONDITION_POSIX(s2n_hmac_state_validate(hmac));
 -    hmac->inner.digest.high_level = backup->inner;
 -    hmac->inner_just_key.digest.high_level = backup->inner_just_key;
 -    hmac->outer.digest.high_level = backup->outer;
 -    hmac->outer_just_key.digest.high_level = backup->outer_just_key;
--    return 0;
+-    POSTCONDITION_POSIX(s2n_hmac_state_validate(hmac));
+-    return S2N_SUCCESS;
 -}
-+/* /\* Preserve the handlers for hmac state pointers to avoid re-allocation  */
-+/*  * Only valid if the HMAC is in EVP mode */
-+/*  *\/ */
-+/* int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac) */
-+/* { */
-+/*     backup->inner = hmac->inner.digest.high_level; */
-+/*     backup->inner_just_key = hmac->inner_just_key.digest.high_level; */
-+/*     backup->outer = hmac->outer.digest.high_level; */
-+/*     backup->outer_just_key = hmac->outer_just_key.digest.high_level; */
-+/*     return 0; */
-+/* } */
-+
-+/* int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac) */
-+/* { */
-+/*     hmac->inner.digest.high_level = backup->inner; */
-+/*     hmac->inner_just_key.digest.high_level = backup->inner_just_key; */
-+/*     hmac->outer.digest.high_level = backup->outer; */
-+/*     hmac->outer_just_key.digest.high_level = backup->outer_just_key; */
-+/*     return 0; */
-+/* } */
++// int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac)
++// {
++//     ENSURE_POSIX_REF(backup);
++//     PRECONDITION_POSIX(s2n_hmac_state_validate(hmac));
++//     backup->inner = hmac->inner.digest.high_level;
++//     backup->inner_just_key = hmac->inner_just_key.digest.high_level;
++//     backup->outer = hmac->outer.digest.high_level;
++//     backup->outer_just_key = hmac->outer_just_key.digest.high_level;
++//     return S2N_SUCCESS;
++// }
++//
++// int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac)
++// {
++//     ENSURE_POSIX_REF(backup);
++//     PRECONDITION_POSIX(s2n_hmac_state_validate(hmac));
++//     hmac->inner.digest.high_level = backup->inner;
++//     hmac->inner_just_key.digest.high_level = backup->inner_just_key;
++//     hmac->outer.digest.high_level = backup->outer;
++//     hmac->outer_just_key.digest.high_level = backup->outer_just_key;
++//     POSTCONDITION_POSIX(s2n_hmac_state_validate(hmac));
++//     return S2N_SUCCESS;
++// }
 diff --git a/tests/sidetrail/working/s2n-cbc/crypto/s2n_hmac.h b/tests/sidetrail/working/s2n-cbc/crypto/s2n_hmac.h
 index 7af7e61..e6382ce 100644
 --- a/tests/sidetrail/working/s2n-cbc/crypto/s2n_hmac.h

--- a/tests/sidetrail/working/patches/safety.patch
+++ b/tests/sidetrail/working/patches/safety.patch
@@ -2,26 +2,20 @@ diff --git a/utils/s2n_safety.c b/utils/s2n_safety.c
 index ae8e5783..cc06a2d0 100644
 --- a/utils/s2n_safety.c
 +++ b/utils/s2n_safety.c
-@@ -57,18 +57,12 @@ pid_t s2n_actual_getpid()
+@@ -57,12 +57,6 @@ pid_t s2n_actual_getpid()
   */
  bool s2n_constant_time_equals(const uint8_t * a, const uint8_t * b, const uint32_t len)
  {
 -    S2N_PUBLIC_INPUT(a);
 -    S2N_PUBLIC_INPUT(b);
 -    S2N_PUBLIC_INPUT(len);
+-    ENSURE_POSIX((a == NULL) || S2N_MEM_IS_READABLE(a, len), S2N_ERR_PRECONDITION_VIOLATION);
+-    ENSURE_POSIX((b == NULL) || S2N_MEM_IS_READABLE(b, len), S2N_ERR_PRECONDITION_VIOLATION);
 -
      if (len != 0 && (a == NULL || b == NULL)) {
          return false;
      }
- 
-     uint8_t xor = 0;
-     for (int i = 0; i < len; i++) {
--        /* Invariants must hold for each execution of the loop
--	 * and at loop exit, hence the <= */
-         S2N_INVARIANT(i <= len);
-         xor |= a[i] ^ b[i];
-     }
-@@ -88,10 +82,6 @@ bool s2n_constant_time_equals(const uint8_t * a, const uint8_t * b, const uint32
+@@ -90,10 +84,6 @@ bool s2n_constant_time_equals(const uint8_t * a, const uint8_t * b, const uint32
   */
  int s2n_constant_time_copy_or_dont(uint8_t * dest, const uint8_t * src, uint32_t len, uint8_t dont)
  {

--- a/tests/sidetrail/working/patches/safety.patch
+++ b/tests/sidetrail/working/patches/safety.patch
@@ -2,20 +2,17 @@ diff --git a/utils/s2n_safety.c b/utils/s2n_safety.c
 index ae8e5783..cc06a2d0 100644
 --- a/utils/s2n_safety.c
 +++ b/utils/s2n_safety.c
-@@ -57,12 +57,6 @@ pid_t s2n_actual_getpid()
+@@ -57,9 +57,6 @@ pid_t s2n_actual_getpid()
   */
  bool s2n_constant_time_equals(const uint8_t * a, const uint8_t * b, const uint32_t len)
  {
 -    S2N_PUBLIC_INPUT(a);
 -    S2N_PUBLIC_INPUT(b);
 -    S2N_PUBLIC_INPUT(len);
--    ENSURE_POSIX((a == NULL) || S2N_MEM_IS_READABLE(a, len), S2N_ERR_PRECONDITION_VIOLATION);
--    ENSURE_POSIX((b == NULL) || S2N_MEM_IS_READABLE(b, len), S2N_ERR_PRECONDITION_VIOLATION);
--
-     if (len != 0 && (a == NULL || b == NULL)) {
-         return false;
-     }
-@@ -90,10 +84,6 @@ bool s2n_constant_time_equals(const uint8_t * a, const uint8_t * b, const uint32
+     ENSURE_POSIX((a == NULL) || S2N_MEM_IS_READABLE(a, len), S2N_ERR_SAFETY);
+     ENSURE_POSIX((b == NULL) || S2N_MEM_IS_READABLE(b, len), S2N_ERR_SAFETY);
+
+@@ -90,10 +87,6 @@ bool s2n_constant_time_equals(const uint8_t * a, const uint8_t * b, const uint32
   */
  int s2n_constant_time_copy_or_dont(uint8_t * dest, const uint8_t * src, uint32_t len, uint8_t dont)
  {

--- a/tests/sidetrail/working/s2n-cbc/stubs/s2n_hash.c
+++ b/tests/sidetrail/working/s2n-cbc/stubs/s2n_hash.c
@@ -43,6 +43,11 @@ int s2n_hash_new(struct s2n_hash_state *state)
   return SUCCESS;
 }
 
+S2N_RESULT s2n_hash_state_validate(struct s2n_hash_state *state)
+{
+    return S2N_RESULT_OK;
+}
+
 int s2n_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm alg)
 {
   __VERIFIER_ASSUME_LEAKAGE(0);
@@ -56,8 +61,8 @@ int num_blocks(int numBytes) {
    * because the backend SMT solver does not handle these non-linear operations well.
    * Instead, hardcode the div function.
    * This trades off speed for generality because we have to assert that no input is larger
-   * the given bound.  Padding length cannot be more than 256, (4 SHA1 blocks). Choosing a 
-   * bound much larger than this ensures that for any padding size we can see the effect on 
+   * the given bound.  Padding length cannot be more than 256, (4 SHA1 blocks). Choosing a
+   * bound much larger than this ensures that for any padding size we can see the effect on
    * the packet.
    */
   __VERIFIER_ASSUME_LEAKAGE(0);
@@ -87,7 +92,7 @@ int s2n_hash_update(struct s2n_hash_state *state, const void *data, uint32_t siz
 
   /* The __VERIFIER_assert statements give better performance but don't add to our current spec.
    * In particular, Boogie is bad about reestablishing invariants on values that have been put
-   * into memory, then read back out. Adding the asserts triggers Boogie to relearn the 
+   * into memory, then read back out. Adding the asserts triggers Boogie to relearn the
    * invariant properties.
    * The proof should hold in their absense (albeit much more slowly).
    */
@@ -96,10 +101,10 @@ int s2n_hash_update(struct s2n_hash_state *state, const void *data, uint32_t siz
    __VERIFIER_assert(size <= MAX_SIZE);
    __VERIFIER_assert(state->currently_in_hash_block < BLOCK_SIZE);
 
-   /* We model a hash function as having two forms of leakage: 
+   /* We model a hash function as having two forms of leakage:
     * A per-byte-cost, which represents the cost of moving the information into the hash bufer
     * A per-block-cost, which represents the cost of compressing one hash-block using the hash fn
-    * As discussed in the README, __VERIFIER_ASSUME_LEAKAGE allows us to annotate these 
+    * As discussed in the README, __VERIFIER_ASSUME_LEAKAGE allows us to annotate these
     * timing costs into the stub
     */
    __VERIFIER_ASSUME_LEAKAGE(PER_BYTE_COST * size);
@@ -161,4 +166,3 @@ int s2n_hash_get_currently_in_hash_total(struct s2n_hash_state *state, uint64_t 
   *out = state->currently_in_hash_block;
   return SUCCESS;
 }
-

--- a/tests/sidetrail/working/s2n-cbc/stubs/s2n_hash.h
+++ b/tests/sidetrail/working/s2n-cbc/stubs/s2n_hash.h
@@ -43,8 +43,8 @@ struct s2n_hash_state {
 
 /* SHA1
  * These fields were determined from the SHA specification, augmented by
- * analyzing SHA implementations. 
- * PER_BLOCK_COST is the cost of a compression round.  Pessimistically assume 
+ * analyzing SHA implementations.
+ * PER_BLOCK_COST is the cost of a compression round.  Pessimistically assume
  * it is 1000 cycles/block, which is worse than real implementations (larger
  * numbers here make lucky13 leakages look worse), and hence large is safer.
  * PER_BYTE_COST is the cost of memcopy one byte that is already in cache,
@@ -53,7 +53,7 @@ struct s2n_hash_state {
 enum {
   PER_BLOCK_COST = 1000,
   PER_BYTE_COST = 1,
-  BLOCK_SIZE = 64,          
+  BLOCK_SIZE = 64,
   LENGTH_FIELD_SIZE = 8,
   DIGEST_SIZE = 20
 };
@@ -67,6 +67,7 @@ enum {
 
 extern int s2n_hash_digest_size(s2n_hash_algorithm alg, uint8_t *out);
 extern int s2n_hash_new(struct s2n_hash_state *state);
+S2N_RESULT s2n_hash_state_validate(struct s2n_hash_state *state);
 extern int s2n_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm alg);
 extern int s2n_hash_update(struct s2n_hash_state *state, const void *data, uint32_t size);
 extern int s2n_hash_digest(struct s2n_hash_state *state, void *out, uint32_t size);
@@ -74,5 +75,3 @@ extern int s2n_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *from)
 extern int s2n_hash_reset(struct s2n_hash_state *state);
 extern int s2n_hash_free(struct s2n_hash_state *state);
 extern int s2n_hash_get_currently_in_hash_total(struct s2n_hash_state *state, uint64_t *out);
-
-

--- a/tests/sidetrail/working/stubs/s2n_hash.c
+++ b/tests/sidetrail/working/stubs/s2n_hash.c
@@ -43,6 +43,11 @@ int s2n_hash_new(struct s2n_hash_state *state)
   return SUCCESS;
 }
 
+S2N_RESULT s2n_hash_state_validate(struct s2n_hash_state *state)
+{
+    return S2N_RESULT_OK;
+}
+
 int s2n_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm alg)
 {
   __VERIFIER_ASSUME_LEAKAGE(0);
@@ -56,8 +61,8 @@ int num_blocks(int numBytes) {
    * because the backend SMT solver does not handle these non-linear operations well.
    * Instead, hardcode the div function.
    * This trades off speed for generality because we have to assert that no input is larger
-   * the given bound.  Padding length cannot be more than 256, (4 SHA1 blocks). Choosing a 
-   * bound much larger than this ensures that for any padding size we can see the effect on 
+   * the given bound.  Padding length cannot be more than 256, (4 SHA1 blocks). Choosing a
+   * bound much larger than this ensures that for any padding size we can see the effect on
    * the packet.
    */
   __VERIFIER_ASSUME_LEAKAGE(0);
@@ -87,7 +92,7 @@ int s2n_hash_update(struct s2n_hash_state *state, const void *data, uint32_t siz
 
   /* The __VERIFIER_assert statements give better performance but don't add to our current spec.
    * In particular, Boogie is bad about reestablishing invariants on values that have been put
-   * into memory, then read back out. Adding the asserts triggers Boogie to relearn the 
+   * into memory, then read back out. Adding the asserts triggers Boogie to relearn the
    * invariant properties.
    * The proof should hold in their absense (albeit much more slowly).
    */
@@ -96,10 +101,10 @@ int s2n_hash_update(struct s2n_hash_state *state, const void *data, uint32_t siz
    __VERIFIER_assert(size <= MAX_SIZE);
    __VERIFIER_assert(state->currently_in_hash_block < BLOCK_SIZE);
 
-   /* We model a hash function as having two forms of leakage: 
+   /* We model a hash function as having two forms of leakage:
     * A per-byte-cost, which represents the cost of moving the information into the hash bufer
     * A per-block-cost, which represents the cost of compressing one hash-block using the hash fn
-    * As discussed in the README, __VERIFIER_ASSUME_LEAKAGE allows us to annotate these 
+    * As discussed in the README, __VERIFIER_ASSUME_LEAKAGE allows us to annotate these
     * timing costs into the stub
     */
    __VERIFIER_ASSUME_LEAKAGE(PER_BYTE_COST * size);
@@ -161,4 +166,3 @@ int s2n_hash_get_currently_in_hash_total(struct s2n_hash_state *state, uint64_t 
   *out = state->currently_in_hash_block;
   return SUCCESS;
 }
-

--- a/tests/sidetrail/working/stubs/s2n_hash.h
+++ b/tests/sidetrail/working/stubs/s2n_hash.h
@@ -43,8 +43,8 @@ struct s2n_hash_state {
 
 /* SHA1
  * These fields were determined from the SHA specification, augmented by
- * analyzing SHA implementations. 
- * PER_BLOCK_COST is the cost of a compression round.  Pessimistically assume 
+ * analyzing SHA implementations.
+ * PER_BLOCK_COST is the cost of a compression round.  Pessimistically assume
  * it is 1000 cycles/block, which is worse than real implementations (larger
  * numbers here make lucky13 leakages look worse), and hence large is safer.
  * PER_BYTE_COST is the cost of memcopy one byte that is already in cache,
@@ -53,7 +53,7 @@ struct s2n_hash_state {
 enum {
   PER_BLOCK_COST = 1000,
   PER_BYTE_COST = 1,
-  BLOCK_SIZE = 64,          
+  BLOCK_SIZE = 64,
   LENGTH_FIELD_SIZE = 8,
   DIGEST_SIZE = 20
 };
@@ -67,6 +67,7 @@ enum {
 
 extern int s2n_hash_digest_size(s2n_hash_algorithm alg, uint8_t *out);
 extern int s2n_hash_new(struct s2n_hash_state *state);
+S2N_RESULT s2n_hash_state_validate(struct s2n_hash_state *state);
 extern int s2n_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm alg);
 extern int s2n_hash_update(struct s2n_hash_state *state, const void *data, uint32_t size);
 extern int s2n_hash_digest(struct s2n_hash_state *state, void *out, uint32_t size);
@@ -74,5 +75,3 @@ extern int s2n_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *from)
 extern int s2n_hash_reset(struct s2n_hash_state *state);
 extern int s2n_hash_free(struct s2n_hash_state *state);
 extern int s2n_hash_get_currently_in_hash_total(struct s2n_hash_state *state, uint64_t *out);
-
-

--- a/utils/s2n_safety.c
+++ b/utils/s2n_safety.c
@@ -60,8 +60,8 @@ bool s2n_constant_time_equals(const uint8_t * a, const uint8_t * b, const uint32
     S2N_PUBLIC_INPUT(a);
     S2N_PUBLIC_INPUT(b);
     S2N_PUBLIC_INPUT(len);
-    ENSURE_POSIX((a == NULL) || S2N_MEM_IS_READABLE(a, len), S2N_ERR_PRECONDITION_VIOLATION);
-    ENSURE_POSIX((b == NULL) || S2N_MEM_IS_READABLE(b, len), S2N_ERR_PRECONDITION_VIOLATION);
+    ENSURE_POSIX((a == NULL) || S2N_MEM_IS_READABLE(a, len), S2N_ERR_SAFETY);
+    ENSURE_POSIX((b == NULL) || S2N_MEM_IS_READABLE(b, len), S2N_ERR_SAFETY);
 
     if (len != 0 && (a == NULL || b == NULL)) {
         return false;

--- a/utils/s2n_safety.c
+++ b/utils/s2n_safety.c
@@ -60,6 +60,8 @@ bool s2n_constant_time_equals(const uint8_t * a, const uint8_t * b, const uint32
     S2N_PUBLIC_INPUT(a);
     S2N_PUBLIC_INPUT(b);
     S2N_PUBLIC_INPUT(len);
+    ENSURE_POSIX((a == NULL) || S2N_MEM_IS_READABLE(a, len), S2N_ERR_PRECONDITION_VIOLATION);
+    ENSURE_POSIX((b == NULL) || S2N_MEM_IS_READABLE(b, len), S2N_ERR_PRECONDITION_VIOLATION);
 
     if (len != 0 && (a == NULL || b == NULL)) {
         return false;


### PR DESCRIPTION
### Resolved issues:

N/A.

### Description of changes: 

Adds pre- and postconditions to ensure memory safety on `s2n_hmac` functions. It also adds two CBMC proof allocators for `s2n_hmac_state` and `s2n_hmac_evp_backup`, respectively, and a validity function for `s2n_hmac_state`.

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
