### PR TITLE
Update PQ fuzz tests to run when PQ is disabled

### DIFF
--- a/tests/fuzz/runFuzzTest.sh
+++ b/tests/fuzz/runFuzzTest.sh
@@ -60,12 +60,7 @@ fi
 FIPS_TEST_MSG=""
 if [ -n "${S2N_TEST_IN_FIPS_MODE}" ];
 then
-    if [[ $TEST_NAME == *bike* ]] || [[ $TEST_NAME == *sike* ]] || [[ $TEST_NAME == *kyber* ]]; then
-        printf "Skipping %s because PQ crypto is not supported in FIPS mode...\n" ${TEST_NAME}
-        exit 0
-    else
-        FIPS_TEST_MSG=" FIPS test"
-    fi
+    FIPS_TEST_MSG=" FIPS test"
 fi
 
 if [ ! -d "./corpus/${TEST_NAME}" ];

--- a/tests/fuzz/s2n_bike_r2_recv_ciphertext_fuzz_test.c
+++ b/tests/fuzz/s2n_bike_r2_recv_ciphertext_fuzz_test.c
@@ -28,14 +28,21 @@
  * prepending BIKE1_L1_R2_CIPHERTEXT_BYTES as two hex-encoded bytes. */
 static struct s2n_kem_params kem_params = { .kem = &s2n_bike1_l1_r2 };
 
