### PR TITLE
Add support for powerpc64

### DIFF
--- a/pq-crypto/sike_r2/P434_internal.h
+++ b/pq-crypto/sike_r2/P434_internal.h
@@ -21,6 +21,9 @@
 #elif (TARGET == TARGET_ARM64)
 #define NWORDS_FIELD 7
 #define p434_ZERO_WORDS 3
+#elif (TARGET == TARGET_PPC64)
+#define NWORDS_FIELD 7
+#define p434_ZERO_WORDS 3
 #endif
 
 // Basic constants

--- a/pq-crypto/sike_r2/config.h
+++ b/pq-crypto/sike_r2/config.h
@@ -40,6 +40,7 @@
 #define TARGET_x86 2
 #define TARGET_ARM 3
 #define TARGET_ARM64 4
+#define TARGET_PPC64 5
 
 #if defined(__x86_64__)
 #define TARGET TARGET_AMD64
@@ -61,6 +62,12 @@ typedef uint32_t digit_t;  // Unsigned 32-bit digit
 typedef uint16_t hdigit_t; // Unsigned 16-bit digit
 #elif defined(__aarch64__)
 #define TARGET TARGET_ARM64
+#define RADIX 64
+#define LOG2RADIX 6
+typedef uint64_t digit_t;  // Unsigned 64-bit digit
+typedef uint32_t hdigit_t; // Unsigned 32-bit digit
+#elif defined(__powerpc64__)
+#define TARGET TARGET_PPC64
 #define RADIX 64
 #define LOG2RADIX 6
 typedef uint64_t digit_t;  // Unsigned 64-bit digit


### PR DESCRIPTION
### Description of changes: 

Code in pq-crypto/sike_r2 requires arch-specific definitions, so I added these to allow compilation on ppc64. The changes are really quite trivial; they're essentially copy/pasted from the other supported 64-bit arches.

### Testing:

I don't directly interact with s2n but I wanted this to work as it's somewhere in the dependency tree of the [Nix package manager](https://github.com/NixOS/nix). I've been using the built nix on ppc64le and haven't run into any issues so far.