### PR TITLE
Added session resumption to key schedule

### DIFF
--- a/crypto/s2n_tls13_keys.c
+++ b/crypto/s2n_tls13_keys.c
@@ -352,11 +352,11 @@ int s2n_tls13_derive_resumption_master_secret(struct s2n_tls13_keys *keys, struc
     notnull_check(secret_blob);
 
     /* Sanity check that input hash is of expected type */
-    S2N_ERROR_IF(keys->hash_algorithm != hashes->alg, S2N_ERR_HASH_INVALID_ALGORITHM);
+    ENSURE_POSIX(keys->hash_algorithm == hashes->alg, S2N_ERR_HASH_INVALID_ALGORITHM);
 
     s2n_tls13_key_blob(message_digest, keys->size);
 
-    /* copy the hashes into the message_digest */
+    /* Copy the hashes into the message_digest */
     DEFER_CLEANUP(struct s2n_hash_state hkdf_hash_copy, s2n_hash_free);
     GUARD(s2n_hash_new(&hkdf_hash_copy));
     GUARD(s2n_hash_copy(&hkdf_hash_copy, hashes));
@@ -369,7 +369,8 @@ int s2n_tls13_derive_resumption_master_secret(struct s2n_tls13_keys *keys, struc
     return S2N_SUCCESS;
 }
 
-S2N_RESULT s2n_tls13_derive_session_ticket_secret(struct s2n_tls13_keys *keys, struct s2n_blob *resumption_secret, struct s2n_blob *ticket_nonce, struct s2n_blob *secret_blob)
+S2N_RESULT s2n_tls13_derive_session_ticket_secret(struct s2n_tls13_keys *keys, struct s2n_blob *resumption_secret, 
+        struct s2n_blob *ticket_nonce, struct s2n_blob *secret_blob)
 {
     ENSURE_REF(keys);
     ENSURE_REF(resumption_secret);

--- a/crypto/s2n_tls13_keys.c
+++ b/crypto/s2n_tls13_keys.c
@@ -41,7 +41,7 @@
  * [x] client_application_traffic_secret_0
  * [x] server_application_traffic_secret_0
  * [ ] exporter_master_secret
- * [ ] resumption_master_secret
+ * [x] resumption_master_secret
  *
  * The TLS 1.3 key generation can be divided into 3 phases
  * 1. early secrets
@@ -74,6 +74,7 @@ S2N_BLOB_LABEL(s2n_tls13_label_server_application_traffic_secret, "s ap traffic"
 
 S2N_BLOB_LABEL(s2n_tls13_label_exporter_master_secret, "exp master")
 S2N_BLOB_LABEL(s2n_tls13_label_resumption_master_secret, "res master")
+S2N_BLOB_LABEL(s2n_tls13_label_session_ticket_secret, "resumption")
 
 /*
  * Traffic secret labels
@@ -342,4 +343,42 @@ int s2n_tls13_update_application_traffic_secret(struct s2n_tls13_keys *keys, str
                                 &s2n_tls13_label_application_traffic_secret_update, &zero_length_blob, new_secret));
 
     return 0;
+}
+
+int s2n_tls13_derive_resumption_master_secret(struct s2n_tls13_keys *keys, struct s2n_hash_state *hashes, struct s2n_blob *secret_blob)
+{
+    notnull_check(keys);
+    notnull_check(hashes);
+    notnull_check(secret_blob);
+
+    /* Sanity check that input hash is of expected type */
+    S2N_ERROR_IF(keys->hash_algorithm != hashes->alg, S2N_ERR_HASH_INVALID_ALGORITHM);
+
+    s2n_tls13_key_blob(message_digest, keys->size);
+
+    /* copy the hashes into the message_digest */
+    DEFER_CLEANUP(struct s2n_hash_state hkdf_hash_copy, s2n_hash_free);
+    GUARD(s2n_hash_new(&hkdf_hash_copy));
+    GUARD(s2n_hash_copy(&hkdf_hash_copy, hashes));
+    GUARD(s2n_hash_digest(&hkdf_hash_copy, message_digest.data, message_digest.size));
+
+    /* Derive master session resumption from master secret */
+    GUARD(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, &keys->extract_secret,
+        &s2n_tls13_label_resumption_master_secret, &message_digest, secret_blob));
+
+    return S2N_SUCCESS;
+}
+
+S2N_RESULT s2n_tls13_derive_session_ticket_secret(struct s2n_tls13_keys *keys, struct s2n_blob *resumption_secret, struct s2n_blob *ticket_nonce, struct s2n_blob *secret_blob)
+{
+    ENSURE_REF(keys);
+    ENSURE_REF(resumption_secret);
+    ENSURE_REF(ticket_nonce);
+    ENSURE_REF(secret_blob);
+
+    /* Derive session ticket secret from master session resumption secret */
+    GUARD_AS_RESULT(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, resumption_secret,
+        &s2n_tls13_label_session_ticket_secret, ticket_nonce, secret_blob));
+
+    return S2N_RESULT_OK;
 }

