### PR TITLE
Remove s2n_cipher_suite_from_wire

### DIFF
--- a/tests/unit/s2n_cipher_suite_match_test.c
+++ b/tests/unit/s2n_cipher_suite_match_test.c
@@ -96,11 +96,11 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
         }
 
-        /**
+        /** Clients MUST verify
          *= https://tools.ietf.org/rfc/rfc8446#section-4.2.11
          *= type=test
-         *# The server MUST ensure that it selects a compatible PSK
-         *# (if any) and cipher suite.
+         *# that the server selected a cipher suite
+         *# indicating a Hash associated with the PSK
          **/
         {
             /* If chosen PSK is set, test error case for incorrect hash match */

--- a/tests/unit/s2n_cipher_suite_match_test.c
+++ b/tests/unit/s2n_cipher_suite_match_test.c
@@ -40,45 +40,6 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13());
-    {
-        struct s2n_connection *conn;
-        uint8_t wire[2];
-        int count;
-        int cipher_suite_order;
-        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
-
-        char *cert_chain;
-        char *private_key;
-        EXPECT_NOT_NULL(cert_chain = malloc(S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_NOT_NULL(private_key = malloc(S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key, S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key(conn->config, cert_chain, private_key));
-
-        /* Test that all cipher suites that s2n negotiates are listed in IANA order */
-        const uint8_t cipher_suite_count = cipher_preferences_test_all.count;
-        for (int i = 0; i < cipher_suite_count-1; ++i) {
-            cipher_suite_order = memcmp(cipher_preferences_test_all.suites[i]->iana_value, cipher_preferences_test_all.suites[i+1]->iana_value, 2);
-            EXPECT_TRUE(cipher_suite_order < 0);
-        }
-        
-        count = 0;
-        for (int i = 0; i < 0xffff; i++) {
-            wire[0] = (i >> 8);
-            wire[1] = i & 0xff;
-
-            struct s2n_cipher_suite *s = s2n_cipher_suite_from_wire(wire);
-            if (s != NULL) {
-                count++;
-            }
-        }
-
-        EXPECT_EQUAL(count, S2N_CIPHER_SUITE_COUNT);
-
-        EXPECT_SUCCESS(s2n_connection_free(conn));
-        free(private_key);
-        free(cert_chain);
-    }
 
     /* Test client cipher selection */
     {

--- a/tests/unit/s2n_cipher_suite_match_test.c
+++ b/tests/unit/s2n_cipher_suite_match_test.c
@@ -319,10 +319,10 @@ int main(int argc, char **argv)
         /* Shouldn't be necessary unless the test fails, but we want the failure to be obvious. */
         conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
         conn->actual_protocol_version = conn->server_protocol_version;
-        const uint8_t expected_rsa_wire_choice[] = { TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA };
+        const struct s2n_cipher_suite *expected_rsa_wire_choice = &s2n_ecdhe_rsa_with_aes_128_cbc_sha;
         EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
         EXPECT_EQUAL(conn->secure_renegotiation, 0);
-        EXPECT_EQUAL(conn->secure.cipher_suite, s2n_cipher_suite_from_wire(expected_rsa_wire_choice));
+        EXPECT_EQUAL(conn->secure.cipher_suite, expected_rsa_wire_choice);
         EXPECT_SUCCESS(s2n_connection_wipe(conn));
 
         /* Test that PQ cipher suites are marked available/unavailable appropriately in s2n_cipher_suites_init() */
@@ -359,12 +359,12 @@ int main(int argc, char **argv)
             conn->secure.client_pq_kem_extension.data = client_extensions_data;
             conn->secure.client_pq_kem_extension.size = client_extensions_len;
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers, cipher_count));
-            const uint8_t bike_cipher[] = {TLS_ECDHE_BIKE_RSA_WITH_AES_256_GCM_SHA384};
-            const uint8_t ecc_cipher[] = {TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384};
+            const struct s2n_cipher_suite *bike_cipher = &s2n_ecdhe_bike_rsa_with_aes_256_gcm_sha384;
+            const struct s2n_cipher_suite *ecc_cipher = &s2n_ecdhe_rsa_with_aes_256_gcm_sha384;
             if (s2n_pq_is_enabled()) {
-                EXPECT_EQUAL(conn->secure.cipher_suite, s2n_cipher_suite_from_wire(bike_cipher));
+                EXPECT_EQUAL(conn->secure.cipher_suite, bike_cipher);
             } else {
-                EXPECT_EQUAL(conn->secure.cipher_suite, s2n_cipher_suite_from_wire(ecc_cipher));
+                EXPECT_EQUAL(conn->secure.cipher_suite, ecc_cipher);
             }
 
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
@@ -373,14 +373,14 @@ int main(int argc, char **argv)
              * only supports TLS 1.1 or below, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA is the first cipher suite that supports
              * TLS 1.1 in KMS-PQ-TLS-1-0-2019-06 */
             for (int i = S2N_TLS10; i <= S2N_TLS11; i++) {
-                const uint8_t expected_classic_wire_choice[] = {TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA};
+                const struct s2n_cipher_suite *expected_classic_wire_choice = &s2n_ecdhe_rsa_with_aes_256_cbc_sha;
                 EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "KMS-PQ-TLS-1-0-2019-06"));
                 conn->actual_protocol_version = i;
                 conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
                 conn->secure.client_pq_kem_extension.data = client_extensions_data;
                 conn->secure.client_pq_kem_extension.size = client_extensions_len;
                 EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers, cipher_count));
