### PR TITLE
Adding server pre_shared_key extension

### DIFF
--- a/tests/unit/s2n_cipher_suite_match_test.c
+++ b/tests/unit/s2n_cipher_suite_match_test.c
@@ -146,8 +146,8 @@ int main(int argc, char **argv)
                 TLS_AES_128_GCM_SHA256,
             };
 
-            /* S2N_HASH_SHA1 is not a matching hash algorithm */
-            conn->psk_params.chosen_psk->hmac_alg = S2N_HASH_SHA1;
+            /* S2N_HMAC_SHA1 is not a matching hmac algorithm */
+            conn->psk_params.chosen_psk->hmac_alg = S2N_HMAC_SHA1;
             EXPECT_FAILURE_WITH_ERRNO(s2n_set_cipher_as_client(conn, valid_tls13_wire_ciphers),
                                       S2N_ERR_CIPHER_NOT_SUPPORTED);
             EXPECT_EQUAL(conn->secure.cipher_suite, &s2n_null_cipher_suite);
@@ -811,8 +811,8 @@ int main(int argc, char **argv)
 
                 EXPECT_OK(s2n_conn_set_chosen_psk(conn));
 
-                /* S2N_HASH_SHA1 is not a matching hash algorithm for the cipher suites present in wire_ciphers_with_tls13 */ 
-                conn->psk_params.chosen_psk->hmac_alg = S2N_HASH_SHA1;
+                /* S2N_HMAC_SHA1 is not a matching hmac algorithm for the cipher suites present in wire_ciphers_with_tls13 */ 
+                conn->psk_params.chosen_psk->hmac_alg = S2N_HMAC_SHA1;
                 EXPECT_FAILURE_WITH_ERRNO(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_tls13, cipher_count_tls13), S2N_ERR_CIPHER_NOT_SUPPORTED);
                 EXPECT_EQUAL(conn->secure.cipher_suite, &s2n_null_cipher_suite);
 

--- a/tests/unit/s2n_cipher_suite_match_test.c
+++ b/tests/unit/s2n_cipher_suite_match_test.c
@@ -81,6 +81,105 @@ int main(int argc, char **argv)
         free(cert_chain);
     }
 
