### PR TITLE
api: add s2n_errno_location function

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -51,6 +51,15 @@ extern "C" {
 S2N_API
 extern __thread int s2n_errno;
 
+/**
+ * Returns the address of the thread-local `s2n_errno` variable
+ *
+ * This function can be used instead of trying to resolve `s2n_errno` directly
+ * in runtimes where thread-local variables may not be easily accessible.
+ */
+S2N_API
+extern int *s2n_errno_location();
+
 typedef enum {
     S2N_ERR_T_OK=0,
     S2N_ERR_T_IO,

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -378,6 +378,9 @@ if (s2n_config_set_cipher_preferences(config, prefs) < 0) {
 
 **NOTE**: To avoid possible confusion, s2n_errno should be cleared after processing an error: `s2n_errno = S2N_ERR_T_OK`
 
+When using s2n outside of `C`, the address of the thread-local `s2n_errno` may be obtained by calling the `int *s2n_errno_location()` function.
+This will ensure that the same TLS mechanisms are used with which s2n was compiled.
+
 ### Stacktraces
 s2n has an mechanism to capture stacktraces when errors occur.
 This mechanism is off by default, but can be enabled in code by calling `s2n_stack_traces_enabled_set()`.

--- a/error/s2n_errno.c
+++ b/error/s2n_errno.c
@@ -31,6 +31,14 @@
 __thread int s2n_errno;
 __thread const char *s2n_debug_str;
 
+/**
+ * Returns the address of the thread-local `s2n_errno` variable
+ */
+int *s2n_errno_location()
+{
+    return &s2n_errno;
+}
+
 static const char *no_such_language = "Language is not supported for error translation";
 static const char *no_such_error = "Internal s2n error";
 

--- a/tests/unit/s2n_error_type_test.c
+++ b/tests/unit/s2n_error_type_test.c
@@ -23,25 +23,36 @@
 
 int main(void)
 {
-	BEGIN_TEST();
+    BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13());
 
-	s2n_errno = S2N_ERR_OK;
-	EXPECT_EQUAL(S2N_ERR_T_OK, s2n_error_get_type(s2n_errno));
-	s2n_errno = S2N_ERR_IO;
-	EXPECT_EQUAL(S2N_ERR_T_IO, s2n_error_get_type(s2n_errno));
-	s2n_errno = S2N_ERR_CLOSED;
-	EXPECT_EQUAL(S2N_ERR_T_CLOSED, s2n_error_get_type(s2n_errno));
-	s2n_errno = S2N_ERR_IO_BLOCKED;
-	EXPECT_EQUAL(S2N_ERR_T_BLOCKED, s2n_error_get_type(s2n_errno));
-	s2n_errno = S2N_ERR_ALERT;
-	EXPECT_EQUAL(S2N_ERR_T_ALERT, s2n_error_get_type(s2n_errno));
-	s2n_errno = S2N_ERR_BAD_MESSAGE;
-	EXPECT_EQUAL(S2N_ERR_T_PROTO, s2n_error_get_type(s2n_errno));
-	s2n_errno = S2N_ERR_FSTAT;
-	EXPECT_EQUAL(S2N_ERR_T_INTERNAL, s2n_error_get_type(s2n_errno));
-	s2n_errno = S2N_ERR_INVALID_BASE64;
-	EXPECT_EQUAL(S2N_ERR_T_USAGE, s2n_error_get_type(s2n_errno));
+    /* Ensure the address of `s2n_errno` is identical to the one returned in `s2n_errno_location()` */
+    EXPECT_EQUAL(&s2n_errno, s2n_errno_location());
 
-	END_TEST();
+    s2n_errno = S2N_ERR_OK;
+    EXPECT_EQUAL(S2N_ERR_T_OK, s2n_error_get_type(s2n_errno));
+    EXPECT_EQUAL(S2N_ERR_T_OK, s2n_error_get_type(*s2n_errno_location()));
+    s2n_errno = S2N_ERR_IO;
+    EXPECT_EQUAL(S2N_ERR_T_IO, s2n_error_get_type(s2n_errno));
+    EXPECT_EQUAL(S2N_ERR_T_IO, s2n_error_get_type(*s2n_errno_location()));
+    s2n_errno = S2N_ERR_CLOSED;
+    EXPECT_EQUAL(S2N_ERR_T_CLOSED, s2n_error_get_type(s2n_errno));
+    EXPECT_EQUAL(S2N_ERR_T_CLOSED, s2n_error_get_type(*s2n_errno_location()));
+    s2n_errno = S2N_ERR_IO_BLOCKED;
+    EXPECT_EQUAL(S2N_ERR_T_BLOCKED, s2n_error_get_type(s2n_errno));
+    EXPECT_EQUAL(S2N_ERR_T_BLOCKED, s2n_error_get_type(*s2n_errno_location()));
+    s2n_errno = S2N_ERR_ALERT;
+    EXPECT_EQUAL(S2N_ERR_T_ALERT, s2n_error_get_type(s2n_errno));
+    EXPECT_EQUAL(S2N_ERR_T_ALERT, s2n_error_get_type(*s2n_errno_location()));
+    s2n_errno = S2N_ERR_BAD_MESSAGE;
+    EXPECT_EQUAL(S2N_ERR_T_PROTO, s2n_error_get_type(s2n_errno));
+    EXPECT_EQUAL(S2N_ERR_T_PROTO, s2n_error_get_type(*s2n_errno_location()));
+    s2n_errno = S2N_ERR_FSTAT;
+    EXPECT_EQUAL(S2N_ERR_T_INTERNAL, s2n_error_get_type(s2n_errno));
+    EXPECT_EQUAL(S2N_ERR_T_INTERNAL, s2n_error_get_type(*s2n_errno_location()));
+    s2n_errno = S2N_ERR_INVALID_BASE64;
+    EXPECT_EQUAL(S2N_ERR_T_USAGE, s2n_error_get_type(s2n_errno));
+    EXPECT_EQUAL(S2N_ERR_T_USAGE, s2n_error_get_type(*s2n_errno_location()));
+
+    END_TEST();
 }


### PR DESCRIPTION
### Description of changes: 

When binding to s2n in a runtime outside of C, resolving the address of a thread-local variable can be tricky to do correctly.

This change adds the `int *s2n_errno_location()` function to the public API, which will ensure customers use the same TLS mechanism with which s2n was compiled. Note that the `errno` from `libc` has similar functionality with the [`__errno_location`](http://refspecs.linux-foundation.org/LSB_4.1.0/LSB-Core-generic/LSB-Core-generic/baselib---errno-location.html) function.

### Call-outs:

This is adding a public function so we want to make sure we're OK with the naming and maintaining it.

### Testing:

I expanded the unit test for obtaining the error type to include checks for the address returned from `s2n_errno_location()`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
