### PR TITLE
tls: add NSS key log callback

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -487,6 +487,33 @@ extern int s2n_async_pkey_op_apply(struct s2n_async_pkey_op *op, struct s2n_conn
 S2N_API
 extern int s2n_async_pkey_op_free(struct s2n_async_pkey_op *op);
 
+/**
+ * Callback function for handling key log events
+ *
+ * Each log line is formatted with the
+ * [NSS Key Log Format](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format)
+ * without a newline.
+ *
+ * @param ctx Context for the callback
+ * @param conn Connection for which the log line is being emitted
+ * @param logline Pointer to the log line data
+ * @param len Length of the log line data
+ */
+typedef int (*s2n_key_log_fn)(void *ctx, struct s2n_connection *conn, uint8_t *logline, size_t len);
+
+/**
+ * Sets a key logging callback on the provided config
+ *
+ * Setting this function enables configurations to emit secrets in the
+ * [NSS Key Log Format](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format)
+ *
+ * @param config Config to set the callback
+ * @param callback The function that should be called for each secret log entry
+ * @param ctx The context to be passed when the callback is called
+ */
+S2N_API
+extern int s2n_config_set_key_log_cb(struct s2n_config *config, s2n_key_log_fn callback, void *ctx);
+
 /* s2n_config_enable_cert_req_dss_legacy_compat adds a dss cert type in the server certificate request when being called.
  * It only sends the dss cert type in the cert request but does not succeed the handshake if a dss cert is received.
  * Please DO NOT call this api unless you know you actually need legacy DSS certificate type compatibility

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -490,6 +490,8 @@ extern int s2n_async_pkey_op_free(struct s2n_async_pkey_op *op);
 /**
  * Callback function for handling key log events
  *
+ * THIS SHOULD BE USED FOR DEBUGGING PURPOSES ONLY!
+ *
  * Each log line is formatted with the
  * [NSS Key Log Format](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format)
  * without a newline.
@@ -508,6 +510,8 @@ typedef int (*s2n_key_log_fn)(void *ctx, struct s2n_connection *conn, uint8_t *l
 
 /**
  * Sets a key logging callback on the provided config
+ *
+ * THIS SHOULD BE USED FOR DEBUGGING PURPOSES ONLY!
  *
  * Setting this function enables configurations to emit secrets in the
  * [NSS Key Log Format](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format)

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -494,6 +494,11 @@ extern int s2n_async_pkey_op_free(struct s2n_async_pkey_op *op);
  * [NSS Key Log Format](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format)
  * without a newline.
  *
+ * # Safety
+ *
+ * * `ctx` MUST be cast into the same type of pointer that was originally created
+ * * `logline` bytes MUST be copied or discarded before this function returns
+ *
  * @param ctx Context for the callback
  * @param conn Connection for which the log line is being emitted
  * @param logline Pointer to the log line data
@@ -506,6 +511,11 @@ typedef int (*s2n_key_log_fn)(void *ctx, struct s2n_connection *conn, uint8_t *l
  *
  * Setting this function enables configurations to emit secrets in the
  * [NSS Key Log Format](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format)
+ *
+ * # Safety
+ *
+ * * `callback` MUST cast `ctx` into the same type of pointer that was originally created
+ * * `ctx` MUST live for at least as long as it is set on the config
  *
  * @param config Config to set the callback
  * @param callback The function that should be called for each secret log entry

--- a/bin/common.c
+++ b/bin/common.c
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <getopt.h>
 #include <errno.h>
+#include <s2n.h>
 
 char *load_file_to_cstring(const char *path)
 {
@@ -61,4 +62,16 @@ char *load_file_to_cstring(const char *path)
     fclose(pem_file);
 
     return pem_out;
+}
+
+int key_log_callback(void *file, struct s2n_connection *conn, uint8_t *logline, size_t len) {
+    if (fwrite(logline, 1, len, (FILE *)file) != len) {
+        return S2N_FAILURE;
+    }
+
+    if (fprintf((FILE *)file, "\n") < 0) {
+        return S2N_FAILURE;
+    }
+
+    return fflush((FILE *)file);
 }

--- a/bin/common.h
+++ b/bin/common.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #define GUARD_EXIT(x, msg)  \
   do {                      \
     if ((x) < 0) {          \
@@ -35,5 +37,6 @@ void print_s2n_error(const char *app_error);
 int echo(struct s2n_connection *conn, int sockfd);
 int negotiate(struct s2n_connection *conn, int sockfd);
 int https(struct s2n_connection *conn, uint32_t bench);
+int key_log_callback(void *ctx, struct s2n_connection *conn, uint8_t *logline, size_t len);
 
 char *load_file_to_cstring(const char *path);

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -91,6 +91,8 @@ void usage()
                     "    The client will generate keyshares only for the curve names present in the ecc_preferences list configured in the security_policy.\n"
                     "    The curves currently supported by s2n are: `x25519`, `secp256r1` and `secp384r1`. Note that `none` represents a list of empty keyshares.\n"
                     "    By default, the client will generate keyshares for all curves present in the ecc_preferences list.\n");
+    fprintf(stderr, "  -L --key-log <path>\n");
+    fprintf(stderr, "    Enable NSS key logging into the provided path\n");
     fprintf(stderr, "\n");
     exit(1);
 }
@@ -256,6 +258,8 @@ int main(int argc, char *const *argv)
     char keyshares[S2N_ECC_EVP_SUPPORTED_CURVES_COUNT][S2N_MAX_ECC_CURVE_NAME_LENGTH];
     char *input = NULL;
     char *token = NULL;
+    const char *key_log_path = NULL;
+    FILE *key_log_file = NULL;
 
     static struct option long_options[] = {
         {"alpn", required_argument, 0, 'a'},
@@ -278,6 +282,8 @@ int main(int argc, char *const *argv)
         {"tls13", no_argument, 0, '3'},
         {"keyshares", required_argument, 0, 'K'},
         {"non-blocking", no_argument, 0, 'B'},
+        {"key-log", required_argument, 0, 'L'},
+        { 0 },
     };
 
     while (1) {
@@ -360,6 +366,9 @@ int main(int argc, char *const *argv)
             break;
         case 'B':
             non_blocking = 1;
+            break;
+        case 'L':
+            key_log_path = optarg;
             break;
         case '?':
         default:
@@ -458,6 +467,17 @@ int main(int argc, char *const *argv)
             GUARD_EXIT(s2n_config_set_session_tickets_onoff(config, 1), "Error enabling session tickets");
         }
 
+        if (key_log_path) {
+            key_log_file = fopen(key_log_path, "a");
+            GUARD_EXIT(key_log_file == NULL ? S2N_FAILURE : S2N_SUCCESS, "Failed to open key log file");
+            GUARD_EXIT(s2n_config_set_key_log_cb(
+                config,
+                key_log_callback,
+                (void *)key_log_file),
+                "Failed to set key log callback"
+            );
+        }
+
         struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
 
         if (conn == NULL) {
@@ -532,6 +552,8 @@ int main(int argc, char *const *argv)
         reconnect--;
 
     } while (reconnect >= 0);
+
+    fclose(key_log_file);
 
     GUARD_EXIT(s2n_cleanup(), "Error running s2n_cleanup()");
 

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -470,10 +470,12 @@ int main(int argc, char *const *argv)
         if (key_log_path) {
             key_log_file = fopen(key_log_path, "a");
             GUARD_EXIT(key_log_file == NULL ? S2N_FAILURE : S2N_SUCCESS, "Failed to open key log file");
-            GUARD_EXIT(s2n_config_set_key_log_cb(
-                config,
-                key_log_callback,
-                (void *)key_log_file),
+            GUARD_EXIT(
+                s2n_config_set_key_log_cb(
+                    config,
+                    key_log_callback,
+                    (void *)key_log_file
+                ),
                 "Failed to set key log callback"
             );
         }

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -553,7 +553,9 @@ int main(int argc, char *const *argv)
 
     } while (reconnect >= 0);
 
-    fclose(key_log_file);
+    if (key_log_file) {
+        fclose(key_log_file);
+    }
 
     GUARD_EXIT(s2n_cleanup(), "Error running s2n_cleanup()");
 

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -817,7 +817,9 @@ int main(int argc, char *const *argv)
         }
     }
 
-    fclose(key_log_file);
+    if (key_log_file) {
+        fclose(key_log_file);
+    }
 
     GUARD_EXIT(s2n_cleanup(),  "Error running s2n_cleanup()");
 

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -286,6 +286,8 @@ void usage()
     fprintf(stderr, "    Run s2nd in a simple https server mode.\n");
     fprintf(stderr, "  -b --https-bench <bytes>\n");
     fprintf(stderr, "    Send number of bytes in https server mode to test throughput.\n");
+    fprintf(stderr, "  -L --key-log <path>\n");
+    fprintf(stderr, "    Enable NSS key logging into the provided path\n");
     fprintf(stderr, "  -h,--help\n");
     fprintf(stderr, "    Display this message and quit.\n");
 
@@ -391,6 +393,7 @@ int main(int argc, char *const *argv)
     const char *session_ticket_key_file_path = NULL;
     const char *cipher_prefs = "default";
     const char *alpn = NULL;
+    const char *key_log_path = NULL;
 
     /* The certificates provided by the user. If there are none provided, we will use the hardcoded default cert.
      * The associated private key for each cert will be at the same index in private_keys. If the user mixes up the
@@ -436,6 +439,7 @@ int main(int argc, char *const *argv)
         {"https-bench", required_argument, 0, 'b'},
         {"alpn", required_argument, 0, 'A'},
         {"non-blocking", no_argument, 0, 'B'},
+        {"key-log", required_argument, 0, 'L'},
         /* Per getopt(3) the last element of the array has to be filled with all zeros */
         { 0 },
     };
