### PR TITLE
Migrate some KEX functions to S2N_RESULT

### DIFF
--- a/tests/unit/s2n_kex_test.c
+++ b/tests/unit/s2n_kex_test.c
@@ -32,17 +32,19 @@ int main(int argc, char **argv)
         test_cipher_with_null_kex.key_exchange_alg = NULL;
 
         /* Null cipher suite kex - possible with tls1.3 cipher suites */
-        EXPECT_FAILURE(s2n_configure_kex(NULL, &conn));
-        EXPECT_FAILURE(s2n_configure_kex(&test_cipher_with_null_kex, NULL));
+        EXPECT_ERROR(s2n_configure_kex(NULL, &conn));
+        EXPECT_ERROR(s2n_configure_kex(&test_cipher_with_null_kex, NULL));
 
         /* Null kex -- possible with tls1.3 cipher suites */
-        EXPECT_FAILURE(s2n_kex_is_ephemeral(NULL));
-        EXPECT_FAILURE(s2n_kex_server_key_recv_parse_data(NULL, &conn, &test_raw_server_data));
-        EXPECT_FAILURE(s2n_kex_server_key_recv_read_data(NULL, &conn, &blob, &test_raw_server_data));
-        EXPECT_FAILURE(s2n_kex_server_key_send(NULL, &conn, &blob));
-        EXPECT_FAILURE(s2n_kex_client_key_recv(NULL, &conn, &blob));
-        EXPECT_FAILURE(s2n_kex_client_key_send(NULL, &conn, &blob));
-        EXPECT_FAILURE(s2n_kex_tls_prf(NULL, &conn, &blob));
+        bool is_ephemeral = false;
+        EXPECT_ERROR(s2n_kex_is_ephemeral(NULL, &is_ephemeral));
+        EXPECT_ERROR(s2n_kex_is_ephemeral(&s2n_rsa, NULL));
+        EXPECT_ERROR(s2n_kex_server_key_recv_parse_data(NULL, &conn, &test_raw_server_data));
+        EXPECT_ERROR(s2n_kex_server_key_recv_read_data(NULL, &conn, &blob, &test_raw_server_data));
+        EXPECT_ERROR(s2n_kex_server_key_send(NULL, &conn, &blob));
+        EXPECT_ERROR(s2n_kex_client_key_recv(NULL, &conn, &blob));
+        EXPECT_ERROR(s2n_kex_client_key_send(NULL, &conn, &blob));
+        EXPECT_ERROR(s2n_kex_tls_prf(NULL, &conn, &blob));
     }
 
     /* Test s2n_kex_includes */

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -1222,12 +1222,14 @@ static int s2n_set_cipher_as_server(struct s2n_connection *conn, uint8_t *wire, 
             /* TLS 1.3 does not include key exchange in cipher suites */
             if (match->minimum_required_tls_version < S2N_TLS13) {
                 /* If the kex is not supported continue to the next candidate */
-                if (!s2n_kex_supported(match, conn)) {
+                bool kex_supported = false;
+                GUARD_AS_POSIX(s2n_kex_supported(match, conn, &kex_supported));
+                if (!kex_supported) {
                     continue;
                 }
 
                 /* If the kex is not configured correctly continue to the next candidate */
-                if (s2n_configure_kex(match, conn)) {
+                if (s2n_result_is_error(s2n_configure_kex(match, conn))) {
                     continue;
                 }
             }

--- a/tls/s2n_client_key_exchange.c
+++ b/tls/s2n_client_key_exchange.c
@@ -37,7 +37,7 @@
 
 #define get_client_hello_protocol_version(conn) (conn->client_hello_version == S2N_SSLv2 ? conn->client_protocol_version : conn->client_hello_version)
 
-typedef int s2n_kex_client_key_method(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *shared_key);
+typedef S2N_RESULT s2n_kex_client_key_method(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *shared_key);
 typedef void *s2n_stuffer_action(struct s2n_stuffer *stuffer, uint32_t data_len);
 
 static int s2n_rsa_client_key_recv_complete(struct s2n_connection *conn, bool rsa_failed, struct s2n_blob *shared_key);
@@ -58,10 +58,10 @@ static int s2n_hybrid_client_action(struct s2n_connection *conn, struct s2n_blob
     const uint32_t start_cursor = *cursor;
 
     DEFER_CLEANUP(struct s2n_blob shared_key_0 = {0}, s2n_free);
-    GUARD(kex_method(hybrid_kex_0, conn, &shared_key_0));
+    GUARD_AS_POSIX(kex_method(hybrid_kex_0, conn, &shared_key_0));
 
     struct s2n_blob *shared_key_1 = &(conn->secure.kem_params.shared_secret);
-    GUARD(kex_method(hybrid_kex_1, conn, shared_key_1));
+    GUARD_AS_POSIX(kex_method(hybrid_kex_1, conn, shared_key_1));
 
     const uint32_t end_cursor = *cursor;
     gte_check(end_cursor, start_cursor);
@@ -81,7 +81,7 @@ static int s2n_hybrid_client_action(struct s2n_connection *conn, struct s2n_blob
 static int s2n_calculate_keys(struct s2n_connection *conn, struct s2n_blob *shared_key)
 {
     /* Turn the pre-master secret into a master secret */
-    GUARD(s2n_kex_tls_prf(conn->secure.cipher_suite->key_exchange_alg, conn, shared_key));
+    GUARD_AS_POSIX(s2n_kex_tls_prf(conn->secure.cipher_suite->key_exchange_alg, conn, shared_key));
     /* Erase the pre-master secret */
     GUARD(s2n_blob_zero(shared_key));
     if (shared_key->allocated) {
@@ -216,7 +216,7 @@ int s2n_client_key_recv(struct s2n_connection *conn)
     const struct s2n_kex *key_exchange = conn->secure.cipher_suite->key_exchange_alg;
     struct s2n_blob shared_key = {0};
 
-    GUARD(s2n_kex_client_key_recv(key_exchange, conn, &shared_key));
+    GUARD_AS_POSIX(s2n_kex_client_key_recv(key_exchange, conn, &shared_key));
 
     GUARD(s2n_calculate_keys(conn, &shared_key));
     return 0;
@@ -312,7 +312,7 @@ int s2n_client_key_send(struct s2n_connection *conn)
     const struct s2n_kex *key_exchange = conn->secure.cipher_suite->key_exchange_alg;
     struct s2n_blob shared_key = {0};
 
-    GUARD(s2n_kex_client_key_send(key_exchange, conn, &shared_key));
+    GUARD_AS_POSIX(s2n_kex_client_key_send(key_exchange, conn, &shared_key));
 
     GUARD(s2n_calculate_keys(conn, &shared_key));
     return 0;

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -724,7 +724,9 @@ skip_cache_lookup:
     /* If we get this far, it's a full handshake */
     conn->handshake.handshake_type |= FULL_HANDSHAKE;
 
-    if (s2n_kex_is_ephemeral(conn->secure.cipher_suite->key_exchange_alg)) {
+    bool is_ephemeral = false;
+    GUARD_AS_POSIX(s2n_kex_is_ephemeral(conn->secure.cipher_suite->key_exchange_alg, &is_ephemeral));
+    if (is_ephemeral) {
         conn->handshake.handshake_type |= TLS12_PERFECT_FORWARD_SECRECY;
     }
 

--- a/tls/s2n_kex.c
+++ b/tls/s2n_kex.c
@@ -24,48 +24,65 @@
 #include "tls/s2n_tls.h"
 #include "utils/s2n_safety.h"
 
-static int s2n_check_rsa_key(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn)
+static S2N_RESULT s2n_check_rsa_key(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn, bool *is_supported)
 {
-    return s2n_get_compatible_cert_chain_and_key(conn, S2N_PKEY_TYPE_RSA) != NULL;
+    ENSURE_REF(cipher_suite);
+    ENSURE_REF(conn);
+    ENSURE_REF(is_supported);
+
+    *is_supported = s2n_get_compatible_cert_chain_and_key(conn, S2N_PKEY_TYPE_RSA) != NULL;
+
+    return S2N_RESULT_OK;
 }
 
-static int s2n_check_dhe(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn)
+static S2N_RESULT s2n_check_dhe(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn, bool *is_supported)
 {
-    return conn->config->dhparams != NULL;
+    ENSURE_REF(cipher_suite);
+    ENSURE_REF(conn);
+    ENSURE_REF(conn->config);
+    ENSURE_REF(is_supported);
+
+    *is_supported = conn->config->dhparams != NULL;
+
+    return S2N_RESULT_OK;
 }
 
-static int s2n_check_ecdhe(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn)
+static S2N_RESULT s2n_check_ecdhe(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn, bool *is_supported)
 {
-    return conn->secure.server_ecc_evp_params.negotiated_curve != NULL;
+    ENSURE_REF(cipher_suite);
+    ENSURE_REF(conn);
+    ENSURE_REF(is_supported);
+
+    *is_supported = conn->secure.server_ecc_evp_params.negotiated_curve != NULL;
+
+    return S2N_RESULT_OK;
 }
 
-static int s2n_check_kem(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn)
+static S2N_RESULT s2n_check_kem(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn, bool *is_supported)
 {
-    /* The int return value is treated like a bool; avoid using notnull_check(), etc */
-    if (cipher_suite == NULL || conn == NULL) {
-        return 0;
-    }
+    ENSURE_REF(cipher_suite);
+    ENSURE_REF(conn);
+    ENSURE_REF(is_supported);
 
-    if (!s2n_pq_is_enabled()) {
-        return 0;
-    }
+    /* If any of the necessary conditions are not met, we will return early and indicate KEM is not supported. */
+    *is_supported = false;
 
     const struct s2n_kem_preferences *kem_preferences = NULL;
-    if (s2n_connection_get_kem_preferences(conn, &kem_preferences) != S2N_SUCCESS) {
-        return 0;
-    }
+    GUARD_AS_RESULT(s2n_connection_get_kem_preferences(conn, &kem_preferences));
+    ENSURE_REF(kem_preferences);
 
-    if (kem_preferences == NULL || kem_preferences->kem_count == 0) {
-        return 0;
+    if (!s2n_pq_is_enabled() || kem_preferences->kem_count == 0) {
+        return S2N_RESULT_OK;
     }
 
     const struct s2n_iana_to_kem *supported_params = NULL;
-    /* If the cipher suite has no supported KEMs return false */
     if (s2n_cipher_suite_to_kem(cipher_suite->iana_value, &supported_params) != S2N_SUCCESS) {
-        return 0;
+        return S2N_RESULT_OK;
     }
+
+    ENSURE_REF(supported_params);
     if (supported_params->kem_count == 0) {
-        return 0;
+        return S2N_RESULT_OK;
     }
 
     struct s2n_blob *client_kem_pref_list = &(conn->secure.client_pq_kem_extension);
@@ -74,58 +91,70 @@ static int s2n_check_kem(const struct s2n_cipher_suite *cipher_suite, struct s2n
         /* If the client did not send a PQ KEM extension, then the server can pick its preferred parameter */
         if (s2n_choose_kem_without_peer_pref_list(cipher_suite->iana_value, kem_preferences->kems,
                 kem_preferences->kem_count, &chosen_kem) != S2N_SUCCESS) {
-            return 0;
+            return S2N_RESULT_OK;
         }
     } else {
         /* If the client did send a PQ KEM extension, then the server must find a mutually supported parameter. */
         if (s2n_choose_kem_with_peer_pref_list(cipher_suite->iana_value, client_kem_pref_list, kem_preferences->kems,
                 kem_preferences->kem_count, &chosen_kem) != S2N_SUCCESS) {
-            return 0;
+            return S2N_RESULT_OK;
         }
     }
 
-    return chosen_kem != NULL;
+    *is_supported = chosen_kem != NULL;
+    return S2N_RESULT_OK;
 }
 
-static int s2n_configure_kem(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn)
+static S2N_RESULT s2n_configure_kem(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn)
 {
-    notnull_check(cipher_suite);
-    notnull_check(conn);
+    ENSURE_REF(cipher_suite);
+    ENSURE_REF(conn);
 
-    ENSURE_POSIX(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
+    ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
 
     const struct s2n_kem_preferences *kem_preferences = NULL;
-    GUARD(s2n_connection_get_kem_preferences(conn, &kem_preferences));
-    notnull_check(kem_preferences);
+    GUARD_AS_RESULT(s2n_connection_get_kem_preferences(conn, &kem_preferences));
+    ENSURE_REF(kem_preferences);
 
     struct s2n_blob *proposed_kems = &(conn->secure.client_pq_kem_extension);
     const struct s2n_kem *chosen_kem = NULL;
     if (proposed_kems == NULL || proposed_kems->data == NULL) {
         /* If the client did not send a PQ KEM extension, then the server can pick its preferred parameter */
-        GUARD(s2n_choose_kem_without_peer_pref_list(cipher_suite->iana_value, kem_preferences->kems,
-                                                    kem_preferences->kem_count, &chosen_kem));
+        GUARD_AS_RESULT(s2n_choose_kem_without_peer_pref_list(cipher_suite->iana_value, kem_preferences->kems,
+                kem_preferences->kem_count, &chosen_kem));
     } else {
         /* If the client did send a PQ KEM extension, then the server must find a mutually supported parameter. */
-        GUARD(s2n_choose_kem_with_peer_pref_list(cipher_suite->iana_value, proposed_kems, kem_preferences->kems,
-                                                 kem_preferences->kem_count, &chosen_kem));
+        GUARD_AS_RESULT(s2n_choose_kem_with_peer_pref_list(cipher_suite->iana_value, proposed_kems, kem_preferences->kems,
+                kem_preferences->kem_count, &chosen_kem));
     }
 
     conn->secure.kem_params.kem = chosen_kem;
-    return 0;
+    return S2N_RESULT_OK;
 }
 
-static int s2n_no_op_configure(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn)
+static S2N_RESULT s2n_no_op_configure(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn)
 {
-    return 0;
+    return S2N_RESULT_OK;
 }
 
-static int s2n_check_hybrid_ecdhe_kem(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn)
+static S2N_RESULT s2n_check_hybrid_ecdhe_kem(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn, bool *is_supported)
 {
-    return s2n_check_ecdhe(cipher_suite, conn) && s2n_check_kem(cipher_suite, conn);
+    ENSURE_REF(cipher_suite);
+    ENSURE_REF(conn);
+    ENSURE_REF(is_supported);
+
+    bool ecdhe_supported = false;
+    bool kem_supported = false;
+    GUARD_RESULT(s2n_check_ecdhe(cipher_suite, conn, &ecdhe_supported));
+    GUARD_RESULT(s2n_check_kem(cipher_suite, conn, &kem_supported));
+
+    *is_supported = ecdhe_supported && kem_supported;
+
+    return S2N_RESULT_OK;
 }
 
 const struct s2n_kex s2n_kem = {
-    .is_ephemeral = 1,
+    .is_ephemeral = true,
     .connection_supported = &s2n_check_kem,
     .configure_connection = &s2n_configure_kem,
     .server_key_recv_read_data = &s2n_kem_server_key_recv_read_data,
@@ -136,7 +165,7 @@ const struct s2n_kex s2n_kem = {
 };
 
 const struct s2n_kex s2n_rsa = {
-    .is_ephemeral = 0,
+    .is_ephemeral = false,
     .connection_supported = &s2n_check_rsa_key,
     .configure_connection = &s2n_no_op_configure,
     .server_key_recv_read_data = NULL,
@@ -148,7 +177,7 @@ const struct s2n_kex s2n_rsa = {
 };
 
 const struct s2n_kex s2n_dhe = {
-    .is_ephemeral = 1,
+    .is_ephemeral = true,
     .connection_supported = &s2n_check_dhe,
     .configure_connection = &s2n_no_op_configure,
     .server_key_recv_read_data = &s2n_dhe_server_key_recv_read_data,
@@ -160,7 +189,7 @@ const struct s2n_kex s2n_dhe = {
 };
 
 const struct s2n_kex s2n_ecdhe = {
-    .is_ephemeral = 1,
+    .is_ephemeral = true,
     .connection_supported = &s2n_check_ecdhe,
     .configure_connection = &s2n_no_op_configure,
     .server_key_recv_read_data = &s2n_ecdhe_server_key_recv_read_data,
@@ -172,7 +201,7 @@ const struct s2n_kex s2n_ecdhe = {
 };
 
 const struct s2n_kex s2n_hybrid_ecdhe_kem = {
-    .is_ephemeral = 1,
+    .is_ephemeral = true,
     .hybrid = { &s2n_ecdhe, &s2n_kem },
     .connection_supported = &s2n_check_hybrid_ecdhe_kem,
     .configure_connection = &s2n_configure_kem,
@@ -184,66 +213,112 @@ const struct s2n_kex s2n_hybrid_ecdhe_kem = {
     .prf = &s2n_hybrid_prf_master_secret,
 };
 
-int s2n_kex_supported(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn)
+S2N_RESULT s2n_kex_supported(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn, bool *is_supported)
 {
-    /* Don't return -1 from notnull_check because that might allow a improperly configured kex to be marked as "supported" */
-    return cipher_suite->key_exchange_alg->connection_supported != NULL && cipher_suite->key_exchange_alg->connection_supported(cipher_suite, conn);
+    ENSURE_REF(cipher_suite);
+    ENSURE_REF(cipher_suite->key_exchange_alg);
+    ENSURE_REF(cipher_suite->key_exchange_alg->connection_supported);
+    ENSURE_REF(conn);
+    ENSURE_REF(is_supported);
+
+    GUARD_RESULT(cipher_suite->key_exchange_alg->connection_supported(cipher_suite, conn, is_supported));
+
+    return S2N_RESULT_OK;
 }
 
-int s2n_configure_kex(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn)
+S2N_RESULT s2n_configure_kex(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn)
 {
-    notnull_check(cipher_suite);
-    notnull_check(cipher_suite->key_exchange_alg);
-    notnull_check(cipher_suite->key_exchange_alg->configure_connection);
-    return cipher_suite->key_exchange_alg->configure_connection(cipher_suite, conn);
+    ENSURE_REF(cipher_suite);
+    ENSURE_REF(cipher_suite->key_exchange_alg);
+    ENSURE_REF(cipher_suite->key_exchange_alg->configure_connection);
+    ENSURE_REF(conn);
+
+    GUARD_RESULT(cipher_suite->key_exchange_alg->configure_connection(cipher_suite, conn));
+
+    return S2N_RESULT_OK;
 }
 
-int s2n_kex_is_ephemeral(const struct s2n_kex *kex)
+S2N_RESULT s2n_kex_is_ephemeral(const struct s2n_kex *kex, bool *is_ephemeral)
 {
-    notnull_check(kex);
-    return kex->is_ephemeral;
+    ENSURE_REF(kex);
+    ENSURE_REF(is_ephemeral);
+
+    *is_ephemeral = kex->is_ephemeral;
+
+    return S2N_RESULT_OK;
 }
 
-int s2n_kex_server_key_recv_parse_data(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_kex_raw_server_data *raw_server_data)
+S2N_RESULT s2n_kex_server_key_recv_parse_data(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_kex_raw_server_data *raw_server_data)
 {
-    notnull_check(kex);
-    notnull_check(kex->server_key_recv_parse_data);
-    return kex->server_key_recv_parse_data(conn, raw_server_data);
+    ENSURE_REF(kex);
+    ENSURE_REF(kex->server_key_recv_parse_data);
+    ENSURE_REF(conn);
+    ENSURE_REF(raw_server_data);
+
+    GUARD_AS_RESULT(kex->server_key_recv_parse_data(conn, raw_server_data));
+
+    return S2N_RESULT_OK;
 }
 
-int s2n_kex_server_key_recv_read_data(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *data_to_verify, struct s2n_kex_raw_server_data *raw_server_data)
+S2N_RESULT s2n_kex_server_key_recv_read_data(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *data_to_verify,
+        struct s2n_kex_raw_server_data *raw_server_data)
 {
-    notnull_check(kex);
-    notnull_check(kex->server_key_recv_read_data);
-    return kex->server_key_recv_read_data(conn, data_to_verify, raw_server_data);
+    ENSURE_REF(kex);
+    ENSURE_REF(kex->server_key_recv_read_data);
+    ENSURE_REF(conn);
+    ENSURE_REF(data_to_verify);
+
+    GUARD_AS_RESULT(kex->server_key_recv_read_data(conn, data_to_verify, raw_server_data));
+
+    return S2N_RESULT_OK;
 }
 
-int s2n_kex_server_key_send(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *data_to_sign)
+S2N_RESULT s2n_kex_server_key_send(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *data_to_sign)
 {
-    notnull_check(kex);
-    notnull_check(kex->server_key_send);
-    return kex->server_key_send(conn, data_to_sign);
+    ENSURE_REF(kex);
+    ENSURE_REF(kex->server_key_send);
+    ENSURE_REF(conn);
+    ENSURE_REF(data_to_sign);
+
+    GUARD_AS_RESULT(kex->server_key_send(conn, data_to_sign));
+
+    return S2N_RESULT_OK;
 }
 
-int s2n_kex_client_key_recv(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *shared_key)
+S2N_RESULT s2n_kex_client_key_recv(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *shared_key)
 {
-    notnull_check(kex);
-    notnull_check(kex->client_key_recv);
-    return kex->client_key_recv(conn, shared_key);
+    ENSURE_REF(kex);
+    ENSURE_REF(kex->client_key_recv);
+    ENSURE_REF(conn);
+    ENSURE_REF(shared_key);
+
+    GUARD_AS_RESULT(kex->client_key_recv(conn, shared_key));
+
+    return S2N_RESULT_OK;
 }
 
-int s2n_kex_client_key_send(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *shared_key)
+S2N_RESULT s2n_kex_client_key_send(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *shared_key)
 {
-    notnull_check(kex);
-    notnull_check(kex->client_key_send);
-    return kex->client_key_send(conn, shared_key);
+    ENSURE_REF(kex);
+    ENSURE_REF(kex->client_key_send);
+    ENSURE_REF(conn);
+    ENSURE_REF(shared_key);
+
+    GUARD_AS_RESULT(kex->client_key_send(conn, shared_key));
+
+    return S2N_RESULT_OK;
 }
 
-int s2n_kex_tls_prf(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *premaster_secret)
+S2N_RESULT s2n_kex_tls_prf(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *premaster_secret)
 {
-    notnull_check(kex);
-    notnull_check(kex->prf);
-    return kex->prf(conn, premaster_secret);
+    ENSURE_REF(kex);
+    ENSURE_REF(kex->prf);
+    ENSURE_REF(conn);
+    ENSURE_REF(premaster_secret);
+
+    GUARD_AS_RESULT(kex->prf(conn, premaster_secret));
+
+    return S2N_RESULT_OK;
 }
 
 bool s2n_kex_includes(const struct s2n_kex *kex, const struct s2n_kex *query)

--- a/tls/s2n_kex.h
+++ b/tls/s2n_kex.h
@@ -18,13 +18,14 @@
 #include <stdint.h>
 #include "tls/s2n_connection.h"
 #include "tls/s2n_kex_data.h"
+#include "utils/s2n_result.h"
 
 struct s2n_kex {
-    uint8_t is_ephemeral;
+    bool is_ephemeral;
     const struct s2n_kex *hybrid[2];
 
-    int (*connection_supported)(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn);
-    int (*configure_connection)(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn);
+    S2N_RESULT (*connection_supported)(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn, bool *is_supported);
+    S2N_RESULT (*configure_connection)(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn);
     int (*server_key_recv_read_data)(struct s2n_connection *conn, struct s2n_blob *data_to_verify, struct s2n_kex_raw_server_data *kex_data);
     int (*server_key_recv_parse_data)(struct s2n_connection *conn, struct s2n_kex_raw_server_data *kex_data);
     int (*server_key_send)(struct s2n_connection *conn, struct s2n_blob *data_to_sign);
@@ -39,17 +40,17 @@ extern const struct s2n_kex s2n_dhe;
 extern const struct s2n_kex s2n_ecdhe;
 extern const struct s2n_kex s2n_hybrid_ecdhe_kem;
 
-extern int s2n_kex_supported(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn);
-extern int s2n_configure_kex(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn);
-extern int s2n_kex_is_ephemeral(const struct s2n_kex *kex);
+extern S2N_RESULT s2n_kex_supported(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn, bool *is_supported);
+extern S2N_RESULT s2n_configure_kex(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn);
+extern S2N_RESULT s2n_kex_is_ephemeral(const struct s2n_kex *kex, bool *is_ephemeral);
 
-extern int s2n_kex_server_key_recv_read_data(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *data_to_verify,
+extern S2N_RESULT s2n_kex_server_key_recv_read_data(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *data_to_verify,
         struct s2n_kex_raw_server_data *raw_server_data);
-extern int s2n_kex_server_key_recv_parse_data(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_kex_raw_server_data *raw_server_data);
-extern int s2n_kex_server_key_send(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *data_to_sign);
-extern int s2n_kex_client_key_recv(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *shared_key);
-extern int s2n_kex_client_key_send(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *shared_key);
+extern S2N_RESULT s2n_kex_server_key_recv_parse_data(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_kex_raw_server_data *raw_server_data);
+extern S2N_RESULT s2n_kex_server_key_send(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *data_to_sign);
+extern S2N_RESULT s2n_kex_client_key_recv(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *shared_key);
+extern S2N_RESULT s2n_kex_client_key_send(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *shared_key);
 
-extern int s2n_kex_tls_prf(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *premaster_secret);
+extern S2N_RESULT s2n_kex_tls_prf(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *premaster_secret);
 
 extern bool s2n_kex_includes(const struct s2n_kex *kex, const struct s2n_kex *query);

--- a/tls/s2n_server_key_exchange.c
+++ b/tls/s2n_server_key_exchange.c
@@ -49,7 +49,7 @@ int s2n_server_key_recv(struct s2n_connection *conn)
 
     /* Read the KEX data */
     struct s2n_kex_raw_server_data kex_data = {0};
-    GUARD(s2n_kex_server_key_recv_read_data(key_exchange, conn, &data_to_verify, &kex_data));
+    GUARD_AS_POSIX(s2n_kex_server_key_recv_read_data(key_exchange, conn, &data_to_verify, &kex_data));
 
     /* Add common signature data */
     struct s2n_signature_scheme active_sig_scheme;
@@ -81,7 +81,7 @@ int s2n_server_key_recv(struct s2n_connection *conn)
     GUARD(s2n_pkey_free(&conn->secure.server_public_key));
 
     /* Parse the KEX data into whatever form needed and save it to the connection object */
-    GUARD(s2n_kex_server_key_recv_parse_data(key_exchange, conn, &kex_data));
+    GUARD_AS_POSIX(s2n_kex_server_key_recv_parse_data(key_exchange, conn, &kex_data));
     return 0;
 }
 
@@ -209,10 +209,10 @@ int s2n_hybrid_server_key_recv_read_data(struct s2n_connection *conn, struct s2n
     notnull_check(total_data_to_verify->data);
 
     struct s2n_blob data_to_verify_0 = {0};
-    GUARD(s2n_kex_server_key_recv_read_data(hybrid_kex_0, conn, &data_to_verify_0, raw_server_data));
+    GUARD_AS_POSIX(s2n_kex_server_key_recv_read_data(hybrid_kex_0, conn, &data_to_verify_0, raw_server_data));
 
     struct s2n_blob data_to_verify_1 = {0};
-    GUARD(s2n_kex_server_key_recv_read_data(hybrid_kex_1, conn, &data_to_verify_1, raw_server_data));
+    GUARD_AS_POSIX(s2n_kex_server_key_recv_read_data(hybrid_kex_1, conn, &data_to_verify_1, raw_server_data));
 
     total_data_to_verify->size = data_to_verify_0.size + data_to_verify_1.size;
     return 0;
@@ -226,8 +226,8 @@ int s2n_hybrid_server_key_recv_parse_data(struct s2n_connection *conn, struct s2
     const struct s2n_kex *hybrid_kex_0 = kex->hybrid[0];
     const struct s2n_kex *hybrid_kex_1 = kex->hybrid[1];
 
-    GUARD(s2n_kex_server_key_recv_parse_data(hybrid_kex_0, conn, raw_server_data));
-    GUARD(s2n_kex_server_key_recv_parse_data(hybrid_kex_1, conn, raw_server_data));
+    GUARD_AS_POSIX(s2n_kex_server_key_recv_parse_data(hybrid_kex_0, conn, raw_server_data));
+    GUARD_AS_POSIX(s2n_kex_server_key_recv_parse_data(hybrid_kex_1, conn, raw_server_data));
     return 0;
 }
 
@@ -241,7 +241,7 @@ int s2n_server_key_send(struct s2n_connection *conn)
     struct s2n_blob data_to_sign = {0};
 
     /* Call the negotiated key exchange method to send it's data */
-    GUARD(s2n_kex_server_key_send(key_exchange, conn, &data_to_sign));
+    GUARD_AS_POSIX(s2n_kex_server_key_send(key_exchange, conn, &data_to_sign));
 
     /* Add common signature data */
     if (conn->actual_protocol_version == S2N_TLS12) {
@@ -315,10 +315,10 @@ int s2n_hybrid_server_key_send(struct s2n_connection *conn, struct s2n_blob *tot
     notnull_check(total_data_to_sign->data);
 
     struct s2n_blob data_to_verify_0 = {0};
-    GUARD(s2n_kex_server_key_send(hybrid_kex_0, conn, &data_to_verify_0));
+    GUARD_AS_POSIX(s2n_kex_server_key_send(hybrid_kex_0, conn, &data_to_verify_0));
 
     struct s2n_blob data_to_verify_1 = {0};
-    GUARD(s2n_kex_server_key_send(hybrid_kex_1, conn, &data_to_verify_1));
+    GUARD_AS_POSIX(s2n_kex_server_key_send(hybrid_kex_1, conn, &data_to_verify_1));
 
     total_data_to_sign->size = data_to_verify_0.size + data_to_verify_1.size;
     return 0;


### PR DESCRIPTION
### Resolved issues:

https://github.com/awslabs/s2n/issues/2522

### Description of changes: 

Migrates some of the KEX functions (particularly `s2n_kex_supported` and `s2n_configured_kex`) to `S2N_RESULT`.

### Call-outs:

The `*_supported()`/`s2n_check*` functions previously returned `int`, but the return value was treated like `bool` to indicate if the KEX was supported. Those functions now take an out parameter (e.g. `bool *is_supported`) to indicate support, and the `S2N_RESULT` return value indicates success/failure.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

* Unit tests have been updated.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

* Integ tests should ensure that overall behavior/usage hasn't changed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
