### PR TITLE
Rework psk_selection_callback to use opaque structures

### DIFF
--- a/tests/unit/s2n_client_psk_extension_test.c
+++ b/tests/unit/s2n_client_psk_extension_test.c
@@ -504,7 +504,7 @@ int main(int argc, char **argv)
 
             struct s2n_psk *expected_chosen_psk = NULL;
             for (size_t local_i = 0; local_i < test_cases[i].local_identities_len; local_i++) {
-                struct s2n_psk *psk;
+                struct s2n_psk *psk = NULL;
                 EXPECT_OK(s2n_array_pushback(&conn->psk_params.psk_list, (void**) &psk));
                 EXPECT_NOT_NULL(psk);
                 EXPECT_SUCCESS(s2n_psk_set_identity(psk, test_cases[i].local_identities[local_i]->data,

--- a/tests/unit/s2n_client_psk_extension_test.c
+++ b/tests/unit/s2n_client_psk_extension_test.c
@@ -25,9 +25,6 @@
 #define TEST_BYTES_2 0x0A, 0x0B, 0x0C
 #define TEST_BYTES_SIZE_2 0x00, 0x03
 
-/* identity size + obfuscated_ticket_age_size + (max num of psk identities + 1) */
-#define TOO_MANY_IDENTITIES (sizeof(uint16_t) + sizeof(uint32_t)) * (MAX_NUM_OF_PSK_IDENTITIES + 1)
-
 struct s2n_psk_test_case {
     s2n_hmac_algorithm hmac_alg;
     uint8_t hash_size;
@@ -35,29 +32,26 @@ struct s2n_psk_test_case {
     size_t identity_size;
 };
 
-static int s2n_test_select_psk_identity_callback(struct s2n_connection *conn, struct s2n_psk_identity *identities,
-                                                 size_t identities_length, uint16_t *chosen_wire_index)
+uint16_t s2n_test_customer_wire_index_choice;
+static int s2n_test_select_psk_identity_callback(struct s2n_connection *conn,
+        struct s2n_offered_psk_list *psk_identity_list, uint16_t *chosen_wire_index)
 {
-    notnull_check(conn);
-    notnull_check(identities);
-    notnull_check(chosen_wire_index);
+    *chosen_wire_index = s2n_test_customer_wire_index_choice;
+    return S2N_SUCCESS;
+}
 
-    struct s2n_array *known_psks = &conn->psk_params.psk_list;
+static int s2n_test_error_select_psk_identity_callback(struct s2n_connection *conn,
+        struct s2n_offered_psk_list *psk_identity_list, uint16_t *chosen_wire_index)
+{
+    S2N_ERROR(S2N_ERR_UNIMPLEMENTED);
+}
 
-    for (size_t i = 0; i < identities_length; i++) {
-        struct s2n_blob wire_identity = { 0 };
-        GUARD(s2n_blob_init(&wire_identity, identities[i].data, identities[i].length));
-
-        struct s2n_psk *local_match = NULL;
-        GUARD_AS_POSIX(s2n_match_psk_identity(known_psks, &wire_identity, &local_match));
-
-        if (local_match != NULL) {
-            *chosen_wire_index = i;
-            return S2N_SUCCESS;
-        }
-    }
-
-    return S2N_FAILURE;
+static S2N_RESULT s2n_write_test_identity(struct s2n_stuffer *out, struct s2n_blob *identity)
+{
+    GUARD_AS_RESULT(s2n_stuffer_write_uint16(out, identity->size));
+    GUARD_AS_RESULT(s2n_stuffer_write(out, identity));
+    GUARD_AS_RESULT(s2n_stuffer_write_uint32(out, 0));
+    return S2N_RESULT_OK;
 }
 
 int main(int argc, char **argv)
@@ -66,9 +60,9 @@ int main(int argc, char **argv)
 
     uint8_t test_bytes_data[] = { TEST_BYTES };
     uint8_t test_bytes_data_2[] = { TEST_BYTES_2 };
-    uint8_t test_zero_bytes[] = { 0 };
     uint8_t test_identity[] = "test identity";
     uint8_t test_identity_2[] = "another identity";
+    uint8_t test_identity_3[] = "identity 3";
     uint8_t test_secret[] = "test secret";
 
     uint8_t single_wire_identity[] = {
@@ -98,8 +92,6 @@ int main(int argc, char **argv)
         0x00, 0x01,             /* identity */
         0x00, 0x00, 0x00, 0x00, /* ticket_age */
     };
-
-    const uint16_t wire_identities_match_index = 2;
 
     /* Test: s2n_client_psk_should_send */
     {
@@ -399,226 +391,141 @@ int main(int argc, char **argv)
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
-            struct s2n_psk_identity psk_identities[] = { 0 };
-            size_t psk_identities_length = 0; 
+            EXPECT_ERROR_WITH_ERRNO(s2n_select_psk_identity(conn, NULL), S2N_ERR_NULL);
 
-            EXPECT_ERROR_WITH_ERRNO(s2n_select_psk_identity(NULL, psk_identities, psk_identities_length), S2N_ERR_NULL);
-
-            EXPECT_ERROR_WITH_ERRNO(s2n_select_psk_identity(conn, NULL, psk_identities_length), S2N_ERR_NULL);
+            struct s2n_offered_psk_list wire_identity_list = { 0 };
+            EXPECT_ERROR_WITH_ERRNO(s2n_select_psk_identity(NULL, &wire_identity_list), S2N_ERR_NULL);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }
 
-        /* Select psk identity from an empty wire identity list and an empty local list */
-        {
+        struct s2n_blob identity_1 = { 0 };
+        EXPECT_SUCCESS(s2n_blob_init(&identity_1, test_identity, sizeof(test_identity)));
+        struct s2n_blob identity_2 = { 0 };
+        EXPECT_SUCCESS(s2n_blob_init(&identity_2, test_identity_2, sizeof(test_identity_2)));
+        struct s2n_blob identity_3 = { 0 };
+        EXPECT_SUCCESS(s2n_blob_init(&identity_3, test_identity_3, sizeof(test_identity_3)));
+
+        struct s2n_blob *all_psks_list[] = { &identity_1, &identity_2, &identity_3 };
+        struct s2n_blob *reverse_order_list[] = { &identity_3, &identity_2, &identity_1 };
+        struct s2n_blob *list_without_psk1[] = { &identity_2, &identity_3 };
+        struct s2n_blob *multiple_psk1[] = { &identity_1, &identity_1, &identity_1 };
+        struct s2n_blob *multiple_psk2[] = { &identity_2, &identity_2, &identity_2 };
+        struct s2n_blob *only_psk1[] = { &identity_1 };
+        struct s2n_blob *only_psk2[] = { &identity_2 };
+        struct s2n_blob *only_psk3[] = { &identity_3 };
+
+        struct {
+            bool match;
+            struct s2n_blob **wire_identities;
+            size_t wire_identities_len;
+            struct s2n_blob **local_identities;
+            size_t local_identities_len;
+            size_t wire_match_index;
+            size_t local_match_index;
+        } test_cases[] = {
+#define WIRE_IDENTITIES(list) .wire_identities = list, .wire_identities_len = s2n_array_len(list)
+#define LOCAL_IDENTITIES(list) .local_identities = list, .local_identities_len = s2n_array_len(list)
+            /* No wire or local identities */
+            { .match = false },
+
+            /* Only wire identities */
+            { .match = false, WIRE_IDENTITIES(only_psk1) },
+            { .match = false, WIRE_IDENTITIES(all_psks_list) },
+
+            /* Only local identities */
+            { .match = false, LOCAL_IDENTITIES(only_psk1) },
+            { .match = false, LOCAL_IDENTITIES(all_psks_list) },
+
+            /* No match with valid lists */
+            { .match = false, WIRE_IDENTITIES(only_psk1), LOCAL_IDENTITIES(only_psk2) },
+            { .match = false, WIRE_IDENTITIES(only_psk1), LOCAL_IDENTITIES(list_without_psk1) },
+            { .match = false, WIRE_IDENTITIES(list_without_psk1), LOCAL_IDENTITIES(only_psk1) },
+
+            /* Single option matches */
+            { .match = true, WIRE_IDENTITIES(only_psk1), LOCAL_IDENTITIES(only_psk1),
+                    .wire_match_index = 0, .local_match_index = 0 },
+
+            /* Single wire option matches */
+            { .match = true, WIRE_IDENTITIES(only_psk1), LOCAL_IDENTITIES(all_psks_list),
+                    .wire_match_index = 0, .local_match_index = 0 },
+            { .match = true, WIRE_IDENTITIES(only_psk2), LOCAL_IDENTITIES(all_psks_list),
+                    .wire_match_index = 0, .local_match_index = 1 },
+            { .match = true, WIRE_IDENTITIES(only_psk3), LOCAL_IDENTITIES(all_psks_list),
+                    .wire_match_index = 0, .local_match_index = 2 },
+
+            /* Single local option matches */
+            { .match = true, WIRE_IDENTITIES(all_psks_list), LOCAL_IDENTITIES(only_psk1),
+                    .wire_match_index = 0, .local_match_index = 0 },
+            { .match = true, WIRE_IDENTITIES(all_psks_list), LOCAL_IDENTITIES(only_psk2),
+                    .wire_match_index = 1, .local_match_index = 0 },
+            { .match = true, WIRE_IDENTITIES(all_psks_list), LOCAL_IDENTITIES(only_psk3),
+                    .wire_match_index = 2, .local_match_index = 0 },
+
+            /* Match with multiple wire and local options: choose first local */
+            { .match = true, WIRE_IDENTITIES(all_psks_list), LOCAL_IDENTITIES(all_psks_list),
+                    .wire_match_index = 0, .local_match_index = 0 },
+            { .match = true, WIRE_IDENTITIES(reverse_order_list), LOCAL_IDENTITIES(all_psks_list),
+                    .wire_match_index = 2, .local_match_index = 0 },
+            { .match = true, WIRE_IDENTITIES(all_psks_list), LOCAL_IDENTITIES(reverse_order_list),
+                    .wire_match_index = 2, .local_match_index = 0 },
+            { .match = true, WIRE_IDENTITIES(list_without_psk1), LOCAL_IDENTITIES(all_psks_list),
+                    .wire_match_index = 0, .local_match_index = 1 },
+            { .match = true, WIRE_IDENTITIES(all_psks_list), LOCAL_IDENTITIES(list_without_psk1),
+                    .wire_match_index = 1, .local_match_index = 0 },
+            { .match = true, WIRE_IDENTITIES(list_without_psk1), LOCAL_IDENTITIES(reverse_order_list),
+                    .wire_match_index = 1, .local_match_index = 0 },
+            { .match = true, WIRE_IDENTITIES(reverse_order_list), LOCAL_IDENTITIES(list_without_psk1),
+                    .wire_match_index = 1, .local_match_index = 0 },
+
+            /* Handle duplicates */
+            { .match = true, WIRE_IDENTITIES(multiple_psk1), LOCAL_IDENTITIES(multiple_psk1),
+                    .wire_match_index = 0, .local_match_index = 0 },
+            { .match = false, WIRE_IDENTITIES(multiple_psk1), LOCAL_IDENTITIES(multiple_psk2)},
+            { .match = true, WIRE_IDENTITIES(multiple_psk1), LOCAL_IDENTITIES(all_psks_list),
+                    .wire_match_index = 0, .local_match_index = 0 },
+            { .match = true, WIRE_IDENTITIES(all_psks_list), LOCAL_IDENTITIES(multiple_psk1),
+                    .wire_match_index = 0, .local_match_index = 0 },
+            { .match = true, WIRE_IDENTITIES(multiple_psk1), LOCAL_IDENTITIES(reverse_order_list),
+                    .wire_match_index = 0, .local_match_index = 2 },
+            { .match = true, WIRE_IDENTITIES(reverse_order_list), LOCAL_IDENTITIES(multiple_psk1),
+                    .wire_match_index = 2, .local_match_index = 0 },
+        };
+
+        for (size_t i = 0; i < s2n_array_len(test_cases); i++) {
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
-            struct s2n_psk_identity psk_identities[] = { 0 };
+            struct s2n_offered_psk_list wire_identity_list = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&wire_identity_list.wire_data, 0));
+            for (size_t wire_i = 0; wire_i < test_cases[i].wire_identities_len; wire_i++) {
+                EXPECT_OK(s2n_write_test_identity(&wire_identity_list.wire_data, test_cases[i].wire_identities[wire_i]));
+            }
 
-            EXPECT_OK(s2n_select_psk_identity(conn, psk_identities, 0));
-            EXPECT_EQUAL(conn->psk_params.chosen_psk, NULL);
+            struct s2n_psk *expected_chosen_psk = NULL;
+            for (size_t local_i = 0; local_i < test_cases[i].local_identities_len; local_i++) {
+                struct s2n_psk *psk;
+                EXPECT_OK(s2n_array_pushback(&conn->psk_params.psk_list, (void**) &psk));
+                EXPECT_NOT_NULL(psk);
+                EXPECT_SUCCESS(s2n_psk_set_identity(psk, test_cases[i].local_identities[local_i]->data,
+                        test_cases[i].local_identities[local_i]->size));
 
-            EXPECT_SUCCESS(s2n_connection_free(conn));
-        }
+                if (local_i == test_cases[i].local_match_index) {
+                    expected_chosen_psk = psk;
+                }
+            }
 
-        /* Select psk identity from an empty wire identity list and a non-empty local list */
-        {
-            struct s2n_connection *conn;
-            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-
-            struct s2n_psk_identity psk_identities[] = { 0 };
-
-            struct s2n_psk *psk = NULL;
-            EXPECT_OK(s2n_array_pushback(&conn->psk_params.psk_list, (void **) &psk));
-            EXPECT_OK(s2n_psk_init(psk, S2N_PSK_TYPE_EXTERNAL));
-            EXPECT_SUCCESS(s2n_psk_set_identity(psk, test_bytes_data, sizeof(test_bytes_data)));
-
-            EXPECT_OK(s2n_select_psk_identity(conn, psk_identities, 0));
-            EXPECT_EQUAL(conn->psk_params.chosen_psk, NULL);
-
-            EXPECT_SUCCESS(s2n_connection_free(conn));
-        }
-
-        /* Select psk identity from a non-empty wire identity list and an empty local list */
-        {
-            struct s2n_connection *conn;
-            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-
-            struct s2n_psk_identity psk_identities[] = { 0 };
-            psk_identities[0].data = test_bytes_data;
-            psk_identities[0].length = sizeof(test_bytes_data);
-            size_t psk_identities_length = sizeof(psk_identities)/sizeof(struct s2n_psk_identity);
-
-            EXPECT_OK(s2n_select_psk_identity(conn, psk_identities, psk_identities_length));
-            EXPECT_EQUAL(conn->psk_params.chosen_psk, NULL);
+            if (test_cases[i].match) {
+                EXPECT_OK(s2n_select_psk_identity(conn, &wire_identity_list));
+                EXPECT_EQUAL(conn->psk_params.chosen_psk_wire_index, test_cases[i].wire_match_index);
+                EXPECT_EQUAL(conn->psk_params.chosen_psk, expected_chosen_psk);
+            } else {
+                EXPECT_ERROR(s2n_select_psk_identity(conn, &wire_identity_list));
+                EXPECT_NULL(conn->psk_params.chosen_psk);
+            }
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
-        }
-
-        /* Select psk identity with no match, when both the wire identity list and the local list are not empty */
-        {
-            struct s2n_connection *conn;
-            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-
-            struct s2n_psk_identity psk_identities[] = { 0 };
-            psk_identities[0].data = test_bytes_data;
-            psk_identities[0].length = sizeof(test_bytes_data);
-            size_t psk_identities_length = sizeof(psk_identities)/sizeof(struct s2n_psk_identity);
-
-            struct s2n_psk *no_match_psk = NULL;
-            EXPECT_OK(s2n_array_pushback(&conn->psk_params.psk_list, (void **) &no_match_psk));
-            EXPECT_OK(s2n_psk_init(no_match_psk, S2N_PSK_TYPE_EXTERNAL));
-            EXPECT_SUCCESS(s2n_psk_set_identity(no_match_psk, test_bytes_data_2, sizeof(test_bytes_data_2)));
-
-            EXPECT_OK(s2n_select_psk_identity(conn, psk_identities, psk_identities_length));
-            EXPECT_EQUAL(conn->psk_params.chosen_psk, NULL);
-
-            EXPECT_SUCCESS(s2n_connection_free(conn));
-        }
-
-        /* Select psk identity with an immediate match in the wire identity list */
-        {
-            struct s2n_connection *conn;
-            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-
-            struct s2n_psk_identity psk_identities[2] = { 0 };
-            psk_identities[0].data = test_bytes_data;
-            psk_identities[0].length = sizeof(test_bytes_data);
-            psk_identities[1].data = test_bytes_data_2;
-            psk_identities[1].length = sizeof(test_bytes_data_2);
-                
-            struct s2n_psk *no_match_psk = NULL;
-            EXPECT_OK(s2n_array_pushback(&conn->psk_params.psk_list, (void **) &no_match_psk));
-            EXPECT_OK(s2n_psk_init(no_match_psk, S2N_PSK_TYPE_EXTERNAL));
-            EXPECT_SUCCESS(s2n_psk_set_identity(no_match_psk, test_zero_bytes, sizeof(test_zero_bytes)));
-    
-            struct s2n_psk *match_psk = NULL;
-            EXPECT_OK(s2n_array_pushback(&conn->psk_params.psk_list, (void **) &match_psk));
-            EXPECT_OK(s2n_psk_init(match_psk, S2N_PSK_TYPE_EXTERNAL));
-            EXPECT_SUCCESS(s2n_psk_set_identity(match_psk, test_bytes_data, sizeof(test_bytes_data)));
-    
-            struct s2n_psk *match_psk_2 = NULL;
-            EXPECT_OK(s2n_array_pushback(&conn->psk_params.psk_list, (void **) &match_psk_2));
-            EXPECT_OK(s2n_psk_init(match_psk_2, S2N_PSK_TYPE_EXTERNAL));
-            EXPECT_SUCCESS(s2n_psk_set_identity(match_psk_2, test_bytes_data_2, sizeof(test_bytes_data_2)));
-
-            size_t psk_identities_length = sizeof(psk_identities)/sizeof(struct s2n_psk_identity);
-
-            EXPECT_OK(s2n_select_psk_identity(conn, psk_identities, psk_identities_length));
-            EXPECT_EQUAL(conn->psk_params.chosen_psk_wire_index, 0);
-            EXPECT_EQUAL(conn->psk_params.chosen_psk, match_psk);
-
-            EXPECT_SUCCESS(s2n_connection_free(conn));
-        }
-
-        /* Select psk identity with a match later in the wire identity list */
-        {
-            struct s2n_connection *conn;
-            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-
-            struct s2n_psk_identity psk_identities[2] = { 0 };
-            psk_identities[0].data = test_bytes_data;
-            psk_identities[0].length = sizeof(test_bytes_data);
-            psk_identities[1].data = test_bytes_data_2;
-            psk_identities[1].length = sizeof(test_bytes_data_2);
-
-            struct s2n_psk *no_match_psk = NULL;
-            EXPECT_OK(s2n_array_pushback(&conn->psk_params.psk_list, (void **) &no_match_psk));
-            EXPECT_OK(s2n_psk_init(no_match_psk, S2N_PSK_TYPE_EXTERNAL));
-            EXPECT_SUCCESS(s2n_psk_set_identity(no_match_psk, test_zero_bytes, sizeof(test_zero_bytes)));
-
-            struct s2n_psk *match_psk = NULL;
-            EXPECT_OK(s2n_array_pushback(&conn->psk_params.psk_list, (void **) &match_psk));
-            EXPECT_OK(s2n_psk_init(match_psk, S2N_PSK_TYPE_EXTERNAL));
-            EXPECT_SUCCESS(s2n_psk_set_identity(match_psk, test_bytes_data_2, sizeof(test_bytes_data_2)));
-
-            size_t psk_identities_length = sizeof(psk_identities)/sizeof(struct s2n_psk_identity);
-
-            EXPECT_OK(s2n_select_psk_identity(conn, psk_identities, psk_identities_length));
-            EXPECT_EQUAL(conn->psk_params.chosen_psk_wire_index, 1);
-            EXPECT_EQUAL(conn->psk_params.chosen_psk, match_psk);
-
-            EXPECT_SUCCESS(s2n_connection_free(conn));
-        }
-
-        /* Select the first psk identity match when there are duplicates in the list */
-        {
-            struct s2n_connection *conn;
-            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-
-            struct s2n_psk_identity psk_identities[3] = { 0 };
-            psk_identities[0].data = test_bytes_data;
-            psk_identities[0].length = sizeof(test_bytes_data);
-            psk_identities[1].data = test_bytes_data_2;
-            psk_identities[1].length = sizeof(test_bytes_data_2);
-            psk_identities[2].data = test_bytes_data_2;
-            psk_identities[2].length = sizeof(test_bytes_data_2);
-
-            struct s2n_psk *no_match_psk = NULL;
-            EXPECT_OK(s2n_array_pushback(&conn->psk_params.psk_list, (void **) &no_match_psk));
-            EXPECT_OK(s2n_psk_init(no_match_psk, S2N_PSK_TYPE_EXTERNAL));
-            EXPECT_SUCCESS(s2n_psk_set_identity(no_match_psk, test_zero_bytes, sizeof(test_zero_bytes)));
-
-            struct s2n_psk *match_psk = NULL;
-            EXPECT_OK(s2n_array_pushback(&conn->psk_params.psk_list, (void **) &match_psk));
-            EXPECT_OK(s2n_psk_init(match_psk, S2N_PSK_TYPE_EXTERNAL));
-            EXPECT_SUCCESS(s2n_psk_set_identity(match_psk, test_bytes_data_2, sizeof(test_bytes_data_2)));
-
-            size_t psk_identities_length = sizeof(psk_identities)/sizeof(struct s2n_psk_identity);
-
-            EXPECT_OK(s2n_select_psk_identity(conn, psk_identities, psk_identities_length));
-            EXPECT_EQUAL(conn->psk_params.chosen_psk_wire_index, 1);
-            EXPECT_EQUAL(conn->psk_params.chosen_psk, match_psk);
-
-            EXPECT_SUCCESS(s2n_connection_free(conn));
-        }
-    }
-
-    /* Test: s2n_count_psk_identities */
-    {
-        /* Safety checks */
-        {
-            struct s2n_stuffer wire_identities_in = { 0 };
-            uint16_t identity_count = 0;
-
-            EXPECT_ERROR_WITH_ERRNO(s2n_count_psk_identities(&wire_identities_in, NULL), S2N_ERR_NULL);
-            EXPECT_ERROR_WITH_ERRNO(s2n_count_psk_identities(NULL, &identity_count), S2N_ERR_NULL);
-        }
-
-        /* Test psk identities count for empty identities list */
-        {
-            struct s2n_stuffer empty_wire_identities_in = { 0 };
-            uint16_t identity_count = 0;
-
-            EXPECT_OK(s2n_count_psk_identities(&empty_wire_identities_in, &identity_count));
-            EXPECT_EQUAL(identity_count, 0);
-        }
-
-        /* Test psk identities count for single identity list */
-        {
-            struct s2n_stuffer wire_identities_in = { 0 };
-            EXPECT_SUCCESS(s2n_stuffer_alloc(&wire_identities_in, sizeof(single_wire_identity)));
-            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&wire_identities_in, single_wire_identity, sizeof(single_wire_identity)));
-            uint16_t identity_count = 0;
-
-            EXPECT_OK(s2n_count_psk_identities(&wire_identities_in, &identity_count));
-            EXPECT_EQUAL(identity_count, 1);
-
-            EXPECT_SUCCESS(s2n_stuffer_free(&wire_identities_in));
-        }
-
-        /* Test psk identities count for identities list containing multiple psk identities */
-        {
-            struct s2n_stuffer wire_identities_in = { 0 };
-            EXPECT_SUCCESS(s2n_stuffer_alloc(&wire_identities_in, sizeof(wire_identities)));
-            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&wire_identities_in, wire_identities, sizeof(wire_identities)));
-            uint16_t identity_count = 0;
-
-            EXPECT_OK(s2n_count_psk_identities(&wire_identities_in, &identity_count));
-            EXPECT_EQUAL(identity_count, 5);
-
-            EXPECT_SUCCESS(s2n_stuffer_free(&wire_identities_in));
+            EXPECT_SUCCESS(s2n_stuffer_free(&wire_identity_list.wire_data));
         }
     }
 
