### PR TITLE
ci: Update CodeBuild docker version, part 2

### DIFF
--- a/codebuild/bin/install_sslyze.sh
+++ b/codebuild/bin/install_sslyze.sh
@@ -28,7 +28,7 @@ case "$ARCH" in
   *)
         python3 -m pip install --user --upgrade pip setuptools
         # Version 3.0.0 introduces backwards incompatible changes in the JSON we parse.
-        # TODO: unpin the version and update the json parsing sslyze output.
+        # TODO: unpin the sslyze version and update the json parsing sslyze output.
         python3 -m pip install --user "sslyze<3.0.0"
         sudo ln -s /root/.local/bin/sslyze /usr/bin/sslyze || true
         which sslyze

--- a/codebuild/codebuild.config
+++ b/codebuild/codebuild.config
@@ -93,16 +93,3 @@ source_type : GITHUB
 source_clonedepth: 1
 source_version:
 env: TESTS=sidetrail
-
-# GitHub Actions Codebuild Shim Job
-[CodeBuild:s2nGithubCodebuild]
-image : aws/codebuild/standard:2.0
-env_type: LINUX_CONTAINER
-compute_type: BUILD_GENERAL1_LARGE
-timeout_in_min: 480
-buildspec: codebuild/spec/buildspec_ubuntu.yml
-source_location: https://github.com/awslabs/s2n.git
-source_type : GITHUB
-source_clonedepth: 1
-source_version:
-env: TESTS=OverRiddenByGithubActions

--- a/codebuild/common.config
+++ b/codebuild/common.config
@@ -10,7 +10,7 @@ account_number: 024603541914
 
 #Reusable templates - use the snippet:NAME
 [UbuntuBoilerplate2XL]
-image : aws/codebuild/standard:2.0
+image : aws/codebuild/standard:4.0
 env_type: LINUX_CONTAINER
 compute_type: BUILD_GENERAL1_2XLARGE
 timeout_in_min: 90
@@ -21,7 +21,7 @@ source_clonedepth: 1
 source_version:
 
 [UbuntuBoilerplateLarge]
-image : aws/codebuild/standard:2.0
+image : aws/codebuild/standard:4.0
 env_type: LINUX_CONTAINER
 compute_type: BUILD_GENERAL1_LARGE
 timeout_in_min: 90

--- a/codebuild/fuzz_codebuild.config
+++ b/codebuild/fuzz_codebuild.config
@@ -6,7 +6,7 @@ stack_name: s2nScheduledFuzz
 
 # CodeBuild Scheduled Fuzz
 [CodeBuild:s2nFuzzScheduled]
-image : aws/codebuild/standard:2.0
+image : aws/codebuild/standard:4.0
 env_type: LINUX_CONTAINER
 compute_type: BUILD_GENERAL1_LARGE
 timeout_in_min: 480

--- a/codebuild/integ_codebuild.config
+++ b/codebuild/integ_codebuild.config
@@ -6,7 +6,7 @@ stack_name: s2nIntegrationScheduled
 
 #Reusable templates - use the snippet:NAME
 [IntegUbuntuBoilerplateLarge]
-image : aws/codebuild/standard:2.0
+image : aws/codebuild/standard:4.0
 env_type: LINUX_CONTAINER
 compute_type: BUILD_GENERAL1_LARGE
 timeout_in_min: 90
@@ -18,7 +18,7 @@ source_version:
 
 # Boring + GCC9, Libre + GCC6
 [CodeBuild:s2nIntegrationBoringLibre]
-image : aws/codebuild/standard:2.0
+image : aws/codebuild/standard:4.0
 env_type: LINUX_CONTAINER
 compute_type: BUILD_GENERAL1_LARGE
 timeout_in_min: 90
@@ -31,7 +31,7 @@ env: TESTS=integration BUILD_S2N=true
 
 # OpenSSL111 + GCC6 + Corked and notCorked + Gcc4.8
 [CodeBuild:s2nIntegrationOpenSSL111PlusCoverage]
-image : aws/codebuild/standard:2.0
+image : aws/codebuild/standard:4.0
 env_type: LINUX_CONTAINER
 compute_type: BUILD_GENERAL1_LARGE
 timeout_in_min: 90
@@ -44,7 +44,7 @@ env: TESTS=integration BUILD_S2N=true
 
 # OpenSSL102 Fips and notFips + GCC6
 [CodeBuild:s2nIntegrationOpenSSL102Plus]
-image : aws/codebuild/standard:2.0
+image : aws/codebuild/standard:4.0
 env_type: LINUX_CONTAINER
 compute_type: BUILD_GENERAL1_LARGE
 timeout_in_min: 90
@@ -57,7 +57,7 @@ env: TESTS=integration BUILD_S2N=true
 
 # OpenSSL102 + GCC6 + Asan and Valgrind
 [CodeBuild:s2nIntegrationOpenSSL102AsanValgrind]
