### PR TITLE
Renaming index to psk_index to prevent name collision

### DIFF
--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -199,7 +199,7 @@ int s2n_offered_psk_list_reset(struct s2n_offered_psk_list *psk_list)
     return s2n_stuffer_reread(&psk_list->wire_data);
 }
 
-S2N_RESULT s2n_offered_psk_list_get_index(struct s2n_offered_psk_list *psk_list, uint16_t index, struct s2n_offered_psk *psk)
+S2N_RESULT s2n_offered_psk_list_get_index(struct s2n_offered_psk_list *psk_list, uint16_t psk_index, struct s2n_offered_psk *psk)
 {
     ENSURE_REF(psk_list);
     ENSURE_MUT(psk);
@@ -209,7 +209,7 @@ S2N_RESULT s2n_offered_psk_list_get_index(struct s2n_offered_psk_list *psk_list,
     GUARD_AS_RESULT(s2n_offered_psk_list_reset(&psk_list_copy));
 
     uint16_t count = 0;
-    while(count <= index) {
+    while(count <= psk_index) {
         GUARD_AS_RESULT(s2n_offered_psk_list_next(&psk_list_copy, psk));
         count++;
     }

--- a/tls/s2n_psk.h
+++ b/tls/s2n_psk.h
@@ -65,7 +65,7 @@ struct s2n_offered_psk {
 struct s2n_offered_psk_list {
     struct s2n_stuffer wire_data;
 };
-S2N_RESULT s2n_offered_psk_list_get_index(struct s2n_offered_psk_list *list, uint16_t index,
+S2N_RESULT s2n_offered_psk_list_get_index(struct s2n_offered_psk_list *list, uint16_t psk_index,
         struct s2n_offered_psk *offered_psk);
 
 S2N_RESULT s2n_finish_psk_extension(struct s2n_connection *conn);


### PR DESCRIPTION

### Resolved Issues 

Related to https://github.com/awslabs/s2n/issues/2591

### Description of changes: 

Renaming variable name index to psk_index to prevent naming collision in RHEL5_64 systems. 

Describe s2n’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.

### Call-outs:

Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