@@ -644,50 +551,13 @@ int main(int argc, char **argv)
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
-            EXPECT_ERROR_WITH_ERRNO(s2n_client_psk_recv_identity_list(conn, &empty_wire_identities_in), S2N_ERR_SAFETY);
+            EXPECT_ERROR(s2n_client_psk_recv_identity_list(conn, &empty_wire_identities_in));
             EXPECT_NULL(conn->psk_params.chosen_psk);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }
 
-        /* Receive a list with a single identity of identity size initialized to zero */
-        {
-            struct s2n_stuffer wire_identities_in = { 0 };
-            uint8_t test_wire_identity[] = {
-                0x00, 0x00,             /* identity size */
-                0x00, 0x00, 0x00, 0x00, /* ticket_age */
-            };
-            EXPECT_SUCCESS(s2n_stuffer_alloc(&wire_identities_in, sizeof(test_wire_identity)));
-            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&wire_identities_in, test_wire_identity, sizeof(test_wire_identity)));
-
-            struct s2n_connection *conn;
-            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-
-            EXPECT_ERROR_WITH_ERRNO(s2n_client_psk_recv_identity_list(conn, &wire_identities_in), S2N_ERR_SAFETY);
-            EXPECT_NULL(conn->psk_params.chosen_psk);
-
-            EXPECT_SUCCESS(s2n_connection_free(conn));
-            EXPECT_SUCCESS(s2n_stuffer_free(&wire_identities_in));
-        }
-
-        /* Receive a list with number of identities greater than the upper limit */
-        {
-            struct s2n_connection *conn;
-            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-
-            struct s2n_stuffer wire_identities_in = { 0 };
-            uint8_t test_wire_identities[TOO_MANY_IDENTITIES] = { 0 };
-
-            EXPECT_SUCCESS(s2n_stuffer_alloc(&wire_identities_in, sizeof(test_wire_identities)));
-            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&wire_identities_in, test_wire_identities, sizeof(test_wire_identities)));
-            EXPECT_ERROR_WITH_ERRNO(s2n_client_psk_recv_identity_list(conn, &wire_identities_in), S2N_ERR_SAFETY);
-            EXPECT_NULL(conn->psk_params.chosen_psk);
-
-            EXPECT_SUCCESS(s2n_connection_free(conn));
-            EXPECT_SUCCESS(s2n_stuffer_free(&wire_identities_in));
-        }
-
-        /* Receive a list without a match */
+        /* Default selection logic: receive a list without a match */
         {
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
@@ -708,7 +578,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_free(&wire_identities_in));
         }
 