-image : aws/codebuild/standard:2.0
+image : aws/codebuild/standard:4.0
 env_type: LINUX_CONTAINER
 compute_type: BUILD_GENERAL1_LARGE
 timeout_in_min: 90

--- a/codebuild/spec/buildspec_amazonlinux2.yml
+++ b/codebuild/spec/buildspec_amazonlinux2.yml
@@ -8,7 +8,7 @@ env:
 phases:
   install:
     runtime-versions:
-      python: 3.7
+      python: 3.x
   pre_build:
     commands:
       - |

--- a/codebuild/spec/buildspec_sidetrail.yml
+++ b/codebuild/spec/buildspec_sidetrail.yml
@@ -21,7 +21,7 @@ env:
 phases:
   install:
     runtime-versions:
-      python: 3.7
+      python: 3.x
     commands:
       - echo Entered the install phase...
       - apt-key list

--- a/codebuild/spec/buildspec_ubuntu.yml
+++ b/codebuild/spec/buildspec_ubuntu.yml
@@ -21,7 +21,7 @@ env:
 phases:
   install:
     runtime-versions:
-      python: 3.7
+      python: 3.x
     commands:
       - echo Entered the install phase...
       - echo "We need a test PPA for gcc-9."

--- a/codebuild/spec/buildspec_ubuntu_integ_awslc.yml
+++ b/codebuild/spec/buildspec_ubuntu_integ_awslc.yml
@@ -24,7 +24,7 @@ env:
 phases:
   install:
     runtime-versions:
-      python: 3.7
+      python: 3.x
     commands:
       - echo Entered the install phase...
       - add-apt-repository ppa:ubuntu-toolchain-r/test -y

--- a/codebuild/spec/buildspec_ubuntu_integ_boringlibre.yml
+++ b/codebuild/spec/buildspec_ubuntu_integ_boringlibre.yml
@@ -21,7 +21,7 @@ env:
 phases:
   install:
     runtime-versions:
-      python: 3.7
+      python: 3.x
     commands:
       - echo Entered the install phase...
       - echo "We need a test PPA for gcc-9."

--- a/codebuild/spec/buildspec_ubuntu_integ_openssl102.yml
+++ b/codebuild/spec/buildspec_ubuntu_integ_openssl102.yml
@@ -21,7 +21,7 @@ env:
 phases:
   install:
     runtime-versions:
-      python: 3.7
+      python: 3.x
     commands:
       - echo Entered the install phase...
       - echo "We need a test PPA for gcc-9."

--- a/codebuild/spec/buildspec_ubuntu_integ_openssl102_asanvalgrind.yml
+++ b/codebuild/spec/buildspec_ubuntu_integ_openssl102_asanvalgrind.yml
@@ -21,7 +21,7 @@ env:
 phases:
   install:
     runtime-versions:
-      python: 3.7
+      python: 3.x
     commands:
       - echo Entered the install phase...
       - echo "We need a test PPA for gcc-9."

--- a/codebuild/spec/buildspec_ubuntu_integ_openssl111.yml
+++ b/codebuild/spec/buildspec_ubuntu_integ_openssl111.yml
@@ -21,7 +21,7 @@ env:
 phases:
   install:
     runtime-versions:
-      python: 3.7
+      python: 3.x
     commands:
       - echo Entered the install phase...
       - echo "We need a test PPA for gcc-9."

--- a/codebuild/spec/buildspec_ubuntu_integrationv2.yml
+++ b/codebuild/spec/buildspec_ubuntu_integrationv2.yml
@@ -21,8 +21,7 @@ env:
 phases:
   install:
     runtime-versions:
-      # This must be pinned to 3.7 because of old sslyze
-      python: 3.7
+      python: 3.x
     commands:
       - echo Entered the install phase...
       - echo "We need a test PPA for gcc-9."


### PR DESCRIPTION
### Resolved issues:

none

### Description of changes: 

In #2527 we bumped the CodeBuild Docker image version for some fuzz tests that were failing.  This PR finishes that update to the remainder of the jobs.  Also remove the GitHub actions shim, since we no longer need it.

### Call-outs:

Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? No.

### Testing:

Simple CodeBuild job against main with the following buildspec:
```
phases:
  install:
    runtime-versions:
      python: 3.x
    commands:
      - echo Entered the install phase...
      - apt update
      - apt install -y curl wget git
      - which python3
      - python3 --version
      - ls -al /usr/bin/python3*
  pre_build:
    commands:
      - $CB_BIN_DIR/install_default_dependencies.sh
  build:
    commands:
      - printenv
      - make
      - make -C tests/integration sslyze
```
which passed using ubuntu standard:4.0

 Is this a refactor change? no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
