### PR TITLE
Adds a proof harnesses for s2n_hmac_digest* functions

### DIFF
--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -548,7 +548,7 @@ int s2n_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm alg)
 int s2n_hash_update(struct s2n_hash_state *state, const void *data, uint32_t size)
 {
     PRECONDITION_POSIX(s2n_hash_state_validate(state));
-    ENSURE_POSIX(size == 0 || S2N_MEM_IS_READABLE(data, size), S2N_ERR_PRECONDITION_VIOLATION);
+    ENSURE_POSIX(S2N_MEM_IS_READABLE(data, size), S2N_ERR_PRECONDITION_VIOLATION);
     notnull_check(state->hash_impl->update);
 
     return state->hash_impl->update(state, data, size);
@@ -557,7 +557,7 @@ int s2n_hash_update(struct s2n_hash_state *state, const void *data, uint32_t siz
 int s2n_hash_digest(struct s2n_hash_state *state, void *out, uint32_t size)
 {
     PRECONDITION_POSIX(s2n_hash_state_validate(state));
-    ENSURE_POSIX(size == 0 || S2N_MEM_IS_READABLE(out, size), S2N_ERR_PRECONDITION_VIOLATION);
+    ENSURE_POSIX(S2N_MEM_IS_READABLE(out, size), S2N_ERR_PRECONDITION_VIOLATION);
     notnull_check(state->hash_impl->digest);
 
     return state->hash_impl->digest(state, out, size);

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -548,7 +548,7 @@ int s2n_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm alg)
 int s2n_hash_update(struct s2n_hash_state *state, const void *data, uint32_t size)
 {
     PRECONDITION_POSIX(s2n_hash_state_validate(state));
-    ENSURE_POSIX(S2N_MEM_IS_READABLE(data, size), S2N_ERR_PRECONDITION_VIOLATION);
+    ENSURE_POSIX(size == 0 || S2N_MEM_IS_READABLE(data, size), S2N_ERR_PRECONDITION_VIOLATION);
     notnull_check(state->hash_impl->update);
 
     return state->hash_impl->update(state, data, size);
@@ -557,7 +557,7 @@ int s2n_hash_update(struct s2n_hash_state *state, const void *data, uint32_t siz
 int s2n_hash_digest(struct s2n_hash_state *state, void *out, uint32_t size)
 {
     PRECONDITION_POSIX(s2n_hash_state_validate(state));
-    ENSURE_POSIX(S2N_MEM_IS_READABLE(out, size), S2N_ERR_PRECONDITION_VIOLATION);
+    ENSURE_POSIX(size == 0 || S2N_MEM_IS_READABLE(out, size), S2N_ERR_PRECONDITION_VIOLATION);
     notnull_check(state->hash_impl->digest);
 
     return state->hash_impl->digest(state, out, size);

--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -299,7 +299,8 @@ int s2n_hmac_digest_two_compression_rounds(struct s2n_hmac_state *state, void *o
      * 17 bytes if the block size is 128.
      */
     const uint8_t space_left = (state->hash_block_size == 128) ? 17 : 9;
-    if (state->currently_in_hash_block > (state->hash_block_size - space_left)) {
+    ENSURE_POSIX(state->currently_in_hash_block <= INT32_MAX, S2N_ERR_INTEGER_OVERFLOW);
+    if ((int32_t)state->currently_in_hash_block > (state->hash_block_size - space_left)) {
         return S2N_SUCCESS;
     }
 

--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -299,8 +299,7 @@ int s2n_hmac_digest_two_compression_rounds(struct s2n_hmac_state *state, void *o
      * 17 bytes if the block size is 128.
      */
     const uint8_t space_left = (state->hash_block_size == 128) ? 17 : 9;
-    ENSURE_POSIX(state->currently_in_hash_block <= INT32_MAX, S2N_ERR_INTEGER_OVERFLOW);
-    if ((int32_t)state->currently_in_hash_block > (state->hash_block_size - space_left)) {
+    if ((int64_t)state->currently_in_hash_block > (state->hash_block_size - space_left)) {
         return S2N_SUCCESS;
     }
 

--- a/tests/cbmc/proofs/s2n_hash_digest/s2n_hash_digest_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_digest/s2n_hash_digest_harness.c
@@ -16,14 +16,13 @@
 #include "crypto/s2n_hash.h"
 
 #include <cbmc_proof/make_common_datastructures.h>
-#include <cbmc_proof/proof_allocators.h>
 
 void s2n_hash_digest_harness()
 {
     /* Non-deterministic inputs. */
     struct s2n_hash_state *state = cbmc_allocate_s2n_hash_state();
     uint32_t size;
-    void* out = bounded_malloc(size);
+    void* out = malloc(size);
 
     /* Assumptions. */
     __CPROVER_assume(s2n_result_is_ok(s2n_hash_state_validate(state)));

--- a/tests/cbmc/proofs/s2n_hash_update/s2n_hash_update_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_update/s2n_hash_update_harness.c
@@ -16,14 +16,13 @@
 #include "crypto/s2n_hash.h"
 
 #include <cbmc_proof/make_common_datastructures.h>
-#include <cbmc_proof/proof_allocators.h>
 
 void s2n_hash_update_harness()
 {
     /* Non-deterministic inputs. */
     struct s2n_hash_state *state = cbmc_allocate_s2n_hash_state();
     uint32_t size;
-    void* data = bounded_malloc(size);
+    void* data = malloc(size);
 
     /* Assumptions. */
     __CPROVER_assume(s2n_result_is_ok(s2n_hash_state_validate(state)));

--- a/tests/cbmc/proofs/s2n_hmac_digest/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_digest/Makefile
@@ -1,0 +1,35 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 2 minutes.
+
+PROOF_UID = s2n_hmac_digest
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_hash_copy.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_hash_digest.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_hash_update.c
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hmac_digest/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_hmac_digest/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_hmac_digest/s2n_hmac_digest_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_digest/s2n_hmac_digest_harness.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "crypto/s2n_hmac.h"
+
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_hmac_digest_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_hmac_state *state = cbmc_allocate_s2n_hmac_state();
+    uint32_t size;
+    void* out = malloc(size);
+
+    /* Assumptions. */
+    __CPROVER_assume(s2n_result_is_ok(s2n_hmac_state_validate(state)));
+    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&state->inner);
+    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&state->outer);
+    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&state->outer_just_key);
+
+    /* Operation under verification. */
+    if (s2n_hmac_digest(state, out, size) == S2N_SUCCESS)
+    {
+        /* Post-conditions. */
+        assert(s2n_result_is_ok(s2n_hmac_state_validate(state)));
+        assert(state->inner.hash_impl->digest != NULL);
+        assert(state->outer.hash_impl->digest != NULL);
+        assert(state->outer.hash_impl->update != NULL);
+        assert(state->outer_just_key.hash_impl->copy != NULL);
+    }
+}

--- a/tests/cbmc/proofs/s2n_hmac_digest_two_compression_rounds/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_digest_two_compression_rounds/Makefile
@@ -1,0 +1,36 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 2 minutes.
+
+PROOF_UID = s2n_hmac_digest_two_compression_rounds
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_hash_copy.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_hash_digest.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_hash_reset.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_hash_update.c
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hmac_digest_two_compression_rounds/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_hmac_digest_two_compression_rounds/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_hmac_digest_two_compression_rounds/s2n_hmac_digest_two_compression_rounds_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_digest_two_compression_rounds/s2n_hmac_digest_two_compression_rounds_harness.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "crypto/s2n_hmac.h"
+
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/proof_allocators.h>
+
+void s2n_hmac_digest_two_compression_rounds_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_hmac_state *state = cbmc_allocate_s2n_hmac_state();
+    uint32_t size;
+    void* out = malloc(size);
+
+    /* Assumptions. */
+    __CPROVER_assume(s2n_result_is_ok(s2n_hmac_state_validate(state)));
+    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&state->inner);
+    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&state->outer);
+    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&state->outer_just_key);
+
+    /* Operation under verification. */
+    if (s2n_hmac_digest_two_compression_rounds(state, out, size) == S2N_SUCCESS)
+    {
+        /* Post-conditions. */
+        assert(s2n_result_is_ok(s2n_hmac_state_validate(state)));
+        assert(state->inner.hash_impl->digest != NULL);
+        assert(state->outer.hash_impl->digest != NULL);
+        assert(state->outer.hash_impl->update != NULL);
+        assert(state->outer_just_key.hash_impl->copy != NULL);
+    }
+}

--- a/tests/cbmc/stubs/s2n_hash_copy.c
+++ b/tests/cbmc/stubs/s2n_hash_copy.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cbmc_proof/nondet.h>
+
+#include "api/s2n.h"
+#include "crypto/s2n_hash.h"
+#include "utils/s2n_safety.h"
+
+int s2n_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *from)
+{
+    PRECONDITION_POSIX(s2n_hash_state_validate(to));
+    PRECONDITION_POSIX(s2n_hash_state_validate(from));
+    notnull_check(from->hash_impl->copy);
+
+    /* return from->hash_impl->copy(to, from); */
+    return nondet_bool() ? S2N_SUCCESS : S2N_FAILURE;
+}

--- a/tests/cbmc/stubs/s2n_hash_digest.c
+++ b/tests/cbmc/stubs/s2n_hash_digest.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cbmc_proof/nondet.h>
+
+#include "api/s2n.h"
+#include "crypto/s2n_hash.h"
+#include "utils/s2n_safety.h"
+
+int s2n_hash_digest(struct s2n_hash_state *state, void *out, uint32_t size)
+{
+    PRECONDITION_POSIX(s2n_hash_state_validate(state));
+    ENSURE_POSIX(size == 0 || S2N_MEM_IS_READABLE(out, size), S2N_ERR_PRECONDITION_VIOLATION);
+    notnull_check(state->hash_impl->digest);
+
+    /* return state->hash_impl->digest(state, out, size); */
+    return nondet_bool() ? S2N_SUCCESS : S2N_FAILURE;
+}

--- a/tests/cbmc/stubs/s2n_hash_digest.c
+++ b/tests/cbmc/stubs/s2n_hash_digest.c
@@ -22,7 +22,7 @@
 int s2n_hash_digest(struct s2n_hash_state *state, void *out, uint32_t size)
 {
     PRECONDITION_POSIX(s2n_hash_state_validate(state));
-    ENSURE_POSIX(size == 0 || S2N_MEM_IS_READABLE(out, size), S2N_ERR_PRECONDITION_VIOLATION);
+    ENSURE_POSIX(S2N_MEM_IS_READABLE(out, size), S2N_ERR_PRECONDITION_VIOLATION);
     notnull_check(state->hash_impl->digest);
 
     /* return state->hash_impl->digest(state, out, size); */

--- a/tests/cbmc/stubs/s2n_hash_reset.c
+++ b/tests/cbmc/stubs/s2n_hash_reset.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cbmc_proof/nondet.h>
+
+#include "api/s2n.h"
+#include "crypto/s2n_hash.h"
+#include "utils/s2n_safety.h"
+
+int s2n_hash_reset(struct s2n_hash_state *state)
+{
+    notnull_check(state);
+    notnull_check(state->hash_impl->reset);
+
+    /* return state->hash_impl->reset(state); */
+    return nondet_bool() ? S2N_SUCCESS : S2N_FAILURE;
+}

--- a/tests/cbmc/stubs/s2n_hash_update.c
+++ b/tests/cbmc/stubs/s2n_hash_update.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cbmc_proof/nondet.h>
+
+#include "api/s2n.h"
+#include "crypto/s2n_hash.h"
+#include "utils/s2n_safety.h"
+
+int s2n_hash_update(struct s2n_hash_state *state, const void *data, uint32_t size)
+{
+    PRECONDITION_POSIX(s2n_hash_state_validate(state));
+    ENSURE_POSIX(size == 0 || S2N_MEM_IS_READABLE(data, size), S2N_ERR_PRECONDITION_VIOLATION);
+    notnull_check(state->hash_impl->update);
+
+    /* return state->hash_impl->update(state, data, size); */
+    return nondet_bool() ? S2N_SUCCESS : S2N_FAILURE;
+}

--- a/tests/cbmc/stubs/s2n_hash_update.c
+++ b/tests/cbmc/stubs/s2n_hash_update.c
@@ -22,7 +22,7 @@
 int s2n_hash_update(struct s2n_hash_state *state, const void *data, uint32_t size)
 {
     PRECONDITION_POSIX(s2n_hash_state_validate(state));
-    ENSURE_POSIX(size == 0 || S2N_MEM_IS_READABLE(data, size), S2N_ERR_PRECONDITION_VIOLATION);
+    ENSURE_POSIX(S2N_MEM_IS_READABLE(data, size), S2N_ERR_PRECONDITION_VIOLATION);
     notnull_check(state->hash_impl->update);
 
     /* return state->hash_impl->update(state, data, size); */


### PR DESCRIPTION
### Resolved issues:

N/A.

### Description of changes: 

- Adds two CBMC proofs for `` and `` functions;
- It adds stubs for `s2n_hash` function to cope with performance for proofs;
- It updates preconditions for `s2n_hash_update` and `s2n_hash_digest`;

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