-                EXPECT_EQUAL(conn->secure.cipher_suite, s2n_cipher_suite_from_wire(expected_classic_wire_choice));
+                EXPECT_EQUAL(conn->secure.cipher_suite, expected_classic_wire_choice);
                 EXPECT_SUCCESS(s2n_connection_wipe(conn));
             }
         }
@@ -398,13 +398,13 @@ int main(int argc, char **argv)
 
         /* TEST ECDSA */
         EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_all_ecdsa"));
-        const uint8_t expected_ecdsa_wire_choice[] = { TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 };
+        const struct s2n_cipher_suite *expected_ecdsa_wire_choice = &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256;
         /* Assume default for negotiated curve. */
         conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
         conn->actual_protocol_version = conn->server_protocol_version;
         EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
         EXPECT_EQUAL(conn->secure_renegotiation, 0);
-        EXPECT_EQUAL(conn->secure.cipher_suite, s2n_cipher_suite_from_wire(expected_ecdsa_wire_choice));
+        EXPECT_EQUAL(conn->secure.cipher_suite, expected_ecdsa_wire_choice);
         EXPECT_SUCCESS(s2n_connection_wipe(conn));
 
         /* TEST ECDSA cipher chosen when RSA cipher is at top */
@@ -414,7 +414,7 @@ int main(int argc, char **argv)
         conn->actual_protocol_version = conn->server_protocol_version;
         EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
         EXPECT_EQUAL(conn->secure_renegotiation, 0);
-        EXPECT_EQUAL(conn->secure.cipher_suite, s2n_cipher_suite_from_wire(expected_ecdsa_wire_choice));
+        EXPECT_EQUAL(conn->secure.cipher_suite, expected_ecdsa_wire_choice);
         EXPECT_SUCCESS(s2n_connection_wipe(conn));
         EXPECT_SUCCESS(s2n_config_free(server_config));
 
@@ -427,27 +427,27 @@ int main(int argc, char **argv)
 
         /* Client sends RSA and ECDSA ciphers, server prioritizes ECDSA, ECDSA + RSA cert is configured */
         {
-            const uint8_t expected_wire_choice[] = { TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 };
+            const struct s2n_cipher_suite *expected_wire_choice = &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256;
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_ecdsa_priority"));
             conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
             conn->actual_protocol_version = conn->server_protocol_version;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
             EXPECT_EQUAL(conn->secure_renegotiation, 0);
-            EXPECT_EQUAL(conn->secure.cipher_suite, s2n_cipher_suite_from_wire(expected_wire_choice));
+            EXPECT_EQUAL(conn->secure.cipher_suite, expected_wire_choice);
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
         }
 
         /* Client sends RSA and ECDSA ciphers, server prioritizes RSA, ECDSA + RSA cert is configured */
         {
-            const uint8_t expected_wire_choice[] = { TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA };
+            const struct s2n_cipher_suite *expected_wire_choice = &s2n_ecdhe_rsa_with_aes_128_cbc_sha;
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_all"));
             conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
             conn->actual_protocol_version = conn->server_protocol_version;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
             EXPECT_EQUAL(conn->secure_renegotiation, 0);
-            EXPECT_EQUAL(conn->secure.cipher_suite, s2n_cipher_suite_from_wire(expected_wire_choice));
+            EXPECT_EQUAL(conn->secure.cipher_suite, expected_wire_choice);
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
         }
 