-int s2n_fuzz_init(int *argc, char **argv[]) {
+int s2n_fuzz_init(int *argc, char **argv[])
+{
     GUARD(s2n_kem_recv_ciphertext_fuzz_test_init(KAT_FILE_NAME, &kem_params));
     return S2N_SUCCESS;
 }
 
-int s2n_fuzz_test(const uint8_t *buf, size_t len) {
+int s2n_fuzz_test(const uint8_t *buf, size_t len)
+{
     GUARD(s2n_kem_recv_ciphertext_fuzz_test(buf, len, &kem_params));
     return S2N_SUCCESS;
 }
 
-S2N_FUZZ_TARGET(s2n_fuzz_init, s2n_fuzz_test, NULL)
+static void s2n_fuzz_cleanup()
+{
+    s2n_kem_free(&kem_params);
+}
+
+S2N_FUZZ_TARGET(s2n_fuzz_init, s2n_fuzz_test, s2n_fuzz_cleanup)

--- a/tests/fuzz/s2n_kyber_r2_recv_ciphertext_fuzz_test.c
+++ b/tests/fuzz/s2n_kyber_r2_recv_ciphertext_fuzz_test.c
@@ -28,14 +28,21 @@
  * prepending KYBER_512_R2_CIPHERTEXT_BYTES as two hex-encoded bytes. */
 static struct s2n_kem_params kem_params = { .kem = &s2n_kyber_512_r2 };
 
-int s2n_fuzz_init(int *argc, char **argv[]) {
+int s2n_fuzz_init(int *argc, char **argv[])
+{
     GUARD(s2n_kem_recv_ciphertext_fuzz_test_init(KAT_FILE_NAME, &kem_params));
     return S2N_SUCCESS;
 }
 
-int s2n_fuzz_test(const uint8_t *buf, size_t len) {
+int s2n_fuzz_test(const uint8_t *buf, size_t len)
+{
     GUARD(s2n_kem_recv_ciphertext_fuzz_test(buf, len, &kem_params));
     return S2N_SUCCESS;
 }
 
-S2N_FUZZ_TARGET(s2n_fuzz_init, s2n_fuzz_test, NULL)
+static void s2n_fuzz_cleanup()
+{
+    s2n_kem_free(&kem_params);
+}
+
+S2N_FUZZ_TARGET(s2n_fuzz_init, s2n_fuzz_test, s2n_fuzz_cleanup)

--- a/tests/fuzz/s2n_sike_r1_recv_ciphertext_fuzz_test.c
+++ b/tests/fuzz/s2n_sike_r1_recv_ciphertext_fuzz_test.c
@@ -28,14 +28,21 @@
  * prepending SIKE_P503_R1_CIPHERTEXT_BYTES as two hex-encoded bytes. */
 static struct s2n_kem_params kem_params = { .kem = &s2n_sike_p503_r1 };
 
-int s2n_fuzz_init(int *argc, char **argv[]) {
+int s2n_fuzz_init(int *argc, char **argv[])
+{
     GUARD(s2n_kem_recv_ciphertext_fuzz_test_init(KAT_FILE_NAME, &kem_params));
     return S2N_SUCCESS;
 }
 
-int s2n_fuzz_test(const uint8_t *buf, size_t len) {
+int s2n_fuzz_test(const uint8_t *buf, size_t len)
+{
     GUARD(s2n_kem_recv_ciphertext_fuzz_test(buf, len, &kem_params));
     return S2N_SUCCESS;
 }
 
-S2N_FUZZ_TARGET(s2n_fuzz_init, s2n_fuzz_test, NULL)
+static void s2n_fuzz_cleanup()
+{
+    s2n_kem_free(&kem_params);
+}
+
+S2N_FUZZ_TARGET(s2n_fuzz_init, s2n_fuzz_test, s2n_fuzz_cleanup)

--- a/tests/fuzz/s2n_sike_r2_recv_ciphertext_fuzz_test.c
+++ b/tests/fuzz/s2n_sike_r2_recv_ciphertext_fuzz_test.c
@@ -29,12 +29,14 @@
  * prepending SIKE_P434_R2_CIPHERTEXT_BYTES as two hex-encoded bytes. */
 static struct s2n_kem_params kem_params = { .kem = &s2n_sike_p434_r2 };
 
-int s2n_fuzz_init(int *argc, char **argv[]) {
+int s2n_fuzz_init(int *argc, char **argv[])
+{
     GUARD(s2n_kem_recv_ciphertext_fuzz_test_init(KAT_FILE_NAME, &kem_params));
     return S2N_SUCCESS;
 }
 
-int s2n_fuzz_test(const uint8_t *buf, size_t len) {
+int s2n_fuzz_test(const uint8_t *buf, size_t len)
+{
     /* Test the portable C code */
     GUARD_AS_POSIX(s2n_disable_sikep434r2_asm());
     GUARD(s2n_kem_recv_ciphertext_fuzz_test(buf, len, &kem_params));
@@ -48,4 +50,9 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len) {
     return S2N_SUCCESS;
 }
 
-S2N_FUZZ_TARGET(s2n_fuzz_init, s2n_fuzz_test, NULL)
+static void s2n_fuzz_cleanup()
+{
+    s2n_kem_free(&kem_params);
+}
+
+S2N_FUZZ_TARGET(s2n_fuzz_init, s2n_fuzz_test, s2n_fuzz_cleanup)


### PR DESCRIPTION
### Resolved issues:

Makes progress toward https://github.com/awslabs/s2n/issues/2285 and https://github.com/awslabs/s2n/issues/1952

### Description of changes: 

* PQ fuzz tests will now run whether or not PQ crypto is enabled. This is the desired behavior to ensure we are testing the higher level parsing/receiving/wrapper functions regardless of which low-level PQ KEM functions may be [defined](https://github.com/awslabs/s2n/blob/567190405f8d00bd18eb9a8e9793924f6e5dd1a2/tls/s2n_kem.c#L482-L509).
  * Because this update runs the PQ fuzz tests when PQ crypto is disabled, we no longer directly fuzz the low-level PQ KEM functions, instead just fuzzing the high-level wrappers. This is fine, as the fuzzer should still reach the crypto KEM functions through the wrapper when PQ is enabled.
* Removes the S2N_NO_PQ ifdefs in the fuzz tests

### Call-outs:

N/A 

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

* This is a test change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
