### PR TITLE
Add CMake config to build benchmarks and fix some minor issues in existing tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,7 +293,29 @@ if (BUILD_TESTING)
     target_include_directories(s2nd PRIVATE $<TARGET_PROPERTY:LibCrypto::Crypto,INTERFACE_INCLUDE_DIRECTORIES>)
     target_include_directories(s2nd PRIVATE api)
     target_compile_options(s2nd PRIVATE -std=gnu99 -D_POSIX_C_SOURCE=200112L)
+
+    if(BENCHMARK)
+        find_package(benchmark REQUIRED)
+        file(GLOB BENCHMARK_SRC "tests/benchmark/*.cc")
+        enable_language(CXX)
+        foreach(benchmark ${BENCHMARK_SRC})
+            string(REGEX REPLACE ".+\\/(.+)\\.cc" "\\1" benchmark_name ${benchmark})
+            add_executable(${benchmark_name} ${benchmark})
+            target_include_directories(${benchmark_name} PRIVATE api)
+            target_include_directories(${benchmark_name} PRIVATE tests)
+            target_link_libraries(${benchmark_name} PUBLIC ${PROJECT_NAME} testss2n benchmark::benchmark)
+
+            # Based off the flags in tests/benchmark/Makefile
+            target_compile_options(${benchmark_name} PRIVATE -pedantic -Wall -Werror -Wunused -Wcomment -Wchar-subscripts
+                    -Wuninitialized -Wshadow -Wcast-qual -Wcast-align -Wwrite-strings -Wno-deprecated-declarations
+                    -Wno-unknown-pragmas -Wformat-security -Wno-missing-braces -fvisibility=hidden -Wno-unreachable-code
+                    -Wno-unused-but-set-variable)
+        endforeach(benchmark)
+
+    endif()
 endif()
+
+
 
 #install the s2n files
 install(FILES ${API_HEADERS} DESTINATION "include/" COMPONENT Development)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,14 @@ try_compile(
         COMPILE_DEFINITIONS "-Werror"
 )
 
+# Determine if __restrict__ is available
+try_compile(
+        __RESTRICT__SUPPORTED
+        ${CMAKE_BINARY_DIR}
+        SOURCES "${CMAKE_CURRENT_LIST_DIR}/tests/features/__restrict__.c"
+        COMPILE_DEFINITIONS "-Werror"
+)
+
 if(APPLE)
     set(OS_LIBS c Threads::Threads)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
@@ -227,6 +235,10 @@ endif()
 
 if (FALL_THROUGH_SUPPORTED)
     target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_FALL_THROUGH_SUPPORTED)
+endif()
+
+if (__RESTRICT__SUPPORTED)
+    target_compile_options(${PROJECT_NAME} PUBLIC -DS2N___RESTRICT__SUPPORTED)
 endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)

--- a/s2n.mk
+++ b/s2n.mk
@@ -178,6 +178,12 @@ ifeq ($(TRY_COMPILE_FALL_THROUGH), 0)
 	DEFAULT_CFLAGS += -DS2N_FALL_THROUGH_SUPPORTED
 endif
 
+# Determine if __restrict__ is available
+TRY_COMPILE__RESTRICT__ := $(call try_compile,$(S2N_ROOT)/tests/features/__restrict__.c)
+ifeq ($(TRY_COMPILE__RESTRICT__), 0)
+	DEFAULT_CFLAGS += -DS2N___RESTRICT__SUPPORTED
+endif
+
 CFLAGS_LLVM = ${DEFAULT_CFLAGS} -emit-llvm -c -g -O1
 
 $(BITCODE_DIR)%.bc: %.c

--- a/tests/benchmark/s2n_base64_benchmark.cc
+++ b/tests/benchmark/s2n_base64_benchmark.cc
@@ -41,7 +41,7 @@ public:
         rc = s2n_blob_init(&r, pad.data(), pad.size());
         assert(rc == 0);
 
-        result  = s2n_get_urandom_data(&r);
+        result  = s2n_get_public_random_data(&r);
         assert(s2n_result_is_ok(result));
         rc = s2n_stuffer_alloc(&entropy, pad.size());
         assert(rc == 0);

--- a/tests/features/__restrict__.c
+++ b/tests/features/__restrict__.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+void swap(int *__restrict__ left, int *__restrict__ right) {
+    int temp = *left;
+    *left = *right;
+    *right = temp;
+}
+
+int main() {
+    int a = 1, b = 2;
+    swap(&a, &b);
+    return 0;
+}
+

--- a/utils/s2n_ensure.h
+++ b/utils/s2n_ensure.h
@@ -67,4 +67,21 @@
     }                                                                            \
   } while(0)
 
+/**
+ * `restrict` is a part of the c99 standard and will work with any C compiler. If you're trying to
+ * compile with a C++ compiler `restrict` is invalid. However GCC and Clang support the use of
+ * `restrict` when compiling C++ code using `__restrict__`. Therefore if the compiler is GCC or
+ * Clang use `__restrict__` which will behave the same as `restrict` and allow g++ and clang++ to
+ * compile it.
+ *
+ * This is helpful for the benchmarks in tests/benchmark which use Google's Benchmark library and
+ * are all written in C++.
+ *
+ * https://gcc.gnu.org/onlinedocs/gcc/Restricted-Pointers.html
+ *
+ */
+#if defined(__GNUC__) || defined(__clang__)
+extern void* s2n_ensure_memcpy_trace(void *__restrict__ to, const void *__restrict__ from, size_t size, const char *debug_str);
+#else
 extern void* s2n_ensure_memcpy_trace(void *restrict to, const void *restrict from, size_t size, const char *debug_str);
