### PR TITLE
Enforce that client psk extension is parsed last

### DIFF
--- a/tests/unit/s2n_extension_list_parse_test.c
+++ b/tests/unit/s2n_extension_list_parse_test.c
@@ -90,7 +90,7 @@ int main()
     /* Test that parse clears existing parsed_extensions */
     {
         s2n_parsed_extensions_list parsed_extension_list = { 0 };
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 1));
 
         parsed_extension_list.parsed_extensions[0].extension_type = 0xFF;
@@ -111,7 +111,7 @@ int main()
     /* Test parse empty extension list - no extension list size */
     {
         s2n_parsed_extensions_list parsed_extension_list = { 0 };
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 1));
 
         EXPECT_SUCCESS(s2n_extension_list_parse(&stuffer, &parsed_extension_list));
@@ -121,6 +121,7 @@ int main()
 
         EXPECT_EQUAL(parsed_extension_list.raw.data, stuffer.blob.data);
         EXPECT_EQUAL(parsed_extension_list.raw.size, 0);
+        EXPECT_EQUAL(parsed_extension_list.count, 0);
 
         EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
     }
@@ -128,7 +129,7 @@ int main()
     /* Test parse empty extension list - with extension list size */
     {
         s2n_parsed_extensions_list parsed_extension_list = { 0 };
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         /* Write zero size */
@@ -140,6 +141,7 @@ int main()
         EXPECT_PARSED_EXTENSION_LIST_EMPTY(parsed_extension_list);
         EXPECT_RAW_EQUAL(parsed_extension_list, stuffer);
         EXPECT_EQUAL(parsed_extension_list.raw.size, 0);
+        EXPECT_EQUAL(parsed_extension_list.count, 0);
 
         EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
     }