@@ -455,7 +455,7 @@ int main(int argc, char **argv)
          * ECDSA + RSA cert is configured.
          */
         {
-            const uint8_t expected_wire_choice[] = { TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA };
+            const struct s2n_cipher_suite *expected_wire_choice = &s2n_ecdhe_rsa_with_aes_128_cbc_sha;
             /* 20170328 only supports RSA ciphers */
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "20170328"));
             conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
@@ -463,7 +463,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
             EXPECT_EQUAL(conn->secure_renegotiation, 0);
-            EXPECT_EQUAL(conn->secure.cipher_suite, s2n_cipher_suite_from_wire(expected_wire_choice));
+            EXPECT_EQUAL(conn->secure.cipher_suite, expected_wire_choice);
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
         }
 
@@ -471,14 +471,14 @@ int main(int argc, char **argv)
          * configured.
          */
         {
-            const uint8_t expected_wire_choice[] = { TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 };
+            const struct s2n_cipher_suite *expected_wire_choice = &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256;
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_all_ecdsa"));
             conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
             conn->actual_protocol_version = conn->server_protocol_version;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
             EXPECT_EQUAL(conn->secure_renegotiation, 0);
-            EXPECT_EQUAL(conn->secure.cipher_suite, s2n_cipher_suite_from_wire(expected_wire_choice));
+            EXPECT_EQUAL(conn->secure.cipher_suite, expected_wire_choice);
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
         }
 
@@ -486,14 +486,14 @@ int main(int argc, char **argv)
          * configured.
          */
         {
-            const uint8_t expected_wire_choice[] = { TLS_RSA_WITH_RC4_128_MD5 };
+            const struct s2n_cipher_suite *expected_wire_choice = &s2n_rsa_with_rc4_128_md5;
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_ecdsa_priority"));
             conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
             conn->actual_protocol_version = conn->server_protocol_version;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers, cipher_count));
             EXPECT_EQUAL(conn->secure_renegotiation, 0);
-            EXPECT_EQUAL(conn->secure.cipher_suite, s2n_cipher_suite_from_wire(expected_wire_choice));
+            EXPECT_EQUAL(conn->secure.cipher_suite, expected_wire_choice);
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
         }
 
@@ -501,14 +501,14 @@ int main(int argc, char **argv)
          * configured.
          */
         {
-            const uint8_t expected_wire_choice[] = { TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA };
+            const struct s2n_cipher_suite *expected_wire_choice = &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha;
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_ecdsa_priority"));
             conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
             conn->actual_protocol_version = conn->server_protocol_version;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_only_ecdsa, cipher_count_only_ecdsa));
             EXPECT_EQUAL(conn->secure_renegotiation, 0);
-            EXPECT_EQUAL(conn->secure.cipher_suite, s2n_cipher_suite_from_wire(expected_wire_choice));
+            EXPECT_EQUAL(conn->secure.cipher_suite, expected_wire_choice);
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
         }
 
@@ -519,7 +519,7 @@ int main(int argc, char **argv)
             /* If there are no shared elliptic curves, we must fall through to a cipher that supports RSA kx.
              * This is the first RSA kx cipher that CloudFront-Upstream supports.
              */
-            const uint8_t expected_wire_choice[] = { TLS_RSA_WITH_AES_256_GCM_SHA384 };
+            const struct s2n_cipher_suite *expected_wire_choice = &s2n_rsa_with_aes_256_gcm_sha384;
             /* Selecting this preference list because it prioritizes ECDHE-ECDSA and ECDHE-RSA over plain RSA kx. */
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "CloudFront-Upstream"));
             /* No shared curve */
@@ -528,7 +528,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_rsa_fallback, cipher_count_rsa_fallback));
             EXPECT_EQUAL(conn->secure_renegotiation, 0);
-            EXPECT_EQUAL(conn->secure.cipher_suite, s2n_cipher_suite_from_wire(expected_wire_choice));
+            EXPECT_EQUAL(conn->secure.cipher_suite, expected_wire_choice);
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
         }
         EXPECT_SUCCESS(s2n_config_free(server_config));
