### PR TITLE
Optimization for client psk extension on hello retry

### DIFF
--- a/tests/unit/s2n_client_psk_extension_test.c
+++ b/tests/unit/s2n_client_psk_extension_test.c
@@ -62,6 +62,35 @@ int main(int argc, char **argv)
         conn->actual_protocol_version = S2N_TLS13;
         EXPECT_TRUE(s2n_client_psk_extension.should_send(conn));
 
+        /* Only send the extension after a retry if at least one PSK matches the cipher suite */
+        {
+            conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
+            const s2n_hmac_algorithm matching_hmac_alg = conn->secure.cipher_suite->prf_alg;
+            const s2n_hmac_algorithm different_hmac_alg = conn->secure.cipher_suite->prf_alg + 1;
+
+            /* Do send if the PSK does NOT match the cipher suite, but this is NOT a retry */
+            conn->handshake.handshake_type = INITIAL;
+            psk->hmac_alg = different_hmac_alg;
+            EXPECT_TRUE(s2n_client_psk_extension.should_send(conn));
+
+            /* Do send if the PSK matches the cipher suite */
+            conn->handshake.handshake_type = HELLO_RETRY_REQUEST;
+            psk->hmac_alg = matching_hmac_alg;
+            EXPECT_TRUE(s2n_client_psk_extension.should_send(conn));
+
+            /* Do NOT send if the PSK does NOT match the cipher suite */
+            conn->handshake.handshake_type = HELLO_RETRY_REQUEST;
+            psk->hmac_alg = different_hmac_alg;
+            EXPECT_FALSE(s2n_client_psk_extension.should_send(conn));
+
+            /* Do send if there are two PSKs, and one matches the cipher suite */
+            conn->handshake.handshake_type = HELLO_RETRY_REQUEST;
+            psk->hmac_alg = different_hmac_alg;
+            EXPECT_OK(s2n_array_pushback(&conn->psk_params.psk_list, (void**) &psk));
+            psk->hmac_alg = matching_hmac_alg;
+            EXPECT_TRUE(s2n_client_psk_extension.should_send(conn));
+        }
+
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
@@ -155,6 +184,67 @@ int main(int argc, char **argv)
 
             EXPECT_EQUAL(s2n_stuffer_data_available(&out),
                     binder_list_size /* binder list size */
+                    + sizeof(uint16_t)) /* size of binder list size */;
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_stuffer_free(&out));
+        }
+
+        /* On the second ClientHello after a retry request,
+         * do not send any PSKs that do not match the cipher suite. */
+        {
+            struct s2n_stuffer out = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));
+
+            const struct s2n_psk_test_case matching_psk = {
+                    .hmac_alg = S2N_HMAC_SHA384, .hash_size = SHA384_DIGEST_LENGTH,
+                    .identity = test_identity, .identity_size = sizeof(test_identity)
+            };
+            const struct s2n_psk_test_case non_matching_psk = {
+                    .hmac_alg = S2N_HMAC_SHA224, .hash_size = SHA224_DIGEST_LENGTH,
+                    .identity = test_identity, .identity_size = sizeof(test_identity)
+            };
+            struct s2n_psk_test_case test_cases[] = { matching_psk, non_matching_psk };
+
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            conn->handshake.handshake_type = HELLO_RETRY_REQUEST;
+            conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
+            EXPECT_EQUAL(conn->secure.cipher_suite->prf_alg, matching_psk.hmac_alg);
+
+            for (size_t i = 0; i < s2n_array_len(test_cases); i++) {
+                struct s2n_psk *psk = NULL;
+                EXPECT_OK(s2n_array_pushback(&conn->psk_params.psk_list, (void**) &psk));
+                EXPECT_SUCCESS(s2n_psk_init(psk, S2N_PSK_TYPE_EXTERNAL));
+                EXPECT_SUCCESS(s2n_psk_new_identity(psk, test_cases[i].identity, test_cases[i].identity_size));
+                psk->hmac_alg = test_cases[i].hmac_alg;
+            }
+
+            EXPECT_SUCCESS(s2n_client_psk_extension.send(conn, &out));
+
+            /* The identity list should only contain the matching psk's identity.
+             * It should NOT contain the non-matching psk. */
+
+            uint16_t identity_list_size = 0;
+            uint16_t identity_size = 0;
+            uint8_t *identity_data;
+            uint32_t obfuscated_ticket_age = 0;
+
+            EXPECT_SUCCESS(s2n_stuffer_read_uint16(&out, &identity_list_size));
+            EXPECT_EQUAL(identity_list_size, sizeof(identity_size) + matching_psk.identity_size + sizeof(obfuscated_ticket_age));
+
+            EXPECT_SUCCESS(s2n_stuffer_read_uint16(&out, &identity_size));
+            EXPECT_EQUAL(identity_size, matching_psk.identity_size);
+            EXPECT_NOT_NULL(identity_data = s2n_stuffer_raw_read(&out, identity_size));
+            EXPECT_BYTEARRAY_EQUAL(identity_data, matching_psk.identity, matching_psk.identity_size);
+
+            EXPECT_SUCCESS(s2n_stuffer_read_uint32(&out, &obfuscated_ticket_age));
+
+            /* The binder list should only reserve space for the matching psk's binder.
+             * It should NOT reserve space for the binder for the non-matching psk. */
+            EXPECT_EQUAL(s2n_stuffer_data_available(&out),
+                    matching_psk.hash_size
+                    + sizeof(uint8_t) /* size of binder size */
                     + sizeof(uint16_t)) /* size of binder list size */;
 
             EXPECT_SUCCESS(s2n_connection_free(conn));

