### PR TITLE
Adds memory-safety proofs for s2n_hmac functions

### DIFF
--- a/tests/cbmc/proofs/s2n_hmac_copy/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_copy/Makefile
@@ -1,0 +1,50 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 2 minutes.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hmac_copy
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(OPENSSL_SOURCE)/bn_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/ec_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_evp.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_free
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_init
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_new
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_reset
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_free
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_init
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_new
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_reset
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hmac_copy/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_copy/Makefile
@@ -19,7 +19,6 @@ PROOF_UID = s2n_hmac_copy
 HARNESS_ENTRY = $(PROOF_UID)_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
 
-PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 PROOF_SOURCES += $(OPENSSL_SOURCE)/bn_override.c
 PROOF_SOURCES += $(OPENSSL_SOURCE)/ec_override.c
 PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
@@ -27,6 +26,7 @@ PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 
 PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
 PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c

--- a/tests/cbmc/proofs/s2n_hmac_copy/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_hmac_copy/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_hmac_copy/s2n_hmac_copy_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_copy/s2n_hmac_copy_harness.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "crypto/s2n_hmac.h"
+
+#include <cbmc_proof/make_common_datastructures.h>
+
+void s2n_hmac_copy_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_hmac_state *to = cbmc_allocate_s2n_hmac_state();
+    struct s2n_hmac_state *from = cbmc_allocate_s2n_hmac_state();
+
+    /* Assumptions. */
+    __CPROVER_assume(s2n_result_is_ok(s2n_hmac_state_validate(to)));
+    __CPROVER_assume(s2n_result_is_ok(s2n_hmac_state_validate(from)));
+    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&to->inner);
+    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&to->inner_just_key);
+    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&to->outer);
+    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&to->outer_just_key);
+    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&from->inner);
+    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&from->inner_just_key);
+    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&from->outer);
+    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&from->outer_just_key);
+
+    /* Operation under verification. */
+    if (s2n_hmac_copy(to, from) == S2N_SUCCESS)
+    {
+        /* Post-conditions. */
+        assert(s2n_result_is_ok(s2n_hmac_state_validate(to)));
+        assert(s2n_result_is_ok(s2n_hmac_state_validate(from)));
+        assert(from->inner.hash_impl->copy != NULL);
+        assert(from->inner_just_key.hash_impl->copy != NULL);
+        assert(from->outer.hash_impl->copy != NULL);
+        assert(from->outer_just_key.hash_impl->copy != NULL);
+    }
+}

--- a/tests/cbmc/proofs/s2n_hmac_reset/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_reset/Makefile
@@ -19,7 +19,6 @@ PROOF_UID = s2n_hmac_reset
 HARNESS_ENTRY = $(PROOF_UID)_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
 
-PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 PROOF_SOURCES += $(OPENSSL_SOURCE)/bn_override.c
 PROOF_SOURCES += $(OPENSSL_SOURCE)/ec_override.c
 PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
@@ -27,6 +26,7 @@ PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 
 PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
 PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c

--- a/tests/cbmc/proofs/s2n_hmac_reset/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_reset/Makefile
@@ -1,0 +1,50 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 2 minutes.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hmac_reset
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(OPENSSL_SOURCE)/bn_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/ec_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_evp.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_free
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_init
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_new
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_reset
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_free
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_init
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_new
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_reset
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hmac_reset/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_hmac_reset/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_hmac_reset/s2n_hmac_reset_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_reset/s2n_hmac_reset_harness.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "crypto/s2n_hmac.h"
+
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_hmac_reset_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_hmac_state *state = cbmc_allocate_s2n_hmac_state();
+
+    /* Assumptions. */
+    __CPROVER_assume(s2n_result_is_ok(s2n_hmac_state_validate(state)));
+    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&state->inner);
+    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&state->inner_just_key);
+
+    /* Operation under verification. */
+    if (s2n_hmac_reset(state) == S2N_SUCCESS)
+    {
+        /* Post-conditions. */
+        assert(s2n_result_is_ok(s2n_hmac_state_validate(state)));
+        assert(state->inner.hash_impl->copy != NULL);
+        assert(state->inner.is_ready_for_input);
+    }
+}


### PR DESCRIPTION
### Resolved issues:

N/A.

### Description of changes: 

Adds CBMC proofs for the following functions in `s2n_hmac` module:
 - `s2n_hmac_copy`;
 - `s2n_hmac_reset`;

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
