### PR TITLE
Remove the manual updating of the Yarn Debian key as CloudBuild as addressed this

### DIFF
--- a/codebuild/bin/install_ubuntu_dependencies.sh
+++ b/codebuild/bin/install_ubuntu_dependencies.sh
@@ -18,9 +18,6 @@
 
 set -ex
 
-# Update Yarn Debian key, see https://github.com/yarnpkg/yarn/issues/7866
-curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg  | apt-key add -
-
 add-apt-repository ppa:ubuntu-toolchain-r/test -y
 add-apt-repository ppa:longsleep/golang-backports -y
 apt-get update -o Acquire::CompressionTypes::Order::=gz


### PR DESCRIPTION
### Description of changes: 

This change removes the manual updating of the Yarn Debian key introduced in #2555 as CloudBuild has now addressed this in the standard Linux images

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.