@@ -542,14 +542,14 @@ int main(int argc, char **argv)
         /* Client sends RSA and ECDSA ciphers, server prioritizes ECDSA, ECDSA + RSA cert is configured,
          * only RSA is default. Expect default RSA used instead of previous test that expects ECDSA for this case. */
         {
-            const uint8_t expected_wire_choice[] = { TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA };
+            const struct s2n_cipher_suite *expected_wire_choice = &s2n_ecdhe_rsa_with_aes_128_cbc_sha;
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_ecdsa_priority"));
             conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
             conn->actual_protocol_version = conn->server_protocol_version;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
             EXPECT_EQUAL(conn->secure_renegotiation, 0);
-            EXPECT_EQUAL(conn->secure.cipher_suite, s2n_cipher_suite_from_wire(expected_wire_choice));
+            EXPECT_EQUAL(conn->secure.cipher_suite, expected_wire_choice);
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
         }
 
@@ -559,14 +559,14 @@ int main(int argc, char **argv)
         /* Client sends RSA and ECDSA ciphers, server prioritizes RSA, ECDSA + RSA cert is configured,
          * only ECDSA is default. Expect default ECDSA used instead of previous test that expects RSA for this case. */
         {
-            const uint8_t expected_wire_choice[] = { TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 };
+            const struct s2n_cipher_suite *expected_wire_choice = &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256;
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_all"));
             conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
             conn->actual_protocol_version = conn->server_protocol_version;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
             EXPECT_EQUAL(conn->secure_renegotiation, 0);
-            EXPECT_EQUAL(conn->secure.cipher_suite, s2n_cipher_suite_from_wire(expected_wire_choice));
+            EXPECT_EQUAL(conn->secure.cipher_suite, expected_wire_choice);
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
         }
 
@@ -576,14 +576,14 @@ int main(int argc, char **argv)
 
         /* Client sends RSA and ECDSA ciphers, server prioritizes ECDSA, ECDSA + RSA cert is configured */
         {
-            const uint8_t expected_wire_choice[] = { TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 };
+            const struct s2n_cipher_suite *expected_wire_choice = &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256;
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_ecdsa_priority"));
             conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
             conn->actual_protocol_version = conn->server_protocol_version;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
             EXPECT_EQUAL(conn->secure_renegotiation, 0);
-            EXPECT_EQUAL(conn->secure.cipher_suite, s2n_cipher_suite_from_wire(expected_wire_choice));
+            EXPECT_EQUAL(conn->secure.cipher_suite, expected_wire_choice);
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
         }
 
@@ -601,14 +601,14 @@ int main(int argc, char **argv)
         /* Client sends RSA and ECDSA ciphers, server prioritizes RSA, ECDSA + RSA cert is configured.
          * RSA default certificate should be chosen. */
         {
-            const uint8_t expected_wire_choice[] = { TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA };
+            const struct s2n_cipher_suite *expected_wire_choice = &s2n_ecdhe_rsa_with_aes_128_cbc_sha;
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_all"));
             conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
             conn->actual_protocol_version = conn->server_protocol_version;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
             EXPECT_EQUAL(conn->secure_renegotiation, 0);
-            EXPECT_EQUAL(conn->secure.cipher_suite, s2n_cipher_suite_from_wire(expected_wire_choice));
+            EXPECT_EQUAL(conn->secure.cipher_suite, expected_wire_choice);
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
         }
 
@@ -635,13 +635,13 @@ int main(int argc, char **argv)
         {
             struct test_case {
                 const char *cipher_pref;
-                uint8_t expected_cipher_wire[2];
+                const struct s2n_cipher_suite *expected_cipher_wire;
             };
 
             struct test_case test_cases[] = {
-                {.cipher_pref = "default_tls13", .expected_cipher_wire = { TLS_AES_256_GCM_SHA384 }},
-                {.cipher_pref = "test_all", .expected_cipher_wire = { TLS_AES_128_GCM_SHA256 }},
-                {.cipher_pref = "test_all_tls13", .expected_cipher_wire = { TLS_AES_128_GCM_SHA256 }},
+                { .cipher_pref = "default_tls13", .expected_cipher_wire = &s2n_tls13_aes_256_gcm_sha384 },
+                { .cipher_pref = "test_all", .expected_cipher_wire = &s2n_tls13_aes_128_gcm_sha256 },
+                { .cipher_pref = "test_all_tls13", .expected_cipher_wire = &s2n_tls13_aes_128_gcm_sha256 },
             };
 
             for (size_t i = 0; i < s2n_array_len(test_cases); i++) {
@@ -650,7 +650,7 @@ int main(int argc, char **argv)
                 conn->actual_protocol_version = S2N_TLS13;
                 conn->server_protocol_version = S2N_TLS13;
                 EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_tls13, cipher_count_tls13));