-        /* Receive a list with an immediate match */
+        /* Default selection logic: receive a list with a match */
         {
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
@@ -730,50 +600,111 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_free(&wire_identities_in));
         }
 
-        /* Receive a list with a match later in the list */
+        /* Customer selection logic: customer rejects all identities */
         {
+            struct s2n_config *config = s2n_config_new();
+            EXPECT_NOT_NULL(config);
+            EXPECT_SUCCESS(s2n_config_set_psk_selection_callback(config, s2n_test_error_select_psk_identity_callback));
+
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
             struct s2n_stuffer wire_identities_in = { 0 };
-            EXPECT_SUCCESS(s2n_stuffer_alloc(&wire_identities_in, sizeof(wire_identities)));
-            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&wire_identities_in, wire_identities, sizeof(wire_identities)));
-
-            struct s2n_psk *match_psk = NULL;
-            EXPECT_OK(s2n_array_pushback(&conn->psk_params.psk_list, (void**) &match_psk));
-            EXPECT_OK(s2n_psk_init(match_psk, S2N_PSK_TYPE_EXTERNAL));
-            EXPECT_SUCCESS(s2n_psk_set_identity(match_psk, test_bytes_data, sizeof(test_bytes_data)));
-
-            EXPECT_OK(s2n_client_psk_recv_identity_list(conn, &wire_identities_in));
-            EXPECT_EQUAL(conn->psk_params.chosen_psk_wire_index, wire_identities_match_index);
-            EXPECT_EQUAL(conn->psk_params.chosen_psk, match_psk);
+            EXPECT_ERROR_WITH_ERRNO(s2n_client_psk_recv_identity_list(conn, &wire_identities_in),
+                    S2N_ERR_UNIMPLEMENTED);
+            EXPECT_EQUAL(conn->psk_params.chosen_psk, NULL);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_config_free(config));
             EXPECT_SUCCESS(s2n_stuffer_free(&wire_identities_in));
         }
 
