### PR TITLE
Removes unnecessary includes from CBMC proof harnesses

### DIFF
--- a/tests/cbmc/proofs/s2n_array_capacity/s2n_array_capacity_harness.c
+++ b/tests/cbmc/proofs/s2n_array_capacity/s2n_array_capacity_harness.c
@@ -13,12 +13,9 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
 #include "utils/s2n_array.h"
 #include "utils/s2n_result.h"
 
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
 void s2n_array_capacity_harness()
@@ -27,7 +24,7 @@ void s2n_array_capacity_harness()
     struct s2n_array *array = cbmc_allocate_s2n_array();
     __CPROVER_assume(s2n_result_is_ok(s2n_array_validate(array)));
     __CPROVER_assume(s2n_array_is_bounded(array, MAX_ARRAY_LEN, MAX_ARRAY_ELEMENT_SIZE));
-    uint32_t* capacity = can_fail_malloc(sizeof(*capacity));
+    uint32_t* capacity = malloc(sizeof(*capacity));
 
     /* Operation under verification. */
     if(s2n_result_is_ok(s2n_array_capacity(array, capacity))) {

--- a/tests/cbmc/proofs/s2n_array_free/s2n_array_free_harness.c
+++ b/tests/cbmc/proofs/s2n_array_free/s2n_array_free_harness.c
@@ -13,13 +13,9 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "error/s2n_errno.h"
 #include "utils/s2n_array.h"
 #include "utils/s2n_result.h"
 
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
 void s2n_array_free_harness()

--- a/tests/cbmc/proofs/s2n_array_free_p/s2n_array_free_p_harness.c
+++ b/tests/cbmc/proofs/s2n_array_free_p/s2n_array_free_p_harness.c
@@ -13,12 +13,8 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "utils/s2n_array.h"
 #include "utils/s2n_result.h"
 
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
 void s2n_array_free_p_harness()

--- a/tests/cbmc/proofs/s2n_array_get/s2n_array_get_harness.c
+++ b/tests/cbmc/proofs/s2n_array_get/s2n_array_get_harness.c
@@ -13,12 +13,9 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
 #include "utils/s2n_array.h"
 #include "utils/s2n_result.h"
 
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
 void s2n_array_get_harness()
@@ -28,7 +25,7 @@ void s2n_array_get_harness()
     __CPROVER_assume(s2n_result_is_ok(s2n_array_validate(array)));
     __CPROVER_assume(s2n_array_is_bounded(array, MAX_ARRAY_LEN, MAX_ARRAY_ELEMENT_SIZE));
     uint32_t index;
-    void **element = can_fail_malloc(sizeof(void *));
+    void **element = malloc(sizeof(void *));
 
     /* Operation under verification. */
     if(s2n_result_is_ok(s2n_array_get(array, index, element))) {

--- a/tests/cbmc/proofs/s2n_array_init/s2n_array_init_harness.c
+++ b/tests/cbmc/proofs/s2n_array_init/s2n_array_init_harness.c
@@ -13,11 +13,8 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
 #include "utils/s2n_array.h"
 
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/cbmc_utils.h>
 

--- a/tests/cbmc/proofs/s2n_array_insert/s2n_array_insert_harness.c
+++ b/tests/cbmc/proofs/s2n_array_insert/s2n_array_insert_harness.c
@@ -14,13 +14,9 @@
  */
 
 #include <sys/param.h>
-#include "api/s2n.h"
-#include "error/s2n_errno.h"
 #include "utils/s2n_array.h"
 #include "utils/s2n_result.h"
 
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
 void s2n_array_insert_harness()
@@ -30,7 +26,7 @@ void s2n_array_insert_harness()
     __CPROVER_assume(s2n_result_is_ok(s2n_array_validate(array)));
     __CPROVER_assume(s2n_array_is_bounded(array, MAX_ARRAY_LEN, MAX_ARRAY_ELEMENT_SIZE));
     uint32_t index;
-    void **element = can_fail_malloc(sizeof(void *));
+    void **element = malloc(sizeof(void *));
 
     nondet_s2n_mem_init();
 

--- a/tests/cbmc/proofs/s2n_array_insert_and_copy/s2n_array_insert_and_copy_harness.c
+++ b/tests/cbmc/proofs/s2n_array_insert_and_copy/s2n_array_insert_and_copy_harness.c
@@ -13,13 +13,9 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "error/s2n_errno.h"
 #include "utils/s2n_array.h"
 #include "utils/s2n_result.h"
 
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
 void s2n_array_insert_and_copy_harness()
@@ -29,7 +25,7 @@ void s2n_array_insert_and_copy_harness()
     __CPROVER_assume(s2n_result_is_ok(s2n_array_validate(array)));
     __CPROVER_assume(s2n_array_is_bounded(array, MAX_ARRAY_LEN, MAX_ARRAY_ELEMENT_SIZE));
     uint32_t index;
-    void *element = can_fail_malloc(array->element_size);
+    void *element = malloc(array->element_size);
 
     nondet_s2n_mem_init();
 

--- a/tests/cbmc/proofs/s2n_array_new/s2n_array_new_harness.c
+++ b/tests/cbmc/proofs/s2n_array_new/s2n_array_new_harness.c
@@ -13,13 +13,8 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "error/s2n_errno.h"
 #include "utils/s2n_array.h"
-#include "utils/s2n_mem.h"
 
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
 void s2n_array_new_harness()

--- a/tests/cbmc/proofs/s2n_array_num_elements/s2n_array_num_elements_harness.c
+++ b/tests/cbmc/proofs/s2n_array_num_elements/s2n_array_num_elements_harness.c
@@ -13,12 +13,9 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
 #include "utils/s2n_array.h"
 #include "utils/s2n_result.h"
 
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
 void s2n_array_num_elements_harness()
@@ -27,7 +24,7 @@ void s2n_array_num_elements_harness()
     struct s2n_array *array = cbmc_allocate_s2n_array();
     __CPROVER_assume(s2n_result_is_ok(s2n_array_validate(array)));
     __CPROVER_assume(s2n_array_is_bounded(array, MAX_ARRAY_LEN, MAX_ARRAY_ELEMENT_SIZE));
-    uint32_t* len = can_fail_malloc(sizeof(*len));
+    uint32_t* len = malloc(sizeof(*len));
 
     /* Operation under verification. */
     if(s2n_result_is_ok(s2n_array_num_elements(array, len))) {

--- a/tests/cbmc/proofs/s2n_array_pushback/s2n_array_pushback_harness.c
+++ b/tests/cbmc/proofs/s2n_array_pushback/s2n_array_pushback_harness.c
@@ -13,13 +13,9 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "error/s2n_errno.h"
 #include "utils/s2n_array.h"
 #include "utils/s2n_result.h"
 
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
 void s2n_array_pushback_harness()

--- a/tests/cbmc/proofs/s2n_array_remove/s2n_array_remove_harness.c
+++ b/tests/cbmc/proofs/s2n_array_remove/s2n_array_remove_harness.c
@@ -13,13 +13,9 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "error/s2n_errno.h"
 #include "utils/s2n_array.h"
 #include "utils/s2n_result.h"
 
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
 void s2n_array_remove_harness()

--- a/tests/cbmc/proofs/s2n_set_add/s2n_set_add_harness.c
+++ b/tests/cbmc/proofs/s2n_set_add/s2n_set_add_harness.c
@@ -13,12 +13,8 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
 #include "utils/s2n_set.h"
-#include "utils/s2n_result.h"
 
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
 void s2n_set_add_harness()
@@ -28,7 +24,7 @@ void s2n_set_add_harness()
     __CPROVER_assume(s2n_result_is_ok(s2n_set_validate(set)));
     __CPROVER_assume(s2n_set_is_bounded(set, MAX_ARRAY_LEN, MAX_ARRAY_ELEMENT_SIZE));
     uint32_t index;
-    void *element = can_fail_malloc(set->data->element_size);
+    void *element = malloc(set->data->element_size);
 
     nondet_s2n_mem_init();
 

--- a/tests/cbmc/proofs/s2n_set_free/s2n_set_free_harness.c
+++ b/tests/cbmc/proofs/s2n_set_free/s2n_set_free_harness.c
@@ -13,12 +13,8 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
 #include "utils/s2n_set.h"
-#include "utils/s2n_result.h"
 
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
 void s2n_set_free_harness()

--- a/tests/cbmc/proofs/s2n_set_free_p/s2n_set_free_p_harness.c
+++ b/tests/cbmc/proofs/s2n_set_free_p/s2n_set_free_p_harness.c
@@ -13,12 +13,8 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
 #include "utils/s2n_set.h"
-#include "utils/s2n_result.h"
 
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
 void s2n_set_free_p_harness()

--- a/tests/cbmc/proofs/s2n_set_get/s2n_set_get_harness.c
+++ b/tests/cbmc/proofs/s2n_set_get/s2n_set_get_harness.c
@@ -13,12 +13,8 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
 #include "utils/s2n_set.h"
-#include "utils/s2n_result.h"
 
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
 void s2n_set_get_harness()
@@ -28,7 +24,7 @@ void s2n_set_get_harness()
     __CPROVER_assume(s2n_result_is_ok(s2n_set_validate(set)));
     __CPROVER_assume(s2n_set_is_bounded(set, MAX_ARRAY_LEN, MAX_ARRAY_ELEMENT_SIZE));
     uint32_t index;
-    void **element = can_fail_malloc(sizeof(void *));
+    void **element = malloc(sizeof(void *));
 
     /* Operation under verification. */
     if(s2n_result_is_ok(s2n_set_get(set, index, element))) {

--- a/tests/cbmc/proofs/s2n_set_len/s2n_set_len_harness.c
+++ b/tests/cbmc/proofs/s2n_set_len/s2n_set_len_harness.c
@@ -13,12 +13,8 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
 #include "utils/s2n_set.h"
-#include "utils/s2n_result.h"
 
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
 void s2n_set_len_harness()
@@ -27,7 +23,7 @@ void s2n_set_len_harness()
     struct s2n_set *set = cbmc_allocate_s2n_set();
     __CPROVER_assume(s2n_result_is_ok(s2n_set_validate(set)));
     __CPROVER_assume(s2n_set_is_bounded(set, MAX_ARRAY_LEN, MAX_ARRAY_ELEMENT_SIZE));
-    uint32_t* len = can_fail_malloc(sizeof(*len));
+    uint32_t* len = malloc(sizeof(*len));
 
     /* Operation under verification. */
     if(s2n_result_is_ok(s2n_set_len(set, len))) {

--- a/tests/cbmc/proofs/s2n_set_new/s2n_set_new_harness.c
+++ b/tests/cbmc/proofs/s2n_set_new/s2n_set_new_harness.c
@@ -13,13 +13,8 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "error/s2n_errno.h"
 #include "utils/s2n_set.h"
-#include "utils/s2n_mem.h"
 
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
 void s2n_set_new_harness()

--- a/tests/cbmc/proofs/s2n_set_remove/s2n_set_remove_harness.c
+++ b/tests/cbmc/proofs/s2n_set_remove/s2n_set_remove_harness.c
@@ -13,13 +13,8 @@
  * permissions and limitations under the License.
  */
 
-#include "api/s2n.h"
-#include "error/s2n_errno.h"
 #include "utils/s2n_set.h"
-#include "utils/s2n_result.h"
 
-#include <assert.h>
-#include <cbmc_proof/proof_allocators.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
 void s2n_set_remove_harness()


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

### Resolved issues:

N/A.

### Description of changes: 

I little bit of clean up in CBMC proofs:
 - Remove unnecessary includes from proof harnesses;
 - We no longer need `can_fail_malloc` since all `malloc`s in CBMC will non-deterministically fail.

### Call-outs:

N/A.

### Testing:

N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
