### PR TITLE
Fix and simplify psk_param lifecycle

### DIFF
--- a/tests/unit/s2n_cipher_suite_match_test.c
+++ b/tests/unit/s2n_cipher_suite_match_test.c
@@ -28,10 +28,9 @@ static s2n_result s2n_conn_set_chosen_psk(struct s2n_connection *conn) {
     ENSURE_REF(conn);
 
     uint8_t psk_identity[] = "psk identity";
-    GUARD_RESULT(s2n_psk_parameters_init(&conn->psk_params));
     GUARD_RESULT(s2n_array_pushback(&conn->psk_params.psk_list, (void**) &conn->psk_params.chosen_psk));
-    GUARD_AS_RESULT(s2n_psk_init(conn->psk_params.chosen_psk, S2N_PSK_TYPE_EXTERNAL));
     ENSURE_REF(conn->psk_params.chosen_psk);
+    GUARD_AS_RESULT(s2n_psk_init(conn->psk_params.chosen_psk, S2N_PSK_TYPE_EXTERNAL));
     GUARD_AS_RESULT(s2n_psk_new_identity(conn->psk_params.chosen_psk, psk_identity, sizeof(psk_identity)));
 
     return S2N_RESULT_OK;
@@ -152,7 +151,6 @@ int main(int argc, char **argv)
                                       S2N_ERR_CIPHER_NOT_SUPPORTED);
             EXPECT_EQUAL(conn->secure.cipher_suite, &s2n_null_cipher_suite);
 
-            EXPECT_SUCCESS(s2n_psk_parameters_free(&conn->psk_params));
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
         }
 
@@ -171,7 +169,6 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_set_cipher_as_client(conn, valid_tls13_wire_ciphers));
             EXPECT_EQUAL(conn->secure.cipher_suite, &s2n_tls13_aes_128_gcm_sha256);
 
-            EXPECT_SUCCESS(s2n_psk_parameters_free(&conn->psk_params));
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
         }
 
@@ -798,7 +795,6 @@ int main(int argc, char **argv)
                 EXPECT_EQUAL(conn->secure.cipher_suite, &s2n_tls13_aes_128_gcm_sha256);
                 EXPECT_EQUAL(conn->secure.cipher_suite->prf_alg, conn->psk_params.chosen_psk->hmac_alg);
 
-                EXPECT_SUCCESS(s2n_psk_parameters_free(&conn->psk_params));
                 EXPECT_SUCCESS(s2n_connection_wipe(conn));
             }
 
@@ -816,7 +812,6 @@ int main(int argc, char **argv)
                 EXPECT_FAILURE_WITH_ERRNO(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_tls13, cipher_count_tls13), S2N_ERR_CIPHER_NOT_SUPPORTED);
                 EXPECT_EQUAL(conn->secure.cipher_suite, &s2n_null_cipher_suite);
 
-                EXPECT_SUCCESS(s2n_psk_parameters_free(&conn->psk_params));
                 EXPECT_SUCCESS(s2n_connection_wipe(conn));
             }
 
@@ -833,7 +828,6 @@ int main(int argc, char **argv)
                 EXPECT_EQUAL(conn->secure.cipher_suite, &s2n_rsa_with_aes_128_cbc_sha);
                 EXPECT_EQUAL(conn->secure.cipher_suite->prf_alg, S2N_HMAC_SHA256);
 
-                EXPECT_SUCCESS(s2n_psk_parameters_free(&conn->psk_params));
                 EXPECT_SUCCESS(s2n_connection_wipe(conn));
             }
 
@@ -851,8 +845,6 @@ int main(int argc, char **argv)
                 EXPECT_EQUAL(conn->secure.cipher_suite->prf_alg, S2N_HMAC_SHA256);
                 EXPECT_NOT_EQUAL(conn->secure.cipher_suite->prf_alg, conn->psk_params.chosen_psk->hmac_alg);
 
-
-                EXPECT_SUCCESS(s2n_psk_parameters_free(&conn->psk_params));
                 EXPECT_SUCCESS(s2n_connection_wipe(conn));
             }
 
@@ -877,7 +869,6 @@ int main(int argc, char **argv)
                 EXPECT_EQUAL(conn->secure.cipher_suite->prf_alg, S2N_HMAC_SHA256);
                 EXPECT_NOT_EQUAL(conn->secure.cipher_suite->prf_alg, conn->psk_params.chosen_psk->hmac_alg);
 
-                EXPECT_SUCCESS(s2n_psk_parameters_free(&conn->psk_params));
                 EXPECT_SUCCESS(s2n_connection_wipe(conn));
             }
 
