### PR TITLE
extensions: fix quic_transport_parameters extension IANA value

### DIFF
--- a/tls/s2n_tls_parameters.h
+++ b/tls/s2n_tls_parameters.h
@@ -115,8 +115,8 @@
 #define TLS_PSK_KE_MODE     0
 #define TLS_PSK_DHE_KE_MODE 1
 
-/* QUIC-TLS extension from https://tools.ietf.org/html/draft-ietf-quic-tls-29#section-8.2 */
-#define TLS_QUIC_TRANSPORT_PARAMETERS      65535
+/* QUIC-TLS extension from https://tools.ietf.org/html/draft-ietf-quic-tls-34#section-10 */
+#define TLS_QUIC_TRANSPORT_PARAMETERS      57
 
 /* TLS Signature Algorithms - RFC 5246 7.4.1.4.1 */
 /* https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-16 */

--- a/tls/s2n_tls_parameters.h
+++ b/tls/s2n_tls_parameters.h
@@ -115,7 +115,11 @@
 #define TLS_PSK_KE_MODE     0
 #define TLS_PSK_DHE_KE_MODE 1
 
-/* QUIC-TLS extension from https://tools.ietf.org/html/draft-ietf-quic-tls-34#section-10 */
+/**
+ *= https://tools.ietf.org/id/draft-ietf-quic-tls-34.txt#section-10
+ *# IANA has registered a codepoint of 57 (or 0x39) for the
+ *# quic_transport_parameters extension
+ */
 #define TLS_QUIC_TRANSPORT_PARAMETERS      57
 
 /* TLS Signature Algorithms - RFC 5246 7.4.1.4.1 */

--- a/tls/s2n_tls_parameters.h
+++ b/tls/s2n_tls_parameters.h
@@ -116,11 +116,12 @@
 #define TLS_PSK_DHE_KE_MODE 1
 
 /**
- *= https://tools.ietf.org/id/draft-ietf-quic-tls-34.txt#section-10
- *# IANA has registered a codepoint of 57 (or 0x39) for the
- *# quic_transport_parameters extension
+ *= https://tools.ietf.org/id/draft-ietf-quic-tls-32.txt#8.2
+ *#   enum {
+ *#      quic_transport_parameters(0xffa5), (65535)
+ *#   } ExtensionType;
  */
-#define TLS_QUIC_TRANSPORT_PARAMETERS      57
+#define TLS_QUIC_TRANSPORT_PARAMETERS      0xffa5
 
 /* TLS Signature Algorithms - RFC 5246 7.4.1.4.1 */
 /* https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-16 */


### PR DESCRIPTION
### Description of changes: 

The implementation seems to be using the IANA value for QUIC of `65535`:

https://github.com/awslabs/s2n/blob/c8d04e4611bb44e3a09bcf991fec1c6ee4282366/tls/s2n_tls_parameters.h#L119

However, according to [the quic spec](https://tools.ietf.org/html/draft-ietf-quic-tls-34#section-10), this should be codepoint `57` (or `0x39`).

The current value appears to be a misread of the maximum length (2^16 - 1)

```
      enum {
         quic_transport_parameters(0x39), (65535)
      } ExtensionType;
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