@@ -538,6 +542,9 @@ int main(int argc, char *const *argv)
             break;
         case 'B':
             non_blocking = 1;
+            break;
+        case 'L':
+            key_log_path = optarg;
             break;
         case '?':
         default:
@@ -751,6 +758,18 @@ int main(int argc, char *const *argv)
         GUARD_EXIT(s2n_config_set_protocol_preferences(config, protocols, s2n_array_len(protocols)), "Failed to set alpn");
     }
 
+    FILE *key_log_file = NULL;
+
+    if (key_log_path) {
+        key_log_file = fopen(key_log_path, "a");
+        GUARD_EXIT(key_log_file == NULL ? S2N_FAILURE : S2N_SUCCESS, "Failed to open key log file");
+        GUARD_EXIT(s2n_config_set_key_log_cb(
+            config,
+            key_log_callback,
+            (void *)key_log_file),
+        "Failed to set key log callback");
+    }
+
     int fd;
     while ((fd = accept(sockfd, ai->ai_addr, &ai->ai_addrlen)) > 0) {
 
@@ -797,6 +816,8 @@ int main(int argc, char *const *argv)
             }
         }
     }
+
+    fclose(key_log_file);
 
     GUARD_EXIT(s2n_cleanup(),  "Error running s2n_cleanup()");
 

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -763,11 +763,14 @@ int main(int argc, char *const *argv)
     if (key_log_path) {
         key_log_file = fopen(key_log_path, "a");
         GUARD_EXIT(key_log_file == NULL ? S2N_FAILURE : S2N_SUCCESS, "Failed to open key log file");
-        GUARD_EXIT(s2n_config_set_key_log_cb(
-            config,
-            key_log_callback,
-            (void *)key_log_file),
-        "Failed to set key log callback");
+        GUARD_EXIT(
+            s2n_config_set_key_log_cb(
+                config,
+                key_log_callback,
+                (void *)key_log_file
+            ),
+            "Failed to set key log callback"
+        );
     }
 
     int fd;