+    /* Test client cipher selection */
+    {
+        /* Setup connections */
+        struct s2n_connection *conn = NULL;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+        /* Setup config */
+        struct s2n_cert_chain_and_key *chain_and_key = NULL;
+        EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
+                S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
+        struct s2n_config *config = NULL;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        /* Test that the client allows the server to select ciphers that were offered in ClientHello */
+        {
+            conn->client_protocol_version = S2N_TLS13;
+            conn->actual_protocol_version = S2N_TLS13;
+            conn->server_protocol_version = S2N_TLS13;
+
+            /* The client will offer the default tls13 ciphersuites */
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default_tls13"));
+
+            /* The server will send a TLS13 cipher over the wire */
+            uint8_t valid_wire_ciphers[] = {
+                TLS_AES_128_GCM_SHA256
+            };
+
+            /* We expect to succeed because the cipher was offered by the client */
+            EXPECT_SUCCESS(s2n_set_cipher_as_client(conn, valid_wire_ciphers));
+
+            EXPECT_SUCCESS(s2n_connection_wipe(conn));
+        }
+
+        /* Test that the client rejects a cipher that was not originally offered in ClientHello */
+        {
+            conn->client_protocol_version = S2N_TLS13;
+            conn->actual_protocol_version = S2N_TLS13;
+            conn->server_protocol_version = S2N_TLS13;
+
+            /* The client will offer the default tls13 ciphersuites */
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_all_tls13"));
+
+            /* The server will send a TLS12 cipher over the wire */
+            uint8_t invalid_wire_ciphers[] = {
+                TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+            };
+
+            /* We expect to fail because the cipher was not offered by the client */
+            EXPECT_FAILURE_WITH_ERRNO(s2n_set_cipher_as_client(conn, invalid_wire_ciphers), S2N_ERR_CIPHER_NOT_SUPPORTED);
+
+            EXPECT_SUCCESS(s2n_connection_wipe(conn));
+        }
+
+        /* If chosen PSK is set, test error case for incorrect hash match */
+        {
+            s2n_connection_set_cipher_preferences(conn, "default_tls13");
+
+            EXPECT_OK(s2n_conn_set_chosen_psk(conn));
+
+            uint8_t valid_tls13_wire_ciphers[] = {
+                TLS_AES_128_GCM_SHA256,
+            };
+
+            /* S2N_HASH_SHA1 is not a matching hash algorithm */
+            conn->psk_params.chosen_psk->hmac_alg = S2N_HASH_SHA1;
+            EXPECT_FAILURE_WITH_ERRNO(s2n_set_cipher_as_client(conn, valid_tls13_wire_ciphers),
+                                      S2N_ERR_CIPHER_NOT_SUPPORTED);
+            EXPECT_EQUAL(conn->secure.cipher_suite, &s2n_null_cipher_suite);
+
+            EXPECT_SUCCESS(s2n_psk_parameters_free(&conn->psk_params));
+            EXPECT_SUCCESS(s2n_connection_wipe(conn));
+        }
+
+        /* If chosen PSK is set, test success case for matching hash algorithm */
+        {
+            s2n_connection_set_cipher_preferences(conn, "default_tls13");
+
+            EXPECT_OK(s2n_conn_set_chosen_psk(conn));
+
+            uint8_t valid_tls13_wire_ciphers[] = {
+                TLS_AES_128_GCM_SHA256,
+            };
+
+            /* S2N_HASH_SHA256 is a matching hash algorithm for the cipher suite present in valid_tls13_wire_ciphers */
+            conn->psk_params.chosen_psk->hmac_alg = S2N_HASH_SHA256;
+            EXPECT_SUCCESS(s2n_set_cipher_as_client(conn, valid_tls13_wire_ciphers));
+            EXPECT_EQUAL(conn->secure.cipher_suite, &s2n_tls13_aes_128_gcm_sha256);
+
+            EXPECT_SUCCESS(s2n_psk_parameters_free(&conn->psk_params));
+            EXPECT_SUCCESS(s2n_connection_wipe(conn));
+        }
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
     /* Test server cipher selection and scsv detection */
     {
         struct s2n_connection *conn;
@@ -819,50 +918,6 @@ int main(int argc, char **argv)
             conn->client_protocol_version = S2N_TLS13;
             conn->actual_protocol_version = S2N_TLS13;
             EXPECT_FAILURE_WITH_ERRNO(s2n_set_cipher_as_tls_server(conn, invalid_cipher_pref, invalid_cipher_count), S2N_ERR_CIPHER_NOT_SUPPORTED);
-            EXPECT_SUCCESS(s2n_connection_wipe(conn));
-            EXPECT_SUCCESS(s2n_disable_tls13());
-        }
-
-        /* Test that the client allows the server to select ciphers that were offered in ClientHello */
-        {
-            EXPECT_SUCCESS(s2n_enable_tls13());
-            conn->client_protocol_version = S2N_TLS13;
-            conn->actual_protocol_version = S2N_TLS13;
-            conn->server_protocol_version = S2N_TLS13;
-
-            /* The client will offer the default tls13 ciphersuites */
-            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default_tls13"));
-
-            /* The server will send a TLS13 cipher over the wire */
-            uint8_t valid_wire_ciphers[] = {
-                TLS_AES_128_GCM_SHA256
-            };
-
-            /* We expect to succeed because the cipher was offered by the client */
-            EXPECT_SUCCESS(s2n_set_cipher_as_client(conn, valid_wire_ciphers));
-
-            EXPECT_SUCCESS(s2n_connection_wipe(conn));
-            EXPECT_SUCCESS(s2n_disable_tls13());
-        }
-
-        /* Test that the client rejects a cipher that was not originally offered in ClientHello */
-        {
-            EXPECT_SUCCESS(s2n_enable_tls13());
-            conn->client_protocol_version = S2N_TLS13;
-            conn->actual_protocol_version = S2N_TLS13;
-            conn->server_protocol_version = S2N_TLS13;
-
-            /* The client will offer the default tls13 ciphersuites */
-            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_all_tls13"));
-
-            /* The server will send a TLS12 cipher over the wire */
-            uint8_t invalid_wire_ciphers[] = {
-                TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
-            };
-
-            /* We expect to fail because the cipher was not offered by the client */
-            EXPECT_FAILURE_WITH_ERRNO(s2n_set_cipher_as_client(conn, invalid_wire_ciphers), S2N_ERR_CIPHER_NOT_SUPPORTED);
-
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
             EXPECT_SUCCESS(s2n_disable_tls13());
         }

--- a/tests/unit/s2n_client_psk_extension_test.c
+++ b/tests/unit/s2n_client_psk_extension_test.c
@@ -243,7 +243,7 @@ int main(int argc, char **argv)
                 0x00, 0x01,             /* identity */
                 0x00, 0x00, 0x00, 0x00, /* ticket_age */
         };
