### PR TITLE
Fix missing GUARDs after s2n_pkey_size calls

### DIFF
--- a/crypto/s2n_pkey.c
+++ b/crypto/s2n_pkey.c
@@ -21,6 +21,7 @@
 #include "crypto/s2n_rsa_pss.h"
 #include "crypto/s2n_pkey.h"
 
+#include "utils/s2n_result.h"
 #include "utils/s2n_safety.h"
 
 int s2n_pkey_zero_init(struct s2n_pkey *pkey) 
@@ -61,11 +62,15 @@ int s2n_pkey_check_key_exists(const struct s2n_pkey *pkey)
     return pkey->check_key(pkey);
 }
 
-int s2n_pkey_size(const struct s2n_pkey *pkey)
+S2N_RESULT s2n_pkey_size(const struct s2n_pkey *pkey, uint32_t *size_out)
 {
-    notnull_check(pkey->size);
+    ENSURE_REF(pkey);
+    ENSURE_REF(pkey->size);
+    ENSURE_REF(size_out);
 
-    return pkey->size(pkey);
+    GUARD_RESULT(pkey->size(pkey, size_out));
+
+    return S2N_RESULT_OK;
 }
 
 int s2n_pkey_sign(const struct s2n_pkey *pkey, s2n_signature_algorithm sig_alg,

--- a/crypto/s2n_pkey.h
+++ b/crypto/s2n_pkey.h
@@ -23,6 +23,7 @@
 #include "crypto/s2n_rsa.h"
 
 #include "utils/s2n_blob.h"
+#include "utils/s2n_result.h"
 
 /* Public/Private Key Type */
 typedef enum {
@@ -43,7 +44,7 @@ struct s2n_pkey {
     } key;
     EVP_PKEY *pkey;
 
-    int (*size)(const struct s2n_pkey *key);
+    S2N_RESULT (*size)(const struct s2n_pkey *key, uint32_t *size_out);
     int (*sign)(const struct s2n_pkey *priv_key, s2n_signature_algorithm sig_alg,
             struct s2n_hash_state *digest, struct s2n_blob *signature);
     int (*verify)(const struct s2n_pkey *pub_key, s2n_signature_algorithm sig_alg,
@@ -59,7 +60,7 @@ int s2n_pkey_zero_init(struct s2n_pkey *pkey);
 int s2n_pkey_setup_for_type(struct s2n_pkey *pkey, s2n_pkey_type pkey_type);
 int s2n_pkey_check_key_exists(const struct s2n_pkey *pkey);
 
-int s2n_pkey_size(const struct s2n_pkey *pkey);
+S2N_RESULT s2n_pkey_size(const struct s2n_pkey *pkey, uint32_t *size_out);
 int s2n_pkey_sign(const struct s2n_pkey *pkey, s2n_signature_algorithm sig_alg,
         struct s2n_hash_state *digest, struct s2n_blob *signature);
 int s2n_pkey_verify(const struct s2n_pkey *pkey, s2n_signature_algorithm sig_alg,

--- a/crypto/s2n_rsa.c
+++ b/crypto/s2n_rsa.c
@@ -13,51 +13,57 @@
  * permissions and limitations under the License.
  */
 
+#include "crypto/s2n_rsa.h"
+
 #include <openssl/evp.h>
 #include <openssl/rsa.h>
 #include <stdint.h>
 
-#include "error/s2n_errno.h"
-
-#include "stuffer/s2n_stuffer.h"
-
-#include "crypto/s2n_hash.h"
 #include "crypto/s2n_drbg.h"
-#include "crypto/s2n_rsa.h"
-#include "crypto/s2n_rsa_signing.h"
+#include "crypto/s2n_hash.h"
 #include "crypto/s2n_pkey.h"
-
-#include "utils/s2n_safety.h"
-#include "utils/s2n_random.h"
+#include "crypto/s2n_rsa_signing.h"
+#include "error/s2n_errno.h"
+#include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_blob.h"
+#include "utils/s2n_random.h"
+#include "utils/s2n_result.h"
+#include "utils/s2n_safety.h"
 
-static int s2n_rsa_modulus_check(RSA *rsa)
+static S2N_RESULT s2n_rsa_modulus_check(RSA *rsa)
 {
-    /* RSA was made opaque starting in Openssl 1.1.0 */
-    #if S2N_OPENSSL_VERSION_AT_LEAST(1,1,0) && !defined(LIBRESSL_VERSION_NUMBER)
-        const BIGNUM *n = NULL;
-        /* RSA still owns the memory for n */
-        RSA_get0_key(rsa, &n, NULL, NULL);
-        notnull_check(n);
-    #else
-        notnull_check(rsa->n);
-    #endif
-    return 0;
+/* RSA was made opaque starting in Openssl 1.1.0 */
+#if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0) && !defined(LIBRESSL_VERSION_NUMBER)
+    const BIGNUM *n = NULL;
+    /* RSA still owns the memory for n */
+    RSA_get0_key(rsa, &n, NULL, NULL);
+    ENSURE_REF(n);
+#else
+    ENSURE_REF(rsa->n);
+#endif
+    return S2N_RESULT_OK;
 }
 
-static int s2n_rsa_encrypted_size(const struct s2n_pkey *key)
+static S2N_RESULT s2n_rsa_encrypted_size(const struct s2n_pkey *key, uint32_t *size_out)
 {
+    ENSURE_REF(key);
+    ENSURE_REF(size_out);
+
     const struct s2n_rsa_key *rsa_key = &key->key.rsa_key;
-    notnull_check(rsa_key->rsa);
-    GUARD(s2n_rsa_modulus_check(rsa_key->rsa));
+    ENSURE_REF(rsa_key->rsa);
+    GUARD_RESULT(s2n_rsa_modulus_check(rsa_key->rsa));
 
-    return RSA_size(rsa_key->rsa);
+    const int size = RSA_size(rsa_key->rsa);
+    GUARD_AS_RESULT(size);
+    *size_out = size;
+
+    return S2N_RESULT_OK;
 }
 
-static int s2n_rsa_sign(const struct s2n_pkey *priv, s2n_signature_algorithm sig_alg,
-        struct s2n_hash_state *digest, struct s2n_blob *signature)
+static int s2n_rsa_sign(const struct s2n_pkey *priv, s2n_signature_algorithm sig_alg, struct s2n_hash_state *digest,
+                        struct s2n_blob *signature)
 {
-    switch(sig_alg) {
+    switch (sig_alg) {
         case S2N_SIGNATURE_RSA:
             return s2n_rsa_pkcs1v15_sign(priv, digest, signature);
         case S2N_SIGNATURE_RSA_PSS_RSAE:
@@ -69,10 +75,10 @@ static int s2n_rsa_sign(const struct s2n_pkey *priv, s2n_signature_algorithm sig
     return S2N_SUCCESS;
 }
 
-static int s2n_rsa_verify(const struct s2n_pkey *pub, s2n_signature_algorithm sig_alg,
-        struct s2n_hash_state *digest, struct s2n_blob *signature)
+static int s2n_rsa_verify(const struct s2n_pkey *pub, s2n_signature_algorithm sig_alg, struct s2n_hash_state *digest,
+                          struct s2n_blob *signature)
 {
-    switch(sig_alg) {
+    switch (sig_alg) {
         case S2N_SIGNATURE_RSA:
             return s2n_rsa_pkcs1v15_verify(pub, digest, signature);
         case S2N_SIGNATURE_RSA_PSS_RSAE:
@@ -86,10 +92,13 @@ static int s2n_rsa_verify(const struct s2n_pkey *pub, s2n_signature_algorithm si
 
 static int s2n_rsa_encrypt(const struct s2n_pkey *pub, struct s2n_blob *in, struct s2n_blob *out)
 {
-    S2N_ERROR_IF(out->size < s2n_rsa_encrypted_size(pub), S2N_ERR_NOMEM);
+    uint32_t size = 0;
+    GUARD_AS_POSIX(s2n_rsa_encrypted_size(pub, &size));
+    S2N_ERROR_IF(out->size < size, S2N_ERR_NOMEM);
 
     const s2n_rsa_public_key *key = &pub->key.rsa_key;
-    int r = RSA_public_encrypt(in->size, (unsigned char *)in->data, (unsigned char *)out->data, key->rsa, RSA_PKCS1_PADDING);
+    int r = RSA_public_encrypt(in->size, ( unsigned char * )in->data, ( unsigned char * )out->data, key->rsa,
+                               RSA_PKCS1_PADDING);
     S2N_ERROR_IF(r != out->size, S2N_ERR_SIZE_MISMATCH);
 
     return 0;
@@ -97,17 +106,18 @@ static int s2n_rsa_encrypt(const struct s2n_pkey *pub, struct s2n_blob *in, stru
 
 static int s2n_rsa_decrypt(const struct s2n_pkey *priv, struct s2n_blob *in, struct s2n_blob *out)
 {
-    unsigned char intermediate[4096];
-    const int expected_size = s2n_rsa_encrypted_size(priv);
+    unsigned char intermediate[ 4096 ];
+    uint32_t      expected_size = 0;
 
-    GUARD(expected_size);
+    GUARD_AS_POSIX(s2n_rsa_encrypted_size(priv, &expected_size));
+
     S2N_ERROR_IF(expected_size > sizeof(intermediate), S2N_ERR_NOMEM);
     S2N_ERROR_IF(out->size > sizeof(intermediate), S2N_ERR_NOMEM);
 
     GUARD_AS_POSIX(s2n_get_public_random_data(out));
 
     const s2n_rsa_private_key *key = &priv->key.rsa_key;
-    int r = RSA_private_decrypt(in->size, (unsigned char *)in->data, intermediate, key->rsa, RSA_NO_PADDING);
+    int r = RSA_private_decrypt(in->size, ( unsigned char * )in->data, intermediate, key->rsa, RSA_NO_PADDING);
     S2N_ERROR_IF(r != expected_size, S2N_ERR_SIZE_MISMATCH);
 
     s2n_constant_time_pkcs1_unpad_or_dont(out->data, intermediate, r, out->size);
@@ -117,14 +127,14 @@ static int s2n_rsa_decrypt(const struct s2n_pkey *priv, struct s2n_blob *in, str
 
 static int s2n_rsa_keys_match(const struct s2n_pkey *pub, const struct s2n_pkey *priv)
 {
-    uint8_t plain_inpad[36] = {1}, plain_outpad[36] = {0}, encpad[8192];
+    uint8_t         plain_inpad[ 36 ] = { 1 }, plain_outpad[ 36 ] = { 0 }, encpad[ 8192 ];
     struct s2n_blob plain_in = { 0 }, plain_out = { 0 }, enc = { 0 };
 
     plain_in.data = plain_inpad;
     plain_in.size = sizeof(plain_inpad);
 
     enc.data = encpad;
-    enc.size = s2n_rsa_encrypted_size(pub);
+    GUARD_AS_POSIX(s2n_rsa_encrypted_size(pub, &enc.size));
     lte_check(enc.size, sizeof(encpad));
     GUARD(s2n_rsa_encrypt(pub, &plain_in, &enc));
 
@@ -140,9 +150,7 @@ static int s2n_rsa_keys_match(const struct s2n_pkey *pub, const struct s2n_pkey 
 static int s2n_rsa_key_free(struct s2n_pkey *pkey)
 {
     struct s2n_rsa_key *rsa_key = &pkey->key.rsa_key;
-    if (rsa_key->rsa == NULL) {
-        return 0;
-    }
+    if (rsa_key->rsa == NULL) { return 0; }
 
     RSA_free(rsa_key->rsa);
     rsa_key->rsa = NULL;
@@ -177,13 +185,13 @@ int s2n_evp_pkey_to_rsa_private_key(s2n_rsa_private_key *rsa_key, EVP_PKEY *evp_
 
 int s2n_rsa_pkey_init(struct s2n_pkey *pkey)
 {
-    pkey->size = &s2n_rsa_encrypted_size;
-    pkey->sign = &s2n_rsa_sign;
-    pkey->verify = &s2n_rsa_verify;
-    pkey->encrypt = &s2n_rsa_encrypt;
-    pkey->decrypt = &s2n_rsa_decrypt;
-    pkey->match = &s2n_rsa_keys_match;
-    pkey->free = &s2n_rsa_key_free;
+    pkey->size      = &s2n_rsa_encrypted_size;
+    pkey->sign      = &s2n_rsa_sign;
+    pkey->verify    = &s2n_rsa_verify;
+    pkey->encrypt   = &s2n_rsa_encrypt;
+    pkey->decrypt   = &s2n_rsa_decrypt;
+    pkey->match     = &s2n_rsa_keys_match;
+    pkey->free      = &s2n_rsa_key_free;
     pkey->check_key = &s2n_rsa_check_key_exists;
     return 0;
 }

--- a/crypto/s2n_rsa_pss.c
+++ b/crypto/s2n_rsa_pss.c
@@ -41,12 +41,17 @@ int s2n_is_rsa_pss_certs_supported()
 
 #if RSA_PSS_CERTS_SUPPORTED
 
-static int s2n_rsa_pss_size(const struct s2n_pkey *key)
+static S2N_RESULT s2n_rsa_pss_size(const struct s2n_pkey *key, uint32_t *size_out)
 {
-    notnull_check(key);
+    ENSURE_REF(key);
+    ENSURE_REF(size_out);
 
     /* For more info, see: https://www.openssl.org/docs/man1.1.0/man3/EVP_PKEY_size.html */
-    return EVP_PKEY_size(key->pkey);
+    const int size = EVP_PKEY_size(key->pkey);
+    GUARD_AS_RESULT(size);
+    *size_out = size;
+
+    return S2N_RESULT_OK;
 }
 
 static int s2n_rsa_is_private_key(RSA *rsa_key)

--- a/tests/unit/s2n_client_cert_verify_test.c
+++ b/tests/unit/s2n_client_cert_verify_test.c
@@ -21,15 +21,17 @@
 
 #include "tls/s2n_tls.h"
 #include "tls/s2n_connection.h"
+#include "utils/s2n_result.h"
 #include "utils/s2n_safety.h"
 
 const uint8_t test_signature_data[] = "I signed this";
 const uint32_t test_signature_size = sizeof(test_signature_data);
 const uint32_t test_max_signature_size = 2 * sizeof(test_signature_data);
 
-static int test_size(const struct s2n_pkey *pkey)
+static S2N_RESULT test_size(const struct s2n_pkey *pkey, uint32_t *size_out)
 {
-    return test_max_signature_size;
+    *size_out = test_max_signature_size;
+    return S2N_RESULT_OK;
 }
 
 static int test_sign(const struct s2n_pkey *priv_key, s2n_signature_algorithm sig_alg,

--- a/tests/unit/s2n_ecdsa_test.c
+++ b/tests/unit/s2n_ecdsa_test.c
@@ -141,8 +141,9 @@ int main(int argc, char **argv)
     uint8_t inputpad[] = "Hello world!";
     struct s2n_blob signature = {0}, bad_signature = {0};
     struct s2n_hash_state hash_one = {0}, hash_two = {0};
-    uint32_t maximum_signature_length = s2n_pkey_size(&priv_key);
 
+    uint32_t maximum_signature_length = 0;
+    EXPECT_OK(s2n_pkey_size(&priv_key, &maximum_signature_length));
     EXPECT_SUCCESS(s2n_alloc(&signature, maximum_signature_length));
 
     EXPECT_SUCCESS(s2n_hash_new(&hash_one));
@@ -173,7 +174,8 @@ int main(int argc, char **argv)
     }
 
     /* Mismatched public/private key should fail verification */
-    EXPECT_SUCCESS(s2n_alloc(&bad_signature, s2n_pkey_size(&unmatched_priv_key)));
+    EXPECT_OK(s2n_pkey_size(&unmatched_priv_key, &maximum_signature_length));
+    EXPECT_SUCCESS(s2n_alloc(&bad_signature, maximum_signature_length));
 
     EXPECT_FAILURE(s2n_pkey_match(&pub_key, &unmatched_priv_key));
 

--- a/tests/unit/s2n_pem_rsa_dhe_test.c
+++ b/tests/unit/s2n_pem_rsa_dhe_test.c
@@ -136,7 +136,9 @@ int main(int argc, char **argv)
     struct s2n_hash_state tls12_one = {0};
     struct s2n_hash_state tls12_two = {0};
 
-    EXPECT_SUCCESS(s2n_alloc(&signature, s2n_pkey_size(&pub_key)));
+    uint32_t maximum_signature_length = 0;
+    EXPECT_OK(s2n_pkey_size(&pub_key, &maximum_signature_length));
+    EXPECT_SUCCESS(s2n_alloc(&signature, maximum_signature_length));
 
     if (s2n_hash_is_available(S2N_HASH_MD5_SHA1)) {
         /* TLS 1.0 use of RSA with DHE is not permitted when FIPS mode is set */

--- a/tls/s2n_async_pkey.c
+++ b/tls/s2n_async_pkey.c
@@ -262,7 +262,8 @@ S2N_RESULT s2n_async_pkey_sign_sync(struct s2n_connection *conn, s2n_signature_a
     const struct s2n_pkey *pkey = conn->handshake_params.our_chain_and_key->private_key;
     DEFER_CLEANUP(struct s2n_blob signed_content = { 0 }, s2n_free);
 
-    uint32_t maximum_signature_length = s2n_pkey_size(pkey);
+    uint32_t maximum_signature_length = 0;
+    GUARD_RESULT(s2n_pkey_size(pkey, &maximum_signature_length));
     GUARD_AS_RESULT(s2n_alloc(&signed_content, maximum_signature_length));
 
     GUARD_AS_RESULT(s2n_pkey_sign(pkey, sig_alg, digest, &signed_content));
@@ -378,7 +379,8 @@ S2N_RESULT s2n_async_pkey_sign_perform(struct s2n_async_pkey_op *op, s2n_cert_pr
 
     struct s2n_async_pkey_sign_data *sign = &op->op.sign;
 
-    uint32_t maximum_signature_length = s2n_pkey_size(pkey);
+    uint32_t maximum_signature_length = 0;
+    GUARD_RESULT(s2n_pkey_size(pkey, &maximum_signature_length));
     GUARD_AS_RESULT(s2n_alloc(&sign->signature, maximum_signature_length));
 
     GUARD_AS_RESULT(s2n_pkey_sign(pkey, sign->sig_alg, &sign->digest, &sign->signature));

--- a/tls/s2n_client_cert_verify.c
+++ b/tls/s2n_client_cert_verify.c
@@ -76,7 +76,8 @@ int s2n_client_cert_verify_send(struct s2n_connection *conn)
     struct s2n_cert_chain_and_key *cert_chain_and_key = conn->handshake_params.our_chain_and_key;
 
     DEFER_CLEANUP(struct s2n_blob signature = {0}, s2n_free);
-    uint32_t max_signature_size = s2n_pkey_size(cert_chain_and_key->private_key);
+    uint32_t max_signature_size = 0;
+    GUARD_AS_POSIX(s2n_pkey_size(cert_chain_and_key->private_key, &max_signature_size));
     GUARD(s2n_alloc(&signature, max_signature_size));
 
     GUARD(s2n_pkey_sign(cert_chain_and_key->private_key, chosen_sig_scheme.sig_alg, &conn->handshake.ccv_hash_copy, &signature));

--- a/tls/s2n_client_key_exchange.c
+++ b/tls/s2n_client_key_exchange.c
@@ -260,8 +260,9 @@ int s2n_rsa_client_key_send(struct s2n_connection *conn, struct s2n_blob *shared
      */
     memcpy_check(conn->secure.rsa_premaster_secret, client_hello_protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN);
 
-    int encrypted_size = s2n_pkey_size(&conn->secure.server_public_key);
-    S2N_ERROR_IF(encrypted_size < 0 || encrypted_size > 0xffff, S2N_ERR_SIZE_MISMATCH);
+    uint32_t encrypted_size = 0;
+    GUARD_AS_POSIX(s2n_pkey_size(&conn->secure.server_public_key, &encrypted_size));
+    S2N_ERROR_IF(encrypted_size > 0xffff, S2N_ERR_SIZE_MISMATCH);
 
     if (conn->actual_protocol_version > S2N_SSLv3) {
         GUARD(s2n_stuffer_write_uint16(&conn->handshake.io, encrypted_size));


### PR DESCRIPTION
### Description of changes: 

Fixes lack of `GUARD`s  after `s2n_pkey_size` calls.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
