### PR TITLE
Add a command to manually update the Yarn Debian key

### DIFF
--- a/codebuild/bin/install_ubuntu_dependencies.sh
+++ b/codebuild/bin/install_ubuntu_dependencies.sh
@@ -19,7 +19,7 @@
 set -ex
 
 # Update Yarn Debian key, see https://github.com/yarnpkg/yarn/issues/7866
-curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg  | sudo apt-key add -
+curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg  | apt-key add -
 
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 sudo add-apt-repository ppa:longsleep/golang-backports -y

--- a/codebuild/bin/install_ubuntu_dependencies.sh
+++ b/codebuild/bin/install_ubuntu_dependencies.sh
@@ -18,6 +18,9 @@
 
 set -ex
 
+# Update Yarn Debian key, see https://github.com/yarnpkg/yarn/issues/7866
+curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg  | sudo apt-key add -
+
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 sudo add-apt-repository ppa:longsleep/golang-backports -y
 sudo apt-get update -o Acquire::CompressionTypes::Order::=gz

--- a/codebuild/bin/install_ubuntu_dependencies.sh
+++ b/codebuild/bin/install_ubuntu_dependencies.sh
@@ -21,9 +21,9 @@ set -ex
 # Update Yarn Debian key, see https://github.com/yarnpkg/yarn/issues/7866
 curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg  | apt-key add -
 
-sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-sudo add-apt-repository ppa:longsleep/golang-backports -y
-sudo apt-get update -o Acquire::CompressionTypes::Order::=gz
+add-apt-repository ppa:ubuntu-toolchain-r/test -y
+add-apt-repository ppa:longsleep/golang-backports -y
+apt-get update -o Acquire::CompressionTypes::Order::=gz
 
 DEPENDENCIES="unzip make indent kwstyle libssl-dev tcpdump valgrind lcov m4 nettle-dev nettle-bin pkg-config gcc g++ zlibc zlib1g-dev python3-pip python3-testresources llvm curl git tox cmake libtool ninja-build golang-go quilt"
 
@@ -32,12 +32,12 @@ if [[ -n "$GCC_VERSION" ]] && [[ "$GCC_VERSION" != "NONE" ]]; then
     DEPENDENCIES+=" gcc-$GCC_VERSION g++-$GCC_VERSION";
 fi
 
-sudo apt-get -y install --no-install-recommends ${DEPENDENCIES}
+apt-get -y install --no-install-recommends ${DEPENDENCIES}
 
 # If prlimit is not on our current PATH, download and compile prlimit manually. s2n needs prlimit to memlock pages
 if ! type prlimit > /dev/null && [[ ! -d "$PRLIMIT_INSTALL_DIR" ]]; then
     mkdir -p "$PRLIMIT_INSTALL_DIR";
-    sudo codebuild/bin/install_prlimit.sh "$(mktemp -d)" "$PRLIMIT_INSTALL_DIR";
+    codebuild/bin/install_prlimit.sh "$(mktemp -d)" "$PRLIMIT_INSTALL_DIR";
 fi
 
 if [[ "$TESTS" == "ctverif" || "$TESTS" == "ALL" ]] && [[ ! -d "$CTVERIF_INSTALL_DIR" ]]; then

--- a/codebuild/bin/s2n_install_test_dependencies.sh
+++ b/codebuild/bin/s2n_install_test_dependencies.sh
@@ -30,10 +30,7 @@ echo "Running ShellCheck..."
 find ./codebuild -type f -name '*.sh' -exec shellcheck -Cnever -s bash {} \;
 
 if [[ "$OS_NAME" == "linux" ]]; then
-    # Only run ubuntu install outside of CodeBuild
-    if [ ! "${CODEBUILD_BUILD_NUMBER}" ]; then
-        codebuild/bin/install_ubuntu_dependencies.sh;
-    fi
+    codebuild/bin/install_ubuntu_dependencies.sh;
 fi
 
 if [[ "$OS_NAME" == "darwin" ]]; then

--- a/codebuild/spec/buildspec_ubuntu.yml
+++ b/codebuild/spec/buildspec_ubuntu.yml
@@ -25,6 +25,8 @@ phases:
     commands:
       - echo Entered the install phase...
       - echo "We need a test PPA for gcc-9."