-        const uint8_t wire_identities_match_index = 2;
+        const uint16_t wire_identities_match_index = 2;
 
         /* Receive an empty list */
         {

--- a/tests/unit/s2n_server_psk_extension_test.c
+++ b/tests/unit/s2n_server_psk_extension_test.c
@@ -1,0 +1,365 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+
+#include "crypto/s2n_hmac.h"
+#include "tls/extensions/s2n_server_psk.h"
+#include "tls/s2n_tls.h"
+#include "utils/s2n_bitmap.h"
+
+#define TEST_PSK_WIRE_INDEX 1
+#define TEST_PSK_HMAC S2N_HMAC_SHA384
+
+uint8_t test_identity[] = "test identity";
+uint8_t test_secret[] = "test secret";
+
+static s2n_result validate_psk_is_wiped(struct s2n_psk *psk)
+{
+    ENSURE_EQ(psk->identity.data, NULL);
+    ENSURE_EQ(psk->identity.size, 0);
+    ENSURE_EQ(psk->secret.data, NULL);
+    ENSURE_EQ(psk->secret.size, 0);
+    ENSURE_EQ(psk->early_secret.data, NULL);
+    ENSURE_EQ(psk->early_secret.size, 0);
+
+    return S2N_RESULT_OK;
+}
+
+static s2n_result validate_psk_is_not_wiped(struct s2n_psk *psk)
+{
+    ENSURE_REF(psk->identity.data);
+    ENSURE_NE(psk->identity.size, 0);
+    ENSURE_REF(psk->secret.data);
+    ENSURE_NE(psk->secret.size, 0);
+
+    return S2N_RESULT_OK;
+}
+
+
+static s2n_result setup_client_psks(struct s2n_connection *client_conn)
+{
+    ENSURE_REF(client_conn);
+
+    /* Setup other client PSK */
+    uint8_t other_client_data[] = "other client data";
+    struct s2n_psk *other_client_psk = NULL;
+    GUARD_RESULT(s2n_array_pushback(&client_conn->psk_params.psk_list, (void**) &other_client_psk));
+    GUARD_AS_RESULT(s2n_psk_init(other_client_psk, S2N_PSK_TYPE_EXTERNAL));
+    GUARD_AS_RESULT(s2n_psk_new_identity(other_client_psk, other_client_data, sizeof(other_client_data)));
+    GUARD_AS_RESULT(s2n_psk_new_secret(other_client_psk, other_client_data, sizeof(other_client_data)));
+    other_client_psk->hmac_alg = S2N_HMAC_SHA256;
+
+    /* Setup shared PSK for client */
+    struct s2n_psk *shared_psk = NULL;
+    GUARD_RESULT(s2n_array_pushback(&client_conn->psk_params.psk_list, (void**) &shared_psk));
+    GUARD_AS_RESULT(s2n_psk_init(shared_psk, S2N_PSK_TYPE_EXTERNAL));
+    GUARD_AS_RESULT(s2n_psk_new_identity(shared_psk, test_identity, sizeof(test_identity)));
+    GUARD_AS_RESULT(s2n_psk_new_secret(shared_psk, test_secret, sizeof(test_secret)));
+    shared_psk->hmac_alg = TEST_PSK_HMAC;
+
+    return S2N_RESULT_OK;
+}
+
+static s2n_result setup_server_psks(struct s2n_connection *server_conn)
+{
+    ENSURE_REF(server_conn);
+
+    /* Setup shared PSK for server */
+    struct s2n_psk *shared_psk = NULL;
+    GUARD_RESULT(s2n_array_pushback(&server_conn->psk_params.psk_list, (void**) &shared_psk));
+    GUARD_AS_RESULT(s2n_psk_init(shared_psk, S2N_PSK_TYPE_EXTERNAL));
+    GUARD_AS_RESULT(s2n_psk_new_identity(shared_psk, test_identity, sizeof(test_identity)));
+    GUARD_AS_RESULT(s2n_psk_new_secret(shared_psk, test_secret, sizeof(test_secret)));
+    shared_psk->hmac_alg = TEST_PSK_HMAC;
+
+    /* Setup other server PSK */
+    uint8_t other_server_data[] = "other server data";
+    struct s2n_psk *other_server_psk = NULL;
+    GUARD_RESULT(s2n_array_pushback(&server_conn->psk_params.psk_list, (void**) &other_server_psk));
+    GUARD_AS_RESULT(s2n_psk_init(other_server_psk, S2N_PSK_TYPE_EXTERNAL));
+    GUARD_AS_RESULT(s2n_psk_new_identity(other_server_psk, other_server_data, sizeof(other_server_data)));
+    GUARD_AS_RESULT(s2n_psk_new_secret(other_server_psk, other_server_data, sizeof(other_server_data)));
+    other_server_psk->hmac_alg = S2N_HMAC_SHA224;
+
+    return S2N_RESULT_OK;
+}
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Test: s2n_server_psk_should_send */
+    {
+        struct s2n_psk *psk = NULL;
+
+        struct s2n_connection *conn = NULL;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+
+        EXPECT_FALSE(s2n_server_psk_extension.should_send(NULL));
+
+        conn->actual_protocol_version = S2N_TLS12;
+        EXPECT_FALSE(s2n_server_psk_extension.should_send(conn));
+        conn->actual_protocol_version = S2N_TLS13;
+        EXPECT_FALSE(s2n_server_psk_extension.should_send(conn));
+
+        EXPECT_OK(s2n_array_pushback(&conn->psk_params.psk_list, (void**) &psk));
+
+        conn->actual_protocol_version = S2N_TLS12;
+        EXPECT_FALSE(s2n_server_psk_extension.should_send(conn));
+        conn->actual_protocol_version = S2N_TLS13;
+        EXPECT_FALSE(s2n_server_psk_extension.should_send(conn));
+
+        conn->psk_params.chosen_psk_wire_index = 0;
+        EXPECT_OK(s2n_array_get(&conn->psk_params.psk_list, conn->psk_params.chosen_psk_wire_index,
+                                (void **)&conn->psk_params.chosen_psk));
+        EXPECT_TRUE(s2n_server_psk_extension.should_send(conn));
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test: s2n_server_psk_send */
+    {
+        /* Send the index of the chosen PSK that is stored on the connection. */
+        {
+            struct s2n_stuffer out = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));
+
+            struct s2n_connection *server_conn = NULL;
+            struct s2n_connection *client_conn = NULL;
+            EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+            EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+
+            EXPECT_OK(setup_client_psks(client_conn));
+            EXPECT_OK(setup_server_psks(server_conn));
+
+            server_conn->psk_params.chosen_psk_wire_index = TEST_PSK_WIRE_INDEX;
+            EXPECT_SUCCESS(s2n_server_psk_extension.send(server_conn, &out));
+
+            uint16_t chosen_psk_wire_index = 0;
+            EXPECT_SUCCESS(s2n_stuffer_read_uint16(&out, &chosen_psk_wire_index));
+            EXPECT_EQUAL(chosen_psk_wire_index, server_conn->psk_params.chosen_psk_wire_index);
+
+            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+            EXPECT_SUCCESS(s2n_connection_free(client_conn));
+            EXPECT_SUCCESS(s2n_stuffer_free(&out));
+        }
+    }
+
+    /* Test: s2n_server_psk_recv */
+    {
+        s2n_extension_type_id key_share_ext_id;
+        EXPECT_SUCCESS(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_KEY_SHARE, &key_share_ext_id));
+
+        /* Test s2n_server_psk_recv for invalid TLS versions <= TLS1.2 */
+        {
+            struct s2n_stuffer out = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));
+
+            struct s2n_connection *conn = NULL;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+            EXPECT_OK(setup_client_psks(conn));
+
+            /* The keyshare extension needs to be present, as s2n currently only
+             * supports pre-shared keys in (EC)DHE key exchange mode.
+             */
+            S2N_CBIT_SET(conn->extension_requests_received, key_share_ext_id);
+
+            uint16_t chosen_psk_wire_index = 1;
+            /* Incorrect protocol version */
+            conn->actual_protocol_version = S2N_TLS12;
+            EXPECT_SUCCESS(s2n_stuffer_write_uint16(&out, chosen_psk_wire_index));
+
+            EXPECT_NULL(conn->psk_params.chosen_psk);
+            EXPECT_SUCCESS(s2n_server_psk_extension.recv(conn, &out));
+            EXPECT_NULL(conn->psk_params.chosen_psk);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_stuffer_free(&out));
+        }
+
+        /* Test s2n_server_psk_recv when server key_share extension is not present */
+        {
+            struct s2n_stuffer out = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));
+
+            struct s2n_connection *conn = NULL;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+            EXPECT_OK(setup_client_psks(conn));
+
+            uint16_t chosen_psk_wire_index = TEST_PSK_WIRE_INDEX;
+            conn->actual_protocol_version = S2N_TLS13;
+
+            EXPECT_SUCCESS(s2n_stuffer_write_uint16(&out, chosen_psk_wire_index));
+
+            EXPECT_NULL(conn->psk_params.chosen_psk);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_server_psk_extension.recv(conn, &out), S2N_ERR_MISSING_EXTENSION);
+            EXPECT_NULL(conn->psk_params.chosen_psk);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_stuffer_free(&out)); 
+        }
+
+        /* Receive invalid chosen psk wire index */
+        {
+            struct s2n_stuffer out = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));
+
+            struct s2n_connection *conn = NULL;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+            EXPECT_OK(setup_client_psks(conn));
+
+            /* The keyshare extension needs to be present, as s2n currently only
+             * supports pre-shared keys in (EC)DHE key exchange mode.
+             */
+            S2N_CBIT_SET(conn->extension_requests_received, key_share_ext_id);
+
+            /* Invalid chosen psk wire index */
+            uint16_t chosen_psk_wire_index = 10;
+            conn->actual_protocol_version = S2N_TLS13;
+
+            EXPECT_SUCCESS(s2n_stuffer_write_uint16(&out, chosen_psk_wire_index));
+
+            EXPECT_NULL(conn->psk_params.chosen_psk);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_server_psk_extension.recv(conn, &out), S2N_ERR_INVALID_ARGUMENT);
+            EXPECT_NULL(conn->psk_params.chosen_psk);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_stuffer_free(&out));
+        }
+
+        /* Receive valid server preshared extension recv */
+        {
+            struct s2n_stuffer out = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));
+
+            struct s2n_connection *conn = NULL;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+            EXPECT_OK(setup_client_psks(conn));
+
+            /* The keyshare extension needs to be present, as s2n currently only
+             * supports pre-shared keys in (EC)DHE key exchange mode.
+             */
+            S2N_CBIT_SET(conn->extension_requests_received, key_share_ext_id);
+
+            uint16_t chosen_psk_wire_index = TEST_PSK_WIRE_INDEX;
+            conn->actual_protocol_version = S2N_TLS13;
+
+            EXPECT_SUCCESS(s2n_stuffer_write_uint16(&out, chosen_psk_wire_index));
+
+            EXPECT_NULL(conn->psk_params.chosen_psk);
+            EXPECT_SUCCESS(s2n_server_psk_extension.recv(conn, &out));
+
+            /* Verify chosen PSK */
+            EXPECT_EQUAL(conn->psk_params.psk_ke_mode, S2N_PSK_DHE_KE);
+            EXPECT_EQUAL(conn->psk_params.chosen_psk_wire_index, TEST_PSK_WIRE_INDEX);
+            EXPECT_EQUAL(conn->psk_params.chosen_psk->identity.size, sizeof(test_identity));
+            EXPECT_BYTEARRAY_EQUAL(conn->psk_params.chosen_psk->identity.data, test_identity, sizeof(test_identity));
+            EXPECT_EQUAL(conn->psk_params.chosen_psk->secret.size, sizeof(test_secret));
+            EXPECT_BYTEARRAY_EQUAL(conn->psk_params.chosen_psk->secret.data, test_secret,sizeof(test_secret));
+            EXPECT_EQUAL(conn->psk_params.chosen_psk->hmac_alg, TEST_PSK_HMAC);
+
+            /* Validate that the chosen PSK is not wiped and PSKs not chosen are wiped */
+            for (size_t i = 0; i < conn->psk_params.psk_list.len; i++) {
+                struct s2n_psk *psk = NULL;
+                EXPECT_OK(s2n_array_get(&conn->psk_params.psk_list, i, (void**)&psk));
+                if (i == conn->psk_params.chosen_psk_wire_index) {
+                    EXPECT_OK(validate_psk_is_not_wiped(psk));
+                } else {
+                    EXPECT_OK(validate_psk_is_wiped(psk));
+                }
+            }
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_stuffer_free(&out)); 
+        }
+    }
+
+    /* Functional test */
+    {
+        /* Setup connections */
+        EXPECT_SUCCESS(s2n_enable_tls13());
+        struct s2n_connection *client_conn, *server_conn;
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+
+        /* Setup config */
+        struct s2n_cert_chain_and_key *chain_and_key = NULL;
+        EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
+                S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
+        struct s2n_config *config = NULL;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
+        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(client_conn, S2N_TLS13));
+        EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
+
+        EXPECT_OK(setup_client_psks(client_conn));
+        EXPECT_OK(setup_server_psks(server_conn));
+
+        EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
+        EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io,
+                s2n_stuffer_data_available(&client_conn->handshake.io)));
+        EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
+
+        /* Verify shared PSK chosen */
+        EXPECT_EQUAL(server_conn->psk_params.chosen_psk_wire_index, TEST_PSK_WIRE_INDEX);
+
+        EXPECT_SUCCESS(s2n_server_hello_send(server_conn));
+
+        EXPECT_SUCCESS(s2n_stuffer_wipe(&client_conn->handshake.io));
+        EXPECT_SUCCESS(s2n_stuffer_copy(&server_conn->handshake.io, &client_conn->handshake.io,
+                s2n_stuffer_data_available(&server_conn->handshake.io)));
+
+        EXPECT_NULL(client_conn->psk_params.chosen_psk);
+        EXPECT_SUCCESS(s2n_server_hello_recv(client_conn));
+
+        /* Verify chosen PSK received */
+        EXPECT_EQUAL(client_conn->psk_params.psk_ke_mode, S2N_PSK_DHE_KE);
+        EXPECT_EQUAL(client_conn->psk_params.chosen_psk_wire_index, TEST_PSK_WIRE_INDEX);
+        EXPECT_EQUAL(client_conn->psk_params.chosen_psk->identity.size, sizeof(test_identity));
+        EXPECT_BYTEARRAY_EQUAL(client_conn->psk_params.chosen_psk->identity.data, test_identity, sizeof(test_identity));
+        EXPECT_EQUAL(client_conn->psk_params.chosen_psk->secret.size, sizeof(test_secret));
+        EXPECT_BYTEARRAY_EQUAL(client_conn->psk_params.chosen_psk->secret.data, test_secret, sizeof(test_secret));
+        EXPECT_EQUAL(client_conn->psk_params.chosen_psk->hmac_alg, TEST_PSK_HMAC);
+
+        /* Validate that the chosen PSK is not wiped and PSKs not chosen are wiped */
+        for (size_t i = 0; i < client_conn->psk_params.psk_list.len; i++) {
+            struct s2n_psk *psk = NULL;
+            EXPECT_OK(s2n_array_get(&client_conn->psk_params.psk_list, i, (void**)&psk));
+            if (i == client_conn->psk_params.chosen_psk_wire_index) {
+                EXPECT_OK(validate_psk_is_not_wiped(psk));
+            } else {
+                EXPECT_OK(validate_psk_is_wiped(psk));
+            }
+        }
+
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
+    END_TEST();
+}