-        /* Receive a list with a match using customer's callback function */
+        /* Customer selection logic: customer selects valid identity */
         {
+            struct s2n_config *config = s2n_config_new();
+            EXPECT_NOT_NULL(config);
+            EXPECT_SUCCESS(s2n_config_set_psk_selection_callback(config, s2n_test_select_psk_identity_callback));
+
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-
-            EXPECT_SUCCESS(s2n_config_set_psk_selection_callback(conn, s2n_test_select_psk_identity_callback));
-            EXPECT_EQUAL(conn->config->psk_selection_cb, s2n_test_select_psk_identity_callback);
-
-            struct s2n_stuffer wire_identities_in = { 0 };
-            EXPECT_SUCCESS(s2n_stuffer_alloc(&wire_identities_in, sizeof(wire_identities)));
-            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&wire_identities_in, wire_identities, sizeof(wire_identities)));
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
             struct s2n_psk *match_psk = NULL;
             EXPECT_OK(s2n_array_pushback(&conn->psk_params.psk_list, (void**) &match_psk));
             EXPECT_OK(s2n_psk_init(match_psk, S2N_PSK_TYPE_EXTERNAL));
             EXPECT_SUCCESS(s2n_psk_set_identity(match_psk, test_bytes_data, sizeof(test_bytes_data)));
 
+            struct s2n_stuffer wire_identities_in = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&wire_identities_in, 0));
+            EXPECT_OK(s2n_write_test_identity(&wire_identities_in, &match_psk->identity));
+
+            s2n_test_customer_wire_index_choice = 0;
             EXPECT_OK(s2n_client_psk_recv_identity_list(conn, &wire_identities_in));
-            EXPECT_EQUAL(conn->psk_params.chosen_psk_wire_index, wire_identities_match_index);
             EXPECT_EQUAL(conn->psk_params.chosen_psk, match_psk);
+            EXPECT_EQUAL(conn->psk_params.chosen_psk_wire_index, 0);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_config_free(config));
+            EXPECT_SUCCESS(s2n_stuffer_free(&wire_identities_in));
+        }
+
+        /* Customer selection logic: customer selects out of bounds index */
+        {
+            struct s2n_config *config = s2n_config_new();
+            EXPECT_NOT_NULL(config);
+            EXPECT_SUCCESS(s2n_config_set_psk_selection_callback(config, s2n_test_select_psk_identity_callback));
+
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+            struct s2n_psk *match_psk = NULL;
+            EXPECT_OK(s2n_array_pushback(&conn->psk_params.psk_list, (void**) &match_psk));
+            EXPECT_OK(s2n_psk_init(match_psk, S2N_PSK_TYPE_EXTERNAL));
+            EXPECT_SUCCESS(s2n_psk_set_identity(match_psk, test_bytes_data, sizeof(test_bytes_data)));
+
+            struct s2n_stuffer wire_identities_in = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&wire_identities_in, 0));
+            EXPECT_OK(s2n_write_test_identity(&wire_identities_in, &match_psk->identity));
+
+            s2n_test_customer_wire_index_choice = 10;
+            EXPECT_ERROR(s2n_client_psk_recv_identity_list(conn, &wire_identities_in));
+            EXPECT_EQUAL(conn->psk_params.chosen_psk, NULL);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_config_free(config));
+            EXPECT_SUCCESS(s2n_stuffer_free(&wire_identities_in));
+        }
+
+        /* Customer selection logic: customer selects index without a local match */
+        {
+            struct s2n_config *config = s2n_config_new();
+            EXPECT_NOT_NULL(config);
+            EXPECT_SUCCESS(s2n_config_set_psk_selection_callback(config, s2n_test_select_psk_identity_callback));
+
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+            struct s2n_psk *local_psk = NULL;
+            EXPECT_OK(s2n_array_pushback(&conn->psk_params.psk_list, (void**) &local_psk));
+            EXPECT_OK(s2n_psk_init(local_psk, S2N_PSK_TYPE_EXTERNAL));
+            EXPECT_SUCCESS(s2n_psk_set_identity(local_psk, test_bytes_data, sizeof(test_bytes_data)));
+
+            struct s2n_blob wire_identity = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&wire_identity, test_bytes_data_2, sizeof(test_bytes_data_2)));
+
+            struct s2n_stuffer wire_identities_in = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&wire_identities_in, 0));
+            EXPECT_OK(s2n_write_test_identity(&wire_identities_in, &wire_identity));
+
+            s2n_test_customer_wire_index_choice = 0;
+            EXPECT_ERROR(s2n_client_psk_recv_identity_list(conn, &wire_identities_in));
+            EXPECT_EQUAL(conn->psk_params.chosen_psk, NULL);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_config_free(config));
             EXPECT_SUCCESS(s2n_stuffer_free(&wire_identities_in));
         }
     }

--- a/tests/unit/s2n_config_test.c
+++ b/tests/unit/s2n_config_test.c
@@ -24,8 +24,8 @@
 #include "tls/s2n_security_policies.h"
 #include "tls/s2n_tls13.h"
 
-static int s2n_test_select_psk_identity_callback(struct s2n_connection *conn, struct s2n_psk_identity *identities,
-                                                 size_t identities_length, uint16_t *chosen_wire_index)
+static int s2n_test_select_psk_identity_callback(struct s2n_connection *conn,
+        struct s2n_offered_psk_list *psk_identity_list, uint16_t *chosen_wire_index)
 {
     *chosen_wire_index = 0;
     return S2N_SUCCESS;
@@ -138,19 +138,19 @@ int main(int argc, char **argv)
 
     /* Test setting the callback to select PSK identity */
     {
-        struct s2n_connection *conn = NULL;
-        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+        struct s2n_config *config = NULL;
+        EXPECT_NOT_NULL(config = s2n_config_new());
 
         /* Safety checks */
         {
             EXPECT_FAILURE_WITH_ERRNO(s2n_config_set_psk_selection_callback(NULL, s2n_test_select_psk_identity_callback), S2N_ERR_NULL);
-            EXPECT_FAILURE_WITH_ERRNO(s2n_config_set_psk_selection_callback(conn, NULL), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_config_set_psk_selection_callback(config, NULL), S2N_ERR_NULL);
         }
 
-        EXPECT_NULL(conn->config->psk_selection_cb);
-        EXPECT_SUCCESS(s2n_config_set_psk_selection_callback(conn, s2n_test_select_psk_identity_callback));
-        EXPECT_EQUAL(conn->config->psk_selection_cb, s2n_test_select_psk_identity_callback);
-        EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_NULL(config->psk_selection_cb);
+        EXPECT_SUCCESS(s2n_config_set_psk_selection_callback(config, s2n_test_select_psk_identity_callback));
+        EXPECT_EQUAL(config->psk_selection_cb, s2n_test_select_psk_identity_callback);
+        EXPECT_SUCCESS(s2n_config_free(config));
     }
 
     /*Test s2n_connection_set_config */

--- a/tests/unit/s2n_psk_offered_test.c
+++ b/tests/unit/s2n_psk_offered_test.c
@@ -253,37 +253,6 @@ int main(int argc, char **argv)
         }
     }
 