--- a/tests/unit/s2n_client_psk_extension_test.c
+++ b/tests/unit/s2n_client_psk_extension_test.c
@@ -227,7 +227,7 @@ int main(int argc, char **argv)
 
             uint16_t identity_list_size = 0;
             uint16_t identity_size = 0;
-            uint8_t *identity_data;
+            uint8_t *identity_data = NULL;
             uint32_t obfuscated_ticket_age = 0;
 
             EXPECT_SUCCESS(s2n_stuffer_read_uint16(&out, &identity_list_size));

--- a/tests/unit/s2n_client_psk_extension_test.c
+++ b/tests/unit/s2n_client_psk_extension_test.c
@@ -191,7 +191,14 @@ int main(int argc, char **argv)
         }
 
         /* On the second ClientHello after a retry request,
-         * do not send any PSKs that do not match the cipher suite. */
+         * do not send any PSKs that do not match the cipher suite.
+         *
+         *= https://tools.ietf.org/rfc/rfc8446#section-4.1.4
+         *= type=test
+         *# In addition, in its updated ClientHello, the client SHOULD NOT offer
+         *# any pre-shared keys associated with a hash other than that of the
+         *# selected cipher suite.
+         */
         {
             struct s2n_stuffer out = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));

--- a/tests/unit/s2n_psk_test.c
+++ b/tests/unit/s2n_psk_test.c
@@ -227,6 +227,95 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(params.psk_list.mem.size, 0);
     }
 
