### PR TITLE
Added new serialization format and updated encryption logic

### DIFF
--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -15,14 +15,18 @@
 
 #include "s2n_test.h"
 
-#include "tls/s2n_cipher_suites.h"
-#include "tls/s2n_connection.h"
 #include "tls/s2n_tls.h"
-#include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_safety.h"
-
+#include "tls/s2n_resume.h"
 /* To test static function */
 #include "tls/s2n_resume.c"
+
+#define S2N_TLS13_STATE_SIZE_WITHOUT_KEY    sizeof(uint8_t)  +  /* serialization format */  \
+                                            sizeof(uint8_t)  +  /* protocol version */      \
+                                            sizeof(uint16_t) +  /* cipher suite */          \
+                                            sizeof(uint64_t) +  /* ticket issue time */     \
+                                            sizeof(uint32_t) +  /* ticket age add */        \
+                                            sizeof(uint8_t)     /* secret size */
 
 int main(int argc, char **argv)
 {
@@ -37,26 +41,26 @@ int main(int argc, char **argv)
     "18df06843d13a08bf2a449844c5f8a"
     "478001bc4d4c627984d5a41da8d0402919");
 
-    /* s2n_serialize_resumption_state */
+    /* s2n_tls12_serialize_resumption_state */
     {
         struct s2n_connection *conn;
-        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         conn->actual_protocol_version = S2N_TLS12;
 
-        struct s2n_blob blob = {0};
-        struct s2n_stuffer stuffer = {0};
+        struct s2n_blob blob = { 0 };
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_blob_init(&blob, conn->secure.master_secret, S2N_TLS_SECRET_LEN));
         EXPECT_SUCCESS(s2n_stuffer_init(&stuffer, &blob));
         EXPECT_SUCCESS(s2n_stuffer_write_bytes(&stuffer, test_master_secret.data, S2N_TLS_SECRET_LEN));
         conn->secure.cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
 
         uint8_t s_data[S2N_STATE_SIZE_IN_BYTES + S2N_TLS_GCM_TAG_LEN] = { 0 };
-        struct s2n_blob state_blob = {0};
+        struct s2n_blob state_blob = { 0 };
         GUARD(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
-        struct s2n_stuffer output = {0};
+        struct s2n_stuffer output = { 0 };
 
         GUARD(s2n_stuffer_init(&output, &state_blob));
-        EXPECT_SUCCESS(s2n_serialize_resumption_state(conn, &output));
+        EXPECT_SUCCESS(s2n_tls12_serialize_resumption_state(conn, &output));
 
         uint8_t serial_id = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8(&output, &serial_id));
@@ -66,14 +70,14 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_read_uint8(&output, &version));
         EXPECT_EQUAL(version, S2N_TLS12);
 
-        uint8_t iana_value[2] = {0};
+        uint8_t iana_value[2] = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_read_bytes(&output, iana_value, S2N_TLS_CIPHER_SUITE_LEN));
         EXPECT_BYTEARRAY_EQUAL(conn->secure.cipher_suite->iana_value, &iana_value, S2N_TLS_CIPHER_SUITE_LEN);
 
         /* Current time */
         EXPECT_SUCCESS(s2n_stuffer_skip_read(&output, sizeof(uint64_t)));
 
-        uint8_t master_secret[S2N_TLS_SECRET_LEN] = {0};
+        uint8_t master_secret[S2N_TLS_SECRET_LEN] = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_read_bytes(&output, master_secret, S2N_TLS_SECRET_LEN));
         EXPECT_BYTEARRAY_EQUAL(test_master_secret.data, master_secret, S2N_TLS_SECRET_LEN);
         
@@ -85,9 +89,9 @@ int main(int argc, char **argv)
         /* Safety checks */
         {
             struct s2n_connection *conn;
-            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
-            struct s2n_stuffer output = {0};
-            struct s2n_ticket_fields ticket_fields = {0};
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            struct s2n_stuffer output = { 0 };
+            struct s2n_ticket_fields ticket_fields = { 0 };
 
             EXPECT_ERROR_WITH_ERRNO(s2n_tls13_serialize_resumption_state(NULL, &ticket_fields, &output), S2N_ERR_NULL);
             EXPECT_ERROR_WITH_ERRNO(s2n_tls13_serialize_resumption_state(conn, NULL, &output), S2N_ERR_NULL);
@@ -99,12 +103,12 @@ int main(int argc, char **argv)
         /* Test TLS1.3 serialization */
         {
             struct s2n_connection *conn;
-            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             conn->actual_protocol_version = S2N_TLS13;
 
             conn->secure.cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
 
-            DEFER_CLEANUP(struct s2n_stuffer output = {0}, s2n_stuffer_free);
+            DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, 0));
 
             struct s2n_ticket_fields ticket_fields = { .ticket_age_add = 1, .session_secret = test_session_secret };