-                EXPECT_EQUAL(conn->secure.cipher_suite, s2n_cipher_suite_from_wire(test_cases[i].expected_cipher_wire));
+                EXPECT_EQUAL(conn->secure.cipher_suite, test_cases[i].expected_cipher_wire);
                 EXPECT_SUCCESS(s2n_connection_wipe(conn));
             }
         }

--- a/tests/unit/s2n_cipher_suites_test.c
+++ b/tests/unit/s2n_cipher_suites_test.c
@@ -61,6 +61,7 @@ int main()
                         if (0 == memcmp(cipher_preferences->suites[cipher_index]->iana_value,
                                         cipher_preferences_test_all.suites[all_index]->iana_value,
                                         S2N_TLS_CIPHER_SUITE_LEN)) {
+                            EXPECT_NULL(match);
                             match = cipher_preferences_test_all.suites[all_index];
                         }
                     }

--- a/tests/unit/s2n_cipher_suites_test.c
+++ b/tests/unit/s2n_cipher_suites_test.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "tls/s2n_cipher_suites.h"
+
+/* This test checks that the compiler correctly implements deferred cleanup */
+int main()
+{
+    BEGIN_TEST();
+
+    /* Test: s2n_cipher_suite_from_wire */
+    {
+        /* Test: all cipher suites in s2n_all_cipher_suites are in IANA order
+         * (Required for s2n_cipher_suite_from_wire to perform a search) */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+
+            int cipher_suite_order;
+            const uint8_t cipher_suite_count = cipher_preferences_test_all.count;
+            for (size_t i = 0; i < cipher_suite_count - 1; i++) {
+                cipher_suite_order = memcmp(cipher_preferences_test_all.suites[i]->iana_value,
+                        cipher_preferences_test_all.suites[i + 1]->iana_value, 2);
+                EXPECT_TRUE(cipher_suite_order < 0);
+            }
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Test: all possible cipher suites are supported */
+        {
+            const struct s2n_security_policy *security_policy = NULL;
+            const struct s2n_cipher_preferences *cipher_preferences = NULL;
+            for (size_t i = 0; security_policy_selection[i].version != NULL; i++) {
+                security_policy = security_policy_selection[i].security_policy;
+                cipher_preferences = security_policy->cipher_preferences;
+                for (size_t j = 0; j < cipher_preferences->count; j++) {
+                    struct s2n_cipher_suite *cipher_suite = s2n_cipher_suite_from_wire(cipher_preferences->suites[j]->iana_value);
+
+                    if (cipher_preferences->suites[j] == &s2n_null_cipher_suite) {
+                        EXPECT_NULL(cipher_suite);
+                        continue;
+                    }
+
+                    EXPECT_NOT_NULL(cipher_suite);
+                    EXPECT_EQUAL(cipher_suite, cipher_preferences->suites[j]);
+                }
+            }
+        }
+
+        /* Test: S2N_CIPHER_SUITE_COUNT matches the number of supported cipher suites */
+        {
+            uint8_t wire[2] = { 0 };
+            size_t actual_cipher_suite_count = 0;
+            for (int i = 0; i < 0xffff; i++) {
+                wire[0] = (i >> 8);
+                wire[1] = i & 0xff;
+
+                struct s2n_cipher_suite *s = s2n_cipher_suite_from_wire(wire);
+                if (s != NULL) {
+                    actual_cipher_suite_count++;
+                }
+            }
+            EXPECT_EQUAL(cipher_preferences_test_all.count, S2N_CIPHER_SUITE_COUNT);
+            EXPECT_EQUAL(actual_cipher_suite_count, S2N_CIPHER_SUITE_COUNT);
+        }
+    }
+
+    END_TEST();
+}

--- a/tests/unit/s2n_cipher_suites_test.c
+++ b/tests/unit/s2n_cipher_suites_test.c
@@ -17,7 +17,6 @@
 
 #include "tls/s2n_cipher_suites.h"
 
