### PR TITLE
[PSK] Correct PSK + cert interaction

### DIFF
--- a/tests/unit/s2n_auth_selection_test.c
+++ b/tests/unit/s2n_auth_selection_test.c
@@ -107,7 +107,7 @@ int main(int argc, char **argv)
             s2n_connection_set_config(conn, no_certs_config);
             EXPECT_FAILURE(s2n_is_cipher_suite_valid_for_auth(conn, RSA_AUTH_CIPHER_SUITE));
             EXPECT_FAILURE(s2n_is_cipher_suite_valid_for_auth(conn, ECDSA_AUTH_CIPHER_SUITE));
-            EXPECT_FAILURE(s2n_is_cipher_suite_valid_for_auth(conn, NO_AUTH_CIPHER_SUITE));
+            EXPECT_SUCCESS(s2n_is_cipher_suite_valid_for_auth(conn, NO_AUTH_CIPHER_SUITE));
 
             /* RSA certs exist */
             s2n_connection_set_config(conn, rsa_cert_config);
@@ -119,7 +119,7 @@ int main(int argc, char **argv)
             s2n_connection_set_config(conn, rsa_pss_cert_config);
             EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_is_cipher_suite_valid_for_auth(conn, RSA_AUTH_CIPHER_SUITE));
             EXPECT_FAILURE(s2n_is_cipher_suite_valid_for_auth(conn, ECDSA_AUTH_CIPHER_SUITE));
-            EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_is_cipher_suite_valid_for_auth(conn, NO_AUTH_CIPHER_SUITE));
+            EXPECT_SUCCESS(s2n_is_cipher_suite_valid_for_auth(conn, NO_AUTH_CIPHER_SUITE));
 
             /* ECDSA certs exist */
             s2n_connection_set_config(conn, ecdsa_cert_config);

--- a/tests/unit/s2n_client_hello_recv_test.c
+++ b/tests/unit/s2n_client_hello_recv_test.c
@@ -431,6 +431,29 @@ int main(int argc, char **argv)
         s2n_config_free(quic_config);
     }
 
+    /* Test that the server will not choose a signature algorithm or certificate if using PSKs */
+    {
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "default_tls13"));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
+
+        EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
+        EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io,
+                s2n_stuffer_data_available(&client_conn->handshake.io)));
+
+        struct s2n_psk chosen_psk = { 0 };
+        chosen_psk.hmac_alg = S2N_HMAC_SHA256;
+        server_conn->psk_params.chosen_psk = &chosen_psk;
+        EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
+
+        EXPECT_EQUAL(server_conn->secure.conn_sig_scheme.iana_value, 0);
+        EXPECT_NULL(server_conn->handshake_params.our_chain_and_key);
+
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+    }
+
     /* Test that curve selection will be NIST P-256 when tls12 client does not sending curve extension. */
     {
         S2N_BLOB_FROM_HEX(tls12_client_hello_no_curves,

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -105,7 +105,7 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_client_hello_send(conn));
             EXPECT_TRUE(s2n_stuffer_data_available(&conn->handshake.io) > 0);
-            EXPECT_FAILURE_WITH_ERRNO(s2n_client_hello_recv(conn), S2N_ERR_CIPHER_NOT_SUPPORTED);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_client_hello_recv(conn), S2N_ERR_INVALID_SIGNATURE_SCHEME);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }

--- a/tests/unit/s2n_client_psk_extension_test.c
+++ b/tests/unit/s2n_client_psk_extension_test.c
@@ -777,18 +777,8 @@ int main(int argc, char **argv)
         struct s2n_connection *client_conn, *server_conn;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-
-        /* Setup config */
-        struct s2n_cert_chain_and_key *chain_and_key = NULL;
-        EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
-                S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
-        struct s2n_config *config;
-        EXPECT_NOT_NULL(config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
-        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
-        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
-        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "default_tls13"));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
 
         /* Create nonblocking pipes */
         struct s2n_test_io_pair io_pair = { 0 };
@@ -839,8 +829,6 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
         EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
-        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
-        EXPECT_SUCCESS(s2n_config_free(config));
     }
 
     END_TEST();

--- a/tests/unit/s2n_server_psk_extension_test.c
+++ b/tests/unit/s2n_server_psk_extension_test.c
@@ -261,21 +261,8 @@ int main(int argc, char **argv)
         struct s2n_connection *client_conn, *server_conn;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-
-        /* Setup config */
-        struct s2n_cert_chain_and_key *chain_and_key = NULL;
-        EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
-                S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
-        struct s2n_config *config = NULL;
-        EXPECT_NOT_NULL(config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
-        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
-        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
-        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
-
-        EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(client_conn, S2N_TLS13));
-        EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "default_tls13"));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
 
         EXPECT_OK(setup_client_psks(client_conn));
         EXPECT_OK(setup_server_psks(server_conn));
@@ -308,8 +295,6 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
-        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
-        EXPECT_SUCCESS(s2n_config_free(config));
     }
 
     END_TEST();

