### PR TITLE
Added new ticket api

### DIFF
--- a/tests/unit/s2n_config_test.c
+++ b/tests/unit/s2n_config_test.c
@@ -153,5 +153,29 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
+    /*Test s2n_connection_set_config */
+    {
+        /* Test that tickets_to_send is set correctly */
+        {
+            struct s2n_connection *conn = NULL;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+
+            struct s2n_config *config;
+            uint8_t num_tickets = 1;
+
+            EXPECT_NOT_NULL(config = s2n_config_new());
+
+            config->initial_tickets_to_send = num_tickets;
+
+            EXPECT_EQUAL(conn->tickets_to_send, 0);
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+            EXPECT_EQUAL(conn->tickets_to_send, num_tickets);
+
+            EXPECT_SUCCESS(s2n_config_free(config));
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+    }
+
     END_TEST();
 }

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -305,6 +305,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
         EXPECT_EQUAL(conn->tickets_to_send, num_tickets);
 
+        EXPECT_SUCCESS(s2n_config_free(config));
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -329,10 +329,9 @@ int main(int argc, char **argv)
         /* Overflow error is caught */
         {
             struct s2n_connection *conn;
-            uint8_t original_num_tickets = UINT8_MAX;
             uint8_t new_num_tickets = 1;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
-            conn->tickets_to_send = original_num_tickets;
+            conn->tickets_to_send = UINT16_MAX;
 
             EXPECT_FAILURE_WITH_ERRNO(s2n_connection_add_new_tickets_to_send(conn, new_num_tickets), S2N_ERR_INTEGER_OVERFLOW);
             

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -290,7 +290,7 @@ int main(int argc, char **argv)
         }
     }
 