-/* This test checks that the compiler correctly implements deferred cleanup */
 int main()
 {
     BEGIN_TEST();

--- a/tests/unit/s2n_cipher_suites_test.c
+++ b/tests/unit/s2n_cipher_suites_test.c
@@ -33,10 +33,9 @@ int main()
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
-            int cipher_suite_order;
             const uint8_t cipher_suite_count = cipher_preferences_test_all.count;
             for (size_t i = 0; i < cipher_suite_count - 1; i++) {
-                cipher_suite_order = memcmp(cipher_preferences_test_all.suites[i]->iana_value,
+                int cipher_suite_order = memcmp(cipher_preferences_test_all.suites[i]->iana_value,
                         cipher_preferences_test_all.suites[i + 1]->iana_value, 2);
                 EXPECT_TRUE(cipher_suite_order < 0);
             }

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -1088,6 +1088,7 @@ int s2n_set_cipher_as_client(struct s2n_connection *conn, uint8_t wire[S2N_TLS_C
         const uint8_t *ours = security_policy->cipher_preferences->suites[i]->iana_value;
         if (memcmp(wire, ours, S2N_TLS_CIPHER_SUITE_LEN) == 0) {
             cipher_suite = security_policy->cipher_preferences->suites[i];
+            break;
         }
     }
     ENSURE_POSIX(cipher_suite != NULL, S2N_ERR_CIPHER_NOT_SUPPORTED);

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -1074,42 +1074,30 @@ int s2n_cipher_suites_cleanup(void)
     return 0;
 }
 
-struct s2n_cipher_suite *s2n_cipher_suite_from_wire(const uint8_t cipher_suite[S2N_TLS_CIPHER_SUITE_LEN])
-{
-    int low = 0;
-    int top = (sizeof(s2n_all_cipher_suites) / sizeof(struct s2n_cipher_suite *)) - 1;
-    /* Perform a textbook binary search */
-    while (low <= top) {
-        /* Check in the middle */
-        int mid = low + ((top - low) / 2);
-        int m = memcmp(s2n_all_cipher_suites[mid]->iana_value, cipher_suite, 2);
-
-        if (m == 0) {
-            return s2n_all_cipher_suites[mid];
-        } else if (m > 0) {
-            top = mid - 1;
-        } else if (m < 0) {
-            low = mid + 1;
-        }
-    }
-
-    return NULL;
-}
-
 int s2n_set_cipher_as_client(struct s2n_connection *conn, uint8_t wire[S2N_TLS_CIPHER_SUITE_LEN])
 {
     notnull_check(conn);
     notnull_check(conn->secure.cipher_suite);
-    struct s2n_cipher_suite *cipher_suite;
 
-    /* See if the cipher is one we support */
-    cipher_suite = s2n_cipher_suite_from_wire(wire);
+    const struct s2n_security_policy *security_policy;
+    GUARD(s2n_connection_get_security_policy(conn, &security_policy));
+    notnull_check(security_policy);
+
+    struct s2n_cipher_suite *cipher_suite = NULL;
+    for (size_t i = 0; i < security_policy->cipher_preferences->count; i++) {
+        const uint8_t *ours = security_policy->cipher_preferences->suites[i]->iana_value;
+        if (memcmp(wire, ours, S2N_TLS_CIPHER_SUITE_LEN) == 0) {
+            cipher_suite = security_policy->cipher_preferences->suites[i];
+        }
+    }
     ENSURE_POSIX(cipher_suite != NULL, S2N_ERR_CIPHER_NOT_SUPPORTED);
+    ENSURE_POSIX(cipher_suite->available, S2N_ERR_CIPHER_NOT_SUPPORTED);
 
-    /* From RFC section: https://tools.ietf.org/html/rfc8446#section-4.2.11:
-     * Client MUST verify that the server selected a cipher suite indicating a Hash
-     * associated with the chosen PSK if it exists. 
-     * */
+    /** Clients MUST verify
+     *= https://tools.ietf.org/rfc/rfc8446#section-4.2.11
+     *# that the server selected a cipher suite
+     *# indicating a Hash associated with the PSK
+     **/
     if (conn->psk_params.chosen_psk) {
         ENSURE_POSIX(cipher_suite->prf_alg == conn->psk_params.chosen_psk->hmac_alg,
                      S2N_ERR_CIPHER_NOT_SUPPORTED);
@@ -1120,29 +1108,8 @@ int s2n_set_cipher_as_client(struct s2n_connection *conn, uint8_t wire[S2N_TLS_C
         ENSURE_POSIX(conn->secure.cipher_suite->iana_value == cipher_suite->iana_value, S2N_ERR_CIPHER_NOT_SUPPORTED);
         return S2N_SUCCESS;
     }
+
     conn->secure.cipher_suite = cipher_suite;
-
-    /* Verify the cipher was part of the originally offered list */
-    const struct s2n_cipher_preferences *cipher_prefs;
-    GUARD(s2n_connection_get_cipher_preferences(conn, &cipher_prefs));
-
-    uint8_t found = 0;
-
-    for (int i = 0; i < cipher_prefs->count; i++ ) {
-        /* The client sends all "available" ciphers in the preference list to the server.
-           The server must pick one of the ciphers offered by the client. */
-        if (cipher_prefs->suites[i]->available) {
-            const uint8_t *server_iana_value = conn->secure.cipher_suite->iana_value;
-            const uint8_t *client_iana_value = cipher_prefs->suites[i]->iana_value;
-
-            if (memcmp(server_iana_value, client_iana_value, S2N_TLS_CIPHER_SUITE_LEN) == 0) {
-                found = 1;
-                break;
-            }
-        }
-    }
-
-    S2N_ERROR_IF(found != 1, S2N_ERR_CIPHER_NOT_SUPPORTED);
 
     /* For SSLv3 use SSLv3-specific ciphers */
     if (conn->actual_protocol_version == S2N_SSLv3) {

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -1197,7 +1197,7 @@ static int s2n_set_cipher_as_server(struct s2n_connection *conn, uint8_t *wire, 
 
         if (s2n_wire_ciphers_contain(ours, wire, count, cipher_suite_len)) {
             /* We have a match */
-            struct s2n_cipher_suite *match = s2n_cipher_suite_from_wire(ours);
+            struct s2n_cipher_suite *match = security_policy->cipher_preferences->suites[i];
 
             /* Never use TLS1.3 ciphers on a pre-TLS1.3 connection, and vice versa */
             if ((conn->actual_protocol_version >= S2N_TLS13) != (match->minimum_required_tls_version >= S2N_TLS13)) {

--- a/tls/s2n_cipher_suites.h
+++ b/tls/s2n_cipher_suites.h
@@ -32,9 +32,8 @@
 
 #define S2N_MAX_POSSIBLE_RECORD_ALGS    2
 
-/* Kept up-to-date by s2n_cipher_suite_match_test */
+/* Kept up-to-date by s2n_cipher_suite_test */
 #define S2N_CIPHER_SUITE_COUNT          39
-
 
 /* Record algorithm flags that can be OR'ed */
 #define S2N_TLS12_AES_GCM_AEAD_NONCE     0x01

--- a/tls/s2n_cipher_suites.h
+++ b/tls/s2n_cipher_suites.h
@@ -160,7 +160,6 @@ extern struct s2n_cipher_suite s2n_tls13_chacha20_poly1305_sha256;
 
 extern int s2n_cipher_suites_init(void);
 extern int s2n_cipher_suites_cleanup(void);
-extern struct s2n_cipher_suite *s2n_cipher_suite_from_wire(const uint8_t cipher_suite[S2N_TLS_CIPHER_SUITE_LEN]);
 extern int s2n_set_cipher_as_client(struct s2n_connection *conn, uint8_t wire[S2N_TLS_CIPHER_SUITE_LEN]);
 extern int s2n_set_cipher_as_sslv2_server(struct s2n_connection *conn, uint8_t * wire, uint16_t count);
 extern int s2n_set_cipher_as_tls_server(struct s2n_connection *conn, uint8_t * wire, uint16_t count);


### PR DESCRIPTION
### Description of changes: 

We match our supported ciphers to wire ciphers, so we don't then need to match the wire ciphers back to our supported ciphers-- it's an unnecessary search that makes the code slower and harder to follow.

### Testing:

I removed unused certificate configuration from the old tests and moved them to a new test file. I also added a test to enforce the requirement that all new cipher suites be added to s2n_all_cipher_suites in IANA order and therefore be findable via s2n_cipher_suite_from_wire.

 How is this change tested (unit tests, fuzz tests, etc.)? Unit tests

 Is this a refactor change? Minor refactor. No tests removed, all tests pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