--- a/crypto/s2n_tls13_keys.h
+++ b/crypto/s2n_tls13_keys.h
@@ -87,3 +87,6 @@ int s2n_tls13_derive_traffic_keys(struct s2n_tls13_keys *handshake, struct s2n_b
 int s2n_tls13_derive_finished_key(struct s2n_tls13_keys *keys, struct s2n_blob *secret_key, struct s2n_blob *output_finish_key);
 int s2n_tls13_calculate_finished_mac(struct s2n_tls13_keys *keys, struct s2n_blob *finished_key, struct s2n_hash_state *hash_state, struct s2n_blob *finished_verify);
 int s2n_tls13_update_application_traffic_secret(struct s2n_tls13_keys *keys, struct s2n_blob *old_secret, struct s2n_blob *new_secret);
+
+int s2n_tls13_derive_resumption_master_secret(struct s2n_tls13_keys *keys, struct s2n_hash_state *hashes, struct s2n_blob *secret_blob);
+S2N_RESULT s2n_tls13_derive_session_ticket_secret(struct s2n_tls13_keys *keys, struct s2n_blob *resumption_secret, struct s2n_blob *ticket_nonce, struct s2n_blob *secret_blob);

--- a/crypto/s2n_tls13_keys.h
+++ b/crypto/s2n_tls13_keys.h
@@ -89,4 +89,5 @@ int s2n_tls13_calculate_finished_mac(struct s2n_tls13_keys *keys, struct s2n_blo
 int s2n_tls13_update_application_traffic_secret(struct s2n_tls13_keys *keys, struct s2n_blob *old_secret, struct s2n_blob *new_secret);
 
 int s2n_tls13_derive_resumption_master_secret(struct s2n_tls13_keys *keys, struct s2n_hash_state *hashes, struct s2n_blob *secret_blob);
-S2N_RESULT s2n_tls13_derive_session_ticket_secret(struct s2n_tls13_keys *keys, struct s2n_blob *resumption_secret, struct s2n_blob *ticket_nonce, struct s2n_blob *secret_blob);
+S2N_RESULT s2n_tls13_derive_session_ticket_secret(struct s2n_tls13_keys *keys, struct s2n_blob *resumption_secret,
+        struct s2n_blob *ticket_nonce, struct s2n_blob *secret_blob);

--- a/tests/unit/s2n_tls13_keys_test.c
+++ b/tests/unit/s2n_tls13_keys_test.c
@@ -145,6 +145,8 @@ int main(int argc, char **argv)
     S2N_BLOB_FROM_HEX(expect_derived_master_resumption_secret, 
         "7df235f2031d2a051287d02b0241"
         "b0bfdaf86cc856231f2d5aba46c434ec196c");
+    
+    S2N_BLOB_FROM_HEX(ticket_nonce, "0000");
 
     S2N_BLOB_FROM_HEX(expected_session_ticket_secret, 
         "4ecd0eb6ec3b4d87f5d6028f922c"
@@ -261,9 +263,6 @@ int main(int argc, char **argv)
 
     /* Test individual session resumption ticket secret */
     s2n_tls13_key_blob(session_ticket_secret, secrets.size);
-    uint8_t nonce[2] = {0};
-    struct s2n_blob ticket_nonce = {0};
-    EXPECT_SUCCESS(s2n_blob_init(&ticket_nonce, nonce, sizeof(nonce)));
 
     EXPECT_OK(s2n_tls13_derive_session_ticket_secret(&secrets, &master_resumption_secret, &ticket_nonce, &session_ticket_secret));
 

--- a/tests/unit/s2n_tls13_keys_test.c
+++ b/tests/unit/s2n_tls13_keys_test.c
@@ -258,14 +258,11 @@ int main(int argc, char **argv)
     /* Test session resumption secret */
     s2n_tls13_key_blob(master_resumption_secret, secrets.size);
     EXPECT_SUCCESS(s2n_tls13_derive_resumption_master_secret(&secrets, &hash_state, &master_resumption_secret));
-
     S2N_BLOB_EXPECT_EQUAL(expect_derived_master_resumption_secret, master_resumption_secret);
 
     /* Test individual session resumption ticket secret */
     s2n_tls13_key_blob(session_ticket_secret, secrets.size);
-
     EXPECT_OK(s2n_tls13_derive_session_ticket_secret(&secrets, &master_resumption_secret, &ticket_nonce, &session_ticket_secret));
-
     S2N_BLOB_EXPECT_EQUAL(expected_session_ticket_secret, session_ticket_secret);
 
     /* Test Traffic Keys */

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -307,6 +307,8 @@ struct s2n_connection {
     uint8_t ticket_ext_data[S2N_TICKET_SIZE_IN_BYTES];
     struct s2n_stuffer client_ticket_to_decrypt;
 
+    uint8_t resumption_master_secret[S2N_TLS13_SECRET_MAX_LEN];
+
     /* application protocols overridden */
     struct s2n_blob application_protocols_overridden;
 

--- a/tls/s2n_crypto.h
+++ b/tls/s2n_crypto.h
@@ -64,7 +64,6 @@ struct s2n_crypto_parameters {
     uint8_t server_implicit_iv[S2N_TLS_MAX_IV_LEN];
     uint8_t client_app_secret[S2N_TLS13_SECRET_MAX_LEN];
     uint8_t server_app_secret[S2N_TLS13_SECRET_MAX_LEN];
-    uint8_t resumption_master_secret[S2N_TLS13_SECRET_MAX_LEN];
     struct s2n_hash_state signature_hash;
     struct s2n_hmac_state client_record_mac;
     struct s2n_hmac_state server_record_mac;

--- a/tls/s2n_crypto.h
+++ b/tls/s2n_crypto.h
@@ -64,6 +64,7 @@ struct s2n_crypto_parameters {
     uint8_t server_implicit_iv[S2N_TLS_MAX_IV_LEN];
     uint8_t client_app_secret[S2N_TLS13_SECRET_MAX_LEN];
     uint8_t server_app_secret[S2N_TLS13_SECRET_MAX_LEN];
+    uint8_t resumption_master_secret[S2N_TLS13_SECRET_MAX_LEN];
     struct s2n_hash_state signature_hash;
     struct s2n_hmac_state client_record_mac;
     struct s2n_hmac_state server_record_mac;

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -317,6 +317,19 @@ static int s2n_tls13_handle_master_secret(struct s2n_connection *conn)
     return S2N_SUCCESS;
 }
 
+static int s2n_tls13_handle_resumption_master_secret(struct s2n_connection *conn)
+{
+    s2n_tls13_connection_keys(keys, conn);
+    
+    struct s2n_hash_state hash_state = {0};
+    GUARD(s2n_handshake_get_hash_state(conn, keys.hash_algorithm, &hash_state));
+    
+    struct s2n_blob resumption_master_secret = {0};
+    GUARD(s2n_blob_init(&resumption_master_secret, conn->secure.resumption_master_secret, keys.size));
+    GUARD(s2n_tls13_derive_resumption_master_secret(&keys, &hash_state, &resumption_master_secret));
+    return S2N_SUCCESS;
+}
+
 int s2n_tls13_handle_secrets(struct s2n_connection *conn)
 {
     notnull_check(conn);
@@ -343,6 +356,7 @@ int s2n_tls13_handle_secrets(struct s2n_connection *conn)
                 GUARD(s2n_tls13_handle_application_secret(conn, S2N_SERVER));
             }
             GUARD(s2n_tls13_handle_application_secret(conn, S2N_CLIENT));
+            GUARD(s2n_tls13_handle_resumption_master_secret(conn));
             break;
         default:
             break;

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -325,7 +325,7 @@ static int s2n_tls13_handle_resumption_master_secret(struct s2n_connection *conn
     GUARD(s2n_handshake_get_hash_state(conn, keys.hash_algorithm, &hash_state));
     
     struct s2n_blob resumption_master_secret = {0};
-    GUARD(s2n_blob_init(&resumption_master_secret, conn->secure.resumption_master_secret, keys.size));
+    GUARD(s2n_blob_init(&resumption_master_secret, conn->resumption_master_secret, keys.size));
     GUARD(s2n_tls13_derive_resumption_master_secret(&keys, &hash_state, &resumption_master_secret));
     return S2N_SUCCESS;
 }


### PR DESCRIPTION
### Resolved issues:

 resolves #2482
### Description of changes: 

Added method to calculate the master resumption secret and a method to calculate an individual session ticket secret.
### Call-outs:

Because we are writing Session Resumption in parts, no code actually calls the method to calculate an individual session ticket secret right now.
### Testing:

I grabbed test vectors from [here](https://tools.ietf.org/html/rfc8448#page-13). The method s2n_tls13_handle_resumption_master_secret has no unit tests; this will have to be tested in a self-talk test.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?
N/A
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