@@ -119,7 +123,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_read_uint8(&output, &version));
             EXPECT_EQUAL(version, S2N_TLS13);
 
-            uint8_t iana_value[2] = {0};
+            uint8_t iana_value[2] = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_read_bytes(&output, iana_value, S2N_TLS_CIPHER_SUITE_LEN));
             EXPECT_BYTEARRAY_EQUAL(conn->secure.cipher_suite->iana_value, &iana_value, S2N_TLS_CIPHER_SUITE_LEN);
 
@@ -134,11 +138,115 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_read_uint8(&output, &secret_len));
             EXPECT_EQUAL(secret_len, ticket_fields.session_secret.size);
 
-            uint8_t session_secret[S2N_TLS_SECRET_LEN] = {0};
+            uint8_t session_secret[S2N_TLS_SECRET_LEN] = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_read_bytes(&output, session_secret, secret_len));
             EXPECT_BYTEARRAY_EQUAL(test_session_secret.data, session_secret, secret_len);
             
             EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Erroneous secret size */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            conn->actual_protocol_version = S2N_TLS13;
+
+            DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, 0));
+
+            struct s2n_ticket_fields ticket_fields = { .ticket_age_add = 1, .session_secret = test_session_secret };
+
+            ticket_fields.session_secret.size = UINT8_MAX + 1;
+            EXPECT_ERROR_WITH_ERRNO(s2n_tls13_serialize_resumption_state(conn, &ticket_fields, &output), S2N_ERR_SAFETY);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+    }
+
+    /* s2n_encrypt_session_ticket */
+    {
+        /* Session ticket keys. Taken from test vectors in https://tools.ietf.org/html/rfc5869 */
+        uint8_t ticket_key_name[16] = "2016.07.26.15\0";
+        S2N_BLOB_FROM_HEX(ticket_key, 
+        "077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5");
+
+        /* Check encrypted data can be decrypted correctly for TLS12 */
+        {
+            struct s2n_connection *conn;
+            struct s2n_config *config;
+            uint64_t current_time;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            EXPECT_NOT_NULL(config = s2n_config_new());
+
+            EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(config, 1));
+            EXPECT_SUCCESS(config->wall_clock(config->sys_clock_ctx, &current_time));
+            EXPECT_SUCCESS(s2n_config_add_ticket_crypto_key(config, ticket_key_name, strlen((char *)ticket_key_name),
+                         ticket_key.data, sizeof(ticket_key), current_time/ONE_SEC_IN_NANOS));
+
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+            conn->actual_protocol_version = S2N_TLS12;
+
+            struct s2n_blob secret = { 0 };
+            struct s2n_stuffer secret_stuffer = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&secret, conn->secure.master_secret, S2N_TLS_SECRET_LEN));
+            EXPECT_SUCCESS(s2n_stuffer_init(&secret_stuffer, &secret));
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&secret_stuffer, test_master_secret.data, S2N_TLS_SECRET_LEN));
+            conn->secure.cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
+
+            uint8_t data[S2N_TICKET_SIZE_IN_BYTES] = { 0 };
+            struct s2n_blob blob = { 0 };
+            struct s2n_stuffer output = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&blob, data, sizeof(data)));
+            EXPECT_SUCCESS(s2n_stuffer_init(&output, &blob));
+
+            EXPECT_SUCCESS(s2n_encrypt_session_ticket(conn, NULL, &output));
+
+            /* Wiping the master secret to prove that the decryption function actually writes the master secret */
+            EXPECT_SUCCESS(s2n_stuffer_wipe(&secret_stuffer));
+
+            conn->client_ticket_to_decrypt = output;
+            EXPECT_SUCCESS(s2n_decrypt_session_ticket(conn));
+
+            /* Check decryption was successful by comparing master key */
+            EXPECT_BYTEARRAY_EQUAL(conn->secure.master_secret, test_master_secret.data, test_session_secret.size);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_config_free(config));
+        }
+
+        /* Check session ticket size is correct for TLS13. The contents of the output will be
+         * tested once the TLS1.3 deserialization function is written. */
+        {
+            struct s2n_connection *conn;
+            struct s2n_config *config;
+            uint64_t current_time;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            EXPECT_NOT_NULL(config = s2n_config_new());
+
+            EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(config, 1));
+            EXPECT_SUCCESS(config->wall_clock(config->sys_clock_ctx, &current_time));
+            EXPECT_SUCCESS(s2n_config_add_ticket_crypto_key(config, ticket_key_name, strlen((char *)ticket_key_name),
+                         ticket_key.data, sizeof(ticket_key), current_time/ONE_SEC_IN_NANOS));
+
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+            conn->actual_protocol_version = S2N_TLS13;
+
+            uint8_t data[S2N_TICKET_KEY_NAME_LEN + S2N_TLS_GCM_IV_LEN + S2N_MAX_STATE_SIZE_IN_BYTES + S2N_TLS_GCM_TAG_LEN] = { 0 };
+            struct s2n_blob blob = { 0 };
+            struct s2n_stuffer output = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&blob, data, sizeof(data)));
+            EXPECT_SUCCESS(s2n_stuffer_init(&output, &blob));
+            struct s2n_ticket_fields ticket_fields = { .ticket_age_add = 1, .session_secret = test_session_secret };
+
+            EXPECT_SUCCESS(s2n_encrypt_session_ticket(conn, &ticket_fields, &output));
+
+            uint32_t expected_size = S2N_TICKET_KEY_NAME_LEN + S2N_TLS_GCM_IV_LEN + 
+                        S2N_TLS13_STATE_SIZE_WITHOUT_KEY + test_session_secret.size + S2N_TLS_GCM_TAG_LEN;
+            EXPECT_EQUAL(expected_size, s2n_stuffer_data_available(&output));
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_config_free(config));
         }
     }
     END_TEST();

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -140,46 +140,6 @@ int main(int argc, char **argv)
             
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }
-
-        /* Test secret that is too large */
-        {
-            S2N_BLOB_FROM_HEX(large_secret,
-            "ee85dd54781bd4d8a100589a9fe6ac9a3797b811e977f549cd"
-            "531be2441d7c63e2b9729d145c11d84af35957727565a400");
-
-            struct s2n_connection *conn;
-            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
-            conn->actual_protocol_version = S2N_TLS13;
-
-            DEFER_CLEANUP(struct s2n_stuffer output = {0}, s2n_stuffer_free);
-            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, 0));
-
-            struct s2n_ticket_fields ticket_fields = { .ticket_age_add = 1, .session_secret = large_secret };
-
-            EXPECT_ERROR_WITH_ERRNO(s2n_tls13_serialize_resumption_state(conn, &ticket_fields, &output), S2N_ERR_SAFETY);
-
-            EXPECT_SUCCESS(s2n_connection_free(conn));
-        }
-
-         /* Test secret that is too small */
-        {
-            S2N_BLOB_FROM_HEX(small_secret,
-            "18df06843d13a08bf2a449844c5f8a"
-            "478001bc4d4c627984d5a41d");
-
-            struct s2n_connection *conn;
-            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
-            conn->actual_protocol_version = S2N_TLS13;
-
-            DEFER_CLEANUP(struct s2n_stuffer output = {0}, s2n_stuffer_free);
-            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, 0));
-
-            struct s2n_ticket_fields ticket_fields = { .ticket_age_add = 1, .session_secret = small_secret };
-
-            EXPECT_ERROR_WITH_ERRNO(s2n_tls13_serialize_resumption_state(conn, &ticket_fields, &output), S2N_ERR_SAFETY);
-
-            EXPECT_SUCCESS(s2n_connection_free(conn));
-        }
     }
     END_TEST();
 }

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -27,67 +27,72 @@
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
-    
+
+    /* Two random secrets of different sizes */
+    S2N_BLOB_FROM_HEX(test_master_secret,
+    "ee85dd54781bd4d8a100589a9fe6ac9a3797b811e977f549cd"
+    "531be2441d7c63e2b9729d145c11d84af35957727565a4");
+
+    S2N_BLOB_FROM_HEX(test_session_secret,
+    "18df06843d13a08bf2a449844c5f8a"
+    "478001bc4d4c627984d5a41da8d0402919");
+
     /* s2n_serialize_resumption_state */