+#endif

--- a/utils/s2n_ensure.h
+++ b/utils/s2n_ensure.h
@@ -69,10 +69,9 @@
 
 /**
  * `restrict` is a part of the c99 standard and will work with any C compiler. If you're trying to
- * compile with a C++ compiler `restrict` is invalid. However GCC and Clang support the use of
- * `restrict` when compiling C++ code using `__restrict__`. Therefore if the compiler is GCC or
- * Clang use `__restrict__` which will behave the same as `restrict` and allow g++ and clang++ to
- * compile it.
+ * compile with a C++ compiler `restrict` is invalid. However some C++ compilers support the behavior
+ * of `restrict` using the `__restrict__` keyword. Therefore if the compiler supports `__restrict__`
+ * use it.
  *
  * This is helpful for the benchmarks in tests/benchmark which use Google's Benchmark library and
  * are all written in C++.
@@ -80,7 +79,7 @@
  * https://gcc.gnu.org/onlinedocs/gcc/Restricted-Pointers.html
  *
  */
-#if defined(__GNUC__) || defined(__clang__)
+#if defined(S2N___RESTRICT__SUPPORTED)
 extern void* s2n_ensure_memcpy_trace(void *__restrict__ to, const void *__restrict__ from, size_t size, const char *debug_str);
 #else
 extern void* s2n_ensure_memcpy_trace(void *restrict to, const void *restrict from, size_t size, const char *debug_str);


### PR DESCRIPTION
### Resolved issues:

This is a step towards addressing https://github.com/awslabs/s2n/issues/1324

### Description of changes: 

s2n's benchmarks were only build-able using the included Makefiles. I like using Clion as my IDE which only supports CMake. This change adds the required CMake config to build the benchmarks though that. Once I have this I will add more targetted benchmarks.

### Call-outs:

Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 

It appears nothing is building the benchmarks in the CI and the existing PEM and base64 tests have drifted and are not compatible with the latest s2n changes. I updated the tests when possible but had to change the method signature of `s2n_ensure_memcpy_trace` to be able to compile with a C++ compiler.

### Testing:

```
cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DBENCHMARK=1 ../
...
ninja
...
desktop git:(benchmark-fix)✗ > ./bin/s2n_pem_parse_benchmark
2021-02-11T16:16:53-08:00
Running ./bin/s2n_pem_parse_benchmark
Run on (12 X 4800 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 256 KiB (x6)
  L3 Unified 12288 KiB (x1)
Load Average: 1.65, 1.83, 2.23
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
-----------------------------------------------------------------------------------
Benchmark                                         Time             CPU   Iterations
-----------------------------------------------------------------------------------
ValidPemTestFixture/Load_Valid_Pem/0           3.99 ns         3.99 ns    175994087
ValidPemTestFixture/Load_Valid_Pem/1           3.97 ns         3.97 ns    176162953
ValidPemTestFixture/Load_Valid_Pem/2           4.07 ns         4.07 ns    176377315
ValidPemTestFixture/Load_Valid_Pem/3           4.06 ns         4.06 ns    172058162
ValidPemTestFixture/Load_Valid_Pem/4           4.01 ns         4.01 ns    172203191
ValidPemTestFixture/Load_Valid_Pem/5           3.97 ns         3.97 ns    176619955
ValidPemTestFixture/Load_Valid_Pem/6           3.98 ns         3.98 ns    176642775
ValidPemTestFixture/Load_Valid_Pem/7           3.97 ns         3.97 ns    176531530
ValidPemTestFixture/Load_Valid_Pem/8           3.98 ns         3.98 ns    174472028
ValidPemTestFixture/Load_Valid_Pem/9           3.98 ns         3.98 ns    175676921
ValidPemTestFixture/Load_Valid_Pem/10          3.99 ns         3.99 ns    172734165
ValidPemTestFixture/Load_Valid_Pem/11          3.97 ns         3.97 ns    175941642
ValidPemTestFixture/Load_Valid_Pem/12          3.97 ns         3.97 ns    176477595
ValidPemTestFixture/Load_Valid_Pem/13          3.97 ns         3.97 ns    176315857
ValidPemTestFixture/Load_Valid_Pem/14          3.97 ns         3.97 ns    176418837
ValidPemTestFixture/Load_Valid_Pem/15          3.97 ns         3.97 ns    176378295
InvalidPemTestFixture/Load_Invalid_Pem/0       4.18 ns         4.18 ns    167130693
InvalidPemTestFixture/Load_Invalid_Pem/1       4.18 ns         4.18 ns    167399371
InvalidPemTestFixture/Load_Invalid_Pem/2       4.26 ns         4.26 ns    167742782
InvalidPemTestFixture/Load_Invalid_Pem/3       4.18 ns         4.18 ns    167772082
InvalidPemTestFixture/Load_Invalid_Pem/4       4.17 ns         4.17 ns    167773674
InvalidPemTestFixture/Load_Invalid_Pem/5       4.18 ns         4.18 ns    167635773

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