+    /* Test s2n_psk_write_binder_list */
+    {
+        uint8_t test_value[] = TEST_VALUE_1;
+
+        struct s2n_blob client_hello_prefix = { 0 };
+        EXPECT_SUCCESS(s2n_blob_init(&client_hello_prefix, test_value, sizeof(test_value)));
+
+        /* Write two binders.
+         * There are no available test vectors for multiple PSKs, but we should at least
+         * verify that we write something relatively sane for this use case. */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+            struct s2n_stuffer out = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));
+
+            struct s2n_psk_parameters *params = &conn->psk_params;
+
+            struct s2n_psk *fist_psk = NULL;
+            EXPECT_OK(s2n_array_pushback(&params->psk_list, (void**) &fist_psk));
+            EXPECT_SUCCESS(s2n_psk_init(fist_psk, S2N_PSK_TYPE_EXTERNAL));
+            EXPECT_SUCCESS(s2n_psk_new_secret(fist_psk, test_value, sizeof(test_value)));
+
+            struct s2n_psk *second_psk = NULL;
+            EXPECT_OK(s2n_array_pushback(&params->psk_list, (void**) &second_psk));
+            EXPECT_SUCCESS(s2n_psk_init(second_psk, S2N_PSK_TYPE_EXTERNAL));
+            EXPECT_SUCCESS(s2n_psk_new_secret(second_psk, test_value, sizeof(test_value)));
+
+            EXPECT_OK(s2n_psk_write_binder_list(conn, &client_hello_prefix, &out));
+
+            uint16_t binder_list_size = 0;
+            EXPECT_SUCCESS(s2n_stuffer_read_uint16(&out, &binder_list_size));
+            EXPECT_EQUAL(binder_list_size, s2n_stuffer_data_available(&out));
+
+            /* After reading both binders, the buffer should be empty. */
+            for (int i = 0; i < 2; i++) {
+                uint8_t binder_size = 0;
+                EXPECT_SUCCESS(s2n_stuffer_read_uint8(&out, &binder_size));
+                EXPECT_SUCCESS(s2n_stuffer_skip_read(&out, binder_size));
+            }
+            EXPECT_EQUAL(s2n_stuffer_data_available(&out), 0);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_stuffer_free(&out));
+        }
+
+        /* On a retry, do not write binders for PSKs that do not match the cipher suite */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            conn->handshake.handshake_type = HELLO_RETRY_REQUEST;
+            conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
+
+            struct s2n_stuffer out = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));
+
+            struct s2n_psk_parameters *params = &conn->psk_params;
+
+            struct s2n_psk *other_psk = NULL;
+            EXPECT_OK(s2n_array_pushback(&params->psk_list, (void**) &other_psk));
+            EXPECT_SUCCESS(s2n_psk_init(other_psk, S2N_PSK_TYPE_EXTERNAL));
+            EXPECT_SUCCESS(s2n_psk_new_secret(other_psk, test_value, sizeof(test_value)));
+            other_psk->hmac_alg = conn->secure.cipher_suite->prf_alg - 1;
+
+            struct s2n_psk *matching_psk = NULL;
+            EXPECT_OK(s2n_array_pushback(&params->psk_list, (void**) &matching_psk));
+            EXPECT_SUCCESS(s2n_psk_init(matching_psk, S2N_PSK_TYPE_EXTERNAL));
+            EXPECT_SUCCESS(s2n_psk_new_secret(matching_psk, test_value, sizeof(test_value)));
+            matching_psk->hmac_alg = conn->secure.cipher_suite->prf_alg;
+
+            EXPECT_OK(s2n_psk_write_binder_list(conn, &client_hello_prefix, &out));
+
+            uint16_t binder_list_size = 0;
+            EXPECT_SUCCESS(s2n_stuffer_read_uint16(&out, &binder_list_size));
+            EXPECT_EQUAL(binder_list_size, s2n_stuffer_data_available(&out));
+
+            /* There should only be one binder in the list
+             * (the other PSK was ignored because it didn't match the cipher suite)
+             * so that one binder should fill the rest of the stuffer. */
+            uint8_t binder_size = 0;
+            EXPECT_SUCCESS(s2n_stuffer_read_uint8(&out, &binder_size));
+            EXPECT_EQUAL(binder_size, s2n_stuffer_data_available(&out));
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_stuffer_free(&out));
+        }
+    }
+
     /* Test binder calculations with known values */
     {
         /* Test Vectors from https://tools.ietf.org/html/rfc8448#section-4 */

--- a/tests/unit/s2n_psk_test.c
+++ b/tests/unit/s2n_psk_test.c
@@ -274,7 +274,16 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_free(&out));
         }
 
-        /* On a retry, do not write binders for PSKs that do not match the cipher suite */
+        /* On a retry, do not write binders for PSKs that do not match the cipher suite.
+         *
+         *= https://tools.ietf.org/rfc/rfc8446#section-4.1.4
+         *= type=test
+         *# In addition, in its updated ClientHello, the client SHOULD NOT offer
+         *# any pre-shared keys associated with a hash other than that of the
+         *# selected cipher suite.  This allows the client to avoid having to
+         *# compute partial hash transcripts for multiple hashes in the second
+         *# ClientHello.
+         */
         {
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));

--- a/tests/unit/s2n_psk_test.c
+++ b/tests/unit/s2n_psk_test.c
@@ -246,10 +246,10 @@ int main(int argc, char **argv)
 
             struct s2n_psk_parameters *params = &conn->psk_params;
 