+      # Update Yarn Debian key, see https://github.com/yarnpkg/yarn/issues/7866
+      - curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg  | apt-key add -
       - add-apt-repository ppa:ubuntu-toolchain-r/test -y
       - apt-get update -o Acquire::CompressionTypes::Order::=gz
       - apt-get update -y

--- a/codebuild/spec/buildspec_ubuntu.yml
+++ b/codebuild/spec/buildspec_ubuntu.yml
@@ -24,12 +24,12 @@ phases:
       python: 3.7
     commands:
       - echo Entered the install phase...
-      - echo "We need a test PPA for gcc-9."
       - |
         if [ -d "third-party-src" ]; then
           cd third-party-src;
         fi
       - $CB_BIN_DIR/install_ubuntu_dependencies.sh
+      - echo "We need a test PPA for gcc-9."
       - add-apt-repository ppa:ubuntu-toolchain-r/test -y
       - apt-get update -o Acquire::CompressionTypes::Order::=gz
       - apt-get update -y

--- a/codebuild/spec/buildspec_ubuntu.yml
+++ b/codebuild/spec/buildspec_ubuntu.yml
@@ -25,6 +25,11 @@ phases:
     commands:
       - echo Entered the install phase...
       - echo "We need a test PPA for gcc-9."
+      - |
+        if [ -d "third-party-src" ]; then
+          cd third-party-src;
+        fi
+      - $CB_BIN_DIR/install_ubuntu_dependencies.sh
       - add-apt-repository ppa:ubuntu-toolchain-r/test -y
       - apt-get update -o Acquire::CompressionTypes::Order::=gz
       - apt-get update -y

--- a/codebuild/spec/buildspec_ubuntu.yml
+++ b/codebuild/spec/buildspec_ubuntu.yml
@@ -25,8 +25,6 @@ phases:
     commands:
       - echo Entered the install phase...
       - echo "We need a test PPA for gcc-9."
-      # Update Yarn Debian key, see https://github.com/yarnpkg/yarn/issues/7866
-      - curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg  | apt-key add -
       - add-apt-repository ppa:ubuntu-toolchain-r/test -y
       - apt-get update -o Acquire::CompressionTypes::Order::=gz
       - apt-get update -y

--- a/codebuild/spec/buildspec_ubuntu_fuzz_afl.yml
+++ b/codebuild/spec/buildspec_ubuntu_fuzz_afl.yml
@@ -28,6 +28,7 @@ phases:
         if [ -d "third-party-src" ]; then
           cd third-party-src;
         fi
+      - $CB_BIN_DIR/install_ubuntu_dependencies.sh
       - TESTS=fuzz $CB_BIN_DIR/install_default_dependencies.sh
       - mkdir tests/fuzz/results
       - mount -t tmpfs -o size=8096m ramdisk tests/fuzz/results

--- a/codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
+++ b/codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
@@ -24,8 +24,6 @@ phases:
       python: 3.x
     commands:
       - echo Entered the install phase...
-      # Update Yarn Debian key, see https://github.com/yarnpkg/yarn/issues/7866
-      - curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg  | apt-key add -
       - apt-key list
       - add-apt-repository ppa:ubuntu-toolchain-r/test -y
       - apt-get update -o Acquire::CompressionTypes::Order::=gz

--- a/codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
+++ b/codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
@@ -24,6 +24,8 @@ phases:
       python: 3.x
     commands:
       - echo Entered the install phase...
+      # Update Yarn Debian key, see https://github.com/yarnpkg/yarn/issues/7866
+      - curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg  | apt-key add -
       - apt-key list
       - add-apt-repository ppa:ubuntu-toolchain-r/test -y
       - apt-get update -o Acquire::CompressionTypes::Order::=gz

--- a/codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
+++ b/codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
@@ -24,6 +24,11 @@ phases:
       python: 3.x
     commands:
       - echo Entered the install phase...
+      - |
+        if [ -d "third-party-src" ]; then
+          cd third-party-src;
+        fi
+      - $CB_BIN_DIR/install_ubuntu_dependencies.sh
       - apt-key list
       - add-apt-repository ppa:ubuntu-toolchain-r/test -y
       - apt-get update -o Acquire::CompressionTypes::Order::=gz

--- a/codebuild/spec/buildspec_ubuntu_integ_awslc.yml
+++ b/codebuild/spec/buildspec_ubuntu_integ_awslc.yml
@@ -27,6 +27,11 @@ phases:
       python: 3.7
     commands:
       - echo Entered the install phase...