--- a/tests/unit/s2n_self_talk_key_log_test.c
+++ b/tests/unit/s2n_self_talk_key_log_test.c
@@ -1,0 +1,167 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+
+static int s2n_test_key_log_cb(void* context, struct s2n_connection *conn,
+                                   uint8_t *logline, size_t len)
+{
+    struct s2n_stuffer* stuffer = (struct s2n_stuffer*)context;
+    GUARD(s2n_stuffer_write_bytes(stuffer, logline, len));
+    GUARD(s2n_stuffer_write_uint8(stuffer, '\n'));
+
+    return S2N_SUCCESS;
+}
+
+S2N_RESULT s2n_test_check_tls12(struct s2n_stuffer *stuffer)
+{
+    size_t len = s2n_stuffer_data_available(stuffer);
+    ENSURE_GT(len, 0);
+    char *out = (char *)s2n_stuffer_raw_read(stuffer, len);
+    ENSURE_REF(out);
+    /**
+     * rather than writing a full parser, we'll just make sure it at least
+     * wrote the labels we would expect for TLS 1.2
+     */
+    ENSURE_REF(strstr(out, "CLIENT_RANDOM "));
+    return S2N_RESULT_OK;
+}
+
+S2N_RESULT s2n_test_check_tls13(struct s2n_stuffer *stuffer)
+{
+    size_t len = s2n_stuffer_data_available(stuffer);
+    ENSURE_GT(len, 0);
+    char *out = (char *)s2n_stuffer_raw_read(stuffer, len);
+    ENSURE_REF(out);
+    /**
+     * rather than writing a full parser, we'll just make sure it at least
+     * wrote the labels we would expect for TLS 1.3
+     */
+    ENSURE_REF(strstr(out, "CLIENT_HANDSHAKE_TRAFFIC_SECRET "));
+    ENSURE_REF(strstr(out, "SERVER_HANDSHAKE_TRAFFIC_SECRET "));
+    ENSURE_REF(strstr(out, "CLIENT_TRAFFIC_SECRET_0 "));
+    ENSURE_REF(strstr(out, "SERVER_TRAFFIC_SECRET_0 "));
+    return S2N_RESULT_OK;
+}
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* TLS 1.2 */
+    {
+        /* Setup connections */
+        struct s2n_connection *client_conn, *server_conn;
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+
+        /* Setup config */
+        struct s2n_cert_chain_and_key *chain_and_key;
+        EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
+            S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
+        struct s2n_config *client_config;
+        EXPECT_NOT_NULL(client_config = s2n_config_new());
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "default"));
+        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(client_config));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(client_config, chain_and_key));
+        DEFER_CLEANUP(struct s2n_stuffer client_key_log, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&client_key_log, 1024));
+        EXPECT_SUCCESS(s2n_config_set_key_log_cb(client_config, s2n_test_key_log_cb, &client_key_log));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
+
+        struct s2n_config *server_config;
+        EXPECT_NOT_NULL(server_config = s2n_config_new());
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "default"));
+        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(server_config));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
+        DEFER_CLEANUP(struct s2n_stuffer server_key_log, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&server_key_log, 1024));
+        EXPECT_SUCCESS(s2n_config_set_key_log_cb(server_config, s2n_test_key_log_cb, &server_key_log));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
+
+        /* Create nonblocking pipes */
+        struct s2n_test_io_pair io_pair;
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
+
+        /* Do handshake */
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+
+        EXPECT_OK(s2n_test_check_tls12(&client_key_log));
+        EXPECT_OK(s2n_test_check_tls12(&server_key_log));
+
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+        EXPECT_SUCCESS(s2n_config_free(server_config));
+        EXPECT_SUCCESS(s2n_config_free(client_config));
+    }
+
+    /* TLS 1.3 */
+    {
+        /* Setup connections */
+        struct s2n_connection *client_conn, *server_conn;
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+
+        /* Setup config */
+        struct s2n_cert_chain_and_key *chain_and_key;
+        EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
+            S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
+        struct s2n_config *client_config;
+        EXPECT_NOT_NULL(client_config = s2n_config_new());
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "default_tls13"));
+        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(client_config));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(client_config, chain_and_key));
+        DEFER_CLEANUP(struct s2n_stuffer client_key_log, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&client_key_log, 1024));
+        EXPECT_SUCCESS(s2n_config_set_key_log_cb(client_config, s2n_test_key_log_cb, &client_key_log));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
+
+        struct s2n_config *server_config;
+        EXPECT_NOT_NULL(server_config = s2n_config_new());
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "default_tls13"));
+        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(server_config));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
+        DEFER_CLEANUP(struct s2n_stuffer server_key_log, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&server_key_log, 1024));
+        EXPECT_SUCCESS(s2n_config_set_key_log_cb(server_config, s2n_test_key_log_cb, &server_key_log));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
+
+        /* Create nonblocking pipes */
+        struct s2n_test_io_pair io_pair;
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
+
+        /* Do handshake */
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+
+        EXPECT_OK(s2n_test_check_tls13(&client_key_log));
+        EXPECT_OK(s2n_test_check_tls13(&server_key_log));
+
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+        EXPECT_SUCCESS(s2n_config_free(server_config));
+        EXPECT_SUCCESS(s2n_config_free(client_config));
+    }
+
+    END_TEST();
+}