@@ -147,7 +149,7 @@ int main()
     /* Test parse with insufficient data to match extension list size */
     {
         s2n_parsed_extensions_list parsed_extension_list = { 0 };
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_stuffer_write_uint16(&stuffer, 100));
@@ -164,7 +166,7 @@ int main()
     /* Test parse with insufficient data for even one extension */
     {
         s2n_parsed_extensions_list parsed_extension_list = { 0 };
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         /* Extension list size */
@@ -184,7 +186,7 @@ int main()
     /* Test parse single extension in list */
     {
         s2n_parsed_extensions_list parsed_extension_list = { 0 };
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         /* Reserve size */
@@ -203,6 +205,7 @@ int main()
         EXPECT_RAW_EQUAL(parsed_extension_list, stuffer);
 
         EXPECT_PARSED_EXTENSION_EQUAL(parsed_extension_list, test_extension.iana_value, test_data, sizeof(test_data));
+        EXPECT_EQUAL(parsed_extension_list.count, 1);
         CLEAR_PARSED_EXTENSION(parsed_extension_list, test_extension.iana_value);
         EXPECT_PARSED_EXTENSION_LIST_EMPTY(parsed_extension_list);
 
@@ -212,7 +215,7 @@ int main()
     /* Test parse single extension in list - malformed extension size */
     {
         s2n_parsed_extensions_list parsed_extension_list = { 0 };
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         /* Reserve size */
@@ -238,7 +241,7 @@ int main()
     /* Test parse single extension in list - extension is empty */
     {
         s2n_parsed_extensions_list parsed_extension_list = { 0 };
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         /* Reserve size */
@@ -253,6 +256,7 @@ int main()
         EXPECT_SUCCESS(s2n_extension_list_parse(&stuffer, &parsed_extension_list));
 
         EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
+        EXPECT_EQUAL(parsed_extension_list.count, 1);
         EXPECT_PARSED_EXTENSION_LIST_NOT_EMPTY(parsed_extension_list);
         EXPECT_RAW_EQUAL(parsed_extension_list, stuffer);
 
@@ -266,7 +270,7 @@ int main()
     /* Test parse single extension in list - ignore unknown extensions */
     {
         s2n_parsed_extensions_list parsed_extension_list = { 0 };
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         /* Reserve size */
@@ -282,6 +286,7 @@ int main()
         EXPECT_SUCCESS(s2n_extension_list_parse(&stuffer, &parsed_extension_list));
 
         EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
+        EXPECT_EQUAL(parsed_extension_list.count, 0);
         EXPECT_PARSED_EXTENSION_LIST_EMPTY(parsed_extension_list);
         EXPECT_RAW_EQUAL(parsed_extension_list, stuffer);
 
@@ -291,7 +296,7 @@ int main()
     /* Test error on duplicate extensions */
     {
         s2n_parsed_extensions_list parsed_extension_list = { 0 };
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         /* Reserve size */
@@ -314,7 +319,7 @@ int main()
     /* Test error on duplicate extensions - extensions are empty */
     {
         s2n_parsed_extensions_list parsed_extension_list = { 0 };
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         /* Reserve size */
@@ -337,7 +342,7 @@ int main()
     /* Test parse multiple extensions */
     {
         s2n_parsed_extensions_list parsed_extension_list = { 0 };
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         s2n_extension_type test_extension_2 = empty_test_extension;
@@ -365,11 +370,49 @@ int main()
         EXPECT_PARSED_EXTENSION_EQUAL(parsed_extension_list, test_extension_2.iana_value, test_data, 0);
         EXPECT_PARSED_EXTENSION_EQUAL(parsed_extension_list, test_extension_3.iana_value, other_test_data, sizeof(other_test_data));
         EXPECT_RAW_EQUAL(parsed_extension_list, stuffer);
+        EXPECT_EQUAL(parsed_extension_list.count, 3);
 
         CLEAR_PARSED_EXTENSION(parsed_extension_list, test_extension.iana_value);
         CLEAR_PARSED_EXTENSION(parsed_extension_list, test_extension_2.iana_value);
         CLEAR_PARSED_EXTENSION(parsed_extension_list, test_extension_3.iana_value);
         EXPECT_PARSED_EXTENSION_LIST_EMPTY(parsed_extension_list);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+    }
+
+    /* Test parsed extensions assigned correct indexes */
+    {
+        s2n_parsed_extensions_list parsed_extension_list = { 0 };
+        struct s2n_stuffer stuffer = { 0 };
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        s2n_extension_type test_extension_2 = test_extension;
+        test_extension_2.iana_value = TLS_EXTENSION_SIGNATURE_ALGORITHMS;
+        s2n_extension_type test_extension_3 = test_extension;
+        test_extension_3.iana_value = TLS_EXTENSION_ALPN;
+
+        /* Reserve size */
+        struct s2n_stuffer_reservation extension_list_size = {0};
+        EXPECT_SUCCESS(s2n_stuffer_reserve_uint16(&stuffer, &extension_list_size));
+        /* Write extensions */
+        EXPECT_SUCCESS(s2n_extension_send(&test_extension, conn, &stuffer));
+        EXPECT_SUCCESS(s2n_extension_send(&test_extension_2, conn, &stuffer));
+        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&stuffer, S2N_UNKNOWN_EXTENSION_IANA));
+        EXPECT_SUCCESS(s2n_stuffer_write_uint16(&stuffer, 0));
+        EXPECT_SUCCESS(s2n_extension_send(&test_extension_3, conn, &stuffer));
+        /* Check / write size */
+        EXPECT_TRUE(s2n_stuffer_data_available(&stuffer) > extension_list_size.length);
+        EXPECT_SUCCESS(s2n_stuffer_write_vector_size(&extension_list_size));
+
+        EXPECT_SUCCESS(s2n_extension_list_parse(&stuffer, &parsed_extension_list));
+
+        uint16_t expected_order[] = { test_extension.iana_value, test_extension_2.iana_value, test_extension_3.iana_value };
+        for (size_t i = 0; i < s2n_array_len(expected_order); i++) {
+            s2n_extension_type_id id;
+            EXPECT_SUCCESS(s2n_extension_supported_iana_value_to_id(expected_order[i], &id));
+            EXPECT_EQUAL(parsed_extension_list.parsed_extensions[id].wire_index, i);
+        }
+        EXPECT_EQUAL(parsed_extension_list.count, 3);
 
         EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
     }

--- a/tls/extensions/s2n_client_psk.c
+++ b/tls/extensions/s2n_client_psk.c
@@ -255,9 +255,9 @@ int s2n_client_psk_recv(struct s2n_connection *conn, struct s2n_stuffer *extensi
     s2n_extension_type_id psk_ext_id;
     GUARD(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_PRE_SHARED_KEY, &psk_ext_id));
     ne_check(conn->client_hello.extensions.count, 0);
-    uint16_t last_index = conn->client_hello.extensions.count - 1;
-    uint16_t extension_index = conn->client_hello.extensions.parsed_extensions[psk_ext_id].wire_index;
-    ENSURE_POSIX(extension_index == last_index, S2N_ERR_UNSUPPORTED_EXTENSION);
+    uint16_t last_wire_index = conn->client_hello.extensions.count - 1;
+    uint16_t extension_wire_index = conn->client_hello.extensions.parsed_extensions[psk_ext_id].wire_index;
+    ENSURE_POSIX(extension_wire_index == last_wire_index, S2N_ERR_UNSUPPORTED_EXTENSION);
 
     /* https://tools.ietf.org/html/rfc8446#section-4.2.9:
      * If clients offer "pre_shared_key" without a "psk_key_exchange_modes" extension,

--- a/tls/extensions/s2n_client_psk.c
+++ b/tls/extensions/s2n_client_psk.c
@@ -247,22 +247,34 @@ int s2n_client_psk_recv(struct s2n_connection *conn, struct s2n_stuffer *extensi
         return S2N_SUCCESS;
     }
 
+    /* https://tools.ietf.org/html/rfc8446#section-4.2.11
+     * The "pre_shared_key" extension MUST be the last extension in the ClientHello.
+     * Servers MUST check that it is the last extension and otherwise fail the handshake
+     * with an "illegal_parameter" alert.
+     */
+    s2n_extension_type_id psk_ext_id;
+    GUARD(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_PRE_SHARED_KEY, &psk_ext_id));
+    ne_check(conn->client_hello.extensions.count, 0);
+    uint16_t last_index = conn->client_hello.extensions.count - 1;
+    uint16_t extension_index = conn->client_hello.extensions.parsed_extensions[psk_ext_id].wire_index;
+    ENSURE_POSIX(extension_index == last_index, S2N_ERR_UNSUPPORTED_EXTENSION);
+
     /* https://tools.ietf.org/html/rfc8446#section-4.2.9:
      * If clients offer "pre_shared_key" without a "psk_key_exchange_modes" extension,
      * servers MUST abort the handshake. We can safely do this check here because s2n_client_psk is
      * required to be the last extension sent in the list.
      */
-    s2n_extension_type_id psk_ke_mode_id;
-    GUARD(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_PSK_KEY_EXCHANGE_MODES, &psk_ke_mode_id));
-    S2N_ERROR_IF(!S2N_CBIT_TEST(conn->extension_requests_received, psk_ke_mode_id), S2N_ERR_MISSING_EXTENSION);
+    s2n_extension_type_id psk_ke_mode_ext_id;
+    GUARD(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_PSK_KEY_EXCHANGE_MODES, &psk_ke_mode_ext_id));
+    ENSURE_POSIX(S2N_CBIT_TEST(conn->extension_requests_received, psk_ke_mode_ext_id), S2N_ERR_MISSING_EXTENSION);
 
     if (conn->psk_params.psk_ke_mode == S2N_PSK_DHE_KE) {
-        s2n_extension_type_id key_share_id;
-        GUARD(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_KEY_SHARE, &key_share_id));
+        s2n_extension_type_id key_share_ext_id;
+        GUARD(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_KEY_SHARE, &key_share_ext_id));
         /* A key_share extension must have been received in order to use a pre-shared key
          * in (EC)DHE key exchange mode.
          */
-        S2N_ERROR_IF(!S2N_CBIT_TEST(conn->extension_requests_received, key_share_id), S2N_ERR_MISSING_EXTENSION);
+        ENSURE_POSIX(S2N_CBIT_TEST(conn->extension_requests_received, key_share_ext_id), S2N_ERR_MISSING_EXTENSION);
     } else {
         /* s2n currently only supports pre-shared keys in (EC)DHE key exchange mode. If we receive keys with any other
          * exchange mode we fall back to a full handshake.

--- a/tls/extensions/s2n_extension_list.h
+++ b/tls/extensions/s2n_extension_list.h
@@ -23,11 +23,13 @@
 typedef struct {
     uint16_t extension_type;
     struct s2n_blob extension;
+    uint16_t wire_index;
 } s2n_parsed_extension;
 
 typedef struct {
     s2n_parsed_extension parsed_extensions[S2N_PARSED_EXTENSIONS_COUNT];
     struct s2n_blob raw; /* Needed by some ClientHello APIs */
+    uint16_t count;
 } s2n_parsed_extensions_list;
 
 typedef enum {


### PR DESCRIPTION
### Description of changes: 

The RFC requires that the client pre shared key extension is the last extension in the ClientHello extension list so that the binder calculated can cover everything except the binders themselves. When receiving the extension, the server needs to verify this. I added wire indexes to each parsed extension to handle this case and any future extension ordering requirements.

### Call-outs:

* *What about sending order?* That's already covered. The extension lists determine extension order when sending.

### Testing:

Unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
