### PR TITLE
Clean up PSKs after early secret calculation

### DIFF
--- a/tests/unit/s2n_psk_test.c
+++ b/tests/unit/s2n_psk_test.c
@@ -131,36 +131,6 @@ int main(int argc, char **argv)
         EXPECT_BYTEARRAY_EQUAL(&expected_params, &params, sizeof(struct s2n_psk_parameters));
     }
 
-    /* Test s2n_psk_parameters_free_unused_psks */
-    {
-        uint8_t test_value[] = TEST_VALUE_1;
-
-        DEFER_CLEANUP(struct s2n_psk_parameters params = { 0 }, s2n_psk_parameters_free);
-        EXPECT_OK(s2n_psk_parameters_init(&params));
-
-        struct s2n_psk *chosen_psk = NULL;
-        EXPECT_OK(s2n_array_pushback(&params.psk_list, (void**) &chosen_psk));
-        EXPECT_SUCCESS(s2n_psk_init(chosen_psk, S2N_PSK_TYPE_EXTERNAL));
-        EXPECT_SUCCESS(s2n_psk_new_identity(chosen_psk, test_value, sizeof(test_value)));
-        params.chosen_psk = chosen_psk;
-
-        struct s2n_psk *other_psk = NULL;
-        EXPECT_OK(s2n_array_pushback(&params.psk_list, (void**) &other_psk));
-        EXPECT_SUCCESS(s2n_psk_init(other_psk, S2N_PSK_TYPE_EXTERNAL));
-        EXPECT_SUCCESS(s2n_psk_new_identity(other_psk, test_value, sizeof(test_value)));
-
-        EXPECT_ERROR_WITH_ERRNO(s2n_psk_parameters_free_unused_psks(NULL), S2N_ERR_NULL);
-        EXPECT_OK(s2n_psk_parameters_free_unused_psks(&params));
-
-        /* Chosen PSKs should NOT be freed. */
-        EXPECT_NOT_EQUAL(chosen_psk->identity.data, NULL);
-        EXPECT_NOT_EQUAL(chosen_psk->identity.size, 0);
-
-        /* Not chosen PSKs should be freed. */
-        EXPECT_EQUAL(other_psk->identity.data, NULL);
-        EXPECT_EQUAL(other_psk->identity.size, 0);
-    }
-
     /* Test s2n_psk_parameters_wipe */
     {
         uint8_t test_value[] = TEST_VALUE_1;
@@ -184,11 +154,12 @@ int main(int argc, char **argv)
         EXPECT_ERROR_WITH_ERRNO(s2n_psk_parameters_wipe(NULL), S2N_ERR_NULL);
         EXPECT_OK(s2n_psk_parameters_wipe(&params));
 
-        /* Both PSKs should be freed. */
+        /* All PSKs should be freed. */
         EXPECT_EQUAL(chosen_psk->identity.data, NULL);
         EXPECT_EQUAL(chosen_psk->identity.size, 0);
         EXPECT_EQUAL(other_psk->identity.data, NULL);
         EXPECT_EQUAL(other_psk->identity.size, 0);
+        EXPECT_EQUAL(params.chosen_psk, NULL);
 
         /* Verify params are wiped.
          * The params should be back to their initial state, but

--- a/tests/unit/s2n_tls13_handshake_test.c
+++ b/tests/unit/s2n_tls13_handshake_test.c
@@ -317,7 +317,7 @@ int main(int argc, char **argv)
 
     /* Test: s2n_tls13_handle_handshake_secrets */
     {
-        /* PSKs are cleaned up */
+        /* PSKs are wiped */
         {
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
@@ -347,7 +347,7 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_tls13_handle_handshake_secrets(conn));
 
-            /* Verify all PSKs are cleaned up */
+            /* Verify all PSKs are wiped */
             for (size_t i = 0; i < S2N_TEST_PSK_COUNT; i++) {
                 struct s2n_psk *psk = test_psks[i];
                 EXPECT_EQUAL(psk->identity.size, 0);

--- a/tls/extensions/s2n_client_psk.c
+++ b/tls/extensions/s2n_client_psk.c
@@ -299,9 +299,6 @@ int s2n_client_psk_recv(struct s2n_connection *conn, struct s2n_stuffer *extensi
         GUARD_AS_POSIX(s2n_client_psk_recv_binders(conn, extension));
     }
 
-    /* At this point, we have either chosen a PSK or fallen back to a full handshake.
-     * Wipe any PSKs not chosen. */
-    GUARD_AS_POSIX(s2n_psk_parameters_free_unused_psks(&conn->psk_params));
-
+    /* At this point, we have either chosen a PSK or fallen back to a full handshake. */
     return S2N_SUCCESS;
 }

--- a/tls/extensions/s2n_server_psk.c
+++ b/tls/extensions/s2n_server_psk.c
@@ -88,8 +88,5 @@ static int s2n_server_psk_recv(struct s2n_connection *conn, struct s2n_stuffer *
     GUARD_AS_POSIX(s2n_array_get(&conn->psk_params.psk_list, conn->psk_params.chosen_psk_wire_index,
                                  (void **)&conn->psk_params.chosen_psk));
 
-    /* Wipe the PSKs not chosen */
-    GUARD_AS_POSIX(s2n_psk_parameters_free_unused_psks(&conn->psk_params));
-
     return S2N_SUCCESS;
 }

--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -78,28 +78,15 @@ S2N_RESULT s2n_psk_parameters_init(struct s2n_psk_parameters *params)
     return S2N_RESULT_OK;
 }
 
-S2N_RESULT s2n_psk_parameters_free_unused_psks(struct s2n_psk_parameters *params)
-{
-    ENSURE_REF(params);
-    for (size_t i = 0; i < params->psk_list.len; i++) {
-        struct s2n_psk *psk;
-        GUARD_RESULT(s2n_array_get(&params->psk_list, i, (void**)&psk));
-
-        if(psk == params->chosen_psk) {
-            continue;
-        }
-        GUARD_AS_RESULT(s2n_psk_free(psk));
-    }
-    return S2N_RESULT_OK;
-}
-
 S2N_RESULT s2n_psk_parameters_wipe(struct s2n_psk_parameters *params)
 {
     ENSURE_REF(params);
 
-    /* Free all PSKs */
-    GUARD_RESULT(s2n_psk_parameters_free_unused_psks(params));
-    GUARD_AS_RESULT(s2n_psk_free(params->chosen_psk));
+    for (size_t i = 0; i < params->psk_list.len; i++) {
+        struct s2n_psk *psk;
+        GUARD_RESULT(s2n_array_get(&params->psk_list, i, (void**)&psk));
+        GUARD_AS_RESULT(s2n_psk_free(psk));
+    }
 
     struct s2n_blob psk_list_mem = params->psk_list.mem;
     s2n_result result = s2n_psk_parameters_init(params);

--- a/tls/s2n_psk.h
+++ b/tls/s2n_psk.h
@@ -57,7 +57,6 @@ int s2n_psk_free(struct s2n_psk *psk);
 
 S2N_RESULT s2n_psk_parameters_init(struct s2n_psk_parameters *params);
 S2N_RESULT s2n_psk_parameters_wipe(struct s2n_psk_parameters *params);
-S2N_RESULT s2n_psk_parameters_free_unused_psks(struct s2n_psk_parameters *params);
 int s2n_psk_parameters_free(struct s2n_psk_parameters *params);
 
 S2N_RESULT s2n_finish_psk_extension(struct s2n_connection *conn);

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -190,6 +190,8 @@ int s2n_tls13_handle_handshake_secrets(struct s2n_connection *conn)
 
     /* derive early secrets */
     GUARD(s2n_tls13_derive_early_secrets(&secrets, conn->psk_params.chosen_psk));
+    /* since early secrets have been computed, PSKs are no longer needed and can be cleaned up */
+    GUARD_AS_POSIX(s2n_psk_parameters_wipe(&conn->psk_params));
 
     /* produce handshake secrets */
     s2n_stack_blob(client_hs_secret, secrets.size, S2N_TLS13_SECRET_MAX_LEN);


### PR DESCRIPTION
### Resolved issues:

https://github.com/awslabs/s2n/issues/2502

### Description of changes: 

Previously, we tried to clean up PSKs as part of the extension logic, but that started to get complicated; bailing early and falling back to a full handshake caused the PSKs not to be cleaned up. I'm simplifying it to match how we handle key shares: just wipe everything after calculating the secrets that use them.

### Call-outs:

**Do we still need to wipe the psk_parameters when we wipe the connection?** Yes. Otherwise if the connection failed before the handshake secret was calculated, we wouldn't clean up the psk_parameters before reusing the connection object.

### Testing:

Unit test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