--- a/tls/s2n_client_key_exchange.c
+++ b/tls/s2n_client_key_exchange.c
@@ -24,6 +24,7 @@
 #include "tls/s2n_cipher_suites.h"
 #include "tls/s2n_connection.h"
 #include "tls/s2n_kex.h"
+#include "tls/s2n_key_log.h"
 #include "tls/s2n_resume.h"
 
 #include "stuffer/s2n_stuffer.h"
@@ -93,6 +94,8 @@ static int s2n_calculate_keys(struct s2n_connection *conn, struct s2n_blob *shar
     if (s2n_allowed_to_cache_connection(conn)) {
         GUARD(s2n_store_to_cache(conn));
     }
+    /* log the secret, if needed */
+    s2n_result_ignore(s2n_key_log_tls12_secret(conn));
     return 0;
 }
 

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -85,47 +85,20 @@ static int s2n_config_setup_fips(struct s2n_config *config)
 
 static int s2n_config_init(struct s2n_config *config)
 {
-    config->cert_allocated = 0;
-    config->dhparams = NULL;
-    memset(&config->application_protocols, 0, sizeof(config->application_protocols));
     config->status_request_type = S2N_STATUS_REQUEST_NONE;
     config->wall_clock = wall_clock;
     config->monotonic_clock = monotonic_clock;
-    config->verify_host = NULL;
-    config->data_for_verify_host = NULL;
-    config->client_hello_cb = NULL;
-    config->client_hello_cb_ctx = NULL;
-    config->cache_store = NULL;
-    config->cache_store_data = NULL;
-    config->cache_retrieve = NULL;
-    config->cache_retrieve_data = NULL;
-    config->cache_delete = NULL;
-    config->cache_delete_data = NULL;
     config->ct_type = S2N_CT_SUPPORT_NONE;
     config->mfl_code = S2N_TLS_MAX_FRAG_LEN_EXT_NONE;
-    config->initial_tickets_to_send = 0;
     config->alert_behavior = S2N_ALERT_FAIL_ON_WARNINGS;
-    config->accept_mfl = 0;
     config->session_state_lifetime_in_nanos = S2N_STATE_LIFETIME_IN_NANOS;
-    config->use_tickets = 0;
-    config->use_session_cache = 0;
-    config->ticket_keys = NULL;
-    config->ticket_key_hashes = NULL;
     config->encrypt_decrypt_key_lifetime_in_nanos = S2N_TICKET_ENCRYPT_DECRYPT_KEY_LIFETIME_IN_NANOS;
     config->decrypt_key_lifetime_in_nanos = S2N_TICKET_DECRYPT_KEY_LIFETIME_IN_NANOS;
-    config->quic_enabled = 0;
 
     /* By default, only the client will authenticate the Server's Certificate. The Server does not request or
      * authenticate any client certificates. */
     config->client_cert_auth_type = S2N_CERT_AUTH_NONE;
     config->check_ocsp = 1;
-    config->disable_x509_validation = 0;
-    config->max_verify_cert_chain_depth = 0;
-    config->max_verify_cert_chain_depth_set = 0;
-    config->cert_tiebreak_cb = NULL;
-    config->async_pkey_cb = NULL;
-    config->psk_selection_cb = NULL;
-    config->cert_req_dss_legacy_compat_enabled = 0;
 
     GUARD(s2n_config_setup_default(config));
     if (s2n_use_default_tls13_config()) {
@@ -136,8 +109,6 @@ static int s2n_config_init(struct s2n_config *config)
 
     notnull_check(config->domain_name_to_cert_map = s2n_map_new_with_initial_capacity(1));
     GUARD_AS_POSIX(s2n_map_complete(config->domain_name_to_cert_map));
-    memset(&config->default_certs_by_type, 0, sizeof(struct certs_by_type));
-    config->default_certs_are_explicit = 0;
 
     s2n_x509_trust_store_init_empty(&config->trust_store);
     s2n_x509_trust_store_from_system_defaults(&config->trust_store);
@@ -284,6 +255,7 @@ struct s2n_config *s2n_config_new(void)
     struct s2n_config *new_config;
 
     GUARD_PTR(s2n_alloc(&allocator, sizeof(struct s2n_config)));
+    GUARD_PTR(s2n_blob_zero(&allocator));
 
     new_config = (struct s2n_config *)(void *)allocator.data;
     if (s2n_config_init(new_config) != S2N_SUCCESS) {

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -868,3 +868,12 @@ int s2n_config_set_psk_selection_callback(struct s2n_config *config, s2n_psk_sel
     config->psk_selection_cb = cb;
     return S2N_SUCCESS;
 }
+
+int s2n_config_set_key_log_cb(struct s2n_config *config, s2n_key_log_fn callback, void *ctx) {
+    ENSURE_POSIX_MUT(config);
+
+    config->key_log_cb = callback;
+    config->key_log_ctx = ctx;
+
+    return S2N_SUCCESS;
+}

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -102,16 +102,16 @@ static int s2n_config_init(struct s2n_config *config)
 
     GUARD(s2n_config_setup_default(config));
     if (s2n_use_default_tls13_config()) {
-       GUARD(s2n_config_setup_tls13(config));
+        GUARD(s2n_config_setup_tls13(config));
     } else if (s2n_is_in_fips_mode()) {
         GUARD(s2n_config_setup_fips(config));
     }
 
-    notnull_check(config->domain_name_to_cert_map = s2n_map_new_with_initial_capacity(1));
+    GUARD_NONNULL(config->domain_name_to_cert_map = s2n_map_new_with_initial_capacity(1));
     GUARD_AS_POSIX(s2n_map_complete(config->domain_name_to_cert_map));
 
     s2n_x509_trust_store_init_empty(&config->trust_store);
-    s2n_x509_trust_store_from_system_defaults(&config->trust_store);
+    GUARD(s2n_x509_trust_store_from_system_defaults(&config->trust_store));
 
     return 0;
 }

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -105,6 +105,9 @@ struct s2n_config {
 
     s2n_async_pkey_fn async_pkey_cb;
     s2n_psk_selection_callback psk_selection_cb;
+
+    s2n_key_log_fn key_log_cb;
+    void *key_log_ctx;
 };
 
 int s2n_config_defaults_init(void);

--- a/tls/s2n_key_log.c
+++ b/tls/s2n_key_log.c
@@ -1,0 +1,130 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <s2n.h>
+#include "tls/s2n_config.h"
+#include "tls/s2n_connection.h"
+#include "tls/s2n_crypto_constants.h"
+#include "tls/s2n_quic_support.h" /* this currently holds the s2n_secret_type_t enum */
+#include "utils/s2n_blob.h"
+#include "utils/s2n_safety.h"
+
+/* hex requires 2 chars per byte */
+#define HEX_ENCODING_SIZE 2
+
+/* https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format */
+
+S2N_RESULT s2n_key_log_hex_encode(struct s2n_stuffer *output, uint8_t *bytes, size_t len)
+{
+    ENSURE_MUT(output);
+    ENSURE_REF(bytes);
+
+    const uint8_t chars[] = "0123456789abcdef";
+
+    for (size_t i = 0; i < len; i++) {
+        uint8_t upper = bytes[i] >> 4;
+        uint8_t lower = bytes[i] & 0x0f;
+
+        GUARD_AS_RESULT(s2n_stuffer_write_uint8(output, chars[upper]));
+        GUARD_AS_RESULT(s2n_stuffer_write_uint8(output, chars[lower]));
+    }
+
+    return S2N_RESULT_OK;
+}
+
+S2N_RESULT s2n_key_log_tls13_secret(struct s2n_connection *conn, struct s2n_blob *secret, s2n_secret_type_t secret_type)
+{
+    ENSURE_REF(conn);
+    ENSURE_REF(conn->config);
+    ENSURE_REF(secret);
+
+    /* only emit keys if the callback has been set */
+    if (!conn->config->key_log_cb) {
+        return S2N_RESULT_OK;
+    }
+
+    const uint8_t client_early_traffic_label[] = "CLIENT_EARLY_TRAFFIC_SECRET ";
+    const uint8_t client_handshake_label[] = "CLIENT_HANDSHAKE_TRAFFIC_SECRET ";
+    const uint8_t server_handshake_label[] = "SERVER_HANDSHAKE_TRAFFIC_SECRET ";
+    const uint8_t client_traffic_label[] = "CLIENT_TRAFFIC_SECRET_0 ";
+    const uint8_t server_traffic_label[] = "SERVER_TRAFFIC_SECRET_0 ";
+
+    const uint8_t *label = NULL;
+    uint8_t label_size = 0;
+
+    switch (secret_type) {
+        case S2N_CLIENT_EARLY_TRAFFIC_SECRET:
+            label = client_early_traffic_label;
+            label_size = sizeof(client_early_traffic_label) - 1;
+            break;
+        case S2N_CLIENT_HANDSHAKE_TRAFFIC_SECRET:
+            label = client_handshake_label;
+            label_size = sizeof(client_handshake_label) - 1;
+            break;
+        case S2N_SERVER_HANDSHAKE_TRAFFIC_SECRET:
+            label = server_handshake_label;
+            label_size = sizeof(server_handshake_label) - 1;
+            break;
+        case S2N_CLIENT_APPLICATION_TRAFFIC_SECRET:
+            label = client_traffic_label;
+            label_size = sizeof(client_traffic_label) - 1;
+            break;
+        case S2N_SERVER_APPLICATION_TRAFFIC_SECRET:
+            label = server_traffic_label;
+            label_size = sizeof(server_traffic_label) - 1;
+            break;
+        default:
+            BAIL(S2N_ERR_SAFETY);
+    }
+
+    const uint8_t len
+        = label_size
+        + S2N_TLS_RANDOM_DATA_LEN * HEX_ENCODING_SIZE
+        + 1 /* SPACE */
+        + secret->size * HEX_ENCODING_SIZE;
+
+    DEFER_CLEANUP(struct s2n_stuffer output, s2n_stuffer_free);
+    GUARD_AS_RESULT(s2n_stuffer_alloc(&output, len));
+
+    GUARD_AS_RESULT(s2n_stuffer_write_bytes(&output, label, label_size));
+    GUARD_RESULT(s2n_key_log_hex_encode(&output, conn->secure.client_random, S2N_TLS_RANDOM_DATA_LEN));
+    GUARD_AS_RESULT(s2n_stuffer_write_uint8(&output, ' '));
+    GUARD_RESULT(s2n_key_log_hex_encode(&output, secret->data, secret->size));
+
+    uint8_t *data = s2n_stuffer_raw_read(&output, len);
+    ENSURE_REF(data);
+
+    conn->config->key_log_cb(conn->config->key_log_ctx, conn, data, len);
+
+    return S2N_RESULT_OK;
+}
+
+S2N_RESULT s2n_key_log_tls12_secret(struct s2n_connection *conn, struct s2n_stuffer *output)
+{
+    ENSURE_REF(conn);
+    ENSURE_MUT(output);
+
+    /* only emit keys if the callback has been set */
+    if (!conn->config->key_log_cb) {
+        return S2N_RESULT_OK;
+    }
+
+    /* const uint8_t client_random_label[] = "CLIENT_RANDOM "; */
+
+    /* TODO */
+
+    return S2N_RESULT_OK;
+}
+

--- a/tls/s2n_key_log.h
+++ b/tls/s2n_key_log.h
@@ -21,6 +21,7 @@
 #include "utils/s2n_blob.h"
 #include "utils/s2n_safety.h"
 
+S2N_RESULT s2n_key_log_hex_encode(struct s2n_stuffer *output, uint8_t *bytes, size_t len);
 S2N_RESULT s2n_key_log_tls12_secret(struct s2n_connection *conn);
 S2N_RESULT s2n_key_log_tls13_secret(struct s2n_connection *conn, struct s2n_blob *secret, s2n_secret_type_t secret_type);
 

--- a/tls/s2n_key_log.h
+++ b/tls/s2n_key_log.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include <s2n.h>
+#include "stuffer/s2n_stuffer.h"
+#include "tls/s2n_quic_support.h"
+#include "utils/s2n_blob.h"
+#include "utils/s2n_safety.h"
+
+S2N_RESULT s2n_key_log_tls12_secret(struct s2n_connection *conn, struct s2n_stuffer *output);
+S2N_RESULT s2n_key_log_tls13_secret(struct s2n_connection *conn, struct s2n_blob *secret, s2n_secret_type_t secret_type);
+

--- a/tls/s2n_key_log.h
+++ b/tls/s2n_key_log.h
@@ -21,6 +21,6 @@
 #include "utils/s2n_blob.h"
 #include "utils/s2n_safety.h"
 
-S2N_RESULT s2n_key_log_tls12_secret(struct s2n_connection *conn, struct s2n_stuffer *output);
+S2N_RESULT s2n_key_log_tls12_secret(struct s2n_connection *conn);
 S2N_RESULT s2n_key_log_tls13_secret(struct s2n_connection *conn, struct s2n_blob *secret, s2n_secret_type_t secret_type);
 

--- a/utils/s2n_result.c
+++ b/utils/s2n_result.c
@@ -91,3 +91,9 @@ inline bool s2n_result_is_error(s2n_result result)
 {
     return result.__error_signal == S2N_FAILURE;
 }
+
+/* ignores the returned result of a function */
+inline void s2n_result_ignore(s2n_result result)
+{
+    /* noop */
+}

--- a/utils/s2n_result.h
+++ b/utils/s2n_result.h
@@ -41,7 +41,14 @@ S2N_RESULT_MUST_USE bool s2n_result_is_ok(s2n_result result);
 /* returns true when the result is S2N_RESULT_ERROR */
 S2N_RESULT_MUST_USE bool s2n_result_is_error(s2n_result result);
 
-/* ignores the returned result of a function */
+/**
+ * Ignores the returned result of a function
+ *
+ * Generally, function results should always be checked. Using this function
+ * could cause the system to behave in unexpected ways. As such, this function
+ * should only be used in scenarios where the system state is not affected by
+ * errors.
+ */
 void s2n_result_ignore(s2n_result result);
 
 /* used in function declarations to signal function fallibility */

--- a/utils/s2n_result.h
+++ b/utils/s2n_result.h
@@ -41,6 +41,9 @@ S2N_RESULT_MUST_USE bool s2n_result_is_ok(s2n_result result);
 /* returns true when the result is S2N_RESULT_ERROR */
 S2N_RESULT_MUST_USE bool s2n_result_is_error(s2n_result result);
 
+/* ignores the returned result of a function */
+void s2n_result_ignore(s2n_result result);
+
 /* used in function declarations to signal function fallibility */
 #define S2N_RESULT S2N_RESULT_MUST_USE s2n_result
 


### PR DESCRIPTION
### Resolved issues:

 resolves #817 #818 #1617 

### Changes

I've added support for key logging in both TLS 1.2 and 1.3. We now have a config option to specify a callback that is called on each secret, which is passed in the [NSS Key Log Format](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format).

I've added support for key logging to `s2nd` and `s2nc`.

I was also getting test failures after adding a new field to `s2n_config`. This was because it was not being zeroed out after being allocated, like the connection is. I've added a similar `s2n_blob_zero(&config)` here as well.

### Future work

Right now the unit tests are pretty basic. Ideally we would use wireshark in the integration tests to ensure that secrets were logged in the correct format. I've created an issue for that: #2587.

## Manual tests

### TLS 1.2

![tls12](https://user-images.githubusercontent.com/799311/107829488-acd56c00-6d3e-11eb-9a7e-e1d7f418f95a.png)

### TLS 1.3

![tls13](https://user-images.githubusercontent.com/799311/107829489-ad6e0280-6d3e-11eb-90f3-b4cb0a58bde4.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