-    /* Test s2n_offered_psk_get_type */
-    {
-        /* Safety checks */
-        {
-            struct s2n_offered_psk psk = { 0 };
-            s2n_psk_type type = 0;
-            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_psk_get_type(NULL, &type), S2N_ERR_NULL);
-            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_psk_get_type(&psk, NULL), S2N_ERR_NULL);
-        }
-
-        /* Resumption */
-        {
-            DEFER_CLEANUP(struct s2n_offered_psk *psk = s2n_offered_psk_new(), s2n_offered_psk_free);
-            psk->type = S2N_PSK_TYPE_RESUMPTION;
-
-            s2n_psk_type type = 0;
-            EXPECT_SUCCESS(s2n_offered_psk_get_type(psk, &type));
-            EXPECT_EQUAL(type, S2N_PSK_TYPE_RESUMPTION);
-        }
-
-        /* External */
-        {
-            DEFER_CLEANUP(struct s2n_offered_psk *psk = s2n_offered_psk_new(), s2n_offered_psk_free);
-            psk->type = S2N_PSK_TYPE_EXTERNAL;
-
-            s2n_psk_type type = 0;
-            EXPECT_SUCCESS(s2n_offered_psk_get_type(psk, &type));
-            EXPECT_EQUAL(type, S2N_PSK_TYPE_EXTERNAL);
-        }
-    }
-
     /* Test s2n_offered_psk_list_get_index */
     {
         /* Safety checks */
@@ -427,38 +396,28 @@ int main(int argc, char **argv)
         uint8_t *data = NULL;
         uint16_t data_size = 0;
         struct s2n_offered_psk psk = { 0 };
-        s2n_psk_type type = 0;
 
         EXPECT_TRUE(s2n_offered_psk_list_has_next(&identity_list));
         EXPECT_SUCCESS(s2n_offered_psk_list_next(&identity_list, &psk));
         EXPECT_SUCCESS(s2n_offered_psk_get_identity(&psk, &data, &data_size));
         EXPECT_EQUAL(data_size, sizeof(wire_identity_1));
         EXPECT_BYTEARRAY_EQUAL(data, wire_identity_1, sizeof(wire_identity_1));
-        EXPECT_SUCCESS(s2n_offered_psk_get_type(&psk, &type));
-        EXPECT_EQUAL(type, S2N_PSK_TYPE_EXTERNAL);
 
         EXPECT_TRUE(s2n_offered_psk_list_has_next(&identity_list));
         EXPECT_SUCCESS(s2n_offered_psk_list_next(&identity_list, &psk));
         EXPECT_SUCCESS(s2n_offered_psk_get_identity(&psk, &data, &data_size));
         EXPECT_EQUAL(data_size, sizeof(wire_identity_2));
         EXPECT_BYTEARRAY_EQUAL(data, wire_identity_2, sizeof(wire_identity_2));
-        EXPECT_SUCCESS(s2n_offered_psk_get_type(&psk, &type));
-        /* Currently, all offered PSKS are assumed to be external */
-        EXPECT_EQUAL(type, S2N_PSK_TYPE_EXTERNAL);
 
         EXPECT_OK(s2n_offered_psk_list_get_index(&identity_list, 1, &psk));
         EXPECT_SUCCESS(s2n_offered_psk_get_identity(&psk, &data, &data_size));
         EXPECT_EQUAL(data_size, sizeof(wire_identity_2));
         EXPECT_BYTEARRAY_EQUAL(data, wire_identity_2, sizeof(wire_identity_2));
-        EXPECT_SUCCESS(s2n_offered_psk_get_type(&psk, &type));
-        /* Currently, all offered PSKS are assumed to be external */
-        EXPECT_EQUAL(type, S2N_PSK_TYPE_EXTERNAL);
 
         EXPECT_OK(s2n_offered_psk_list_get_index(&identity_list, 0, &psk));
         EXPECT_SUCCESS(s2n_offered_psk_get_identity(&psk, &data, &data_size));
         EXPECT_EQUAL(data_size, sizeof(wire_identity_1));
         EXPECT_BYTEARRAY_EQUAL(data, wire_identity_1, sizeof(wire_identity_1));
-        EXPECT_SUCCESS(s2n_offered_psk_get_type(&psk, &type));
 
         EXPECT_SUCCESS(s2n_offered_psk_list_reset(&identity_list));
 
@@ -467,8 +426,6 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_offered_psk_get_identity(&psk, &data, &data_size));
         EXPECT_EQUAL(data_size, sizeof(wire_identity_1));
         EXPECT_BYTEARRAY_EQUAL(data, wire_identity_1, sizeof(wire_identity_1));
-        EXPECT_SUCCESS(s2n_offered_psk_get_type(&psk, &type));
-        EXPECT_EQUAL(type, S2N_PSK_TYPE_EXTERNAL);
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
         EXPECT_SUCCESS(s2n_stuffer_free(&identity_list.wire_data));