@@ -901,7 +892,6 @@ int main(int argc, char **argv)
                 EXPECT_EQUAL(conn->secure.cipher_suite->prf_alg, S2N_HMAC_SHA256);
                 EXPECT_NOT_EQUAL(conn->secure.cipher_suite->prf_alg, conn->psk_params.chosen_psk->hmac_alg);
 
-                EXPECT_SUCCESS(s2n_psk_parameters_free(&conn->psk_params));
                 EXPECT_SUCCESS(s2n_connection_wipe(conn));
             }
         }

--- a/tests/unit/s2n_client_psk_extension_test.c
+++ b/tests/unit/s2n_client_psk_extension_test.c
@@ -216,7 +216,7 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(match, expected_match);
         }
 
-        EXPECT_SUCCESS(s2n_psk_parameters_wipe(&params));
+        EXPECT_OK(s2n_psk_parameters_wipe(&params));
     }
 
     /* Test: s2n_client_psk_recv_identity_list */

--- a/tests/unit/s2n_client_psk_extension_test.c
+++ b/tests/unit/s2n_client_psk_extension_test.c
@@ -216,7 +216,7 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(match, expected_match);
         }
 
-        EXPECT_SUCCESS(s2n_psk_parameters_free(&params));
+        EXPECT_SUCCESS(s2n_psk_parameters_wipe(&params));
     }
 
     /* Test: s2n_client_psk_recv_identity_list */

--- a/tests/unit/s2n_psk_test.c
+++ b/tests/unit/s2n_psk_test.c
@@ -151,8 +151,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_psk_init(other_psk, S2N_PSK_TYPE_EXTERNAL));
         EXPECT_SUCCESS(s2n_psk_new_identity(other_psk, test_value, sizeof(test_value)));
 
-        EXPECT_FAILURE_WITH_ERRNO(s2n_psk_parameters_wipe(NULL), S2N_ERR_NULL);
-        EXPECT_SUCCESS(s2n_psk_parameters_wipe(&params));
+        EXPECT_ERROR_WITH_ERRNO(s2n_psk_parameters_wipe(NULL), S2N_ERR_NULL);
+        EXPECT_OK(s2n_psk_parameters_wipe(&params));
 
         /* Verify params are wiped.
          * The params should be back to their initial state. */

--- a/tests/unit/s2n_tls13_handshake_test.c
+++ b/tests/unit/s2n_tls13_handshake_test.c
@@ -341,6 +341,8 @@ int main(int argc, char **argv)
                 EXPECT_NOT_EQUAL(psk->identity.size, 0);
                 EXPECT_NOT_EQUAL(psk->identity.data, NULL);
             }
+
+            EXPECT_NOT_EQUAL(conn->psk_params.psk_list.mem.allocated, 0);
             EXPECT_EQUAL(conn->psk_params.psk_list.len, S2N_TEST_PSK_COUNT);
 
             EXPECT_SUCCESS(s2n_tls13_handle_handshake_secrets(conn));

--- a/tests/unit/s2n_tls13_handshake_test.c
+++ b/tests/unit/s2n_tls13_handshake_test.c
@@ -333,7 +333,6 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
 
             const uint8_t psk_data[] = "test";
-            struct s2n_psk *test_psks[S2N_TEST_PSK_COUNT] = { 0 };
             for (size_t i = 0; i < S2N_TEST_PSK_COUNT; i++) {
                 struct s2n_psk *psk = NULL;
                 EXPECT_OK(s2n_array_pushback(&conn->psk_params.psk_list, (void**) &psk));
@@ -341,18 +340,13 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_psk_new_identity(psk, psk_data, sizeof(psk_data)));
                 EXPECT_NOT_EQUAL(psk->identity.size, 0);
                 EXPECT_NOT_EQUAL(psk->identity.data, NULL);
-                test_psks[i] = psk;
             }
             EXPECT_EQUAL(conn->psk_params.psk_list.len, S2N_TEST_PSK_COUNT);
 
             EXPECT_SUCCESS(s2n_tls13_handle_handshake_secrets(conn));
 