--- a/tls/s2n_auth_selection.c
+++ b/tls/s2n_auth_selection.c
@@ -130,11 +130,15 @@ static int s2n_certs_exist_for_sig_scheme(struct s2n_connection *conn, const str
 
 static int s2n_certs_exist_for_auth_method(struct s2n_connection *conn, s2n_authentication_method auth_method)
 {
+    if (auth_method == S2N_AUTHENTICATION_METHOD_SENTINEL) {
+        return S2N_SUCCESS;
+    }
+
     s2n_authentication_method auth_method_for_cert_type;
     for (int i = 0; i < S2N_CERT_TYPE_COUNT; i++) {
         GUARD(s2n_get_auth_method_for_cert_type(i, &auth_method_for_cert_type));
 
-        if (auth_method != S2N_AUTHENTICATION_METHOD_SENTINEL && auth_method != auth_method_for_cert_type) {
+        if (auth_method != auth_method_for_cert_type) {
             continue;
         }
 
@@ -145,11 +149,10 @@ static int s2n_certs_exist_for_auth_method(struct s2n_connection *conn, s2n_auth
     S2N_ERROR(S2N_ERR_CERT_TYPE_UNSUPPORTED);
 }
 
-/* A cipher suite is valid if:
- * - At least one compatible cert is configured
+/* TLS1.3 ciphers are always valid, as they don't include an auth method.
  *
- * TLS1.3 ciphers are valid if ANY certs are configured, as authentication
- * method is not tied to cipher suites in TLS1.3.
+ * A pre-TLS1.3 cipher suite is valid if:
+ * - At least one compatible cert is configured
  *
  * This method is called by the server when choosing a cipher suite.
  */

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -1232,11 +1232,12 @@ static int s2n_set_cipher_as_server(struct s2n_connection *conn, uint8_t *wire, 
                 }
             }
 
-            /* For TLS1.3 when PSKs are present, the server must consider the hash algorithm associated with the chosen PSK
-             * when choosing a cipher suite. Server MUST reject any cipher suite without a matching hash algorithm and 
-             * continue to the next candidate. 
-             * */     
-            if (conn->actual_protocol_version >= S2N_TLS13 && conn->psk_params.chosen_psk != NULL) {
+            /**
+             *= https://tools.ietf.org/rfc/rfc8446#section-4.2.11
+             *# The server MUST ensure that it selects a compatible PSK
+             *# (if any) and cipher suite.
+             **/
+            if (conn->psk_params.chosen_psk != NULL) {
                 if (match->prf_alg != conn->psk_params.chosen_psk->hmac_alg) {
                     continue;
                 }

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -285,6 +285,12 @@ int s2n_process_client_hello(struct s2n_connection *conn)
     /* Now choose the ciphers we have certs for. */
     GUARD(s2n_set_cipher_as_tls_server(conn, client_hello->cipher_suites.data, client_hello->cipher_suites.size / 2));
 
+    /* If we're using a PSK, we don't need to choose a signature algorithm or certificate,
+     * because no additional auth is required. */
+    if (conn->psk_params.chosen_psk != NULL) {
+        return S2N_SUCCESS;
+    }
+
     /* And set the signature and hash algorithm used for key exchange signatures */
     GUARD(s2n_choose_sig_scheme_from_peer_preference_list(conn,
         &conn->handshake_params.client_sig_hash_algs,
@@ -293,7 +299,7 @@ int s2n_process_client_hello(struct s2n_connection *conn)
     /* And finally, set the certs specified by the final auth + sig_alg combo. */
     GUARD(s2n_select_certs_for_server_auth(conn, &conn->handshake_params.our_chain_and_key));
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_client_hello_recv(struct s2n_connection *conn)


### PR DESCRIPTION
### Description of changes: 

A certificate should not be required to negotiate a PSK connection, but currently negotiation fails if attempted without a certificate because:

1. Despite not having auth methods, TLS1.3 cipher suites are not considered "valid" for negotiation unless at least one cert (of any type) is configured
2. We always select a signature algorithm at the end of the ClientHello, which requires at least one certificate to be configured
3. We always select a certificate at the end of the ClientHello, which obviously requires at least one certificate to be configured

This fixes these issues by:
1. Always considering a TLS1.3 cipher suite "valid" with respect to auth. This makes more sense than the old logic, because in TLS1.3 cipher suites don't depend on an auth method.
2. Skipping signature algorithm selection when using a PSK
3. Skipping certificate selection when using a PSK

### Call-outs:

**Failing tests**: The test refactor I did as part of this PR exposed a problem with s2n_psk_parameters and the s2n_connection lifecycle. I fix the memory leak in this PR: https://github.com/awslabs/s2n/pull/2523 Including it in this PR made both changes harder to follow.

**Removed tests**: I removed the "and is TLS1.3" check from the cipher selection logic. It should be impossible to have a chosen PSK without TLS1.3, and if we want to keep the check it should be an assertion / ENSURE_POSIX instead (but I think it's unnecessary). This simplified the testing.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