--- a/tests/unit/s2n_psk_offered_test.c
+++ b/tests/unit/s2n_psk_offered_test.c
@@ -1,0 +1,478 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+#include "tls/extensions/s2n_client_psk.h"
+
+static S2N_RESULT s2n_write_test_identity(struct s2n_stuffer *out, const uint8_t *identity, uint16_t identity_size)
+{
+    GUARD_AS_RESULT(s2n_stuffer_write_uint16(out, identity_size));
+    GUARD_AS_RESULT(s2n_stuffer_write_bytes(out, identity, identity_size));
+    GUARD_AS_RESULT(s2n_stuffer_write_uint32(out, 0));
+    return S2N_RESULT_OK;
+}
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    const uint8_t wire_identity_1[] = { "one" };
+    const uint8_t wire_identity_2[] = { "two" };
+    const uint8_t wire_identity_3[] = { "many" };
+
+    /* Test s2n_offered_psk_list_has_next */
+    {
+        struct s2n_offered_psk_list psk_list = { 0 };
+
+        /* Safety check */
+        EXPECT_FALSE(s2n_offered_psk_list_has_next(NULL));
+
+        /* Empty list */
+        EXPECT_FALSE(s2n_offered_psk_list_has_next(&psk_list));
+
+        /* Contains data */
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&psk_list.wire_data, 0));
+        EXPECT_SUCCESS(s2n_stuffer_skip_write(&psk_list.wire_data, 1));
+        EXPECT_TRUE(s2n_offered_psk_list_has_next(&psk_list));
+
+        /* Out of data */
+        EXPECT_SUCCESS(s2n_stuffer_skip_read(&psk_list.wire_data, 1));
+        EXPECT_FALSE(s2n_offered_psk_list_has_next(&psk_list));
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&psk_list.wire_data));
+    }
+
+    /* Test s2n_offered_psk_list_next */
+    {
+        /* Safety checks */
+        {
+            struct s2n_offered_psk_list psk_list = { 0 };
+            struct s2n_offered_psk psk = { 0 };
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_psk_list_next(&psk_list, NULL), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_psk_list_next(NULL, &psk), S2N_ERR_NULL);
+        }
+
+        /* Empty list */
+        {
+            struct s2n_offered_psk_list psk_list = { 0 };
+            struct s2n_offered_psk psk = { 0 };
+
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_psk_list_next(&psk_list, &psk), S2N_ERR_STUFFER_OUT_OF_DATA);
+            EXPECT_EQUAL(psk.identity.size, 0);
+            EXPECT_EQUAL(psk.identity.data, NULL);
+
+            /* Calling again produces same result */
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_psk_list_next(&psk_list, &psk), S2N_ERR_STUFFER_OUT_OF_DATA);
+            EXPECT_EQUAL(psk.identity.size, 0);
+            EXPECT_EQUAL(psk.identity.data, NULL);
+        }
+
+        /* Parses only element in list */
+        {
+            struct s2n_offered_psk psk = { 0 };
+            struct s2n_offered_psk_list psk_list = { 0 };
+
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&psk_list.wire_data, 0));
+            EXPECT_OK(s2n_write_test_identity(&psk_list.wire_data, wire_identity_1, sizeof(wire_identity_1)));
+
+            EXPECT_SUCCESS(s2n_offered_psk_list_next(&psk_list, &psk));
+            EXPECT_EQUAL(psk.identity.size, sizeof(wire_identity_1));
+            EXPECT_BYTEARRAY_EQUAL(psk.identity.data, wire_identity_1, sizeof(wire_identity_1));
+
+            /* Trying to retrieve a second element fails */
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_psk_list_next(&psk_list, &psk), S2N_ERR_STUFFER_OUT_OF_DATA);
+            EXPECT_EQUAL(psk.identity.size, 0);
+            EXPECT_EQUAL(psk.identity.data, NULL);
+
+            EXPECT_SUCCESS(s2n_stuffer_free(&psk_list.wire_data));
+        }
+
+        /* Fails to parse zero-length identities */
+        {
+            struct s2n_offered_psk psk = { 0 };
+            struct s2n_offered_psk_list psk_list = { 0 };
+
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&psk_list.wire_data, 0));
+            EXPECT_OK(s2n_write_test_identity(&psk_list.wire_data, wire_identity_1, 0));
+
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_psk_list_next(&psk_list, &psk), S2N_ERR_BAD_MESSAGE);
+            EXPECT_EQUAL(psk.identity.size, 0);
+            EXPECT_EQUAL(psk.identity.data, NULL);
+
+            EXPECT_SUCCESS(s2n_stuffer_free(&psk_list.wire_data));
+        }
+
+        /* Fails to parse partial identities */
+        {
+            struct s2n_offered_psk psk = { 0 };
+            struct s2n_offered_psk_list psk_list = { 0 };
+
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&psk_list.wire_data, 0));
+            EXPECT_OK(s2n_write_test_identity(&psk_list.wire_data, wire_identity_1, 0));
+            EXPECT_SUCCESS(s2n_stuffer_wipe_n(&psk_list.wire_data, 1));
+
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_psk_list_next(&psk_list, &psk), S2N_ERR_BAD_MESSAGE);
+            EXPECT_EQUAL(psk.identity.size, 0);
+            EXPECT_EQUAL(psk.identity.data, NULL);
+
+            EXPECT_SUCCESS(s2n_stuffer_free(&psk_list.wire_data));
+        }
+
+        /* Parses multiple elements from list */
+        {
+            struct s2n_offered_psk psk = { 0 };
+            struct s2n_offered_psk_list psk_list = { 0 };
+
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&psk_list.wire_data, 0));
+            EXPECT_OK(s2n_write_test_identity(&psk_list.wire_data, wire_identity_1, sizeof(wire_identity_1)));
+            EXPECT_OK(s2n_write_test_identity(&psk_list.wire_data, wire_identity_2, sizeof(wire_identity_2)));
+
+            EXPECT_SUCCESS(s2n_offered_psk_list_next(&psk_list, &psk));
+            EXPECT_EQUAL(psk.identity.size, sizeof(wire_identity_1));
+            EXPECT_BYTEARRAY_EQUAL(psk.identity.data, wire_identity_1, sizeof(wire_identity_1));
+
+            EXPECT_SUCCESS(s2n_offered_psk_list_next(&psk_list, &psk));
+            EXPECT_EQUAL(psk.identity.size, sizeof(wire_identity_2));
+            EXPECT_BYTEARRAY_EQUAL(psk.identity.data, wire_identity_2, sizeof(wire_identity_2));
+
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_psk_list_next(&psk_list, &psk), S2N_ERR_STUFFER_OUT_OF_DATA);
+            EXPECT_EQUAL(psk.identity.size, 0);
+            EXPECT_EQUAL(psk.identity.data, NULL);
+
+            EXPECT_SUCCESS(s2n_stuffer_free(&psk_list.wire_data));
+        }
+    }
+
+    /* Test s2n_offered_psk_list_reset */
+    {
+        /* Safety check */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_offered_psk_list_reset(NULL), S2N_ERR_NULL);
+
+        /* No-op on empty list */
+        {
+            struct s2n_offered_psk psk = { 0 };
+            struct s2n_offered_psk_list psk_list = { 0 };
+
+            EXPECT_SUCCESS(s2n_offered_psk_list_reset(&psk_list));
+            EXPECT_SUCCESS(s2n_offered_psk_list_reset(&psk_list));
+
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_psk_list_next(&psk_list, &psk), S2N_ERR_STUFFER_OUT_OF_DATA);
+        }
+
+        /* Resets non-empty list */
+        {
+            struct s2n_offered_psk psk = { 0 };
+            struct s2n_offered_psk_list psk_list = { 0 };
+
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&psk_list.wire_data, 0));
+            EXPECT_OK(s2n_write_test_identity(&psk_list.wire_data, wire_identity_1, sizeof(wire_identity_1)));
+
+            EXPECT_SUCCESS(s2n_offered_psk_list_next(&psk_list, &psk));
+            EXPECT_EQUAL(psk.identity.size, sizeof(wire_identity_1));
+            EXPECT_BYTEARRAY_EQUAL(psk.identity.data, wire_identity_1, sizeof(wire_identity_1));
+
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_psk_list_next(&psk_list, &psk), S2N_ERR_STUFFER_OUT_OF_DATA);
+
+            EXPECT_SUCCESS(s2n_offered_psk_list_reset(&psk_list));
+
+            EXPECT_SUCCESS(s2n_offered_psk_list_next(&psk_list, &psk));
+            EXPECT_EQUAL(psk.identity.size, sizeof(wire_identity_1));
+            EXPECT_BYTEARRAY_EQUAL(psk.identity.data, wire_identity_1, sizeof(wire_identity_1));
+
+            EXPECT_SUCCESS(s2n_stuffer_free(&psk_list.wire_data));
+        }
+    }
+
+    /* Test s2n_offered_psk_new */
+    {
+        struct s2n_offered_psk zeroed_psk = { 0 };
+        DEFER_CLEANUP(struct s2n_offered_psk *new_psk = s2n_offered_psk_new(), s2n_offered_psk_free);
+        EXPECT_NOT_NULL(new_psk);
+
+        /* _new equivalent to a zero-inited structure */
+        EXPECT_BYTEARRAY_EQUAL(&zeroed_psk, new_psk, sizeof(struct s2n_offered_psk));
+    }
+
+    /* Test s2n_offered_psk_free */
+    {
+        EXPECT_SUCCESS(s2n_offered_psk_free(NULL));
+
+        struct s2n_offered_psk *new_psk = s2n_offered_psk_new();
+        EXPECT_NOT_NULL(new_psk);
+        EXPECT_SUCCESS(s2n_offered_psk_free(&new_psk));
+        EXPECT_NULL(new_psk);
+    }
+
+    /* Test s2n_offered_psk_get_identity */
+    {
+        /* Safety checks */
+        {
+            struct s2n_offered_psk psk = { 0 };
+            uint8_t *data = NULL;
+            uint16_t size = 0;
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_psk_get_identity(NULL, &data, &size), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_psk_get_identity(&psk, NULL, &size), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_psk_get_identity(&psk, &data, NULL), S2N_ERR_NULL);
+        }
+
+        /* Empty identity */
+        {
+            DEFER_CLEANUP(struct s2n_offered_psk *psk = s2n_offered_psk_new(), s2n_offered_psk_free);
+
+            uint8_t *data = NULL;
+            uint16_t size = 0;
+            EXPECT_SUCCESS(s2n_offered_psk_get_identity(psk, &data, &size));
+            EXPECT_EQUAL(size, 0);
+            EXPECT_EQUAL(data, NULL);
+        }
+
+        /* Valid identity */
+        {
+            uint8_t wire_identity[] = "identity";
+            DEFER_CLEANUP(struct s2n_offered_psk *psk = s2n_offered_psk_new(), s2n_offered_psk_free);
+            EXPECT_SUCCESS(s2n_blob_init(&psk->identity, wire_identity, sizeof(wire_identity)));
+
+            uint8_t *data = NULL;
+            uint16_t size = 0;
+            EXPECT_SUCCESS(s2n_offered_psk_get_identity(psk, &data, &size));
+            EXPECT_EQUAL(size, sizeof(wire_identity));
+            EXPECT_BYTEARRAY_EQUAL(data, wire_identity, sizeof(wire_identity));
+        }
+    }
+
+    /* Test s2n_offered_psk_get_type */
+    {
+        /* Safety checks */
+        {
+            struct s2n_offered_psk psk = { 0 };
+            s2n_psk_type type = 0;
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_psk_get_type(NULL, &type), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_psk_get_type(&psk, NULL), S2N_ERR_NULL);
+        }
+
+        /* Resumption */
+        {
+            DEFER_CLEANUP(struct s2n_offered_psk *psk = s2n_offered_psk_new(), s2n_offered_psk_free);
+            psk->type = S2N_PSK_TYPE_RESUMPTION;
+
+            s2n_psk_type type = 0;
+            EXPECT_SUCCESS(s2n_offered_psk_get_type(psk, &type));
+            EXPECT_EQUAL(type, S2N_PSK_TYPE_RESUMPTION);
+        }
+
+        /* External */
+        {
+            DEFER_CLEANUP(struct s2n_offered_psk *psk = s2n_offered_psk_new(), s2n_offered_psk_free);
+            psk->type = S2N_PSK_TYPE_EXTERNAL;
+
+            s2n_psk_type type = 0;
+            EXPECT_SUCCESS(s2n_offered_psk_get_type(psk, &type));
+            EXPECT_EQUAL(type, S2N_PSK_TYPE_EXTERNAL);
+        }
+    }
+
+    /* Test s2n_offered_psk_list_get_index */
+    {
+        /* Safety checks */
+        {
+            struct s2n_offered_psk psk = { 0 };
+            struct s2n_offered_psk_list psk_list = { 0 };
+
+            EXPECT_ERROR_WITH_ERRNO(s2n_offered_psk_list_get_index(NULL, 0, &psk), S2N_ERR_NULL);
+            EXPECT_ERROR_WITH_ERRNO(s2n_offered_psk_list_get_index(&psk_list, 0, NULL), S2N_ERR_NULL);
+        }
+
+        /* Get non-existent elements from empty list */
+        {
+            struct s2n_offered_psk psk = { 0 };
+            struct s2n_offered_psk_list psk_list = { 0 };
+
+            EXPECT_ERROR_WITH_ERRNO(s2n_offered_psk_list_get_index(&psk_list, 0, &psk), S2N_ERR_STUFFER_OUT_OF_DATA);
+            EXPECT_EQUAL(psk.identity.size, 0);
+
+            EXPECT_ERROR_WITH_ERRNO(s2n_offered_psk_list_get_index(&psk_list, 10, &psk), S2N_ERR_STUFFER_OUT_OF_DATA);
+            EXPECT_EQUAL(psk.identity.size, 0);
+        }
+
+        /* Get first element */
+        {
+            struct s2n_offered_psk psk = { 0 };
+            struct s2n_offered_psk_list psk_list = { 0 };
+
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&psk_list.wire_data, 0));
+            EXPECT_OK(s2n_write_test_identity(&psk_list.wire_data, wire_identity_1, sizeof(wire_identity_1)));
+
+            EXPECT_OK(s2n_offered_psk_list_get_index(&psk_list, 0, &psk));
+            EXPECT_EQUAL(psk.identity.size, sizeof(wire_identity_1));
+            EXPECT_BYTEARRAY_EQUAL(psk.identity.data, wire_identity_1, sizeof(wire_identity_1));
+
+            EXPECT_SUCCESS(s2n_stuffer_free(&psk_list.wire_data));
+        }
+
+        /* Get non-existent element from list with valid elements */
+        {
+            struct s2n_offered_psk psk = { 0 };
+            struct s2n_offered_psk_list psk_list = { 0 };
+
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&psk_list.wire_data, 0));
+            EXPECT_OK(s2n_write_test_identity(&psk_list.wire_data, wire_identity_1, sizeof(wire_identity_1)));
+
+            EXPECT_ERROR_WITH_ERRNO(s2n_offered_psk_list_get_index(&psk_list, 10, &psk), S2N_ERR_STUFFER_OUT_OF_DATA);
+            EXPECT_EQUAL(psk.identity.size, 0);
+
+            EXPECT_ERROR_WITH_ERRNO(s2n_offered_psk_list_get_index(&psk_list, 100, &psk), S2N_ERR_STUFFER_OUT_OF_DATA);
+            EXPECT_EQUAL(psk.identity.size, 0);
+
+            EXPECT_SUCCESS(s2n_stuffer_free(&psk_list.wire_data));
+        }
+
+        /* Get later element */
+        {
+            struct s2n_offered_psk psk = { 0 };
+            struct s2n_offered_psk_list psk_list = { 0 };
+
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&psk_list.wire_data, 0));
+            EXPECT_OK(s2n_write_test_identity(&psk_list.wire_data, wire_identity_1, sizeof(wire_identity_1)));
+            EXPECT_OK(s2n_write_test_identity(&psk_list.wire_data, wire_identity_2, sizeof(wire_identity_2)));
+            EXPECT_OK(s2n_write_test_identity(&psk_list.wire_data, wire_identity_3, sizeof(wire_identity_3)));
+
+            EXPECT_OK(s2n_offered_psk_list_get_index(&psk_list, 2, &psk));
+            EXPECT_EQUAL(psk.identity.size, sizeof(wire_identity_3));
+            EXPECT_BYTEARRAY_EQUAL(psk.identity.data, wire_identity_3, sizeof(wire_identity_3));
+
+            EXPECT_OK(s2n_offered_psk_list_get_index(&psk_list, 0, &psk));
+            EXPECT_EQUAL(psk.identity.size, sizeof(wire_identity_1));
+            EXPECT_BYTEARRAY_EQUAL(psk.identity.data, wire_identity_1, sizeof(wire_identity_1));
+
+            EXPECT_OK(s2n_offered_psk_list_get_index(&psk_list, 1, &psk));
+            EXPECT_EQUAL(psk.identity.size, sizeof(wire_identity_2));
+            EXPECT_BYTEARRAY_EQUAL(psk.identity.data, wire_identity_2, sizeof(wire_identity_2));
+
+            EXPECT_SUCCESS(s2n_stuffer_free(&psk_list.wire_data));
+        }
+
+        /* Does not effect progress via _next */
+        {
+            struct s2n_offered_psk psk = { 0 };
+            struct s2n_offered_psk_list psk_list = { 0 };
+
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&psk_list.wire_data, 0));
+            EXPECT_OK(s2n_write_test_identity(&psk_list.wire_data, wire_identity_1, sizeof(wire_identity_1)));
+            EXPECT_OK(s2n_write_test_identity(&psk_list.wire_data, wire_identity_2, sizeof(wire_identity_2)));
+            EXPECT_OK(s2n_write_test_identity(&psk_list.wire_data, wire_identity_3, sizeof(wire_identity_3)));
+
+            EXPECT_OK(s2n_offered_psk_list_get_index(&psk_list, 2, &psk));
+            EXPECT_EQUAL(psk.identity.size, sizeof(wire_identity_3));
+            EXPECT_BYTEARRAY_EQUAL(psk.identity.data, wire_identity_3, sizeof(wire_identity_3));
+
+            EXPECT_SUCCESS(s2n_offered_psk_list_next(&psk_list, &psk));
+            EXPECT_EQUAL(psk.identity.size, sizeof(wire_identity_1));
+            EXPECT_BYTEARRAY_EQUAL(psk.identity.data, wire_identity_1, sizeof(wire_identity_1));
+
+            EXPECT_OK(s2n_offered_psk_list_get_index(&psk_list, 0, &psk));
+            EXPECT_EQUAL(psk.identity.size, sizeof(wire_identity_1));
+            EXPECT_BYTEARRAY_EQUAL(psk.identity.data, wire_identity_1, sizeof(wire_identity_1));
+
+            EXPECT_SUCCESS(s2n_offered_psk_list_next(&psk_list, &psk));
+            EXPECT_EQUAL(psk.identity.size, sizeof(wire_identity_2));
+            EXPECT_BYTEARRAY_EQUAL(psk.identity.data, wire_identity_2, sizeof(wire_identity_2));
+
+            EXPECT_SUCCESS(s2n_stuffer_free(&psk_list.wire_data));
+        }
+    }
+
+    /* Functional test: Process the output of sending the psk extension */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(conn);
+
+        const uint8_t test_secret[] = "secret";
+
+        struct s2n_psk *psk1 = NULL;
+        EXPECT_OK(s2n_array_pushback(&conn->psk_params.psk_list, (void**) &psk1));
+        EXPECT_OK(s2n_psk_init(psk1, S2N_PSK_TYPE_EXTERNAL));
+        EXPECT_SUCCESS(s2n_psk_set_identity(psk1, wire_identity_1, sizeof(wire_identity_1)));
+        EXPECT_SUCCESS(s2n_psk_set_secret(psk1, test_secret, sizeof(test_secret)));
+
+        struct s2n_psk *psk2 = NULL;
+        EXPECT_OK(s2n_array_pushback(&conn->psk_params.psk_list, (void**) &psk2));
+        EXPECT_OK(s2n_psk_init(psk2, S2N_PSK_TYPE_RESUMPTION));
+        EXPECT_SUCCESS(s2n_psk_set_identity(psk2, wire_identity_2, sizeof(wire_identity_2)));
+        EXPECT_SUCCESS(s2n_psk_set_secret(psk2, test_secret, sizeof(test_secret)));
+
+        EXPECT_SUCCESS(s2n_client_psk_extension.send(conn, &conn->handshake.io));
+
+        /* Skip identity list size */
+        EXPECT_SUCCESS(s2n_stuffer_skip_read(&conn->handshake.io, sizeof(uint16_t)));
+
+        struct s2n_offered_psk_list identity_list = { 0 };
+        const size_t size = s2n_stuffer_data_available(&conn->handshake.io);
+        EXPECT_SUCCESS(s2n_stuffer_alloc(&identity_list.wire_data, size));
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&identity_list.wire_data,
+                s2n_stuffer_raw_read(&conn->handshake.io, size), size));
+
+        uint8_t *data = NULL;
+        uint16_t data_size = 0;
+        struct s2n_offered_psk psk = { 0 };
+        s2n_psk_type type = 0;
+
+        EXPECT_TRUE(s2n_offered_psk_list_has_next(&identity_list));
+        EXPECT_SUCCESS(s2n_offered_psk_list_next(&identity_list, &psk));
+        EXPECT_SUCCESS(s2n_offered_psk_get_identity(&psk, &data, &data_size));
+        EXPECT_EQUAL(data_size, sizeof(wire_identity_1));
+        EXPECT_BYTEARRAY_EQUAL(data, wire_identity_1, sizeof(wire_identity_1));
+        EXPECT_SUCCESS(s2n_offered_psk_get_type(&psk, &type));
+        EXPECT_EQUAL(type, S2N_PSK_TYPE_EXTERNAL);
+
+        EXPECT_TRUE(s2n_offered_psk_list_has_next(&identity_list));
+        EXPECT_SUCCESS(s2n_offered_psk_list_next(&identity_list, &psk));
+        EXPECT_SUCCESS(s2n_offered_psk_get_identity(&psk, &data, &data_size));
+        EXPECT_EQUAL(data_size, sizeof(wire_identity_2));
+        EXPECT_BYTEARRAY_EQUAL(data, wire_identity_2, sizeof(wire_identity_2));
+        EXPECT_SUCCESS(s2n_offered_psk_get_type(&psk, &type));
+        /* Currently, all offered PSKS are assumed to be external */
+        EXPECT_EQUAL(type, S2N_PSK_TYPE_EXTERNAL);
+
+        EXPECT_OK(s2n_offered_psk_list_get_index(&identity_list, 1, &psk));
+        EXPECT_SUCCESS(s2n_offered_psk_get_identity(&psk, &data, &data_size));
+        EXPECT_EQUAL(data_size, sizeof(wire_identity_2));
+        EXPECT_BYTEARRAY_EQUAL(data, wire_identity_2, sizeof(wire_identity_2));
+        EXPECT_SUCCESS(s2n_offered_psk_get_type(&psk, &type));
+        /* Currently, all offered PSKS are assumed to be external */
+        EXPECT_EQUAL(type, S2N_PSK_TYPE_EXTERNAL);
+
+        EXPECT_OK(s2n_offered_psk_list_get_index(&identity_list, 0, &psk));
+        EXPECT_SUCCESS(s2n_offered_psk_get_identity(&psk, &data, &data_size));
+        EXPECT_EQUAL(data_size, sizeof(wire_identity_1));
+        EXPECT_BYTEARRAY_EQUAL(data, wire_identity_1, sizeof(wire_identity_1));
+        EXPECT_SUCCESS(s2n_offered_psk_get_type(&psk, &type));
+
+        EXPECT_SUCCESS(s2n_offered_psk_list_reset(&identity_list));
+
+        EXPECT_TRUE(s2n_offered_psk_list_has_next(&identity_list));
+        EXPECT_SUCCESS(s2n_offered_psk_list_next(&identity_list, &psk));
+        EXPECT_SUCCESS(s2n_offered_psk_get_identity(&psk, &data, &data_size));
+        EXPECT_EQUAL(data_size, sizeof(wire_identity_1));
+        EXPECT_BYTEARRAY_EQUAL(data, wire_identity_1, sizeof(wire_identity_1));
+        EXPECT_SUCCESS(s2n_offered_psk_get_type(&psk, &type));
+        EXPECT_EQUAL(type, S2N_PSK_TYPE_EXTERNAL);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_stuffer_free(&identity_list.wire_data));
+    }
+
+    END_TEST();
+}

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -861,12 +861,10 @@ int s2n_config_enable_cert_req_dss_legacy_compat(struct s2n_config *config)
     return S2N_SUCCESS;
 }
 