-            struct s2n_psk *fist_psk = NULL;
-            EXPECT_OK(s2n_array_pushback(&params->psk_list, (void**) &fist_psk));
-            EXPECT_SUCCESS(s2n_psk_init(fist_psk, S2N_PSK_TYPE_EXTERNAL));
-            EXPECT_SUCCESS(s2n_psk_new_secret(fist_psk, test_value, sizeof(test_value)));
+            struct s2n_psk *first_psk = NULL;
+            EXPECT_OK(s2n_array_pushback(&params->psk_list, (void**) &first_psk));
+            EXPECT_SUCCESS(s2n_psk_init(first_psk, S2N_PSK_TYPE_EXTERNAL));
+            EXPECT_SUCCESS(s2n_psk_new_secret(first_psk, test_value, sizeof(test_value)));
 
             struct s2n_psk *second_psk = NULL;
             EXPECT_OK(s2n_array_pushback(&params->psk_list, (void**) &second_psk));

--- a/tls/extensions/s2n_client_psk.c
+++ b/tls/extensions/s2n_client_psk.c
@@ -87,8 +87,9 @@ static int s2n_client_psk_send(struct s2n_connection *conn, struct s2n_stuffer *
         GUARD_AS_POSIX(s2n_array_get(psk_list, i, (void**) &psk));
         notnull_check(psk);
 
-        /*= https://tools.ietf.org/html/rfc8446#section-4.1.4
-         *# In its updated ClientHello, the client SHOULD NOT offer
+        /**
+         *= https://tools.ietf.org/rfc/rfc8446#section-4.1.4
+         *# In addition, in its updated ClientHello, the client SHOULD NOT offer
          *# any pre-shared keys associated with a hash other than that of the
          *# selected cipher suite.
          */

--- a/tls/extensions/s2n_client_psk.c
+++ b/tls/extensions/s2n_client_psk.c
@@ -87,10 +87,10 @@ static int s2n_client_psk_send(struct s2n_connection *conn, struct s2n_stuffer *
         GUARD_AS_POSIX(s2n_array_get(psk_list, i, (void**) &psk));
         notnull_check(psk);
 
-        /* From https://tools.ietf.org/html/rfc8446#section-4.1.4:
-         *   In its updated ClientHello, the client SHOULD NOT offer
-         *   any pre-shared keys associated with a hash other than that of the
-         *   selected cipher suite.
+        /*= https://tools.ietf.org/html/rfc8446#section-4.1.4
+         *# In its updated ClientHello, the client SHOULD NOT offer
+         *# any pre-shared keys associated with a hash other than that of the
+         *# selected cipher suite.
          */
         if (s2n_is_hello_retry_handshake(conn) && conn->secure.cipher_suite->prf_alg != psk->hmac_alg) {
             continue;

--- a/tls/extensions/s2n_client_psk.c
+++ b/tls/extensions/s2n_client_psk.c
@@ -41,8 +41,33 @@ const s2n_extension_type s2n_client_psk_extension = {
 
 bool s2n_client_psk_should_send(struct s2n_connection *conn)
 {
-    return conn && s2n_connection_get_protocol_version(conn) >= S2N_TLS13
-            && conn->psk_params.psk_list.len;
+    if (conn == NULL) {
+        return false;
+    }
+
+    if (s2n_connection_get_protocol_version(conn) < S2N_TLS13) {
+        return false;
+    }
+
+    /* If this is NOT the second ClientHello after a retry, then all PSKs are viable.
+     * Send the extension if any PSKs are configured.
+     */
+    if (!s2n_is_hello_retry_handshake(conn)) {
+        return conn->psk_params.psk_list.len > 0;
+    }
+
+    /* If this is the second ClientHello after a retry, then only PSKs that match the cipher suite
+     * are viable. Only send the extension if at least one configured PSK matches the cipher suite.
+     */
+    for (size_t i = 0; i < conn->psk_params.psk_list.len; i++) {
+        struct s2n_psk *psk = NULL;
+        if (s2n_result_is_ok(s2n_array_get(&conn->psk_params.psk_list, i, (void**) &psk))
+                && psk != NULL
+                && conn->secure.cipher_suite->prf_alg == psk->hmac_alg) {
+            return true;
+        }
+    }
+    return false;
 }
 
 static int s2n_client_psk_send(struct s2n_connection *conn, struct s2n_stuffer *out)
@@ -61,6 +86,15 @@ static int s2n_client_psk_send(struct s2n_connection *conn, struct s2n_stuffer *
         struct s2n_psk *psk = NULL;
         GUARD_AS_POSIX(s2n_array_get(psk_list, i, (void**) &psk));
         notnull_check(psk);
+
+        /* From https://tools.ietf.org/html/rfc8446#section-4.1.4:
+         *   In its updated ClientHello, the client SHOULD NOT offer
+         *   any pre-shared keys associated with a hash other than that of the
+         *   selected cipher suite.
+         */
+        if (s2n_is_hello_retry_handshake(conn) && conn->secure.cipher_suite->prf_alg != psk->hmac_alg) {
+            continue;
+        }
 
         /* Write the identity */
         GUARD(s2n_stuffer_write_uint16(out, psk->identity.size));

--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -246,10 +246,11 @@ static S2N_RESULT s2n_psk_write_binder_list(struct s2n_connection *conn, const s
         GUARD_RESULT(s2n_array_get(psk_list, i, (void**) &psk));
         ENSURE_REF(psk);
 
-        /*= https://tools.ietf.org/html/rfc8446#section-4.1.4
-         *# In its updated ClientHello, the client SHOULD NOT offer
+        /**
+         *= https://tools.ietf.org/rfc/rfc8446#section-4.1.4
+         *# In addition, in its updated ClientHello, the client SHOULD NOT offer
          *# any pre-shared keys associated with a hash other than that of the
-         *# selected cipher suite. This allows the client to avoid having to
+         *# selected cipher suite.  This allows the client to avoid having to
          *# compute partial hash transcripts for multiple hashes in the second
          *# ClientHello.
          */

--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -246,12 +246,12 @@ static S2N_RESULT s2n_psk_write_binder_list(struct s2n_connection *conn, const s
         GUARD_RESULT(s2n_array_get(psk_list, i, (void**) &psk));
         ENSURE_REF(psk);
 
-        /* From https://tools.ietf.org/html/rfc8446#section-4.1.4:
-         *   In its updated ClientHello, the client SHOULD NOT offer
-         *   any pre-shared keys associated with a hash other than that of the
-         *   selected cipher suite. This allows the client to avoid having to
-         *   compute partial hash transcripts for multiple hashes in the second
-         *   ClientHello.
+        /*= https://tools.ietf.org/html/rfc8446#section-4.1.4
+         *# In its updated ClientHello, the client SHOULD NOT offer
+         *# any pre-shared keys associated with a hash other than that of the
+         *# selected cipher suite. This allows the client to avoid having to
+         *# compute partial hash transcripts for multiple hashes in the second
+         *# ClientHello.
          */
         if (s2n_is_hello_retry_handshake(conn) && conn->secure.cipher_suite->prf_alg != psk->hmac_alg) {
             continue;

--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -246,6 +246,17 @@ static S2N_RESULT s2n_psk_write_binder_list(struct s2n_connection *conn, const s
         GUARD_RESULT(s2n_array_get(psk_list, i, (void**) &psk));
         ENSURE_REF(psk);
 
+        /* From https://tools.ietf.org/html/rfc8446#section-4.1.4:
+         *   In its updated ClientHello, the client SHOULD NOT offer
+         *   any pre-shared keys associated with a hash other than that of the
+         *   selected cipher suite. This allows the client to avoid having to
+         *   compute partial hash transcripts for multiple hashes in the second
+         *   ClientHello.
+         */
+        if (s2n_is_hello_retry_handshake(conn) && conn->secure.cipher_suite->prf_alg != psk->hmac_alg) {
+            continue;
+        }
+
         /* Retrieve or calculate the binder hash. */
         struct s2n_blob *binder_hash = &binder_hashes[psk->hmac_alg];
         if (binder_hash->size == 0) {


### PR DESCRIPTION
### Resolved issues:

related to https://github.com/awslabs/s2n/issues/2326

### Description of changes: 

When the client PSK extension is re-sent as part of a retry handshake, we can skip any PSKs that don't match the cipher suite chosen by the server. This improves performance, because we won't have to calculate binders for any of the skipped PSKs. If none of the PSKs are allowed by the cipher suite, then we don't have to send the extension at all.

### Call-outs:

We're adding comments that @camshaft's compliance tool can read now. Here's the report generated by the compliance tool: 
<img width="719" alt="Screen Shot 2021-01-12 at 10 51 53 AM" src="https://user-images.githubusercontent.com/22861302/104359291-53221d80-54c4-11eb-857f-0ff298658c06.png">



### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Unit tests.

 Is this a refactor change? No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
