### PR TITLE
Add APIs to configure early data for external PSKs

### DIFF
--- a/tests/unit/s2n_early_data_test.c
+++ b/tests/unit/s2n_early_data_test.c
@@ -80,28 +80,19 @@ int main(int argc, char **argv)
     /* Test s2n_psk_configure_early_data */
     {
         /* Safety */
-        EXPECT_FAILURE_WITH_ERRNO(s2n_psk_configure_early_data(NULL, 1, 1, 1, 1), S2N_ERR_NULL);
-
-        /* Set invalid protocol version */
-        {
-            struct s2n_psk psk = { 0 };
-            EXPECT_FAILURE_WITH_ERRNO(s2n_psk_configure_early_data(&psk, 1000, S2N_TLS12, 1, 1),
-                    S2N_ERR_INVALID_ARGUMENT);
-            EXPECT_EQUAL(psk.early_data_config.max_early_data, 0);
-        }
+        EXPECT_FAILURE_WITH_ERRNO(s2n_psk_configure_early_data(NULL, 1, 1, 1), S2N_ERR_NULL);
 
         /* Set valid configuration */
         {
             uint32_t expected_max_early_data = 1000;
-            uint8_t expected_protocol_version = S2N_TLS13;
             uint8_t expected_cipher_suite[] = { 0x01, 0xAB };
 
             struct s2n_psk psk = { 0 };
-            EXPECT_SUCCESS(s2n_psk_configure_early_data(&psk, expected_max_early_data, expected_protocol_version,
+            EXPECT_SUCCESS(s2n_psk_configure_early_data(&psk, expected_max_early_data,
                     expected_cipher_suite[0], expected_cipher_suite[1]));
 
             EXPECT_EQUAL(psk.early_data_config.max_early_data, expected_max_early_data);
-            EXPECT_EQUAL(psk.early_data_config.protocol_version, expected_protocol_version);
+            EXPECT_EQUAL(psk.early_data_config.protocol_version, S2N_TLS13);
             EXPECT_BYTEARRAY_EQUAL(psk.early_data_config.cipher_suite_iana, expected_cipher_suite,
                     sizeof(expected_cipher_suite));
         }

--- a/tests/unit/s2n_early_data_test.c
+++ b/tests/unit/s2n_early_data_test.c
@@ -1,0 +1,189 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+
+#include "tls/s2n_early_data.h"
+
+#define TEST_SIZE 10
+
+static S2N_RESULT s2n_alloc_test_config_buffers(struct s2n_early_data_config *config)
+{
+    GUARD_AS_RESULT(s2n_alloc(&config->application_protocol, TEST_SIZE));
+    ENSURE_NE(config->application_protocol.size, 0);
+    GUARD_AS_RESULT(s2n_alloc(&config->context, TEST_SIZE));
+    ENSURE_NE(config->context.size, 0);
+    return S2N_RESULT_OK;
+}
+
+static S2N_RESULT s2n_test_config_buffers_freed(struct s2n_early_data_config *config)
+{
+    ENSURE_EQ(config->application_protocol.data, NULL);
+    ENSURE_EQ(config->application_protocol.size, 0);
+    ENSURE_EQ(config->context.data, NULL);
+    ENSURE_EQ(config->context.size, 0);
+    return S2N_RESULT_OK;
+}
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+    const uint8_t test_value[] = "test value";
+    const uint8_t test_value_2[] = "more test data";
+
+    /* Test s2n_early_data_config_free */
+    {
+        /* Safety check */
+        EXPECT_OK(s2n_early_data_config_free(NULL));
+
+        /* Resets everything */
+        {
+            struct s2n_early_data_config config = { 0 };
+            EXPECT_OK(s2n_alloc_test_config_buffers(&config));
+
+            EXPECT_OK(s2n_early_data_config_free(&config));
+            EXPECT_OK(s2n_test_config_buffers_freed(&config));
+        }
+
+        /* Called by s2n_psk_wipe */
+        {
+            struct s2n_psk psk = { 0 };
+            EXPECT_OK(s2n_alloc_test_config_buffers(&psk.early_data_config));
+
+            EXPECT_OK(s2n_psk_wipe(&psk));
+            EXPECT_OK(s2n_test_config_buffers_freed(&psk.early_data_config));
+        }
+
+        /* Called by s2n_psk_free */
+        {
+            struct s2n_psk *psk = s2n_external_psk_new();
+            EXPECT_OK(s2n_alloc_test_config_buffers(&psk->early_data_config));
+
+            EXPECT_SUCCESS(s2n_psk_free(&psk));
+            /* A memory leak in this test would indicate that s2n_psk_free isn't freeing the buffers. */
+        }
+    }
+
+    /* Test s2n_psk_configure_early_data */
+    {
+        /* Safety */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_psk_configure_early_data(NULL, 1, 1, 1, 1), S2N_ERR_NULL);
+
+        /* Set invalid protocol version */
+        {
+            struct s2n_psk psk = { 0 };
+            EXPECT_FAILURE_WITH_ERRNO(s2n_psk_configure_early_data(&psk, 1000, S2N_TLS12, 1, 1),
+                    S2N_ERR_INVALID_ARGUMENT);
+            EXPECT_EQUAL(psk.early_data_config.max_early_data, 0);
+        }
+
+        /* Set valid configuration */
+        {
+            uint32_t expected_max_early_data = 1000;
+            uint8_t expected_protocol_version = S2N_TLS13;
+            uint8_t expected_cipher_suite[] = { 0x01, 0xAB };
+
+            struct s2n_psk psk = { 0 };
+            EXPECT_SUCCESS(s2n_psk_configure_early_data(&psk, expected_max_early_data, expected_protocol_version,
+                    expected_cipher_suite[0], expected_cipher_suite[1]));
+
+            EXPECT_EQUAL(psk.early_data_config.max_early_data, expected_max_early_data);
+            EXPECT_EQUAL(psk.early_data_config.protocol_version, expected_protocol_version);
+            EXPECT_BYTEARRAY_EQUAL(psk.early_data_config.cipher_suite_iana, expected_cipher_suite,
+                    sizeof(expected_cipher_suite));
+        }
+    }
+
+    /* Test s2n_psk_set_application_protocol */
+    {
+        /* Safety checks */
+        {
+            struct s2n_psk psk = { 0 };
+            EXPECT_FAILURE_WITH_ERRNO(s2n_psk_set_application_protocol(&psk, NULL, 1), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_psk_set_application_protocol(NULL, test_value, 1), S2N_ERR_NULL);
+        }
+
+        DEFER_CLEANUP(struct s2n_psk *psk = s2n_external_psk_new(), s2n_psk_free);
+        EXPECT_EQUAL(psk->early_data_config.application_protocol.size, 0);
+        EXPECT_EQUAL(psk->early_data_config.application_protocol.allocated, 0);
+
+        /* Set empty value as no-op */
+        EXPECT_SUCCESS(s2n_psk_set_application_protocol(psk, test_value, 0));
+        EXPECT_EQUAL(psk->early_data_config.application_protocol.size, 0);
+        EXPECT_EQUAL(psk->early_data_config.application_protocol.allocated, 0);
+
+        /* Set valid value */
+        EXPECT_SUCCESS(s2n_psk_set_application_protocol(psk, test_value, sizeof(test_value)));
+        EXPECT_EQUAL(psk->early_data_config.application_protocol.size, sizeof(test_value));
+        EXPECT_BYTEARRAY_EQUAL(psk->early_data_config.application_protocol.data, test_value, sizeof(test_value));
+
+        /* Replace previous value */
+        EXPECT_SUCCESS(s2n_psk_set_application_protocol(psk, test_value_2, sizeof(test_value_2)));
+        EXPECT_EQUAL(psk->early_data_config.application_protocol.size, sizeof(test_value_2));
+        EXPECT_BYTEARRAY_EQUAL(psk->early_data_config.application_protocol.data, test_value_2, sizeof(test_value_2));
+
+        /* Clear with empty value */
+        EXPECT_SUCCESS(s2n_psk_set_application_protocol(psk, test_value, 0));
+        EXPECT_EQUAL(psk->early_data_config.application_protocol.size, 0);
+        EXPECT_EQUAL(psk->early_data_config.application_protocol.allocated, 0);
+
+        /* Repeat clear */
+        EXPECT_SUCCESS(s2n_psk_set_application_protocol(psk, test_value, 0));
+        EXPECT_EQUAL(psk->early_data_config.application_protocol.size, 0);
+        EXPECT_EQUAL(psk->early_data_config.application_protocol.allocated, 0);
+    }
+
+    /* Test s2n_psk_set_context */
+    {
+        /* Safety checks */
+        {
+            struct s2n_psk psk = { 0 };
+            EXPECT_FAILURE_WITH_ERRNO(s2n_psk_set_context(&psk, NULL, 1), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_psk_set_context(NULL, test_value, 1), S2N_ERR_NULL);
+        }
+
+        DEFER_CLEANUP(struct s2n_psk *psk = s2n_external_psk_new(), s2n_psk_free);
+        EXPECT_EQUAL(psk->early_data_config.context.size, 0);
+        EXPECT_EQUAL(psk->early_data_config.context.allocated, 0);
+
+        /* Set empty value as no-op */
+        EXPECT_SUCCESS(s2n_psk_set_context(psk, test_value, 0));
+        EXPECT_EQUAL(psk->early_data_config.context.size, 0);
+        EXPECT_EQUAL(psk->early_data_config.context.allocated, 0);
+
+        /* Set valid value */
+        EXPECT_SUCCESS(s2n_psk_set_context(psk, test_value, sizeof(test_value)));
+        EXPECT_EQUAL(psk->early_data_config.context.size, sizeof(test_value));
+        EXPECT_BYTEARRAY_EQUAL(psk->early_data_config.context.data, test_value, sizeof(test_value));
+
+        /* Replace previous value */
+        EXPECT_SUCCESS(s2n_psk_set_context(psk, test_value_2, sizeof(test_value_2)));
+        EXPECT_EQUAL(psk->early_data_config.context.size, sizeof(test_value_2));
+        EXPECT_BYTEARRAY_EQUAL(psk->early_data_config.context.data, test_value_2, sizeof(test_value_2));
+
+        /* Clear with empty value */
+        EXPECT_SUCCESS(s2n_psk_set_context(psk, test_value, 0));
+        EXPECT_EQUAL(psk->early_data_config.context.size, 0);
+        EXPECT_EQUAL(psk->early_data_config.context.allocated, 0);
+
+        /* Repeat clear */
+        EXPECT_SUCCESS(s2n_psk_set_context(psk, test_value, 0));
+        EXPECT_EQUAL(psk->early_data_config.context.size, 0);
+        EXPECT_EQUAL(psk->early_data_config.context.allocated, 0);
+    }
+
+    END_TEST();
+}

--- a/tests/unit/s2n_early_data_test.c
+++ b/tests/unit/s2n_early_data_test.c
@@ -84,14 +84,14 @@ int main(int argc, char **argv)
 
         /* Set valid configuration */
         {
-            uint32_t expected_max_early_data = 1000;
+            uint32_t expected_max_early_data_size = 1000;
             uint8_t expected_cipher_suite[] = { 0x01, 0xAB };
 
             struct s2n_psk psk = { 0 };
-            EXPECT_SUCCESS(s2n_psk_configure_early_data(&psk, expected_max_early_data,
+            EXPECT_SUCCESS(s2n_psk_configure_early_data(&psk, expected_max_early_data_size,
                     expected_cipher_suite[0], expected_cipher_suite[1]));
 
-            EXPECT_EQUAL(psk.early_data_config.max_early_data, expected_max_early_data);
+            EXPECT_EQUAL(psk.early_data_config.max_early_data_size, expected_max_early_data_size);
             EXPECT_EQUAL(psk.early_data_config.protocol_version, S2N_TLS13);
             EXPECT_BYTEARRAY_EQUAL(psk.early_data_config.cipher_suite_iana, expected_cipher_suite,
                     sizeof(expected_cipher_suite));

--- a/tests/unit/s2n_psk_test.c
+++ b/tests/unit/s2n_psk_test.c
@@ -37,13 +37,13 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(psk.type, S2N_PSK_TYPE_EXTERNAL);
         EXPECT_EQUAL(psk.hmac_alg, S2N_HMAC_SHA256);
         EXPECT_EQUAL(psk.obfuscated_ticket_age, 0);
-        EXPECT_EQUAL(psk.early_data_config.max_early_data, 0);
+        EXPECT_EQUAL(psk.early_data_config.max_early_data_size, 0);
 
         EXPECT_OK(s2n_psk_init(&psk, S2N_PSK_TYPE_RESUMPTION));
         EXPECT_EQUAL(psk.type, S2N_PSK_TYPE_RESUMPTION);
         EXPECT_EQUAL(psk.hmac_alg, S2N_HMAC_SHA256);
         EXPECT_EQUAL(psk.obfuscated_ticket_age, 0);
-        EXPECT_EQUAL(psk.early_data_config.max_early_data, 0);
+        EXPECT_EQUAL(psk.early_data_config.max_early_data_size, 0);
     }
 
     /* Test s2n_external_psk_new */

--- a/tests/unit/s2n_psk_test.c
+++ b/tests/unit/s2n_psk_test.c
@@ -37,11 +37,13 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(psk.type, S2N_PSK_TYPE_EXTERNAL);
         EXPECT_EQUAL(psk.hmac_alg, S2N_HMAC_SHA256);
         EXPECT_EQUAL(psk.obfuscated_ticket_age, 0);
+        EXPECT_EQUAL(psk.early_data_config.max_early_data, 0);
 
         EXPECT_OK(s2n_psk_init(&psk, S2N_PSK_TYPE_RESUMPTION));
         EXPECT_EQUAL(psk.type, S2N_PSK_TYPE_RESUMPTION);
         EXPECT_EQUAL(psk.hmac_alg, S2N_HMAC_SHA256);
         EXPECT_EQUAL(psk.obfuscated_ticket_age, 0);
+        EXPECT_EQUAL(psk.early_data_config.max_early_data, 0);
     }
 
     /* Test s2n_external_psk_new */

--- a/tls/s2n_early_data.c
+++ b/tls/s2n_early_data.c
@@ -29,11 +29,11 @@ S2N_CLEANUP_RESULT s2n_early_data_config_free(struct s2n_early_data_config *conf
     return S2N_RESULT_OK;
 }
 
-int s2n_psk_configure_early_data(struct s2n_psk *psk, uint32_t max_early_data,
+int s2n_psk_configure_early_data(struct s2n_psk *psk, uint32_t max_early_data_size,
         uint8_t cipher_suite_first_byte, uint8_t cipher_suite_second_byte)
 {
     notnull_check(psk);
-    psk->early_data_config.max_early_data = max_early_data;
+    psk->early_data_config.max_early_data_size = max_early_data_size;
     psk->early_data_config.protocol_version = S2N_TLS13;
     psk->early_data_config.cipher_suite_iana[0] = cipher_suite_first_byte;
     psk->early_data_config.cipher_suite_iana[1] = cipher_suite_second_byte;

--- a/tls/s2n_early_data.c
+++ b/tls/s2n_early_data.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "tls/s2n_early_data.h"
+
+#include "tls/s2n_psk.h"
+#include "utils/s2n_safety.h"
+#include "utils/s2n_mem.h"
+
+S2N_CLEANUP_RESULT s2n_early_data_config_free(struct s2n_early_data_config *config)
+{
+    if (config == NULL) {
+        return S2N_RESULT_OK;
+    }
+    GUARD_AS_RESULT(s2n_free(&config->application_protocol));
+    GUARD_AS_RESULT(s2n_free(&config->context));
+    return S2N_RESULT_OK;
+}
+
+int s2n_psk_configure_early_data(struct s2n_psk *psk, uint32_t max_early_data, uint8_t protocol_version,
+        uint8_t cipher_suite_first_byte, uint8_t cipher_suite_second_byte)
+{
+    notnull_check(psk);
+    ENSURE_POSIX(protocol_version >= S2N_TLS13, S2N_ERR_INVALID_ARGUMENT);
+    psk->early_data_config.max_early_data = max_early_data;
+    psk->early_data_config.protocol_version = protocol_version;
+    psk->early_data_config.cipher_suite_iana[0] = cipher_suite_first_byte;
+    psk->early_data_config.cipher_suite_iana[1] = cipher_suite_second_byte;
+    return S2N_SUCCESS;
+}
+
+int s2n_psk_set_application_protocol(struct s2n_psk *psk, const uint8_t *application_protocol, uint8_t size)
+{
+    notnull_check(psk);
+    if (size > 0) {
+        notnull_check(application_protocol);
+    }
+    struct s2n_blob *protocol_blob = &psk->early_data_config.application_protocol;
+    GUARD(s2n_realloc(protocol_blob, size));
+    memcpy_check(protocol_blob->data, application_protocol, size);
+    return S2N_SUCCESS;
+}
+
+int s2n_psk_set_context(struct s2n_psk *psk, const uint8_t *context, uint16_t size)
+{
+    notnull_check(psk);
+    if (size > 0) {
+        notnull_check(context);
+    }
+    struct s2n_blob *context_blob = &psk->early_data_config.context;
+    GUARD(s2n_realloc(context_blob, size));
+    memcpy_check(context_blob->data, context, size);
+    return S2N_SUCCESS;
+}

--- a/tls/s2n_early_data.c
+++ b/tls/s2n_early_data.c
@@ -29,13 +29,12 @@ S2N_CLEANUP_RESULT s2n_early_data_config_free(struct s2n_early_data_config *conf
     return S2N_RESULT_OK;
 }
 
-int s2n_psk_configure_early_data(struct s2n_psk *psk, uint32_t max_early_data, uint8_t protocol_version,
+int s2n_psk_configure_early_data(struct s2n_psk *psk, uint32_t max_early_data,
         uint8_t cipher_suite_first_byte, uint8_t cipher_suite_second_byte)
 {
     notnull_check(psk);
-    ENSURE_POSIX(protocol_version >= S2N_TLS13, S2N_ERR_INVALID_ARGUMENT);
     psk->early_data_config.max_early_data = max_early_data;
-    psk->early_data_config.protocol_version = protocol_version;
+    psk->early_data_config.protocol_version = S2N_TLS13;
     psk->early_data_config.cipher_suite_iana[0] = cipher_suite_first_byte;
     psk->early_data_config.cipher_suite_iana[1] = cipher_suite_second_byte;
     return S2N_SUCCESS;

--- a/tls/s2n_early_data.h
+++ b/tls/s2n_early_data.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include <s2n.h>
+
+#include "tls/s2n_crypto_constants.h"
+#include "utils/s2n_blob.h"
+#include "utils/s2n_result.h"
+
+struct s2n_early_data_config {
+    uint32_t max_early_data;
+    uint8_t protocol_version;
+    uint8_t cipher_suite_iana[S2N_TLS_CIPHER_SUITE_LEN];
+    struct s2n_blob application_protocol;
+    struct s2n_blob context;
+};
+S2N_CLEANUP_RESULT s2n_early_data_config_free(struct s2n_early_data_config *config);
+
+/* Public Interface -- will be made visible and moved to s2n.h when the 0RTT feature is released */
+
+struct s2n_psk;
+int s2n_psk_configure_early_data(struct s2n_psk *psk, uint32_t max_early_data, uint8_t protocol_version,
+        uint8_t cipher_suite_first_byte, uint8_t cipher_suite_second_byte);
+int s2n_psk_set_application_protocol(struct s2n_psk *psk, const uint8_t *application_protocol, uint8_t size);
+int s2n_psk_set_context(struct s2n_psk *psk, const uint8_t *context, uint16_t size);

--- a/tls/s2n_early_data.h
+++ b/tls/s2n_early_data.h
@@ -33,7 +33,7 @@ S2N_CLEANUP_RESULT s2n_early_data_config_free(struct s2n_early_data_config *conf
 /* Public Interface -- will be made visible and moved to s2n.h when the 0RTT feature is released */
 
 struct s2n_psk;
-int s2n_psk_configure_early_data(struct s2n_psk *psk, uint32_t max_early_data, uint8_t protocol_version,
+int s2n_psk_configure_early_data(struct s2n_psk *psk, uint32_t max_early_data,
         uint8_t cipher_suite_first_byte, uint8_t cipher_suite_second_byte);
 int s2n_psk_set_application_protocol(struct s2n_psk *psk, const uint8_t *application_protocol, uint8_t size);
 int s2n_psk_set_context(struct s2n_psk *psk, const uint8_t *context, uint16_t size);

--- a/tls/s2n_early_data.h
+++ b/tls/s2n_early_data.h
@@ -22,7 +22,7 @@
 #include "utils/s2n_result.h"
 
 struct s2n_early_data_config {
-    uint32_t max_early_data;
+    uint32_t max_early_data_size;
     uint8_t protocol_version;
     uint8_t cipher_suite_iana[S2N_TLS_CIPHER_SUITE_LEN];
     struct s2n_blob application_protocol;
@@ -33,7 +33,7 @@ S2N_CLEANUP_RESULT s2n_early_data_config_free(struct s2n_early_data_config *conf
 /* Public Interface -- will be made visible and moved to s2n.h when the 0RTT feature is released */
 
 struct s2n_psk;
-int s2n_psk_configure_early_data(struct s2n_psk *psk, uint32_t max_early_data,
+int s2n_psk_configure_early_data(struct s2n_psk *psk, uint32_t max_early_data_size,
         uint8_t cipher_suite_first_byte, uint8_t cipher_suite_second_byte);
 int s2n_psk_set_application_protocol(struct s2n_psk *psk, const uint8_t *application_protocol, uint8_t size);
 int s2n_psk_set_context(struct s2n_psk *psk, const uint8_t *context, uint16_t size);

--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -82,6 +82,7 @@ S2N_CLEANUP_RESULT s2n_psk_wipe(struct s2n_psk *psk)
     GUARD_AS_RESULT(s2n_free(&psk->early_secret));
     GUARD_AS_RESULT(s2n_free(&psk->identity));
     GUARD_AS_RESULT(s2n_free(&psk->secret));
+    GUARD_RESULT(s2n_early_data_config_free(&psk->early_data_config));
 
     return S2N_RESULT_OK;
 }

--- a/tls/s2n_psk.h
+++ b/tls/s2n_psk.h
@@ -18,6 +18,7 @@
 #include <s2n.h>
 
 #include "crypto/s2n_hmac.h"
+#include "tls/s2n_early_data.h"
 #include "utils/s2n_array.h"
 #include "utils/s2n_blob.h"
 #include "utils/s2n_result.h"
@@ -40,6 +41,7 @@ struct s2n_psk {
     s2n_hmac_algorithm hmac_alg;
     uint32_t obfuscated_ticket_age;
     struct s2n_blob early_secret;
+    struct s2n_early_data_config early_data_config;
 };
 S2N_RESULT s2n_psk_init(struct s2n_psk *psk, s2n_psk_type type);
 S2N_CLEANUP_RESULT s2n_psk_wipe(struct s2n_psk *psk);

--- a/tls/s2n_psk.h
+++ b/tls/s2n_psk.h
@@ -18,6 +18,7 @@
 #include <s2n.h>
 
 #include "crypto/s2n_hmac.h"
+#include "stuffer/s2n_stuffer.h"
 #include "tls/s2n_early_data.h"
 #include "utils/s2n_array.h"
 #include "utils/s2n_blob.h"


### PR DESCRIPTION
### Resolved issues:

https://github.com/awslabs/s2n/issues/2563

### Description of changes: 

Add APIs to configure additional information needed to determine whether a PSK can be used for early data. From the RFC:
```
   In order to accept early data, the server MUST have accepted a PSK
   cipher suite and selected the first key offered in the client's
   "pre_shared_key" extension.  In addition, it MUST verify that the
   following values are the same as those associated with the
   selected PSK:

   -  The TLS version number

   -  The selected cipher suite

   -  The selected ALPN [RFC7301] protocol, if any

   These requirements are a superset of those needed to perform a 1-RTT
   handshake using the PSK in question.  For externally established
   PSKs, the associated values are those provisioned along with the key.
```

### Call-outs:

* **Does the protocol version need to be included in s2n_psk_configure_early_data?** I'm curious what other people think of this question. At the moment, the only possible value for the protocol is TLS1.3, because previous versions don't support early data. If future versions also support early data, we could add a separate "psk_set_protocol_version" API, and have the protocol version otherwise default to the highest version supported.
* The APIs are not added to s2n.h or the documentation yet. They'll be released when the feature is ready.

### Testing:

Basic unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