--- a/tests/unit/s2n_server_psk_extension_test.c
+++ b/tests/unit/s2n_server_psk_extension_test.c
@@ -139,11 +139,8 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));
 
             struct s2n_connection *server_conn = NULL;
-            struct s2n_connection *client_conn = NULL;
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-            EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
 
-            EXPECT_OK(setup_client_psks(client_conn));
             EXPECT_OK(setup_server_psks(server_conn));
 
             server_conn->psk_params.chosen_psk_wire_index = TEST_PSK_WIRE_INDEX;
@@ -154,7 +151,6 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(chosen_psk_wire_index, server_conn->psk_params.chosen_psk_wire_index);
 
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
-            EXPECT_SUCCESS(s2n_connection_free(client_conn));
             EXPECT_SUCCESS(s2n_stuffer_free(&out));
         }
     }
@@ -273,7 +269,7 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(conn->psk_params.chosen_psk->identity.size, sizeof(test_identity));
             EXPECT_BYTEARRAY_EQUAL(conn->psk_params.chosen_psk->identity.data, test_identity, sizeof(test_identity));
             EXPECT_EQUAL(conn->psk_params.chosen_psk->secret.size, sizeof(test_secret));
-            EXPECT_BYTEARRAY_EQUAL(conn->psk_params.chosen_psk->secret.data, test_secret,sizeof(test_secret));
+            EXPECT_BYTEARRAY_EQUAL(conn->psk_params.chosen_psk->secret.data, test_secret, sizeof(test_secret));
             EXPECT_EQUAL(conn->psk_params.chosen_psk->hmac_alg, TEST_PSK_HMAC);
 
             /* Validate that the chosen PSK is not wiped and PSKs not chosen are wiped */