-int s2n_config_set_psk_selection_callback(struct s2n_connection *conn, s2n_psk_selection_callback cb)
+int s2n_config_set_psk_selection_callback(struct s2n_config *config, s2n_psk_selection_callback cb)
 {
-    notnull_check(conn);
+    notnull_check(config);
     notnull_check(cb);
-
-    conn->config->psk_selection_cb = cb;
-
+    config->psk_selection_cb = cb;
     return S2N_SUCCESS;
 }

--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -179,7 +179,6 @@ S2N_RESULT s2n_offered_psk_list_read_next(struct s2n_offered_psk_list *psk_list,
     GUARD_AS_RESULT(s2n_stuffer_skip_read(&psk_list->wire_data, sizeof(uint32_t)));
 
     GUARD_AS_RESULT(s2n_blob_init(&psk->identity, identity_data, identity_size));
-    psk->type = S2N_PSK_TYPE_EXTERNAL;
     return S2N_RESULT_OK;
 }
 
@@ -243,14 +242,6 @@ int s2n_offered_psk_get_identity(struct s2n_offered_psk *psk, uint8_t** identity
     notnull_check(size);
     *identity = psk->identity.data;
     *size = psk->identity.size;
-    return S2N_SUCCESS;
-}
-
-int s2n_offered_psk_get_type(struct s2n_offered_psk *psk, s2n_psk_type *type)
-{
-    notnull_check(psk);
-    notnull_check(type);
-    *type = psk->type;
     return S2N_SUCCESS;
 }
 