-    /* s2n_config_set_requested_new_ticket_count */
+    /* s2n_config_set_initial_ticket_count */
     {
         struct s2n_connection *conn;
         struct s2n_config *config;
@@ -300,7 +300,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_EQUAL(conn->tickets_to_send, 0);
 
-        EXPECT_SUCCESS(s2n_config_set_requested_new_ticket_count(config, num_tickets));
+        EXPECT_SUCCESS(s2n_config_set_initial_ticket_count(config, num_tickets));
 
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
         EXPECT_EQUAL(conn->tickets_to_send, num_tickets);
@@ -309,9 +309,9 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
-    /* s2n_connection_request_new_tickets */
+    /* s2n_connection_add_new_tickets_to_send */
     {
-        /* s2n_connection_request_new_tickets sets new number of session tickets */
+        /* New number of session tickets can be set */
         {
             struct s2n_connection *conn;
             uint8_t original_num_tickets = 1;
@@ -319,14 +319,14 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             conn->tickets_to_send = original_num_tickets;
 
-            EXPECT_SUCCESS(s2n_connection_request_new_tickets(conn, new_num_tickets));
+            EXPECT_SUCCESS(s2n_connection_add_new_tickets_to_send(conn, new_num_tickets));
 
             EXPECT_EQUAL(conn->tickets_to_send, original_num_tickets + new_num_tickets);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }
 
-        /* s2n_connection_request_new_tickets will catch an overflow error */
+        /* Overflow error is caught */
         {
             struct s2n_connection *conn;
             uint8_t original_num_tickets = UINT8_MAX;
@@ -334,7 +334,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             conn->tickets_to_send = original_num_tickets;
 
-            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_request_new_tickets(conn, new_num_tickets), S2N_ERR_INTEGER_OVERFLOW);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_add_new_tickets_to_send(conn, new_num_tickets), S2N_ERR_INTEGER_OVERFLOW);
             
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -103,6 +103,7 @@ static int s2n_config_init(struct s2n_config *config)
     config->cache_delete_data = NULL;
     config->ct_type = S2N_CT_SUPPORT_NONE;
     config->mfl_code = S2N_TLS_MAX_FRAG_LEN_EXT_NONE;
+    config->initial_tickets_to_send = 0;
     config->alert_behavior = S2N_ALERT_FAIL_ON_WARNINGS;
     config->accept_mfl = 0;
     config->session_state_lifetime_in_nanos = S2N_STATE_LIFETIME_IN_NANOS;

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -98,6 +98,8 @@ struct s2n_config {
 
     uint8_t mfl_code;
 
+    uint8_t initial_tickets_to_send;
+
     struct s2n_x509_trust_store trust_store;
     uint16_t max_verify_cert_chain_depth;
 

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -523,6 +523,7 @@ int s2n_connection_set_config(struct s2n_connection *conn, struct s2n_config *co
             GUARD(s2n_x509_validator_set_max_chain_depth(&conn->x509_validator, config->max_verify_cert_chain_depth));
         }
     }
+    conn->tickets_to_send = config->initial_tickets_to_send;
 
     conn->config = config;
     return 0;

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -331,6 +331,8 @@ struct s2n_connection {
      */
     bool send_in_use;
     bool recv_in_use;
+    
+    uint8_t tickets_to_send;
 };
 
 int s2n_connection_is_managed_corked(const struct s2n_connection *s2n_connection);

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -332,7 +332,7 @@ struct s2n_connection {
     bool send_in_use;
     bool recv_in_use;
     
-    uint8_t tickets_to_send;
+    uint16_t tickets_to_send;
 };
 
 int s2n_connection_is_managed_corked(const struct s2n_connection *s2n_connection);

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -751,3 +751,22 @@ int s2n_config_store_ticket_key(struct s2n_config *config, struct s2n_ticket_key
     GUARD_AS_POSIX(s2n_set_add(config->ticket_keys, key));
     return S2N_SUCCESS;
 }
+
+int s2n_config_set_requested_new_ticket_count(struct s2n_config *config, uint8_t num)
+{
+    notnull_check(config);
+
+    config->initial_tickets_to_send = num;
+
+    return S2N_SUCCESS;
+}
+
+int s2n_connection_request_new_tickets(struct s2n_connection *conn, uint8_t num) {
+    notnull_check(conn);
+
+    uint16_t out = conn->tickets_to_send + num;
+    ENSURE_POSIX(out <= UINT8_MAX, S2N_ERR_INTEGER_OVERFLOW);
+    conn->tickets_to_send = out;
+
+    return S2N_SUCCESS;
+}

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -764,8 +764,8 @@ int s2n_config_set_initial_ticket_count(struct s2n_config *config, uint8_t num)
 int s2n_connection_add_new_tickets_to_send(struct s2n_connection *conn, uint8_t num) {
     notnull_check(conn);
 
-    uint16_t out = conn->tickets_to_send + num;
-    ENSURE_POSIX(out <= UINT8_MAX, S2N_ERR_INTEGER_OVERFLOW);
+    uint32_t out = conn->tickets_to_send + num;
+    ENSURE_POSIX(out <= UINT16_MAX, S2N_ERR_INTEGER_OVERFLOW);
     conn->tickets_to_send = out;
 
     return S2N_SUCCESS;

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -752,7 +752,7 @@ int s2n_config_store_ticket_key(struct s2n_config *config, struct s2n_ticket_key
     return S2N_SUCCESS;
 }
 
-int s2n_config_set_requested_new_ticket_count(struct s2n_config *config, uint8_t num)
+int s2n_config_set_initial_ticket_count(struct s2n_config *config, uint8_t num)
 {
     notnull_check(config);
 
@@ -761,7 +761,7 @@ int s2n_config_set_requested_new_ticket_count(struct s2n_config *config, uint8_t
     return S2N_SUCCESS;
 }
 
-int s2n_connection_request_new_tickets(struct s2n_connection *conn, uint8_t num) {
+int s2n_connection_add_new_tickets_to_send(struct s2n_connection *conn, uint8_t num) {
     notnull_check(conn);
 
     uint16_t out = conn->tickets_to_send + num;

--- a/tls/s2n_resume.h
+++ b/tls/s2n_resume.h
@@ -90,6 +90,5 @@ extern int s2n_resume_from_cache(struct s2n_connection *conn);
 extern int s2n_store_to_cache(struct s2n_connection *conn);
 
 /* This function will be labeled S2N_API and become a publicly visible api once we release the psk API. */
-int s2n_config_set_requested_new_ticket_count(struct s2n_config *config, uint8_t num);
-/* This function will be labeled S2N_API and become a publicly visible api once we release the psk API. */
-int s2n_connection_request_new_tickets(struct s2n_connection *conn, uint8_t num);
+int s2n_config_set_initial_ticket_count(struct s2n_config *config, uint8_t num);
+int s2n_connection_add_new_tickets_to_send(struct s2n_connection *conn, uint8_t num);

--- a/tls/s2n_resume.h
+++ b/tls/s2n_resume.h
@@ -88,3 +88,8 @@ typedef enum {
 extern int s2n_allowed_to_cache_connection(struct s2n_connection *conn);
 extern int s2n_resume_from_cache(struct s2n_connection *conn);
 extern int s2n_store_to_cache(struct s2n_connection *conn);
+
+/* This function will be labeled S2N_API and become a publicly visible api once we release the psk API. */
+int s2n_config_set_requested_new_ticket_count(struct s2n_config *config, uint8_t num);
+/* This function will be labeled S2N_API and become a publicly visible api once we release the psk API. */
+int s2n_connection_request_new_tickets(struct s2n_connection *conn, uint8_t num);

--- a/tls/s2n_resume.h
+++ b/tls/s2n_resume.h
@@ -89,6 +89,7 @@ extern int s2n_allowed_to_cache_connection(struct s2n_connection *conn);
 extern int s2n_resume_from_cache(struct s2n_connection *conn);
 extern int s2n_store_to_cache(struct s2n_connection *conn);
 
-/* This function will be labeled S2N_API and become a publicly visible api once we release the psk API. */
+/* These functions will be labeled S2N_API and become a publicly visible api 
+ * once we release the session resumption API. */
 int s2n_config_set_initial_ticket_count(struct s2n_config *config, uint8_t num);
 int s2n_connection_add_new_tickets_to_send(struct s2n_connection *conn, uint8_t num);


### PR DESCRIPTION
### Resolved issues:

 resolves #2484 

### Description of changes: 
Added new apis to request session tickets.

### Call-outs:

s2n has an s2n_add_overflow function, but it is only for uint32_t numbers so I could not use it. 
### Testing:

Unit tests.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