+    {
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        conn->actual_protocol_version = S2N_TLS12;
+
+        struct s2n_blob blob = {0};
+        struct s2n_stuffer stuffer = {0};
+        EXPECT_SUCCESS(s2n_blob_init(&blob, conn->secure.master_secret, S2N_TLS_SECRET_LEN));
+        EXPECT_SUCCESS(s2n_stuffer_init(&stuffer, &blob));
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&stuffer, test_master_secret.data, S2N_TLS_SECRET_LEN));
+        conn->secure.cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
+
+        uint8_t s_data[S2N_STATE_SIZE_IN_BYTES + S2N_TLS_GCM_TAG_LEN] = { 0 };
+        struct s2n_blob state_blob = {0};
+        GUARD(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
+        struct s2n_stuffer output = {0};
+
+        GUARD(s2n_stuffer_init(&output, &state_blob));
+        EXPECT_SUCCESS(s2n_serialize_resumption_state(conn, &output));
+
+        uint8_t serial_id = 0;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint8(&output, &serial_id));
+        EXPECT_EQUAL(serial_id, S2N_TLS12_SERIALIZED_FORMAT_VERSION);
+
+        uint8_t version = 0;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint8(&output, &version));
+        EXPECT_EQUAL(version, S2N_TLS12);
+
+        uint8_t iana_value[2] = {0};
+        EXPECT_SUCCESS(s2n_stuffer_read_bytes(&output, iana_value, S2N_TLS_CIPHER_SUITE_LEN));
+        EXPECT_BYTEARRAY_EQUAL(conn->secure.cipher_suite->iana_value, &iana_value, S2N_TLS_CIPHER_SUITE_LEN);
+
+        /* Current time */
+        EXPECT_SUCCESS(s2n_stuffer_skip_read(&output, sizeof(uint64_t)));
+
+        uint8_t master_secret[S2N_TLS_SECRET_LEN] = {0};
+        EXPECT_SUCCESS(s2n_stuffer_read_bytes(&output, master_secret, S2N_TLS_SECRET_LEN));
+        EXPECT_BYTEARRAY_EQUAL(test_master_secret.data, master_secret, S2N_TLS_SECRET_LEN);
+        
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+    
+    /* s2n_tls13_serialize_resumption_state */
     {
         /* Safety checks */
         {
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             struct s2n_stuffer output = {0};
+            struct s2n_ticket_fields ticket_fields = {0};
 
-            EXPECT_ERROR_WITH_ERRNO(s2n_serialize_resumption_state(NULL, NULL, &output), S2N_ERR_NULL);
-            EXPECT_ERROR_WITH_ERRNO(s2n_serialize_resumption_state(conn, NULL, NULL), S2N_ERR_NULL);
+            EXPECT_ERROR_WITH_ERRNO(s2n_tls13_serialize_resumption_state(NULL, &ticket_fields, &output), S2N_ERR_NULL);
+            EXPECT_ERROR_WITH_ERRNO(s2n_tls13_serialize_resumption_state(conn, NULL, &output), S2N_ERR_NULL);
+            EXPECT_ERROR_WITH_ERRNO(s2n_tls13_serialize_resumption_state(conn, &ticket_fields, NULL), S2N_ERR_NULL);
 
-            EXPECT_SUCCESS(s2n_connection_free(conn));
-        }
-
-        /* Two random secrets of different sizes */
-        S2N_BLOB_FROM_HEX(test_master_secret,
-        "ee85dd54781bd4d8a100589a9fe6ac9a3797b811e977f549cd"
-        "531be2441d7c63e2b9729d145c11d84af35957727565a4");
-
-        S2N_BLOB_FROM_HEX(test_session_secret,
-        "18df06843d13a08bf2a449844c5f8a"
-        "478001bc4d4c627984d5a41da8d0402919");
-
-        /* Test TLS1.2 serialization */
-        {
-            struct s2n_connection *conn;
-            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
-            conn->actual_protocol_version = S2N_TLS12;
-
-            struct s2n_blob blob = {0};
-            struct s2n_stuffer stuffer = {0};
-            EXPECT_SUCCESS(s2n_blob_init(&blob, conn->secure.master_secret, S2N_TLS_SECRET_LEN));
-            EXPECT_SUCCESS(s2n_stuffer_init(&stuffer, &blob));
-            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&stuffer, test_master_secret.data, S2N_TLS_SECRET_LEN));
-            conn->secure.cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
-
-            DEFER_CLEANUP(struct s2n_stuffer output = {0}, s2n_stuffer_free);
-            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, 0));
-
-            EXPECT_OK(s2n_serialize_resumption_state(conn, NULL, &output));
-
-            uint8_t serial_id = 0;
-            EXPECT_SUCCESS(s2n_stuffer_read_uint8(&output, &serial_id));
-            EXPECT_EQUAL(serial_id, S2N_SERIALIZED_FORMAT_VERSION);
-
-            uint8_t version = 0;
-            EXPECT_SUCCESS(s2n_stuffer_read_uint8(&output, &version));
-            EXPECT_EQUAL(version, S2N_TLS12);
-
-            uint8_t iana_value[2] = {0};
-            EXPECT_SUCCESS(s2n_stuffer_read_bytes(&output, iana_value, S2N_TLS_CIPHER_SUITE_LEN));
-            EXPECT_BYTEARRAY_EQUAL(conn->secure.cipher_suite->iana_value, &iana_value, S2N_TLS_CIPHER_SUITE_LEN);
-
-            /* Current time */
-            EXPECT_SUCCESS(s2n_stuffer_skip_read(&output, sizeof(uint64_t)));
-
-            uint8_t master_secret[S2N_TLS_SECRET_LEN] = {0};
-            EXPECT_SUCCESS(s2n_stuffer_read_bytes(&output, master_secret, S2N_TLS_SECRET_LEN));
-            EXPECT_BYTEARRAY_EQUAL(test_master_secret.data, master_secret, S2N_TLS_SECRET_LEN);
-            
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }
 
