### PR TITLE
ci: Fix annoying NONE error

### DIFF
--- a/s2n.mk
+++ b/s2n.mk
@@ -98,15 +98,15 @@ CFLAGS += ${DEFAULT_CFLAGS}
 ifdef GCC_VERSION
 	ifneq ("$(GCC_VERSION)","NONE")
 		CC=gcc-$(GCC_VERSION)
-	endif
-	# Make doesn't support greater than checks, this uses `test` to compare values, then `echo $$?` to return the value of test's
-	# exit code and finally using the built in make `ifeq` to check if it was true and then add the extra flag.
-	ifeq ($(shell test $(GCC_VERSION) -gt 7; echo $$?), 0)
-		CFLAGS += -Wimplicit-fallthrough
-	endif
+		# Make doesn't support greater than checks, this uses `test` to compare values, then `echo $$?` to return the value of test's
+		# exit code and finally using the built in make `ifeq` to check if it was true and then add the extra flag.
+		ifeq ($(shell test $(GCC_VERSION) -gt 7; echo $$?), 0)
+			CFLAGS += -Wimplicit-fallthrough
+		endif
 
-	ifeq ($(shell test $(GCC_VERSION) -ge 10; echo $$?), 0)
-		CFLAGS += -fanalyzer
+		ifeq ($(shell test $(GCC_VERSION) -ge 10; echo $$?), 0)
+			CFLAGS += -fanalyzer
+		endif
 	endif
 endif
 

--- a/s2n.mk
+++ b/s2n.mk
@@ -99,7 +99,7 @@ ifdef GCC_VERSION
 	ifneq ("$(GCC_VERSION)","NONE")
 		CC=gcc-$(GCC_VERSION)
 		# Make doesn't support greater than checks, this uses `test` to compare values, then `echo $$?` to return the value of test's
-		# exit code and finally using the built in make `ifeq` to check if it was true and then add the extra flag.
+		# exit code and finally uses the built in make `ifeq` to check if it was true and then adds the extra flag.
 		ifeq ($(shell test $(GCC_VERSION) -gt 7; echo $$?), 0)
 			CFLAGS += -Wimplicit-fallthrough
 		endif


### PR DESCRIPTION
### Resolved issues:

None found

### Description of changes: 

For any test where GCC_VERSION is `NONE`, test throws an error:
```
/bin/sh: line 0: test: NONE: integer expression expected
/bin/sh: line 0: test: NONE: integer expression expected
```

Move the numeric check inside the "not equals NONE" condition.

### Call-outs:

Make treats this like a warning- it has no real effect on running the build.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer? 

repro steps/fix verification:
```
TESTS=integration GCC_VERSION=NONE make
```

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