--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -153,6 +153,107 @@ S2N_CLEANUP_RESULT s2n_psk_parameters_wipe(struct s2n_psk_parameters *params)
     return S2N_RESULT_OK;
 }
 
+bool s2n_offered_psk_list_has_next(struct s2n_offered_psk_list *psk_list)
+{
+    return psk_list != NULL && s2n_stuffer_data_available(&psk_list->wire_data) > 0;
+}
+
+S2N_RESULT s2n_offered_psk_list_read_next(struct s2n_offered_psk_list *psk_list, struct s2n_offered_psk *psk)
+{
+    ENSURE_REF(psk_list);
+    ENSURE_MUT(psk);
+
+    uint16_t identity_size = 0;
+    GUARD_AS_RESULT(s2n_stuffer_read_uint16(&psk_list->wire_data, &identity_size));
+    ENSURE_GT(identity_size, 0);
+
+    uint8_t *identity_data = NULL;
+    identity_data = s2n_stuffer_raw_read(&psk_list->wire_data, identity_size);
+    ENSURE_REF(identity_data);
+
+    /**
+     *= https://tools.ietf.org/rfc/rfc8446#section-4.2.11
+     *# For identities established externally, an obfuscated_ticket_age of 0 SHOULD be
+     *# used, and servers MUST ignore the value.
+     */
+    GUARD_AS_RESULT(s2n_stuffer_skip_read(&psk_list->wire_data, sizeof(uint32_t)));
+
+    GUARD_AS_RESULT(s2n_blob_init(&psk->identity, identity_data, identity_size));
+    psk->type = S2N_PSK_TYPE_EXTERNAL;
+    return S2N_RESULT_OK;
+}
+
+int s2n_offered_psk_list_next(struct s2n_offered_psk_list *psk_list, struct s2n_offered_psk *psk)
+{
+    notnull_check(psk_list);
+    notnull_check(psk);
+    *psk = (struct s2n_offered_psk){ 0 };
+    ENSURE_POSIX(s2n_offered_psk_list_has_next(psk_list), S2N_ERR_STUFFER_OUT_OF_DATA);
+    ENSURE_POSIX(s2n_result_is_ok(s2n_offered_psk_list_read_next(psk_list, psk)), S2N_ERR_BAD_MESSAGE);
+    return S2N_SUCCESS;
+}
+
+int s2n_offered_psk_list_reset(struct s2n_offered_psk_list *psk_list)
+{
+    notnull_check(psk_list);
+    return s2n_stuffer_reread(&psk_list->wire_data);
+}
+
+S2N_RESULT s2n_offered_psk_list_get_index(struct s2n_offered_psk_list *psk_list, uint16_t index, struct s2n_offered_psk *psk)
+{
+    ENSURE_REF(psk_list);
+    ENSURE_MUT(psk);
+
+    /* We don't want to lose our original place in the list, so copy it */
+    struct s2n_offered_psk_list psk_list_copy = { .wire_data = psk_list->wire_data };
+    GUARD_AS_RESULT(s2n_offered_psk_list_reset(&psk_list_copy));
+
+    uint16_t count = 0;
+    while(count <= index) {
+        GUARD_AS_RESULT(s2n_offered_psk_list_next(&psk_list_copy, psk));
+        count++;
+    }
+    return S2N_RESULT_OK;
+}
+
+struct s2n_offered_psk* s2n_offered_psk_new()
+{
+    DEFER_CLEANUP(struct s2n_blob mem = { 0 }, s2n_free);
+    GUARD_PTR(s2n_alloc(&mem, sizeof(struct s2n_offered_psk)));
+
+    struct s2n_offered_psk *psk = (struct s2n_offered_psk*)(void*) mem.data;
+    *psk = (struct s2n_offered_psk){ 0 };
+
+    ZERO_TO_DISABLE_DEFER_CLEANUP(mem);
+    return psk;
+}
+
+int s2n_offered_psk_free(struct s2n_offered_psk **psk)
+{
+    if (psk == NULL) {
+        return S2N_SUCCESS;
+    }
+    return s2n_free_object((uint8_t **) psk, sizeof(struct s2n_offered_psk));
+}
+
+int s2n_offered_psk_get_identity(struct s2n_offered_psk *psk, uint8_t** identity, uint16_t *size)
+{
+    notnull_check(psk);
+    notnull_check(identity);
+    notnull_check(size);
+    *identity = psk->identity.data;
+    *size = psk->identity.size;
+    return S2N_SUCCESS;
+}
+
+int s2n_offered_psk_get_type(struct s2n_offered_psk *psk, s2n_psk_type *type)
+{
+    notnull_check(psk);
+    notnull_check(type);
+    *type = psk->type;
+    return S2N_SUCCESS;
+}
+
 /* The binder hash is computed by hashing the concatenation of the current transcript
  * and a partial ClientHello that does not include the binders themselves.
  */

--- a/tls/s2n_psk.h
+++ b/tls/s2n_psk.h
@@ -57,7 +57,6 @@ S2N_CLEANUP_RESULT s2n_psk_parameters_wipe(struct s2n_psk_parameters *params);
 
 struct s2n_offered_psk {
     struct s2n_blob identity;
-    s2n_psk_type type;
 };
 
 struct s2n_offered_psk_list {
@@ -96,7 +95,6 @@ struct s2n_offered_psk;
 struct s2n_offered_psk* s2n_offered_psk_new();
 int s2n_offered_psk_free(struct s2n_offered_psk **psk);
 int s2n_offered_psk_get_identity(struct s2n_offered_psk *psk, uint8_t** identity, uint16_t *size);
-int s2n_offered_psk_get_type(struct s2n_offered_psk *psk, s2n_psk_type *type);
 
 struct s2n_offered_psk_list;
 bool s2n_offered_psk_list_has_next(struct s2n_offered_psk_list *psk_list);


### PR DESCRIPTION
### Description of changes: 

Part 2 of correcting the PSK APIs to use opaque structures. These changes are solely focused on s2n_psk_selection_callback. s2n_connection_set_external_psks is out of scope.

I also fixed s2n_config_set_psk_selection_callback (which was operating on a connection instead of a config) and s2n_select_psk_identity (which was choosing the first valid PSK based on wire ordering, not local ordering).

### Call-outs:

* Removed MAX_NUM_OF_PSK_IDENTITIES. We no longer allocate data based on the number of identities received, so the worst an attacker could do by sending thousands of psk identities is make processing the ClientHello take a long time.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Unit tests

 Is this a refactor change? Yes. However, behavior also changes, so it's difficult to compare to the previous version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
