### PR TITLE
compliance: format a few comments 

### DIFF
--- a/tls/extensions/s2n_client_psk.c
+++ b/tls/extensions/s2n_client_psk.c
@@ -138,11 +138,6 @@ static S2N_RESULT s2n_client_psk_recv_identity_list(struct s2n_connection *conn,
         struct s2n_blob identity = { 0 };
         GUARD_AS_RESULT(s2n_blob_init(&identity, identity_data, identity_size));
 
-        /* TODO: Validate obfuscated_ticket_age when using session tickets:
-         *
-         *       https://github.com/awslabs/s2n/issues/2417
-         */
-
         /**
          *= https://tools.ietf.org/rfc/rfc8446#section-4.2.11
          *# For identities established externally, an obfuscated_ticket_age of 0 SHOULD be

--- a/tls/extensions/s2n_client_psk.c
+++ b/tls/extensions/s2n_client_psk.c
@@ -138,10 +138,13 @@ static S2N_RESULT s2n_client_psk_recv_identity_list(struct s2n_connection *conn,
         struct s2n_blob identity = { 0 };
         GUARD_AS_RESULT(s2n_blob_init(&identity, identity_data, identity_size));
 
+        /* TODO: Validate obfuscated_ticket_age when using session tickets:
+         *
+         *       https://github.com/awslabs/s2n/issues/2417
+         */
+
         /**
          *= https://tools.ietf.org/rfc/rfc8446#section-4.2.11
-         *= type=TODO
-         *= tracking-issue=2417
          *# For identities established externally, an obfuscated_ticket_age of 0 SHOULD be
          *# used, and servers MUST ignore the value.
          */

--- a/tls/extensions/s2n_client_psk.c
+++ b/tls/extensions/s2n_client_psk.c
@@ -141,7 +141,7 @@ static S2N_RESULT s2n_client_psk_recv_identity_list(struct s2n_connection *conn,
         /**
          *= https://tools.ietf.org/rfc/rfc8446#section-4.2.11
          *= type=TODO
-         *= tracking-issue=https://github.com/awslabs/s2n/issues/2417
+         *= tracking-issue=2417
          *# For identities established externally, an obfuscated_ticket_age of 0 SHOULD be
          *# used, and servers MUST ignore the value.
          */

--- a/tls/extensions/s2n_client_psk.c
+++ b/tls/extensions/s2n_client_psk.c
@@ -138,11 +138,12 @@ static S2N_RESULT s2n_client_psk_recv_identity_list(struct s2n_connection *conn,
         struct s2n_blob identity = { 0 };
         GUARD_AS_RESULT(s2n_blob_init(&identity, identity_data, identity_size));
 
-        /* TODO: Validate obfuscated_ticket_age when using session tickets:
-         *       https://github.com/awslabs/s2n/issues/2417
-         *
-         * "For identities established externally, an obfuscated_ticket_age of 0 SHOULD be
-         * used, and servers MUST ignore the value."
+        /**
+         *= https://tools.ietf.org/rfc/rfc8446#section-4.2.11
+         *= type=TODO
+         *= tracking-issue=https://github.com/awslabs/s2n/issues/2417
+         *# For identities established externally, an obfuscated_ticket_age of 0 SHOULD be
+         *# used, and servers MUST ignore the value.
          */
         uint32_t obfuscated_ticket_age = 0;
         GUARD_AS_RESULT(s2n_stuffer_read_uint32(wire_identities_in, &obfuscated_ticket_age));
@@ -247,10 +248,12 @@ int s2n_client_psk_recv(struct s2n_connection *conn, struct s2n_stuffer *extensi
         return S2N_SUCCESS;
     }
 
-    /* https://tools.ietf.org/html/rfc8446#section-4.2.11
-     * The "pre_shared_key" extension MUST be the last extension in the ClientHello.
-     * Servers MUST check that it is the last extension and otherwise fail the handshake
-     * with an "illegal_parameter" alert.
+    /**
+     *= https://tools.ietf.org/rfc/rfc8446#section-4.2.11
+     *# The "pre_shared_key" extension MUST be the last extension in the
+     *# ClientHello (this facilitates implementation as described below).
+     *# Servers MUST check that it is the last extension and otherwise fail
+     *# the handshake with an "illegal_parameter" alert.
      */
     s2n_extension_type_id psk_ext_id;
     GUARD(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_PRE_SHARED_KEY, &psk_ext_id));
@@ -259,9 +262,12 @@ int s2n_client_psk_recv(struct s2n_connection *conn, struct s2n_stuffer *extensi
     uint16_t extension_wire_index = conn->client_hello.extensions.parsed_extensions[psk_ext_id].wire_index;
     ENSURE_POSIX(extension_wire_index == last_wire_index, S2N_ERR_UNSUPPORTED_EXTENSION);
 
-    /* https://tools.ietf.org/html/rfc8446#section-4.2.9:
-     * If clients offer "pre_shared_key" without a "psk_key_exchange_modes" extension,
-     * servers MUST abort the handshake. We can safely do this check here because s2n_client_psk is
+    /**
+     *= https://tools.ietf.org/rfc/rfc8446#section-4.2.9
+     *# If clients offer "pre_shared_key" without a "psk_key_exchange_modes" extension,
+     *# servers MUST abort the handshake.
+     *
+     * We can safely do this check here because s2n_client_psk is
      * required to be the last extension sent in the list.
      */
     s2n_extension_type_id psk_ke_mode_ext_id;
@@ -283,18 +289,21 @@ int s2n_client_psk_recv(struct s2n_connection *conn, struct s2n_stuffer *extensi
     }
 
     if (s2n_result_is_error(s2n_client_psk_recv_identities(conn, extension))) {
-        /* https://tools.ietf.org/html/rfc8446#section-4.2.11:
-         *   "If no acceptable PSKs are found, the server SHOULD perform a non-PSK
-         *   handshake if possible."
+        /**
+         *= https://tools.ietf.org/rfc/rfc8446#section-4.2.11
+         *# If no acceptable PSKs are found, the server SHOULD perform a non-PSK
+         *# handshake if possible.
          */
         conn->psk_params.chosen_psk = NULL;
     }
 
     if (conn->psk_params.chosen_psk) {
-        /* https://tools.ietf.org/html/rfc8446#section-4.2.11:
-         *   "Prior to accepting PSK key establishment, the server MUST validate
-         *   the corresponding binder value. If this value is not present or does
-         *   not validate, the server MUST abort the handshake."
+        /**
+         *= https://tools.ietf.org/rfc/rfc8446#section-4.2.11
+         *# Prior to accepting PSK key establishment, the server MUST validate
+         *# the corresponding binder value (see Section 4.2.11.2 below).  If this
+         *# value is not present or does not validate, the server MUST abort the
+         *# handshake.
          */
         GUARD_AS_POSIX(s2n_client_psk_recv_binders(conn, extension));
     }


### PR DESCRIPTION
### Description of changes: 

In anticipation of using a tool to extract out RFC citations, this fixes a few comments to be in a more machine-readable format.

### Format

The citations must be written with the following format:

```c
/**
 *= https://tools.ietf.org/rfc/rfc8446#section-4.2.11
 *# CITATION TEXT
 *# GOES HERE
 */
```

Notice that we're linking to **rfc/rfc8446#section-4.2.11** and not html/rfc8446#section-4.2.11 or rfc/rfc8446.txt#section-4.2.11. This is important so the links stay canonical and consistent.

### Citation types

#### Implementation
By default, a citation is saying that the following block of code implements the requirement:

```c
/**
 *= https://tools.ietf.org/rfc/rfc8446#section-4.2.11
 *# CITATION TEXT
 *# GOES HERE
 */

/* my implementation here */
```

#### Tests
If the citation is a test, it should be written like

```c
/**
 *= https://tools.ietf.org/rfc/rfc8446#section-4.2.11
 *= type=test
 *# CITATION TEXT
 *# GOES HERE
 */

/* my test here */
```

#### TODO
If the citation is being written in but hasn't been implemented it can be marked as TODO:

```c
/**
 *= https://tools.ietf.org/rfc/rfc8446#section-4.2.11
 *= type=TODO
 *= tracking-issue=1234
 *# CITATION TEXT
 *# GOES HERE
 */
```

#### Exception

If we've decided not to implement something, it can be marked with an exception:

```c
/**
 *= https://tools.ietf.org/rfc/rfc8446#section-4.2.11
 *= type=exception
 *= reason=We don't think this is a good idea
 *# CITATION TEXT
 *# GOES HERE
 */
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
