### PR TITLE
Probe for support of fall through attribute

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,13 +149,12 @@ check_c_source_compiles("
 
     int main() {
         char val = 'A';
-        int result = 0;
         switch (val) {
             case 'A' :
-                result++;
+                val++;
                 FALL_THROUGH;
             case 'B' :
-                result *= 2;
+                val *= 2;
                 break;
             default :
                 break;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,23 +126,19 @@ endif()
 # Probe for execinfo.h extensions (not present on some systems, notably android)
 include(CheckCSourceCompiles)
 
-# Ensure we can compile without warnings
-set (CMAKE_REQUIRED_FLAGS "-Werror")
-
-check_c_source_compiles("
-    #include <execinfo.h>
-    int main() {
-        void *array[20];
-        int backtrace_size = backtrace(array, 20);
-        backtrace_symbols(array, backtrace_size);
-        return 0;
-    }" S2N_HAVE_EXECINFO)
+# Determine if execinfo.h is available
+try_compile(
+        S2N_HAVE_EXECINFO
+        ${CMAKE_BINARY_DIR}
+        SOURCES "${CMAKE_CURRENT_LIST_DIR}/tests/features/execinfo.c"
+)
 
 # Determine if cpuid.h is available
-check_c_source_compiles("
-    #include <cpuid.h>
-    int main() { return 0; }" S2N_CPUID_AVAILABLE)
-
+try_compile(
+        S2N_CPUID_AVAILABLE
+        ${CMAKE_BINARY_DIR}
+        SOURCES "${CMAKE_CURRENT_LIST_DIR}/tests/features/cpuid.c"
+)
 
 # Determine if __attribute__((fallthrough)) is available
 try_compile(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,24 +143,14 @@ check_c_source_compiles("
     #include <cpuid.h>
     int main() { return 0; }" S2N_CPUID_AVAILABLE)
 
-# Determine if __attribute__((fallthrough)) is available
-check_c_source_compiles("
-    #define FALL_THROUGH __attribute__((fallthrough))
 
-    int main() {
-        char val = 'A';
-        switch (val) {
-            case 'A' :
-                val++;
-                FALL_THROUGH;
-            case 'B' :
-                val *= 2;
-                break;
-            default :
-                break;
-        }
-        return 0;
-    }" FALL_THROUGH_SUPPORTED)
+# Determine if __attribute__((fallthrough)) is available
+try_compile(
+        FALL_THROUGH_SUPPORTED
+        ${CMAKE_BINARY_DIR}
+        SOURCES "${CMAKE_CURRENT_LIST_DIR}/tests/features/fallthrough.c"
+        COMPILE_DEFINITIONS "-Werror"
+)
 
 if(APPLE)
     set(OS_LIBS c Threads::Threads)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,10 @@ endif()
 
 # Probe for execinfo.h extensions (not present on some systems, notably android)
 include(CheckCSourceCompiles)
+
+# Ensure we can compile without warnings
+set (CMAKE_REQUIRED_FLAGS "-Werror")
+
 check_c_source_compiles("
     #include <execinfo.h>
     int main() {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,26 @@ check_c_source_compiles("
     #include <cpuid.h>
     int main() { return 0; }" S2N_CPUID_AVAILABLE)
 
+# Determine if __attribute__((fallthrough)) is available
+check_c_source_compiles("
+    #define FALL_THROUGH __attribute__((fallthrough))
+
+    int main() {
+        char val = 'A';
+        int result = 0;
+        switch (val) {
+            case 'A' :
+                result++;
+                FALL_THROUGH;
+            case 'B' :
+                result *= 2;
+                break;
+            default :
+                break;
+        }
+        return 0;
+    }" FALL_THROUGH_SUPPORTED)
+
 if(APPLE)
     set(OS_LIBS c Threads::Threads)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
@@ -214,6 +234,10 @@ endif()
 
 if(S2N_UNSAFE_FUZZING_MODE)
     target_compile_options(${PROJECT_NAME} PRIVATE -fsanitize-coverage=trace-pc-guard -fsanitize=address,undefined,leak -fuse-ld=gold -DS2N_ADDRESS_SANITIZER=1)
+endif()
+
+if (FALL_THROUGH_SUPPORTED)
+    target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_FALL_THROUGH_SUPPORTED)
 endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)

--- a/s2n.mk
+++ b/s2n.mk
@@ -170,7 +170,7 @@ ifeq ($(TRY_COMPILE_CPUID), 0)
 endif
 
 # Determine if __attribute__((fallthrough)) is available
-TRY_COMPILE_FALL_THROUGH := $(shell echo "\#define FALL_THROUGH __attribute__((fallthrough))\nint main()\n {\nchar val = 'A';\nswitch (val) {\ncase 'A' :\nval++;\nFALL_THROUGH;\ncase\n'B' :\nbreak;\ndefault :\nbreak;\nreturn 0;\n}" | $(CC) -Werror -o test_fall_through.o -xc - > /dev/null 2>&1; echo $$?; rm test_fall_through.o > /dev/null 2>&1)
+TRY_COMPILE_FALL_THROUGH := $(shell cat ./tests/features/fallthrough.c  | $(CC) -Werror -o test_fall_through.o -xc - > /dev/null 2>&1; echo $$?; rm test_fall_through.o > /dev/null 2>&1)
 ifeq ($(TRY_COMPILE_FALL_THROUGH), 0)
 	DEFAULT_CFLAGS += -DS2N_FALL_THROUGH_SUPPORTED
 endif

--- a/s2n.mk
+++ b/s2n.mk
@@ -169,6 +169,12 @@ ifeq ($(TRY_COMPILE_CPUID), 0)
 	DEFAULT_CFLAGS += -DS2N_CPUID_AVAILABLE
 endif
 
+# Determine if __attribute__((fallthrough)) is available
+TRY_COMPILE_FALL_THROUGH := $(shell echo "\#define FALL_THROUGH __attribute__((fallthrough))\nint main()\n {\nchar val = 'A';\nswitch (val) {\ncase 'A' :\nval++;\nFALL_THROUGH;\ncase\n'B' :\nbreak;\ndefault :\nbreak;\nreturn 0;\n}" | $(CC) -Werror -o test_fall_through.o -xc - > /dev/null 2>&1; echo $$?; rm test_fall_through.o > /dev/null 2>&1)
+ifeq ($(TRY_COMPILE_FALL_THROUGH), 0)
+	DEFAULT_CFLAGS += -DS2N_FALL_THROUGH_SUPPORTED
+endif
+
 CFLAGS_LLVM = ${DEFAULT_CFLAGS} -emit-llvm -c -g -O1
 
 $(BITCODE_DIR)%.bc: %.c

--- a/s2n.mk
+++ b/s2n.mk
@@ -88,11 +88,6 @@ ifdef S2N_NO_PQ
 	DEFAULT_CFLAGS += -DS2N_NO_PQ
 endif
 
-# All native platforms have execinfo.h, cross-compile targets often don't (android, ARM/alpine)
-ifndef CROSS_COMPILE
-	DEFAULT_CFLAGS += -DS2N_HAVE_EXECINFO
-endif
-
 CFLAGS += ${DEFAULT_CFLAGS}
 
 ifdef GCC_VERSION
@@ -163,8 +158,14 @@ ifndef COV_TOOL
 	endif
 endif
 
+# Determine if execinfo.h is available
+TRY_COMPILE_EXECINFO := $(shell cat $(S2N_ROOT)/tests/features/execinfo.c  | $(CC) -Werror -o test_exec_info.o -xc - > /dev/null 2>&1; echo $$?; rm test_exec_info.o > /dev/null 2>&1)
+ifeq ($(TRY_COMPILE_EXECINFO), 0)
+	DEFAULT_CFLAGS += -DS2N_HAVE_EXECINFO
+endif
+
 # Determine if cpuid.h is available
-TRY_COMPILE_CPUID := $(shell echo "\#include <cpuid.h>\nint main() { return 0; }" | $(CC) -o test_cpuid.o -xc - > /dev/null 2>&1; echo $$?; rm test_cpuid.o > /dev/null 2>&1)
+TRY_COMPILE_CPUID := $(shell cat $(S2N_ROOT)/tests/features/cpuid.c  | $(CC) -o test_cpuid.o -xc - > /dev/null 2>&1; echo $$?; rm test_cpuid.o > /dev/null 2>&1)
 ifeq ($(TRY_COMPILE_CPUID), 0)
 	DEFAULT_CFLAGS += -DS2N_CPUID_AVAILABLE
 endif

--- a/s2n.mk
+++ b/s2n.mk
@@ -170,7 +170,7 @@ ifeq ($(TRY_COMPILE_CPUID), 0)
 endif
 
 # Determine if __attribute__((fallthrough)) is available
-TRY_COMPILE_FALL_THROUGH := $(shell cat ./tests/features/fallthrough.c  | $(CC) -Werror -o test_fall_through.o -xc - > /dev/null 2>&1; echo $$?; rm test_fall_through.o > /dev/null 2>&1)
+TRY_COMPILE_FALL_THROUGH := $(shell cat $(S2N_ROOT)/tests/features/fallthrough.c  | $(CC) -Werror -o test_fall_through.o -xc - > /dev/null 2>&1; echo $$?; rm test_fall_through.o > /dev/null 2>&1)
 ifeq ($(TRY_COMPILE_FALL_THROUGH), 0)
 	DEFAULT_CFLAGS += -DS2N_FALL_THROUGH_SUPPORTED
 endif

--- a/s2n.mk
+++ b/s2n.mk
@@ -158,20 +158,22 @@ ifndef COV_TOOL
 	endif
 endif
 
+try_compile = $(shell cat $(1) | $(CC) -Werror -o tmp.o -xc - > /dev/null 2>&1; echo $$?; rm tmp.o > /dev/null 2>&1)
+
 # Determine if execinfo.h is available
-TRY_COMPILE_EXECINFO := $(shell cat $(S2N_ROOT)/tests/features/execinfo.c  | $(CC) -Werror -o test_exec_info.o -xc - > /dev/null 2>&1; echo $$?; rm test_exec_info.o > /dev/null 2>&1)
+TRY_COMPILE_EXECINFO := $(call try_compile,$(S2N_ROOT)/tests/features/execinfo.c)
 ifeq ($(TRY_COMPILE_EXECINFO), 0)
 	DEFAULT_CFLAGS += -DS2N_HAVE_EXECINFO
 endif
 
 # Determine if cpuid.h is available
-TRY_COMPILE_CPUID := $(shell cat $(S2N_ROOT)/tests/features/cpuid.c  | $(CC) -o test_cpuid.o -xc - > /dev/null 2>&1; echo $$?; rm test_cpuid.o > /dev/null 2>&1)
+TRY_COMPILE_CPUID := $(call try_compile,$(S2N_ROOT)/tests/features/cpuid.c)
 ifeq ($(TRY_COMPILE_CPUID), 0)
 	DEFAULT_CFLAGS += -DS2N_CPUID_AVAILABLE
 endif
 
 # Determine if __attribute__((fallthrough)) is available
-TRY_COMPILE_FALL_THROUGH := $(shell cat $(S2N_ROOT)/tests/features/fallthrough.c  | $(CC) -Werror -o test_fall_through.o -xc - > /dev/null 2>&1; echo $$?; rm test_fall_through.o > /dev/null 2>&1)
+TRY_COMPILE_FALL_THROUGH := $(call try_compile,$(S2N_ROOT)/tests/features/fallthrough.c)
 ifeq ($(TRY_COMPILE_FALL_THROUGH), 0)
 	DEFAULT_CFLAGS += -DS2N_FALL_THROUGH_SUPPORTED
 endif

--- a/tests/features/cpuid.c
+++ b/tests/features/cpuid.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <cpuid.h>
+int main() {
+    __get_cpuid_max(0, 0);
+    return 0;
+}

--- a/tests/features/execinfo.c
+++ b/tests/features/execinfo.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <execinfo.h>
+int main() {
+    void *array[20];
+    int backtrace_size = backtrace(array, 20);
+    backtrace_symbols(array, backtrace_size);
+    return 0;
+}

--- a/tests/features/fallthrough.c
+++ b/tests/features/fallthrough.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#define FALL_THROUGH __attribute__((fallthrough))
+
+int main() {
+    char val = 'A';
+    switch (val) {
+        case 'A' :
+            val++;
+            FALL_THROUGH;
+        case 'B' :
+            val *= 2;
+            break;
+        default :
+            break;
+    }
+
+    return 0;
+}

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -306,7 +306,7 @@
 /**
  * Marks a case of a switch statement as able to fall through to the next case
  */
-#if (defined(__clang__) && __clang_major__ >= 10) || (defined(__GNUC__) && __GNUC__ >= 7)
+#if defined(S2N_FALL_THROUGH_SUPPORTED)
 #    define FALL_THROUGH __attribute__((fallthrough))
 #else
 #    define FALL_THROUGH ((void)0)


### PR DESCRIPTION
### Description of changes: 

This change adds a check in CMakeLists.txt and s2n.mk to try to compile a small amount of code that uses `__attribute__(fallthrough)` to determine if it is available with the given compiler. If it is available, a compile option is passed so that s2n_safety can define FALL_THROUGH. Existing similar checks for cpuid.h and execinfo.h were also moved to files for ease of use.

Issue: #1806

### Testing:

Built locally on MacOS