@@ -104,7 +109,7 @@ int main(int argc, char **argv)
 
             struct s2n_ticket_fields ticket_fields = { .ticket_age_add = 1, .session_secret = test_session_secret };
 
-            EXPECT_OK(s2n_serialize_resumption_state(conn, &ticket_fields, &output));
+            EXPECT_OK(s2n_tls13_serialize_resumption_state(conn, &ticket_fields, &output));
 
             uint8_t serial_id = 0;
             EXPECT_SUCCESS(s2n_stuffer_read_uint8(&output, &serial_id));
@@ -135,7 +140,46 @@ int main(int argc, char **argv)
             
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }
-        
+
+        /* Test secret that is too large */
+        {
+            S2N_BLOB_FROM_HEX(large_secret,
+            "ee85dd54781bd4d8a100589a9fe6ac9a3797b811e977f549cd"
+            "531be2441d7c63e2b9729d145c11d84af35957727565a400");
+
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            conn->actual_protocol_version = S2N_TLS13;
+
+            DEFER_CLEANUP(struct s2n_stuffer output = {0}, s2n_stuffer_free);
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, 0));
+
+            struct s2n_ticket_fields ticket_fields = { .ticket_age_add = 1, .session_secret = large_secret };
+
+            EXPECT_ERROR_WITH_ERRNO(s2n_tls13_serialize_resumption_state(conn, &ticket_fields, &output), S2N_ERR_SAFETY);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+         /* Test secret that is too small */
+        {
+            S2N_BLOB_FROM_HEX(small_secret,
+            "18df06843d13a08bf2a449844c5f8a"
+            "478001bc4d4c627984d5a41d");
+
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            conn->actual_protocol_version = S2N_TLS13;
+
+            DEFER_CLEANUP(struct s2n_stuffer output = {0}, s2n_stuffer_free);
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, 0));
+
+            struct s2n_ticket_fields ticket_fields = { .ticket_age_add = 1, .session_secret = small_secret };
+
+            EXPECT_ERROR_WITH_ERRNO(s2n_tls13_serialize_resumption_state(conn, &ticket_fields, &output), S2N_ERR_SAFETY);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
     }
     END_TEST();
 }

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -1,0 +1,141 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "tls/s2n_cipher_suites.h"
+#include "tls/s2n_connection.h"
+#include "tls/s2n_tls.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_safety.h"
+
+/* To test static function */
+#include "tls/s2n_resume.c"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+    
+    /* s2n_serialize_resumption_state */
+    {
+        /* Safety checks */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            struct s2n_stuffer output = {0};
+
+            EXPECT_ERROR_WITH_ERRNO(s2n_serialize_resumption_state(NULL, NULL, &output), S2N_ERR_NULL);
+            EXPECT_ERROR_WITH_ERRNO(s2n_serialize_resumption_state(conn, NULL, NULL), S2N_ERR_NULL);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Two random secrets of different sizes */
+        S2N_BLOB_FROM_HEX(test_master_secret,
+        "ee85dd54781bd4d8a100589a9fe6ac9a3797b811e977f549cd"
+        "531be2441d7c63e2b9729d145c11d84af35957727565a4");
+
+        S2N_BLOB_FROM_HEX(test_session_secret,
+        "18df06843d13a08bf2a449844c5f8a"
+        "478001bc4d4c627984d5a41da8d0402919");
+
+        /* Test TLS1.2 serialization */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            conn->actual_protocol_version = S2N_TLS12;
+
+            struct s2n_blob blob = {0};
+            struct s2n_stuffer stuffer = {0};
+            EXPECT_SUCCESS(s2n_blob_init(&blob, conn->secure.master_secret, S2N_TLS_SECRET_LEN));
+            EXPECT_SUCCESS(s2n_stuffer_init(&stuffer, &blob));
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&stuffer, test_master_secret.data, S2N_TLS_SECRET_LEN));
+            conn->secure.cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
+
+            DEFER_CLEANUP(struct s2n_stuffer output = {0}, s2n_stuffer_free);
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, 0));
+
+            EXPECT_OK(s2n_serialize_resumption_state(conn, NULL, &output));
+
+            uint8_t serial_id = 0;
+            EXPECT_SUCCESS(s2n_stuffer_read_uint8(&output, &serial_id));
+            EXPECT_EQUAL(serial_id, S2N_SERIALIZED_FORMAT_VERSION);
+
+            uint8_t version = 0;
+            EXPECT_SUCCESS(s2n_stuffer_read_uint8(&output, &version));
+            EXPECT_EQUAL(version, S2N_TLS12);
+
+            uint8_t iana_value[2] = {0};
+            EXPECT_SUCCESS(s2n_stuffer_read_bytes(&output, iana_value, S2N_TLS_CIPHER_SUITE_LEN));
+            EXPECT_BYTEARRAY_EQUAL(conn->secure.cipher_suite->iana_value, &iana_value, S2N_TLS_CIPHER_SUITE_LEN);
+
+            /* Current time */
+            EXPECT_SUCCESS(s2n_stuffer_skip_read(&output, sizeof(uint64_t)));
+
+            uint8_t master_secret[S2N_TLS_SECRET_LEN] = {0};
+            EXPECT_SUCCESS(s2n_stuffer_read_bytes(&output, master_secret, S2N_TLS_SECRET_LEN));
+            EXPECT_BYTEARRAY_EQUAL(test_master_secret.data, master_secret, S2N_TLS_SECRET_LEN);
+            
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Test TLS1.3 serialization */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            conn->actual_protocol_version = S2N_TLS13;
+
+            conn->secure.cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
+
+            DEFER_CLEANUP(struct s2n_stuffer output = {0}, s2n_stuffer_free);
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, 0));
+
+            struct s2n_ticket_fields ticket_fields = { .ticket_age_add = 1, .session_secret = test_session_secret };
+
+            EXPECT_OK(s2n_serialize_resumption_state(conn, &ticket_fields, &output));
+
+            uint8_t serial_id = 0;
+            EXPECT_SUCCESS(s2n_stuffer_read_uint8(&output, &serial_id));
+            EXPECT_EQUAL(serial_id, S2N_TLS13_SERIALIZED_FORMAT_VERSION);
+
+            uint8_t version = 0;
+            EXPECT_SUCCESS(s2n_stuffer_read_uint8(&output, &version));
+            EXPECT_EQUAL(version, S2N_TLS13);
+
+            uint8_t iana_value[2] = {0};
+            EXPECT_SUCCESS(s2n_stuffer_read_bytes(&output, iana_value, S2N_TLS_CIPHER_SUITE_LEN));
+            EXPECT_BYTEARRAY_EQUAL(conn->secure.cipher_suite->iana_value, &iana_value, S2N_TLS_CIPHER_SUITE_LEN);
+
+            /* Current time */
+            EXPECT_SUCCESS(s2n_stuffer_skip_read(&output, sizeof(uint64_t)));
+
+            uint32_t ticket_age_add = 0;
+            EXPECT_SUCCESS(s2n_stuffer_read_uint32(&output, &ticket_age_add));
+            EXPECT_EQUAL(ticket_age_add, ticket_fields.ticket_age_add);
+
+            uint8_t secret_len = 0;
+            EXPECT_SUCCESS(s2n_stuffer_read_uint8(&output, &secret_len));
+            EXPECT_EQUAL(secret_len, ticket_fields.session_secret.size);
+
+            uint8_t session_secret[S2N_TLS_SECRET_LEN] = {0};
+            EXPECT_SUCCESS(s2n_stuffer_read_bytes(&output, session_secret, secret_len));
+            EXPECT_BYTEARRAY_EQUAL(test_session_secret.data, session_secret, secret_len);
+            
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+        
+    }
+    END_TEST();
+}

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -545,7 +545,8 @@ int s2n_encrypt_session_ticket(struct s2n_connection *conn, struct s2n_ticket_fi
     } else {
         uint8_t s_data[S2N_TLS13_MAX_STATE_SIZE_IN_BYTES + S2N_TLS_GCM_TAG_LEN] = {0};
         /* TLS1.3 session resumption ticket size varies based on session secret size */
-        GUARD(s2n_blob_init(&state_blob, s_data, sizeof(S2N_TLS13_STATE_SIZE_IN_BYTES + ticket_fields->session_secret.size)));
+        GUARD(s2n_blob_init(&state_blob, s_data, S2N_TLS13_STATE_SIZE_IN_BYTES + 
+                ticket_fields->session_secret.size + S2N_TLS_GCM_TAG_LEN));
         GUARD(s2n_stuffer_init(&state, &state_blob));
         GUARD_AS_POSIX(s2n_tls13_serialize_resumption_state(conn, ticket_fields, &state));
     }

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -552,7 +552,7 @@ int s2n_encrypt_session_ticket(struct s2n_connection *conn, struct s2n_ticket_fi
     GUARD_AS_POSIX(s2n_serialize_resumption_state(conn, ticket_fields, &state));
     
     /* Get the correct session resumption ticket size */
-    state_blob.size = state.write_cursor + S2N_TLS_GCM_TAG_LEN;
+    state_blob.size = s2n_stuffer_data_available(&state) + S2N_TLS_GCM_TAG_LEN;
 
     GUARD(s2n_aes256_gcm.io.aead.encrypt(&aes_ticket_key, &iv, &aad_blob, &state_blob, &state_blob));
 

--- a/tls/s2n_resume.h
+++ b/tls/s2n_resume.h
@@ -20,6 +20,7 @@
 #include "stuffer/s2n_stuffer.h"
 
 #define S2N_SERIALIZED_FORMAT_VERSION   1
+#define S2N_TLS13_SERIALIZED_FORMAT_VERSION   2
 #define S2N_STATE_LIFETIME_IN_NANOS     54000000000000      /* 15 hours */
 #define S2N_STATE_SIZE_IN_BYTES         (1 + 8 + 1 + S2N_TLS_CIPHER_SUITE_LEN + S2N_TLS_SECRET_LEN)
 #define S2N_TLS_SESSION_CACHE_TTL       (6 * 60 * 60)
@@ -50,6 +51,11 @@ struct s2n_ticket_key {
 struct s2n_ticket_key_weight {
     double key_weight;
     uint8_t key_index;
+};
+
+struct s2n_ticket_fields {
+    struct s2n_blob session_secret;
+    uint32_t ticket_age_add;
 };
 
 extern struct s2n_ticket_key *s2n_find_ticket_key(struct s2n_config *config, const uint8_t *name);

--- a/tls/s2n_resume.h
+++ b/tls/s2n_resume.h
@@ -22,13 +22,13 @@
 #define S2N_STATE_LIFETIME_IN_NANOS     54000000000000      /* 15 hours */
 #define S2N_STATE_SIZE_IN_BYTES         (1 + 8 + 1 + S2N_TLS_CIPHER_SUITE_LEN + S2N_TLS_SECRET_LEN)
 
-#define S2N_TLS13_STATE_SIZE_IN_BYTES   sizeof(uint8_t) +  /* serialization format */  \
-                                        sizeof(uint8_t) +  /* protocol version */      \
-                                        sizeof(uint16_t) + /* cipher suite */          \
-                                        sizeof(uint64_t) + /* ticket issue time */     \
-                                        sizeof(uint32_t)   /* ticket age add */
-
-#define S2N_TLS13_MAX_STATE_SIZE_IN_BYTES   S2N_TLS13_STATE_SIZE_IN_BYTES + S2N_TLS_SECRET_LEN
+#define S2N_MAX_STATE_SIZE_IN_BYTES     sizeof(uint8_t)  +  /* serialization format */  \
+                                        sizeof(uint8_t)  +  /* protocol version */      \
+                                        sizeof(uint16_t) +  /* cipher suite */          \
+                                        sizeof(uint64_t) +  /* ticket issue time */     \
+                                        sizeof(uint32_t) +  /* ticket age add */        \
+                                        sizeof(uint8_t)  +  /* secret size */            \
+                                        S2N_TLS_SECRET_LEN
 
 #define S2N_TLS_SESSION_CACHE_TTL       (6 * 60 * 60)
 #define S2N_TICKET_KEY_NAME_LEN         16

--- a/tls/s2n_resume.h
+++ b/tls/s2n_resume.h
@@ -21,6 +21,15 @@
 
 #define S2N_STATE_LIFETIME_IN_NANOS     54000000000000      /* 15 hours */
 #define S2N_STATE_SIZE_IN_BYTES         (1 + 8 + 1 + S2N_TLS_CIPHER_SUITE_LEN + S2N_TLS_SECRET_LEN)
+
+#define S2N_TLS13_STATE_SIZE_IN_BYTES   sizeof(uint8_t) +  /* serialization format */  \
+                                        sizeof(uint8_t) +  /* protocol version */      \
+                                        sizeof(uint16_t) + /* cipher suite */          \
+                                        sizeof(uint64_t) + /* ticket issue time */     \
+                                        sizeof(uint32_t)   /* ticket age add */
+
+#define S2N_TLS13_MAX_STATE_SIZE_IN_BYTES   S2N_TLS13_STATE_SIZE_IN_BYTES + S2N_TLS_SECRET_LEN
+
 #define S2N_TLS_SESSION_CACHE_TTL       (6 * 60 * 60)
 #define S2N_TICKET_KEY_NAME_LEN         16
 #define S2N_TICKET_AAD_IMPLICIT_LEN     12
@@ -57,7 +66,7 @@ struct s2n_ticket_fields {
 };
 
 extern struct s2n_ticket_key *s2n_find_ticket_key(struct s2n_config *config, const uint8_t *name);
-extern int s2n_encrypt_session_ticket(struct s2n_connection *conn, struct s2n_stuffer *to);
+extern int s2n_encrypt_session_ticket(struct s2n_connection *conn, struct s2n_ticket_fields *ticket_fields, struct s2n_stuffer *to);
 extern int s2n_decrypt_session_ticket(struct s2n_connection *conn);
 extern int s2n_encrypt_session_cache(struct s2n_connection *conn, struct s2n_stuffer *to); 
 extern int s2n_decrypt_session_cache(struct s2n_connection *conn, struct s2n_stuffer *from); 

--- a/tls/s2n_resume.h
+++ b/tls/s2n_resume.h
@@ -19,8 +19,6 @@
 
 #include "stuffer/s2n_stuffer.h"
 
-#define S2N_SERIALIZED_FORMAT_VERSION   1
-#define S2N_TLS13_SERIALIZED_FORMAT_VERSION   2
 #define S2N_STATE_LIFETIME_IN_NANOS     54000000000000      /* 15 hours */
 #define S2N_STATE_SIZE_IN_BYTES         (1 + 8 + 1 + S2N_TLS_CIPHER_SUITE_LEN + S2N_TLS_SECRET_LEN)
 #define S2N_TLS_SESSION_CACHE_TTL       (6 * 60 * 60)
@@ -72,6 +70,11 @@ typedef enum {
     S2N_STATE_WITH_SESSION_ID = 0,
     S2N_STATE_WITH_SESSION_TICKET
 } s2n_client_tls_session_state_format;
+
+typedef enum {
+    S2N_TLS12_SERIALIZED_FORMAT_VERSION = 1,
+    S2N_TLS13_SERIALIZED_FORMAT_VERSION
+} s2n_serial_format_version;
 
 extern int s2n_allowed_to_cache_connection(struct s2n_connection *conn);
 extern int s2n_resume_from_cache(struct s2n_connection *conn);

--- a/tls/s2n_server_new_session_ticket.c
+++ b/tls/s2n_server_new_session_ticket.c
@@ -69,7 +69,7 @@ int s2n_server_nst_send(struct s2n_connection *conn)
     GUARD(s2n_stuffer_write_uint32(&conn->handshake.io, lifetime_hint_in_secs));
     GUARD(s2n_stuffer_write_uint16(&conn->handshake.io, session_ticket_len));
 
-    GUARD(s2n_encrypt_session_ticket(conn, &to));
+    GUARD(s2n_encrypt_session_ticket(conn, NULL, &to));
     GUARD(s2n_stuffer_write(&conn->handshake.io, &to.blob));
 
     return 0;


### PR DESCRIPTION
### Resolved issues:

 resolves #2480 resolves #2479
### Description of changes: 

Adds new serialization logic and encryption logic to session resumption.
### Call-outs:
Because the tls13 deserialize function is being written later on, the tests for tls1.3 s2n_encrypt_session_ticket are not complete yet, although I do have a unit test that checks that the encryption size is correct.
### Testing:

Unit tests for tls1.2 and tls1.3.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