--- a/tests/unit/s2n_tls13_support_test.c
+++ b/tests/unit/s2n_tls13_support_test.c
@@ -141,7 +141,7 @@ int main(int argc, char **argv)
         s2n_extension_type_list *tls13_server_hello_extensions = NULL;
         EXPECT_SUCCESS(s2n_extension_type_list_get(S2N_EXTENSION_LIST_SERVER_HELLO_TLS13, &tls13_server_hello_extensions));
         EXPECT_NOT_NULL(tls13_server_hello_extensions);
-        EXPECT_EQUAL(tls13_server_hello_extensions->count, 3);
+        EXPECT_EQUAL(tls13_server_hello_extensions->count, 4);
 
         struct s2n_connection *server_conn;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));

--- a/tls/extensions/s2n_client_psk.c
+++ b/tls/extensions/s2n_client_psk.c
@@ -127,7 +127,7 @@ static S2N_RESULT s2n_client_psk_recv_identity_list(struct s2n_connection *conn,
     ENSURE_REF(conn);
     ENSURE_REF(wire_identities_in);
 
-    uint8_t wire_index = 0;
+    uint16_t wire_index = 0;
     while (s2n_stuffer_data_available(wire_identities_in) > 0) {
         uint16_t identity_size = 0;
         GUARD_AS_RESULT(s2n_stuffer_read_uint16(wire_identities_in, &identity_size));
@@ -169,7 +169,7 @@ static S2N_RESULT s2n_client_psk_recv_binder_list(struct s2n_connection *conn, s
     ENSURE_REF(conn);
     ENSURE_REF(wire_binders_in);
 
-    uint8_t wire_index = 0;
+    uint16_t wire_index = 0;
     while (s2n_stuffer_data_available(wire_binders_in) > 0) {
         uint8_t wire_binder_size = 0;
         GUARD_AS_RESULT(s2n_stuffer_read_uint8(wire_binders_in, &wire_binder_size));

--- a/tls/extensions/s2n_extension_type_lists.c
+++ b/tls/extensions/s2n_extension_type_lists.c
@@ -46,6 +46,7 @@
 #include "tls/extensions/s2n_server_signature_algorithms.h"
 #include "tls/extensions/s2n_server_supported_versions.h"
 #include "tls/extensions/s2n_server_key_share.h"
+#include "tls/extensions/s2n_server_psk.h"
 
 static const s2n_extension_type *const client_hello_extensions[] = {
         &s2n_client_supported_versions_extension,
@@ -83,6 +84,7 @@ static const s2n_extension_type *const tls13_server_hello_extensions[] = {
         &s2n_server_supported_versions_extension,
         &s2n_server_key_share_extension,
         &s2n_server_cookie_extension,
+        &s2n_server_psk_extension, /* MUST appear after keyshare extension */
 };
 
 static const s2n_extension_type *const encrypted_extensions[] = {

--- a/tls/extensions/s2n_server_psk.c
+++ b/tls/extensions/s2n_server_psk.c
@@ -60,8 +60,9 @@ static int s2n_server_psk_recv(struct s2n_connection *conn, struct s2n_stuffer *
         return S2N_SUCCESS;
     }
 
-    /* A key_share extension must have been received in order to use a pre-shared key
-     * in (EC)DHE key exchange mode.
+    /* Currently in s2n, only (EC)DHE key exchange mode is supported.
+     * Any other mode selected by the server is invalid because it was not offered by the client.
+     * A key_share extension MUST have been received in order to use a pre-shared key in (EC)DHE key exchange mode.
      */
     s2n_extension_type_id key_share_ext_id;
     GUARD(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_KEY_SHARE, &key_share_ext_id));

--- a/tls/extensions/s2n_server_psk.c
+++ b/tls/extensions/s2n_server_psk.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <sys/param.h>
+#include <stdint.h>
+
+#include "tls/s2n_tls.h"
+#include "tls/extensions/s2n_server_psk.h"
+
+#include "utils/s2n_safety.h"
+#include "utils/s2n_bitmap.h"
+
+static bool s2n_server_psk_should_send(struct s2n_connection *conn);
+static int s2n_server_psk_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+static int s2n_server_psk_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
+
+const s2n_extension_type s2n_server_psk_extension = {
+    .iana_value = TLS_EXTENSION_PRE_SHARED_KEY,
+    .is_response = true,
+    .send = s2n_server_psk_send,
+    .recv = s2n_server_psk_recv,
+    .should_send = s2n_server_psk_should_send,
+    .if_missing = s2n_extension_noop_if_missing,
+};
+
+static bool s2n_server_psk_should_send(struct s2n_connection *conn)
+{
+    /* Only send a server pre_shared_key extension if a chosen PSK is set on the connection */
+    return conn && s2n_connection_get_protocol_version(conn) >= S2N_TLS13
+            && conn->psk_params.chosen_psk;
+}
+
+static int s2n_server_psk_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    notnull_check(conn);
+
+    /* Send the index of the chosen PSK that is stored on the connection. */
+    GUARD(s2n_stuffer_write_uint16(out, conn->psk_params.chosen_psk_wire_index));
+
+    return S2N_SUCCESS;
+}
+
+static int s2n_server_psk_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    notnull_check(conn);
+
+    if (s2n_connection_get_protocol_version(conn) < S2N_TLS13) {
+        return S2N_SUCCESS;
+    }
+
+    /* A key_share extension must have been received in order to use a pre-shared key
+     * in (EC)DHE key exchange mode.
+     */
+    s2n_extension_type_id key_share_ext_id;
+    GUARD(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_KEY_SHARE, &key_share_ext_id));
+    ENSURE_POSIX(S2N_CBIT_TEST(conn->extension_requests_received, key_share_ext_id), S2N_ERR_MISSING_EXTENSION);
+
+    /* From RFC section: https://tools.ietf.org/html/rfc8446#section-4.2.8.1
+     * Any future values that are allocated must ensure that the transmitted protocol messages
+     * unambiguously identify which mode was selected by the server; at present, this is
+     * indicated by the presence of the "key_share" in the ServerHello.
+     */
+    conn->psk_params.psk_ke_mode = S2N_PSK_DHE_KE;
+
+    uint16_t chosen_psk_wire_index = 0;
+    GUARD(s2n_stuffer_read_uint16(extension, &chosen_psk_wire_index));
+
+    /* From RFC section: https://tools.ietf.org/html/rfc8446#section-4.2.11 
+     * Clients MUST verify that the server's selected_identity is within the
+     * range supplied by the client.
+     */
+    ENSURE_POSIX(chosen_psk_wire_index < conn->psk_params.psk_list.len, S2N_ERR_INVALID_ARGUMENT);
+    conn->psk_params.chosen_psk_wire_index = chosen_psk_wire_index;
+
+    GUARD_AS_POSIX(s2n_array_get(&conn->psk_params.psk_list, conn->psk_params.chosen_psk_wire_index,
+                                 (void **)&conn->psk_params.chosen_psk));
+
+    /* Wipe the PSKs not chosen */
+    GUARD_AS_POSIX(s2n_psk_parameters_free_unused_psks(&conn->psk_params));
+
+    return S2N_SUCCESS;
+}

--- a/tls/extensions/s2n_server_psk.h
+++ b/tls/extensions/s2n_server_psk.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include "tls/extensions/s2n_extension_type.h"
+
+extern const s2n_extension_type s2n_server_psk_extension;

--- a/tls/s2n_psk.h
+++ b/tls/s2n_psk.h
@@ -45,7 +45,7 @@ struct s2n_psk {
 struct s2n_psk_parameters {
     struct s2n_array psk_list;
     uint16_t binder_list_size;
-    uint8_t chosen_psk_wire_index;
+    uint16_t chosen_psk_wire_index;
     struct s2n_psk *chosen_psk;
     s2n_psk_key_exchange_mode psk_ke_mode;
 };


### PR DESCRIPTION
### Resolved issues:

resolves #2392

### Description of changes: 

The server must send a pre_shared key extension indicating which PSK it accepted by sending the chosen psk wire index value. The client must receive this extension and set its own chosen PSK accordingly.

The extension itself is pretty straightforward:

- is_response: true. Should only be sent/received if the client version was.
- should_send: true if a chosen PSK is set on the connection.
- if_missing: Not an error. For now, we can always fall back to key_share.
- send: Send the index of the chosen PSK that is stored on the connection.
- recv: Set the chosen PSK pointer to the PSK at the index received. Wipe the other PSKs.


Other misc checks the client has to do on recv: 

- “Clients MUST verify that the server's selected_identity is within the range supplied by the client, that the server selected a cipher suite indicating a Hash associated with the PSK, and that a server "key_share" extension is present if required by the ClientHello "psk_key_exchange_modes" extension [note: we should leave the mode requirement until we implement modes]. If these values are not consistent, the client MUST abort the handshake with an "illegal_parameter" alert."

Describe s2n’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.

### Call-outs:

Client verification that the server selected a cipher suite indicating a Hash is associated with the PSK is done during `s2n_server_hello_recv` in the `s2n_server_hello_parse` logic as `conn->secure.cipher_suite` is set only after calling the server psk extension `s2n_server_psk_recv`, and `conn->secure.cipher_suite` is NULL within `s2n_server_psk_recv` logic flow. 

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer? Unit and Functional Testing

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? No, but changes struct `s2n_psk_parameters.chosen_psk_wire_index` from uint8_t to uint16_t to match the RFC, the changes are tested in unit tests. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
