### PR TITLE
quic: ignore middlebox mode

### DIFF
--- a/tests/unit/s2n_client_hello_recv_test.c
+++ b/tests/unit/s2n_client_hello_recv_test.c
@@ -378,7 +378,8 @@ int main(int argc, char **argv)
         s2n_connection_free(server_conn);
     }
 
-    /* Test that S2N will reject a ClientHello with legacy_session_id set when running with QUIC.
+    /* Test that S2N will accept a ClientHello with legacy_session_id set when running with QUIC.
+     * Since this requirement is a SHOULD, we're accepting it for non-compliant endpoints.
      * https://tools.ietf.org/html/draft-ietf-quic-tls-32#section-8.4*/
     {
         EXPECT_SUCCESS(s2n_reset_tls13());
@@ -408,7 +409,7 @@ int main(int argc, char **argv)
             s2n_connection_free(server_conn);
         }
 
-        /* Fails with a session id */
+        /* Also, succeeds with a session id */
         {
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
             EXPECT_SUCCESS(s2n_connection_set_config(server_conn, quic_config));
@@ -422,7 +423,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
             EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io,
                     s2n_stuffer_data_available(&client_conn->handshake.io)));
-            EXPECT_FAILURE_WITH_ERRNO(s2n_client_hello_recv(server_conn), S2N_ERR_BAD_MESSAGE);
+            EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
 
             s2n_connection_free(client_conn);
             s2n_connection_free(server_conn);

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -271,12 +271,6 @@ int s2n_process_client_hello(struct s2n_connection *conn)
 
     if (conn->config->quic_enabled) {
         ENSURE_POSIX(conn->actual_protocol_version >= S2N_TLS13, S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
-
-        /* In TLS1.3, legacy_session_id is only set to indicate middlebox compatability mode.
-         * When running with QUIC, S2N does not support middlebox compatability mode.
-         * https://tools.ietf.org/html/draft-ietf-quic-tls-32#section-8.4
-         */
-        ENSURE_POSIX(conn->session_id_len == 0, S2N_ERR_BAD_MESSAGE);
     }
 
     /* Find potential certificate matches before we choose the cipher. */


### PR DESCRIPTION
### Description of changes: 

Our current quic support has a strict check in place to ensure the client is not sending a legacy_session_id.

From the spec: https://tools.ietf.org/html/draft-ietf-quic-tls-34#section-8.4
>   A server SHOULD treat the receipt of a
>   TLS ClientHello with a non-empty legacy_session_id field as a
>   connection error of type PROTOCOL_VIOLATION.

In testing, I've found a few TLS implementations still sending this so I'm thinking it might be best to remove this check for the sake of compatibility.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
