### PR TITLE
Update PQ KEM branches to use constant time functions.

### DIFF
--- a/pq-crypto/sike_r1/sike_r1_kem.c
+++ b/pq-crypto/sike_r1/sike_r1_kem.c
@@ -117,8 +117,11 @@ int SIKE_P503_r1_crypto_kem_dec(unsigned char *ss, const unsigned char *ct, cons
 
     // Generate shared secret ss <- H(m||ct) or output ss <- H(s||ct)
     EphemeralKeyGeneration_A(ephemeralsk_.d, c0_);
-    bool copy_or_dont = s2n_constant_time_equals(c0_, ct, SIKE_P503_R1_PUBLIC_KEY_BYTES);
-    s2n_constant_time_copy_or_dont(temp, sk, MSG_BYTES, copy_or_dont);
+
+    // We only want to copy the data if c0_ and ct are different
+    bool dont_copy = s2n_constant_time_equals(c0_, ct, SIKE_P503_R1_PUBLIC_KEY_BYTES);
+    // The last argument to s2n_constant_time_copy_or_dont is dont and thus prevents the copy when non-zero/true
+    s2n_constant_time_copy_or_dont(temp, sk, MSG_BYTES, dont_copy);
 
     memcpy(&temp[MSG_BYTES], ct, SIKE_P503_R1_CIPHERTEXT_BYTES);
     cshake256_simple(ss, SIKE_P503_R1_SHARED_SECRET_BYTES, H, temp, SIKE_P503_R1_CIPHERTEXT_BYTES+MSG_BYTES);

--- a/pq-crypto/sike_r1/sike_r1_kem.c
+++ b/pq-crypto/sike_r1/sike_r1_kem.c
@@ -117,9 +117,9 @@ int SIKE_P503_r1_crypto_kem_dec(unsigned char *ss, const unsigned char *ct, cons
 
     // Generate shared secret ss <- H(m||ct) or output ss <- H(s||ct)
     EphemeralKeyGeneration_A(ephemeralsk_.d, c0_);
-    if (memcmp(c0_, ct, SIKE_P503_R1_PUBLIC_KEY_BYTES) != 0) {
-        memcpy(temp, sk, MSG_BYTES);
-    }
+    bool copy_or_dont = s2n_constant_time_equals(c0_, ct, SIKE_P503_R1_PUBLIC_KEY_BYTES);
+    s2n_constant_time_copy_or_dont(temp, sk, MSG_BYTES, copy_or_dont);
+
     memcpy(&temp[MSG_BYTES], ct, SIKE_P503_R1_CIPHERTEXT_BYTES);
     cshake256_simple(ss, SIKE_P503_R1_SHARED_SECRET_BYTES, H, temp, SIKE_P503_R1_CIPHERTEXT_BYTES+MSG_BYTES);
 

--- a/pq-crypto/sike_r1/sike_r1_kem.c
+++ b/pq-crypto/sike_r1/sike_r1_kem.c
@@ -118,6 +118,7 @@ int SIKE_P503_r1_crypto_kem_dec(unsigned char *ss, const unsigned char *ct, cons
     // Generate shared secret ss <- H(m||ct) or output ss <- H(s||ct)
     EphemeralKeyGeneration_A(ephemeralsk_.d, c0_);
 
+    // Note: This step deviates from the NIST supplied code by using constant time operations.
     // We only want to copy the data if c0_ and ct are different
     bool dont_copy = s2n_constant_time_equals(c0_, ct, SIKE_P503_R1_PUBLIC_KEY_BYTES);
     // The last argument to s2n_constant_time_copy_or_dont is dont and thus prevents the copy when non-zero/true

--- a/pq-crypto/sike_r2/sike_r2_kem.c
+++ b/pq-crypto/sike_r2/sike_r2_kem.c
@@ -111,6 +111,7 @@ int SIKE_P434_r2_crypto_kem_dec(unsigned char *ss, const unsigned char *ct, cons
     // Generate shared secret ss <- H(m||ct) or output ss <- H(s||ct)
     EphemeralKeyGeneration_A(ephemeralsk_.d, c0_);
 
+    // Note: This step deviates from the NIST supplied code by using constant time operations.
     // We only want to copy the data if c0_ and ct are different
     bool dont_copy = s2n_constant_time_equals(c0_, ct, CRYPTO_PUBLICKEYBYTES);
     // The last argument to s2n_constant_time_copy_or_dont is dont and thus prevents the copy when non-zero/true

--- a/pq-crypto/sike_r2/sike_r2_kem.c
+++ b/pq-crypto/sike_r2/sike_r2_kem.c
@@ -110,9 +110,9 @@ int SIKE_P434_r2_crypto_kem_dec(unsigned char *ss, const unsigned char *ct, cons
 
     // Generate shared secret ss <- H(m||ct) or output ss <- H(s||ct)
     EphemeralKeyGeneration_A(ephemeralsk_.d, c0_);
-    if (memcmp(c0_, ct, CRYPTO_PUBLICKEYBYTES) != 0) {
-        memcpy(temp, sk, MSG_BYTES);
-    }
+    bool copy_or_dont = s2n_constant_time_equals(c0_, ct, CRYPTO_PUBLICKEYBYTES);
+    s2n_constant_time_copy_or_dont(temp, sk, MSG_BYTES, copy_or_dont);
+
     memcpy(&temp[MSG_BYTES], ct, CRYPTO_CIPHERTEXTBYTES);
     shake256(ss, CRYPTO_BYTES, temp, CRYPTO_CIPHERTEXTBYTES + MSG_BYTES);
 

--- a/pq-crypto/sike_r2/sike_r2_kem.c
+++ b/pq-crypto/sike_r2/sike_r2_kem.c
@@ -110,8 +110,11 @@ int SIKE_P434_r2_crypto_kem_dec(unsigned char *ss, const unsigned char *ct, cons
 
     // Generate shared secret ss <- H(m||ct) or output ss <- H(s||ct)
     EphemeralKeyGeneration_A(ephemeralsk_.d, c0_);
-    bool copy_or_dont = s2n_constant_time_equals(c0_, ct, CRYPTO_PUBLICKEYBYTES);
-    s2n_constant_time_copy_or_dont(temp, sk, MSG_BYTES, copy_or_dont);
+
+    // We only want to copy the data if c0_ and ct are different
+    bool dont_copy = s2n_constant_time_equals(c0_, ct, CRYPTO_PUBLICKEYBYTES);
+    // The last argument to s2n_constant_time_copy_or_dont is dont and thus prevents the copy when non-zero/true
+    s2n_constant_time_copy_or_dont(temp, sk, MSG_BYTES, dont_copy);
 
     memcpy(&temp[MSG_BYTES], ct, CRYPTO_CIPHERTEXTBYTES);
     shake256(ss, CRYPTO_BYTES, temp, CRYPTO_CIPHERTEXTBYTES + MSG_BYTES);


### PR DESCRIPTION
### Description of changes: 

Use constant time functions to perform `memcmp` and `memcpy` behavior in PQ KEM code.

### Testing:

Pipeline and Github CI.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