+      - |
+        if [ -d "third-party-src" ]; then
+          cd third-party-src;
+        fi
+      - $CB_BIN_DIR/install_ubuntu_dependencies.sh
       - add-apt-repository ppa:ubuntu-toolchain-r/test -y
       # Add repo to get latest golang version. https://github.com/golang/go/wiki/Ubuntu
       - add-apt-repository ppa:longsleep/golang-backports -y

--- a/codebuild/spec/buildspec_ubuntu_integ_boringlibre.yml
+++ b/codebuild/spec/buildspec_ubuntu_integ_boringlibre.yml
@@ -24,6 +24,11 @@ phases:
       python: 3.7
     commands:
       - echo Entered the install phase...
+      - |
+        if [ -d "third-party-src" ]; then
+          cd third-party-src;
+        fi
+      - $CB_BIN_DIR/install_ubuntu_dependencies.sh
       - echo "We need a test PPA for gcc-9."
       - add-apt-repository ppa:ubuntu-toolchain-r/test -y
       - apt-get update -o Acquire::CompressionTypes::Order::=gz

--- a/codebuild/spec/buildspec_ubuntu_integ_openssl102.yml
+++ b/codebuild/spec/buildspec_ubuntu_integ_openssl102.yml
@@ -24,6 +24,11 @@ phases:
       python: 3.7
     commands:
       - echo Entered the install phase...
+      - |
+        if [ -d "third-party-src" ]; then
+          cd third-party-src;
+        fi
+      - $CB_BIN_DIR/install_ubuntu_dependencies.sh
       - echo "We need a test PPA for gcc-9."
       - add-apt-repository ppa:ubuntu-toolchain-r/test -y
       - apt-get update -o Acquire::CompressionTypes::Order::=gz

--- a/codebuild/spec/buildspec_ubuntu_integ_openssl102_asanvalgrind.yml
+++ b/codebuild/spec/buildspec_ubuntu_integ_openssl102_asanvalgrind.yml
@@ -24,6 +24,11 @@ phases:
       python: 3.7
     commands:
       - echo Entered the install phase...
+      - |
+        if [ -d "third-party-src" ]; then
+          cd third-party-src;
+        fi
+      - $CB_BIN_DIR/install_ubuntu_dependencies.sh
       - echo "We need a test PPA for gcc-9."
       - add-apt-repository ppa:ubuntu-toolchain-r/test -y
       - apt-get update -o Acquire::CompressionTypes::Order::=gz

--- a/codebuild/spec/buildspec_ubuntu_integ_openssl111.yml
+++ b/codebuild/spec/buildspec_ubuntu_integ_openssl111.yml
@@ -24,6 +24,11 @@ phases:
       python: 3.7
     commands:
       - echo Entered the install phase...
+      - |
+        if [ -d "third-party-src" ]; then
+          cd third-party-src;
+        fi
+      - $CB_BIN_DIR/install_ubuntu_dependencies.sh
       - echo "We need a test PPA for gcc-9."
       - add-apt-repository ppa:ubuntu-toolchain-r/test -y
       - apt-get update -o Acquire::CompressionTypes::Order::=gz

--- a/codebuild/spec/buildspec_ubuntu_integrationv2.yml
+++ b/codebuild/spec/buildspec_ubuntu_integrationv2.yml
@@ -25,6 +25,11 @@ phases:
       python: 3.7
     commands:
       - echo Entered the install phase...
+      - |
+        if [ -d "third-party-src" ]; then
+          cd third-party-src;
+        fi
+      - $CB_BIN_DIR/install_ubuntu_dependencies.sh
       - echo "We need a test PPA for gcc-9."
       - add-apt-repository ppa:ubuntu-toolchain-r/test -y
       - apt-get update -o Acquire::CompressionTypes::Order::=gz


### PR DESCRIPTION
### Description of changes: 
Addresses this error:

> W: GPG error: https://dl.yarnpkg.com/debian stable InRelease: The following signatures were invalid: EXPKEYSIG 23E7166788B63E1E Yarn Packaging <yarn@dan.cx>
> E: The repository 'https://dl.yarnpkg.com/debian stable InRelease' is not signed.

See https://github.com/yarnpkg/yarn/issues/7866

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
