### PR TITLE
add secp521r1 curve in test fips security policy

### DIFF
--- a/tests/integration/s2n_handshake_test_gnutls-cli.py
+++ b/tests/integration/s2n_handshake_test_gnutls-cli.py
@@ -333,9 +333,7 @@ def main():
                 return -1
 
     # Produce permutations of every curve s2n supports in every possible order
-    curves = ["CURVE-SECP256R1", "CURVE-SECP384R1"]
-    if not fips_mode:
-        curves.append("CURVE-SECP521R1")
+    curves = ["CURVE-SECP256R1", "CURVE-SECP384R1", "CURVE-SECP521R1"]
     for size in range(1, len(curves) + 1):
         print("\n\tTesting named curve preferences of size: " + str(size))
         threadpool = create_thread_pool()

--- a/tests/integration/s2n_handshake_test_s_client.py
+++ b/tests/integration/s2n_handshake_test_s_client.py
@@ -633,9 +633,7 @@ def elliptic_curve_test(host, port, libcrypto_version, fips_mode, **kwargs):
     Acceptance test for supported elliptic curves. Tests all possible supported curves with unsupported curves mixed in
     for noise.
     """
-    supported_curves = ["P-256", "P-384"]
-    if not fips_mode:
-        supported_curves.append("P-521")
+    supported_curves = ["P-256", "P-384", "P-521"]
     unsupported_curves = ["B-163", "K-409"]
     print("\n\tRunning elliptic curve tests:")
     print("\tExpected supported:   " + str(supported_curves))

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -488,8 +488,8 @@ const struct s2n_security_policy security_policy_test_all_fips = {
     .minimum_protocol_version = S2N_TLS10,
     .cipher_preferences = &cipher_preferences_test_all_fips,
     .kem_preferences = &kem_preferences_null,
-    .signature_preferences = &s2n_signature_preferences_20140601,
-    .ecc_preferences = &s2n_ecc_preferences_20140601,
+    .signature_preferences = &s2n_signature_preferences_20201021,
+    .ecc_preferences = &s2n_ecc_preferences_20201021,
 };
 
 const struct s2n_security_policy security_policy_test_all_ecdsa = {


### PR DESCRIPTION
### Description of changes: 

The secp521r1 curve is also fips compliance and should be test in fips mode. Update test_all_fips security policy to enable secp521r1 curve.

### Call-outs:

NA

### Testing:

Adding integ test for secp521r1 in fips mode.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
