### PR TITLE
ci: CodeBuild docker image version bump

### DIFF
--- a/codebuild/codebuild.config
+++ b/codebuild/codebuild.config
@@ -9,11 +9,11 @@ stack_name: s2nCodeBuildTests
 # The prefix CodeBuild: is required for the script to build this as a CB project
 # Fuzzers
 [CodeBuild:s2nfuzzerOpenSSL111Coverage]
-snippet: UbuntuBoilerplate2XL
+snippet: UbuntuFuzzJob
 env: S2N_LIBCRYPTO=openssl-1.1.1 LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=60 FUZZ_COVERAGE=true CODECOV_IO_UPLOAD=true
 
 [CodeBuild:s2nfuzzerOpenSSL102FIPS]
-snippet: UbuntuBoilerplate2XL
+snippet: UbuntuFuzzJob
 env: S2N_LIBCRYPTO=openssl-1.0.2-fips LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=60
 
 # Integration tests

--- a/codebuild/common.config
+++ b/codebuild/common.config
@@ -30,3 +30,19 @@ source_location: https://github.com/awslabs/s2n.git
 source_type : GITHUB
 source_clonedepth: 1
 source_version:
+
+# CodeBuild Scheduled Fuzz
+[UbuntuFuzzJob]
+image : aws/codebuild/standard:5.0
+env_type: LINUX_CONTAINER
+compute_type: BUILD_GENERAL1_LARGE
+timeout_in_min: 480
+buildspec: codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
+source_location: https://github.com/awslabs/private-s2n-fuzz.git
+source_type : GITHUB
+source_clonedepth: 1
+source_version:
+# This next value MUST match the buildspec files
+# secondary-artifacts, and can be a comma sep. list
+artifact_secondary_identifiers: logs
+artifact_s3_bucket: s2n-build-artifacts

--- a/codebuild/spec/buildspec_omnibus.yml
+++ b/codebuild/spec/buildspec_omnibus.yml
@@ -310,6 +310,7 @@ batch:
       env:
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
+        image: aws/codebuild/standard:5.0
         variables:
           S2N_LIBCRYPTO: openssl-1.1.1
           LATEST_CLANG: true
@@ -323,6 +324,7 @@ batch:
       env:
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
+        image: aws/codebuild/standard:5.0
         variables:
           S2N_LIBCRYPTO: openssl-1.0.2
           LATEST_CLANG: true
@@ -334,8 +336,10 @@ batch:
       env:
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
+        image: aws/codebuild/standard:5.0
         variables:
           S2N_LIBCRYPTO: openssl-1.0.2-fips
           LATEST_CLANG: true
           TESTS: fuzz
           FUZZ_TIMEOUT_SEC: 60
+

--- a/codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
+++ b/codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
@@ -21,7 +21,7 @@ env:
 phases:
   install:
     runtime-versions:
-      python: 3.7
+      python: 3.x
     commands:
       - echo Entered the install phase...
       - apt-key list


### PR DESCRIPTION
### Resolved issues:

 None

### Description of changes: 

s2n uses (mostly) AWS [CodeBuild managed docker images](https://github.com/aws/aws-codebuild-docker-images/releases), who announced deprecation of ubuntu standard:2.0 back in 2020.  One of our fuzz tests is failing, and it's time to update which images we use.

### Call-outs:

- Changes in #2504 will need merging
- Now ALL libfuzz jobs are using the same buildspec
 
### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
```
TESTS=fuzz FUZZ_TESTS=s2n_openssl_diff_pem_parsing_test FUZZ_TIMEOUT_SEC=60 LATEST_CLANG=true S2N_LIBCRYPTO=openssl-1.1.1 ./codebuild/bin/s2n_codebuild.sh
```
[Successful run](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nfuzzerOpenSSL111Coverage/build/s2nfuzzerOpenSSL111Coverage%3A73c505fb-baa8-4936-bdf1-ab15ecaeeb11/config?region=us-west-2)

Is this a refactor change? No, blast radius greatly reduced from draft; only updates 3 fuzz jobs and omnibus.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
