### PR TITLE
New CloudFront 2021 security policy

### DIFF
--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -244,6 +244,7 @@ int main(int argc, char **argv)
             "CloudFront-TLS-1-1-2016",
             "CloudFront-TLS-1-2-2018",
             "CloudFront-TLS-1-2-2019",
+            "CloudFront-TLS-1-2-2021",
         };
         for (size_t i = 0; i < s2n_array_len(tls13_security_policy_strings); i++) {
             security_policy = NULL;

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -989,6 +989,21 @@ const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_2_2019 =
     .suites = cipher_suites_cloudfront_tls_1_2_2019,
 };
 
+struct s2n_cipher_suite *cipher_suites_cloudfront_tls_1_2_2021[] = {
+    S2N_TLS13_CLOUDFRONT_CIPHER_SUITES_20200716,
+    &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_ecdsa_with_chacha20_poly1305_sha256,
+    &s2n_ecdhe_rsa_with_chacha20_poly1305_sha256
+};
+
+const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_2_2021 = {
+    .count = s2n_array_len(cipher_suites_cloudfront_tls_1_2_2021),
+    .suites = cipher_suites_cloudfront_tls_1_2_2021,
+};
+
 struct s2n_cipher_suite *cipher_suites_kms_tls_1_0_2018_10[] = {
     &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
     &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -76,6 +76,7 @@ extern const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_0
 extern const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_1_2016;
 extern const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_2_2018;
 extern const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_2_2019;
+extern const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_2_2021;
 
 /* CloudFront viewer facing legacy TLS 1.2 policies */
 extern const struct s2n_cipher_preferences cipher_preferences_cloudfront_ssl_v_3_legacy;

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -224,6 +224,14 @@ const struct s2n_security_policy security_policy_cloudfront_tls_1_2_2019 = {
     .ecc_preferences = &s2n_ecc_preferences_20200310,
 };
 
+const struct s2n_security_policy security_policy_cloudfront_tls_1_2_2021 = {
+    .minimum_protocol_version = S2N_TLS12,
+    .cipher_preferences = &cipher_preferences_cloudfront_tls_1_2_2021,
+    .kem_preferences = &kem_preferences_null,
+    .signature_preferences = &s2n_signature_preferences_20200207,
+    .ecc_preferences = &s2n_ecc_preferences_20200310,
+};
+
 /* CloudFront viewer facing legacy TLS 1.2 policies */
 const struct s2n_security_policy security_policy_cloudfront_ssl_v_3_legacy = {
     .minimum_protocol_version = S2N_SSLv3,
@@ -558,6 +566,7 @@ struct s2n_security_policy_selection security_policy_selection[] = {
     { .version="CloudFront-TLS-1-1-2016", .security_policy=&security_policy_cloudfront_tls_1_1_2016, .ecc_extension_required=0, .pq_kem_extension_required=0 },
     { .version="CloudFront-TLS-1-2-2018", .security_policy=&security_policy_cloudfront_tls_1_2_2018, .ecc_extension_required=0, .pq_kem_extension_required=0 },
     { .version="CloudFront-TLS-1-2-2019", .security_policy=&security_policy_cloudfront_tls_1_2_2019, .ecc_extension_required=0, .pq_kem_extension_required=0 },
+    { .version="CloudFront-TLS-1-2-2021", .security_policy=&security_policy_cloudfront_tls_1_2_2021, .ecc_extension_required=0, .pq_kem_extension_required=0 },
     /* CloudFront Legacy (TLS 1.2) policies */
     { .version="CloudFront-SSL-v-3-Legacy", .security_policy=&security_policy_cloudfront_ssl_v_3_legacy, .ecc_extension_required=0, .pq_kem_extension_required=0 },
     { .version="CloudFront-TLS-1-0-2014-Legacy", .security_policy=&security_policy_cloudfront_tls_1_0_2014_legacy, .ecc_extension_required=0, .pq_kem_extension_required=0 },

--- a/tls/s2n_security_policies.h
+++ b/tls/s2n_security_policies.h
@@ -97,6 +97,7 @@ extern const struct s2n_security_policy security_policy_cloudfront_tls_1_0_2016;
 extern const struct s2n_security_policy security_policy_cloudfront_tls_1_1_2016;
 extern const struct s2n_security_policy security_policy_cloudfront_tls_1_2_2018;
 extern const struct s2n_security_policy security_policy_cloudfront_tls_1_2_2019;
+extern const struct s2n_security_policy security_policy_cloudfront_tls_1_2_2021;
 
 extern const struct s2n_security_policy security_policy_kms_tls_1_0_2018_10;
 extern const struct s2n_security_policy security_policy_kms_fips_tls_1_2_2018_10;


### PR DESCRIPTION
Add a new security policy which is similar to 2019 one, without weak
ciphers s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384, s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256 and
s2n_ecdhe_rsa_with_aes_128_cbc_sha256.

### Resolved issues:

 resolves #ISSUE-NUMBER1, resolves #ISSUE-NUMBER2, etc.

### Description of changes: 

Describe s2n’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.
### Call-outs:

Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
