### PR TITLE
Adds a proof harness for s2n_hmac_init

### DIFF
--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -200,6 +200,7 @@ S2N_RESULT s2n_hmac_state_validate(struct s2n_hmac_state *state)
 
 int s2n_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm alg, const void *key, uint32_t klen)
 {
+    notnull_check(state);
     if (!s2n_hmac_is_available(alg)) {
         /* Prevent hmacs from being used if they are not available. */
         S2N_ERROR(S2N_ERR_HMAC_INVALID_ALGORITHM);

--- a/tests/cbmc/proofs/s2n_hash_init/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_init/Makefile
@@ -1,0 +1,47 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 5 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hash_init
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/md5_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/sha_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_evp.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_copy
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_new
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_reset
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_free
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_allow_md5_for_fips
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_copy
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_free
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_new
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_reset
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hash_init/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_hash_init/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_hash_init/s2n_hash_init_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_init/s2n_hash_init_harness.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <cbmc_proof/make_common_datastructures.h>
+
+#include "crypto/s2n_hash.h"
+
+void s2n_hash_init_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_hash_state *state = cbmc_allocate_s2n_hash_state();
+    s2n_hash_algorithm alg;
+
+    /* Operation under verification. */
+    if (s2n_hash_init(state, alg) == S2N_SUCCESS) {
+        /* Post-conditions. */
+        assert(s2n_result_is_ok(s2n_hash_state_validate(state)));
+    }
+}

--- a/tests/cbmc/proofs/s2n_hmac_init/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_init/Makefile
@@ -1,0 +1,66 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hmac_init
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/md5_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/sha_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_evp.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_new
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_reset
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_free
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_digest
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_update
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_free
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_new
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_reset
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_digest
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_update
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_allow_md5_for_fips
+REMOVE_FUNCTION_BODY += s2n_hash_allow_md5_for_fips
+
+# The upper bound limit for these loops is me maximum possible value for xor_pad_size field
+# in struct s2n_hmac_state (128) plus one. See definition for struct s2n_hmac_state
+UNWINDSET += __CPROVER_file_local_s2n_hmac_c_s2n_sslv3_mac_init.0:129
+UNWINDSET += __CPROVER_file_local_s2n_hmac_c_s2n_sslv3_mac_init.1:129
+UNWINDSET += __CPROVER_file_local_s2n_hmac_c_s2n_sslv3_mac_init.2:129
+UNWINDSET += __CPROVER_file_local_s2n_hmac_c_s2n_sslv3_mac_init.3:129
+UNWINDSET += __CPROVER_file_local_s2n_hmac_c_s2n_sslv3_mac_init.4:129
+UNWINDSET += __CPROVER_file_local_s2n_hmac_c_s2n_sslv3_mac_init.5:129
+UNWINDSET += __CPROVER_file_local_s2n_hmac_c_s2n_tls_hmac_init.0:129
+UNWINDSET += __CPROVER_file_local_s2n_hmac_c_s2n_tls_hmac_init.1:129
+UNWINDSET += __CPROVER_file_local_s2n_hmac_c_s2n_tls_hmac_init.2:129
+UNWINDSET += __CPROVER_file_local_s2n_hmac_c_s2n_tls_hmac_init.3:129
+UNWINDSET += __CPROVER_file_local_s2n_hmac_c_s2n_tls_hmac_init.4:129
+UNWINDSET += __CPROVER_file_local_s2n_hmac_c_s2n_tls_hmac_init.5:129
+UNWINDSET += __CPROVER_file_local_s2n_hmac_c_s2n_tls_hmac_init.6:129
+UNWINDSET += __CPROVER_file_local_s2n_hmac_c_s2n_tls_hmac_init.8:129
+UNWINDSET += __CPROVER_file_local_s2n_hmac_c_s2n_tls_hmac_init.9:129
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hmac_init/cbmc-batch.yaml
+++ b/tests/cbmc/proofs/s2n_hmac_init/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/tests/cbmc/proofs/s2n_hmac_init/s2n_hmac_init_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_init/s2n_hmac_init_harness.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <cbmc_proof/make_common_datastructures.h>
+
+#include "crypto/s2n_hmac.h"
+
+void s2n_hmac_init_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_hmac_state *state = cbmc_allocate_s2n_hmac_state();
+    s2n_hmac_algorithm alg;
+    uint32_t klen;
+    uint8_t *key = malloc(klen);
+
+    /* Operation under verification. */
+    if (s2n_hmac_init(state, alg, key, klen) == S2N_SUCCESS) {
+        /* Post-conditions. */
+        assert(s2n_result_is_ok(s2n_hmac_state_validate(state)));
+        assert(S2N_MEM_IS_READABLE(key, klen));
+    }
+}


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

### Resolved issues:

N/A.

### Description of changes: 

- Adds a proof harness for `s2n_hash_init`;
- Adds a proof harness for `s2n_hmac_init`;
- Adds a nullness check in `s2n_hmac_init`.

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