-            /* Verify all PSKs are wiped */
-            for (size_t i = 0; i < S2N_TEST_PSK_COUNT; i++) {
-                struct s2n_psk *psk = test_psks[i];
-                EXPECT_EQUAL(psk->identity.size, 0);
-                EXPECT_EQUAL(psk->identity.data, NULL);
-            }
+            /* Verify PSKs are wiped */
+            EXPECT_EQUAL(conn->psk_params.psk_list.mem.allocated, 0);
             EXPECT_EQUAL(conn->psk_params.psk_list.len, 0);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -452,7 +452,7 @@ int s2n_connection_free(struct s2n_connection *conn)
 {
     GUARD(s2n_connection_wipe_keys(conn));
     GUARD(s2n_connection_free_keys(conn));
-    GUARD(s2n_psk_parameters_free(&conn->psk_params));
+    GUARD(s2n_psk_parameters_wipe(&conn->psk_params));
 
     GUARD(s2n_prf_free(conn));
 
@@ -628,7 +628,7 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     GUARD(s2n_stuffer_wipe(&conn->in));
     GUARD(s2n_stuffer_wipe(&conn->out));
 
-    GUARD_AS_POSIX(s2n_psk_parameters_wipe(&conn->psk_params));
+    GUARD(s2n_psk_parameters_wipe(&conn->psk_params));
 
     /* Wipe the I/O-related info and restore the original socket if necessary */
     GUARD(s2n_connection_wipe_io(conn));

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -452,7 +452,7 @@ int s2n_connection_free(struct s2n_connection *conn)
 {
     GUARD(s2n_connection_wipe_keys(conn));
     GUARD(s2n_connection_free_keys(conn));
-    GUARD(s2n_psk_parameters_wipe(&conn->psk_params));
+    GUARD_AS_POSIX(s2n_psk_parameters_wipe(&conn->psk_params));
 
     GUARD(s2n_prf_free(conn));
 
@@ -628,7 +628,7 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     GUARD(s2n_stuffer_wipe(&conn->in));
     GUARD(s2n_stuffer_wipe(&conn->out));
 
-    GUARD(s2n_psk_parameters_wipe(&conn->psk_params));
+    GUARD_AS_POSIX(s2n_psk_parameters_wipe(&conn->psk_params));
 
     /* Wipe the I/O-related info and restore the original socket if necessary */
     GUARD(s2n_connection_wipe_io(conn));

--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -78,19 +78,19 @@ S2N_RESULT s2n_psk_parameters_init(struct s2n_psk_parameters *params)
     return S2N_RESULT_OK;
 }
 
-int s2n_psk_parameters_wipe(struct s2n_psk_parameters *params)
+S2N_CLEANUP_RESULT s2n_psk_parameters_wipe(struct s2n_psk_parameters *params)
 {
-    notnull_check(params);
+    ENSURE_REF(params);
 
     for (size_t i = 0; i < params->psk_list.len; i++) {
         struct s2n_psk *psk;
-        GUARD_AS_POSIX(s2n_array_get(&params->psk_list, i, (void**)&psk));
-        GUARD(s2n_psk_free(psk));
+        GUARD_RESULT(s2n_array_get(&params->psk_list, i, (void**)&psk));
+        GUARD_AS_RESULT(s2n_psk_free(psk));
     }
-    GUARD(s2n_free(&params->psk_list.mem));
-    GUARD_AS_POSIX(s2n_psk_parameters_init(params));
+    GUARD_AS_RESULT(s2n_free(&params->psk_list.mem));
+    GUARD_RESULT(s2n_psk_parameters_init(params));
 
-    return S2N_SUCCESS;
+    return S2N_RESULT_OK;
 }
 
 /* The binder hash is computed by hashing the concatenation of the current transcript

--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -78,28 +78,18 @@ S2N_RESULT s2n_psk_parameters_init(struct s2n_psk_parameters *params)
     return S2N_RESULT_OK;
 }
 
-S2N_RESULT s2n_psk_parameters_wipe(struct s2n_psk_parameters *params)
+int s2n_psk_parameters_wipe(struct s2n_psk_parameters *params)
 {
-    ENSURE_REF(params);
+    notnull_check(params);
 
     for (size_t i = 0; i < params->psk_list.len; i++) {
         struct s2n_psk *psk;
-        GUARD_RESULT(s2n_array_get(&params->psk_list, i, (void**)&psk));
-        GUARD_AS_RESULT(s2n_psk_free(psk));
+        GUARD_AS_POSIX(s2n_array_get(&params->psk_list, i, (void**)&psk));
+        GUARD(s2n_psk_free(psk));
     }
-
-    struct s2n_blob psk_list_mem = params->psk_list.mem;
-    s2n_result result = s2n_psk_parameters_init(params);
-    params->psk_list.mem = psk_list_mem;
-
-    return result;
-}
-
-int s2n_psk_parameters_free(struct s2n_psk_parameters *params)
-{
-    notnull_check(params);
-    GUARD_AS_POSIX(s2n_psk_parameters_wipe(params));
     GUARD(s2n_free(&params->psk_list.mem));
+    GUARD_AS_POSIX(s2n_psk_parameters_init(params));
+
     return S2N_SUCCESS;
 }
 

--- a/tls/s2n_psk.h
+++ b/tls/s2n_psk.h
@@ -56,7 +56,7 @@ int s2n_psk_new_secret(struct s2n_psk *psk, const uint8_t *secret, size_t secret
 int s2n_psk_free(struct s2n_psk *psk);
 
 S2N_RESULT s2n_psk_parameters_init(struct s2n_psk_parameters *params);
-int s2n_psk_parameters_wipe(struct s2n_psk_parameters *params);
+S2N_CLEANUP_RESULT s2n_psk_parameters_wipe(struct s2n_psk_parameters *params);
 
 S2N_RESULT s2n_finish_psk_extension(struct s2n_connection *conn);
 

--- a/tls/s2n_psk.h
+++ b/tls/s2n_psk.h
@@ -56,8 +56,7 @@ int s2n_psk_new_secret(struct s2n_psk *psk, const uint8_t *secret, size_t secret
 int s2n_psk_free(struct s2n_psk *psk);
 
 S2N_RESULT s2n_psk_parameters_init(struct s2n_psk_parameters *params);
-S2N_RESULT s2n_psk_parameters_wipe(struct s2n_psk_parameters *params);
-int s2n_psk_parameters_free(struct s2n_psk_parameters *params);
+int s2n_psk_parameters_wipe(struct s2n_psk_parameters *params);
 
 S2N_RESULT s2n_finish_psk_extension(struct s2n_connection *conn);
 

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -191,7 +191,7 @@ int s2n_tls13_handle_handshake_secrets(struct s2n_connection *conn)
     /* derive early secrets */
     GUARD(s2n_tls13_derive_early_secrets(&secrets, conn->psk_params.chosen_psk));
     /* since early secrets have been computed, PSKs are no longer needed and can be cleaned up */
-    GUARD_AS_POSIX(s2n_psk_parameters_wipe(&conn->psk_params));
+    GUARD(s2n_psk_parameters_wipe(&conn->psk_params));
 
     /* produce handshake secrets */
     s2n_stack_blob(client_hs_secret, secrets.size, S2N_TLS13_SECRET_MAX_LEN);

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -191,7 +191,7 @@ int s2n_tls13_handle_handshake_secrets(struct s2n_connection *conn)
     /* derive early secrets */
     GUARD(s2n_tls13_derive_early_secrets(&secrets, conn->psk_params.chosen_psk));
     /* since early secrets have been computed, PSKs are no longer needed and can be cleaned up */
-    GUARD(s2n_psk_parameters_wipe(&conn->psk_params));
+    GUARD_AS_POSIX(s2n_psk_parameters_wipe(&conn->psk_params));
 
     /* produce handshake secrets */
     s2n_stack_blob(client_hs_secret, secrets.size, S2N_TLS13_SECRET_MAX_LEN);

--- a/utils/s2n_result.h
+++ b/utils/s2n_result.h
@@ -44,5 +44,10 @@ S2N_RESULT_MUST_USE bool s2n_result_is_error(s2n_result result);
 /* used in function declarations to signal function fallibility */
 #define S2N_RESULT S2N_RESULT_MUST_USE s2n_result
 
+/* The DEFER_CLEANUP macro discards the result of its cleanup function.
+ * We need a version of s2n_result which can be ignored.
+ */
+#define S2N_CLEANUP_RESULT s2n_result
+
 /* converts the S2N_RESULT into posix error codes */
 #define S2N_RESULT_TO_POSIX( x ) (s2n_result_is_ok(x) ? S2N_SUCCESS : S2N_FAILURE)


### PR DESCRIPTION
### Description of changes: 

The memory leaks in https://github.com/awslabs/s2n/pull/2519 are caused by incorrect behavior in s2n_connection_wipe. Previously, s2n_psk_parameters_wipe wiped the individual PSK blobs (for identity, secret, etc) but not the memory allocated for the list, to avoid re-allocating the list memory. However after that call, s2n_connection_wipe() calls s2n_connection_zero(), which zeroes the entire connection object, including the s2n_psk_parameters. Not only did this lead to us NOT reusing the psk list memory, it led to that memory leaking. 

To fix this, I'm simplifying the s2n_psk_parameters lifecycle. Now we just free all the memory associated with the s2n_psk_parameters when the connection is wiped. If this proves to be a performance issue later, we can always optimize later.

## Callouts

**Why remove the EXPECTS in the unit tests that verify the identity/secrets of PSKs are freed?** Because the PSKs themselves are now freed when the psk_list array memory is freed. We can't check that a pointer in a freed block of memory is NULL. However, our CI includes builds that check for memory leaks, which should verify that the identity/secret memory wasn't leaked.

**Why create S2N_CLEANUP_RESULT instead of just using s2n_result?** Having both "s2n_result" and "S2N_RESULT" return types could cause confusion, possibly leading to people using "s2n_result" when "S2N_RESULT" should have been used. S2N_CLEANUP_RESULT documents what the purpose of the new return type is in its name, so that people won't try to use it outside of cleanup methods.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Unit tests, including one written to explicitly test the connection new/wipe/free lifecycle for psk_params.

 Is this a refactor change? No, different behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
